### PR TITLE
Fix memleaks

### DIFF
--- a/doc/5.reference/message-help.pd
+++ b/doc/5.reference/message-help.pd
@@ -15,7 +15,7 @@ the printout window:;
 #X text 239 139 <--- message;
 #X text 223 165 <--- object (different border);
 #X text 14 197 You can separate multiple messages by commas. Also \,
-you can use "$1" \, "$2" \, etc. to make variable messages:;
+you can use "\$1" \, "\$2" \, etc. to make variable messages:;
 #X text 14 323 Finally \, if you separate messages by a semicolon instead
 of a comma \, the following message(s) are re-routed to named objects
 such as "receives":;

--- a/src/x_time.c
+++ b/src/x_time.c
@@ -626,6 +626,8 @@ static void pipe_free(t_pipe *x)
 {
     pipe_clear(x);
     freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
+    freebytes(x->x_gp, x->x_nptr * sizeof(*x->x_gp));
+
 }
 
 static void pipe_setup(void)

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -272,6 +272,7 @@ expr_donew(struct expr *expr, int ac, t_atom *av)
                         list, expr->exp_stack[expr->exp_nexpr - 1], (long *)0);
                 if (!ret)
                         goto error;
+                fts_free(list);
         }
         *ret = nullex;
         t_freebytes(exp_string, exp_strlen+1);


### PR DESCRIPTION
this fixes two memleaks (the expr-one recently discovered by @claudeha )
it also includes a minor help-patch fix, to get rid of a `$1 out of range` error when opening `5.reference/message-help.pd`