### PR TITLE
remove non-existent files from recent files menu

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -996,6 +996,10 @@ msgid "Delete"
 msgstr "Uitwis"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/az.po
+++ b/po/az.po
@@ -987,6 +987,10 @@ msgid "Delete"
 msgstr "Sil"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/be.po
+++ b/po/be.po
@@ -989,6 +989,10 @@ msgid "Delete"
 msgstr "Выдаліць"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -988,6 +988,10 @@ msgid "Delete"
 msgstr "Изтриване"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -935,6 +935,10 @@ msgstr "Bearbeiten..."
 msgid "Delete"
 msgstr "Löschen"
 
+#, fuzzy, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr "Überspringe '%s': kein Pd-File"
+
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "Überspringe '%s': kein Pd-File"

--- a/po/el.po
+++ b/po/el.po
@@ -952,6 +952,10 @@ msgid "Delete"
 msgstr "Διαγραφή πίνακα"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/en_ca.po
+++ b/po/en_ca.po
@@ -907,5 +907,9 @@ msgid "Delete"
 msgstr ""
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -3,7 +3,8 @@
 # Federico Camara Halac <camarafede@gmail.com>, 2017.
 #
 msgid ""
-msgstr "Project-Id-Version: Pure Data 0.48.0\n"
+msgstr ""
+"Project-Id-Version: Pure Data 0.48.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
 "PO-Revision-Date: 2017-07-20 21:14-0400\n"
 "Last-Translator: Federico Camara Halac <camarafede@gmail.com>\n"
@@ -155,7 +156,8 @@ msgid "no Pd settings to erase"
 msgstr "No hay configuraciones para borrar"
 
 msgid "skipping loading preferences... Pd seems to have crashed on startup."
-msgstr "salteando el cargado de preferencias... Pd parece haber crasheado al inicio."
+msgstr ""
+"salteando el cargado de preferencias... Pd parece haber crasheado al inicio."
 
 msgid "(re-save preferences to reinstate them)"
 msgstr "(click en Guardar Preferencias para reestablecerlas)"
@@ -281,7 +283,8 @@ msgid "Save All Settings"
 msgstr "Guardar Configuraciones"
 
 msgid "WARNING: unknown graphme flags received in pdtk_canvas_dialog"
-msgstr "ADVERTENCIA: banderas graphme desconocidas recibidas en pdtk_canvas_dialog"
+msgstr ""
+"ADVERTENCIA: banderas graphme desconocidas recibidas en pdtk_canvas_dialog"
 
 msgid "Canvas Properties"
 msgstr "Propiedades de Canvas"
@@ -589,7 +592,8 @@ msgstr "[deken]: version instalada [%1$s] == %2$s...salteando!"
 
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
-msgstr "[deken] deken-plugin.tcl (Búsqueda de externals para Pd) cargado de %s."
+msgstr ""
+"[deken] deken-plugin.tcl (Búsqueda de externals para Pd) cargado de %s."
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
@@ -605,7 +609,9 @@ msgid "Search"
 msgstr "Buscar"
 
 msgid "To get a list of all available externals, try an empty search."
-msgstr "Para ver una lista de todos los externos disponibles, prueba una búsqueda vacía."
+msgstr ""
+"Para ver una lista de todos los externos disponibles, prueba una búsqueda "
+"vacía."
 
 msgid "Find externals"
 msgstr "Buscar Externos"
@@ -624,10 +630,13 @@ msgid "Unable to perform search. Are you online?"
 msgstr "La búsqueda no pudo ser realizada. ¿Está usted online?"
 
 msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
-msgstr "No se han encontrado externos con ese nombre. Prueba usando el nombre completo, por ejemplo: 'freeverb'."
+msgstr ""
+"No se han encontrado externos con ese nombre. Prueba usando el nombre "
+"completo, por ejemplo: 'freeverb'."
 
 msgid "Please select a (writable) installation directory!"
-msgstr "Por favor, selecciona un directorio de instalacion con permisos de escritura!"
+msgstr ""
+"Por favor, selecciona un directorio de instalacion con permisos de escritura!"
 
 #, tcl-format
 msgid "Install to %s ?"
