### PR TITLE
bugfix for windowpositions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# make sure that .gitignore, .travis.yml,... are not part of a
+# source-package generated via 'git archive'
+.git*      	export-ignore
+/.*		export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # source-package generated via 'git archive'
 .git*      	export-ignore
 /.*		export-ignore
+/debian/	export-ignore

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -546,6 +546,7 @@ proc pdtk_pd_startup {major minor bugfix test
     ::pdwindow::create_window
     ::pdwindow::configure_menubar
     ::pd_menus::configure_for_pdwindow
+    ::pdwindow::create_window_finalize
     ::pdtk_canvas::create_popup
     load_startup_plugins
     open_filestoopen

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -11,7 +11,7 @@ package require pd_menucommands
 # use {} quotes so that $::focused_window is interpreted when the menu item
 # is called, not when the command is mapped to the menu item.  This is the
 # opposite of the 'bind' commands in pd_bindings.tcl
-    
+
 namespace eval ::pd_menus:: {
     variable accelerator
     variable menubar ".menubar"
@@ -26,7 +26,7 @@ namespace eval ::pd_menus:: {
 }
 
 # ------------------------------------------------------------------------------
-# 
+#
 proc ::pd_menus::create_menubar {} {
     variable accelerator
     variable menubar
@@ -38,7 +38,7 @@ proc ::pd_menus::create_menubar {} {
     menu $menubar
     if {$::windowingsystem eq "aqua"} {create_apple_menu $menubar}
     set menulist [_ "file edit put find media window help"]
-    foreach mymenu $menulist {    
+    foreach mymenu $menulist {
         if {$mymenu eq "find"} {
             set underlined 3
         } {
@@ -101,7 +101,7 @@ proc ::pd_menus::configure_for_canvas {mytoplevel} {
     for {set i 0} {$i <= [$menubar.put index end]} {incr i} {
         # catch errors that happen when trying to disable separators
         if {[$menubar.put type $i] ne "separator"} {
-            $menubar.put entryconfigure $i -state normal 
+            $menubar.put entryconfigure $i -state normal
         }
     }
     update_undo_on_menu $mytoplevel
@@ -210,7 +210,7 @@ proc ::pd_menus::build_put_menu {mymenu} {
     # sticking to the mouse cursor. The iemguis alway do that when created
     # from the menu, as defined in canvas_iemguis()
     $mymenu add command -label [_ "Object"]   -accelerator "$accelerator+1" \
-        -command {menu_send_float $::focused_window obj 0} 
+        -command {menu_send_float $::focused_window obj 0}
     $mymenu add command -label [_ "Message"]  -accelerator "$accelerator+2" \
         -command {menu_send_float $::focused_window msg 0}
     $mymenu add command -label [_ "Number"]   -accelerator "$accelerator+3" \
@@ -252,7 +252,7 @@ proc ::pd_menus::build_find_menu {mymenu} {
     $mymenu add command -label [_ "Find Again"] -accelerator "$accelerator+G" \
         -command {menu_send $::focused_window findagain}
     $mymenu add command -label [_ "Find Last Error"] \
-        -command {pdsend {pd finderror}} 
+        -command {pdsend {pd finderror}}
 }
 
 proc ::pd_menus::build_media_menu {mymenu} {
@@ -264,9 +264,9 @@ proc ::pd_menus::build_media_menu {mymenu} {
 
     $mymenu add  separator
     $mymenu add command -label [_ "Test Audio and MIDI..."] \
-        -command {menu_doc_open doc/7.stuff/tools testtone.pd} 
+        -command {menu_doc_open doc/7.stuff/tools testtone.pd}
     $mymenu add command -label [_ "Load Meter"] \
-        -command {menu_doc_open doc/7.stuff/tools load-meter.pd} 
+        -command {menu_doc_open doc/7.stuff/tools load-meter.pd}
 
     set audio_apilist_length [llength $::audio_apilist]
     if {$audio_apilist_length > 0} {$mymenu add separator}
@@ -276,7 +276,7 @@ proc ::pd_menus::build_media_menu {mymenu} {
             -value [lindex [lindex $::audio_apilist $x] 1]\
             -command {pdsend "pd audio-setapi $::pd_whichapi"}
     }
-    
+
     set midi_apilist_length [llength $::midi_apilist]
     if {$midi_apilist_length > 0} {$mymenu add separator}
     for {set x 0} {$x<$midi_apilist_length} {incr x} {
@@ -324,19 +324,19 @@ proc ::pd_menus::build_window_menu {mymenu} {
 
 proc ::pd_menus::build_help_menu {mymenu} {
     if {$::windowingsystem ne "aqua"} {
-        $mymenu add command -label [_ "About Pd"] -command {menu_aboutpd} 
+        $mymenu add command -label [_ "About Pd"] -command {menu_aboutpd}
     }
     $mymenu add command -label [_ "HTML Manual..."] \
         -command {menu_doc_open doc/1.manual index.htm}
     $mymenu add command -label [_ "Browser..."] \
-        -command {menu_helpbrowser} 
+        -command {menu_helpbrowser}
     $mymenu add command -label [_ "List of objects..."] \
-        -command {menu_objectlist} 
+        -command {menu_objectlist}
     $mymenu add  separator
     $mymenu add command -label [_ "puredata.info"] \
-        -command {menu_openfile {http://puredata.info}} 
+        -command {menu_openfile {http://puredata.info}}
     $mymenu add command -label [_ "Report a bug"] -command {menu_openfile \
-        {http://sourceforge.net/tracker/?func=add&group_id=55736&atid=478070}} 
+        {http://sourceforge.net/tracker/?func=add&group_id=55736&atid=478070}}
 }
 
 #------------------------------------------------------------------------------#
@@ -481,8 +481,8 @@ proc ::pd_menus::add_list_to_menu {mymenu window parentlist} {
 # update the list of windows on the Window menu. This expects run on the
 # Window menu, and to insert below the last separator
 proc ::pd_menus::update_window_menu {} {
-    
-    # TK 8.5+ Cocoa on Mac handles the window list for us 
+
+    # TK 8.5+ Cocoa on Mac handles the window list for us
     if {$::windowingsystem eq "aqua" && $::tcl_version >= 8.5} {
         return 0
     }
@@ -589,7 +589,7 @@ proc ::pd_menus::build_window_menu_aqua {mymenu} {
 }
 
 # the "Help" does not have cross-platform differences
- 
+
 # ------------------------------------------------------------------------------
 # menu building functions for UNIX/X11
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -34,6 +34,7 @@ namespace eval ::pdtk_canvas:: {
 # easy for people to customize these calculations based on their Window
 # Manager, desires, etc.
 proc pdtk_canvas_place_window {width height geometry} {
+    ::pdwindow::configure_window_offset
     set screenwidth [lindex [wm maxsize .] 0]
     set screenheight [lindex [wm maxsize .] 1]
 

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -415,22 +415,41 @@ proc ::pdwindow::create_window {} {
 
     # set some layout variables
     ::pdwindow::set_layout
-
-    # wait until .pdwindow.tcl.entry is visible before opening files so that
-    # the loading logic can grab it and put up the busy cursor
-    tkwait visibility .pdwindow.text
-    #    create_tcl_entry
-
-    # on X11 measure the size of the window decoration, so we can open windows at the correct position
-    if {$::windowingsystem eq "x11"} {
-        regexp -- {([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+)} [wm geometry .pdwindow] -> \
-            _ _ _left _top
-        set ::windowframex [expr {[winfo rootx .pdwindow] - $_left}]
-        set ::windowframey [expr {[winfo rooty .pdwindow] - $_top}]
-    }
 }
 
 #--configure the window menu---------------------------------------------------#
+proc ::pdwindow::create_window_finalize {} {
+    # wait until .pdwindow.tcl.entry is visible before opening files so that
+    # the loading logic can grab it and put up the busy cursor
+
+    # this ought to be called after all elements of the window (including the
+    # menubar!) have been created!
+    if {![winfo viewable .pdwindow.text]} { tkwait visibility .pdwindow.text }
+}
+
+proc ::pdwindow::configure_window_offset {{winid .pdwindow}} {
+    # on X11 measure the size of the window decoration, so we can open windows at the correct position
+    if {$::windowingsystem eq "x11"} {
+        if {[winfo viewable $winid]} {
+            # wait for possible race-conditions at startup...
+            if {[winfo viewable .pdwindow] && ![winfo viewable .pdwindow.text]} {
+                tkwait visibility .pdwindow.text
+            }
+
+            regexp -- {([0-9]+)x([0-9]+)\+([0-9]+)\+([0-9]+)} [wm geometry $winid] -> \
+                _ _ _left _top
+            set ::windowframex [expr {[winfo rootx $winid] - $_left}]
+            set ::windowframey [expr {[winfo rooty $winid] - $_top}]
+
+            #puts "======================="
+            #puts "[wm geometry $winid]"
+            #puts "winfo [winfo rootx $winid] [winfo rooty $winid]"
+            #puts "windowframe: $winid $::windowframex $::windowframey"
+            #puts "======================="
+        }
+    }
+}
+
 
 # this needs to happen *after* the main menu is created, otherwise the default Wish
 # menu is not replaced by the custom Apple menu on OSX

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -40,7 +40,7 @@ proc ::pdwindow::set_layout {} {
 
 # grab focus on part of the Pd window when Pd is busy
 proc ::pdwindow::busygrab {} {
-    # set the mouse cursor to look busy and grab focus so it stays that way    
+    # set the mouse cursor to look busy and grab focus so it stays that way
     .pdwindow.text configure -cursor watch
     grab set .pdwindow.text
 }
@@ -107,7 +107,7 @@ proc ::pdwindow::logpost {object_id level message} {
     variable lastlevel $level
 
     buffer_message $object_id $level $message
-    if {[llength [info commands .pdwindow.text.internal]] && 
+    if {[llength [info commands .pdwindow.text.internal]] &&
         ($level <= $::loglevel || $maxloglevel == $::loglevel)} {
         # cancel any pending move of the scrollbar, and schedule it
         # after writing a line. This way the scrollbar is only moved once
@@ -183,7 +183,7 @@ proc ::pdwindow::pdtk_pd_dio {red} {
     } else {
         .pdwindow.header.ioframe.dio configure -foreground lightgray
     }
-        
+
 }
 
 proc ::pdwindow::pdtk_pd_audio {state} {
@@ -232,7 +232,7 @@ proc ::pdwindow::eval_tclentry {} {
     if {$tclentry eq ""} {return} ;# no need to do anything if empty
     if {[catch {uplevel #0 $tclentry} errorname]} {
         global errorInfo
-        switch -regexp -- $errorname { 
+        switch -regexp -- $errorname {
             "missing close-brace" {
                 ::pdwindow::error [concat [_ "(Tcl) MISSING CLOSE-BRACE '\}': "] $errorInfo]\n
             } "missing close-bracket" {
@@ -407,7 +407,7 @@ proc ::pdwindow::create_window {} {
             "default" { return [eval ::.pdwindow.text.internal $args] }
         }
     }
-    
+
     # print whatever is in the queue after the event loop finishes
     after idle [list after 0 ::pdwindow::filter_buffer_to_text]
 


### PR DESCRIPTION
this is a follow-up fix for the window position problem as resolved in #44 (but which was effectively undone by merging in the `osx-retina-support` branch).

the PR also includes a `.gitattributes` file to exclude all the various dotfiles from the *source package* (as created via `git archive`)