### PR TITLE
Pd Help menu now opens manual

### DIFF
--- a/tcl/apple_events.tcl
+++ b/tcl/apple_events.tcl
@@ -57,7 +57,7 @@ proc ::tk::mac::Quit {args} {
 # is provided by default and cannot disabled or removed 
 proc ::tk::mac::ShowHelp {args} {
     ::pdwindow::verbose 1 "::tk::mac::ShowHelp $args ++++++++++++\n"
-    ::pd_menucommands::menu_helpbrowser
+    ::pd_menucommands::menu_manual
 }
 
 # these I gleaned by reading the source (tkMacOSXHLEvents.c)

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -151,6 +151,10 @@ proc ::pd_menucommands::menu_startup_dialog {} {
     }
 }
 
+proc ::pd_menucommands::menu_manual {} {
+    ::pd_menucommands::menu_doc_open doc/1.manual index.htm
+}
+
 proc ::pd_menucommands::menu_helpbrowser {} {
     ::helpbrowser::open_helpbrowser
 }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -335,10 +335,14 @@ proc ::pd_menus::build_window_menu {mymenu} {
 proc ::pd_menus::build_help_menu {mymenu} {
     variable accelerator
     if {$::windowingsystem ne "aqua"} {
+        # Tk creates this automatically on Mac
         $mymenu add command -label [_ "About Pd"] -command {menu_aboutpd}
     }
-    $mymenu add command -label [_ "HTML Manual..."] \
-        -command {menu_doc_open doc/1.manual index.htm}
+    if {$::windowingsystem ne "aqua" || $::tcl_version < 8.5} {
+        # TK 8.5+ on Mac creates this automatically, other platforms do not
+        $mymenu add command -label [_ "HTML Manual..."] \
+                -command {menu_manual}
+    }
     $mymenu add command -label [_ "Browser..."] -accelerator "$accelerator+B" \
         -command {menu_helpbrowser}
     $mymenu add command -label [_ "List of objects..."] \


### PR DESCRIPTION
This PR changes the Help menu on macOS when TK > 8.5:

* Pd Help menu now opens manual
* HTML Manual... entry removed

The Pd Help entry is created automatically by Tk Cocoa and cannot be changed or removed. This solution simple uses it in lieu of the HTML Manual... entry to avoid duplicate menu entries at the slight cost of a different menu entry name on 1 platform.

This fixes #172.