### PR TITLE
calculate window position offsets (rather than hardcoding them)

### DIFF
--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -417,5 +417,14 @@ proc ::pdwindow::create_window {} {
     # wait until .pdwindow.tcl.entry is visible before opening files so that
     # the loading logic can grab it and put up the busy cursor
     tkwait visibility .pdwindow.text
-#    create_tcl_entry
+    #    create_tcl_entry
+
+    # on X11 measure the size of the window decoration, so we can open windows at the correct position
+    if {$::windowingsystem eq "x11"} {
+        regexp -- {([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+)} [wm geometry .pdwindow] -> \
+            _ _ _left _top
+        set ::windowframex [expr {[winfo rootx .pdwindow] - $_left}]
+        set ::windowframey [expr {[winfo rooty .pdwindow] - $_top}]
+        puts "window frame: $::windowframex $::windowframey"
+    }
 }

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -425,6 +425,5 @@ proc ::pdwindow::create_window {} {
             _ _ _left _top
         set ::windowframex [expr {[winfo rootx .pdwindow] - $_left}]
         set ::windowframey [expr {[winfo rooty .pdwindow] - $_top}]
-        puts "window frame: $::windowframex $::windowframey"
     }
 }


### PR DESCRIPTION
on X11, this ensures that windows are always opened at the same position.
so we can do `[vis 0, vis 1(` repeatedly without moving the window around...

the fix uses the pdwindow (once it is visible) to calculate the difference between the decorated window `wm geometry` and the `winfo xroot` ...