### PR TITLE
Set deken install path in the Path dialog

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -595,10 +595,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -647,9 +656,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/az.po
+++ b/po/az.po
@@ -591,10 +591,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -643,9 +652,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/be.po
+++ b/po/be.po
@@ -591,10 +591,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -614,7 +623,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Help Browser"
-msgstr "Агляд.."
+msgstr "Агляд..."
 
 msgid "(Tcl) MISSING CLOSE-BRACE '}': "
 msgstr ""
@@ -643,9 +652,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/bg.po
+++ b/po/bg.po
@@ -592,10 +592,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -644,9 +653,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/de.po
+++ b/po/de.po
@@ -562,11 +562,20 @@ msgstr ""
 "Verzeichnisse, in denen Pd nach Objekten, Hilfe, Schriftarten und ähnlichem "
 "sucht"
 
+msgid "Install externals to:"
+msgstr "Bibliotheken installieren Verzeichnis:"
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr "Standardpfade durchsuchen"
 
 msgid "Verbose"
 msgstr "Ausführliche Meldungen"
+
+msgid "Install externals to directory:"
+msgstr "Bibliotheken in folgendes Verzeichnis installieren:"
 
 msgid "Add new library"
 msgstr "Neue Bibliothek hinzufügen"
@@ -617,9 +626,6 @@ msgstr "[deken] Pd Paketmanager vom Pfad %s geladen."
 #, tcl-format
 msgid "[deken] Platform detected: %s"
 msgstr "[deken] Plattform gefunden: %s"
-
-msgid "Install libraries to directory:"
-msgstr "Bibliotheken in folgendes Verzeichnis installieren:"
 
 msgid "Show all"
 msgstr "Alle anzeigen"

--- a/po/el.po
+++ b/po/el.po
@@ -571,10 +571,19 @@ msgstr "Θύρες Εξόδου:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -623,9 +632,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/en_ca.po
+++ b/po/en_ca.po
@@ -543,10 +543,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -594,9 +603,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/es.po
+++ b/po/es.po
@@ -545,11 +545,21 @@ msgstr "Puertos de Salida:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr "Ruta de búsqueda de Pd para objetos, ayuda, fuentes, y otros archivos"
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr "Usar rutas estándar"
 
 msgid "Verbose"
 msgstr "Verbosa"
+
+#, fuzzy
+msgid "Install externals to directory:"
+msgstr "Instalar librerías en directorio:"
 
 msgid "Add new library"
 msgstr "Añadir nueva librería"
@@ -598,9 +608,6 @@ msgstr ""
 #, tcl-format
 msgid "[deken] Platform detected: %s"
 msgstr "[deken] Plataforma detectada: %s"
-
-msgid "Install libraries to directory:"
-msgstr "Instalar librerías en directorio:"
 
 msgid "Show all"
 msgstr "Ver todo"

--- a/po/eu.po
+++ b/po/eu.po
@@ -594,10 +594,19 @@ msgstr "Aterako Portuetan:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -646,9 +655,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/fr.po
+++ b/po/fr.po
@@ -155,7 +155,9 @@ msgid "no Pd settings to erase"
 msgstr "pas de paramètres a effacer"
 
 msgid "skipping loading preferences... Pd seems to have crashed on startup."
-msgstr "Pd semble ne pas avoir démarré correctement, les préférences n'ont pas été chargés"
+msgstr ""
+"Pd semble ne pas avoir démarré correctement, les préférences n'ont pas été "
+"chargés"
 
 msgid "(re-save preferences to reinstate them)"
 msgstr "(sauver a nouveau les préférences pour les charger)"
@@ -542,11 +544,20 @@ msgstr "Ports de sortie:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr "Chemins pour la recherche d'objets, aides, fontes et autres"
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr "Naviguer"
+
 msgid "Use standard paths"
 msgstr "Utiliser les extensions standard"
 
 msgid "Verbose"
 msgstr "Verbeux"
