### PR TITLE
Make cosine table symmetric

### DIFF
--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -205,7 +205,8 @@ static void cos_dsp(t_cos *x, t_signal **sp)
 static void cos_maketable(void)
 {
     int i;
-    float *fp, phase, phsinc = (2.0 * M_PI) / COSTABSIZE;
+    double phase, phsinc = (2.0 * M_PI) / COSTABSIZE;
+    float *fp;
     union tabfudge tf;
 
     if (cos_table) return;
@@ -213,7 +214,7 @@ static void cos_maketable(void)
 	phase = 0;
 	fp = cos_table;
 	for (i = COSTABSIZE/4; i--; fp++, phase += phsinc)
-		*fp = cos(phase);
+		*fp = (float)cos(phase);
 	*fp++ = 0.;
 	for (i = COSTABSIZE/4; i--; fp++)
 		*fp = -cos_table[i];

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -10,6 +10,9 @@
 
 #define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338327950288
+#endif
 
 #if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
     || defined(__OpenBSD__)
@@ -202,15 +205,22 @@ static void cos_dsp(t_cos *x, t_signal **sp)
 static void cos_maketable(void)
 {
     int i;
-    float *fp, phase, phsinc = (2. * 3.14159) / COSTABSIZE;
+    float *fp, phase, phsinc = (2.0 * M_PI) / COSTABSIZE;
     union tabfudge tf;
 
     if (cos_table) return;
-    cos_table = (float *)getbytes(sizeof(float) * (COSTABSIZE+1));
-    for (i = COSTABSIZE + 1, fp = cos_table, phase = 0; i--;
-        fp++, phase += phsinc)
-            *fp = cos(phase);
-
+     cos_table = (float *)getbytes(sizeof(float) * (COSTABSIZE+1));
+	phase = 0;
+	fp = cos_table;
+	for (i = COSTABSIZE/4; i--; fp++, phase += phsinc)
+		*fp = cos(phase);
+	*fp++ = 0.;
+	for (i = COSTABSIZE/4; i--; fp++)
+		*fp = -cos_table[i];
+	for (i = COSTABSIZE/2; i--; fp++)
+		*fp = cos_table[i];
+	
+		
         /* here we check at startup whether the byte alignment
             is as we declared it.  If not, the code has to be
             recompiled the other way. */


### PR DESCRIPTION
This is a fix for issue #105.

It replaces the one-shot cosine table construction with one that copies the segment from 0 to pi/2, making FM using [osc~] stable. I did not include a backwards compatibility flag, but one could be added very easily.