@@ -638,7 +647,8 @@ msgid ""
 "Commencing downloading of:\n"
 "%1$s\n"
 "Into %2$s..."
-msgstr "Comenzando descarga de:\n"
+msgstr ""
+"Comenzando descarga de:\n"
 "%1$s\n"
 "En %2$s..."
 
@@ -821,7 +831,8 @@ msgstr "Borrar Menu"
 msgid ""
 "Delete all preferences?\n"
 "(takes effect when Pd is restarted)"
-msgstr "¿Desea eliminar todas las preferencias?\n"
+msgstr ""
+"¿Desea eliminar todas las preferencias?\n"
 "(efectivizará cuando Pd reinicie)"
 
 msgid "Path..."
@@ -907,6 +918,10 @@ msgstr "Editar..."
 
 msgid "Delete"
 msgstr "Eliminar"
+
+#, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
 
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"

--- a/po/eu.po
+++ b/po/eu.po
@@ -987,6 +987,10 @@ msgid "Delete"
 msgstr "Array ezabatu"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -916,6 +916,10 @@ msgstr "Éditer..."
 msgid "Delete"
 msgstr "Supprimer"
 
+#, fuzzy, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr "'%s' ne semble par être un fichier Pd"
+
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "'%s' ne semble par être un fichier Pd"

--- a/po/gu.po
+++ b/po/gu.po
@@ -989,6 +989,10 @@ msgid "Delete"
 msgstr "દૂર કરો"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -967,6 +967,10 @@ msgid "Delete"
 msgstr ""
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -986,6 +986,10 @@ msgid "Delete"
 msgstr "मिटाओ"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -952,6 +952,10 @@ msgid "Delete"
 msgstr "Array-t töröl"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -948,6 +948,10 @@ msgid "Delete"
 msgstr "Cancella array"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -988,6 +988,10 @@ msgid "Delete"
 msgstr "ਹਟਾਓ"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -571,7 +571,8 @@ msgid "Out Ports:"
 msgstr "Portas de Saída:"
 
 msgid "Pd search path for objects, help, fonts, and other files"
-msgstr "Caminho de busca do PD para objetos, arquivos de ajuda, fontes e outros"
+msgstr ""
+"Caminho de busca do PD para objetos, arquivos de ajuda, fontes e outros"
 
 msgid "Use standard paths"
 msgstr "Usar caminhos padrões"
@@ -636,7 +637,9 @@ msgid "Search"
 msgstr "Procurar"
 
 msgid "To get a list of all available externals, try an empty search."
-msgstr "Para receber uma lista com todos os externals disponíveis, tente uma busca vazia."
+msgstr ""
+"Para receber uma lista com todos os externals disponíveis, tente uma busca "
+"vazia."
 
 msgid "Find externals"
 msgstr "Procurar por externals"
@@ -655,7 +658,8 @@ msgid "Unable to perform search. Are you online?"
 msgstr "Incapaz de realizar busca. Você está online?"
 
 msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
-msgstr "Nenhum external encontrado. Tente usar o nome completo (como 'freeverb')."
+msgstr ""
+"Nenhum external encontrado. Tente usar o nome completo (como 'freeverb')."
 
 msgid "Please select a (writable) installation directory!"
 msgstr "Por favor escolha um diretório de instalação com permissão de escrita!"
@@ -941,6 +945,10 @@ msgstr "Editar..."
 msgid "Delete"
 msgstr "Deletar"
 
+#, fuzzy, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr "Ignorando '%s': não parece ser um arquivo de PD válido"
+
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "Ignorando '%s': não parece ser um arquivo de PD válido"
@@ -1048,7 +1056,8 @@ msgstr "Ignorando '%s': não parece ser um arquivo de PD válido"
 #~ msgstr "Dispositivo de saída 2:"
 
 #~ msgid "WARNING: %s failed to find font size (%s) that fits into %sx%s!"