+
+msgid "Install externals to directory:"
+msgstr ""
 
 msgid "Add new library"
 msgstr "Ajouter une bibliothèque"
@@ -593,9 +604,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/gu.po
+++ b/po/gu.po
@@ -593,10 +593,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -645,9 +654,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/he.po
+++ b/po/he.po
@@ -579,10 +579,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -631,9 +640,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/hi.po
+++ b/po/hi.po
@@ -590,10 +590,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr "ब्राउज़"
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -642,9 +651,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/hu.po
+++ b/po/hu.po
@@ -573,10 +573,19 @@ msgstr "Kimenő portok:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -625,9 +634,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/it.po
+++ b/po/it.po
@@ -572,10 +572,19 @@ msgstr "Porte Uscita:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -623,9 +632,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/pa.po
+++ b/po/pa.po
@@ -592,10 +592,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -644,9 +653,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -574,11 +574,20 @@ msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 "Caminho de busca do PD para objetos, arquivos de ajuda, fontes e outros"
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr "Usar caminhos padrões"
 
 msgid "Verbose"
 msgstr "Verbose"
+
+msgid "Install externals to directory:"
+msgstr "Instalar bibliotecas no diretório:"
 
 msgid "Add new library"
 msgstr "Adicionar nova biblioteca"
@@ -626,9 +635,6 @@ msgstr "[deken] deken-plugin.tcl (busca de externals Pd) carregado de %s."
 #, tcl-format
 msgid "[deken] Platform detected: %s"
 msgstr "[deken] Platforma detectada: %s"
-
-msgid "Install libraries to directory:"
-msgstr "Instalar bibliotecas no diretório:"
 
 msgid "Show all"
 msgstr "Mostrar todos"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -567,10 +567,19 @@ msgstr "Ports de saída:"
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -619,9 +628,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/sq.po
+++ b/po/sq.po
@@ -591,10 +591,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -643,9 +652,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/sv.po
+++ b/po/sv.po
@@ -580,10 +580,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -632,9 +641,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/template.pot
+++ b/po/template.pot
@@ -543,10 +543,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -594,9 +603,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/po/vi.po
+++ b/po/vi.po
@@ -591,10 +591,19 @@ msgstr ""
 msgid "Pd search path for objects, help, fonts, and other files"
 msgstr ""
 
+msgid "Install externals to:"
+msgstr ""
+
+msgid "Browse"
+msgstr ""
+
 msgid "Use standard paths"
 msgstr ""
 
 msgid "Verbose"
+msgstr ""
+
+msgid "Install externals to directory:"
 msgstr ""
 
 msgid "Add new library"
