### PR TITLE
live dialog updates

### DIFF
--- a/tcl/dialog_canvas.tcl
+++ b/tcl/dialog_canvas.tcl
@@ -42,8 +42,8 @@ proc ::dialog_canvas::ok {mytoplevel} {
 
 proc ::dialog_canvas::checkcommand {mytoplevel} {
     if { $::graphme_button($mytoplevel) != 0 } {
-        $mytoplevel.scale.x.entry configure -state disabled
-        $mytoplevel.scale.y.entry configure -state disabled
+        $mytoplevel.scale.x.entry configure -state disabled -takefocus 0
+        $mytoplevel.scale.y.entry configure -state disabled -takefocus 0
         $mytoplevel.parent.hidetext configure -state normal
         $mytoplevel.range.x.from_entry configure -state normal
         $mytoplevel.range.x.to_entry configure -state normal
@@ -73,8 +73,8 @@ proc ::dialog_canvas::checkcommand {mytoplevel} {
             $mytoplevel.range.y.margin_entry insert 0 100
        }
     } else {
-        $mytoplevel.scale.x.entry configure -state normal
-        $mytoplevel.scale.y.entry configure -state normal
+        $mytoplevel.scale.x.entry configure -state normal -takefocus 1
+        $mytoplevel.scale.y.entry configure -state normal -takefocus 1
         $mytoplevel.parent.hidetext configure -state disabled
         $mytoplevel.range.x.from_entry configure -state disabled
         $mytoplevel.range.x.to_entry configure -state disabled
@@ -216,4 +216,67 @@ proc ::dialog_canvas::create_dialog {mytoplevel} {
     button $mytoplevel.buttons.ok -text [_ "OK"] \
         -command "::dialog_canvas::ok $mytoplevel"
     pack $mytoplevel.buttons.ok -side left -expand 1 -fill x -padx 10
+
+    # live checkbutton & entry Return updates on OSX
+    if {$::windowingsystem eq "aqua"} {
+
+        # call apply on checkbutton changes
+        $mytoplevel.parent.graphme config -command [ concat ::dialog_canvas::checkcommand_and_apply $mytoplevel ]
+        $mytoplevel.parent.hidetext config -command [ concat ::dialog_canvas::checkcommand_and_apply $mytoplevel ]
+
+        # call apply on Return in entry boxes that are in focus & rebind Return to ok button
+        bind $mytoplevel.scale.x.entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.scale.y.entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.x.from_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.y.from_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.x.to_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.y.to_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.x.size_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.y.size_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.x.margin_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.range.y.margin_entry <KeyPress-Return> "::dialog_canvas::apply_and_rebind_return $mytoplevel"
+
+        # unbind Return from ok button when an entry takes focus
+        $mytoplevel.scale.x.entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.scale.y.entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.x.from_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.y.from_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.x.to_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.y.to_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.x.size_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.y.size_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.x.margin_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+        $mytoplevel.range.y.margin_entry config -validate focusin -vcmd "::dialog_canvas::unbind_return $mytoplevel"
+
+        # remove cancel button from focus list since it's not activated on Return
+        $mytoplevel.buttons.cancel config -takefocus 0
+
+        # can't see focus for checkbuttons, so disable it
+        $mytoplevel.parent.graphme config -takefocus 0
+        $mytoplevel.parent.hidetext config -takefocus 0
+
+        # show active focus on the ok button as it *is* activated on Return
+        bind $mytoplevel.buttons.ok <FocusIn> "$mytoplevel.buttons.ok config -default active"
+        bind $mytoplevel.buttons.ok <FocusOut> "$mytoplevel.buttons.ok config -default normal"
+    }
  }
+
+# for live updates on OSX
+proc ::dialog_canvas::checkcommand_and_apply {mytoplevel} {
+    ::dialog_canvas::checkcommand $mytoplevel
+    ::dialog_canvas::apply $mytoplevel
+}
+
+ # for live widget updates on OSX
+proc ::dialog_canvas::apply_and_rebind_return {mytoplevel} {
+    ::dialog_canvas::apply $mytoplevel
+    bind $mytoplevel <KeyPress-Return> "::dialog_canvas::ok $mytoplevel"
+    focus $mytoplevel.buttons.ok
+    return 0
+}
+
+# for live widget updates on OSX
+proc ::dialog_canvas::unbind_return {mytoplevel} {
+    bind $mytoplevel <KeyPress-Return> break
+    return 1
+}

--- a/tcl/dialog_gatom.tcl
+++ b/tcl/dialog_gatom.tcl
@@ -87,6 +87,8 @@ proc ::dialog_gatom::pdtk_gatom_dialog {mytoplevel initwidth initlower initupper
         $mytoplevel.s_r.receive.entry insert 0 \
             [::dialog_gatom::unescape $initreceive]
     }
+    $mytoplevel.width.entry select range 0 end
+    focus $mytoplevel.width.entry
 }
 
 proc ::dialog_gatom::create_dialog {mytoplevel} {
@@ -158,18 +160,62 @@ proc ::dialog_gatom::create_dialog {mytoplevel} {
     frame $mytoplevel.buttonframe -pady 5
     pack $mytoplevel.buttonframe -side top -fill x -expand 1 -pady 2m
     button $mytoplevel.buttonframe.cancel -text [_ "Cancel"] \
-        -command "::dialog_gatom::cancel $mytoplevel"
+        -command "::dialog_gatom::cancel $mytoplevel" -highlightcolor green
     pack $mytoplevel.buttonframe.cancel -side left -expand 1 -fill x -padx 10
     if {$::windowingsystem ne "aqua"} {
         button $mytoplevel.buttonframe.apply -text [_ "Apply"] \
             -command "::dialog_gatom::apply $mytoplevel"
-    pack $mytoplevel.buttonframe.apply -side left -expand 1 -fill x -padx 10
+        pack $mytoplevel.buttonframe.apply -side left -expand 1 -fill x -padx 10
     }
     button $mytoplevel.buttonframe.ok -text [_ "OK"] \
-        -command "::dialog_gatom::ok $mytoplevel"
+        -command "::dialog_gatom::ok $mytoplevel" -default active
     pack $mytoplevel.buttonframe.ok -side left -expand 1 -fill x -padx 10
 
-    $mytoplevel.width.entry select from 0
-    $mytoplevel.width.entry select adjust end
-    focus $mytoplevel.width.entry
+    # live widget updates on OSX in lieu of Apply button
+    if {$::windowingsystem eq "aqua"} {
+
+        # call apply on radiobutton changes
+        $mytoplevel.gatomlabel.radio.left config -command [ concat ::dialog_gatom::apply $mytoplevel ]
+        $mytoplevel.gatomlabel.radio.right config -command [ concat ::dialog_gatom::apply $mytoplevel ]
+        $mytoplevel.gatomlabel.radio.top config -command [ concat ::dialog_gatom::apply $mytoplevel ]
+        $mytoplevel.gatomlabel.radio.bottom config -command [ concat ::dialog_gatom::apply $mytoplevel ]
+
+        # call apply on Return in entry boxes that are in focus & rebind Return to ok button
+        bind $mytoplevel.width.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.limits.lower.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.limits.upper.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.gatomlabel.name.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.s_r.send.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+        bind $mytoplevel.s_r.receive.entry <KeyPress-Return> "::dialog_gatom::apply_and_rebind_return $mytoplevel"
+
+        # unbind Return from ok button when an entry takes focus
+        $mytoplevel.width.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.width.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.limits.lower.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.limits.upper.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.gatomlabel.name.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.s_r.send.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+        $mytoplevel.s_r.receive.entry config -validate focusin -vcmd "::dialog_gatom::unbind_return $mytoplevel"
+
+        # remove cancel button from focus list since it's not activated on Return
+        $mytoplevel.buttonframe.cancel config -takefocus 0
+
+        # show active focus on the ok button as it *is* activated on Return
+        bind $mytoplevel.buttonframe.ok <FocusIn> "$mytoplevel.buttonframe.ok config -default active"
+        bind $mytoplevel.buttonframe.ok <FocusOut> "$mytoplevel.buttonframe.ok config -default normal"
+    }
+}
+
+# for live widget updates on OSX
+proc ::dialog_gatom::apply_and_rebind_return {mytoplevel} {
+    ::dialog_gatom::apply $mytoplevel
+    bind $mytoplevel <KeyPress-Return> "::dialog_gatom::ok $mytoplevel"
+    focus $mytoplevel.buttonframe.ok
+    return 0
+}
+
+# for live widget updates on OSX
+proc ::dialog_gatom::unbind_return {mytoplevel} {
+    bind $mytoplevel <KeyPress-Return> break
+    return 1
 }

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -142,20 +142,20 @@ proc ::dialog_iemgui::set_col_example {mytoplevel} {
     set var_iemgui_lcol [concat iemgui_lcol_$vid]
     global $var_iemgui_lcol
     
-    $mytoplevel.colors.sections.lb_bk configure \
+    $mytoplevel.colors.sections.exp.lb_bk configure \
         -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
         -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
         -foreground [format "#%6.6x" [eval concat $$var_iemgui_lcol]] \
         -activeforeground [format "#%6.6x" [eval concat $$var_iemgui_lcol]]
     
     if { [eval concat $$var_iemgui_fcol] >= 0 } {
-        $mytoplevel.colors.sections.fr_bk configure \
+        $mytoplevel.colors.sections.exp.fr_bk configure \
             -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -foreground [format "#%6.6x" [eval concat $$var_iemgui_fcol]] \
             -activeforeground [format "#%6.6x" [eval concat $$var_iemgui_fcol]]
     } else {
-        $mytoplevel.colors.sections.fr_bk configure \
+        $mytoplevel.colors.sections.exp.fr_bk configure \
             -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -foreground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
@@ -252,13 +252,13 @@ proc ::dialog_iemgui::toggle_font {mytoplevel gn_f} {
         1 { set current_font "Helvetica" }
         2 { set current_font "Times" }
     }
-    set current_font_spec "{$current_font} 16 $::font_weight"
+    set current_font_spec "{$current_font} 14 $::font_weight"
     
     $mytoplevel.label.fontpopup_label configure -text $current_font \
-        -font $current_font_spec
+        -font [list $current_font 16 $::font_weight]
     $mytoplevel.label.name_entry configure -font $current_font_spec
-    $mytoplevel.colors.sections.fr_bk configure -font $current_font_spec
-    $mytoplevel.colors.sections.lb_bk configure -font $current_font_spec
+    $mytoplevel.colors.sections.exp.fr_bk configure -font $current_font_spec
+    $mytoplevel.colors.sections.exp.lb_bk configure -font $current_font_spec
 }
 
 proc ::dialog_iemgui::lb {mytoplevel} {
@@ -363,7 +363,7 @@ proc ::dialog_iemgui::apply {mytoplevel} {
     set hhhrcv [unspace_text $hhhrcv]
     set hhhgui_nam [unspace_text $hhhgui_nam]
 
-# make sure the offset boxes have a value
+    # make sure the offset boxes have a value
     if {[eval concat $$var_iemgui_gn_dx] eq ""} {set $var_iemgui_gn_dx 0}
     if {[eval concat $$var_iemgui_gn_dy] eq ""} {set $var_iemgui_gn_dy 0}
 
@@ -497,9 +497,66 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     set $var_iemgui_lcol $lcol
     
     set $var_iemgui_l2_f1_b0 0
+
+    # set labels based on gui type, override incoming values for now
+    # this is a proof of concept, the real way to do this involves
+    # removing label string sending from C and handling strings
+    # (& translations) here
+    set iemgui_type ""
+    set iemgui_range_header [_ "Output Range"]
+    switch -- $mainheader {
+        "|bang|" {
+            set iemgui_type [_ "Bang"]
+            set wdt_label "Size:"
+            set iemgui_range_header [_ "Flash Time (msec)"]
+            set min_rng_label [_ "Intrrpt:"]
+            set max_rng_label [_ "Hold:"] }
+        "|tgl|" {
+            set iemgui_type [_ "Toggle"]
+            set wdt_label [_ "Size:"]
+            set iemgui_range_header [_ "Non Zero Value"]
+            set min_rng_label [_ "Value:"] }
+        "|nbx|" {
+            set iemgui_type [_ "Number2"]
+            set wdt_label [_ "Width (digits):"]
+            set hgt_label [_ "Height:"]
+            set min_rng_label [_ "Lower:"]
+            set max_rng_label [_ "Upper:"]
+            set num_label [_ "Log height:"] }
+        "|vsl|" {
+            set iemgui_type [_ "Vslider"]
+            set wdt_label [_ "Width:"]
+            set hgt_label [_ "Height:"]
+            set min_rng_label [_ "Lower:"]
+            set max_rng_label [_ "Upper:"] }
+        "|hsl|" {
+            set iemgui_type [_ "Hslider"]
+            set wdt_label [_ "Width:"]
+            set hgt_label [_ "Height:"]
+            set min_rng_label [_ "Lower:"]
+            set max_rng_label [_ "Upper:"] }
+        "|vradio|" {
+            set iemgui_type [_ "Vradio"]
+            set wdt_label [_ "Size:"]
+            set num_label [_ "Num cells:"] }
+        "|hradio|" {
+            set iemgui_type [_ "Hradio"]
+            set wdt_label [_ "Size:"]
+            set num_label [_ "Num cells:"] }
+        "|vu|" {
+            set iemgui_type [_ "VU Meter"]
+            set wdt_label [_ "Width:"]
+            set hgt_label [_ "Height:"] }
+        "|cnv|" {
+            set iemgui_type [_ "Canvas"]
+            set wdt_label [_ "Size:"]
+            set min_rng_label [_ "Width:"]
+            set max_rng_label [_ "Height:"]
+            set iemgui_range_header [_ "Visible Rectangle (pix)"] }
+    }
     
     toplevel $mytoplevel -class DialogWindow
-    wm title $mytoplevel [format [_ "%s Properties"] $mainheader]
+    wm title $mytoplevel [format [_ "%s Properties"] $iemgui_type]
     wm group $mytoplevel .
     wm resizable $mytoplevel 0 0
     wm transient $mytoplevel $::focused_window
@@ -507,57 +564,69 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     $mytoplevel configure -padx 0 -pady 0
     ::pd_bindings::dialog_bindings $mytoplevel "iemgui"
 
-    frame $mytoplevel.dim
+    # dimensions
+    frame $mytoplevel.dim -height 7
     pack $mytoplevel.dim -side top
     label $mytoplevel.dim.head -text [_ $dim_header]
-    label $mytoplevel.dim.w_lab -text [_ $wdt_label] -width 6
-    entry $mytoplevel.dim.w_ent -textvariable $var_iemgui_wdt -width 5
-    label $mytoplevel.dim.dummy1 -text " " -width 10
-    label $mytoplevel.dim.h_lab -text [_ $hgt_label] -width 6
-    entry $mytoplevel.dim.h_ent -textvariable $var_iemgui_hgt -width 5
-    pack $mytoplevel.dim.head -side top
-    pack $mytoplevel.dim.w_lab $mytoplevel.dim.w_ent $mytoplevel.dim.dummy1 -side left
+    label $mytoplevel.dim.w_lab -text [_ $wdt_label]
+    entry $mytoplevel.dim.w_ent -textvariable $var_iemgui_wdt -width 4
+    label $mytoplevel.dim.dummy1 -text "" -width 1
+    label $mytoplevel.dim.h_lab -text [_ $hgt_label]
+    entry $mytoplevel.dim.h_ent -textvariable $var_iemgui_hgt -width 4
+    #pack $mytoplevel.dim.head -side top
+    pack $mytoplevel.dim.w_lab $mytoplevel.dim.w_ent -side left
     if { $hgt_label ne "empty" } {
-        pack $mytoplevel.dim.h_lab $mytoplevel.dim.h_ent -side left}
+        pack $mytoplevel.dim.dummy1 $mytoplevel.dim.h_lab $mytoplevel.dim.h_ent -side left }
     
-    frame $mytoplevel.rng
-    pack $mytoplevel.rng -side top
+    # range
+    labelframe $mytoplevel.rng
+    pack $mytoplevel.rng -side top -fill x
     label $mytoplevel.rng.head -text [_ $rng_header]
-    label $mytoplevel.rng.min_lab -text [_ $min_rng_label] -width 6
-    entry $mytoplevel.rng.min_ent -textvariable $var_iemgui_min_rng -width 9
-    label $mytoplevel.rng.dummy1 -text " " -width 1
-    label $mytoplevel.rng.max_lab -text [_ $max_rng_label] -width 8
-    entry $mytoplevel.rng.max_ent -textvariable $var_iemgui_max_rng -width 9
+    frame $mytoplevel.rng.min
+    label $mytoplevel.rng.min.lab -text [_ $min_rng_label]
+    entry $mytoplevel.rng.min.ent -textvariable $var_iemgui_min_rng -width 7
+    label $mytoplevel.rng.dummy1 -text "" -width 1
+    label $mytoplevel.rng.max_lab -text [_ $max_rng_label]
+    entry $mytoplevel.rng.max_ent -textvariable $var_iemgui_max_rng -width 7
     if { $rng_header ne "empty" } {
-        pack $mytoplevel.rng.head -side top
+        #pack $mytoplevel.rng.head -side top
+        $mytoplevel.rng config -borderwidth 1 -pady 4 -text [_ $iemgui_range_header]
         if { $min_rng_label ne "empty" } {
-            pack $mytoplevel.rng.min_lab $mytoplevel.rng.min_ent -side left}
+            pack $mytoplevel.rng.min
+            pack $mytoplevel.rng.min.lab $mytoplevel.rng.min.ent -side left }
         if { $max_rng_label ne "empty" } {
-            pack $mytoplevel.rng.dummy1 \
-                $mytoplevel.rng.max_lab $mytoplevel.rng.max_ent -side left} }
+            $mytoplevel.rng config -padx 26
+            pack configure $mytoplevel.rng.min -side left
+            pack $mytoplevel.rng.dummy1 $mytoplevel.rng.max_lab $mytoplevel.rng.max_ent -side left}
+    }
     
-    if { [eval concat $$var_iemgui_lin0_log1] >= 0 || [eval concat $$var_iemgui_loadbang] >= 0 || [eval concat $$var_iemgui_num] > 0 || [eval concat $$var_iemgui_steady] >= 0 } {
-        label $mytoplevel.space1 -text ""
-        pack $mytoplevel.space1 -side top }
-    
-    frame $mytoplevel.para
-    pack $mytoplevel.para -side top
-    label $mytoplevel.para.dummy2 -text "" -width 1
-    label $mytoplevel.para.dummy3 -text "" -width 1
+    # if { [eval concat $$var_iemgui_lin0_log1] >= 0 || [eval concat $$var_iemgui_loadbang] >= 0 || [eval concat $$var_iemgui_num] > 0 || [eval concat $$var_iemgui_steady] >= 0 } {
+    #     label $mytoplevel.space1 -text ""
+    #     pack $mytoplevel.space1 -side top }
+
+    labelframe $mytoplevel.para -borderwidth 1 -padx 5 -pady 5 -text [_ "Parameters"]
+    pack $mytoplevel.para -side top -fill x -pady 5
+    #label $mytoplevel.para.dummy2 -text "" -width 0
+    #label $mytoplevel.para.dummy3 -text "" -width 0
     if {[eval concat $$var_iemgui_lin0_log1] == 0} {
         button $mytoplevel.para.lilo -text [_ [eval concat $$var_iemgui_lilo0]] -width 5 \
             -command "::dialog_iemgui::lilo $mytoplevel" }
     if {[eval concat $$var_iemgui_lin0_log1] == 1} {
         button $mytoplevel.para.lilo -text [_ [eval concat $$var_iemgui_lilo1]] -width 5 \
             -command "::dialog_iemgui::lilo $mytoplevel" }
+    if { $iemgui_type eq "VU Meter" } {
+        # VU needs more room to display "no_scale"
+        $mytoplevel.para.lilo configure -width 8 }
     if {[eval concat $$var_iemgui_loadbang] == 0} {
         button $mytoplevel.para.lb -text [_ "No init"] \
-            -command "::dialog_iemgui::lb $mytoplevel" }
+            -command "::dialog_iemgui::lb $mytoplevel" -width 7 }
     if {[eval concat $$var_iemgui_loadbang] == 1} {
-        button $mytoplevel.para.lb -text [_ "Save"] \
-            -command "::dialog_iemgui::lb $mytoplevel" }
-    label $mytoplevel.para.num_lab -text [_ $num_label] -width 9
-    entry $mytoplevel.para.num_ent -textvariable $var_iemgui_num -width 4
+        button $mytoplevel.para.lb -text [_ "Init"] \
+            -command "::dialog_iemgui::lb $mytoplevel" -width 7 }
+    frame $mytoplevel.para.num
+    label $mytoplevel.para.num.lab -text [_ $num_label]
+    entry $mytoplevel.para.num.ent -textvariable $var_iemgui_num -width 4
+    pack $mytoplevel.para.num.ent $mytoplevel.para.num.lab -side right -anchor e
 
     if {[eval concat $$var_iemgui_steady] == 0} {
         button $mytoplevel.para.stdy_jmp -command "::dialog_iemgui::stdy_jmp $mytoplevel" \
@@ -568,30 +637,30 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     if {[eval concat $$var_iemgui_lin0_log1] >= 0} {
         pack $mytoplevel.para.lilo -side left -expand 1}
     if {[eval concat $$var_iemgui_loadbang] >= 0} {
-        pack $mytoplevel.para.dummy2 $mytoplevel.para.lb -side left -expand 1}
+        pack $mytoplevel.para.lb -side left -expand 1}
     if {[eval concat $$var_iemgui_num] > 0} {
-        pack $mytoplevel.para.dummy3 $mytoplevel.para.num_lab $mytoplevel.para.num_ent -side left -expand 1}
+        pack $mytoplevel.para.num -side left -expand 1}
     if {[eval concat $$var_iemgui_steady] >= 0} {
-        pack $mytoplevel.para.dummy3 $mytoplevel.para.stdy_jmp -side left -expand 1}
+        pack $mytoplevel.para.stdy_jmp -side left -expand 1}
     
