### PR TITLE
[WIP] proposed updates to alloca include

### DIFF
--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -21,13 +21,13 @@ for another, more permissive-sounding copyright notice.  -MSP
 /* ---------- Pd interface to OOURA FFT; imitate Mayer API ---------- */
 #include "m_pd.h"
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 #define FFTFLT double
 void cdft(int, int, FFTFLT *, int *, FFTFLT *);

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -574,13 +574,13 @@ done:
 
 #ifdef HAVE_ALLOCA
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 #define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < HUGEMSG ?  \
         alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -36,13 +36,13 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 #if 1
 #define FAKEBLOCKING

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -23,13 +23,13 @@
 #include <windows.h>
 #endif
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 #include <string.h>
 #include "m_pd.h"

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -16,13 +16,13 @@
 #endif
 extern t_pd *newest;    /* OK - this should go into a .h file now :) */
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 #ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -3,7 +3,7 @@
 * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
-/* #include <string.h> */
+#include <string.h>
 
 #ifdef _MSC_VER
 # include <malloc.h> /* MSVC */

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -5,14 +5,13 @@
 #include "m_pd.h"
 /* #include <string.h> */
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
-#include <string.h>
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 extern t_pd *newest;
 

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -32,13 +32,13 @@
 #define CLOCKHZ CLOCKS_PER_SEC
 #endif
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 /* -------------------------- random ------------------------------ */
 /* this is strictly homebrew and untested. */

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -20,13 +20,13 @@
 #define SOCKET_ERROR -1
 #endif
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif
 
 static t_class *netsend_class;
 

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -19,13 +19,13 @@ moment it also defines "text" but it may later be better to split this off. */
 extern t_pd *newest;    /* OK - this should go into a .h file now :) */
 static t_class *text_define_class;
 
-#ifdef HAVE_ALLOCA_H        /* ifdef nonsense to find include for alloca() */
-# include <alloca.h>        /* linux, mac, mingw, cygwin */
-#elif defined _MSC_VER
-# include <malloc.h>        /* MSVC */
+#ifdef _MSC_VER
+# include <malloc.h> /* MSVC */
+#elif defined(__linux__) || defined(__APPLE__) || defined(_WIN32)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stddef.h>        /* BSDs for example */
-#endif                      /* end alloca() ifdef nonsense */
+# include <stdlib.h> /* BSDs for example */
+#endif  
 
 #ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1


### PR DESCRIPTION
This is a proposed set of updates to replace the existing alloca if/def platform includes with platform checks themselves. I'm proposing this mainly since compilation leads to warnings when forgetting to define HAVE_ALLOCA_H on OS X.

This also fixes a bug where BSD needs stdlib.h instead of stddef.h.

There is also a small fix that uncomments the string.h include on OS X in x_list.c to fix an unknown strlen warning.

Also, what's the purpose of the HAVE_ALLOCA define in the following files? 

* x_array.c line 27
* x_list.c line 28
* x_text.c line 30
* m_binbuf.c line 571

It seems like it's overridden, so maybe it's not needed anymore?