### PR TITLE
Gui Preferences

### DIFF
--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -58,8 +58,8 @@ package require pd_guiprefs
 namespace import ::pd_guiprefs::init
 namespace import ::pd_guiprefs::update_recentfiles
 namespace import ::pd_guiprefs::write_recentfiles
-# make global since they are used throughout    
-namespace import ::pd_menucommands::* 
+# make global since they are used throughout
+namespace import ::pd_menucommands::*
 
 # import into the global namespace for backwards compatibility
 namespace import ::pd_connect::pdsend
@@ -209,7 +209,7 @@ array set editingtext {};# if an obj, msg, or comment is being edited, per patch
 array set loaded {}     ;# store whether a patch has completed loading
 array set xscrollable {};# keep track of whether the scrollbars are present
 array set yscrollable {}
-# patch window tree, these might contain patch IDs without a mapped toplevel 
+# patch window tree, these might contain patch IDs without a mapped toplevel
 array set windowname {}    ;# window names based on mytoplevel IDs
 array set childwindows {}  ;# all child windows based on mytoplevel IDs
 array set parentwindows {} ;# topmost parent window ID based on mytoplevel IDs
@@ -239,8 +239,8 @@ namespace eval ::pdgui:: {
 #
 # these are preliminary ideas, we'll change them as we work things out:
 # - when possible use "" doublequotes to delimit messages
-# - use '$::myvar' instead of 'global myvar' 
-# - for the sake of clarity, there should not be any inline code, everything 
+# - use '$::myvar' instead of 'global myvar'
+# - for the sake of clarity, there should not be any inline code, everything
 #   should be in a proc that is ultimately triggered from main()
 # - if a menu_* proc opens a dialog panel, that proc is called menu_*_dialog
 # - use "eq/ne" for string comparison, NOT "==/!=" (http://wiki.tcl.tk/15323)
@@ -291,7 +291,7 @@ proc init_for_platform {} {
             option add *PatchWindow*Canvas.background "white" startupFile
             # add control to show/hide hidden files in the open panel (load
             # the tk_getOpenFile dialog once, otherwise it will not work)
-            catch {tk_getOpenFile -with-invalid-argument} 
+            catch {tk_getOpenFile -with-invalid-argument}
             set ::tk::dialog::file::showHiddenBtn 1
             set ::tk::dialog::file::showHiddenVar 0
             # set file types that open/save recognize
@@ -375,7 +375,7 @@ proc init_for_platform {} {
             set ::menubarsize 0
             # Tk handles the window placement differently on each platform, on
             # Mac OS X, the x,y placement refers to the content window's upper
-            # left corner. http://wiki.tcl.tk/11502 
+            # left corner. http://wiki.tcl.tk/11502
             # TODO this probably needs a script layer: http://wiki.tcl.tk/11291
             set ::windowframex 0
             set ::windowframey 0
@@ -415,7 +415,7 @@ proc load_locale {} {
         }
     } elseif {$::tcl_platform(platform) eq "windows"} {
         # using LANG on Windows is useful for easy debugging
-        if {[info exists ::env(LANG)] && $::env(LANG) ne "C" && $::env(LANG) ne ""} {  
+        if {[info exists ::env(LANG)] && $::env(LANG) ne "C" && $::env(LANG) ne ""} {
             ::msgcat::mclocale $::env(LANG)
         } elseif {![catch {package require registry}]} {
             ::msgcat::mclocale [string tolower \
@@ -564,7 +564,7 @@ proc pdtk_plugin_dispatch { args } {
 
 # ------------------------------------------------------------------------------
 # parse command line args when Wish/pd-gui.tcl is started first
- 
+
 proc parse_args {argc argv} {
     opt_parser::init {
         {-stderr    set {::stderr}}
@@ -576,7 +576,7 @@ proc parse_args {argc argv} {
         if { [string is int $argv] && $argv > 0} {
             # 'pd-gui' got the port number from 'pd'
             set ::host "localhost"
-            set ::port $argv 
+            set ::port $argv
         } else {
             set hostport [split $argv ":"]
             set ::port [lindex $hostport 1]

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -113,6 +113,7 @@ set TCL_BUGFIX_VERSION 0
 
 # for testing which platform we are running on ("aqua", "win32", or "x11")
 set windowingsystem ""
+set platform ""
 
 # args about how much and where to log
 set loglevel 2
@@ -735,6 +736,11 @@ proc load_startup_plugins {} {
 proc main {argc argv} {
     # TODO Tcl/Tk 8.3 doesn't have [tk windowingsystem]
     set ::windowingsystem [tk windowingsystem]
+    set ::platform $::tcl_platform(os)
+    if { $::tcl_platform(platform) eq "windows"} {
+       set ::platform W32
+    }
+
     tk appname pd-gui
     load_locale
     parse_args $argc $argv

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -174,26 +174,6 @@ proc ::pd_guiprefs::init_x11 {} {
     prepare_configdir
 }
 
-# ------------------------------------------------------------------------------
-# write recent files
-#
-proc ::pd_guiprefs::write_recentfiles {} {
-    write_config $::recentfiles_list $::pd_guiprefs::domain $::recentfiles_key true
-}
-
-# ------------------------------------------------------------------------------
-# this is called when opening a document (wheredoesthisshouldgo.tcl)
-#
-proc ::pd_guiprefs::update_recentfiles {afile} {
-    # remove duplicates first
-    set index [lsearch -exact $::recentfiles_list $afile]
-    set ::recentfiles_list [lreplace $::recentfiles_list $index $index]
-    # insert new one in the beginning and crop the list
-    set ::recentfiles_list [linsert $::recentfiles_list 0 $afile]
-    set ::recentfiles_list [lrange $::recentfiles_list 0 $::total_recentfiles]
-    ::pd_menus::update_recentfiles_menu
-}
-
 #################################################################
 # main read/write procedures
 #################################################################
@@ -260,4 +240,30 @@ proc ::pd_guiprefs::plist_array_to_tcl_list {arr} {
 # so they need to be escaped
 proc ::pd_guiprefs::escape_for_plist {str} {
     return \"[regsub -all -- {"} $str {\\"}]\"
+}
+
+
+#################################################################
+# recent files
+#################################################################
+
+
+# ------------------------------------------------------------------------------
+# write recent files
+#
+proc ::pd_guiprefs::write_recentfiles {} {
+    write_config $::recentfiles_list $::pd_guiprefs::domain $::recentfiles_key true
+}
+
+# ------------------------------------------------------------------------------
+# this is called when opening a document (wheredoesthisshouldgo.tcl)
+#
+proc ::pd_guiprefs::update_recentfiles {afile} {
+    # remove duplicates first
+    set index [lsearch -exact $::recentfiles_list $afile]
+    set ::recentfiles_list [lreplace $::recentfiles_list $index $index]
+    # insert new one in the beginning and crop the list
+    set ::recentfiles_list [linsert $::recentfiles_list 0 $afile]
+    set ::recentfiles_list [lrange $::recentfiles_list 0 $::total_recentfiles]
+    ::pd_menus::update_recentfiles_menu
 }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -14,7 +14,7 @@ namespace eval ::pd_guiprefs:: {
 
 # FIXME should these be globals ?
 set ::recentfiles_key ""
-set ::recentfiles_domain ""
+set ::pd_guiprefs::domain ""
 
 
 #################################################################
@@ -33,26 +33,26 @@ proc ::pd_guiprefs::init {} {
     # osx special case for arrays
     set arr [expr { $::windowingsystem eq "aqua" }]
     set ::recentfiles_list ""
-    catch {set ::recentfiles_list [get_config $::recentfiles_domain \
+    catch {set ::recentfiles_list [get_config $::pd_guiprefs::domain \
         $::recentfiles_key $arr]}
 }
 
 proc ::pd_guiprefs::init_aqua {} {
     # osx has a "Open Recent" menu with 10 recent files (others have 5 inlined)
-    set ::recentfiles_domain org.puredata
+    set ::pd_guiprefs::domain org.puredata
     set ::recentfiles_key "NSRecentDocuments"
     set ::total_recentfiles 10
 }
 
 proc ::pd_guiprefs::init_win {} {
     # windows uses registry
-    set ::recentfiles_domain "HKEY_CURRENT_USER\\Software\\Pure-Data"
+    set ::pd_guiprefs::domain "HKEY_CURRENT_USER\\Software\\Pure-Data"
     set ::recentfiles_key "RecentDocs"
 }
 
 proc ::pd_guiprefs::init_x11 {} {
     # linux uses ~/.config/pure-data dir
-    set ::recentfiles_domain "~/.config/pure-data"
+    set ::pd_guiprefs::domain "~/.config/pure-data"
     set ::recentfiles_key "recentfiles.conf"
     prepare_configdir
 }
@@ -61,7 +61,7 @@ proc ::pd_guiprefs::init_x11 {} {
 # write recent files
 #
 proc ::pd_guiprefs::write_recentfiles {} {
-    write_config $::recentfiles_list $::recentfiles_domain $::recentfiles_key true
+    write_config $::recentfiles_list $::pd_guiprefs::domain $::recentfiles_key true
 }
 
 # ------------------------------------------------------------------------------
@@ -225,12 +225,12 @@ proc ::pd_guiprefs::write_config_x11 {data {adomain} {akey}} {
 #
 proc ::pd_guiprefs::prepare_configdir {} {
     if { [catch {
-        if {[file isdirectory $::recentfiles_domain] != 1} {
-            file mkdir $::recentfiles_domain
-            ::pdwindow::debug "$::recentfiles_domain was created.\n"
+        if {[file isdirectory $::pd_guiprefs::domain] != 1} {
+            file mkdir $::pd_guiprefs::domain
+            ::pdwindow::debug "$::pd_guiprefs::domain was created.\n"
             }
     }]} {
-                ::pdwindow::error "$::recentfiles_domain was *NOT* created.\n"
+                ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created.\n"
     }
 }
 

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -49,7 +49,7 @@ proc ::pd_guiprefs::init {} {
             proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
                 # FIXME empty and write again so we don't loose the order
                 if {[catch {exec defaults write $adomain $akey -array} errorMsg]} {
-                    ::pdwindow::error "write_config $akey: $errorMsg"
+                    ::pdwindow::error "write_config $akey: $errorMsg\n"
                 }
                 if {$arr} {
                     foreach filepath $data {
@@ -92,11 +92,11 @@ proc ::pd_guiprefs::init {} {
                 # FIXME: ugly
                 if {$arr} {
                     if {[catch {registry set $adomain $akey $data multi_sz} errorMsg]} {
-                        ::pdwindow::error "write_config $data $akey: $errorMsg"
+                        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
                     }
                 } else {
                     if {[catch {registry set $adomain $akey $data sz} errorMsg]} {
-                        ::pdwindow::error "write_config $data $akey: $errorMsg"
+                        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
                     }
                 }
             }
@@ -131,7 +131,7 @@ proc ::pd_guiprefs::init {} {
                 set data [join $data "\n"]
                 set filename [file join $adomain $akey]
                 if {[catch {set fl [open $filename w]} errorMsg]} {
-                    ::pdwindow::error "write_config $data $akey: $errorMsg"
+                    ::pdwindow::error "write_config $data $akey: $errorMsg\n"
                 } else {
                     puts -nonewline $fl $data
                     close $fl
@@ -193,12 +193,15 @@ proc ::pd_guiprefs::update_recentfiles {afile} {
 
 ## these are stubs that will be overwritten in ::pd_guiprefs::init()
 proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
-    ::pdwindow::error "::pd_guiprefs::write_config not implemented for $::windowingsystem"
+    ::pdwindow::error "::pd_guiprefs::write_config not implemented for $::windowingsystem\n"
 }
 proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
-    ::pdwindow::error "::pd_guiprefs::get_config not implemented for $::windowingsystem"
+    ::pdwindow::error "::pd_guiprefs::get_config not implemented for $::windowingsystem\n"
 }
 
+# the new API
+proc ::pd_guiprefs::write {key data {arr false} {domain $::pd_guiprefs::domain}} {
+    puts "::pd_guiprefs::write '${key}' '${data}' '${arr}' '${domain}'"
 }
 
 #################################################################
@@ -215,7 +218,7 @@ proc ::pd_guiprefs::prepare_configdir {} {
             ::pdwindow::debug "$::pd_guiprefs::domain was created.\n"
             }
     }]} {
-                ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created.\n"
+        ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created.\n"
     }
 }
 

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -200,9 +200,16 @@ proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
     ::pdwindow::error "::pd_guiprefs::get_config not implemented for $::windowingsystem\n"
 }
 
-# the new API
-proc ::pd_guiprefs::write {key data {arr false} {domain $::pd_guiprefs::domain}} {
-    puts "::pd_guiprefs::write '${key}' '${data}' '${arr}' '${domain}'"
+# simple API (with a default domain)
+proc ::pd_guiprefs::write {key data {arr false} {domain {}}} {
+    if {"" eq $domain} { set domain ${::pd_guiprefs::domain} }
+    set result [::pd_guiprefs::write_config $data $domain $key $arr]
+    return $result
+}
+proc ::pd_guiprefs::get {key {arr false} {domain {}}} {
+    if {"" eq $domain} { set domain ${::pd_guiprefs::domain} }
+    set result [::pd_guiprefs::get_config $domain $key $arr]
+    return $result
 }
 
 #################################################################

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -120,34 +120,14 @@ proc ::pd_guiprefs::init {} {
             # linux: read a config file and return its lines splitted.
             #
             proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
-                set filename [file join $adomain ${akey}.conf]
-                set conf {}
-                if {
-                    [file exists $filename] == 1
-                    && [file readable $filename]
-                } {
-                    set fl [open $filename r]
-                    while {[gets $fl line] >= 0} {
-                        lappend conf $line
-                    }
-                    close $fl
-                }
-                return $conf
+                return [::pd_guiprefs::get_config_file $adomain $akey $arr]
             }
             # ------------------------------------------------------------------------------
             # linux: write configs to USER_APP_CONFIG_DIR
             # $arr is true if the data needs to be written in an array
             #
             proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
-                # right now I (yvan) assume that data are just \n separated, i.e. no keys
-                set data [join $data "\n"]
-                set filename [file join $adomain ${akey}.conf]
-                if {[catch {set fl [open $filename w]} errorMsg]} {
-                    ::pdwindow::error "write_config $data $akey: $errorMsg\n"
-                } else {
-                    puts -nonewline $fl $data
-                    close $fl
-                }
+                return [::pd_guiprefs::write_config_file $data $adomain $akey $arr]
             }
         }
     }
@@ -159,6 +139,39 @@ proc ::pd_guiprefs::init {} {
         $::recentfiles_key $arr]}
 }
 
+# ------------------------------------------------------------------------------
+# read a config file and return its lines splitted.
+#
+proc ::pd_guiprefs::get_config_file {adomain {akey} {arr false}} {
+    set filename [file join ${adomain} ${akey}.conf]
+    set conf {}
+    if {
+        [file exists $filename] == 1
+        && [file readable $filename]
+    } {
+        set fl [open $filename r]
+        while {[gets $fl line] >= 0} {
+            lappend conf $line
+        }
+        close $fl
+    }
+    return $conf
+}
+# ------------------------------------------------------------------------------
+# write configs to USER_APP_CONFIG_DIR
+# $arr is true if the data needs to be written in an array
+#
+proc ::pd_guiprefs::write_config_file {data {adomain} {akey} {arr false}} {
+    # right now I (yvan) assume that data are just \n separated, i.e. no keys
+    set data [join $data "\n"]
+    set filename [file join ${adomain} ${akey}.conf]
+    if {[catch {set fl [open $filename w]} errorMsg]} {
+        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
+    } else {
+        puts -nonewline $fl $data
+        close $fl
+    }
+}
 
 #################################################################
 # main read/write procedures

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -28,6 +28,17 @@ proc ::pd_guiprefs::init {} {
 
     switch -- $::platform {
         "Darwin" {
+            set backend "plist"
+        }
+        "W32" {
+            set backend "registry"
+        }
+        default {
+            set backend "file"
+        }
+
+    switch -- $backend {
+        "plist" {
             # osx has a "Open Recent" menu with 10 recent files (others have 5 inlined)
             set ::pd_guiprefs::domain org.puredata
             set ::recentfiles_key "NSRecentDocuments"
@@ -78,7 +89,7 @@ proc ::pd_guiprefs::init {} {
                 return
             }
         }
-        "W32" {
+        "registry" {
             # windows uses registry
             set ::pd_guiprefs::domain "HKEY_CURRENT_USER\\Software\\Pure-Data"
             set ::recentfiles_key "RecentDocs"
@@ -112,7 +123,7 @@ proc ::pd_guiprefs::init {} {
                 return
             }
         }
-        default {
+        "file" {
             set ::recentfiles_key "recentfiles"
             set ::pd_guiprefs::domain [prepare_configdir]
 
@@ -130,6 +141,10 @@ proc ::pd_guiprefs::init {} {
                 return [::pd_guiprefs::write_config_file $data $adomain $akey $arr]
             }
         }
+        default {
+            ::pdwindow::error "Unknown configuration backend '$backend'.\n"
+        }
+
     }
     # assign gui preferences
     set ::recentfiles_list ""

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -24,12 +24,16 @@ set ::pd_guiprefs::domain ""
 # init preferences
 #
 proc ::pd_guiprefs::init {} {
-    switch -- $::windowingsystem {
-        "aqua" {
+    set arr 0
+
+    switch -- $::platform {
+        "Darwin" {
             # osx has a "Open Recent" menu with 10 recent files (others have 5 inlined)
             set ::pd_guiprefs::domain org.puredata
             set ::recentfiles_key "NSRecentDocuments"
             set ::total_recentfiles 10
+            # osx special case for arrays
+            set arr 1
 
             # ------------------------------------------------------------------------------
             # osx: read a plist file
@@ -73,9 +77,8 @@ proc ::pd_guiprefs::init {} {
                 exec defaults write $adomain NSQuitAlwaysKeepsWindows -bool false
                 return
             }
-
         }
-        "win32" {
+        "W32" {
             # windows uses registry
             set ::pd_guiprefs::domain "HKEY_CURRENT_USER\\Software\\Pure-Data"
             set ::recentfiles_key "RecentDocs"
@@ -108,9 +111,8 @@ proc ::pd_guiprefs::init {} {
                 }
                 return
             }
-
         }
-        "x11" {
+        default {
             set ::pd_guiprefs::domain pure-data
             set ::recentfiles_key "recentfiles"
 
@@ -132,8 +134,6 @@ proc ::pd_guiprefs::init {} {
         }
     }
     # assign gui preferences
-    # osx special case for arrays
-    set arr [expr { $::windowingsystem eq "aqua" }]
     set ::recentfiles_list ""
     catch {set ::recentfiles_list [get_config $::pd_guiprefs::domain \
         $::recentfiles_key $arr]}

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -163,7 +163,13 @@ proc ::pd_guiprefs::init_win {} {
 
 proc ::pd_guiprefs::init_x11 {} {
     # linux uses ~/.config/pure-data dir
-    set ::pd_guiprefs::domain "~/.config/pure-data"
+    if {[info exists ::env(XDG_CONFIG_HOME)]} {
+        set confdir $::env(XDG_CONFIG_HOME)
+    } {set confdir ""}
+    if {"" eq ${confdir}} {
+        set confdir [file join ~ .config]
+    }
+    set ::pd_guiprefs::domain [file join $confdir pure-data]
     set ::recentfiles_key "recentfiles"
     prepare_configdir
 }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -204,12 +204,24 @@ proc ::pd_guiprefs::get {key {arr false} {domain {}}} {
 #
 proc ::pd_guiprefs::prepare_configdir {{domain pure-data}} {
     set confdir ""
-    # linux uses ~/.config/pure-data dir
-    if {[info exists ::env(XDG_CONFIG_HOME)]} {
-        set confdir $::env(XDG_CONFIG_HOME)
-    }
-    if {"" eq ${confdir}} {
-        set confdir [file join ~ .config]
+    switch -- $::platform {
+        "W32" {
+            # W32 uses %AppData%/Pd/config dir
+            if { "" eq ${domain} } { set domain [file join "Pd" "GUI-Preferences" ]}
+            if {[info exists ::env(AppData)]} {
+                set confdir [file join $::env(AppData)]
+            }
+        }
+        "Linux" {
+            # linux uses ~/.config/pure-data dir
+            if { "" eq ${domain} } { set domain "pure-data" }
+            if {[info exists ::env(XDG_CONFIG_HOME)]} {
+                set confdir $::env(XDG_CONFIG_HOME)
+            }
+            if {"" eq ${confdir}} {
+                set confdir [file join ~ .config]
+            }
+        }
     }
     set ::pd_guiprefs::configdir $confdir
     set fullconfigdir [file join $confdir $::pd_guiprefs::domain]

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -67,6 +67,7 @@ proc ::pd_guiprefs::init {} {
                 # asked for by holding the Option/Alt button when quitting via the File
                 # menu or with the Cmd+Q key binding.
                 exec defaults write $adomain NSQuitAlwaysKeepsWindows -bool false
+                return
             }
 
         }
@@ -79,9 +80,8 @@ proc ::pd_guiprefs::init {} {
                 package require registry
                 if {![catch {registry get $adomain $akey} conf]} {
                     return [expr {$conf}]
-                } else {
-                    return {}
                 }
+                return {}
             }
             # ------------------------------------------------------------------------------
             # w32: write configs to registry
@@ -99,6 +99,7 @@ proc ::pd_guiprefs::init {} {
                         ::pdwindow::error "write_config $data $akey: $errorMsg\n"
                     }
                 }
+                return
             }
 
         }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -25,9 +25,119 @@ set ::pd_guiprefs::domain ""
 #
 proc ::pd_guiprefs::init {} {
     switch -- $::windowingsystem {
-        "aqua"  { init_aqua }
-        "win32" { init_win }
-        "x11"   { init_x11 }
+        "aqua" {
+            init_aqua
+            # ------------------------------------------------------------------------------
+            # osx: read a plist file
+            #
+            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+                if {![catch {exec defaults read $adomain $akey} conf]} {
+                    if {$arr} {
+                        set conf [plist_array_to_tcl_list $conf]
+                    }
+                } else {
+                    # initialize NSRecentDocuments with an empty array
+                    exec defaults write $adomain $akey -array
+                    set conf {}
+                }
+                return $conf
+            }
+            # ------------------------------------------------------------------------------
+            # write configs to plist file
+            # if $arr is true, we write an array
+            #
+            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+                # FIXME empty and write again so we don't loose the order
+                if {[catch {exec defaults write $adomain $akey -array} errorMsg]} {
+                    ::pdwindow::error "write_config $akey: $errorMsg"
+                }
+                if {$arr} {
+                    foreach filepath $data {
+                        set escaped [escape_for_plist $filepath]
+                        exec defaults write $adomain $akey -array-add "$escaped"
+                    }
+                } else {
+                    set escaped [escape_for_plist $data]
+                    exec defaults write $adomain $akey '$escaped'
+                }
+
+                # Disable window state saving by default for 10.7+ as there is a chance
+                # pd will hang on start due to conflicting patch resources until the state
+                # is purged. State saving will still work, it just has to be explicitly
+                # asked for by holding the Option/Alt button when quitting via the File
+                # menu or with the Cmd+Q key binding.
+                exec defaults write $adomain NSQuitAlwaysKeepsWindows -bool false
+            }
+
+        }
+        "win32" {
+            init_win
+            # ------------------------------------------------------------------------------
+            # w32: read in the registry
+            #
+            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+                package require registry
+                if {![catch {registry get $adomain $akey} conf]} {
+                    return [expr {$conf}]
+                } else {
+                    return {}
+                }
+            }
+            # ------------------------------------------------------------------------------
+            # w32: write configs to registry
+            # if $arr is true, we write an array
+            #
+            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+                package require registry
+                # FIXME: ugly
+                if {$arr} {
+                    if {[catch {registry set $adomain $akey $data multi_sz} errorMsg]} {
+                        ::pdwindow::error "write_config $data $akey: $errorMsg"
+                    }
+                } else {
+                    if {[catch {registry set $adomain $akey $data sz} errorMsg]} {
+                        ::pdwindow::error "write_config $data $akey: $errorMsg"
+                    }
+                }
+            }
+
+        }
+        "x11" {
+            init_x11
+            # ------------------------------------------------------------------------------
+            # linux: read a config file and return its lines splitted.
+            #
+            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+                set filename [file join $adomain $akey]
+                set conf {}
+                if {
+                    [file exists $filename] == 1
+                    && [file readable $filename]
+                } {
+                    set fl [open $filename r]
+                    while {[gets $fl line] >= 0} {
+                        lappend conf $line
+                    }
+                    close $fl
+                }
+                return $conf
+            }
+            # ------------------------------------------------------------------------------
+            # linux: write configs to USER_APP_CONFIG_DIR
+            # $arr is true if the data needs to be written in an array
+            #
+            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+                # right now I (yvan) assume that data are just \n separated, i.e. no keys
+                set data [join $data "\n"]
+                set filename [file join $adomain $akey]
+                if {[catch {set fl [open $filename w]} errorMsg]} {
+                    ::pdwindow::error "write_config $data $akey: $errorMsg"
+                } else {
+                    puts -nonewline $fl $data
+                    close $fl
+                }
+            }
+        }
     }
     # assign gui preferences
     # osx special case for arrays
@@ -81,139 +191,14 @@ proc ::pd_guiprefs::update_recentfiles {afile} {
 # main read/write procedures
 #################################################################
 
-# ------------------------------------------------------------------------------
-# get configs from a file or the registry
-#
-proc ::pd_guiprefs::get_config {adomain {akey} {arr}} {
-    switch -- $::windowingsystem {
-        "aqua"  { set conf [get_config_aqua $adomain $akey $arr] }
-        "win32" { set conf [get_config_win $adomain $akey $arr] }
-        "x11"   { set conf [get_config_x11 $adomain $akey $arr] }
-    }
-    return $conf
-}
-
-# ------------------------------------------------------------------------------
-# write configs to a file or to the registry
-# $arr is true if the data needs to be written in an array
-#
+## these are stubs that will be overwritten in ::pd_guiprefs::init()
 proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
-    switch -- $::windowingsystem {
-        "aqua"  { write_config_aqua $data $adomain $akey $arr }
-        "win32" { write_config_win $data $adomain $akey $arr }
-        "x11"   { write_config_x11 $data $adomain $akey }
-    }
+    ::pdwindow::error "::pd_guiprefs::write_config not implemented for $::windowingsystem"
+}
+proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+    ::pdwindow::error "::pd_guiprefs::get_config not implemented for $::windowingsystem"
 }
 
-#################################################################
-# os specific procedures
-#################################################################
-
-# ------------------------------------------------------------------------------
-# osx: read a plist file
-#
-proc ::pd_guiprefs::get_config_aqua {adomain {akey} {arr false}} {
-    if {![catch {exec defaults read $adomain $akey} conf]} {
-        if {$arr} {
-            set conf [plist_array_to_tcl_list $conf]
-        }
-    } else {
-        # initialize NSRecentDocuments with an empty array
-        exec defaults write $adomain $akey -array
-        set conf {}
-    }
-    return $conf
-}
-
-# ------------------------------------------------------------------------------
-# win: read in the registry
-#
-proc ::pd_guiprefs::get_config_win {adomain {akey} {arr false}} {
-    package require registry
-    if {![catch {registry get $adomain $akey} conf]} {
-        return [expr {$conf}]
-    } else {
-        return {}
-    }
-}
-
-# ------------------------------------------------------------------------------
-# linux: read a config file and return its lines splitted.
-#
-proc ::pd_guiprefs::get_config_x11 {adomain {akey} {arr false}} {
-    set filename [file join $adomain $akey]
-    set conf {}
-    if {
-        [file exists $filename] == 1
-        && [file readable $filename]
-    } {
-        set fl [open $filename r]
-        while {[gets $fl line] >= 0} {
-           lappend conf $line
-        }
-        close $fl
-    }
-    return $conf
-}
-
-# ------------------------------------------------------------------------------
-# osx: write configs to plist file
-# if $arr is true, we write an array
-#
-proc ::pd_guiprefs::write_config_aqua {data {adomain} {akey} {arr false}} {
-    # FIXME empty and write again so we don't loose the order
-    if {[catch {exec defaults write $adomain $akey -array} errorMsg]} {
-        ::pdwindow::error "write_config_aqua $akey: $errorMsg"
-    }
-    if {$arr} {
-        foreach filepath $data {
-            set escaped [escape_for_plist $filepath]
-            exec defaults write $adomain $akey -array-add "$escaped"
-        }
-    } else {
-        set escaped [escape_for_plist $data]
-        exec defaults write $adomain $akey '$escaped'
-    }
-
-    # Disable window state saving by default for 10.7+ as there is a chance
-    # pd will hang on start due to conflicting patch resources until the state
-    # is purged. State saving will still work, it just has to be explicitly
-    # asked for by holding the Option/Alt button when quitting via the File
-    # menu or with the Cmd+Q key binding.
-    exec defaults write $adomain NSQuitAlwaysKeepsWindows -bool false
-}
-
-# ------------------------------------------------------------------------------
-# win: write configs to registry
-# if $arr is true, we write an array
-#
-proc ::pd_guiprefs::write_config_win {data {adomain} {akey} {arr false}} {
-    package require registry
-    # FIXME: ugly
-    if {$arr} {
-        if {[catch {registry set $adomain $akey $data multi_sz} errorMsg]} {
-            ::pdwindow::error "write_config_win $data $akey: $errorMsg"
-        }
-    } else {
-        if {[catch {registry set $adomain $akey $data sz} errorMsg]} {
-            ::pdwindow::error "write_config_win $data $akey: $errorMsg"
-        }
-    }
-}
-
-# ------------------------------------------------------------------------------
-# linux: write configs to USER_APP_CONFIG_DIR
-#
-proc ::pd_guiprefs::write_config_x11 {data {adomain} {akey}} {
-    # right now I (yvan) assume that data are just \n separated, i.e. no keys
-    set data [join $data "\n"]
-    set filename [file join $adomain $akey]
-    if {[catch {set fl [open $filename w]} errorMsg]} {
-        ::pdwindow::error "write_config_x11 $data $akey: $errorMsg"
-    } else {
-        puts -nonewline $fl $data
-        close $fl
-    }
 }
 
 #################################################################

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -15,7 +15,7 @@ namespace eval ::pd_guiprefs:: {
 # FIXME should these be globals ?
 set ::recentfiles_key ""
 set ::pd_guiprefs::domain ""
-
+set ::pd_guiprefs::configdir ""
 
 #################################################################
 # global procedures
@@ -113,10 +113,8 @@ proc ::pd_guiprefs::init {} {
             }
         }
         default {
-            set ::pd_guiprefs::domain pure-data
             set ::recentfiles_key "recentfiles"
-
-            prepare_configdir
+            set ::pd_guiprefs::domain [prepare_configdir]
 
             # ------------------------------------------------------------------------------
             # linux: read a config file and return its lines splitted.
@@ -143,7 +141,7 @@ proc ::pd_guiprefs::init {} {
 # read a config file and return its lines splitted.
 #
 proc ::pd_guiprefs::get_config_file {adomain {akey} {arr false}} {
-    set filename [file join ${adomain} ${akey}.conf]
+    set filename [file join ${::pd_guiprefs::configdir} ${adomain} ${akey}.conf]
     set conf {}
     if {
         [file exists $filename] == 1
@@ -164,7 +162,7 @@ proc ::pd_guiprefs::get_config_file {adomain {akey} {arr false}} {
 proc ::pd_guiprefs::write_config_file {data {adomain} {akey} {arr false}} {
     # right now I (yvan) assume that data are just \n separated, i.e. no keys
     set data [join $data "\n"]
-    set filename [file join ${adomain} ${akey}.conf]
+    set filename [file join ${::pd_guiprefs::configdir} ${adomain} ${akey}.conf]
     if {[catch {set fl [open $filename w]} errorMsg]} {
         ::pdwindow::error "write_config $data $akey: $errorMsg\n"
     } else {
@@ -213,17 +211,18 @@ proc ::pd_guiprefs::prepare_configdir {{domain pure-data}} {
     if {"" eq ${confdir}} {
         set confdir [file join ~ .config]
     }
-    set configfile [file join $confdir $domain]
-    set ::pd_guiprefs::domain $configfile
+    set ::pd_guiprefs::configdir $confdir
+    set fullconfigdir [file join $confdir $::pd_guiprefs::domain]
 
     if { [catch {
-        if {[file isdirectory $configfile] != 1} {
-            file mkdir $configfile
-            ::pdwindow::debug "$::pd_guiprefs::domain was created.\n"
+        if {[file isdirectory $fullconfigdir] != 1} {
+            file mkdir $fullconfigdir
+            ::pdwindow::debug "$::pd_guiprefs::domain was created in $confdir.\n"
             }
     }]} {
-        ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created.\n"
+        ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created in $confdir.\n"
     }
+    return $domain
 }
 
 # ------------------------------------------------------------------------------

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -285,7 +285,9 @@ proc ::pd_guiprefs::prepare_configdir {domain} {
     }
     # let the user override the Pd-config-path
     if {[info exists ::env(PD_CONFIG_DIR)]} {
-        set confdir $::env(PD_CONFIG_DIR)
+        if { "$::env(PD_CONFIG_DIR)" != "" } {
+            set confdir $::env(PD_CONFIG_DIR)
+        }
     }
 
     set ::pd_guiprefs::configdir $confdir

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -109,7 +109,7 @@ proc ::pd_guiprefs::init {} {
             # linux: read a config file and return its lines splitted.
             #
             proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
-                set filename [file join $adomain $akey]
+                set filename [file join $adomain ${akey}.conf]
                 set conf {}
                 if {
                     [file exists $filename] == 1
@@ -130,7 +130,7 @@ proc ::pd_guiprefs::init {} {
             proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
                 # right now I (yvan) assume that data are just \n separated, i.e. no keys
                 set data [join $data "\n"]
-                set filename [file join $adomain $akey]
+                set filename [file join $adomain ${akey}.conf]
                 if {[catch {set fl [open $filename w]} errorMsg]} {
                     ::pdwindow::error "write_config $data $akey: $errorMsg\n"
                 } else {
@@ -164,7 +164,7 @@ proc ::pd_guiprefs::init_win {} {
 proc ::pd_guiprefs::init_x11 {} {
     # linux uses ~/.config/pure-data dir
     set ::pd_guiprefs::domain "~/.config/pure-data"
-    set ::recentfiles_key "recentfiles.conf"
+    set ::recentfiles_key "recentfiles"
     prepare_configdir
 }
 


### PR DESCRIPTION
this PR extends the `tcl/pd_guiprefs` to be more generally useful (the current implementation was tied to the very specific recentfiles functionality).

if you prefer a squashed PR, let me know.

### new features

- simple API that requires a minimum amount of data:

      ::pd_guiprefs::write foo "bla" # write a key/value pair to the default domain
      ::pd_guiprefs::read foo        # read a value associated with the key from the default domain

- consistent use of `$::pd_guiprefs::domain` (it's always a domain-like string, that can be used regardless of the actual storage backend); the default is `org.puredata.pd.pd-gui`
- honours `PD_CONFIG_DIR` environment variable to specify the filesystem location of Pd's config directory
- honours [`XDG_CONFIG_HOME`](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) (on linux) to specify the filesystem location of the configuration
- easy to switch to filesystem-based storage on OSX and W32 (though the default is still the native storage), simply by setting the `PD_CONFIG_DIR` variable (if set to an empty-value, sane defaults are assumed)

- as a side-effect, Pd now also exposes a `::platform` variable, that can be used to distinguish between OSX/linux/W32/... (rather than abusing the `windowingsystem` for that kind of information)

- some trailing whitespace has also been removed from the edited files


### (in)compatibility with old system
the rewrite retains API-compatibility with the old system.
however, i expect that after applying this fix, any data stored with an old version of Pd might not be availble in the new version.
Afaict, this only affects the recentfiles (which i consider non-critical data).

we are now using a slightly different domain `org.puredata.pd.pd-gui`, which changes the actual storage path of the preferences (compared to older versions of Pd).
the main effect of this is, that the old settings stored via the guiprefs will not be available anymore.


### tested systems
the new implementation has been tested on linux and W32.
i haven't tested on OSX (yet).

also the default-domain on OSX is still `org.puredata`, because i don't know whether the *RecentFiles* functionality is somehow bound to that key.
eventually, that should be changed to  `org.puredata.pd.pd-gui` as well.