### PR TITLE
check for weak jack

### DIFF
--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -10,7 +10,7 @@ OTHERDATA =
 pd__la_SOURCES = pd~.c
 pdsched_la_SOURCES = pdsched.c
 
-EXTRA_DIST = makefile notes.txt
+EXTRA_DIST = makefile notes.txt binarymsg.c
 
 #########################################
 ##### Files, Binaries, & Libs #####

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -12,7 +12,9 @@
 #include <string.h>
 #include "m_pd.h"
 #include "s_stuff.h"
+#ifdef __APPLE__
 #include <jack/weakjack.h>
+#endif
 #include <jack/jack.h>
 #include <regex.h>
 

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -307,13 +307,11 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
     int srate;
     jack_status_t status;
 
-#ifdef __APPLE__
     if (!jack_client_open)
     {
-        error("Can't open Jack (it seems not to be installed on this Mac)");
+        error("Can't open Jack (it seems not to be installed)");
         return 1;
     }
-#endif
 
     jack_dio_error = 0;
 


### PR DESCRIPTION
we might have weak jack symbols on non-apple platforms as well (i just stumbled upon this on Ubuntu-16.04LTS, where Pd would crash when switching to jack), so the check whether the jack-functions are non-null should be unconditional.

(the overhead is minimal anyhow)