### PR TITLE
verbose log print for deken platform

### DIFF
--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -237,6 +237,9 @@ if { "" != "$::current_plugin_loadpath" } {
     ::pdwindow::post "\n"
     ::pdwindow::post [format [_ "\[deken\] Platform detected: %s" ] $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit ]
     ::pdwindow::post "\n"
+} else {
+    ::pdwindow::verbose 0 [format [_ "\[deken\] Platform detected: %s" ] $::deken::platform(os)-$::deken::platform(machine)-$::deken::platform(bits)bit ]
+    ::pdwindow::verbose 0 "\n"
 }
 
 # architectures that can be substituted for eachother


### PR DESCRIPTION
This small PR adds a verbose log print for the detected deken platform. This should be help when debugging issues with deken included in Pd.

This is also in a PR to the deken repo: https://github.com/pure-data/deken/pull/158