### PR TITLE
[WIP] MIDI updates

### DIFF
--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -84,7 +84,7 @@ static double sys_newdactimeminusrealtime = -1e20;
 static double sys_newadctimeminusrealtime = -1e20;
 static double sys_whenupdate;
 
-void sys_initmidiqueue( void)
+void sys_initmidiqueue(void)
 {
     sys_midiinittime = clock_getlogicaltime();
     sys_dactimeminusrealtime = sys_adctimeminusrealtime = 0;
@@ -118,17 +118,17 @@ void sys_setmiditimediff(double inbuftime, double outbuftime)
     /* return the logical time of the DAC sample we believe is currently
     going out, based on how much "system time" has elapsed since the
     last time sys_setmiditimediff got called. */
-static double sys_getmidioutrealtime( void)
+static double sys_getmidioutrealtime(void)
 {
     return (sys_getrealtime() + sys_dactimeminusrealtime);
 }
 
-static double sys_getmidiinrealtime( void)
+static double sys_getmidiinrealtime(void)
 {
     return (sys_getrealtime() + sys_adctimeminusrealtime);
 }
 
-static void sys_putnext( void)
+static void sys_putnext(void)
 {
     int portno = midi_outqueue[midi_outtail].q_portno;
 #ifdef USEAPI_ALSA
@@ -154,7 +154,7 @@ static void sys_putnext( void)
 
 /*  #define TEST_DEJITTER */
 
-void sys_pollmidioutqueue( void)
+void sys_pollmidioutqueue(void)
 {
 #ifdef TEST_DEJITTER
     static int db = 0;
@@ -553,7 +553,7 @@ static void sys_dispatchnextmidiin(void)
     midi_intail = (midi_intail + 1 == MIDIQSIZE ? 0 : midi_intail + 1);
 }
 
-void sys_pollmidiinqueue( void)
+void sys_pollmidiinqueue(void)
 {
 #ifdef TEST_DEJITTER
     static int db = 0;
@@ -594,8 +594,6 @@ void sys_pollmidiinqueue( void)
     /* this should be called from the system dependent MIDI code when a byte
     comes in, as a result of our calling sys_poll_midi.  We stick it on a
     timetag queue and dispatch it at the appropriate logical time. */
-
-
 void sys_midibytein(int portno, int byte)
 {
     static int warned = 0;
@@ -621,7 +619,7 @@ void sys_midibytein(int portno, int byte)
     sys_pollmidiinqueue();
 }
 
-void sys_pollmidiqueue( void)
+void sys_pollmidiqueue(void)
 {
 #if 0
     static double lasttime;
@@ -647,12 +645,11 @@ void sys_pollmidiqueue( void)
 
 #define DEVONSET 1  /* To agree with command line flags, normally start at 1 */
 
-
 #ifdef USEAPI_ALSA
-void midi_alsa_init( void);
+void midi_alsa_init(void);
 #endif
 #ifdef USEAPI_OSS
-void midi_oss_init( void);
+void midi_oss_init(void);
 #endif
 
     /* last requested parameters */
@@ -734,9 +731,9 @@ void sys_open_midi(int nmidiindev, int *midiindev,
         midi_oss_init();
 #endif
 #ifdef USEAPI_ALSA
-        if (sys_midiapi == API_ALSA)
-            sys_alsa_do_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev);
-        else
+    if (sys_midiapi == API_ALSA)
+        sys_alsa_do_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev);
+    else
 #endif /* ALSA */
             sys_do_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev);
     }
@@ -748,7 +745,7 @@ void sys_open_midi(int nmidiindev, int *midiindev,
 }
 
     /* open midi using whatever parameters were last used */
-void sys_reopen_midi( void)
+void sys_reopen_midi(void)
 {
     int nmidiindev, midiindev[MAXMIDIINDEV];
     int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
@@ -756,7 +753,7 @@ void sys_reopen_midi( void)
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 1);
 }
 
-void sys_listmididevs(void )
+void sys_listmididevs(void)
 {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i;
@@ -802,7 +799,7 @@ void glob_midi_setapi(void *dummy, t_floatarg f)
             sys_alsa_close_midi();
         else
 #endif
-              sys_close_midi();
+            sys_close_midi();
         sys_midiapi = newapi;
         sys_reopen_midi();
     }
@@ -972,9 +969,8 @@ void sys_get_midi_devs(char *indevlist, int *nindevs,
   midi_getdevs(indevlist, nindevs, outdevlist, noutdevs, maxndevs, devdescsize);
 }
 
