### PR TITLE
Fix structure crash

### DIFF
--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -422,6 +422,7 @@ static void scalar_free(t_scalar *x)
 {
     int i;
     t_dataslot *datatypes, *dt;
+    sys_unqueuegui(x);
     t_symbol *templatesym = x->sc_template;
     t_template *template = template_findbyname(templatesym);
     if (!template)


### PR DESCRIPTION
I think _sys_unqueuegui_ must be called from _scalar_free_ to avoid crashes (see #69)
For info: _sys_queuegui_ is called [here](https://github.com/pure-data/pure-data/blob/master/src/g_scalar.c#L334) that's why it is necessary to call _sys_unqueuegui_ in the free method otherwise _scalar_doredraw_ (and _scalar_vis_) can be called when the object is already deleted.