### PR TITLE
appveyor support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 #
 # this automatically builds Pd for W32 using VisualStudio,
 # whenever a new commit is pushed to github...
-#   https://ci.appveyor.com/project/pure-data/pure-data
+#   https://ci.appveyor.com/project/umlaeute/pure-data
 
 environment:
   matrix:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,49 @@
+## AppVeyor configuration for Pure Data
+#
+# this automatically builds Pd for W32 using VisualStudio,
+# whenever a new commit is pushed to github...
+#   https://ci.appveyor.com/project/pure-data/pure-data
+
+environment:
+  matrix:
+  - platform: x86
+    AFLAGS: "/D__i386__"
+  - platform: x64
+    AFLAGS: "/D__x86_64__  /DPD_LONGINTTYPE=\\\"long long\\\""
+
+matrix:
+  allow_failures:
+    - platform: x64
+
+shallow_clone: true
+
+install:
+  - echo init
+  - mkdir bin
+
+# the version included with the Pd binaries,
+# is actually ftp://sourceware.org/pub/pthreads-win32/pthreads-dll-2002-03-02
+  - curl ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip -o pthreads.zip
+  - 7z x -opthreads pthreads.zip  Pre-built.2/dll Pre-built.2/lib Pre-built.2/include
+  - set pthreaddir="%APPVEYOR_BUILD_FOLDER%\\pthreads\\Pre-built.2"
+  - cd "%pthreaddir%\\include" && copy "*.h" "%APPVEYOR_BUILD_FOLDER%\\src\\"
+  - cd "%pthreaddir%\\dll\\%platform%" && copy "pthreadVC2.dll" "%APPVEYOR_BUILD_FOLDER%\\bin\\pthreadVC2.dll"
+  - cd "%pthreaddir%\\lib\\%platform%" && copy "pthreadVC2.lib" "%APPVEYOR_BUILD_FOLDER%\\bin\\pthreadVC.lib"
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+
+build_script:
+  - echo build_script
+  - call "%ProgramFiles%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /%platform%
+  - call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" %platform%
+  - cd src
+  - nmake /f makefile.msvc AFLAGS="%AFLAGS%"
+
+test_script:
+  - ..\bin\pd.com -version
+
+deploy: off
+
+artifacts:
+  - path: 'bin'
+    name: Pure Data (bin %platform%)
+    type: zip

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,116 @@ DEBUG_CFLAGS="-O0"
 RELEASE_CFLAGS="-ffast-math -funroll-loops -fomit-frame-pointer"
 
 #########################################
