### PR TITLE
added commandline option to disable jack automatic connections

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -33,6 +33,7 @@ static jack_client_t *jack_client = NULL;
 char *jack_client_names[MAX_CLIENTS];
 static int jack_dio_error;
 static t_audiocallback jack_callback;
+static int jack_should_autoconnect = 1;
 pthread_mutex_t jack_mutex;
 pthread_cond_t jack_sem;
 
@@ -461,7 +462,7 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
             memset(jack_outbuf + j * BUF_JACK, 0,
                 BUF_JACK * sizeof(t_sample));
 
-        if (jack_client_names[0])
+        if (jack_client_names[0] && jack_should_autoconnect)
             jack_connect_ports(jack_client_names[0]);
 
         pthread_mutex_init(&jack_mutex, NULL);
@@ -559,6 +560,11 @@ void jack_getdevs(char *indevlist, int *nindevs,
 void jack_listdevs( void)
 {
     post("device listing not implemented for jack yet\n");
+}
+
+void jack_autoconnect(int v)
+{
+    jack_should_autoconnect = v;
 }
 
 #endif /* JACK */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -356,7 +356,8 @@ static char *(usagemessage[]) = {
 
 #ifdef USEAPI_JACK
 "-jack            -- use JACK audio API\n",
-"-jacknoauto      -- don't make any automatic connections to the jack graph\n",
+"-nojackconnect   -- do not automatically connect pd to the JACK graph\n",
+"-jackconnect     -- automatically connect pd to the JACK graph [default]\n",
 #endif
 
 #ifdef USEAPI_PORTAUDIO
@@ -684,9 +685,14 @@ int sys_argparse(int argc, char **argv)
             sys_set_audio_api(API_JACK);
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-jacknoauto"))
+        else if (!strcmp(*argv, "-nojackconnect"))
         {
             jack_autoconnect(0);
+            argc--; argv++;
+        }
+        else if (!strcmp(*argv, "-jackconnect"))
+        {
+            jack_autoconnect(1);
             argc--; argv++;
         }
 #endif

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -356,6 +356,7 @@ static char *(usagemessage[]) = {
 
 #ifdef USEAPI_JACK
 "-jack            -- use JACK audio API\n",
+"-jacknoauto      -- don't make any automatic connections to the jack graph\n",
 #endif
 
 #ifdef USEAPI_PORTAUDIO
@@ -681,6 +682,11 @@ int sys_argparse(int argc, char **argv)
         else if (!strcmp(*argv, "-jack"))
         {
             sys_set_audio_api(API_JACK);
+            argc--; argv++;
+        }
+        else if (!strcmp(*argv, "-jacknoauto"))
+        {
+            jack_autoconnect(0);
             argc--; argv++;
         }
 #endif

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -304,6 +304,7 @@ void jack_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti,
         int maxndev, int devdescsize);
 void jack_listdevs(void);
+void jack_autoconnect(int);
 
 int mmio_open_audio(int naudioindev, int *audioindev,
     int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,


### PR DESCRIPTION
Sometimes I don't want pd to automatically connect to any jack clients, this enables that. 

```
  -nojackconnect
```