-/* convert a device name to a (1-based) device number.  (Output device if
-'output' parameter is true, otherwise input device).  Negative on failure. */
-
+/* convert a device name to a (1-based) device number. (Output device if
+'output' parameter is true, otherwise input device). Negative on failure. */
 int sys_mididevnametonumber(int output, const char *name)
 {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
@@ -1016,10 +1012,8 @@ int sys_mididevnametonumber(int output, const char *name)
     return (-1);
 }
 
-/* convert a (1-based) device number to a device name.  (Output device if
-'output' parameter is true, otherwise input device).  Empty string on failure.
-*/
-
+/* convert a (1-based) device number to a device name. (Output device if
+'output' parameter is true, otherwise input device). Empty string on failure. */
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize)
 {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -294,6 +294,7 @@ void inmidi_pitchbend(int portno, int channel, int value);
 void inmidi_aftertouch(int portno, int channel, int value);
 void inmidi_polyaftertouch(int portno, int channel, int pitch, int value);
 void inmidi_clk(double timing);
+void inmidi_songpos(int portno, int value);
 
 static void sys_dispatchnextmidiin(void)
 {
@@ -406,7 +407,10 @@ static void sys_dispatchnextmidiin(void)
                     break;
                 case MIDI_SONGPOS:
                     if (gotbyte1)
+                    {
+                        inmidi_songpos(portno, ((byte << 7) + byte1));
                         parserp->mp_gotbyte1 = 0, parser->mp_status = 0;
+                    }
                     else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_SONGSELECT:

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -258,7 +258,7 @@ void outmidi_polyaftertouch(int portno, int channel, int pitch, int value)
 
 void outmidi_mclk(int portno)
 {
-   sys_queuemidimess(portno, 1, 0xf8, 0,0);
+   sys_queuemidimess(portno, 1, MIDI_CLOCK, 0, 0);
 }
 
 void outmidi_byte(int portno, int value)
@@ -273,6 +273,21 @@ void outmidi_byte(int portno, int value)
     {
       sys_putmidibyte(portno, value);
     }
+}
+
+void outmidi_songpos(int portno, int value)
+{
+    if (value < 0) value = 0;
+    else if (value > 16383) value = 16383;
+    sys_queuemidimess(portno, 0, MIDI_SONGPOS,
+        (value & 127), ((value>>7) & 127));
+}
+
+void outmidi_song(int portno, int value)
+{
+    if (value < 0) value = 0;
+    else if (value > 127) value = 127;
+    sys_queuemidimess(portno, 0, MIDI_SONGSELECT, value, 0);
 }
 
 /* ------------------------- MIDI input queue handling ------------------ */
@@ -295,6 +310,7 @@ void inmidi_aftertouch(int portno, int channel, int value);
 void inmidi_polyaftertouch(int portno, int channel, int pitch, int value);
 void inmidi_clk(double timing);
 void inmidi_songpos(int portno, int value);
+void inmidi_song(int portno, int value);
 
 static void sys_dispatchnextmidiin(void)
 {
@@ -414,6 +430,7 @@ static void sys_dispatchnextmidiin(void)
                     else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_SONGSELECT:
+                    inmidi_song(portno, byte);
                     parserp->mp_status = 0;
                     break;
             }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -293,32 +293,32 @@ void outmidi_song(int portno, int value)
 void outmidi_timecode(int portno, int hour, int minute,
     int second, int frame, int fps)
 {
-    /* these values are 4 bit */
+    /* 6 bit */
     if (minute < 0) minute = 0;
-    else if (minute > 255) minute = 255;
+    else if (minute > 59) minute = 59;
     if (second < 0) second = 0;
-    else if (second > 255) second = 255;
-    if (frame < 0) frame = 0;
-    else if (frame > 255) frame = 255;
-    /* these are not */
+    else if (second > 59) second = 59;
+    /* 5 bit */
     if (hour < 0) hour = 0;
-    else if (hour > 511) hour = 511;
-    /* valid fps values are 0x0-0x3 */
+    else if (hour > 23) hour = 23;
+    if (frame < 0) frame = 0;
+    else if (frame > 29) frame = 29;
+    /* 2 bit */
     if (fps < 0) fps = 0;
     else if (fps > 3) fps = 3;
     //post("%02d:%02d:%02d:%02d %02d fps", hour, minute, second, frame, fps);
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
         0x00 | (frame & 0x0F), 0);             /* low nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
-        0x10 | ((frame & 0xF0) >> 4), 0);      /* high nibble */
+        0x10 | ((frame & 0x10) >> 4), 0);      /* high nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
         0x20 | (second & 0x0F), 0);            /* low nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
-        0x30 | ((second & 0xF0) >> 4), 0);     /* high nibble */
+        0x30 | ((second & 0x30) >> 4), 0);     /* high nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
         0x40 | (minute & 0x0F), 0);            /* low nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
-        0x50 | ((minute & 0xF0) >> 4), 0);     /* high nibble */
+        0x50 | ((minute & 0x30) >> 4), 0);     /* high nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,
         0x60 | (hour & 0x0F), 0);              /* low nibble */
     sys_queuemidimess(portno, 0, MIDI_TIMECODE,

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -24,6 +24,35 @@
 #include <stdio.h>
 #include <signal.h>
 
+/* channel voice messages */     /* dec, # */
+#define MIDI_NOTEOFF        0x80 /* 128, 2 */
+#define MIDI_NOTEON         0x90 /* 144, 2 */
+#define MIDI_POLYAFTERTOUCH 0xa0 /* 160, 2 (aka key pressure) */
+#define MIDI_CONTROLCHANGE  0xb0 /* 176, 2 */
+#define MIDI_PROGRAMCHANGE  0xc0 /* 192, 1 */
+#define MIDI_AFTERTOUCH     0xd0 /* 208, 1 (aka channel pressure) */
+#define MIDI_PITCHBEND      0xe0 /* 224, 2 */
+
+/* system common messages */
+#define MIDI_SYSEX          0xf0 /* 240, N (until MIDI_SYSEXEND) */
+#define MIDI_TIMECODE       0xf1 /* 241, 1 */
+#define MIDI_SONGPOS        0xf2 /* 242, 2 */
+#define MIDI_SONGSELECT     0xf3 /* 243, 1 */
+#define MIDI_RESERVED1      0xf4 /* 244, ? */
+#define MIDI_RESERVED2      0xf5 /* 245, ? */
+#define MIDI_TUNEREQUEST    0xf6 /* 246, 0 */
+#define MIDI_SYSEXEND       0xf7 /* 247, 0 */
+
+/* realtime messages */
+#define MIDI_CLOCK          0xf8 /* 248, 0 */
+//      MIDI_RESERVED3      0xf9 /* 249, ? */
+#define MIDI_START          0xfa /* 250, 0 */
+#define MIDI_CONTINUE       0xfb /* 251, 0 */
+#define MIDI_STOP           0xfc /* 252, 0 */
+//      MIDI_RESERVED4      0xfd /* 253, ? */
+#define MIDI_ACTIVESENSING  0xfe /* 254, 0 */
+#define MIDI_SYSTEMRESET    0xff /* 255, 0 */
+
 typedef struct _midiqelem
 {
     double q_time;
@@ -153,6 +182,8 @@ void sys_pollmidioutqueue( void)
     }
 }
 