-    frame $mytoplevel.spacer0 -height 4
-    pack $mytoplevel.spacer0 -side top
+    #frame $mytoplevel.spacer0 -height 4
+    #pack $mytoplevel.spacer0 -side top
     
-    labelframe $mytoplevel.s_r -borderwidth 1 -pady 4 -text [_ "Messages"]
-    pack $mytoplevel.s_r -side top -fill x -ipadx 5
+    labelframe $mytoplevel.s_r -borderwidth 1 -padx 5 -pady 5 -text [_ "Messages"]
+    pack $mytoplevel.s_r -side top -fill x
     frame $mytoplevel.s_r.send
-    pack $mytoplevel.s_r.send -side top -padx 4 -fill x -expand 1
-    label $mytoplevel.s_r.send.lab -text [_ "Send symbol:"] -justify left
-    entry $mytoplevel.s_r.send.ent -textvariable $var_iemgui_snd -width 22
+    pack $mytoplevel.s_r.send -side top -anchor e -padx 5
+    label $mytoplevel.s_r.send.lab -text [_ "Send symbol:"]
+    entry $mytoplevel.s_r.send.ent -textvariable $var_iemgui_snd -width 21
     if { $snd ne "nosndno" } {
         pack $mytoplevel.s_r.send.lab $mytoplevel.s_r.send.ent -side left \
             -fill x -expand 1
     }
     
     frame $mytoplevel.s_r.receive
