### PR TITLE
expr mention in the release notes not accurate

### DIFF
--- a/doc/1.manual/x5.htm
+++ b/doc/1.manual/x5.htm
@@ -35,9 +35,7 @@ stuff and path maintanance.
 <P> The expr family (expr, expr~, fexpr~) got an update from Shahrokh Yadegari,
 and the help file was reorganized and updated by Alexandre Porres.  Many more
 math functions are supported, and the parser was updated so that expressions
-using "if" skip evaluating the argument that isn't used.  In an older
-improvement that wasn't reported here, expr can read and write variables
-stored in "v" objects.
+using "if" skip evaluating the argument that isn't used.
 
 <P> New "fudiparse", "fudiformat" objects.
 


### PR DESCRIPTION
hi, I removed this mentioning of the "value" object, because that had in fact already been mentioned before, see notes for 0.47-0 release.

"Shahrokh Yadegari has updated the
source and made manifold improvements in the objects.  Notably, they now allow
access to variables in Pd defined via the "value" object."

The problem is that it wasn't then that it was able to access variables defined via "value" objects. In 0.47-0, expr version was upgraded to version 0.5, and this feature was added in expr version 0.4, which seems to pretty old, but older than that.

Anyway, maybe not a big deal and just leave as it is, but I thought it was pretty weird to mention this feature twice, in close versions in the release notes, saying it hadn't been mentioned before, when it actually had.

cheers