+/* ------------------------- MIDI output queue handling ------------------ */
+
 static void sys_queuemidimess(int portno, int onebyte, int a, int b, int c)
 {
     t_midiqelem *midiqelem;
@@ -172,13 +203,6 @@ static void sys_queuemidimess(int portno, int onebyte, int a, int b, int c)
     midi_outhead = newhead;
     sys_pollmidioutqueue();
 }
-
-#define MIDI_NOTEON 144
-#define MIDI_POLYAFTERTOUCH 160
-#define MIDI_CONTROLCHANGE 176
-#define MIDI_PROGRAMCHANGE 192
-#define MIDI_AFTERTOUCH 208
-#define MIDI_PITCHBEND 224
 
 void outmidi_noteon(int portno, int channel, int pitch, int velo)
 {
@@ -254,33 +278,10 @@ void outmidi_byte(int portno, int value)
 /* ------------------------- MIDI input queue handling ------------------ */
 typedef struct midiparser
 {
-    int mp_status;
-    int mp_gotbyte1;
-    int mp_byte1;
+    int mp_status;   /* current status byte */
+    int mp_gotbyte1; /* do we have a second data byte? */
+    int mp_byte1;    /* second data byte */
 } t_midiparser;
-
-#define MIDINOTEOFF       0x80  /* 2 following 'data bytes' */
-#define MIDINOTEON        0x90  /* 2 */
-#define MIDIPOLYTOUCH     0xa0  /* 2 */
-#define MIDICONTROLCHANGE 0xb0  /* 2 */
-#define MIDIPROGRAMCHANGE 0xc0  /* 1 */
-#define MIDICHANNELTOUCH  0xd0  /* 1 */
-#define MIDIPITCHBEND     0xe0  /* 2 */
-#define MIDISTARTSYSEX    0xf0  /* (until F7) */
-#define MIDITIMECODE      0xf1  /* 1 */
-#define MIDISONGPOS       0xf2  /* 2 */
-#define MIDISONGSELECT    0xf3  /* 1 */
-#define MIDIRESERVED1     0xf4  /* ? */
-#define MIDIRESERVED2     0xf5  /* ? */
-#define MIDITUNEREQUEST   0xf6  /* 0 */
-#define MIDIENDSYSEX      0xf7  /* 0 */
-#define MIDICLOCK         0xf8  /* 0 */
-#define MIDITICK          0xf9  /* 0 */
-#define MIDISTART         0xfa  /* 0 */
-#define MIDICONT          0xfb  /* 0 */
-#define MIDISTOP          0xfc  /* 0 */
-#define MIDIACTIVESENSE   0xfe  /* 0 */
-#define MIDIRESET         0xff  /* 0 */
 
     /* functions in x_midi.c */
 void inmidi_realtimein(int portno, int cmd);
@@ -292,8 +293,9 @@ void inmidi_programchange(int portno, int channel, int value);
 void inmidi_pitchbend(int portno, int channel, int value);
 void inmidi_aftertouch(int portno, int channel, int value);
 void inmidi_polyaftertouch(int portno, int channel, int pitch, int value);
+void inmidi_clk(double timing);
 
-static void sys_dispatchnextmidiin( void)
+static void sys_dispatchnextmidiin(void)
 {
     static t_midiparser parser[MAXMIDIINDEV], *parserp;
     int portno = midi_inqueue[midi_intail].q_portno,
@@ -305,93 +307,115 @@ static void sys_dispatchnextmidiin( void)
     parserp = parser + portno;
     outlet_setstacklim();
 
-    if (byte >= 0xf8)
+    if (byte >= MIDI_CLOCK)
+    {
+        /* realtime message */
         inmidi_realtimein(portno, byte);
+        if (byte == MIDI_CLOCK)
+            inmidi_clk(sys_getmidiinrealtime());
+    }
     else
     {
-        inmidi_byte(portno, byte);
         if (byte & 0x80)
         {
-            if (byte == MIDITUNEREQUEST || byte == MIDIRESERVED1 ||
-                byte == MIDIRESERVED2)
-                    parserp->mp_status = 0;
-            else if (byte == MIDISTARTSYSEX)
+            /* status byte */
+            inmidi_byte(portno, byte);
+            if (byte == MIDI_TUNEREQUEST || byte == MIDI_RESERVED1 ||
+                byte == MIDI_RESERVED2)
+            {
+                /* system messages clear running status,
+                   rest are handled in the data byte section below */
+                parserp->mp_status = 0;
+            }
+            else if (byte == MIDI_SYSEX)
             {
                 inmidi_sysex(portno, byte);
                 parserp->mp_status = byte;
             }
-            else if (byte == MIDIENDSYSEX)
+            else if (byte == MIDI_SYSEXEND)
             {
                 inmidi_sysex(portno, byte);
                 parserp->mp_status = 0;
             }
             else
             {
+                /* channel message or system message not handled here */
                 parserp->mp_status = byte;
             }
             parserp->mp_gotbyte1 = 0;
         }
+        else if(parser->mp_status < MIDI_NOTEOFF)
+        {
+            /* running status w/out prev status byte or other invalid message */
+            bug("dropping unexpected midi byte %02X", byte);
+        }
         else
         {
-            int cmd = (parserp->mp_status >= 0xf0 ? parserp->mp_status :
-                (parserp->mp_status & 0xf0));
-            int chan = (parserp->mp_status & 0xf);
+            /* data byte */
+            inmidi_byte(portno, byte);
+            int status = (parserp->mp_status >= MIDI_SYSEX ?
+                            parserp->mp_status : (parserp->mp_status & 0xf0));
+            int chan = (parserp->mp_status & 0xf0);
             int byte1 = parserp->mp_byte1, gotbyte1 = parserp->mp_gotbyte1;
-            switch (cmd)
+            switch (status)
             {
-            case MIDINOTEOFF:
-                if (gotbyte1)
-                    inmidi_noteon(portno, chan, byte1, 0),
-                        parserp->mp_gotbyte1 = 0;
-                else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
-                break;
-            case MIDINOTEON:
-                if (gotbyte1)
-                    inmidi_noteon(portno, chan, byte1, byte),
-                        parserp->mp_gotbyte1 = 0;
-                else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
-                break;
-            case MIDIPOLYTOUCH:
-                if (gotbyte1)
-                    inmidi_polyaftertouch(portno, chan, byte1, byte),
-                        parserp->mp_gotbyte1 = 0;
-                else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
-                break;
-            case MIDICONTROLCHANGE:
-                if (gotbyte1)
-                    inmidi_controlchange(portno, chan, byte1, byte),
-                        parserp->mp_gotbyte1 = 0;
-                else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
-                break;
-            case MIDIPROGRAMCHANGE:
-                inmidi_programchange(portno, chan, byte);
-                break;
-            case MIDICHANNELTOUCH:
-                inmidi_aftertouch(portno, chan, byte);
-                break;
-            case MIDIPITCHBEND:
-                if (gotbyte1)
-                    inmidi_pitchbend(portno, chan, ((byte << 7) + byte1)),
-                        parserp->mp_gotbyte1 = 0;
-                else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
-                break;
-            case MIDISTARTSYSEX:
-                inmidi_sysex(portno, byte);
-                break;
+                case MIDI_NOTEOFF:
+                    if (gotbyte1)
+                        inmidi_noteon(portno, chan, byte1, 0),
+                            parserp->mp_gotbyte1 = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_NOTEON:
+                    if (gotbyte1)
+                        inmidi_noteon(portno, chan, byte1, byte),
+                            parserp->mp_gotbyte1 = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_POLYAFTERTOUCH:
+                    if (gotbyte1)
+                        inmidi_polyaftertouch(portno, chan, byte1, byte),
+                            parserp->mp_gotbyte1 = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_CONTROLCHANGE:
+                    if (gotbyte1)
+                        inmidi_controlchange(portno, chan, byte1, byte),
+                            parserp->mp_gotbyte1 = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_PROGRAMCHANGE:
+                    inmidi_programchange(portno, chan, byte);
+                    break;
+                case MIDI_AFTERTOUCH:
+                    inmidi_aftertouch(portno, chan, byte);
+                    break;
+                case MIDI_PITCHBEND:
+                    if (gotbyte1)
+                        inmidi_pitchbend(portno, chan, ((byte << 7) + byte1)),
+                            parserp->mp_gotbyte1 = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_SYSEX:
+                    inmidi_sysex(portno, byte);
+                    break;
 
-                /* other kinds of messages are just dropped here.  We'll
-                need another status byte before we start letting MIDI in
-                again (no running status across "system" messages). */
-            case MIDITIMECODE:     /* 1 data byte*/
-                break;
-            case MIDISONGPOS:       /* 2 */
-                break;
-            case MIDISONGSELECT:    /* 1 */
-                break;
+                    /* We'll need another status byte before letting MIDI in
+                       again (no running status across "system" messages). */
+                case MIDI_TIMECODE:
+                    parser->mp_status = 0;
+                    break;
+                case MIDI_SONGPOS:
+                    if (gotbyte1)
+                        parserp->mp_gotbyte1 = 0, parser->mp_status = 0;
+                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    break;
+                case MIDI_SONGSELECT:
+                    parserp->mp_status = 0;
+                    break;
             }
         }
     }
-    midi_intail  = (midi_intail + 1 == MIDIQSIZE ? 0 : midi_intail + 1);
+    midi_intail = (midi_intail + 1 == MIDIQSIZE ? 0 : midi_intail + 1);
 }
 
 void sys_pollmidiinqueue( void)

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -18,6 +18,20 @@
 #include "m_pd.h"
 #include "s_stuff.h"
 
+/* full status byte definitions in s_midi.c */
+/* channel voice messages */
+#define MIDI_NOTEOFF        0x80
+#define MIDI_NOTEON         0x90
+#define MIDI_POLYAFTERTOUCH 0xa0
+#define MIDI_CONTROLCHANGE  0xb0
+#define MIDI_PROGRAMCHANGE  0xc0
+#define MIDI_AFTERTOUCH     0xd0
+#define MIDI_PITCHBEND      0xe0
+/* system common messages */
+#define MIDI_TIMECODE       0xf1
+#define MIDI_SONGPOS        0xf2
+#define MIDI_SONGSELECT     0xf3
+
 //the maximum length of input messages
 #ifndef ALSA_MAX_EVENT_SIZE
 #define ALSA_MAX_EVENT_SIZE 512
@@ -47,45 +61,45 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
 
     if (nmidiout == 0 && nmidiin == 0) return;
 
-    if(nmidiin>MAXMIDIINDEV )
-      {
+    if (nmidiin > MAXMIDIINDEV )
+    {
         post("midi input ports reduced to maximum %d", MAXMIDIINDEV);
-        nmidiin=MAXMIDIINDEV;
-      }
-    if(nmidiout>MAXMIDIOUTDEV)
-      {
+        nmidiin = MAXMIDIINDEV;
+    }
+    if (nmidiout > MAXMIDIOUTDEV)
+    {
         post("midi output ports reduced to maximum %d", MAXMIDIOUTDEV);
-        nmidiout=MAXMIDIOUTDEV;
-      }
+        nmidiout = MAXMIDIOUTDEV;
+    }
 
-    if (nmidiin>0 && nmidiout>0)
-        err = snd_seq_open(&midi_handle,"default",SND_SEQ_OPEN_DUPLEX,0);
+    if (nmidiin > 0 && nmidiout > 0)
+        err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_DUPLEX, 0);
     else if (nmidiin > 0)
