### PR TITLE
Fix pdinstance_free

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -218,7 +218,19 @@ EXTERN void pdinstance_free(t_pdinstance *x)
         while ((s = x->pd_symhash[i]))
         {
             x->pd_symhash[i] = s->s_next;
-            freebytes(s, sizeof(*s));
+            if(s != &x->pd_s_pointer &&
+               s != &x->pd_s_float &&
+               s != &x->pd_s_symbol &&
+               s != &x->pd_s_bang &&
+               s != &x->pd_s_list &&
+               s != &x->pd_s_anything &&
+               s != &x->pd_s_signal &&
+               s != &x->pd_s__N &&
+               s != &x->pd_s__X &&
+               s != &x->pd_s_x &&
+               s != &x->pd_s_y &&
+               s != &x->pd_s_)
+                freebytes(s, sizeof(*s));
         }
     }
     freebytes(x->pd_symhash, SYMTABHASHSIZE * sizeof (*x->pd_symhash));


### PR DESCRIPTION
The issue is explained here #129 and to avoid the crash we just need to avoid to free the symbols that are not allocated dynamically