@@ -643,9 +652,6 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr ""
-
-msgid "Install libraries to directory:"
 msgstr ""
 
 msgid "Show all"

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -38,10 +38,12 @@ proc ::dialog_path::create_dialog {mytoplevel} {
     scrollboxwindow::make $mytoplevel $::sys_searchpath \
         dialog_path::add dialog_path::edit dialog_path::commit \
         [_ "Pd search path for objects, help, fonts, and other files"] \
-        450 340 1
+        450 300 1
     ::pd_bindings::dialog_bindings $mytoplevel "path"
 
+    # add deken path widgets if deken is available, increase window height to make room
     if {[namespace exists ::deken]} {
+        wm geometry $mytoplevel "=450x340"
         frame $mytoplevel.installpath
         pack $mytoplevel.installpath -side top -anchor e -expand 1 -fill x -padx 2m
         label $mytoplevel.installpath.entryname -text [_ "Install externals to:"]

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -38,8 +38,21 @@ proc ::dialog_path::create_dialog {mytoplevel} {
     scrollboxwindow::make $mytoplevel $::sys_searchpath \
         dialog_path::add dialog_path::edit dialog_path::commit \
         [_ "Pd search path for objects, help, fonts, and other files"] \
-        400 300 1
+        450 340 1
     ::pd_bindings::dialog_bindings $mytoplevel "path"
+
+    if {[namespace exists ::deken]} {
+        frame $mytoplevel.installpath
+        pack $mytoplevel.installpath -side top -anchor e -expand 1 -fill x -padx 2m
+        label $mytoplevel.installpath.entryname -text [_ "Install externals to:"]
+        entry $mytoplevel.installpath.entry -textvariable ::deken::installpath \
+            -state readonly -readonlybackground [lindex [$mytoplevel configure -background] end]
+        button $mytoplevel.installpath.browse -text [_ "Browse"] \
+            -command "::dialog_path::browse_installpath %W"
+        pack $mytoplevel.installpath.browse -side right -fill x -ipadx 10
+        pack $mytoplevel.installpath.entry -side right -expand 1 -fill x
+        pack $mytoplevel.installpath.entryname -side right
+    }
 
     frame $mytoplevel.extraframe
     pack $mytoplevel.extraframe -side bottom -fill x -pady 2m
@@ -69,6 +82,21 @@ proc ::dialog_path::create_dialog {mytoplevel} {
         $mytoplevel.nb.buttonframe.ok config -highlightthickness 0
         $mytoplevel.nb.buttonframe.cancel config -highlightthickness 0
     }
+}
+
+# browse for a new deken installpath, this assumes deken is available
+proc ::dialog_path::browse_installpath {mytoplevel} {
+    if { ! [file isdirectory $::deken::installpath]} {
+        set path $::env(HOME)
+    } else {
+        set path $::deken::installpath
+    }
+    set newpath [tk_chooseDirectory -initialdir $path -title [_ "Install externals to directory:"]]
+    if {$newpath ne ""} {
+        ::deken::set_installpath $newpath
+        return 1
+    }
+    return 0
 }
 
 # for focus handling on OSX

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -43,7 +43,8 @@ proc ::dialog_path::create_dialog {mytoplevel} {
 
     # add deken path widgets if deken is available, increase window height to make room
     if {[namespace exists ::deken]} {
-        wm geometry $mytoplevel "=450x340"
+        wm geometry $mytoplevel "450x340"
+        wm minsize $mytoplevel 450 340
         frame $mytoplevel.installpath
         pack $mytoplevel.installpath -side top -anchor e -expand 1 -fill x -padx 2m
         label $mytoplevel.installpath.entryname -text [_ "Install externals to:"]

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -434,7 +434,7 @@ proc ::deken::clicked_link {URL filename} {
     ### if ::deken::installpath is set, use the first writable item
     ### if not, get a writable item from one of the searchpaths
     ### if this still doesn't help, ask the user
-    set installdir ::deken::find_installpath
+    set installdir [::deken::find_installpath]
     if { "$installdir" == "" } {
         ## ask the user (and remember the decision)
         ::deken::prompt_installdir

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -268,7 +268,7 @@ proc ::deken::highlightable_posttag {tag} {
     $mytoplevelref.results tag raise highlight
 }
 proc ::deken::prompt_installdir {} {
-    set installdir [tk_chooseDirectory -title [_ "Install libraries to directory:"] ]
+    set installdir [tk_chooseDirectory -title [_ "Install externals to directory:"] ]
     if { "$installdir" != "" } {
         ::deken::set_installpath $installdir
         return 1


### PR DESCRIPTION
This PR adds an entry box to the Path dialog for the deken install path. A browse button lets you choose a new directory. This functionality is only added if the `::deken` namespace is is loaded.

This should eliminate the ambiguity as to where people might want to install things & puts this option into the "standard place" with the other paths.

~~Currently, the deken path is empty in a new install so this path shows nothing. That is normal behavior as deken, by default, installs to the ../extra dir for the first time and gives the user a prompt.~~

EDIT: We now show the default path if nothing is set, see updated screenshot

![screen shot 2017-07-25 at 10 34 50 am](https://user-images.githubusercontent.com/480637/28563206-87c7208e-7125-11e7-9a47-e74b7f2abdbd.png)