-        err = snd_seq_open(&midi_handle,"default",SND_SEQ_OPEN_INPUT,0);
+        err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_INPUT, 0);
     else if (nmidiout > 0)
-        err = snd_seq_open(&midi_handle,"default",SND_SEQ_OPEN_OUTPUT,0);
+        err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_OUTPUT, 0);
 
-    if (err!=0)
+    if (err != 0)
     {
             sys_setalarm(1000000);
             post("couldn't open alsa sequencer");
             return;
     }
-    for (i=0;i<nmidiin;i++)
+    for (i = 0; i < nmidiin; i++)
     {
         int port;
-        sprintf(portname,"Pure Data Midi-In %d",i+1);
+        sprintf(portname, "Pure Data Midi-In %d", i+1);
         port = snd_seq_create_simple_port(midi_handle,portname,
-                                          SND_SEQ_PORT_CAP_WRITE |SND_SEQ_PORT_CAP_SUBS_WRITE,
+                                          SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE,
                                           SND_SEQ_PORT_TYPE_APPLICATION);
         alsa_midiinfd[i] = port;
         if (port < 0) goto error;
     }
 
-    for (i=0;i<nmidiout;i++)
+    for (i = 0; i < nmidiout; i++)
     {
         int port;
-        sprintf(portname,"Pure Data Midi-Out %d",i+1);
+        sprintf(portname,"Pure Data Midi-Out %d", i+1);
         port = snd_seq_create_simple_port(midi_handle,portname,
                                           SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ,
                                           SND_SEQ_PORT_TYPE_APPLICATION);
@@ -94,14 +108,14 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
     }
 
     snd_seq_client_info_malloc(&alsainfo);
