### PR TITLE
pd_guiprefs string quote fix on macOS

### DIFF
--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -14,12 +14,14 @@ namespace eval ::pd_guiprefs:: {
     namespace export write_loglevel
 }
 
-# FIXME should these be globals ?
-set ::recentfiles_key ""
-set ::loglevel_key "loglevel"
+# preference keys
+set ::pd_guiprefs::recentfiles_key ""
+set ::pd_guiprefs::loglevel_key "loglevel"
+
+# platform specific
 set ::pd_guiprefs::domain ""
 set ::pd_guiprefs::configdir ""
-set ::recentfiles_is_array false
+set ::pd_guiprefs::recentfiles_is_array false
 
 #################################################################
 # perferences storage locations
@@ -84,10 +86,10 @@ proc ::pd_guiprefs::init {} {
     switch -- $backend {
         "plist" {
             # macOS has a "Open Recent" menu with 10 recent files (others have 5 inlined)
-            set ::recentfiles_key "NSRecentDocuments"
+            set ::pd_guiprefs::recentfiles_key "NSRecentDocuments"
             set ::total_recentfiles 10
             # store recent files as an array, not a string
-            set ::recentfiles_is_array true
+            set ::pd_guiprefs::recentfiles_is_array true
 
             # ------------------------------------------------------------------------------
             # macOS: read a plist file using the 'defaults' command
@@ -146,7 +148,7 @@ proc ::pd_guiprefs::init {} {
         "registry" {
             # windows uses registry
             set ::pd_guiprefs::registrypath "HKEY_CURRENT_USER\\Software\\Pure-Data"
-            set ::recentfiles_key "RecentDocs"
+            set ::pd_guiprefs::recentfiles_key "RecentDocs"
 
             # ------------------------------------------------------------------------------
             # w32: read in the registry
@@ -180,7 +182,7 @@ proc ::pd_guiprefs::init {} {
             }
         }
         "file" {
-            set ::recentfiles_key "recentfiles"
+            set ::pd_guiprefs::recentfiles_key "recentfiles"
             prepare_configdir ${::pd_guiprefs::domain}
 
             # ------------------------------------------------------------------------------
@@ -204,11 +206,11 @@ proc ::pd_guiprefs::init {} {
     }
     # init gui preferences
     set ::recentfiles_list [::pd_guiprefs::init_config $::pd_guiprefs::domain \
-                                                       $::recentfiles_key \
+                                                       $::pd_guiprefs::recentfiles_key \
                                                        $::recentfiles_list \
-                                                       $::recentfiles_is_array]
+                                                       $::pd_guiprefs::recentfiles_is_array]
     set ::loglevel [::pd_guiprefs::init_config $::pd_guiprefs::domain \
-                                               $::loglevel_key \
+                                               $::pd_guiprefs::loglevel_key \
                                                $::loglevel]
 }
 
@@ -404,8 +406,9 @@ proc ::pd_guiprefs::escape_for_plist {str} {
 # write recent files
 #
 proc ::pd_guiprefs::write_recentfiles {} {
-    write_config $::recentfiles_list $::pd_guiprefs::domain $::recentfiles_key \
-                 $::recentfiles_is_array
+    write_config $::recentfiles_list $::pd_guiprefs::domain \
+                 $::pd_guiprefs::recentfiles_key \
+                 $::pd_guiprefs::recentfiles_is_array
 }
 
 # ------------------------------------------------------------------------------
@@ -431,5 +434,5 @@ proc ::pd_guiprefs::update_recentfiles {afile {remove false}} {
 # write log level
 #
 proc ::pd_guiprefs::write_loglevel {} {
-    write_config $::loglevel $::pd_guiprefs::domain $::loglevel_key
+    write_config $::loglevel $::pd_guiprefs::domain $::pd_guiprefs::loglevel_key
 }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -128,9 +128,6 @@ proc ::pd_guiprefs::init {} {
                         }
                     }
                 } else {
-                    if {[catch {exec defaults write $adomain $akey ""} errorMsg]} {
-                        puts "write_config $akey: $errorMsg\n"
-                    }
                     set escaped [escape_for_plist $data]
                     if {[catch {exec defaults write $adomain $akey $escaped} errorMsg]} {
                         puts "write_config $akey: $errorMsg\n"

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -90,7 +90,7 @@ proc ::pd_guiprefs::init {} {
             set ::recentfiles_is_array true
 
             # ------------------------------------------------------------------------------
-            # macOS: read a plist file
+            # macOS: read a plist file using the 'defaults' command
             #
             proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
                 if {![catch {exec defaults read $adomain $akey} conf]} {
@@ -106,7 +106,7 @@ proc ::pd_guiprefs::init {} {
                     } else {
                         # not an array
                         exec defaults write $adomain $akey ""
-                        set ""
+                        set conf ""
                     }
                 }
                 return $conf
@@ -335,7 +335,7 @@ proc ::pd_guiprefs::prepare_domain {{domain {}}} {
 #
 # becomes: "/path1/hello.pd /path2/world.pd /foo/bar/baz.pd"
 #
-proc ::pd_guiprefs::defaults_array_to_tcl_list {arr} {
+proc ::pd_guiprefs::plist_array_to_tcl_list {arr} {
     set result {}
     set filelist $arr
     regsub -all -- {("?),\s+("?)} $filelist {\1 \2} filelist
@@ -360,7 +360,7 @@ proc ::pd_guiprefs::defaults_array_to_tcl_list {arr} {
 # while others strangely do (found via trial and error), this is ensures the
 # single quotes do not pass through and are saved with the string
 #
-# TODO:
+# FIXME:
 #   * " are not escaped
 #   * \ seem to be swallowed
 #   * mixing ' & parens doesn't work

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -202,13 +202,14 @@ proc ::pd_guiprefs::init {} {
         }
 
     }
-    # assign gui preferences
-    set ::recentfiles_list {}
-    catch {set ::recentfiles_list [get_config $::pd_guiprefs::domain \
-                                       $::recentfiles_key $::recentfiles_is_array]}
-    catch {set ::loglevel [get_config $::pd_guiprefs::domain $::loglevel_key]}
-    # reset default if value was not found
-    if {$::loglevel == ""} {set ::loglevel 2}
+    # init gui preferences
+    set ::recentfiles_list [::pd_guiprefs::init_config $::pd_guiprefs::domain \
+                                                       $::recentfiles_key \
+                                                       $::recentfiles_list \
+                                                       $::recentfiles_is_array]
+    set ::loglevel [::pd_guiprefs::init_config $::pd_guiprefs::domain \
+                                               $::loglevel_key \
+                                               $::loglevel]
 }
 
 # ------------------------------------------------------------------------------
@@ -321,6 +322,16 @@ proc ::pd_guiprefs::prepare_domain {{domain {}}} {
         ::pdwindow::error "$::pd_guiprefs::domain was *NOT* created in $confdir.\n"
     }
     return $domain
+}
+
+# ------------------------------------------------------------------------------
+# convenience proc to init prefs value, returns default if not found
+#
+proc ::pd_guiprefs::init_config {adomain akey {default ""} {arr false}} {
+    set conf ""
+    catch {set conf [get_config $adomain $akey $arr]}
+    if {$conf eq ""} {set conf $default}
+    return $conf
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the currently buggy pd_guiprefs string quoting when calling exec with the macOS defaults command.

From my testing, I found that strings with special Tcl characters (parens, braces, curly braces) needed to be enclosed in single quotes while other strings without did not, merely having single quotes or spaces escaped with forward slashes. This also negates the need for shell expansion via calling `/bin/sh -rc`.

This approach is not foolproof though. Strings with both special Tcl chars and double/single quotes will cause problems but, hopefully that is an edge case. I added a catch around the write calls so these strings do not halt the GUI at least.

Also done: small cleanups regarding pref value init and moved pd_guiprefs variables out of the global namespace.