### PR TITLE
binary mode for [stdout]

### DIFF
--- a/extra/stdout/stdout-help.pd
+++ b/extra/stdout/stdout-help.pd
@@ -1,19 +1,38 @@
-#N canvas 121 60 539 339 12;
+#N canvas 124 51 758 493 12;
 #X msg 126 203 walk the dog;
 #X msg 117 156 1;
 #X obj 117 240 stdout;
-#X text 269 287 updated for Pd version 0.42;
 #X obj 14 13 stdout;
 #X text 67 14 - write messages to standard output;
 #X msg 122 179 1 2;
-#X obj 119 291 pd~;
-#X text 44 291 see also:;
+#X obj 119 431 pd~;
+#X text 44 431 see also:;
 #X text 34 39 Sends messages to Pd's standard output. This is useful
 in conjunction with the pd~ object \, which starts a pd sub-process.
 Messages sent to the sub-process standard output appear on the output
 of the pd~ object in the owning process. This might also be useful
 in other situations. Note that there's no corresponding "stdin" object
 - there seems to be no one canonical way such a thing should act.;
+#X msg 256 203 walk the dog;
+#X msg 247 156 1;
+#X msg 252 179 1 2;
+#X text 269 427 updated for Pd version 0.48;
+#X obj 247 240 stdout -cr;
+#X msg 383 178 100 111 117 98 108 101 32 32 115 112 97 99 101 44 32
+80 100 10, f 32;
+#X obj 383 240 stdout -b;
+#X text 45 307 special flags:;
+#X text 76 332 -cr: omit trailing semicolon in output (like [print])
+;
+#X text 79 352 -b \, -binary: binary mode;
+#X text 79 392 -nf \, -noflush: do not fflush the output after each
+message;
+#X text 79 372 -f \, -flush: fflush the output after each message (default
+on W32), f 65;
 #X connect 0 0 2 0;
 #X connect 1 0 2 0;
-#X connect 6 0 2 0;
+#X connect 5 0 2 0;
+#X connect 9 0 13 0;
+#X connect 10 0 13 0;
+#X connect 11 0 13 0;
+#X connect 14 0 15 0;

--- a/extra/stdout/stdout.c
+++ b/extra/stdout/stdout.c
@@ -12,17 +12,81 @@ static t_class *stdout_class;
 typedef struct _stdout
 {
     t_object x_obj;
+    int x_mode; /* 0=FUDI; 1=printf (no terminating semicolon); -1=binary */
+    int x_flush; /* fflush() stdout after each message */
 } t_stdout;
 
-static void *stdout_new(t_float fnonrepeat)
+static void *stdout_new(t_symbol*s, int argc, t_atom*argv)
 {
     t_stdout *x = (t_stdout *)pd_new(stdout_class);
+        /* for some reason in MS windows we have to flush standard out here -
+        otherwise these outputs get out of order from the ones from pdsched.c
+        over in ../pd~.  I'm guessing mingw (with its different C runtime
+        support) will handle this correctly and so am only ifdeffing this on
+        Microsoft C compiler.  It's an efficiency hit, possibly a serious
+        one. */
+#ifdef _MSC_VER
+    x->x_flush = 1;
+#endif
+
+    while(argc--)
+    {
+        s = atom_getsymbol(argv++);
+        if (gensym("-cr") == s)
+        {
+                /* No-semicolon mode */
+            x->x_mode = 1;
+        }
+        else if ((gensym("-b") == s) || (gensym("-binary") == s))
+        {
+                /* Binary mode:
+                   no extra characters (semicolons, CR,...) is appended
+                 */
+            x->x_mode = -1;
+        }
+        else if ((gensym("-f") == s) || (gensym("-flush") == s))
+        {
+            x->x_flush = 1;
+        }
+        else if ((gensym("-nf") == s) || (gensym("-noflush") == s))
+        {
+            x->x_flush = 0;
+        }
+        else if (gensym("") != s)
+        {
+                /* unknown mode; ignore it */
+        }
+    }
     return (x);
+}
+
+static void stdout_binary(t_stdout *x, int argc, t_atom *argv)
+{
+#define BUFSIZE 65535
+    char buf[BUFSIZE+1];
+    int i;
+    if(argc>BUFSIZE)
+        argc = BUFSIZE;
+    for (i=0; i<argc; i++)
+        ((unsigned char *)buf)[i] = atom_getfloatarg(i, argc, argv);
+    buf[i>BUFSIZE?BUFSIZE:i] = 0;
+    printf("%s", buf);
+
+    if (x->x_flush || !argc)
+        fflush(stdout);
 }
 
 static void stdout_anything(t_stdout *x, t_symbol *s, int argc, t_atom *argv)
 {
     char msgbuf[MAXPDSTRING], *sp, *ep = msgbuf+MAXPDSTRING;
+    if (x->x_mode < 0)
+    {
+        if ((gensym("list") == s) || (gensym("float") == s) || (gensym("bang") == s))
+            stdout_binary(x, argc, argv);
+        else
+            pd_error(x, "stdout: only 'list' messages allowed in binary mode (got '%s')", s->s_name);
+        return;
+    }
     msgbuf[0] = 0;
     strncpy(msgbuf, s->s_name, MAXPDSTRING);
     msgbuf[MAXPDSTRING-1] = 0;
@@ -34,16 +98,15 @@ static void stdout_anything(t_stdout *x, t_symbol *s, int argc, t_atom *argv)
         atom_string(argv++, sp, ep-sp);
         sp += strlen(sp);
     }
-    printf("%s;\n", msgbuf);
-        /* for some reason in MS windows we have to flush standard out here -
-        otherwise these outputs get out of order from the ones from pdsched.c
-        over in ../pd~.  I'm guessing mingw (with its different C runtime
-        support) will handle this correctly and so am only ifdeffing this on
-        Microsoft C compiler.  It's an efficiency hit, possibly a serious
-        one. */
-#ifdef _MSC_VER   
-    fflush(stdout);
-#endif
+    switch(x->x_mode) {
+    case 1:
+        printf("%s\n", msgbuf);
+        break;
+    default:
+        printf("%s;\n", msgbuf);
+    }
+    if (x->x_flush)
+        fflush(stdout);
 }
 
 static void stdout_free(t_stdout *x)
@@ -54,6 +117,6 @@ static void stdout_free(t_stdout *x)
 void stdout_setup(void)
 {
     stdout_class = class_new(gensym("stdout"), (t_newmethod)stdout_new,
-        (t_method)stdout_free, sizeof(t_stdout), 0, 0);
+        (t_method)stdout_free, sizeof(t_stdout), 0, A_GIMME, 0);
     class_addanything(stdout_class, stdout_anything);
 }


### PR DESCRIPTION
this PR adds a few options to `[stdout]` to switch between various modes useful outside of the use with `[pd~]`.

namely:
- *binary mode*: allows to send arbitrary strings to the stdout as list of bytes
- *no-semicolon mode*: omits the trailing semicolon (which is rather annoying if you want to communicate with any other program (which typically does not speak FUDI) over the `stdout`)
- *no/force fflush mode*: allow to override the default fflush mode (on for W32, off for the rest of the world)


i think with these additions, `[stdout]` becomes an object of general usefulness.

btw, is there a reason why `[stdout]` is kept in *extra* (rather than built-in)