### PR TITLE
Further helpbrowser updates

### DIFF
--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -136,6 +136,9 @@ proc ::dialog_path::edit { currentpath } {
 proc ::dialog_path::commit { new_path } {
     global use_standard_paths_button
     global verbose_button
+    set changed false
+    if {"$new_path" ne "$::sys_searchpath"} {set changed true}
     set ::sys_searchpath $new_path
     pdsend "pd path-dialog $use_standard_paths_button $verbose_button [pdtk_encode $::sys_searchpath]"
+    if {$changed} {::helpbrowser::refresh}
 }

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -61,7 +61,6 @@ proc ::helpbrowser::check_destroy {level} {
     # check for [file readable]?
     # requires Tcl 8.5 but probably deals with special chars better:
     #        destroy {*}[lrange [winfo children .helpbrowser.frame] [expr {2 * $count}] end]
-
     if {[catch { eval destroy $winlist } errorMessage]} {
         ::pdwindow::error "helpbrowser: error destroying listbox\n"
     }
@@ -182,8 +181,7 @@ proc ::helpbrowser::root_navigate {window x y} {
     }
     set filename $reference_paths($item)
     if {[file isdirectory $filename]} {
-        # FIXME the lbox var is not used, but seems to fix an error
-        set lbox [make_liblistbox $filename false]
+        make_liblistbox $filename false
     }
 }
 
@@ -359,8 +357,7 @@ proc ::helpbrowser::dir_navigate {dir count window x y} {
     if {$count > $maxcols} {return}
     set dir_to_open [file join $dir $newdir]
     if {[file isdirectory $dir_to_open]} {
-        # FIXME the lbox var is not used, but seems to fix an error
-        set lbox [make_doclistbox $dir_to_open $count false]
+        make_doclistbox $dir_to_open $count false
     }
 }
 

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -410,6 +410,7 @@ proc ::helpbrowser::build_references {} {
     variable reference_count
     variable reference_paths
 
+    set searchpaths {}
     array set reference_count {}
     array set reference_paths [list " Pure Data/" $::sys_libdir/doc \
                                     "-------- Libraries --------" "" ]
@@ -418,33 +419,34 @@ proc ::helpbrowser::build_references {} {
     foreach pathdir $::sys_staticpath {
         if { ! [file isdirectory $pathdir]} {continue}
 
-        # Fix the directory name, this ensures the directory name is in the
-        # native format for the platform and contains a final directory separator
+        # fix the directory name, this ensures the directory name is in the
+        # native format for the platform and contains a final dir separator
         set dir [string trimright [file join [file normalize $pathdir] { }]]
 
-        # entry for each subdir of this directory in Help browser's root column
+        # add an entry for each subdir of this directory in the root column
         foreach filename [glob -nocomplain -type d -path $dir "*"] {
-            add_entry libdirlist $filename
+            lappend searchpaths $filename
         }
 
         # don't add core object references to root column
         if {[string match "*doc/5.reference" $pathdir]} {continue}
 
-        ## find stray help patches
+        # find stray help patches
         foreach filename [glob -nocomplain -type f -path $dir "*-help.pd"] {
             add_entry helplist $filename
         }
     }
 
     # sys_searchpath (aka preferences)
-    # remove any exact duplicates from the user search paths and
-    # add an entry for seach directory in Help browser's root column
-    set searchpaths {}
     foreach pathdir $::sys_searchpath {
-        set dir [string trimright [file join [file normalize $pathdir] { }]]
+        set dir [string trimright [file normalize $pathdir]]
         lappend searchpaths $dir
     }
+
+    # remove any *exact* duplicates between user search paths and system paths
     set searchpaths [lsort -unique $searchpaths]
+
+    # now add all search path entries to the Help browser's root column
     foreach pathdir $searchpaths {
         if { ! [file isdirectory $pathdir]} {continue}
         add_entry libdirlist $pathdir

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -34,7 +34,7 @@ proc ::helpbrowser::open_helpbrowser {} {
         }
 
         # set the maximum number of child columns to create
-        set ::helpbrowser::maxcols 3
+        set ::helpbrowser::maxcols 5
 
         # TODO wrap frame in a canvas with a horz scrollbar,
         # currently we simply add cols to the left until we reach max cols
@@ -427,7 +427,7 @@ proc ::helpbrowser::add_entry {reflist entry} {
 }
 
 proc ::helpbrowser::build_references {} {
-    variable libdirlist {" Pure Data/" "-------- Libraries --------"}
+    variable libdirlist {" Pure Data/" "-------- Externals --------"}
     variable helplist {}
     variable reference_count
     variable reference_paths
@@ -435,7 +435,7 @@ proc ::helpbrowser::build_references {} {
     set searchpaths {}
     array set reference_count {}
     array set reference_paths [list " Pure Data/" $::sys_libdir/doc \
-                                    "-------- Libraries --------" "" ]
+                                    "-------- Externals --------" "" ]
 
     # sys_staticpath (aka hardcoded)
     foreach pathdir $::sys_staticpath {

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -24,6 +24,9 @@ proc ::helpbrowser::open_helpbrowser {} {
         wm group .helpbrowser .
         wm transient .helpbrowser
         wm title .helpbrowser [_ "Help Browser"]
+
+        bind .helpbrowser <$::modifier-Shift-Key-r> "::helpbrowser::refresh"
+        bind .helpbrowser <$::modifier-Shift-Key-R> "::helpbrowser::refresh"
         bind .helpbrowser <$::modifier-Key-w> "wm withdraw .helpbrowser"
 
         if {$::windowingsystem eq "aqua"} {

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -333,12 +333,13 @@ proc ::pd_menus::build_window_menu {mymenu} {
 }
 
 proc ::pd_menus::build_help_menu {mymenu} {
+    variable accelerator
     if {$::windowingsystem ne "aqua"} {
         $mymenu add command -label [_ "About Pd"] -command {menu_aboutpd}
     }
     $mymenu add command -label [_ "HTML Manual..."] \
         -command {menu_doc_open doc/1.manual index.htm}
-    $mymenu add command -label [_ "Browser..."] \
+    $mymenu add command -label [_ "Browser..."] -accelerator "$accelerator+B" \
         -command {menu_helpbrowser}
     $mymenu add command -label [_ "List of objects..."] \
         -command {menu_objectlist}


### PR DESCRIPTION
Yet more help browser updates, partially from test release feedback:

* [x] catch duplicates in both static *and* user search paths
* [x] added missing MOD+B menu accelerator
* [x] now refreshes automatically if paths have changed when pressing Path dialog ok
* [x] added MOD-Shift-R manual refresh binding
* [x] renamed "Libraries" header text to "Externals"