### PR TITLE
emacs configuration file for proper indentation

### DIFF
--- a/src/.dir-locals.el
+++ b/src/.dir-locals.el
@@ -1,0 +1,12 @@
+; see also https://github.com/erdc-cm/petsc-dev/blob/master/.dir-locals.el
+(
+ (nil . ((indent-tabs-mode . nil)
+         (tab-width . 4)
+         (fill-column . 80)))
+ ;; Warn about spaces used for indentation:
+ (c-mode . ((c-file-style . "bsd")
+	    (c-basic-offset . 4)
+	    (c-comment-only-line-offset . 4)
+	    ))
+ (haskell-mode . ((eval . (highlight-regexp "^ *"))))
+ (java-mode . ((c-file-style . "bsd"))))


### PR DESCRIPTION
the .dir-locals.el makes emacs apply Pd's indentation style to all C-files in this folder.

this makes it easier for people using emacs to submit files properly indented.
other editors are not affected...