### PR TITLE
set deken arch from pd-core

### DIFF
--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -253,6 +253,19 @@ set ::deken::architecture_substitutes(ppc) [list "PowerPC"]
 # try to set install path when plugin is loaded
 set ::deken::installpath [::deken::find_installpath]
 
+proc ::deken::set_platform {os machine bits floatwidth} {
+    if { $os != $::deken::platform(os) ||
+         $machine != $::deken::platform(machine) ||
+         $bits != $::deken::platform(bits)} {
+        set ::deken::platform(os) ${os}
+        set ::deken::platform(machine) ${machine}
+        set ::deken::platform(bits) ${bits}
+
+        ::pdwindow::verbose 1 [format [_ "\[deken\] Platform re-detected: %s" ] ${os}-${machine}-${bits}bit ]
+        ::pdwindow::verbose 1 "\n"
+    }
+}
+
 proc ::deken::status {msg} {
     #variable mytoplevelref
     #$mytoplevelref.results insert end "$msg\n"


### PR DESCRIPTION
this adds a small callback function to `deken`, so the Pd-core can send the proper architecture to the deken (since Pd-GUI can run on a different architecture than Pd-Core).
In Pd-core there is a corresponding function that sends the current architecture up (including OS, CPU, pointer-size and float-size)

the patch still ignores the `bits` field (i think the arch-string requires more discussion anyhow, see  pure-data/deken/issues/161)