### PR TITLE
some more fixes discovered by coverity-scan

### DIFF
--- a/extra/pd~/pdsched.c
+++ b/extra/pd~/pdsched.c
@@ -104,5 +104,6 @@ int pd_extern_sched(char *flags)
         else if (fill == BUFSIZE)
             fprintf(stderr, "pd-extern: input buffer overflow\n");
     }
+    binbuf_free(b);
     return (0);
 }

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -65,7 +65,7 @@ typedef struct peak
 /********************** service routines **************************/
 
 /* these three are dapted from elsewhere in Pd but included here for
-cmolpeteness */
+   completeness */
 static int sigmund_ilog2(int n)
 {
     int ret = -1;
@@ -924,7 +924,14 @@ static void sigmund_npts(t_sigmund *x, t_floatarg f)
 
 static void sigmund_hop(t_sigmund *x, t_floatarg f)
 {
-    x->x_hop = f;
+    int hop = f;
+    if (hop < 0)
+    {
+        error("sigmund~: ignoring negative hopsize %d", hop);
+        return;
+    }
+    x->x_hop = hop;
+    if (0 == hop) return;
         /* check parameter ranges */
     if (x->x_hop != (1 << sigmund_ilog2(x->x_hop)))
         post("sigmund~: adjusting analysis size to %d points",

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1925,9 +1925,9 @@ void canvas_motion(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
             int wantwidth = xpos - x11;
             t_gotfn sizefn;
             t_object *ob = pd_checkobject(&y1->g_pd);
-            if ((ob && ob->te_pd->c_wb == &text_widgetbehavior) ||
+            if (ob && ((ob->te_pd->c_wb == &text_widgetbehavior) ||
                     (pd_checkglist(&ob->te_pd) &&
-                        !((t_canvas *)ob)->gl_isgraph))
+                     !((t_canvas *)ob)->gl_isgraph)))
             {
                 wantwidth = wantwidth / glist_fontwidth(x);
                 if (wantwidth < 1)

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -23,7 +23,6 @@ t_int atom_getint(t_atom *a)
 
 t_symbol *atom_getsymbol(t_atom *a)  /* LATER think about this more carefully */
 {
-    char buf[30];
     if (a->a_type == A_SYMBOL) return (a->a_w.w_symbol);
     else return (&s_float);
 }

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -562,7 +562,7 @@ t_symbol *binbuf_realizedollsym(t_symbol *s, int ac, t_atom *av, int tonew)
         }
         else
         {
-            strcat(buf2, str);
+            strncat(buf2, str, MAXPDSTRING-1);
             goto done;
         }
     }

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1036,6 +1036,7 @@ static int sys_do_startgui(const char *libdir)
                 perror("bind");
                 fprintf(stderr,
                     "Pd was unable to find a port number to bind to\n");
+                sys_closesocket(xsock);
                 return (1);
             }
             portno++;


### PR DESCRIPTION
this fixes a few issues discovered by the coverity-scan code analysis tool.

it also fixes a freeze  when specifying negative hopsizes for sigmund~ (not directly discovered by coverity; but discovered while trying to test the fix for an issue found previously).
it also fixes the problem that only ports 5400-5420 were allowed gui-ports and Pd would give up if all of these were blocked (again, the code was close enough to a coverity-found issue)