### PR TITLE
jack client name

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -336,7 +336,7 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
         yvan volochine, June 2013) */
     if (!jack_client) {
         do {
-          if (strlen(desired_client_name)) {
+          if (desired_client_name && strlen(desired_client_name)) {
             if (client_iterator == 0)
               strcpy(client_name, desired_client_name);
             else
@@ -573,6 +573,7 @@ void jack_client_name(char *name)
 {
     if (desired_client_name) {
       free(desired_client_name);
+      desired_client_name = NULL;
     }
     if (name) {
       desired_client_name = (char*)getbytes(strlen(name) + 1);

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -30,6 +30,7 @@ static jack_port_t *input_port[MAX_JACK_PORTS];
 static jack_port_t *output_port[MAX_JACK_PORTS];
 static int outport_count = 0;
 static jack_client_t *jack_client = NULL;
+static char * desired_client_name = NULL;
 char *jack_client_names[MAX_CLIENTS];
 static int jack_dio_error;
 static t_audiocallback jack_callback;
@@ -335,7 +336,14 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
         yvan volochine, June 2013) */
     if (!jack_client) {
         do {
-          sprintf(client_name,"pure_data_%d",client_iterator);
+          if (strlen(desired_client_name)) {
+            if (client_iterator == 0)
+              strcpy(client_name, desired_client_name);
+            else
+              sprintf(client_name,"%s_%d", desired_client_name, client_iterator);
+          } else {
+            sprintf(client_name,"pure_data_%d",client_iterator);
+          }
           client_iterator++;
           jack_client = jack_client_open (client_name, JackNoStartServer,
             &status, NULL);
@@ -559,6 +567,17 @@ void jack_getdevs(char *indevlist, int *nindevs,
 void jack_listdevs( void)
 {
     post("device listing not implemented for jack yet\n");
+}
+
+void jack_client_name(char *name)
+{
+    if (desired_client_name) {
+      free(desired_client_name);
+    }
+    if (name) {
+      desired_client_name = (char*)getbytes(strlen(name) + 1);
+      strcpy(desired_client_name, name);
+    }
 }
 
 #endif /* JACK */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -356,6 +356,7 @@ static char *(usagemessage[]) = {
 
 #ifdef USEAPI_JACK
 "-jack            -- use JACK audio API\n",
+"-jackname <name> -- a name for your JACK client\n",
 #endif
 
 #ifdef USEAPI_PORTAUDIO
@@ -682,6 +683,13 @@ int sys_argparse(int argc, char **argv)
         {
             sys_set_audio_api(API_JACK);
             argc--; argv++;
+        }
+        else if (!strcmp(*argv, "-jackname") && (argc > 1))
+        {
+            if (argc > 1)
+                jack_client_name(argv[1]);
+            else goto usage;
+            argc -= 2; argv +=2;
         }
 #endif
 #ifdef USEAPI_PORTAUDIO

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -304,6 +304,7 @@ void jack_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti,
         int maxndev, int devdescsize);
 void jack_listdevs(void);
+void jack_client_name(char *name);
 
 int mmio_open_audio(int naudioindev, int *audioindev,
     int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,


### PR DESCRIPTION
I added a command-line argument and the appropriate additional code to set a desired name for the jack client that pd creates when enabled with `-jack -jackname thename`

This is especially useful if you'd like to run pd with multiple instances and be able to differentiate between them in your jack graph.