-    snd_seq_get_client_info(midi_handle,alsainfo);
+    snd_seq_get_client_info(midi_handle, alsainfo);
     snd_seq_client_info_set_name(alsainfo,"Pure Data");
     client = snd_seq_client_info_get_client(alsainfo);
-    snd_seq_set_client_info(midi_handle,alsainfo);
+    snd_seq_set_client_info(midi_handle, alsainfo);
     snd_seq_client_info_free(alsainfo);
-    post("Opened Alsa Client %d in:%d out:%d",client,nmidiin,nmidiout);
+    post("opened alsa client %d in:%d out:%d", client, nmidiin, nmidiout);
     sys_setalarm(0);
-    snd_midi_event_new(ALSA_MAX_EVENT_SIZE,&midiev);
+    snd_midi_event_new(ALSA_MAX_EVENT_SIZE, &midiev);
     alsa_nmidiout = nmidiout;
     alsa_nmidiin = nmidiin;
 
@@ -112,50 +126,62 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
     return;
 }
 
-#define md_msglen(x) (((x)<0xC0)?2:((x)<0xE0)?1:((x)<0xF0)?2:\
-    ((x)==0xF2)?2:((x)<0xF4)?1:0)
-
 void sys_alsa_putmidimess(int portno, int a, int b, int c)
 {
+    int status;
     int channel;
     snd_seq_event_t ev;
     snd_seq_ev_clear(&ev);
     if (portno >= 0 && portno < alsa_nmidiout)
     {
-        if (a >= 224)   // pitchbend
+        status = a & 0xf0
+        channel = a & 0x0f
+        switch (status)
         {
-            channel = a-224;
-            snd_seq_ev_set_pitchbend(&ev, channel, (((c<<7)|b)-8192)); /* b and c are already correct but alsa needs to recalculate them */
-        }
-        else if (a >= 208)      // touch
-        {
-            channel = a-208;
-            snd_seq_ev_set_chanpress(&ev,channel,b);
-        }
-        else if (a >= 192)      // program
-        {
-            channel = a-192;
-            snd_seq_ev_set_pgmchange(&ev,channel,b);
-        }
-        else if (a >= 176)      // controller
-        {
-            channel = a-176;
-            snd_seq_ev_set_controller(&ev,channel,b,c);
-        }
-        else if (a >= 160)      // polytouch
-        {
-            channel = a-160;
-            snd_seq_ev_set_keypress(&ev,channel,b,c);
-        }
-        else if (a >= 144)      // note on
-        {
-            channel = a-144;
-            snd_seq_ev_set_noteon(&ev,channel,b,c);
-        }
-        else if (a >= 128)      // note off
-        {
-            channel = a-128;
-            snd_seq_ev_set_noteoff(&ev,channel,b,c);
+            case MIDI_NOTEON:
+                snd_seq_ev_set_noteon(&ev, channel, b, c);
+                break;
+            case MIDI_NOTOFF:
+                snd_seq_ev_set_noteoff(&ev, channel, b, c);
+                break;
+            case MIDI_POLYAFTERTOUCH:
+                snd_seq_ev_set_chanpress(&ev, channel, b);
+                break;
+            case MIDI_CONTROLCHANGE:
+                snd_seq_ev_set_controller(&ev, channel, b, c);
+                break;
+            case MIDI_PROGRAMCHANGE:
+                snd_seq_ev_set_pgmchange(&ev, channel, b);
+                break;
+            case MIDI_AFTERTOUCH:
+                snd_seq_ev_set_chanpress(&ev, channel, b);
+                break;
+            case MIDI_PITCHBEND:
+                /* b and c are already correct but alsa needs to recalculate them */
+                snd_seq_ev_set_pitchbend(&ev, channel, (((c<<7)|b)-8192));
+                break;
+            case MIDI_TIMECODE:
+                ev->type = SND_SEQ_EVENT_QFRAME;
+                snd_seq_event_set_fixed(ev);
+                ev->data->raw32[0] = a & 0xff; /* status */
+                ev->data->raw32[1] = b & 0x7F; /* data */
+                break;
+            case MIDI_SONGPOS:
+                ev->type = SND_SEQ_EVENT_SONGPOS;
+                snd_seq_event_set_fixed(ev);
+                ev->data->raw32[0] = a & 0xff; /* status */
+                ev->data->raw32[1] = b & 0x7f; /* data */
+                ev->data->raw32[1] = c & 0x7f; /* data */
+                break;
+            case MIDI_SONGSELECT:
+                ev->type = SND_SEQ_EVENT_SONGSEL;
+                snd_seq_event_set_fixed(ev);
+                ev->data->raw32[0] = a & 0xff; /* status */
+                ev->data->raw32[1] = b & 0x7f; /* data */
+                break;
+            default:
+                bug("couldn't put alsa midi message");
+                continue;
         }
         snd_seq_ev_set_direct(&ev);
         snd_seq_ev_set_subs(&ev);
@@ -203,23 +229,23 @@ void sys_alsa_poll_midi(void)
    snd_midi_event_init(midiev);
 
    if (!alsa_nmidiout && !alsa_nmidiin) return;
-   count = snd_seq_event_input_pending(midi_handle,1);
+   count = snd_seq_event_input_pending(midi_handle, 1);
    if (count != 0)
-        count = snd_seq_event_input(midi_handle,&midievent);
+        count = snd_seq_event_input(midi_handle, &midievent);
    if (midievent != NULL)
    {
-       count = snd_midi_event_decode(midiev,buf,sizeof(buf),midievent);
+       count = snd_midi_event_decode(midiev, buf, sizeof(buf), midievent);
        alsa_source = midievent->dest.port;
-       for(i=0;i<count;i++)
+       for(i = 0; i < count; i++)
            sys_midibytein(alsa_source, (buf[i] & 0xff));
-       //post("received %d midi bytes\n",count);
+       //post("received %d midi bytes\n", count);
    }
 }
 
 void sys_alsa_close_midi()
 {
     alsa_nmidiin = alsa_nmidiout = 0;
-    if(midi_handle)
+    if (midi_handle)
     {
         snd_seq_close(midi_handle);
         midi_handle = NULL;

--- a/src/x_canvas.c
+++ b/src/x_canvas.c
@@ -1,0 +1,45 @@
+/* (C) 2005 Guenter Geiger */
+
+#include "m_pd.h"
+#include "g_canvas.h"
+
+typedef struct canvas
+{
+    t_object x_ob;
+    t_canvas *x_canvas;
+    t_outlet *x_outlet;
+    int x_level;
+} t_getdir;
+
+
+static void canvas_bang(t_getdir *x)
+{
+    int i = x->x_level;
+    t_canvas* last = x->x_canvas;
+
+    while (i>0) {
+        i--;
+        if (last->gl_owner) last = last->gl_owner;
+    }
+
+    outlet_symbol(x->x_outlet,canvas_getdir(last));
+}
+
+t_class *canvas_class;
+
+static void *canvas_new(t_floatarg level)
+{
+    t_getdir *x = (t_getdir *)pd_new(getdir_class);
+    x->x_canvas =  canvas_getcurrent();
+    x->x_outlet =  outlet_new(&x->x_ob, &s_);
+    x->x_level  =  level;
+    return (void *)x;
+}
+
+void canvas_setup(void)
+{
+    getdir_class = class_new(gensym("canvas"), (t_newmethod)getdir_new, 0,
+    	sizeof(t_getdir), 0, A_DEFFLOAT,0);
+    class_addbang(getdir_class, getdir_bang);
+}
+

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -44,7 +44,7 @@ typedef struct _midiin
     t_outlet *x_outlet2;
 } t_midiin;
 
-static void *midiin_new( void)
+static void *midiin_new(void)
 {
     t_midiin *x = (t_midiin *)pd_new(midiin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
@@ -64,7 +64,7 @@ static void midiin_free(t_midiin *x)
     pd_unbind(&x->x_obj.ob_pd, pd_this->pd_midi->m_midiin_sym);
 }
 
-static void *sysexin_new( void)
+static void *sysexin_new(void)
 {
     t_midiin *x = (t_midiin *)pd_new(sysexin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
@@ -523,7 +523,7 @@ typedef struct _songposin
     t_outlet *x_outlet2;
 } t_songposin;
 
-static void *songposin_new()
+static void *songposin_new(void)
 {
     t_songposin *x = (t_songposin *)pd_new(songposin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
@@ -577,7 +577,7 @@ typedef struct _songin
     t_outlet *x_outlet2;
 } t_songin;
 
-static void *songin_new()
+static void *songin_new(void)
 {
     t_songin *x = (t_songin *)pd_new(songin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
@@ -635,7 +635,7 @@ typedef struct _timecodein
     t_outlet *x_outlet6;
 } t_timecodein;
 
-static void *timecodein_new()
+static void *timecodein_new(void)
 {
     t_timecodein *x = (t_timecodein *)pd_new(timecodein_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
@@ -774,7 +774,7 @@ void inmidi_clk(double timing)
 
         if (count == 3)
         {  /* 24 count per quoter note */
-             SETFLOAT(at, 1 );
+             SETFLOAT(at, 1);
              count = 0;
         }
         else SETFLOAT(at, 0);
@@ -1289,7 +1289,7 @@ typedef struct _stripnote
     t_outlet *x_velout;
 } t_stripnote;
 
-static void *stripnote_new(void )
+static void *stripnote_new(void)
 {
     t_stripnote *x = (t_stripnote *)pd_new(stripnote_class);
     floatinlet_new(&x->x_obj, &x->x_velo);
@@ -1464,7 +1464,7 @@ typedef struct _bag
     t_bagelem *x_first;
 } t_bag;
 
-static void *bag_new(void )
+static void *bag_new(void)
 {
     t_bag *x = (t_bag *)pd_new(bag_class);
     x->x_velo = 0;
@@ -1570,7 +1570,7 @@ void x_midi_setup(void)
     bag_setup();
 }
 
-void x_midi_newpdinstance( void)
+void x_midi_newpdinstance(void)
 {
     pd_this->pd_midi = getbytes(sizeof(t_instancemidi));
     pd_this->pd_midi->m_midiin_sym = gensym("#midiin");
@@ -1588,7 +1588,7 @@ void x_midi_newpdinstance( void)
     pd_this->pd_midi->m_timecodein_sym = gensym("#timecodein");
 }
 
-void x_midi_freepdinstance( void)
+void x_midi_freepdinstance(void)
 {
     freebytes(pd_this->pd_midi, sizeof(t_instancemidi));
 }


### PR DESCRIPTION
This PR contains updates to the Pure Data MIDI handling:

* [x] fix portmidi infinite loop bug when receiving active sense during running status messages on macOS
* [x] all messages are now received
* [x] slight code cleanup favoring MIDI status byte defines for readability and some commenting
* [x] enable [midiclkin] object
* [ ] decide on [midiclkin] tick range and possible reset message (for use with tick position counting)
* [x] possibly add [songposin]/[songposout] & [songin]/[songout] objects
* [ ] MIDI time code handling

The work so far has been tested with a simple utility program [miditester](https://github.com/danomatika/miditester) and Logic Pro X on macOS. This will need testing on other platforms.