-#~ msgstr "AVISO: %s Falha ao procurar tamanho de fonte (%s) que caiba em %sx%s!"
+#~ msgstr ""
+#~ "AVISO: %s Falha ao procurar tamanho de fonte (%s) que caiba em %sx%s!"
 
 #~ msgid "ERROR: 'pd' never showed up, 'pd-gui' quitting!"
 #~ msgstr "ERRO: 'pd' nunca apareceu, 'pd-gui' fechando!"
@@ -1060,7 +1069,8 @@ msgstr "Ignorando '%s': não parece ser um arquivo de PD válido"
 #~ msgstr "Enviar Mensagem..."
 
 #~ msgid "ERROR: %s failed to find font size (%s) that fits into %sx%s!"
-#~ msgstr "ERRO: %s Falha ao procurar tamanho de fonte (%s) que caiba em %sx%s!"
+#~ msgstr ""
+#~ "ERRO: %s Falha ao procurar tamanho de fonte (%s) que caiba em %sx%s!"
 
 #~ msgid "Pd Files"
 #~ msgstr "Arquivos de Pd"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -946,6 +946,10 @@ msgid "Delete"
 msgstr "Apagar array"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/sq.po
+++ b/po/sq.po
@@ -987,6 +987,10 @@ msgid "Delete"
 msgstr "Fshij"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -961,6 +961,10 @@ msgid "Delete"
 msgstr "Radera array"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/po/template.pot
+++ b/po/template.pot
@@ -907,5 +907,9 @@ msgid "Delete"
 msgstr ""
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -987,6 +987,10 @@ msgid "Delete"
 msgstr "Xóa bỏ"
 
 #, tcl-format
+msgid "Ignoring '%s': doesn't exist"
+msgstr ""
+
+#, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr ""
 

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -365,13 +365,15 @@ proc ::pd_guiprefs::write_recentfiles {} {
 # ------------------------------------------------------------------------------
 # this is called when opening a document (wheredoesthisshouldgo.tcl)
 #
-proc ::pd_guiprefs::update_recentfiles {afile} {
+proc ::pd_guiprefs::update_recentfiles {afile {remove false}} {
     # remove duplicates first
     set index [lsearch -exact $::recentfiles_list $afile]
     set ::recentfiles_list [lreplace $::recentfiles_list $index $index]
-    # insert new one in the beginning and crop the list
-    set ::recentfiles_list [linsert $::recentfiles_list 0 $afile]
-    set ::recentfiles_list [lrange $::recentfiles_list 0 $::total_recentfiles]
+    if {! $remove} {
+        # insert new one in the beginning and crop the list
+        set ::recentfiles_list [linsert $::recentfiles_list 0 $afile]
+        set ::recentfiles_list [lrange $::recentfiles_list 0 $::total_recentfiles]
+    }
     ::pd_menus::update_recentfiles_menu
 }
 

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -6,15 +6,18 @@ package provide wheredoesthisgo 0.1
 proc open_file {filename} {
     set directory [file normalize [file dirname $filename]]
     set basename [file tail $filename]
-    if {
-        [file exists $filename]
-        && [regexp -nocase -- "\.(pd|pat|mxt)$" $filename]
-    } then {
+    if { ! [file exists $filename]} {
+        ::pdwindow::post [format [_ "Ignoring '%s': doesn't exist"] $filename]
+        # remove from recent files
+        ::pd_guiprefs::update_recentfiles $filename true
+        return
+    }
+    if {[regexp -nocase -- "\.(pd|pat|mxt)$" $filename]} {
         ::pdtk_canvas::started_loading_file [format "%s/%s" $basename $filename]
         pdsend "pd open [enquote_path $basename] [enquote_path $directory]"
         # now this is done in pd_guiprefs
         ::pd_guiprefs::update_recentfiles $filename
-    } {
+    } else {
         ::pdwindow::post [format [_ "Ignoring '%s': doesn't look like a Pd-file"] $filename]
     }
 }


### PR DESCRIPTION
This small PR adds code to remove any non-existent files for the recent files menu if they fail to open when clicked on. It also adds a better error message.