-    pack $mytoplevel.s_r.receive -side top -padx 4 -fill x -expand 1
-    label $mytoplevel.s_r.receive.lab -text [_ "Receive symbol:"] -justify left
-    entry $mytoplevel.s_r.receive.ent -textvariable $var_iemgui_rcv -width 22
+    pack $mytoplevel.s_r.receive -side top -anchor e -padx 5
+    label $mytoplevel.s_r.receive.lab -text [_ "Receive symbol:"]
+    entry $mytoplevel.s_r.receive.ent -textvariable $var_iemgui_rcv -width 21
     if { $rcv ne "norcvno" } {
         pack $mytoplevel.s_r.receive.lab $mytoplevel.s_r.receive.ent -side left \
             -fill x -expand 1
@@ -604,33 +673,35 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     if {[eval concat $$var_iemgui_gn_f] == 2} \
         { set current_font "Times" }
     
-    frame $mytoplevel.spacer1 -height 7
-    pack $mytoplevel.spacer1 -side top
+    # frame $mytoplevel.spacer1 -height 7
+    # pack $mytoplevel.spacer1 -side top
     
-    labelframe $mytoplevel.label -borderwidth 1 -text [_ "Label"] -pady 4
-    pack $mytoplevel.label -side top -fill x
+    labelframe $mytoplevel.label -borderwidth 1 -text [_ "Label"] -padx 5 -pady 5
+    pack $mytoplevel.label -side top -fill x -pady 5
     entry $mytoplevel.label.name_entry -textvariable $var_iemgui_gui_nam \
-        -width 30 -font [list $current_font 12 $::font_weight]
-    pack $mytoplevel.label.name_entry -side top -expand yes -fill both -padx 5
+        -width 30 -font [list $current_font 14 $::font_weight]
+    pack $mytoplevel.label.name_entry -side top -fill both -padx 5
     
-    frame $mytoplevel.label.xy -padx 27 -pady 1
+    frame $mytoplevel.label.xy -padx 20 -pady 1
     pack $mytoplevel.label.xy -side top
-    label $mytoplevel.label.xy.x_lab -text [_ "X offset"]
+    label $mytoplevel.label.xy.x_lab -text [_ "X offset:"]
     entry $mytoplevel.label.xy.x_entry -textvariable $var_iemgui_gn_dx -width 5
-    label $mytoplevel.label.xy.dummy1 -text " " -width 2
-    label $mytoplevel.label.xy.y_lab -text [_ "Y offset"]
+    label $mytoplevel.label.xy.dummy1 -text " " -width 1
+    label $mytoplevel.label.xy.y_lab -text [_ "Y offset:"]
     entry $mytoplevel.label.xy.y_entry -textvariable $var_iemgui_gn_dy -width 5
     pack $mytoplevel.label.xy.x_lab $mytoplevel.label.xy.x_entry $mytoplevel.label.xy.dummy1 \
-        $mytoplevel.label.xy.y_lab $mytoplevel.label.xy.y_entry -side left -anchor e
+        $mytoplevel.label.xy.y_lab $mytoplevel.label.xy.y_entry -side left
     
     button $mytoplevel.label.fontpopup_label -text $current_font \
-        -font [list $current_font 16 $::font_weight]
+        -font [list $current_font 16 $::font_weight] -pady 4
     pack $mytoplevel.label.fontpopup_label -side left -anchor w \
         -expand 1 -fill x -padx 5
-    label $mytoplevel.label.fontsize_label -text [_ "Size:"]
-    entry $mytoplevel.label.fontsize_entry -textvariable $var_iemgui_gn_fs -width 5
-    pack $mytoplevel.label.fontsize_entry $mytoplevel.label.fontsize_label \
-        -side right -anchor e -padx 5 -pady 5
+    frame $mytoplevel.label.fontsize
+    pack $mytoplevel.label.fontsize -side right -padx 5 -pady 5
+    label $mytoplevel.label.fontsize.label -text [_ "Size:"]
+    entry $mytoplevel.label.fontsize.entry -textvariable $var_iemgui_gn_fs -width 4
+    pack $mytoplevel.label.fontsize.entry $mytoplevel.label.fontsize.label \
+        -side right -anchor e
     menu $mytoplevel.popup
     $mytoplevel.popup add command \
         -label $::font_family \
@@ -647,11 +718,11 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     bind $mytoplevel.label.fontpopup_label <Button> \
         [list tk_popup $mytoplevel.popup %X %Y]
     
-    frame $mytoplevel.spacer2 -height 7
-    pack $mytoplevel.spacer2 -side top
+    # frame $mytoplevel.spacer2 -height 7
+    # pack $mytoplevel.spacer2 -side top
     
-    labelframe $mytoplevel.colors -borderwidth 1 -text [_ "Colors"]
-    pack $mytoplevel.colors -fill x -ipadx 5 -ipady 4
+    labelframe $mytoplevel.colors -borderwidth 1 -text [_ "Colors"] -padx 5 -pady 5
+    pack $mytoplevel.colors -fill x
     
     frame $mytoplevel.colors.select
     pack $mytoplevel.colors.select -side top
@@ -672,30 +743,32 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     pack $mytoplevel.colors.sections -side top
     button $mytoplevel.colors.sections.but -text [_ "Compose color"] \
         -command "::dialog_iemgui::choose_col_bkfrlb $mytoplevel"
-    pack $mytoplevel.colors.sections.but -side left -anchor w -padx 10 -pady 5 \
+    pack $mytoplevel.colors.sections.but -side left -anchor w -pady 5 \
         -expand yes -fill x
+    frame $mytoplevel.colors.sections.exp
+    pack $mytoplevel.colors.sections.exp -side right -padx 5
     if { [eval concat $$var_iemgui_fcol] >= 0 } {
-        label $mytoplevel.colors.sections.fr_bk -text "o=||=o" -width 6 \
+        label $mytoplevel.colors.sections.exp.fr_bk -text "o=||=o" -width 6 \
             -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -foreground [format "#%6.6x" [eval concat $$var_iemgui_fcol]] \
             -activeforeground [format "#%6.6x" [eval concat $$var_iemgui_fcol]] \
-            -font [list $current_font 12 $::font_weight] -padx 2 -pady 2 -relief ridge
+            -font [list $current_font 14 $::font_weight] -padx 2 -pady 2 -relief ridge
     } else {
-        label $mytoplevel.colors.sections.fr_bk -text "o=||=o" -width 6 \
+        label $mytoplevel.colors.sections.exp.fr_bk -text "o=||=o" -width 6 \
             -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -foreground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
             -activeforeground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
-            -font [list $current_font 12 $::font_weight] -padx 2 -pady 2 -relief ridge
+            -font [list $current_font 14 $::font_weight] -padx 2 -pady 2 -relief ridge
     }
-    label $mytoplevel.colors.sections.lb_bk -text [_ "Test label"] \
+    label $mytoplevel.colors.sections.exp.lb_bk -text [_ "Test label"] \
         -background [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
         -activebackground [format "#%6.6x" [eval concat $$var_iemgui_bcol]] \
         -foreground [format "#%6.6x" [eval concat $$var_iemgui_lcol]] \
         -activeforeground [format "#%6.6x" [eval concat $$var_iemgui_lcol]] \
-        -font [list $current_font 12 $::font_weight] -padx 2 -pady 2 -relief ridge
-    pack $mytoplevel.colors.sections.lb_bk $mytoplevel.colors.sections.fr_bk \
+        -font [list $current_font 14 $::font_weight] -padx 2 -pady 2 -relief ridge
+    pack $mytoplevel.colors.sections.exp.lb_bk $mytoplevel.colors.sections.exp.fr_bk \
         -side right -anchor e -expand yes -fill both -pady 7
     
     # color scheme by Mary Ann Benedetto http://piR2.org


### PR DESCRIPTION
**_This is a reference PR. Do not merge._**

Updates to dialog boxes for live updates on OS X since the Apply button has been removed to better match Apple's Human Interface Guidelines. Also includes updates for better keyboard editing.

Approach:

* entry boxes apply changes when Return is pressed after editing
* checkbuttons & radio buttons send changes
* focus is removed from Ok button (aka Return to exit) when editing an entry box
* OK button takes focus when entry editing is finished
* remove widgets from focus list if they do not highlight on focus

TODO:

* find a way to highlight check buttons & radiobuttons when focused 

Dialogs done so far:

* dialog_atom.tcl
* dialog_canvas.tcl

Related discussion:

* [[PD-dev] Canvas Dialog Apply](http://lists.puredata.info/pipermail/pd-dev/2015-11/020478.html)
* [number and symbol atom properties dialog width text field not selected](http://sourceforge.net/p/pure-data/patches/565/)

[WIP screengrab video](https://www.youtube.com/watch?v=PZCjgIFMc9g):

[![WIP screengrab video](http://img.youtube.com/vi/PZCjgIFMc9g/0.jpg)](http://www.youtube.com/watch?v=PZCjgIFMc9g)