### PR TITLE
various fixes for null-pointer dereferences, ...

### DIFF
--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -402,7 +402,7 @@ void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
     t_dataslot *ds;
     t_template *template = template_findbyname(templatesym);
     t_atom *a = (t_atom *)t_getbytes(0);
-    int i, n = template->t_n, natom = 0;
+    int i, n = template?(template->t_n):0, natom = 0;
     if (!amarrayelement)
     {
         t_atom templatename;
@@ -704,12 +704,13 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
     for (i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
-        int j, m = template->t_n;
+        int j, m;
         if (!template)
         {
             bug("canvas_savetemplatesto");
             continue;
         }
+        m = template->t_n;
             /* drop "pd-" prefix from template symbol to print */
         binbuf_addv(b, "sss", &s__N, gensym("struct"),
             gensym(templatevec[i]->s_name + 3));

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -493,7 +493,7 @@ void obj_disconnect(t_object *source, int outno, t_object *sink, int inno)
     t_pd *to;
     t_outconnect *oc, *oc2;
 
-    for (o = source->ob_outlet; o && outno; o = o->o_next, outno--)
+    for (o = source->ob_outlet; o && outno; o = o->o_next, outno--) ;
     if (!o) return;
     if (sink->ob_pd->c_firstin)
     {

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -562,6 +562,8 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
 void sys_closesocket(int fd)
 {
 #ifdef HAVE_UNISTD_H
+    if(fd<0)
+        return;
     close(fd);
 #endif
 #ifdef _WIN32

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -180,7 +180,8 @@ static int sys_domicrosleep(int microsec, int pollem)
                 Sleep(microsec/1000);
         else
 #endif
-        select(sys_maxfd+1, &readset, &writeset, &exceptset, &timout);
+        if(select(sys_maxfd+1, &readset, &writeset, &exceptset, &timout) < 0)
+          perror("microsleep select");
         for (i = 0; i < sys_nfdpoll; i++)
             if (FD_ISSET(sys_fdpoll[i].fdp_fd, &readset))
         {
@@ -1226,7 +1227,8 @@ int sys_startgui(const char *libdir)
                 close our copy - otherwise it might hang waiting for some
                 stupid child process (as seems to happen if jackd auto-starts
                 for us.) */
-            fcntl(pipe9[1], F_SETFD, FD_CLOEXEC);
+            if(fcntl(pipe9[1], F_SETFD, FD_CLOEXEC) < 0)
+              perror("close-on-exec");
             sys_watchfd = pipe9[1];
                 /* We also have to start the ping loop in the GUI;
                 this is done later when the socket is open. */

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1087,6 +1087,7 @@ int sys_startgui(const char *libdir)
         {
             if (errno) perror("sys_startgui");
             else fprintf(stderr, "sys_startgui failed\n");
+            sys_closesocket(xsock);
             return (1);
         }
         else if (!childpid)                     /* we're the child */
@@ -1196,6 +1197,7 @@ int sys_startgui(const char *libdir)
             if (errno)
                 perror("sys_startgui");
             else fprintf(stderr, "sys_startgui failed\n");
+            sys_closesocket(xsock);
             return (1);
         }
         else if (!watchpid)             /* we're the child */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -575,8 +575,11 @@ int sys_argparse(int argc, char **argv)
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-inchannels") && (argc > 1))
+        else if (!strcmp(*argv, "-inchannels"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nchin,
                 sys_chinlist, MAXAUDIOINDEV, argv[1]);
 
@@ -585,8 +588,11 @@ int sys_argparse(int argc, char **argv)
 
           argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-outchannels") && (argc > 1))
+        else if (!strcmp(*argv, "-outchannels"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nchout, sys_choutlist,
                 MAXAUDIOOUTDEV, argv[1]);
 
@@ -595,8 +601,11 @@ int sys_argparse(int argc, char **argv)
 
           argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-channels") && (argc > 1))
+        else if (!strcmp(*argv, "-channels"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nchin, sys_chinlist,MAXAUDIOINDEV,
                 argv[1]);
             sys_parsedevlist(&sys_nchout, sys_choutlist,MAXAUDIOOUTDEV,
@@ -607,8 +616,11 @@ int sys_argparse(int argc, char **argv)
 
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-soundbuf") || (!strcmp(*argv, "-audiobuf") && (argc > 1)))
+        else if (!strcmp(*argv, "-soundbuf") || (!strcmp(*argv, "-audiobuf")))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_main_advance = atoi(argv[1]);
             argc -= 2; argv += 2;
         }
@@ -627,8 +639,11 @@ int sys_argparse(int argc, char **argv)
             sys_main_blocksize = atoi(argv[1]);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-sleepgrain") && (argc > 1))
+        else if (!strcmp(*argv, "-sleepgrain"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_sleepgrain = 1000 * atof(argv[1]);
             argc -= 2; argv += 2;
         }
@@ -668,11 +683,12 @@ int sys_argparse(int argc, char **argv)
             sys_set_audio_api(API_ALSA);
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-alsaadd") && (argc > 1))
+        else if (!strcmp(*argv, "-alsaadd"))
         {
-            if (argc > 1)
-                alsa_adddev(argv[1]);
-            else goto usage;
+            if (argc < 2)
+                goto usage;
+
+            alsa_adddev(argv[1]);
             argc -= 2; argv +=2;
         }
         else if (!strcmp(*argv, "-alsamidi"))
@@ -697,11 +713,12 @@ int sys_argparse(int argc, char **argv)
             jack_autoconnect(1);
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-jackname") && (argc > 1))
+        else if (!strcmp(*argv, "-jackname"))
         {
-            if (argc > 1)
-                sys_set_audio_api(API_JACK), jack_client_name(argv[1]);
-            else goto usage;
+            if (argc < 2)
+                goto usage;
+
+            sys_set_audio_api(API_JACK), jack_client_name(argv[1]);
             argc -= 2; argv +=2;
 
         }
@@ -755,24 +772,33 @@ int sys_argparse(int argc, char **argv)
             sys_nmidiin = sys_nmidiout = 0;
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-midiindev") && (argc > 1))
+        else if (!strcmp(*argv, "-midiindev"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV,
                 argv[1]);
             if (!sys_nmidiin)
                 goto usage;
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-midioutdev") && (argc > 1))
+        else if (!strcmp(*argv, "-midioutdev"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV,
                 argv[1]);
             if (!sys_nmidiout)
                 goto usage;
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-mididev") && (argc > 1))
+        else if (!strcmp(*argv, "-mididev"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV,
                 argv[1]);
             sys_parsedevlist(&sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV,
@@ -781,8 +807,11 @@ int sys_argparse(int argc, char **argv)
                 goto usage;
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-midiaddindev") && (argc > 1))
+        else if (!strcmp(*argv, "-midiaddindev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nmidiin < 0)
                 sys_nmidiin = 0;
             if (sys_nmidiin < MAXMIDIINDEV)
@@ -797,8 +826,11 @@ int sys_argparse(int argc, char **argv)
                 MAXMIDIINDEV);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-midiaddoutdev") && (argc > 1))
+        else if (!strcmp(*argv, "-midiaddoutdev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nmidiout < 0)
                 sys_nmidiout = 0;
             if (sys_nmidiout < MAXMIDIINDEV)
@@ -813,8 +845,11 @@ int sys_argparse(int argc, char **argv)
                 MAXMIDIINDEV);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-midiadddev") && (argc > 1))
+        else if (!strcmp(*argv, "-midiadddev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nmidiin < 0)
                 sys_nmidiin = 0;
             if (sys_nmidiout < 0)
@@ -836,8 +871,11 @@ int sys_argparse(int argc, char **argv)
                 MAXMIDIINDEV);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-path") && (argc > 1))
+        else if (!strcmp(*argv, "-path"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_searchpath = namelist_append_files(sys_searchpath, argv[1]);
             argc -= 2; argv += 2;
         }
@@ -853,36 +891,52 @@ int sys_argparse(int argc, char **argv)
         }
         else if (!strcmp(*argv, "-helppath"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_helppath = namelist_append_files(sys_helppath, argv[1]);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-open") && argc > 1)
+        else if (!strcmp(*argv, "-open"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_openlist = namelist_append_files(sys_openlist, argv[1]);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-lib") && argc > 1)
+        else if (!strcmp(*argv, "-lib"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_externlist = namelist_append_files(sys_externlist, argv[1]);
             argc -= 2; argv += 2;
         }
-        else if ((!strcmp(*argv, "-font-size") || !strcmp(*argv, "-font"))
-            && argc > 1)
+        else if ((!strcmp(*argv, "-font-size") || !strcmp(*argv, "-font")))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_defaultfont = sys_nearestfontsize(atoi(argv[1]));
             argc -= 2;
             argv += 2;
         }
-        else if ((!strcmp(*argv, "-font-face") || !strcmp(*argv, "-typeface"))
-            && argc > 1)
+        else if ((!strcmp(*argv, "-font-face") || !strcmp(*argv, "-typeface")))
         {
+            if (argc < 2)
+                goto usage;
+
             strncpy(sys_font,*(argv+1),sizeof(sys_font)-1);
             sys_font[sizeof(sys_font)-1] = 0;
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-font-weight") && argc > 1)
+        else if (!strcmp(*argv, "-font-weight"))
         {
+            if (argc < 2)
+                goto usage;
+
             strncpy(sys_fontweight,*(argv+1),sizeof(sys_fontweight)-1);
             sys_fontweight[sizeof(sys_fontweight)-1] = 0;
             argc -= 2;
@@ -945,13 +999,19 @@ int sys_argparse(int argc, char **argv)
             sys_printtostderr = 1;
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-guicmd") && argc > 1)
+        else if (!strcmp(*argv, "-guicmd"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_guicmd = argv[1];
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-send") && argc > 1)
+        else if (!strcmp(*argv, "-send"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_messagelist = namelist_append(sys_messagelist, argv[1], 1);
             argc -= 2; argv += 2;
         }
@@ -960,8 +1020,11 @@ int sys_argparse(int argc, char **argv)
             sys_listplease = 1;
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-schedlib") && argc > 1)
+        else if (!strcmp(*argv, "-schedlib"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_externalschedlib = 1;
             strncpy(sys_externalschedlibname, argv[1],
                 sizeof(sys_externalschedlibname) - 1);
@@ -977,8 +1040,11 @@ int sys_argparse(int argc, char **argv)
             argv += 2;
             argc -= 2;
         }
-        else if (!strcmp(*argv, "-extraflags") && argc > 1)
+        else if (!strcmp(*argv, "-extraflags"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_extraflags = 1;
             strncpy(sys_extraflagsstring, argv[1],
                 sizeof(sys_extraflagsstring) - 1);
@@ -1005,9 +1071,12 @@ int sys_argparse(int argc, char **argv)
             sys_noautopatch = 1;
             argc--; argv++;
         }
-        else if (!strcmp(*argv, "-compatibility") && argc > 1)
+        else if (!strcmp(*argv, "-compatibility"))
         {
             float f;
+            if (argc < 2)
+                goto usage;
+
             if (sscanf(argv[1], "%f", &f) < 1)
                 goto usage;
             pd_compatibilitylevel = 0.5 + 100. * f; /* e.g., 2.44 --> 244 */
@@ -1048,15 +1117,20 @@ int sys_argparse(int argc, char **argv)
         else if (!strcmp(*argv, "-soundoutdev") ||
             !strcmp(*argv, "-audiooutdev"))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nsoundout, sys_soundoutdevlist,
                 MAXAUDIOOUTDEV, argv[1]);
             if (!sys_nsoundout)
                 goto usage;
             argc -= 2; argv += 2;
         }
-        else if ((!strcmp(*argv, "-sounddev") || !strcmp(*argv, "-audiodev"))
-                 && (argc > 1))
+        else if ((!strcmp(*argv, "-sounddev") || !strcmp(*argv, "-audiodev")))
         {
+            if (argc < 2)
+                goto usage;
+
             sys_parsedevlist(&sys_nsoundin, sys_soundindevlist,
                 MAXAUDIOINDEV, argv[1]);
             sys_parsedevlist(&sys_nsoundout, sys_soundoutdevlist,
@@ -1065,8 +1139,11 @@ int sys_argparse(int argc, char **argv)
                 goto usage;
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-audioaddindev") && (argc > 1))
+        else if (!strcmp(*argv, "-audioaddindev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nsoundin < 0)
                 sys_nsoundin = 0;
             if (sys_nsoundin < MAXAUDIOINDEV)
@@ -1081,8 +1158,11 @@ int sys_argparse(int argc, char **argv)
                 MAXAUDIOINDEV);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-audioaddoutdev") && (argc > 1))
+        else if (!strcmp(*argv, "-audioaddoutdev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nsoundout < 0)
                 sys_nsoundout = 0;
             if (sys_nsoundout < MAXAUDIOINDEV)
@@ -1097,8 +1177,11 @@ int sys_argparse(int argc, char **argv)
                 MAXAUDIOINDEV);
             argc -= 2; argv += 2;
         }
-        else if (!strcmp(*argv, "-audioadddev") && (argc > 1))
+        else if (!strcmp(*argv, "-audioadddev"))
         {
+            if (argc < 2)
+                goto usage;
+
             if (sys_nsoundin < 0)
                 sys_nsoundin = 0;
             if (sys_nsoundout < 0)

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -673,7 +673,13 @@ int sys_argparse(int argc, char **argv)
         }
         else if (!strcmp(*argv, "-ossmidi"))
         {
-          sys_set_midi_api(API_OSS);
+            sys_set_midi_api(API_OSS);
+            argc--; argv++;
+        }
+#else
+        else if (!strcmp(*argv, "-oss") || !strcmp(*argv, "-ossmidi"))
+        {
+            fprintf(stderr, "Pd compiled without OSS-support, ignoring '%s' flag\n", *argv);
             argc--; argv++;
         }
 #endif
@@ -693,8 +699,21 @@ int sys_argparse(int argc, char **argv)
         }
         else if (!strcmp(*argv, "-alsamidi"))
         {
-          sys_set_midi_api(API_ALSA);
+            sys_set_midi_api(API_ALSA);
             argc--; argv++;
+        }
+#else
+        else if (!strcmp(*argv, "-alsa") || !strcmp(*argv, "-alsamidi"))
+        {
+            fprintf(stderr, "Pd compiled without ALSA-support, ignoring '%s' flag\n", *argv);
+            argc--; argv++;
+        }
+        else if (!strcmp(*argv, "-alsaadd"))
+        {
+            if (argc < 2)
+                goto usage;
+            fprintf(stderr, "Pd compiled without ALSA-support, ignoring '%s' flag\n", *argv);
+            argc -= 2; argv +=2;
         }
 #endif
 #ifdef USEAPI_JACK
@@ -722,16 +741,36 @@ int sys_argparse(int argc, char **argv)
             argc -= 2; argv +=2;
 
         }
+#else
+        else if (!strcmp(*argv, "-jack") || !strcmp(*argv, "-nojackconnect")
+            || !strcmp(*argv, "-jackconnect"))
+        {
+            fprintf(stderr, "Pd compiled without JACK-support, ignoring '%s' flag\n", *argv);
+            argc--; argv++;
+        }
+        else if (!strcmp(*argv, "-jackname"))
+        {
+            if (argc < 2)
+                goto usage;
+            fprintf(stderr, "Pd compiled without JACK-support, ignoring '%s' flag\n", *argv);
+            argc -= 2; argv +=2;
+        }
 #endif
 #ifdef USEAPI_PORTAUDIO
         else if (!strcmp(*argv, "-pa") || !strcmp(*argv, "-portaudio")
-#ifdef _WIN32
             || !strcmp(*argv, "-asio")
-#endif
             )
         {
             sys_set_audio_api(API_PORTAUDIO);
             sys_mmio = 0;
+            argc--; argv++;
+        }
+#else
+        else if (!strcmp(*argv, "-pa") || !strcmp(*argv, "-portaudio")
+            || !strcmp(*argv, "-asio")
+            )
+        {
+            fprintf(stderr, "Pd compiled without PortAudio-support, ignoring '%s' flag\n", *argv);
             argc--; argv++;
         }
 #endif
@@ -740,6 +779,12 @@ int sys_argparse(int argc, char **argv)
         {
             sys_set_audio_api(API_MMIO);
             sys_mmio = 1;
+            argc--; argv++;
+        }
+#else
+        else if (!strcmp(*argv, "-mmio"))
+        {
+            fprintf(stderr, "Pd compiled without MMIO-support, ignoring '%s' flag\n", *argv);
             argc--; argv++;
         }
 #endif
@@ -1092,6 +1137,14 @@ int sys_argparse(int argc, char **argv)
         else if (!strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort") || !strcmp(*argv, "-norealtime"))
         {
             sys_hipriority = 0;
+            argc--; argv++;
+        }
+#else
+        else if (!strcmp(*argv, "-rt") || !strcmp(*argv, "-realtime")
+                 || !strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort")
+                 || !strcmp(*argv, "-norealtime"))
+        {
+            fprintf(stderr, "Pd compiled without realtime priority-support, ignoring '%s' flag\n", *argv);
             argc--; argv++;
         }
 #endif

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -409,6 +409,11 @@ static void array_size_float(t_array_size *x, t_floatarg f)
         {
             t_garray *y = (t_garray *)pd_findbyclass(x->x_tc.tc_sym,
                 garray_class);
+            if (!y)
+            {
+                pd_error(x, "no such array '%s'", x->x_tc.tc_sym->s_name);
+                return;
+            }
             garray_resize(y, f);
         }
         else

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -863,6 +863,8 @@ ex_getsym(char *p, fts_symbol_t *s)
 const char *
 ex_symname(fts_symbol_t s)
 {
+        if (!s)
+            return (0);
         return (fts_symbol_name(s));
 }
 
@@ -892,7 +894,7 @@ max_ex_tab(struct expr *expr, fts_symbol_t s, struct ex_ex *arg,
         {
                 optr->ex_type = ET_FLT;
                 optr->ex_flt = 0;
-                pd_error(expr, "no such table '%s'", s->s_name);
+                pd_error(expr, "no such table '%s'", ex_symname(s));
                 return (1);
         }
         optr->ex_type = ET_FLT;


### PR DESCRIPTION
this PR contains a number of fixes for problems discovered by coverity-scan (a static code analysis tool)

https://scan.coverity.com/projects/pure-data-pure-data

the issues fixed are mostly:
- ressource leaks (e.g. not closing socket file descriptors before they leave scope)
- forgotten NULL-checks before dereferencing (or more often: the NULL check is done after dereferencing)
- unused code
- ...