### PR TITLE
bendin fix

### DIFF
--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -356,7 +356,7 @@ void inmidi_pitchbend(int portno, int channel, int value)
     if (pd_this->pd_bendin_sym->s_thing)
     {
         t_atom at[2];
-        SETFLOAT(at, value);
+        SETFLOAT(at, value-8192);
         SETFLOAT(at+1, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_bendin_sym->s_thing, &s_list, 2, at);
     }


### PR DESCRIPTION
This fixes up bendin so that it delivers values starting at -8192 to be consistent with bendout. Fixes ticket #1262: https://sourceforge.net/p/pure-data/bugs/1262/

Caveat: This bug has been there forever, so bug compatibility with older Pd versions may be an issue here. FWIW, I really think that it should be fixed anyway, it's just wrong the way it is, and having the bipolar bend range -8192..8191 throughout just makes patches employing these values a lot simpler.