### PR TITLE
Use long long for PD_LONGINTTYPE on 64-bit Windows

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -83,7 +83,11 @@ typedef unsigned __int64  uint64_t;
 
 /* signed and unsigned integer types the size of a pointer:  */
 #if !defined(PD_LONGINTTYPE)
+#if defined(_WIN32) && defined(__x86_64__)
+#define PD_LONGINTTYPE long long
+#else 
 #define PD_LONGINTTYPE long
+#endif
 #endif
 
 #if !defined(PD_FLOATSIZE)


### PR DESCRIPTION
This matches the pointer size (regular longs are size 4 on 64-bit Windows rather than 8) and yields, in my testing so far, a perfectly working 64bit Pd on Windows.
