### PR TITLE
CFBundleVersion updating for macOS builds

### DIFF
--- a/mac/build-mac64
+++ b/mac/build-mac64
@@ -26,6 +26,8 @@ mv "Wish Shell.app" Pd-$1-64bit.app
 cd Pd-$1-64bit.app/Contents
 rm -f Info.plist
 cp -p  ../../stuff/Info.plist .
+VERSION=${1/-/.}; VERSION=${VERSION/test/.}
+plutil -replace CFBundleVersion -string $VERSION ./Info.plist
 cd MacOS
 mv "Wish Shell" Pd
 cd ..

--- a/mac/build-macosx
+++ b/mac/build-macosx
@@ -18,6 +18,8 @@ mv "Wish Shell.app" Pd-$1.app
 cd Pd-$1.app/Contents
 rm -f Info.plist
 cp -p  ../../stuff/Info.plist .
+VERSION=${1/-/.}; VERSION=${VERSION/test/.}
+plutil -replace CFBundleVersion -string $VERSION ./Info.plist
 cd MacOS
 mv "Wish Shell" Pd
 cd ..


### PR DESCRIPTION
Apply string substitution on the version number (as typed) to replace `-` and `test` with `.`, then update `CFBundleVersion` key in Info.plist with resulting value using the `plutil` command.