+##### OS Detection #####
+
+# you will need to install XCode on Mac OS X to use this:
+PD_CHECK_IPHONE(IPHONEOS=yes, IPHONEOS=no, AC_MSG_ERROR([iOS SDK not available]))
+PD_CHECK_ANDROID(ANDROID=yes, ANDROID=no, AC_MSG_ERROR([Android SDK not available]))
+
+case $host in
+*darwin*)
+    if test "x${IPHONEOS}" = "xno"; then
+        MACOSX=yes
+        platform="Mac OSX"
+        coreaudio=yes
+        portaudio=yes
+        portmidi=yes
+        EXTERNAL_CFLAGS="-fPIC"
+        EXTERNAL_EXTENSION=d_fat
+
+        # required for dlopen & weak linking for older OSX version support
+        CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
+    else
+        platform=iOS
+        locales=no
+    fi
+
+    # homebrew paths
+    if test -e /usr/local ; then
+        AM_CPPFLAGS="-I/usr/local/include $INCLUDES"
+        LDFLAGS="-L/usr/local/lib $LDFLAGS"
+    fi
+
+    # fink paths
+    if test -e /sw ; then
+        AM_CPPFLAGS="-I/sw/include $INCLUDES"
+        LDFLAGS="-L/sw/lib $LDFLAGS"
+    fi
+
+    # macports paths
+    if test -e /opt/local ; then
+        AM_CPPFLAGS="-I/opt/local/include $INCLUDES"
+        LDFLAGS="-L/opt/local/lib $LDFLAGS"
+    fi
+
+    EXTERNAL_LDFLAGS="-bundle -undefined dynamic_lookup"
+    ;;
+*linux*|*kfreebsd*gnu*)
+    # GNU/kFreeBSD are for Debian, were they are treated very similar to linux
+    if test "x${ANDROID}" = "xno"; then
+        LINUX=yes
+        platform=Linux
+        portaudio=yes
+        EXTERNAL_CFLAGS="-fPIC"
+        EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
+        EXTERNAL_EXTENSION=pd_linux
+    else
+        platform=Android
+    fi
+    ;;
+*-*-gnu*)
+    HURD=yes
+    platform=Hurd
+    EXTERNAL_CFLAGS="-fPIC"
+    EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
+    EXTERNAL_EXTENSION=pd_linux
+    ;;
+*mingw*)
+    WINDOWS=yes
+    MINGW=yes
+    platform=Mingw
+    portaudio=yes
+
+    # ASIO doesn't build yet with the autotools setup. We need to figure out how
+    # to make the final linking phase use g++
+    asio=yes
+
+    # externals are dynamically linked to pd.dll in their individual automake files
+    EXTERNAL_CFLAGS="-mms-bitfields"
+    EXTERNAL_LDFLAGS="-s -Wl,--enable-auto-import -no-undefined -lpd"
+    EXTERNAL_EXTENSION=dll
+
+    # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling
+    ac_cv_func_malloc_0_nonnull=yes
+    ac_cv_func_realloc_0_nonnull=yes
+    ;;
+*cygwin*)
+    WINDOWS=yes
+    CYGWIN=yes
+    platform=Cygwin
+    portaudio=yes
+
+    # externals are dynamically linked to pd.dll in their individual automake files
+    EXTERNAL_CFLAGS=
+    EXTERNAL_LDFLAGS="-Wl,--export-dynamic"
+    EXTERNAL_EXTENSION=dll
+    ;;
+*)
+    platform=Unknown
+    ;;
+esac
+
+AM_CONDITIONAL(ANDROID, test x$ANDROID = xyes)
+AM_CONDITIONAL(IPHONEOS, test x$IPHONEOS = xyes)
+AM_CONDITIONAL(LINUX, test x$LINUX = xyes)
+AM_CONDITIONAL(HURD, test x$HURD = xyes)
+AM_CONDITIONAL(MACOSX, test x$MACOSX = xyes)
+AM_CONDITIONAL(WINDOWS, test x$WINDOWS = xyes)
+AM_CONDITIONAL(CYGWIN, test x$CYGWIN = xyes)
+AM_CONDITIONAL(MINGW, test x$MINGW = xyes)
+
+
+#########################################
 ##### Check for programs, libs, & headers #####
 
 # Configure libtool.
@@ -123,111 +233,6 @@ AC_SUBST(EXTERNAL_CFLAGS)
 AC_SUBST(EXTERNAL_LDFLAGS)
 AC_SUBST([ALSA_LIBS])
 AC_SUBST([JACK_LIBS])
