### PR TITLE
fixed tcl error when using Undo and Redo menu entries

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -626,9 +626,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Aangaande"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 #, fuzzy
 msgid "Save"
 msgstr "Stoor"

--- a/po/az.po
+++ b/po/az.po
@@ -622,9 +622,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "_Haqqında"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Qeyd Et"
 

--- a/po/be.po
+++ b/po/be.po
@@ -622,9 +622,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Аб праграме"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Захаваць"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -623,9 +623,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "_Относно"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Запазване"
 

--- a/po/de.po
+++ b/po/de.po
@@ -607,9 +607,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Über Pd"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Speichern"
 

--- a/po/el.po
+++ b/po/el.po
@@ -596,9 +596,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Περί..."
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Αποθήκευση"
 

--- a/po/en_ca.po
+++ b/po/en_ca.po
@@ -569,9 +569,6 @@ msgstr ""
 msgid "About Pd"
 msgstr ""
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -622,9 +622,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Pd-ri Buruz"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Gorde"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -591,9 +591,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "À propos de Pd"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Sauvegarder"
 

--- a/po/gu.po
+++ b/po/gu.po
@@ -624,9 +624,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "વિશે (_A)"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "સંગ્રહ કરો"
 

--- a/po/he.po
+++ b/po/he.po
@@ -610,9 +610,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "אודות איקס-צ'אט"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -621,9 +621,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "के बारे में (_A)"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "सहेजें"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -598,9 +598,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "A Pd-ről"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Ment"
 

--- a/po/it.po
+++ b/po/it.po
@@ -596,9 +596,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Informazioni su Pd..."
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Salva"
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -623,9 +623,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "ਇਸ ਬਾਰੇ(_A)"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "ਸੰਭਾਲੋ"
 

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -616,9 +616,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Sobre PD"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Salvar"
 

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -592,9 +592,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Sobre o Pd"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Guardar"
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -622,9 +622,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "_Rreth"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Ruaj"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -607,9 +607,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "Om Pd"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Spara"
 

--- a/po/template.pot
+++ b/po/template.pot
@@ -569,9 +569,6 @@ msgstr ""
 msgid "About Pd"
 msgstr ""
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -622,9 +622,6 @@ msgstr ""
 msgid "About Pd"
 msgstr "_Giới thiệu"
 
-msgid "file edit put find media window help"
-msgstr ""
-
 msgid "Save"
 msgstr "Lưu"
 

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -165,9 +165,9 @@ proc ::pd_menus::build_file_menu {mymenu} {
 proc ::pd_menus::build_edit_menu {mymenu} {
     variable accelerator
     $mymenu add command -label [_ "Undo"]       -accelerator "$accelerator+Z" \
-        -command {menu_undo $::focused_window}
+        -command {menu_undo}
     $mymenu add command -label [_ "Redo"]       -accelerator "Shift+$accelerator+Z" \
-        -command {menu_redo $::focused_window}
+        -command {menu_redo}
     $mymenu add  separator
     $mymenu add command -label [_ "Cut"]        -accelerator "$accelerator+X" \
         -command {menu_send $::focused_window cut}

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -37,7 +37,7 @@ proc ::pd_menus::create_menubar {} {
     }
     menu $menubar
     if {$::windowingsystem eq "aqua"} {create_apple_menu $menubar}
-    set menulist [_ "file edit put find media window help"]
+    set menulist "file edit put find media window help"
     foreach mymenu $menulist {    
         if {$mymenu eq "find"} {
             set underlined 3


### PR DESCRIPTION
This fixes an error with the menu binds which were calling menu_undo and menu_redo with the focused window argument. The problem is that neither of these procs requires an argument.