### PR TITLE
make font-handling robust against invalid font-metrics

### DIFF
--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -10,7 +10,7 @@ OTHERDATA =
 pd__la_SOURCES = pd~.c
 pdsched_la_SOURCES = pdsched.c
 
-EXTRA_DIST = makefile notes.txt
+EXTRA_DIST = makefile notes.txt binarymsg.c
 
 #########################################
 ##### Files, Binaries, & Libs #####

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -224,6 +224,7 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     char *cwd = atom_getsymbolarg(0, argc, argv)->s_name;
     t_namelist *nl;
     unsigned int i;
+    int did_fontwarning = 0;
     int j;
     sys_oldtclversion = atom_getfloatarg(1, argc, argv);
     if (argc != 2 + 3 * NZOOM * NFONT)
@@ -231,12 +232,23 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     for (j = 0; j < NZOOM; j++)
         for (i = 0; i < NFONT; i++)
     {
-        sys_gotfonts[j][i].fi_pointsize =
-            atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
-        sys_gotfonts[j][i].fi_width =
-            atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
-        sys_gotfonts[j][i].fi_height =
-            atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
+        int size   = atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
+        int width  = atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
+        int height = atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
+        if (!(size && width && height))
+        {
+            size   = (j+1)*sys_fontspec[i].fi_pointsize;
+            width  = (j+1)*sys_fontspec[i].fi_width;
+            height = (j+1)*sys_fontspec[i].fi_height;
+            if (!did_fontwarning)
+            {
+                error("Ignoring invalid font-metrics from GUI!");
+                did_fontwarning = 1;
+            }
+        }
+        sys_gotfonts[j][i].fi_pointsize = size;
+        sys_gotfonts[j][i].fi_width = width;
+        sys_gotfonts[j][i].fi_height = height;
 #if 0
             fprintf(stderr, "font (%d %d %d)\n",
                 sys_gotfonts[j][i].fi_pointsize, sys_gotfonts[j][i].fi_width,


### PR DESCRIPTION
sometimes the GUI is unable to come-up with proper font-metrics, and returns `0` instead (see #90 ).

This patch checks the font-metrics as received by from GUI, and falls back to the built-in `sys_fontspec` if the values look fishy.

this will give slightly off font-metrics for broken tcl/tk builds (which i think is better than segfaulting or refusing to work).