-
-#########################################
-##### OS Detection #####
-
-# you will need to install XCode on Mac OS X to use this:
-PD_CHECK_IPHONE(IPHONEOS=yes, IPHONEOS=no, AC_MSG_ERROR([iOS SDK not available]))
-PD_CHECK_ANDROID(ANDROID=yes, ANDROID=no, AC_MSG_ERROR([Android SDK not available]))
-
-case $host in
-*darwin*)
-    if test "x${IPHONEOS}" = "xno"; then
-        MACOSX=yes
-        platform="Mac OSX"
-        coreaudio=yes
-        portaudio=yes
-        portmidi=yes
-        EXTERNAL_CFLAGS="-fPIC"
-        EXTERNAL_EXTENSION=d_fat
-
-        # required for dlopen & weak linking for older OSX version support
-        CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
-    else
-        platform=iOS
-        locales=no
-    fi
-
-    # homebrew paths
-    if test -e /usr/local ; then
-        AM_CPPFLAGS="-I/usr/local/include $INCLUDES"
-        LDFLAGS="-L/usr/local/lib $LDFLAGS"
-    fi
-
-    # fink paths
-    if test -e /sw ; then
-        AM_CPPFLAGS="-I/sw/include $INCLUDES"
-        LDFLAGS="-L/sw/lib $LDFLAGS"
-    fi
-
-    # macports paths
-    if test -e /opt/local ; then
-        AM_CPPFLAGS="-I/opt/local/include $INCLUDES"
-        LDFLAGS="-L/opt/local/lib $LDFLAGS"
-    fi
-
-    EXTERNAL_LDFLAGS="-bundle -undefined dynamic_lookup"
-    ;;
-*linux*|*kfreebsd*gnu*)
-    # GNU/kFreeBSD are for Debian, were they are treated very similar to linux
-    if test "x${ANDROID}" = "xno"; then
-        LINUX=yes
-        platform=Linux
-        portaudio=yes
-        EXTERNAL_CFLAGS="-fPIC"
-        EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
-        EXTERNAL_EXTENSION=pd_linux
-    else
-        platform=Android
-    fi
-    ;;
-*-*-gnu*)
-    HURD=yes
-    platform=Hurd
-    EXTERNAL_CFLAGS="-fPIC"
-    EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
-    EXTERNAL_EXTENSION=pd_linux
-    ;;
-*mingw*)
-    WINDOWS=yes
-    MINGW=yes
-    platform=Mingw
-    portaudio=yes
-
-    # ASIO doesn't build yet with the autotools setup. We need to figure out how
-    # to make the final linking phase use g++
-    asio=yes
-
-    # externals are dynamically linked to pd.dll in their individual automake files
-    EXTERNAL_CFLAGS="-mms-bitfields"
-    EXTERNAL_LDFLAGS="-s -Wl,--enable-auto-import -no-undefined -lpd"
-    EXTERNAL_EXTENSION=dll
-    ;;
-*cygwin*)
-    WINDOWS=yes
-    CYGWIN=yes
-    platform=Cygwin
-    portaudio=yes
-
-    # externals are dynamically linked to pd.dll in their individual automake files
-    EXTERNAL_CFLAGS=
-    EXTERNAL_LDFLAGS="-Wl,--export-dynamic"
-    EXTERNAL_EXTENSION=dll
-    ;;
-*)
-    platform=Unknown
-    ;;
-esac
-
-AM_CONDITIONAL(ANDROID, test x$ANDROID = xyes)
-AM_CONDITIONAL(IPHONEOS, test x$IPHONEOS = xyes)
-AM_CONDITIONAL(LINUX, test x$LINUX = xyes)
-AM_CONDITIONAL(HURD, test x$HURD = xyes)
-AM_CONDITIONAL(MACOSX, test x$MACOSX = xyes)
-AM_CONDITIONAL(WINDOWS, test x$WINDOWS = xyes)
-AM_CONDITIONAL(CYGWIN, test x$CYGWIN = xyes)
-AM_CONDITIONAL(MINGW, test x$MINGW = xyes)
 
 # pass include paths down to all Makefiles
 AC_SUBST([AM_CPPFLAGS], [$AM_CPPFLAGS])

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -312,7 +312,7 @@ int sys_main(int argc, char **argv)
         _fmode = _O_BINARY;
     }
 # endif /* _MSC_VER */
-#endif  /* WIN32 */
+#endif  /* _WIN32 */
 #ifndef _WIN32
     /* long ago Pd used setuid to promote itself to real-time priority.
     Just in case anyone's installation script still makes it setuid, we
@@ -322,7 +322,7 @@ int sys_main(int argc, char **argv)
         fprintf(stderr, "warning: canceling setuid privelege\n");
         setuid(getuid());
     }
-#endif  /* WIN32 */
+#endif  /* _WIN32 */
     pd_init();                                  /* start the message system */
     sys_findprogdir(argv[0]);                   /* set sys_progname, guipath */
     for (i = noprefs = 0; i < argc; i++)        /* prescan args for noprefs */

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -45,7 +45,7 @@ static void *midiin_new( void)
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_midiin_sym);
-#ifdef WIN32
+#ifdef _WIN32
     pd_error(x, "midiin: windows: not supported");
 #endif
     return (x);
@@ -68,7 +68,7 @@ static void *sysexin_new( void)
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_sysexin_sym);
-#ifdef WIN32
+#ifdef _WIN32
     pd_error(x, "sysexin: windows: not supported");
 #endif
     return (x);


### PR DESCRIPTION
this PR adds support for the [appveyor](https://appveyor.com) Continuous Integration service.

this is run a new test-build using Microsoft Visual Studio whenever something is pushed to the github repository (or whenever a pull request is made), allowing to find build failures early (given that nobody builds with MSVC regularily these days...).

The build is executed both in a 32bit and a 64bit environment.

The build logs can be found on the [appveyor project page](https://ci.appveyor.com/project/umlaeute/pure-data).
There are also artifacts attached to each (successful) build, which contain the produced binaries (the `bin/` folder), which can be downloaded for easy testing. 