### PR TITLE
helpbrowser: col output now updates based on key navigation

### DIFF
--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -401,7 +401,7 @@ proc ::helpbrowser::add_entry {reflist entry} {
 }
 
 proc ::helpbrowser::build_references {} {
-    variable libdirlist {" Pure Data/" "---- libraries: -----"}
+    variable libdirlist {" Pure Data/"   "-------- Libraries --------"}
     variable helplist {}
     variable reference_count
     variable reference_paths
@@ -409,25 +409,35 @@ proc ::helpbrowser::build_references {} {
     array set reference_count {}
     array set reference_paths [list \
                                    " Pure Data/" $::sys_libdir/doc \
-                                   "---- libraries: -----" "" \
+                                   "-------- Libraries --------" "" \
                                   ]
-    foreach pathdir $::sys_staticpath {
+    foreach pathdir [concat $::sys_staticpath $::sys_searchpath] {
         if { ! [file isdirectory $pathdir]} {continue}
 
         # Fix the directory name, this ensures the directory name is in the
         # native format for the platform and contains a final directory seperator
         set dir [string trimright [file join [file normalize $pathdir] { }]]
 
-        ## don't find libdirs anymore: supported libs should be in search path
-        # Directory comes from sys_staticpath (aka hardcoded)
-        # Then add an entry for each subdir of this directory in Help browser's root column :
+        ## find the libdirs
 
-        foreach filename [glob -nocomplain -type d -path $dir "*"] {
-            add_entry libdirlist $filename
-        }
-        ## find the stray help patches
-        foreach filename [glob -nocomplain -type f -path $dir "*-help.pd"] {
-            add_entry helplist $filename
+        if { [lsearch $::sys_searchpath $pathdir] ne -1} {
+            # Directory comes from sys_searchpath (aka preferences & -path)
+            # Then add an entry for this directory in Help browser's root column :
+            add_entry libdirlist $dir
+        } else {
+            # Directory comes from sys_staticpath (aka hardcoded)
+            # Then add an entry for each subdir of this directory in Help browser's root column :
+            foreach filename [glob -nocomplain -type d -path $dir "*"] {
+                add_entry libdirlist $filename
+            }
+
+            # don't add core object references to root column
+            if {[string match "*doc/5.reference" $pathdir]} {continue}
+
+            ## find the stray help patches
+            foreach filename [glob -nocomplain -type f -path $dir "*-help.pd"] {
+                add_entry helplist $filename
+            }
         }
     }
 }

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -401,17 +401,23 @@ proc ::helpbrowser::add_entry {reflist entry} {
 }
 
 proc ::helpbrowser::build_references {} {
-    variable libdirlist {" Pure Data/"   "-------- Libraries --------"}
+    variable libdirlist {" Pure Data/" "-------- Libraries --------"}
     variable helplist {}
     variable reference_count
     variable reference_paths
 
     array set reference_count {}
-    array set reference_paths [list \
-                                   " Pure Data/" $::sys_libdir/doc \
-                                   "-------- Libraries --------" "" \
-                                  ]
-    foreach pathdir [concat $::sys_staticpath $::sys_searchpath] {
+    array set reference_paths [list " Pure Data/" $::sys_libdir/doc \
+                                    "-------- Libraries --------" "" ]
+
+    # remove any exact duplicates from the user search paths
+    set searchpaths {}
+    foreach pathdir $::sys_searchpath {
+        lappend searchpaths [file normalize $pathdir]
+    }
+    set searchpaths [lsort -unique $searchpaths]
+
+    foreach pathdir [concat $::sys_staticpath $searchpaths] {
         if { ! [file isdirectory $pathdir]} {continue}
 
         # Fix the directory name, this ensures the directory name is in the
@@ -421,7 +427,7 @@ proc ::helpbrowser::build_references {} {
         ## find the libdirs
 
         if { [lsearch $::sys_searchpath $pathdir] ne -1} {
-            # Directory comes from sys_searchpath (aka preferences & -path)
+            # Directory comes from sys_searchpath (aka preferences)
             # Then add an entry for this directory in Help browser's root column :
             add_entry libdirlist $dir
         } else {

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -439,7 +439,10 @@ proc ::helpbrowser::build_references {} {
     # add an entry for seach directory in Help browser's root column
     set searchpaths {}
     foreach pathdir $::sys_searchpath {
-        lappend searchpaths [string trimright [file join [file normalize $pathdir] { }]]
+        # trim separator so we don't append an extra one before list -unique
+        set trimmed [string trimright [file normalize $pathdir] [file separator]]
+        # add the separator (again)
+        lappend searchpaths [file join $trimmed { }]
     }
     set searchpaths [lsort -unique $searchpaths]
     foreach pathdir $searchpaths {

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -172,6 +172,7 @@ proc ::helpbrowser::root_doubleclick {window x y} {
     set dir [file dirname $reference_paths($item)]
     set filename [file tail $reference_paths($item)]
     open_path $dir $filename
+    focus $window
 }
 
 # try closing child col & mark selection on first window focus
@@ -345,6 +346,7 @@ proc ::helpbrowser::dir_doubleclick {dir count window x y} {
         return
     }
     open_path $dir $filename
+    focus $window
 }
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
This is a PR based on feedback from the 0.48 test releases. It mainly adds "live" interaction by refreshing the columns when navigating with the keyboard. This behavior is modeled on the macOS 
Finder column view (inherited from NextStep).

This builds on browser key bindings by Sebastian Shader: https://sourceforge.net/p/pure-data/patches/579/

Also, libdir display based on the current user search paths was brought back and exact path duplicates are now filtered. The core object help files no longer show in the root column as they can be found in Pure Data -> 5.reference.

Current TODOs:

* [x] update child col when moving from one col to the next with the right key
* [x] reintroduce user libdirs
* [x] filter *exact* path duplicates (keep warning for similar basenames)

Demo Video: <https://www.youtube.com/embed/2hL1brds1XA>