### PR TITLE
mac script updates

### DIFF
--- a/mac/tcltk-wish.sh
+++ b/mac/tcltk-wish.sh
@@ -18,7 +18,7 @@ set -e
 UNIVERSAL=false
 ARCH=
 
-# set deployment target to enable weak-linking for older OSX version support
+# set deployment target to enable weak-linking for older macOS version support
 CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
 
 # Help message
@@ -27,8 +27,8 @@ help() {
 echo -e "
 Usage: tcltk-wish.sh [OPTIONS] VERSION
 
-  Downloads and builds a Wish-VERSION.app with the
-  chosen Tcl/Tk framework version
+  Downloads and builds a Wish-VERSION.app for macOS
+  with the chosen Tcl/Tk framework version
 
 Options:
   -h,--help           display this help message


### PR DESCRIPTION
As suggested on the pd-list...

osx-app.sh:

* version arg now optional (defaults to Pd.app)
* plist version string now taken from configure --version output
* added /Library/Frameworks to System Wish.app search paths

updated both script references to macOS to reflect newer OS naming