### PR TITLE
fixed undo/redo calls from menu

### DIFF
--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -165,9 +165,9 @@ proc ::pd_menus::build_file_menu {mymenu} {
 proc ::pd_menus::build_edit_menu {mymenu} {
     variable accelerator
     $mymenu add command -label [_ "Undo"]       -accelerator "$accelerator+Z" \
-        -command {menu_undo $::focused_window}
+        -command {menu_undo}
     $mymenu add command -label [_ "Redo"]       -accelerator "Shift+$accelerator+Z" \
-        -command {menu_redo $::focused_window}
+        -command {menu_redo}
     $mymenu add  separator
     $mymenu add command -label [_ "Cut"]        -accelerator "$accelerator+X" \
         -command {menu_send $::focused_window cut}


### PR DESCRIPTION
as reported on the pd-list, the "Undo" and "Redo" entries in the menu throw an error (Undo/Redo works fine via the accelerator keys).

That's because the `menu_undo` (and `menu_redo`) do not accept any arguments, but the menu-entries supply one.

this PR fixes this.