### PR TITLE
keybinding bugfixes & cleanups

### DIFF
--- a/tcl/apple_events.tcl
+++ b/tcl/apple_events.tcl
@@ -72,7 +72,7 @@ proc ::tk::mac::OpenApplication {args} {
 proc ::tk::mac::ReopenApplication {args} {
     ::pdwindow::verbose 1 "::tk::mac::ReopenApplication $args ++++++++++\n"
     # raise pdwindow if it's hidden and there are no other windows visible
-    if {![winfo viewable .pdwindow] && [llength [wm stackorder .]] == 0} {
+    if {[winfo exists .pdwindow] && ![winfo viewable .pdwindow] && [llength [wm stackorder .]] == 0} {
         ::pd_menucommands::menu_raise_pdwindow
     }
 }

--- a/tcl/apple_events.tcl
+++ b/tcl/apple_events.tcl
@@ -71,4 +71,8 @@ proc ::tk::mac::OpenApplication {args} {
 
 proc ::tk::mac::ReopenApplication {args} {
     ::pdwindow::verbose 1 "::tk::mac::ReopenApplication $args ++++++++++\n"
+    # raise pdwindow if it's hidden and there are no other windows visible
+    if {![winfo viewable .pdwindow] && [llength [wm stackorder .]] == 0} {
+        ::pd_menucommands::menu_raise_pdwindow
+    }
 }

--- a/tcl/dialog_data.tcl
+++ b/tcl/dialog_data.tcl
@@ -44,8 +44,8 @@ proc ::dialog_data::pdtk_data_dialog {mytoplevel stuff} {
         -command "::dialog_data::send $mytoplevel"
     button $mytoplevel.buttonframe.ok -text [_ "Done ($modkeyname-D)"] \
         -command "::dialog_data::ok $mytoplevel"
-    pack $mytoplevel.buttonframe.send -side left -expand 1
-    pack $mytoplevel.buttonframe.ok -side left -expand 1
+    pack $mytoplevel.buttonframe.send -side left -expand 1 -padx 15 -ipadx 10
+    pack $mytoplevel.buttonframe.ok -side left -expand 1 -padx 15 -ipadx 10
 
     text $mytoplevel.text -relief raised -highlightthickness 0 -bd 2 -height 40 -width 60 \
         -yscrollcommand "$mytoplevel.scroll set" -background white

--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -108,7 +108,14 @@ proc ::dialog_find::ok {mytoplevel} {
 
 # mytoplevel isn't used here, but is kept for compatibility with other dialog cancel procs
 proc ::dialog_find::cancel {mytoplevel} {
+    variable find_in_window
     wm withdraw .find
+    # focus on target window or next available
+    if {[winfo exists $find_in_window] && [winfo viewable $find_in_window]} {
+        focus $find_in_window
+    } else {
+        focus [lindex [wm stackorder .] end]
+    }
 }
 
 # focus on the entry in the find dialog

--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -242,6 +242,11 @@ proc ::dialog_find::create_dialog {mytoplevel} {
 # update the passthrough key bindings based on the current target search window
 proc ::dialog_find::update_bindings {} {
     variable find_in_window
+    # disable first
+    bind .find <$::modifier-Key-s>       {bell; break}
+    bind .find <$::modifier-Shift-Key-s> {bell; break}
+    bind .find <$::modifier-Shift-Key-S> {bell; break}
+    bind .find <$::modifier-Key-p>       {bell; break}
     # sending these commands to the Find Dialog Panel should forward them to
     # the currently focused patch or the pdwindow
     if {[winfo exists $find_in_window]} {
@@ -257,12 +262,6 @@ proc ::dialog_find::update_bindings {} {
             bind .find <$::modifier-Key-p> \
                 "menu_print $find_in_window; break"
         }
-    } else {
-        # disable
-        bind .find <$::modifier-Key-s>       {bell; break}
-        bind .find <$::modifier-Shift-Key-s> {bell; break}
-        bind .find <$::modifier-Shift-Key-S> {bell; break}
-        bind .find <$::modifier-Key-p>       {bell; break}
     }
 }
 

--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -139,11 +139,6 @@ proc ::dialog_find::set_window_to_search {mytoplevel} {
         if {$find_in_window eq ".find"} {
             set find_in_window [winfo toplevel [lindex [wm stackorder .] end-1]]
         }
-        # this has funny side effects in tcl 8.4 ???
-        # update: seems to work fine in 8.4 on macOS...
-        # if {$::tcl_version >= 8.5} {
-             wm transient .find $find_in_window
-        # }
         .find.searchin configure -text \
             [format [_ "Search in %s for:"] [lookup_windowname $find_in_window] ]
     }

--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -243,18 +243,20 @@ proc ::dialog_find::create_dialog {mytoplevel} {
 proc ::dialog_find::update_bindings {} {
     variable find_in_window
     # sending these commands to the Find Dialog Panel should forward them to
-    # the currently focused patch
-     ::pdwindow::post "updating find dialog bindings\n"
-    if {$find_in_window ne ".pdwindow" && [winfo exists $find_in_window]} {
-        ::pdwindow::post "... setting\n"
+    # the currently focused patch or the pdwindow
+    if {[winfo exists $find_in_window]} {
         # the "; break" part stops executing other binds
-        bind .find <$::modifier-Key-s> \
-            "menu_send $find_in_window menusave; break"
         bind .find <$::modifier-Shift-Key-s> \
             "menu_send $find_in_window menusaveas; break"
         bind .find <$::modifier-Shift-Key-S> \
             "menu_send $find_in_window menusaveas; break"
-        bind .find <$::modifier-Key-p> "menu_print $find_in_window; break"
+        if {$find_in_window ne ".pdwindow"} {
+            # these don't do anything in the pdwindow
+            bind .find <$::modifier-Key-s> \
+                "menu_send $find_in_window menusave; break"
+            bind .find <$::modifier-Key-p> \
+                "menu_print $find_in_window; break"
+        }
     } else {
         # disable
         bind .find <$::modifier-Key-s>       {bell; break}

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -46,7 +46,7 @@ proc ::dialog_path::create_dialog {mytoplevel} {
         wm geometry $mytoplevel "450x340"
         wm minsize $mytoplevel 450 340
         frame $mytoplevel.installpath
-        pack $mytoplevel.installpath -side top -anchor e -expand 1 -fill x -padx 2m
+        pack $mytoplevel.installpath -side top -anchor e -expand 1 -fill x -padx {2m 4m}
         label $mytoplevel.installpath.entryname -text [_ "Install externals to:"]
         entry $mytoplevel.installpath.entry -textvariable ::deken::installpath \
             -state readonly -readonlybackground [lindex [$mytoplevel configure -background] end]

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -199,9 +199,6 @@ set popup_xcanvas 0
 set popup_ycanvas 0
 # modifier for key commands (Ctrl/Control on most platforms, Cmd/Mod1 on MacOSX)
 set modifier ""
-# most backends require uppercase letters when binding with the shift key,
-# but some (ie. TK Cocoa) need lowercase
-set bind_shiftcaps 1
 # current state of the Edit Mode menu item
 set editmode_button 0
 
@@ -335,9 +332,6 @@ proc init_for_platform {} {
                 # old default font for Tk 8.4 on macOS
                 # since font detection requires 8.5+
                 set ::font_family "Monaco"
-            } else {
-                # Tk Cocoa wants lower case keys when binding with shift
-                set ::bind_shiftcaps 0
             }
             option add *DialogWindow*background "#E8E8E8" startupFile
             option add *DialogWindow*Entry.highlightBackground "#E8E8E8" startupFile

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -75,7 +75,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-B> {menu_send %W bng}
     bind all <$::modifier-Shift-Key-C> {menu_send %W mycnv}
     bind all <$::modifier-Shift-Key-D> {menu_send %W vradio}
-    bind all <$::modifier-Shift-Key-H> {menu_send %W hslider}
+    bind all <$::modifier-Shift-Key-J> {menu_send %W hslider}
     bind all <$::modifier-Shift-Key-I> {menu_send %W hradio}
     bind all <$::modifier-Shift-Key-L> {menu_clear_console}
     bind all <$::modifier-Shift-Key-N> {menu_send %W numbox}
@@ -90,7 +90,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-b> {menu_send %W bng}
     bind all <$::modifier-Shift-Key-c> {menu_send %W mycnv}
     bind all <$::modifier-Shift-Key-d> {menu_send %W vradio}
-    bind all <$::modifier-Shift-Key-h> {menu_send %W hslider}
+    bind all <$::modifier-Shift-Key-j> {menu_send %W hslider}
     bind all <$::modifier-Shift-Key-i> {menu_send %W hradio}
     bind all <$::modifier-Shift-Key-l> {menu_clear_console}
     bind all <$::modifier-Shift-Key-n> {menu_send %W numbox}
@@ -135,7 +135,7 @@ proc ::pd_bindings::global_bindings {} {
         bind all <$::modifier-Shift-Key-D> {menu_send %W vradio}
         bind all <$::modifier-Shift-Key-G> {menu_send %W graph}
         bind all <$::modifier-Shift-Key-I> {menu_send %W hradio}
-        bind all <$::modifier-Shift-Key-H> {menu_send %W hslider}
+        bind all <$::modifier-Shift-Key-J> {menu_send %W hslider}
         bind all <$::modifier-Shift-Key-M> {menu_message_dialog}
         bind all <$::modifier-Shift-Key-L> {menu_clear_console}
         bind all <$::modifier-Shift-Key-N> {menu_send %W numbox}
@@ -155,7 +155,7 @@ proc ::pd_bindings::global_bindings {} {
         bind all <$::modifier-Shift-Key-d> {menu_send %W vradio}
         bind all <$::modifier-Shift-Key-g> {menu_send %W graph}
         bind all <$::modifier-Shift-Key-i> {menu_send %W hradio}
-        bind all <$::modifier-Shift-Key-h> {menu_send %W hslider}
+        bind all <$::modifier-Shift-Key-j> {menu_send %W hslider}
         bind all <$::modifier-Shift-Key-m> {menu_message_dialog}
         bind all <$::modifier-Shift-Key-l> {menu_clear_console}
         bind all <$::modifier-Shift-Key-n> {menu_send %W numbox}

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -91,7 +91,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-T> {menu_send %W toggle}
     bind all <$::modifier-Shift-Key-U> {menu_send %W vumeter}
     bind all <$::modifier-Shift-Key-V> {menu_send %W vslider}
-    bind all <$::modifier-Shift-Key-W> {menu_send_float %W menuclose 1}
+    bind all <$::modifier-Shift-Key-W> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-Z> {menu_redo}
     # lowercase bindings, for the CapsLock case
     bind all <$::modifier-Shift-Key-a> {menu_send %W menuarray}
@@ -110,7 +110,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-t> {menu_send %W toggle}
     bind all <$::modifier-Shift-Key-u> {menu_send %W vumeter}
     bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
-    bind all <$::modifier-Shift-Key-w> {menu_send_float %W menuclose 1}
+    bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
 
     # OS-specific bindings
@@ -127,7 +127,7 @@ proc ::pd_bindings::global_bindings {} {
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown
-        # these can conflict with Cmd+comma & Cmd+period bindings in Tk Cococa
+        # these can conflict with CMD+comma & CMD+period bindings in Tk Cococa
         bind all <$::modifier-greater>     {menu_raisenextwindow}
         bind all <$::modifier-less>        {menu_raisepreviouswindow}
     }
@@ -227,15 +227,15 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     # "right clicks" are defined differently on each platform
     switch -- $::windowingsystem { 
         "aqua" {
-            bind $tkcanvas <ButtonPress-2>        "pdtk_canvas_rightclick %W %x %y %b"
+            bind $tkcanvas <ButtonPress-2>    "pdtk_canvas_rightclick %W %x %y %b"
             # on Mac OS X, make a rightclick with Ctrl-click for 1 button mice
             bind $tkcanvas <Control-Button-1> "pdtk_canvas_rightclick %W %x %y %b"
         } "x11" {
-            bind $tkcanvas <ButtonPress-3>     "pdtk_canvas_rightclick %W %x %y %b"
+            bind $tkcanvas <ButtonPress-3>    "pdtk_canvas_rightclick %W %x %y %b"
             # on X11, button 2 "pastes" from the X windows clipboard
-            bind $tkcanvas <ButtonPress-2>   "pdtk_canvas_clickpaste %W %x %y %b"
+            bind $tkcanvas <ButtonPress-2>    "pdtk_canvas_clickpaste %W %x %y %b"
         } "win32" {
-            bind $tkcanvas <ButtonPress-3>   "pdtk_canvas_rightclick %W %x %y %b"
+            bind $tkcanvas <ButtonPress-3>    "pdtk_canvas_rightclick %W %x %y %b"
         }
     }
 
@@ -270,14 +270,17 @@ proc ::pd_bindings::window_focusin {mytoplevel} {
 
 # global window close event, patch windows are closed by pd
 # while other window types are closed via their own bindings
-proc ::pd_bindings::window_close {mytoplevel} {
+# force argument:
+#   0: request to close, verifying whether clean or dirty
+#   1: request to close, no verification
+proc ::pd_bindings::window_close {mytoplevel {force 0}} {
     # catch any non-existent windows
     # ie. the helpbrowser after it's been
     # closed by it's own binding
-    if {![winfo exists $mytoplevel]} {
+    if {$force eq 0 && ![winfo exists $mytoplevel]} {
         return
     }
-    menu_send_float $mytoplevel menuclose 0
+    menu_send_float $mytoplevel menuclose $force
 }
 
 # "map" event tells us when the canvas becomes visible, and "unmap",

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -37,7 +37,7 @@ proc ::pd_bindings::class_bindings {} {
 proc ::pd_bindings::global_bindings {} {
     # we use 'bind all' everywhere to get as much of Tk's automatic binding
     # behaviors as possible, things like not sending an event for 'O' when
-    # 'Control-O' is pressed.
+    # 'Control-O' is pressed
     bind all <$::modifier-Key-a>      {menu_send %W selectall}
     bind all <$::modifier-Key-b>      {menu_helpbrowser}
     bind all <$::modifier-Key-c>      {menu_send %W copy}
@@ -50,6 +50,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Key-p>      {menu_print $::focused_window}
     bind all <$::modifier-Key-r>      {menu_raise_pdwindow}
     bind all <$::modifier-Key-s>      {menu_send %W menusave}
+    bind all <$::modifier-Key-t>      {menu_font_dialog}
     bind all <$::modifier-Key-v>      {menu_send %W paste}
     bind all <$::modifier-Key-w>      {::pd_bindings::window_close %W}
     bind all <$::modifier-Key-x>      {menu_send %W cut}
@@ -65,21 +66,27 @@ proc ::pd_bindings::global_bindings {} {
     # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
     # "+" key... this only makes sense on US keyboards but some users
     # expected it... go figure.
-    bind all <$::modifier-Key-equal>  {menu_send_float %W zoom 2}
-    bind all <$::modifier-Key-plus>   {menu_send_float %W zoom 2}
-    bind all <$::modifier-Key-minus>  {menu_send_float %W zoom 1}
+    bind all <$::modifier-Key-equal>       {menu_send_float %W zoom 2}
+    bind all <$::modifier-Key-plus>        {menu_send_float %W zoom 2}
+    bind all <$::modifier-Key-minus>       {menu_send_float %W zoom 1}
     bind all <$::modifier-Key-KP_Add>      {menu_send_float %W zoom 2}
     bind all <$::modifier-Key-KP_Subtract> {menu_send_float %W zoom 1}
 
+    # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
+
     # annoying, but Tk's bind needs uppercase letter to get the Shift
+    bind all <$::modifier-Shift-Key-A> {menu_send %W menuarray}
     bind all <$::modifier-Shift-Key-B> {menu_send %W bng}
     bind all <$::modifier-Shift-Key-C> {menu_send %W mycnv}
     bind all <$::modifier-Shift-Key-D> {menu_send %W vradio}
+    bind all <$::modifier-Shift-Key-G> {menu_send %W graph}
     bind all <$::modifier-Shift-Key-J> {menu_send %W hslider}
     bind all <$::modifier-Shift-Key-I> {menu_send %W hradio}
     bind all <$::modifier-Shift-Key-L> {menu_clear_console}
+    bind all <$::modifier-Shift-Key-M> {menu_message_dialog}
     bind all <$::modifier-Shift-Key-N> {menu_send %W numbox}
     bind all <$::modifier-Shift-Key-Q> {pdsend "pd quit"}
+    bind all <$::modifier-Shift-Key-R> {menu_send %W tidy}
     bind all <$::modifier-Shift-Key-S> {menu_send %W menusaveas}
     bind all <$::modifier-Shift-Key-T> {menu_send %W toggle}
     bind all <$::modifier-Shift-Key-U> {menu_send %W vumeter}
@@ -87,86 +94,42 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-W> {menu_send_float %W menuclose 1}
     bind all <$::modifier-Shift-Key-Z> {menu_redo}
     # lowercase bindings, for the CapsLock case
+    bind all <$::modifier-Shift-Key-a> {menu_send %W menuarray}
     bind all <$::modifier-Shift-Key-b> {menu_send %W bng}
     bind all <$::modifier-Shift-Key-c> {menu_send %W mycnv}
     bind all <$::modifier-Shift-Key-d> {menu_send %W vradio}
+    bind all <$::modifier-Shift-Key-g> {menu_send %W graph}
     bind all <$::modifier-Shift-Key-j> {menu_send %W hslider}
     bind all <$::modifier-Shift-Key-i> {menu_send %W hradio}
     bind all <$::modifier-Shift-Key-l> {menu_clear_console}
+    bind all <$::modifier-Shift-Key-m> {menu_message_dialog}
     bind all <$::modifier-Shift-Key-n> {menu_send %W numbox}
     bind all <$::modifier-Shift-Key-q> {pdsend "pd quit"}
+    bind all <$::modifier-Shift-Key-r> {menu_send %W tidy}
     bind all <$::modifier-Shift-Key-s> {menu_send %W menusaveas}
     bind all <$::modifier-Shift-Key-t> {menu_send %W toggle}
     bind all <$::modifier-Shift-Key-u> {menu_send %W vumeter}
     bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
     bind all <$::modifier-Shift-Key-w> {menu_send_float %W menuclose 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
+
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
-        # Cmd-m = Minimize and Cmd-t = Font on macOS for all apps
-        bind all <$::modifier-Key-t>         {menu_font_dialog}
+         # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
         if {$::tcl_version < 8.5} {
-            # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
-            bind all <$::modifier-Key-q>     {pdsend "pd verifyquit"}
-            bind all <$::modifier-Key-m>     {menu_minimize %W}
-            bind all <$::modifier-Key-comma> {pdsend "pd start-path-dialog"}
-            bind all <$::modifier-Shift-Key-M> {menu_message_dialog}
-            bind all <$::modifier-Key-M>       {menu_minimize %W}
-            bind all <$::modifier-Key-T>       {menu_font_dialog}
-
+            bind all <$::modifier-Key-q>       {pdsend "pd verifyquit"}
+            bind all <$::modifier-Key-m>       {menu_minimize %W}
             bind all <$::modifier-quoteleft>   {menu_raisenextwindow}
         }
     } else {
         bind all <$::modifier-Key-q>       {pdsend "pd verifyquit"}
-        bind all <$::modifier-Key-M>       {menu_message_dialog}
+        bind all <$::modifier-Key-m>       {menu_minimize %W}
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown
         # these can conflict with Cmd+comma & Cmd+period bindings in Tk Cococa
         bind all <$::modifier-greater>     {menu_raisenextwindow}
         bind all <$::modifier-less>        {menu_raisepreviouswindow}
-    }
-
-    # annoying, but somtimes Tk's bind needs uppercase letters to get the Shift
-    if {$::bind_shiftcaps == 1 } {
-        bind all <$::modifier-Shift-Key-A> {menu_send %W menuarray}
-        bind all <$::modifier-Shift-Key-B> {menu_send %W bng}
-        bind all <$::modifier-Shift-Key-C> {menu_send %W mycnv}
-        bind all <$::modifier-Shift-Key-D> {menu_send %W vradio}
-        bind all <$::modifier-Shift-Key-G> {menu_send %W graph}
-        bind all <$::modifier-Shift-Key-I> {menu_send %W hradio}
-        bind all <$::modifier-Shift-Key-J> {menu_send %W hslider}
-        bind all <$::modifier-Shift-Key-M> {menu_message_dialog}
-        bind all <$::modifier-Shift-Key-L> {menu_clear_console}
-        bind all <$::modifier-Shift-Key-N> {menu_send %W numbox}
-        bind all <$::modifier-Shift-Key-Q> {pdsend "pd quit"}
-        bind all <$::modifier-Shift-Key-R> {menu_send %W tidy}
-        bind all <$::modifier-Shift-Key-S> {menu_send %W menusaveas}
-        bind all <$::modifier-Shift-Key-T> {menu_send %W toggle}
-        bind all <$::modifier-Shift-Key-U> {menu_send %W vumeter}
-        bind all <$::modifier-Shift-Key-V> {menu_send %W vslider}
-        bind all <$::modifier-Shift-Key-W> {menu_send_float %W menuclose 1}
-        bind all <$::modifier-Shift-Key-Z> {menu_redo}
-    } else {
-        # ... and sometimes not (I'm looking at you Tk Cocoa on Mac)
-        bind all <$::modifier-Shift-Key-a> {menu_send %W menuarray}
-        bind all <$::modifier-Shift-Key-b> {menu_send %W bng}
-        bind all <$::modifier-Shift-Key-c> {menu_send %W mycnv}
-        bind all <$::modifier-Shift-Key-d> {menu_send %W vradio}
-        bind all <$::modifier-Shift-Key-g> {menu_send %W graph}
-        bind all <$::modifier-Shift-Key-i> {menu_send %W hradio}
-        bind all <$::modifier-Shift-Key-j> {menu_send %W hslider}
-        bind all <$::modifier-Shift-Key-m> {menu_message_dialog}
-        bind all <$::modifier-Shift-Key-l> {menu_clear_console}
-        bind all <$::modifier-Shift-Key-n> {menu_send %W numbox}
-        bind all <$::modifier-Shift-Key-q> {pdsend "pd quit"}
-        bind all <$::modifier-Shift-Key-r> {menu_send %W tidy}
-        bind all <$::modifier-Shift-Key-s> {menu_send %W menusaveas}
-        bind all <$::modifier-Shift-Key-t> {menu_send %W toggle}
-        bind all <$::modifier-Shift-Key-u> {menu_send %W vumeter}
-        bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
-        bind all <$::modifier-Shift-Key-w> {menu_send_float %W menuclose 1}
-        bind all <$::modifier-Shift-Key-z> {menu_redo}
     }
 
     bind all <KeyPress>         {::pd_bindings::sendkey %W 1 %K %A 0}
@@ -188,17 +151,16 @@ proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
     bind $mytoplevel <$::modifier-Key-w> "dialog_${dialogname}::cancel $mytoplevel"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
-    bind $mytoplevel <$::modifier-Key-s>       {bell; break}
-    bind $mytoplevel <$::modifier-Shift-Key-s> {bell; break}
-    bind $mytoplevel <$::modifier-Shift-Key-S> {bell; break}
-    bind $mytoplevel <$::modifier-Key-p>       {bell; break}
-    bind $mytoplevel <$::modifier-Key-t>       {bell; break}
-    # and the CapsLock case...
-    bind $mytoplevel <$::modifier-Key-W> "dialog_${dialogname}::cancel $mytoplevel"
-    bind $mytoplevel <$::modifier-Key-S>       {bell; break}
-    bind $mytoplevel <$::modifier-Shift-Key-s> {bell; break}
-    bind $mytoplevel <$::modifier-Key-P>       {bell; break}
-    bind $mytoplevel <$::modifier-Key-T>       {bell; break}
+    if {$mytoplevel ne".find"} {
+        bind $mytoplevel <$::modifier-Key-s>       {bell; break}
+        bind $mytoplevel <$::modifier-Shift-Key-s> {bell; break}
+        bind $mytoplevel <$::modifier-Shift-Key-S> {bell; break}
+        bind $mytoplevel <$::modifier-Key-p>       {bell; break}
+    } else {
+        # find may may allow passthrough to it's target search patch
+        ::dialog_find::update_bindings
+    }
+    bind $mytoplevel <$::modifier-Key-t>           {bell; break}
 
     wm protocol $mytoplevel WM_DELETE_WINDOW "dialog_${dialogname}::cancel $mytoplevel"
 }
@@ -220,10 +182,10 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     # mouse bindings -----------------------------------------------------------
     # these need to be bound to $tkcanvas because %W will return $mytoplevel for
     # events over the window frame and $tkcanvas for events over the canvas
-    bind $tkcanvas <Motion>                   "pdtk_canvas_motion %W %x %y 0"
-    bind $tkcanvas <Shift-Motion>             "pdtk_canvas_motion %W %x %y 1"
-    bind $tkcanvas <$::modifier-Motion>       "pdtk_canvas_motion %W %x %y 2"
-    bind $tkcanvas <$::modifier-Shift-Motion> "pdtk_canvas_motion %W %x %y 3"
+    bind $tkcanvas <Motion>                    "pdtk_canvas_motion %W %x %y 0"
+    bind $tkcanvas <Shift-Motion>              "pdtk_canvas_motion %W %x %y 1"
+    bind $tkcanvas <$::modifier-Motion>        "pdtk_canvas_motion %W %x %y 2"
+    bind $tkcanvas <$::modifier-Shift-Motion>  "pdtk_canvas_motion %W %x %y 3"
     bind $tkcanvas <$alt-Motion>               "pdtk_canvas_motion %W %x %y 4"
     bind $tkcanvas <$alt-Shift-Motion>         "pdtk_canvas_motion %W %x %y 5"
     bind $tkcanvas <$::modifier-$alt-Motion>   "pdtk_canvas_motion %W %x %y 6"

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -103,7 +103,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-z> {menu_redo}
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
-        # Cmd-m = Minimize and Cmd-t = Font on Mac OS X for all apps
+        # Cmd-m = Minimize and Cmd-t = Font on macOS for all apps
         bind all <$::modifier-Key-t>         {menu_font_dialog}
         if {$::tcl_version < 8.5} {
             # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
@@ -118,9 +118,7 @@ proc ::pd_bindings::global_bindings {} {
         }
     } else {
         bind all <$::modifier-Key-q>       {pdsend "pd verifyquit"}
-        #bind all <$::modifier-Key-t>       {menu_texteditor}
         bind all <$::modifier-Key-M>       {menu_message_dialog}
-        #bind all <$::modifier-Key-T>       {menu_texteditor}
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -37,7 +37,8 @@ proc ::pd_menucommands::menu_open {} {
 # TODO set the current font family & size via the -fontmap option:
 # http://wiki.tcl.tk/41871
 proc ::pd_menucommands::menu_print {mytoplevel} {
-    set filename [tk_getSaveFile -initialfile pd.ps \
+    set initialfile "[file rootname [lookup_windowname $mytoplevel]].ps"
+    set filename [tk_getSaveFile -initialfile $initialfile \
                       -defaultextension .ps \
                       -filetypes { {{postscript} {.ps}} }]
     if {$filename ne ""} {

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -42,7 +42,7 @@ proc ::pd_menucommands::menu_print {mytoplevel} {
                       -filetypes { {{postscript} {.ps}} }]
     if {$filename ne ""} {
         set tkcanvas [tkcanvas_name $mytoplevel]
-        $tkcanvas postscript -file $filename 
+        $tkcanvas postscript -file $filename
     }
 }
 
@@ -142,10 +142,6 @@ proc ::pd_menucommands::menu_startup_dialog {} {
 
 proc ::pd_menucommands::menu_helpbrowser {} {
     ::helpbrowser::open_helpbrowser
-}
-
-proc ::pd_menucommands::menu_texteditor {} {
-    ::pdwindow::error "the text editor is not implemented"
 }
 
 # ------------------------------------------------------------------------------

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -40,10 +40,20 @@ proc ::pd_menucommands::menu_print {mytoplevel} {
     set initialfile "[file rootname [lookup_windowname $mytoplevel]].ps"
     set filename [tk_getSaveFile -initialfile $initialfile \
                       -defaultextension .ps \
-                      -filetypes { {{postscript} {.ps}} }]
+                      -filetypes { {{Postscript} {.ps}} }]
     if {$filename ne ""} {
         set tkcanvas [tkcanvas_name $mytoplevel]
-        $tkcanvas postscript -file $filename
+        if {$::font_family eq "DejaVu Sans Mono"} {
+            # FIXME hack to fix incorrect PS font naming,
+            # this could be removed in the future
+            set ps [$tkcanvas postscript]
+            regsub -all "DejavuSansMono" $ps "DejaVuSansMono" ps
+            set f [open $filename w]
+            puts $f $ps
+            close $f
+        } else {
+            $tkcanvas postscript -file $filename
+        }
     }
 }
 

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -117,7 +117,15 @@ proc ::pd_menus::configure_for_dialog {mytoplevel} {
     # the ones that make sense in the Find dialog panel and it's canvas
     # File menu
     $menubar.file entryconfigure [_ "Close"] -state disabled
-    if {$mytoplevel ne ".find" && $mytoplevel ne ".pdwindow"} {
+    if {$mytoplevel eq ".find"} {
+        # these bindings are passed through Find to it's target search window
+        $menubar.file entryconfigure [_ "Save As..."] -state disabled
+        if {$mytoplevel ne ".pdwindow"} {
+            # these don't do anything in the pdwindow
+            $menubar.file entryconfigure [_ "Save"] -state disabled
+            $menubar.file entryconfigure [_ "Print..."] -state disabled
+        }
+    } else {
         $menubar.file entryconfigure [_ "Save"] -state disabled
         $menubar.file entryconfigure [_ "Save As..."] -state disabled
         $menubar.file entryconfigure [_ "Print..."] -state disabled

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -226,7 +226,7 @@ proc ::pd_menus::build_put_menu {mymenu} {
         -command {menu_send $::focused_window numbox}
     $mymenu add command -label [_ "Vslider"]  -accelerator "Shift+$accelerator+V" \
         -command {menu_send $::focused_window vslider}
-    $mymenu add command -label [_ "Hslider"]  -accelerator "Shift+$accelerator+H" \
+    $mymenu add command -label [_ "Hslider"]  -accelerator "Shift+$accelerator+J" \
         -command {menu_send $::focused_window hslider}
     $mymenu add command -label [_ "Vradio"]   -accelerator "Shift+$accelerator+D" \
         -command {menu_send $::focused_window vradio}

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -57,10 +57,11 @@ proc ::pd_menus::configure_for_pdwindow {} {
     variable menubar
     # these are meaningless for the Pd window, so disable them
     # File menu
+    $menubar.file entryconfigure [_ "Close"] -state disabled
     $menubar.file entryconfigure [_ "Save"] -state disabled
     $menubar.file entryconfigure [_ "Save As..."] -state normal
     $menubar.file entryconfigure [_ "Print..."] -state disabled
-    $menubar.file entryconfigure [_ "Close"] -state disabled
+
     # Edit menu
     $menubar.edit entryconfigure [_ "Duplicate"] -state disabled
     $menubar.edit entryconfigure [_ "Font"] -state normal
@@ -85,10 +86,10 @@ proc ::pd_menus::configure_for_pdwindow {} {
 proc ::pd_menus::configure_for_canvas {mytoplevel} {
     variable menubar
     # File menu
+    $menubar.file entryconfigure [_ "Close"] -state normal
     $menubar.file entryconfigure [_ "Save"] -state normal
     $menubar.file entryconfigure [_ "Save As..."] -state normal
     $menubar.file entryconfigure [_ "Print..."] -state normal
-    $menubar.file entryconfigure [_ "Close"] -state normal
     # Edit menu
     $menubar.edit entryconfigure [_ "Duplicate"] -state normal
     $menubar.edit entryconfigure [_ "Font"] -state normal
@@ -113,14 +114,15 @@ proc ::pd_menus::configure_for_canvas {mytoplevel} {
 proc ::pd_menus::configure_for_dialog {mytoplevel} {
     variable menubar
     # these are meaningless for the dialog panels, so disable them except for
-    # the ones that make sense in the Find dialog panel
+    # the ones that make sense in the Find dialog panel and it's canvas
     # File menu
-    if {$mytoplevel ne ".find"} {
+    $menubar.file entryconfigure [_ "Close"] -state disabled
+    if {$mytoplevel ne ".find" && $mytoplevel ne ".pdwindow"} {
         $menubar.file entryconfigure [_ "Save"] -state disabled
         $menubar.file entryconfigure [_ "Save As..."] -state disabled
         $menubar.file entryconfigure [_ "Print..."] -state disabled
     }
-    $menubar.file entryconfigure [_ "Close"] -state disabled
+
     # Edit menu
     $menubar.edit entryconfigure [_ "Font"] -state disabled
     $menubar.edit entryconfigure [_ "Duplicate"] -state disabled
@@ -305,6 +307,8 @@ proc ::pd_menus::build_window_menu {mymenu} {
                 -command {menu_bringalltofront}
         }
     } else {
+        $mymenu add command -label [_ "Minimize"] -accelerator "$accelerator+M" \
+                -command {menu_minimize $::focused_window}
         $mymenu add command -label [_ "Next Window"] \
             -command {menu_raisenextwindow} \
             -accelerator [_ "$accelerator+Page Down"]

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -180,8 +180,6 @@ proc ::pd_menus::build_edit_menu {mymenu} {
     $mymenu add command -label [_ "Select All"] -accelerator "$accelerator+A" \
         -command {menu_send $::focused_window selectall}
     $mymenu add  separator
-#   $mymenu add command -label [_ "Text Editor"] -accelerator "$accelerator+T" \
-#       -command {menu_texteditor}
     $mymenu add command -label [_ "Font"]       -accelerator "$accelerator+T" \
         -command {menu_font_dialog}
     $mymenu add command -label [_ "Zoom In"]    -accelerator "$accelerator++" \

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -163,7 +163,7 @@ proc ::pd_menus::build_file_menu {mymenu} {
     $mymenu entryconfigure [_ "Save"]       -command {menu_send $::focused_window menusave}
     $mymenu entryconfigure [_ "Save As..."] -command {menu_send $::focused_window menusaveas}
     #$mymenu entryconfigure [_ "Revert*"]    -command {menu_revert $::focused_window}
-    $mymenu entryconfigure [_ "Close"]      -command {menu_send_float $::focused_window menuclose 0}
+    $mymenu entryconfigure [_ "Close"]      -command {::pd_bindings::window_close $::focused_window}
     $mymenu entryconfigure [_ "Message..."] -command {menu_message_dialog}
     $mymenu entryconfigure [_ "Print..."]   -command {menu_print $::focused_window}
     # update recent files

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -220,9 +220,6 @@ proc ::pdwindow::pdwindow_bindings {} {
     # so no more bindings run
     bind .pdwindow <$::modifier-Key-s> {bell; break}
     bind .pdwindow <$::modifier-Key-p> {bell; break}
-    # and the CapsLock case...
-    bind .pdwindow <$::modifier-Key-S> {bell; break}
-    bind .pdwindow <$::modifier-Key-P> {bell; break}
 
     # ways of hiding/closing the Pd window
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -160,7 +160,9 @@ proc ::pdwindow::save_logbuffer_to_file {} {
     puts $f "Pd $::PD_MAJOR_VERSION.$::PD_MINOR_VERSION.$::PD_BUGFIX_VERSION.$::PD_TEST_VERSION on $::windowingsystem"
     puts $f "Tcl/Tk [info patchlevel]"
     puts $f "------------------------------------------------------------------------------"
-    puts $f $logbuffer
+    foreach {object_id level message} $logbuffer {
+        puts $f $message
+    }
     close $f
 }
 # this has 'args' to satisfy trace, but its not used


### PR DESCRIPTION
This PR addresses some keybinding issues & feedback from 0.48.0test5 (as well as other stuff I found):

* changed hsl bindings back to MOD-Shift-J, this fixes the MOD-Shift-H binding triggering the default "hide Pd" behavior on macOS

* cleaned up extraneous bindings (non-shift bindings don't need a double bind with uppercase, checking for TK 8.5 not really needed for most things), this was a vestige of my previous work updating things for TK 8.5+ on macOS & the upper case shift key bindings from IOhannes

* menu_print now uses the canvas window name + .ps extension for the default filename

* make sure find_dialog is raised on creation, this fixes Find sometimes opening behind a canvas window

* fixed find_dialog print, save, & saveas key binding pass through & update the menus to reflect this, also no longer set the print pass through bindings if the target search window is the Pd Window

* window focus is now shifted to target/next available after find window is closed

* show Pd window on macOS when the dock icon is clicked and there are no windows visible

Some TODOs ~remain~ and done:

* [x] opening a find window for a patch & then closing the patch leaves stale Find keybindings
* [x] Pd window saves log output is not fully escaped and contains the buffer Tcl list braces
* [x] find dialog sometimes moves & closes wth canvas window
* [x] Pd gui crash on occasional find creation after open/close cycle