### PR TITLE
Use info.puredata.pd for macOS CFBundleIdentifier

### DIFF
--- a/mac/stuff/Info.plist
+++ b/mac/stuff/Info.plist
@@ -22,7 +22,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Pd</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.puredata</string>
+	<string>info.puredata.pd</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -237,12 +237,12 @@ static int sys_getpreference(const char *key, char *value, int size)
     struct stat statbuf;
    /* the 'defaults' command expects the filename without .plist at the
         end */
-    snprintf(embedded_prefs, MAXPDSTRING, "%s/../org.puredata.pd",
+    snprintf(embedded_prefs, MAXPDSTRING, "%s/../info.puredata.pd",
         sys_libdir->s_name);
     snprintf(user_prefs, MAXPDSTRING,
-        "%s/Library/Preferences/org.puredata.pd.plist", homedir);
+        "%s/Library/Preferences/info.puredata.pd.plist", homedir);
     if (stat(user_prefs, &statbuf) == 0)
-        snprintf(cmdbuf, 256, "defaults read org.puredata.pd %s 2> /dev/null\n",
+        snprintf(cmdbuf, 256, "defaults read info.puredata.pd %s 2> /dev/null\n",
             key);
     else snprintf(cmdbuf, 256, "defaults read %s %s 2> /dev/null\n",
             embedded_prefs, key);
@@ -277,7 +277,7 @@ static void sys_putpreference(const char *key, const char *value)
 {
     char cmdbuf[MAXPDSTRING];
     snprintf(cmdbuf, MAXPDSTRING,
-        "defaults write org.puredata.pd %s \"%s\" 2> /dev/null\n", key, value);
+        "defaults write info.puredata.pd %s \"%s\" 2> /dev/null\n", key, value);
     system(cmdbuf);
 }
 

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -39,7 +39,7 @@ proc ::pd_guiprefs::init {} {
 
 proc ::pd_guiprefs::init_aqua {} {
     # osx has a "Open Recent" menu with 10 recent files (others have 5 inlined)
-    set ::recentfiles_domain org.puredata
+    set ::recentfiles_domain info.puredata.pd
     set ::recentfiles_key "NSRecentDocuments"
     set ::total_recentfiles 10
 }


### PR DESCRIPTION
This PR proposes using `info.puredata.pd` for the macOS CFBundleIdentifier string, as per https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102070

> The string should also be in reverse-DNS format. For example, if your company’s domain is `Ajax.com` and you create an app named Hello, you could assign the string `com.Ajax.Hello` as your app’s bundle identifier.

i.e. the Pd domain is <http://puredata.info> and app name is `pd` hence `info.puredata.pd`

Please review the changes as this is a pretty dirty find/replace of the source.