### PR TITLE
osx-app.sh default Wish should be included Tk 8.4

### DIFF
--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -13,7 +13,7 @@
 WD=$(dirname $0)
 
 verbose=
-included_wish=false
+included_wish=true
 TK=Current
 
 # Help message
@@ -28,9 +28,9 @@ Options:
   -h,--help           display this help message
   -v,--verbose        verbose copy prints
   -t,--tk VER         build using a specific version of the Tk
-                      Wish.app on the system (default: Current)
+                      Wish.app on the system
   -i,--included-wish  build using the included Tk 8.4 Wish.app,
-                      *may not* be present (default: no)
+                      *may not* be present (default)
 
 Arguments:
 


### PR DESCRIPTION
A small commit to use the included TK 8.4 Wish by default instead of the system's buggy Tk 8.5 Wish. This is something fixed in the osx-retina-support/TK 8.6 branch but did not migrate back yet.