### PR TITLE
Fix typo - help files

### DIFF
--- a/doc/5.reference/abs~-help.pd
+++ b/doc/5.reference/abs~-help.pd
@@ -1,12 +1,12 @@
-#N canvas 286 197 499 284 10;
+#N canvas 286 197 598 316 12;
 #X obj 19 108 sig~;
 #X obj 71 133 loadbang;
 #X obj 71 157 metro 100;
 #X obj 71 181 snapshot~;
-#X floatatom 19 87 5 0 0 0 - - -;
-#X floatatom 71 206 7 0 0 0 - - -;
+#X floatatom 19 87 5 0 0 0 - - -, f 5;
+#X floatatom 71 206 7 0 0 0 - - -, f 7;
 #X text 316 257 updated for Pd version 0.42.;
-#X obj 20 132 abs~;
+#X obj 19 132 abs~;
 #X obj 21 14 abs~;
 #X text 60 14 - absolute value;
 #X text 82 33 Passes nonnegative values unchanged \, but replaces negative

--- a/doc/5.reference/acoustics~-help.pd
+++ b/doc/5.reference/acoustics~-help.pd
@@ -2,32 +2,32 @@
 #X obj 158 118 mtof~;
 #X obj 158 174 snapshot~;
 #X obj 698 132 metro 100;
-#X floatatom 158 205 0 0 0;
+#X floatatom 158 205 0 0 0 0 - - -;
 #X obj 49 174 snapshot~;
-#X floatatom 49 55 0 0 0;
-#X floatatom 49 205 0 0 0;
+#X floatatom 49 55 0 0 0 0 - - -;
+#X floatatom 49 205 0 0 0 0 - - -;
 #X obj 49 118 ftom~;
 #X obj 264 174 snapshot~;
-#X floatatom 264 205 0 0 0;
+#X floatatom 264 205 0 0 0 0 - - -;
 #X obj 264 118 dbtorms~;
-#X obj 697 58 loadbang;
+#X obj 698 58 loadbang;
 #X msg 709 88 \; pd dsp 1;
 #X obj 49 86 sig~;
-#X floatatom 158 55 0 0 0;
+#X floatatom 158 55 0 0 0 0 - - -;
 #X obj 158 86 sig~;
-#X floatatom 264 54 0 0 0;
+#X floatatom 264 54 0 0 0 0 - - -;
 #X obj 264 86 sig~;
 #X obj 492 172 snapshot~;
-#X floatatom 492 203 0 0 0;
+#X floatatom 492 203 0 0 0 0 - - -;
 #X obj 383 172 snapshot~;
-#X floatatom 383 53 0 0 0;
-#X floatatom 383 203 0 0 0;
+#X floatatom 383 53 0 0 0 0 - - -;
+#X floatatom 383 203 0 0 0 0 - - -;
 #X obj 607 172 snapshot~;
-#X floatatom 607 203 0 0 0;
+#X floatatom 607 203 0 0 0 0 - - -;
 #X obj 383 84 sig~;
-#X floatatom 492 53 0 0 0;
+#X floatatom 492 53 0 0 0 0 - - -;
 #X obj 492 84 sig~;
-#X floatatom 607 53 0 0 0;
+#X floatatom 607 53 0 0 0 0 - - -;
 #X obj 607 84 sig~;
 #X obj 383 115 rmstodb~;
 #X obj 492 115 dbtopow~;
@@ -38,15 +38,15 @@
 #X obj 145 400 mtof;
 #X text 192 400 (etc.);
 #X text 547 416 updated for Pd version 0.33;
+#X text 41 343 Boundary conditions are handled "reasonably". 100 db
+is assigned an RMS of 1 \, and dbtorms~ and dbtopow~ output true zero
+for 0 dB and less.;
 #X text 43 241 These objects convert MIDI pitch to frequency and back
