### PR TITLE
Fix incorrect paths in About Pd menu command

### DIFF
--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -234,7 +234,7 @@ proc ::pd_menucommands::menu_aboutpd {} {
         set textfile [open $filename]
         while {![eof $textfile]} {
             set bigstring [read $textfile 1000]
-            regsub -all PD_BASEDIR $bigstring $::sys_guidir bigstring2
+            regsub -all PD_BASEDIR $bigstring $::sys_libdir bigstring2
             regsub -all PD_VERSION $bigstring2 $versionstring bigstring3
             .aboutpd.text insert end $bigstring3
         }


### PR DESCRIPTION
When clicking About Pd, the path for doc/1.manual and LICENSE.txt is incorrect.