### PR TITLE
Autoconf clean-pdlib missing target warning fix & small Windows configure tweaks 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,8 +192,9 @@ case $host in
 *mingw*)
     WINDOWS=yes
     MINGW=yes
-    platform=Mingw
+    platform=MinGW
     portaudio=yes
+    portmidi=yes
 
     # ASIO doesn't build yet with the autotools setup. We need to figure out how
     # to make the final linking phase use g++
@@ -209,6 +210,7 @@ case $host in
     CYGWIN=yes
     platform=Cygwin
     portaudio=yes
+    portmidi=yes
 
     # externals are dynamically linked to pd.dll in their individual automake files
     EXTERNAL_CFLAGS=
@@ -487,6 +489,7 @@ AC_MSG_NOTICE([
     CFLAGS:               $CFLAGS
     LDFLAGS:              $LDFLAGS
     INCLUDES:             $AM_CPPFLAGS
+    LIBS:                 $LIBS
 
     External extension:   $EXTERNAL_EXTENSION
     External CFLAGS:      $EXTERNAL_CFLAGS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -248,6 +248,10 @@ pd_LDFLAGS += -lpthread
 
 # force linking to dl, which should really be done with some autotools way
 pd_LDFLAGS += -ldl
+
+# dummy target for Windows build
+clean-pdlib:
+
 endif
 
 ##### GNU/Linux #####
@@ -262,6 +266,10 @@ pd_LDFLAGS += -export-dynamic
 
 # on Ubuntu/Karmic 9.10, it doesn't seem to find libm, so force it
 pd_LDFLAGS += $(LIBM)
+
+# dummy target for Windows build
+clean-pdlib:
+
 endif
 
 ##### Apple Mac OSX #####
@@ -276,6 +284,9 @@ pd_CFLAGS += -DMACOSX
 
 # for dynamic loading & threading
 LIBS += -ldl -lm -lpthread
+
+# dummy target for Windows build
+clean-pdlib:
 
 endif
 
@@ -292,8 +303,6 @@ noinst_SCRIPTS = libpd.a
 pd.lib pd.def: pd$(EXEEXT)
 libpd.a: pd.lib
 	$(LN_S) $^ $@
-clean-local: clean-pdlib
-
 clean-pdlib:
 	-rm -f pd.lib pd.def libpd.a
 endif
@@ -324,7 +333,7 @@ convenience-links: $(libpdbin_PROGRAMS) $(bin_PROGRAMS)
 	$(LN_S) $(top_srcdir)/tcl/pd-gui.in $(top_builddir)/bin/pd-gui
 	test -e $(top_builddir)/src/pd-watchdog$(EXEEXT) && $(LN_S) $(top_builddir)/src/pd-watchdog$(EXEEXT) $(top_builddir)/bin/pd-watchdog$(EXEEXT) || true
 
-clean-local:
+clean-local: clean-pdlib
 	rm -rf $(top_builddir)/bin
 
 # link to $(libdir)/pd/bin so the tcl scripts can


### PR DESCRIPTION
This is a simple bugfix for clean-pdlib missing targets warning thrown by autoconf.

Also included are some small tweaks to configure.ac for windows, mainly that port midi should be built by default.