-\, and dB to and from RMS and power. THey take audio signals as input
+\, and dB to and from RMS and power. They take audio signals as input
 and output (and work sample by sample.) Since they call library math
 functions \, they may be much more expensive than other workaday tilde
 objects such as *~ and osc~ \, depending on your hardware and math
 library.;
-#X text 41 343 Boundary conditions are handled "reasonably". 100 db
-is assigned an RMS of 1 \, and dbtorms~ and dbtopow~ output true zero
-for 0 dB and less.;
 #X connect 0 0 1 0;
 #X connect 1 0 3 0;
 #X connect 2 0 1 0;

--- a/doc/5.reference/operators-help.pd
+++ b/doc/5.reference/operators-help.pd
@@ -29,7 +29,7 @@ right inlet:, f 34;
 #X floatatom 231 310 0 0 0 0 - - -;
 #X floatatom 140 309 0 0 0 0 - - -;
 #X floatatom 376 315 0 0 0 0 - - -;
-#X floatatom 65 141 0 0 0 0 - - -;
+#X floatatom 64 141 0 0 0 0 - - -;
 #X floatatom 136 142 0 0 0 0 - - -;
 #X obj 136 170 t b f;
 #X text 51 115 set left and right inputs here;
@@ -46,7 +46,7 @@ right inlet:, f 34;
 #X obj 332 287 max;
 #X obj 376 288 min;
 #X text 36 47 The arithmetic binary operators perform the 4 arithmetic
-funcitons (+ \, etc) \, raise a number to a power (pow) \, or output
+functions (+ \, etc) \, raise a number to a power (pow) \, or output
 the minimum or maximum of two numbers (min \, max).;
 #X connect 4 0 6 0;
 #X connect 6 0 5 0;

--- a/doc/5.reference/until-help.pd
+++ b/doc/5.reference/until-help.pd
@@ -1,19 +1,23 @@
-#N canvas 142 97 410 273 10;
-#X msg 65 116 bang;
+#N canvas 142 97 547 332 12;
+#X msg 65 156 bang;
 #X obj 66 15 until;
 #X text 114 16 - LOOP;
-#X text 24 36 The until object's left inlet starts a loop in which it outputs "bang" until its right inlet gets a bang which stops it. If you start "until" with a number \, it iterates at most that number of times \, as in the Max "uzi" object.;
-#X text 24 85 WARNING: if you bang an "until" which doesn't have a stopping mechanism \, Pd goes into an infinite loop!;
-#X obj 65 168 until;
-#X text 110 115 start;
-#X msg 73 137 3;
-#X text 109 138 start limited to 3 iterations;
-#X obj 65 196 f;
-#X obj 96 198 + 1;
-#X obj 140 198 sel 0;
-#X obj 65 240 print;
-#X obj 96 219 mod 10;
-#X text 225 247 updated for Pd version 0.28;
+#X text 24 36 The until object's left inlet starts a loop in which
+it outputs "bang" until its right inlet gets a bang which stops it.
+If you start "until" with a number \, it iterates at most that number
+of times \, as in the Max "uzi" object.;
+#X text 24 105 WARNING: if you bang an "until" which doesn't have a
+stopping mechanism \, Pd goes into an infinite loop!;
+#X obj 65 214 until;
+#X text 110 155 start;
+#X msg 73 183 3;
+#X text 109 184 start limited to 3 iterations;
+#X obj 65 242 f;
+#X obj 103 242 + 1;
+#X obj 148 241 sel 0;
+#X obj 65 296 print;
+#X obj 103 268 mod 10;
+#X text 225 287 updated for Pd version 0.28;
 #X connect 0 0 5 0;
 #X connect 5 0 9 0;
 #X connect 7 0 5 0;


### PR DESCRIPTION
Fix the typo (and change the font size) of some help files, the name of the commits are explicits so you can do it manually if you prefer.
- [ ] operators-help.pd: funcitons -> functions
- [ ] abs~-help.pd: change font size from 10 to 12
- [ ] acoustics~-help.pd: THey -> They
- [ ] until-help.pd: change font size from 10 to 12