### PR TITLE
Soundfiler fix

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1412,20 +1412,22 @@ long soundfiler_dowrite(void *obj, t_canvas *canvas,
                 argv[i].a_w.w_symbol->s_name);
         if (nframes > vecsize - onset)
             nframes = vecsize - onset;
-
-        for (j = 0; j < vecsize; j++)
-        {
-            if (vecs[i][j].w_float > biggest)
-                biggest = vecs[i][j].w_float;
-            else if (-vecs[i][j].w_float > biggest)
-                biggest = -vecs[i][j].w_float;
-        }
     }
     if (nframes <= 0)
     {
         pd_error(obj, "soundfiler_write: no samples at onset %ld", onset);
         goto fail;
     }
+    for (i = 0; i < nchannels; i++) // find biggest sample in final computed range
+    {   
+        for (j = onset; j < nframes + onset; j++)
+        {
+            if (vecs[i][j].w_float > biggest)
+                biggest = vecs[i][j].w_float;
+            else if (-vecs[i][j].w_float > biggest)
+                biggest = -vecs[i][j].w_float;
+        }
+    }    
 
     if ((fd = create_soundfile(canvas, filesym->s_name, filetype,
         nframes, bytespersamp, bigendian, nchannels,

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1448,6 +1448,7 @@ long soundfiler_dowrite(void *obj, t_canvas *canvas,
     else normfactor = 1;
 
     bufframes = SAMPBUFSIZE / (nchannels * bytespersamp);
+    onset *= sizeof(t_word)/sizeof(t_sample);  // convert onset to t_word vector offset  
 
     for (itemswritten = 0; itemswritten < nframes; )
     {


### PR DESCRIPTION
soundfiler write operation needs some fixes:
- 'skip' doesn't work properly on 64bit
- 'normalize' currently computes the biggest sample on the entire pd array, while it should only take account of the range selected with skip/nframes, in order the sound file to be actually normalized.
