### PR TITLE
clang implicit conversion warning fixes

### DIFF
--- a/extra/fiddle~/fiddle~.c
+++ b/extra/fiddle~/fiddle~.c
@@ -1141,8 +1141,8 @@ int sigfiddle_doinit(t_sigfiddle *x, long npoints, long npitch,
         buf4[i].po_freq = buf4[i].po_amp = 0;
     x->x_peakbuf = buf4;
 
-    x->x_npeakout = npeakout;
-    x->x_npeakanal = npeakanal;
+    x->x_npeakout = (int)npeakout;
+    x->x_npeakanal = (int)npeakanal;
     x->x_phase = 0;
     x->x_histphase = 0;
     x->x_sr = 44100;            /* this and the next are filled in later */
@@ -1157,7 +1157,7 @@ int sigfiddle_doinit(t_sigfiddle *x, long npoints, long npitch,
             x->x_hist[i].h_amps[j] = x->x_hist[i].h_pitches[j] = 0;
     }
     x->x_nprint = 0;
-    x->x_npitch = npitch;
+    x->x_npitch = (int)npitch;
     for (i = 0; i < HISTORY; i++) x->x_dbs[i] = 0;
     x->x_dbage = 0;
     x->x_peaked = 0;

--- a/extra/pique/pique.c
+++ b/extra/pique/pique.c
@@ -178,10 +178,10 @@ static void pique_doit(int npts, t_word *fpreal, t_word *fpimag,
 
 static void pique_list(t_pique *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int npts = (int)atom_getintarg(0, argc, argv);
+    int npts = atom_getintarg(0, argc, argv);
     t_symbol *symreal = atom_getsymbolarg(1, argc, argv);
     t_symbol *symimag = atom_getsymbolarg(2, argc, argv);
-    int npeak = (int)atom_getintarg(3, argc, argv);
+    int npeak = atom_getintarg(3, argc, argv);
     int n;
     t_garray *a;
     t_word *fpreal, *fpimag;

--- a/extra/pique/pique.c
+++ b/extra/pique/pique.c
@@ -178,10 +178,10 @@ static void pique_doit(int npts, t_word *fpreal, t_word *fpimag,
 
 static void pique_list(t_pique *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int npts = atom_getintarg(0, argc, argv);
+    int npts = (int)atom_getintarg(0, argc, argv);
     t_symbol *symreal = atom_getsymbolarg(1, argc, argv);
     t_symbol *symimag = atom_getsymbolarg(2, argc, argv);
-    int npeak = atom_getintarg(3, argc, argv);
+    int npeak = (int)atom_getintarg(3, argc, argv);
     int n;
     t_garray *a;
     t_word *fpreal, *fpimag;

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -1300,8 +1300,8 @@ static void *sigmund_new(t_symbol *s, int argc, t_atom *argv)
 static void sigmund_list(t_sigmund *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *syminput = atom_getsymbolarg(0, argc, argv);
-    int npts = (int)atom_getintarg(1, argc, argv);
-    int onset = (int)atom_getintarg(2, argc, argv);
+    int npts = atom_getintarg(1, argc, argv);
+    int onset = atom_getintarg(2, argc, argv);
     t_float srate = atom_getfloatarg(3, argc, argv);
     int loud = atom_getfloatarg(4, argc, argv);
     int arraysize, totstorage, nfound, i;

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -1300,8 +1300,8 @@ static void *sigmund_new(t_symbol *s, int argc, t_atom *argv)
 static void sigmund_list(t_sigmund *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *syminput = atom_getsymbolarg(0, argc, argv);
-    int npts = atom_getintarg(1, argc, argv);
-    int onset = atom_getintarg(2, argc, argv);
+    int npts = (int)atom_getintarg(1, argc, argv);
+    int onset = (int)atom_getintarg(2, argc, argv);
     t_float srate = atom_getfloatarg(3, argc, argv);
     int loud = atom_getfloatarg(4, argc, argv);
     int arraysize, totstorage, nfound, i;

--- a/extra/stdout/stdout.c
+++ b/extra/stdout/stdout.c
@@ -135,7 +135,7 @@ static void stdout_anything(t_stdout *x, t_symbol *s, int argc, t_atom *argv)
     {
         if (sp < ep-1)
             sp[0] = ' ', sp[1] = 0, sp++;
-        atom_string(argv++, sp, ep-sp);
+        atom_string(argv++, sp, (unsigned int)(ep-sp));
         sp += strlen(sp);
     }
     switch(x->x_mode) {

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -708,7 +708,7 @@ static t_int *tabsend_perform(t_int *w)
 {
     t_tabsend *x = (t_tabsend *)(w[1]);
     t_sample *in = (t_sample *)(w[2]);
-    t_int n = w[3];
+    int n = (int)w[3];
     t_word *dest = x->x_vec;
     int i = x->x_graphcount;
     if (!x->x_vec) goto bad;
@@ -792,7 +792,7 @@ static t_int *tabreceive_perform(t_int *w)
 {
     t_tabreceive *x = (t_tabreceive *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
-    t_int n = w[3];
+    int n = (int)w[3];
     t_word *from = x->x_vec;
     if (from)
     {

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -233,8 +233,8 @@ static void tabplay_tilde_list(t_tabplay_tilde *x, t_symbol *s,
     if (length <= 0)
         x->x_limit = 0x7fffffff;
     else
-        x->x_limit = start + length;
-    x->x_phase = start;
+        x->x_limit = (int)(start + length);
+    x->x_phase = (int)start;
 }
 
 static void tabplay_tilde_stop(t_tabplay_tilde *x)
@@ -708,7 +708,7 @@ static t_int *tabsend_perform(t_int *w)
 {
     t_tabsend *x = (t_tabsend *)(w[1]);
     t_sample *in = (t_sample *)(w[2]);
-    int n = w[3];
+    t_int n = w[3];
     t_word *dest = x->x_vec;
     int i = x->x_graphcount;
     if (!x->x_vec) goto bad;
@@ -792,11 +792,11 @@ static t_int *tabreceive_perform(t_int *w)
 {
     t_tabreceive *x = (t_tabreceive *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
-    int n = w[3];
+    t_int n = w[3];
     t_word *from = x->x_vec;
     if (from)
     {
-        int vecsize = x->x_npoints;
+        t_int vecsize = x->x_npoints;
         if (vecsize > n)
             vecsize = n;
         while (vecsize--)

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -774,7 +774,7 @@ static t_int *threshold_tilde_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_threshold_tilde *x = (t_threshold_tilde *)(w[2]);
-    t_int n = w[3];
+    int n = (int)w[3];
     if (x->x_deadwait > 0)
         x->x_deadwait -= x->x_msecpertick;
     else if (x->x_state)

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -774,7 +774,7 @@ static t_int *threshold_tilde_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_threshold_tilde *x = (t_threshold_tilde *)(w[2]);
-    int n = (t_int)(w[3]);
+    t_int n = w[3];
     if (x->x_deadwait > 0)
         x->x_deadwait -= x->x_msecpertick;
     else if (x->x_state)

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -47,7 +47,7 @@ static void dac_dsp(t_dac *x, t_signal **sp)
     t_signal **sp2;
     for (i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
-        t_int ch = *ip - 1;
+        int ch = (int)(*ip - 1);
         if ((*sp2)->s_n != DEFDACBLKSIZE)
             error("dac~: bad vector size");
         else if (ch >= 0 && ch < sys_get_outchannels())

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -47,7 +47,7 @@ static void dac_dsp(t_dac *x, t_signal **sp)
     t_signal **sp2;
     for (i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
-        int ch = *ip - 1;
+        t_int ch = *ip - 1;
         if ((*sp2)->s_n != DEFDACBLKSIZE)
             error("dac~: bad vector size");
         else if (ch >= 0 && ch < sys_get_outchannels())
@@ -162,7 +162,7 @@ static void adc_dsp(t_adc *x, t_signal **sp)
     t_signal **sp2;
     for (i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
-        int ch = *ip - 1;
+        int ch = (int)(*ip - 1);
         if ((*sp2)->s_n != DEFDACBLKSIZE)
             error("adc~: bad vector size");
         else if (ch >= 0 && ch < sys_get_inchannels())

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -18,7 +18,7 @@ static t_int *sigfft_swap(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_sample *in2 = (t_sample *)(w[2]);
-    int n = w[3];
+    t_int n = w[3];
     for (;n--; in1++, in2++)
     {
         t_sample f = *in1;
@@ -36,7 +36,7 @@ static t_int *sigrfft_flip(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
-    int n = w[3];
+    t_int n = w[3];
     while (n--)
         *(--out) = - *in++;
     return (w+4);
@@ -75,7 +75,7 @@ static t_int *sigfft_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_sample *in2 = (t_sample *)(w[2]);
-    int n = w[3];
+    int n = (int)w[3];
     mayer_fft(n, in1, in2);
     return (w+4);
 }
@@ -84,7 +84,7 @@ static t_int *sigifft_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_sample *in2 = (t_sample *)(w[2]);
-    int n = w[3];
+    int n = (int)w[3];
     mayer_ifft(n, in1, in2);
     return (w+4);
 }
@@ -159,7 +159,7 @@ static void *sigrfft_new(void)
 static t_int *sigrfft_perform(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
-    int n = w[2];
+    int n = (int)w[2];
     mayer_realfft(n, in);
     return (w+3);
 }
@@ -217,7 +217,7 @@ static void *sigrifft_new(void)
 static t_int *sigrifft_perform(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
-    int n = w[2];
+    int n = (int)w[2];
     mayer_realifft(n, in);
     return (w+3);
 }
@@ -284,8 +284,8 @@ static t_int *sigframp_perform(t_int *w)
     t_sample *outamp = (t_sample *)(w[4]);
     t_sample lastreal = 0, currentreal = inreal[0], nextreal = inreal[1];
     t_sample lastimag = 0, currentimag = inimag[0], nextimag = inimag[1];
-    int n = w[5];
-    int m = n + 1;
+    t_int n = w[5];
+    t_int m = n + 1;
     t_sample fbin = 1, oneovern2 = 1.f/((t_sample)n * (t_sample)n);
 
     inreal += 2;

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -18,7 +18,7 @@ static t_int *sigfft_swap(t_int *w)
 {
     t_sample *in1 = (t_sample *)(w[1]);
     t_sample *in2 = (t_sample *)(w[2]);
-    t_int n = w[3];
+    int n = (int)w[3];
     for (;n--; in1++, in2++)
     {
         t_sample f = *in1;
@@ -36,7 +36,7 @@ static t_int *sigrfft_flip(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
-    t_int n = w[3];
+    int n = (int)w[3];
     while (n--)
         *(--out) = - *in++;
     return (w+4);
@@ -284,8 +284,8 @@ static t_int *sigframp_perform(t_int *w)
     t_sample *outamp = (t_sample *)(w[4]);
     t_sample lastreal = 0, currentreal = inreal[0], nextreal = inreal[1];
     t_sample lastimag = 0, currentimag = inimag[0], nextimag = inimag[1];
-    t_int n = w[5];
-    t_int m = n + 1;
+    int n = (int)w[5];
+    int m = n + 1;
     t_sample fbin = 1, oneovern2 = 1.f/((t_sample)n * (t_sample)n);
 
     inreal += 2;

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -57,7 +57,7 @@ static t_int *sighip_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_hipctl *c = (t_hipctl *)(w[3]);
-    t_int n = w[4];
+    int n = (int)w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -88,7 +88,7 @@ static t_int *sighip_perform_old(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_hipctl *c = (t_hipctl *)(w[3]);
-    t_int n = w[4];
+    int n = (int)w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -195,7 +195,7 @@ static t_int *siglop_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_lopctl *c = (t_lopctl *)(w[3]);
-    t_int n = w[4];
+    int n = (int)w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -320,7 +320,7 @@ static t_int *sigbp_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_bpctl *c = (t_bpctl *)(w[3]);
-    t_int n = w[4];
+    int n = (int)w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
@@ -408,7 +408,7 @@ static t_int *sigbiquad_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_biquadctl *c = (t_biquadctl *)(w[3]);
-    t_int n = w[4];
+    int n = (int)w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
@@ -523,7 +523,7 @@ static t_int *sigsamphold_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigsamphold *x = (t_sigsamphold *)(w[4]);
-    t_int n = w[5];
+    int n = (int)w[5];
     int i;
     t_sample lastin = x->x_lastin;
     t_sample lastout = x->x_lastout;
@@ -599,7 +599,7 @@ static t_int *sigrpole_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrpole *x = (t_sigrpole *)(w[4]);
-    t_int n = w[5];
+    int n = (int)w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -672,7 +672,7 @@ static t_int *sigrzero_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrzero *x = (t_sigrzero *)(w[4]);
-    t_int n = w[5];
+    int n = (int)w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -744,7 +744,7 @@ static t_int *sigrzero_rev_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrzero_rev *x = (t_sigrzero_rev *)(w[4]);
-    t_int n = w[5];
+    int n = (int)w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -827,7 +827,7 @@ static t_int *sigcpole_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigcpole *x = (t_sigcpole *)(w[7]);
-    t_int n = w[8];
+    int n = (int)w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
@@ -920,7 +920,7 @@ static t_int *sigczero_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigczero *x = (t_sigczero *)(w[7]);
-    t_int n = w[8];
+    int n = (int)w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
@@ -1010,7 +1010,7 @@ static t_int *sigczero_rev_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigczero_rev *x = (t_sigczero_rev *)(w[7]);
-    t_int n = w[8];
+    int n = (int)w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -57,7 +57,7 @@ static t_int *sighip_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_hipctl *c = (t_hipctl *)(w[3]);
-    int n = (t_int)(w[4]);
+    t_int n = w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -88,7 +88,7 @@ static t_int *sighip_perform_old(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_hipctl *c = (t_hipctl *)(w[3]);
-    int n = (t_int)(w[4]);
+    t_int n = w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -195,7 +195,7 @@ static t_int *siglop_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_lopctl *c = (t_lopctl *)(w[3]);
-    int n = (t_int)(w[4]);
+    t_int n = w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
@@ -320,7 +320,7 @@ static t_int *sigbp_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_bpctl *c = (t_bpctl *)(w[3]);
-    int n = (t_int)(w[4]);
+    t_int n = w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
@@ -408,7 +408,7 @@ static t_int *sigbiquad_perform(t_int *w)
     t_sample *in = (t_sample *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
     t_biquadctl *c = (t_biquadctl *)(w[3]);
-    int n = (t_int)(w[4]);
+    t_int n = w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
@@ -523,7 +523,7 @@ static t_int *sigsamphold_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigsamphold *x = (t_sigsamphold *)(w[4]);
-    int n = (t_int)(w[5]);
+    t_int n = w[5];
     int i;
     t_sample lastin = x->x_lastin;
     t_sample lastout = x->x_lastout;
@@ -599,7 +599,7 @@ static t_int *sigrpole_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrpole *x = (t_sigrpole *)(w[4]);
-    int n = (t_int)(w[5]);
+    t_int n = w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -672,7 +672,7 @@ static t_int *sigrzero_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrzero *x = (t_sigrzero *)(w[4]);
-    int n = (t_int)(w[5]);
+    t_int n = w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -744,7 +744,7 @@ static t_int *sigrzero_rev_perform(t_int *w)
     t_sample *in2 = (t_sample *)(w[2]);
     t_sample *out = (t_sample *)(w[3]);
     t_sigrzero_rev *x = (t_sigrzero_rev *)(w[4]);
-    int n = (t_int)(w[5]);
+    t_int n = w[5];
     int i;
     t_sample last = x->x_last;
     for (i = 0; i < n; i++)
@@ -827,7 +827,7 @@ static t_int *sigcpole_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigcpole *x = (t_sigcpole *)(w[7]);
-    int n = (t_int)(w[8]);
+    t_int n = w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
@@ -920,7 +920,7 @@ static t_int *sigczero_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigczero *x = (t_sigczero *)(w[7]);
-    int n = (t_int)(w[8]);
+    t_int n = w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
@@ -1010,7 +1010,7 @@ static t_int *sigczero_rev_perform(t_int *w)
     t_sample *outre = (t_sample *)(w[5]);
     t_sample *outim = (t_sample *)(w[6]);
     t_sigczero_rev *x = (t_sigczero_rev *)(w[7]);
-    int n = (t_int)(w[8]);
+    t_int n = w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -378,7 +378,7 @@ static t_int *sigvcf_perform(t_int *w)
     float *out1 = (float *)(w[3]);
     float *out2 = (float *)(w[4]);
     t_vcfctl *c = (t_vcfctl *)(w[5]);
-    t_int n = w[6];
+    int n = (int)w[6];
     int i;
     float re = c->c_re, re2;
     float im = c->c_im;

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -378,7 +378,7 @@ static t_int *sigvcf_perform(t_int *w)
     float *out1 = (float *)(w[3]);
     float *out2 = (float *)(w[4]);
     t_vcfctl *c = (t_vcfctl *)(w[5]);
-    int n = (t_int)(w[6]);
+    t_int n = w[6];
     int i;
     float re = c->c_re, re2;
     float im = c->c_im;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -2272,7 +2272,8 @@ static void *writesf_child_main(void *zz)
         else if (x->x_requestcode == REQUEST_OPEN)
         {
             char boo[80];
-            int fd, sysrtn, writebytes;
+            int fd, writebytes;
+            long sysrtn;
 
                 /* copy file stuff out of the data structure so we can
                 relinquish the mutex while we're in open_soundfile(). */

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -260,9 +260,9 @@ static void outlet_soundfile_info(t_outlet *out, t_soundfile_info *info)
 
 int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
 {
-    int format, nchannels, bigendian, bytespersamp, samprate, swap, sysrtn;
+    int format, nchannels, bigendian, bytespersamp, samprate, swap;
     int headersize = 0;
-    long bytelimit = 0x7fffffff;
+    long  sysrtn, bytelimit = 0x7fffffff;
     errno = 0;
     if (p_info->headersize >= 0) /* header detection overridden */
     {
@@ -284,7 +284,7 @@ int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
             t_datachunk b_datachunk;
             t_comm b_commchunk;
         } buf;
-        int bytesread = read(fd, buf.b_c, READHDRSIZE);
+        long bytesread = read(fd, buf.b_c, READHDRSIZE);
         int format;
         if (bytesread < 4)
             goto badheader;
@@ -384,7 +384,7 @@ int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
                     wavechunk->wc_id[1],
                     wavechunk->wc_id[2],
                     wavechunk->wc_id[3], seekto); */
-                headersize = seekto;
+                headersize = (int)seekto;
             }
             bytelimit = swap4(wavechunk->wc_size, swap);
             headersize += 8;
@@ -442,7 +442,7 @@ int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
                 if (read(fd, buf.b_c, sizeof(t_datachunk)) <
                     (int) sizeof(t_datachunk))
                         goto badheader;
-                headersize = seekto;
+                headersize = (int)seekto;
             }
             bytelimit = swap4(datachunk->dc_size, swap) - 8;
             headersize += sizeof(t_datachunk);
@@ -574,10 +574,11 @@ static void soundfile_xferin_sample(int sfchannels, int nvecs, t_sample **vecs,
 }
 
 static void soundfile_xferin_words(int sfchannels, int nvecs, t_word **vecs,
-    long itemsread, unsigned char *buf, int nitems, int bytespersamp,
+    long itemsread, unsigned char *buf, long nitems, int bytespersamp,
     int bigendian)
 {
-    int i, j;
+	int i;
+	long j;
     unsigned char *sp, *sp2;
     t_word *wp;
     int nchannels = (sfchannels < nvecs ? sfchannels : nvecs);
@@ -827,7 +828,7 @@ usage:
 
 /* p_headersize is a getter, set to NULL if not needed */
 static int create_soundfile(t_canvas *canvas, const char *filename,
-    int filetype, int nframes, int bytespersamp, int bigendian, int nchannels,
+    int filetype, long nframes, int bytespersamp, int bigendian, int nchannels,
     int swap, t_float samplerate, int *p_headersize)
 {
     char filenamebuf[MAXPDSTRING], buf2[MAXPDSTRING];
@@ -865,17 +866,17 @@ static int create_soundfile(t_canvas *canvas, const char *filename,
             strcmp(filenamebuf + strlen(filenamebuf)-5, ".aiff"))
                 strcat(filenamebuf, ".aif");
         strncpy(aiffhdr->a_fileid, "FORM", 4);
-        aiffhdr->a_chunksize = swap4(datasize + sizeof(*aiffhdr) + 4, swap);
+        aiffhdr->a_chunksize = swap4((uint32_t)(datasize + sizeof(*aiffhdr) + 4), swap);
         strncpy(aiffhdr->a_aiffid, "AIFF", 4);
         strncpy(aiffhdr->a_fmtid, "COMM", 4);
         aiffhdr->a_fmtchunksize = swap4(18, swap);
         aiffhdr->a_nchannels = swap2(nchannels, swap);
-        longtmp = swap4(nframes, swap);
+        longtmp = swap4((uint32_t)nframes, swap);
         memcpy(&aiffhdr->a_nframeshi, &longtmp, 4);
         aiffhdr->a_bitspersamp = swap2(8 * bytespersamp, swap);
         makeaiffsamprate(samplerate, aiffhdr->a_samprate);
         strncpy(((char *)(&aiffhdr->a_samprate))+10, "SSND", 4);
-        longtmp = swap4(datasize + 8, swap);
+        longtmp = swap4((uint32_t)(datasize + 8), swap);
         memcpy(((char *)(&aiffhdr->a_samprate))+14, &longtmp, 4);
         memset(((char *)(&aiffhdr->a_samprate))+18, 0, 8);
         headersize = AIFFPLUS;
@@ -886,7 +887,7 @@ static int create_soundfile(t_canvas *canvas, const char *filename,
         if (strcmp(filenamebuf + strlen(filenamebuf)-4, ".wav"))
             strcat(filenamebuf, ".wav");
         strncpy(wavehdr->w_fileid, "RIFF", 4);
-        wavehdr->w_chunksize = swap4(datasize + sizeof(*wavehdr) - 8, swap);
+        wavehdr->w_chunksize = swap4((uint32_t)(datasize + sizeof(*wavehdr) - 8), swap);
         strncpy(wavehdr->w_waveid, "WAVE", 4);
         strncpy(wavehdr->w_fmtid, "fmt ", 4);
         wavehdr->w_fmtchunksize = swap4(16, swap);
@@ -899,7 +900,7 @@ static int create_soundfile(t_canvas *canvas, const char *filename,
         wavehdr->w_nblockalign = swap2(nchannels * bytespersamp, swap);
         wavehdr->w_nbitspersample = swap2(8 * bytespersamp, swap);
         strncpy(wavehdr->w_datachunkid, "data", 4);
-        wavehdr->w_datachunksize = swap4(datasize, swap);
+        wavehdr->w_datachunksize = swap4((uint32_t)datasize, swap);
         headersize = sizeof(t_wave);
     }
 
@@ -934,14 +935,14 @@ static void soundfile_finishwrite(void *obj, char *filename, int fd,
                 ((char *)(&((t_wave *)0)->w_chunksize)) - (char *)0,
                     SEEK_SET) == 0)
                         goto baddonewrite;
-            mofo = swap4(datasize + sizeof(t_wave) - 8, swap);
+            mofo = swap4((uint32_t)(datasize + sizeof(t_wave) - 8), swap);
             if (write(fd, (char *)(&mofo), 4) < 4)
                 goto baddonewrite;
             if (lseek(fd,
                 ((char *)(&((t_wave *)0)->w_datachunksize)) - (char *)0,
                     SEEK_SET) == 0)
                         goto baddonewrite;
-            mofo = swap4(datasize, swap);
+            mofo = swap4((uint32_t)datasize, swap);
             if (write(fd, (char *)(&mofo), 4) < 4)
                 goto baddonewrite;
         }
@@ -952,19 +953,19 @@ static void soundfile_finishwrite(void *obj, char *filename, int fd,
                 ((char *)(&((t_aiff *)0)->a_nframeshi)) - (char *)0,
                     SEEK_SET) == 0)
                         goto baddonewrite;
-            mofo = swap4(itemswritten, swap);
+            mofo = swap4((uint32_t)itemswritten, swap);
             if (write(fd, (char *)(&mofo), 4) < 4)
                 goto baddonewrite;
             if (lseek(fd,
                 ((char *)(&((t_aiff *)0)->a_chunksize)) - (char *)0,
                     SEEK_SET) == 0)
                         goto baddonewrite;
-            mofo = swap4(itemswritten*bytesperframe+AIFFHDRSIZE, swap);
+            mofo = swap4((uint32_t)(itemswritten*bytesperframe+AIFFHDRSIZE), swap);
             if (write(fd, (char *)(&mofo), 4) < 4)
                 goto baddonewrite;
             if (lseek(fd, (AIFFHDRSIZE+4), SEEK_SET) == 0)
                 goto baddonewrite;
-            mofo = swap4(itemswritten*bytesperframe, swap);
+            mofo = swap4((uint32_t)(itemswritten*bytesperframe), swap);
             if (write(fd, (char *)(&mofo), 4) < 4)
                 goto baddonewrite;
         }
@@ -1096,7 +1097,7 @@ static void soundfile_xferout_sample(int nchannels, t_sample **vecs,
 }
 
 static void soundfile_xferout_words(int nchannels, t_word **vecs,
-    unsigned char *buf, int nitems, long onset, int bytespersamp,
+    unsigned char *buf, long nitems, long onset, int bytespersamp,
     int bigendian, t_sample normalfactor)
 {
     int i, j;
@@ -1241,15 +1242,16 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     int argc, t_atom *argv)
 {
     t_soundfile_info info;
-    int resize = 0, i, j;
+    int resize = 0, i;
     long skipframes = 0, finalsize = 0, itemsleft,
-        maxsize = DEFMAXSIZE, itemsread = 0;
+        maxsize = DEFMAXSIZE, itemsread = 0, j;
     int fd = -1;
     char endianness, *filename;
     t_garray *garrays[MAXSFCHANS];
     t_word *vecs[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
-    int bufframes, nitems;
+	int bufframes;
+	long nitems;
     FILE *fp;
     info.samplerate = 0,
     info.channels = 0,
@@ -1389,7 +1391,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
 
     for (itemsread = 0; itemsread < finalsize; )
     {
-        int thisread = finalsize - itemsread;
+        long thisread = finalsize - itemsread;
         thisread = (thisread > bufframes ? bufframes : thisread);
         nitems = fread(sampbuf, info.channels * info.bytespersample, thisread, fp);
         if (nitems <= 0) break;
@@ -1438,9 +1440,9 @@ done:
 long soundfiler_dowrite(void *obj, t_canvas *canvas,
     int argc, t_atom *argv, t_soundfile_info *info)
 {
-    int endianness, swap, filetype, normalize, i, j;
+    int endianness, swap, filetype, normalize, i;
     long onset, nframes, itemsleft,
-        maxsize = DEFMAXSIZE, itemswritten = 0;
+        maxsize = DEFMAXSIZE, itemswritten = 0, j;
     t_garray *garrays[MAXSFCHANS];
     t_word *vectors[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
@@ -1518,7 +1520,7 @@ long soundfiler_dowrite(void *obj, t_canvas *canvas,
 
     for (itemswritten = 0; itemswritten < nframes; )
     {
-        int thiswrite = nframes - itemswritten, nitems, nbytes;
+        long thiswrite = nframes - itemswritten, nitems, nbytes;
         thiswrite = (thiswrite > bufframes ? bufframes : thiswrite);
         soundfile_xferout_words(argc, vectors, (unsigned char *)sampbuf,
             thiswrite, onset, info->bytespersample, info->bigendian, normfactor);
@@ -1714,7 +1716,7 @@ static void *readsf_child_main(void *zz)
         else if (x->x_requestcode == REQUEST_OPEN)
         {
             char boo[80];
-            int sysrtn, wantbytes;
+            long sysrtn, wantbytes;
 
                 /* copy file stuff out of the data structure so we can
                 relinquish the mutex while we're in open_soundfile(). */
@@ -2403,7 +2405,7 @@ static void *writesf_child_main(void *zz)
                 fifotail = x->x_fifotail;
                 fd = x->x_fd;
                 pthread_mutex_unlock(&x->x_mutex);
-                sysrtn = write(fd, buf + fifotail, writebytes);
+                sysrtn = (int)write(fd, buf + fifotail, writebytes);
                 pthread_mutex_lock(&x->x_mutex);
                 if (x->x_requestcode != REQUEST_BUSY &&
                     x->x_requestcode != REQUEST_CLOSE)

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -262,7 +262,7 @@ int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
 {
     int format, nchannels, bigendian, bytespersamp, samprate, swap;
     int headersize = 0;
-    long  sysrtn, bytelimit = 0x7fffffff;
+    long sysrtn, bytelimit = 0x7fffffff;
     errno = 0;
     if (p_info->headersize >= 0) /* header detection overridden */
     {
@@ -577,8 +577,8 @@ static void soundfile_xferin_words(int sfchannels, int nvecs, t_word **vecs,
     long itemsread, unsigned char *buf, long nitems, int bytespersamp,
     int bigendian)
 {
-	int i;
-	long j;
+    int i;
+    long j;
     unsigned char *sp, *sp2;
     t_word *wp;
     int nchannels = (sfchannels < nvecs ? sfchannels : nvecs);
@@ -1250,8 +1250,8 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     t_garray *garrays[MAXSFCHANS];
     t_word *vecs[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
-	int bufframes;
-	long nitems;
+    int bufframes;
+    long nitems;
     FILE *fp;
     info.samplerate = 0,
     info.channels = 0,
@@ -2405,7 +2405,7 @@ static void *writesf_child_main(void *zz)
                 fifotail = x->x_fifotail;
                 fd = x->x_fd;
                 pthread_mutex_unlock(&x->x_mutex);
-                sysrtn = (int)write(fd, buf + fifotail, writebytes);
+                sysrtn = write(fd, buf + fifotail, writebytes);
                 pthread_mutex_lock(&x->x_mutex);
                 if (x->x_requestcode != REQUEST_BUSY &&
                     x->x_requestcode != REQUEST_CLOSE)

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -198,7 +198,7 @@ t_symbol *iemgui_new_dogetname(t_iemgui *iemgui, int indx, t_atom *argv)
     else if (IS_A_FLOAT(argv, indx))
     {
         char str[80];
-        sprintf(str, "%d", (int)atom_getintarg(indx, 100000, argv));
+        sprintf(str, "%d", atom_getintarg(indx, 100000, argv));
         return (gensym(str));
     }
     else return (gensym("empty"));
@@ -298,7 +298,7 @@ static int iemgui_getcolorarg(int index, int argc, t_atom*argv)
     if(index < 0 || index >= argc)
         return 0;
     if(IS_A_FLOAT(argv,index))
-        return (int)atom_getintarg(index, argc, argv);
+        return atom_getintarg(index, argc, argv);
     if(IS_A_SYMBOL(argv,index))
     {
         t_symbol*s=atom_getsymbolarg(index, argc, argv);
@@ -314,7 +314,7 @@ static int colfromatomload(t_atom*colatom)
         /* old-fashioned color arguement, either a number or symbol
         evaluating to an integer */
     if (colatom->a_type == A_FLOAT)
-        color = (int)atom_getint(colatom);
+        color = atom_getint(colatom);
     else if (colatom->a_type == A_SYMBOL &&
         (isdigit(colatom->a_w.w_symbol->s_name[0]) ||
             colatom->a_w.w_symbol->s_name[0] == '-'))
@@ -349,7 +349,7 @@ int iemgui_compatible_colorarg(int index, int argc, t_atom* argv)
         return 0;
     if(IS_A_FLOAT(argv,index))
         {
-            int col = (int)atom_getintarg(index, argc, argv);
+            int col = atom_getintarg(index, argc, argv);
             if(col >= 0)
             {
                 int idx = iemgui_modulo_color(col);
@@ -453,8 +453,8 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
 
 void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    iemgui->x_ldx = (int)atom_getintarg(0, ac, av);
-    iemgui->x_ldy = (int)atom_getintarg(1, ac, av);
+    iemgui->x_ldx = atom_getintarg(0, ac, av);
+    iemgui->x_ldy = atom_getintarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
         sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
                  glist_getcanvas(iemgui->x_glist), x,
@@ -464,7 +464,7 @@ void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av
 
 void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    int f = (int)atom_getintarg(0, ac, av);
+    int f = atom_getintarg(0, ac, av);
 
     if(f == 1) strcpy(iemgui->x_font, "helvetica");
     else if(f == 2) strcpy(iemgui->x_font, "times");
@@ -474,7 +474,7 @@ void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *a
         strcpy(iemgui->x_font, sys_font);
     }
     iemgui->x_fsf.x_font_style = f;
-    f = (int)atom_getintarg(1, ac, av);
+    f = atom_getintarg(1, ac, av);
     if(f < 4)
         f = 4;
     iemgui->x_fontsize = f;
@@ -495,8 +495,8 @@ void iemgui_size(void *x, t_iemgui *iemgui)
 
 void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    iemgui->x_obj.te_xpix += (int)atom_getintarg(0, ac, av);
-    iemgui->x_obj.te_ypix += (int)atom_getintarg(1, ac, av);
+    iemgui->x_obj.te_xpix += atom_getintarg(0, ac, av);
+    iemgui->x_obj.te_ypix += atom_getintarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
     {
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_MOVE);
@@ -506,8 +506,8 @@ void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 
 void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    iemgui->x_obj.te_xpix = (int)atom_getintarg(0, ac, av);
-    iemgui->x_obj.te_ypix = (int)atom_getintarg(1, ac, av);
+    iemgui->x_obj.te_xpix = atom_getintarg(0, ac, av);
+    iemgui->x_obj.te_ypix = atom_getintarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
     {
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_MOVE);
@@ -612,11 +612,11 @@ void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
 {
     char str[144];
-    int init = (int)atom_getintarg(5, argc, argv);
-    int ldx = (int)atom_getintarg(10, argc, argv);
-    int ldy = (int)atom_getintarg(11, argc, argv);
-    int f = (int)atom_getintarg(12, argc, argv);
-    int fs = (int)atom_getintarg(13, argc, argv);
+    int init = atom_getintarg(5, argc, argv);
+    int ldx = atom_getintarg(10, argc, argv);
+    int ldy = atom_getintarg(11, argc, argv);
+    int f = atom_getintarg(12, argc, argv);
+    int fs = atom_getintarg(13, argc, argv);
     int bcol = (int)iemgui_getcolorarg(14, argc, argv);
     int fcol = (int)iemgui_getcolorarg(15, argc, argv);
     int lcol = (int)iemgui_getcolorarg(16, argc, argv);
@@ -630,21 +630,21 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
         srl[0] = atom_getsymbolarg(7, argc, argv);
     else if(IS_A_FLOAT(argv,7))
     {
-        sprintf(str, "%d", (int)atom_getintarg(7, argc, argv));
+        sprintf(str, "%d", atom_getintarg(7, argc, argv));
         srl[0] = gensym(str);
     }
     if(IS_A_SYMBOL(argv,8))
         srl[1] = atom_getsymbolarg(8, argc, argv);
     else if(IS_A_FLOAT(argv,8))
     {
-        sprintf(str, "%d", (int)atom_getintarg(8, argc, argv));
+        sprintf(str, "%d", atom_getintarg(8, argc, argv));
         srl[1] = gensym(str);
     }
     if(IS_A_SYMBOL(argv,9))
         srl[2] = atom_getsymbolarg(9, argc, argv);
     else if(IS_A_FLOAT(argv,9))
     {
-        sprintf(str, "%d", (int)atom_getintarg(9, argc, argv));
+        sprintf(str, "%d", atom_getintarg(9, argc, argv));
         srl[2] = gensym(str);
     }
     if(init != 0) init = 1;

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -298,12 +298,12 @@ static int iemgui_getcolorarg(int index, int argc, t_atom*argv)
     if(index < 0 || index >= argc)
         return 0;
     if(IS_A_FLOAT(argv,index))
-        return atom_getintarg(index, argc, argv);
+        return (int)atom_getintarg(index, argc, argv);
     if(IS_A_SYMBOL(argv,index))
     {
         t_symbol*s=atom_getsymbolarg(index, argc, argv);
         if ('#' == s->s_name[0])
-            return strtol(s->s_name+1, 0, 16);
+            return (int)strtol(s->s_name+1, 0, 16);
     }
     return 0;
 }
@@ -314,7 +314,7 @@ static int colfromatomload(t_atom*colatom)
         /* old-fashioned color arguement, either a number or symbol
         evaluating to an integer */
     if (colatom->a_type == A_FLOAT)
-        color = atom_getint(colatom);
+        color = (int)atom_getint(colatom);
     else if (colatom->a_type == A_SYMBOL &&
         (isdigit(colatom->a_w.w_symbol->s_name[0]) ||
             colatom->a_w.w_symbol->s_name[0] == '-'))
@@ -349,7 +349,7 @@ int iemgui_compatible_colorarg(int index, int argc, t_atom* argv)
         return 0;
     if(IS_A_FLOAT(argv,index))
         {
-            int col=atom_getintarg(index, argc, argv);
+            int col = (int)atom_getintarg(index, argc, argv);
             if(col >= 0)
             {
                 int idx = iemgui_modulo_color(col);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -471,7 +471,7 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
         if (size != a->a_n)
             garray_resize_long(x, size);
         else if (style != stylewas)
-            garray_fittograph(x, size, style);
+            garray_fittograph(x, (int)size, style);
         template_setfloat(scalartemplate, gensym("style"),
             x->x_scalar->sc_vec, (t_float)style, 0);
 
@@ -912,9 +912,9 @@ static void garray_dofo(t_garray *x, long npoints, t_float dcval,
     }
     if (npoints == 0)
         npoints = 512;  /* dunno what a good default would be... */
-    if (npoints != (1 << ilog2(npoints)))
+    if (npoints != (1 << ilog2((int)npoints)))
         post("%s: rounnding to %d points", array->a_templatesym->s_name,
-            (npoints = (1<<ilog2(npoints))));
+            (npoints = (1<<ilog2((int)npoints))));
     garray_resize_long(x, npoints + 3);
     phaseincr = 2. * 3.14159 / npoints;
     for (i = 0, phase = -phaseincr; i < array->a_n; i++, phase += phaseincr)
@@ -1178,10 +1178,10 @@ void garray_resize_long(t_garray *x, long n)
     t_glist *gl = x->x_glist;
     if (n < 1)
         n = 1;
-    garray_fittograph(x, n, template_getfloat(
+    garray_fittograph(x, (int)n, template_getfloat(
         template_findbyname(x->x_scalar->sc_template),
             gensym("style"), x->x_scalar->sc_vec, 1));
-    array_resize_and_redraw(array, x->x_glist, n);
+    array_resize_and_redraw(array, x->x_glist, (int)n);
     if (x->x_usedindsp)
         canvas_update_dsp();
 }

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -458,11 +458,11 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
         a = (int)atom_getintarg(0, argc, argv);
         fthold = (int)atom_getintarg(1, argc, argv);
         ftbreak = (int)atom_getintarg(2, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(3, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(3, argc, argv));
         iemgui_new_getnames(&x->x_gui, 4, argv);
         ldx = (int)atom_getintarg(7, argc, argv);
         ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
         fs = (int)atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
     }

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -322,9 +322,9 @@ static void bng_bang2(t_bng *x)/*wird immer gesendet, wenn moeglich*/
 static void bng_dialog(t_bng *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getintarg(0, argc, argv);
-    int fthold = (int)atom_getintarg(2, argc, argv);
-    int ftbreak = (int)atom_getintarg(3, argc, argv);
+    int a = atom_getintarg(0, argc, argv);
+    int fthold = atom_getintarg(2, argc, argv);
+    int ftbreak = atom_getintarg(3, argc, argv);
     int sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
 
     x->x_gui.x_w = iemgui_clip_size(a);
@@ -377,7 +377,7 @@ static void bng_loadbang(t_bng *x, t_floatarg action)
 
 static void bng_size(t_bng *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -390,8 +390,8 @@ static void bng_pos(t_bng *x, t_symbol *s, int ac, t_atom *av)
 
 static void bng_flashtime(t_bng *x, t_symbol *s, int ac, t_atom *av)
 {
-    bng_check_minmax(x, (int)atom_getintarg(0, ac, av),
-                     (int)atom_getintarg(1, ac, av));
+    bng_check_minmax(x, atom_getintarg(0, ac, av),
+                     atom_getintarg(1, ac, av));
 }
 
 static void bng_color(t_bng *x, t_symbol *s, int ac, t_atom *av)
@@ -455,15 +455,15 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10))
     {
 
-        a = (int)atom_getintarg(0, argc, argv);
-        fthold = (int)atom_getintarg(1, argc, argv);
-        ftbreak = (int)atom_getintarg(2, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(3, argc, argv));
+        a = atom_getintarg(0, argc, argv);
+        fthold = atom_getintarg(1, argc, argv);
+        ftbreak = atom_getintarg(2, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(3, argc, argv));
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getintarg(7, argc, argv);
-        ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
-        fs = (int)atom_getintarg(10, argc, argv);
+        ldx = atom_getintarg(7, argc, argv);
+        ldy = atom_getintarg(8, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        fs = atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
     }
     else iemgui_new_getnames(&x->x_gui, 4, 0);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -331,20 +331,20 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
 
     if (argc == 5)  /* toplevel: x, y, w, h, font */
     {
-        xloc = (int)atom_getintarg(0, argc, argv);
-        yloc = (int)atom_getintarg(1, argc, argv);
-        width = (int)atom_getintarg(2, argc, argv);
-        height = (int)atom_getintarg(3, argc, argv);
-        font = (int)atom_getintarg(4, argc, argv);
+        xloc = atom_getintarg(0, argc, argv);
+        yloc = atom_getintarg(1, argc, argv);
+        width = atom_getintarg(2, argc, argv);
+        height = atom_getintarg(3, argc, argv);
+        font = atom_getintarg(4, argc, argv);
     }
     else if (argc == 6)  /* subwindow: x, y, w, h, name, vis */
     {
-        xloc = (int)atom_getintarg(0, argc, argv);
-        yloc = (int)atom_getintarg(1, argc, argv);
-        width = (int)atom_getintarg(2, argc, argv);
-        height = (int)atom_getintarg(3, argc, argv);
+        xloc = atom_getintarg(0, argc, argv);
+        yloc = atom_getintarg(1, argc, argv);
+        width = atom_getintarg(2, argc, argv);
+        height = atom_getintarg(3, argc, argv);
         s = atom_getsymbolarg(4, argc, argv);
-        vis = (int)atom_getintarg(5, argc, argv);
+        vis = atom_getintarg(5, argc, argv);
     }
         /* (otherwise assume we're being created from the menu.) */
     if (THISGUI->i_newdirectory &&
@@ -409,15 +409,15 @@ static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     x->gl_y1 = atom_getfloatarg(1, argc, argv);
     x->gl_x2 = atom_getfloatarg(2, argc, argv);
     x->gl_y2 = atom_getfloatarg(3, argc, argv);
-    x->gl_pixwidth = (int)atom_getintarg(4, argc, argv);
-    x->gl_pixheight = (int)atom_getintarg(5, argc, argv);
+    x->gl_pixwidth = atom_getintarg(4, argc, argv);
+    x->gl_pixheight = atom_getintarg(5, argc, argv);
     if (argc <= 7)
-        canvas_setgraph(x, (int)atom_getintarg(6, argc, argv), 1);
+        canvas_setgraph(x, atom_getintarg(6, argc, argv), 1);
     else
     {
-        x->gl_xmargin = (int)atom_getintarg(7, argc, argv);
-        x->gl_ymargin = (int)atom_getintarg(8, argc, argv);
-        canvas_setgraph(x, (int)atom_getintarg(6, argc, argv), 0);
+        x->gl_xmargin = atom_getintarg(7, argc, argv);
+        x->gl_ymargin = atom_getintarg(8, argc, argv);
+        canvas_setgraph(x, atom_getintarg(6, argc, argv), 0);
     }
 }
 
@@ -1207,7 +1207,7 @@ void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv)
     int newstate;
     if (argc)
     {
-        newstate = (int)atom_getintarg(0, argc, argv);
+        newstate = atom_getintarg(0, argc, argv);
         if (newstate && !THISGUI->i_dspstate)
         {
             sys_set_audio_state(1);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -196,7 +196,7 @@ void canvas_makefilename(t_canvas *x, char *file, char *result, int resultsize)
         int nleft;
         strncpy(result, dir, resultsize);
         result[resultsize-1] = 0;
-        nleft = resultsize - strlen(result) - 1;
+        nleft = resultsize - (int)strlen(result) - 1;
         if (nleft <= 0) return;
         strcat(result, "/");
         strncat(result, file, nleft);
@@ -331,20 +331,20 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
 
     if (argc == 5)  /* toplevel: x, y, w, h, font */
     {
-        xloc = atom_getintarg(0, argc, argv);
-        yloc = atom_getintarg(1, argc, argv);
-        width = atom_getintarg(2, argc, argv);
-        height = atom_getintarg(3, argc, argv);
-        font = atom_getintarg(4, argc, argv);
+        xloc = (int)atom_getintarg(0, argc, argv);
+        yloc = (int)atom_getintarg(1, argc, argv);
+        width = (int)atom_getintarg(2, argc, argv);
+        height = (int)atom_getintarg(3, argc, argv);
+        font = (int)atom_getintarg(4, argc, argv);
     }
     else if (argc == 6)  /* subwindow: x, y, w, h, name, vis */
     {
-        xloc = atom_getintarg(0, argc, argv);
-        yloc = atom_getintarg(1, argc, argv);
-        width = atom_getintarg(2, argc, argv);
-        height = atom_getintarg(3, argc, argv);
+        xloc = (int)atom_getintarg(0, argc, argv);
+        yloc = (int)atom_getintarg(1, argc, argv);
+        width = (int)atom_getintarg(2, argc, argv);
+        height = (int)atom_getintarg(3, argc, argv);
         s = atom_getsymbolarg(4, argc, argv);
-        vis = atom_getintarg(5, argc, argv);
+        vis = (int)atom_getintarg(5, argc, argv);
     }
         /* (otherwise assume we're being created from the menu.) */
     if (THISGUI->i_newdirectory &&
@@ -409,15 +409,15 @@ static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     x->gl_y1 = atom_getfloatarg(1, argc, argv);
     x->gl_x2 = atom_getfloatarg(2, argc, argv);
     x->gl_y2 = atom_getfloatarg(3, argc, argv);
-    x->gl_pixwidth = atom_getintarg(4, argc, argv);
-    x->gl_pixheight = atom_getintarg(5, argc, argv);
+    x->gl_pixwidth = (int)atom_getintarg(4, argc, argv);
+    x->gl_pixheight = (int)atom_getintarg(5, argc, argv);
     if (argc <= 7)
-        canvas_setgraph(x, atom_getintarg(6, argc, argv), 1);
+        canvas_setgraph(x, (int)atom_getintarg(6, argc, argv), 1);
     else
     {
-        x->gl_xmargin = atom_getintarg(7, argc, argv);
-        x->gl_ymargin = atom_getintarg(8, argc, argv);
-        canvas_setgraph(x, atom_getintarg(6, argc, argv), 0);
+        x->gl_xmargin = (int)atom_getintarg(7, argc, argv);
+        x->gl_ymargin = (int)atom_getintarg(8, argc, argv);
+        canvas_setgraph(x, (int)atom_getintarg(6, argc, argv), 0);
     }
 }
 
@@ -1207,7 +1207,7 @@ void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv)
     int newstate;
     if (argc)
     {
-        newstate = atom_getintarg(0, argc, argv);
+        newstate = (int)atom_getintarg(0, argc, argv);
         if (newstate && !THISGUI->i_dspstate)
         {
             sys_set_audio_state(1);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -988,7 +988,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 (unsigned long)c);
             while (c->gl_owner) {
                 c = c->gl_owner;
-                cbuflen = strlen(cbuf);
+                cbuflen = (int)strlen(cbuf);
                 snprintf(cbuf + cbuflen,
                          MAXPDSTRING - cbuflen - 2,/* leave 2 for "\n\0" */
                          " .x%lx", (unsigned long)c);

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -291,9 +291,9 @@ static void hradio_properties(t_gobj *z, t_glist *owner)
 static void hradio_dialog(t_hradio *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getintarg(0, argc, argv);
-    int chg = (int)atom_getintarg(4, argc, argv);
-    int num = (int)atom_getintarg(6, argc, argv);
+    int a = atom_getintarg(0, argc, argv);
+    int chg = atom_getintarg(4, argc, argv);
+    int num = atom_getintarg(6, argc, argv);
     int sr_flags;
 
     if(chg != 0) chg = 1;
@@ -512,7 +512,7 @@ static void hradio_number(t_hradio *x, t_floatarg num)
 
 static void hradio_size(t_hradio *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -577,15 +577,15 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
        &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)&&IS_A_FLOAT(argv,14))
     {
-        a = (int)atom_getintarg(0, argc, argv);
-        chg = (int)atom_getintarg(1, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(2, argc, argv));
-        num = (int)atom_getintarg(3, argc, argv);
+        a = atom_getintarg(0, argc, argv);
+        chg = atom_getintarg(1, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(2, argc, argv));
+        num = atom_getintarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getintarg(7, argc, argv);
-        ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
-        fs = (int)atom_getintarg(10, argc, argv);
+        ldx = atom_getintarg(7, argc, argv);
+        ldy = atom_getintarg(8, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        fs = atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
         fval = atom_getfloatarg(14, argc, argv);
     }

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -579,12 +579,12 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     {
         a = (int)atom_getintarg(0, argc, argv);
         chg = (int)atom_getintarg(1, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(2, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(2, argc, argv));
         num = (int)atom_getintarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
         ldx = (int)atom_getintarg(7, argc, argv);
         ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
         fs = (int)atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
         fval = atom_getfloatarg(14, argc, argv);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -543,11 +543,11 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
         lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
         ldx = (int)atom_getintarg(9, argc, argv);
         ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
         fs = (int)atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -347,12 +347,12 @@ static void hslider_bang(t_hslider *x)
 static void hslider_dialog(t_hslider *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getintarg(0, argc, argv);
-    int h = (int)atom_getintarg(1, argc, argv);
+    int w = atom_getintarg(0, argc, argv);
+    int h = atom_getintarg(1, argc, argv);
     double min = (double)atom_getfloatarg(2, argc, argv);
     double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getintarg(4, argc, argv);
-    int steady = (int)atom_getintarg(17, argc, argv);
+    int lilo = atom_getintarg(4, argc, argv);
+    int steady = atom_getintarg(17, argc, argv);
     int sr_flags;
 
     if(lilo != 0) lilo = 1;
@@ -436,9 +436,9 @@ static int hslider_newclick(t_gobj *z, struct _glist *glist,
 
 static void hslider_size(t_hslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    hslider_check_width(x, (int)atom_getintarg(0, ac, av));
+    hslider_check_width(x, atom_getintarg(0, ac, av));
     if(ac > 1)
-        x->x_gui.x_h = iemgui_clip_size((int)atom_getintarg(1, ac, av));
+        x->x_gui.x_h = iemgui_clip_size(atom_getintarg(1, ac, av));
     iemgui_size((void *)x, &x->x_gui);
 }
 
@@ -538,23 +538,23 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
        &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
     {
-        w = (int)atom_getintarg(0, argc, argv);
-        h = (int)atom_getintarg(1, argc, argv);
+        w = atom_getintarg(0, argc, argv);
+        h = atom_getintarg(1, argc, argv);
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
+        lilo = atom_getintarg(4, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getintarg(9, argc, argv);
-        ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
-        fs = (int)atom_getintarg(12, argc, argv);
+        ldx = atom_getintarg(9, argc, argv);
+        ldy = atom_getintarg(10, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        fs = atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);
     }
     else iemgui_new_getnames(&x->x_gui, 6, 0);
     if((argc == 18)&&IS_A_FLOAT(argv,17))
-        steady = (int)atom_getintarg(17, argc, argv);
+        steady = atom_getintarg(17, argc, argv);
 
     x->x_gui.x_draw = (t_iemfunptr)hslider_draw;
 

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -190,9 +190,9 @@ static void my_canvas_get_pos(t_my_canvas *x)
 static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getintarg(0, argc, argv);
-    int w = (int)atom_getintarg(2, argc, argv);
-    int h = (int)atom_getintarg(3, argc, argv);
+    int a = atom_getintarg(0, argc, argv);
+    int w = atom_getintarg(2, argc, argv);
+    int h = atom_getintarg(3, argc, argv);
     int sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
 
     x->x_gui.x_isa.x_loadinit = 0;
@@ -212,7 +212,7 @@ static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv
 
 static void my_canvas_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
-    int i = (int)atom_getintarg(0, ac, av);
+    int i = atom_getintarg(0, ac, av);
 
     if(i < 1)
         i = 1;
@@ -231,13 +231,13 @@ static void my_canvas_vis_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
     int i;
 
-    i = (int)atom_getintarg(0, ac, av);
+    i = atom_getintarg(0, ac, av);
     if(i < 1)
         i = 1;
     x->x_vis_w = i;
     if(ac > 1)
     {
-        i = (int)atom_getintarg(1, ac, av);
+        i = atom_getintarg(1, ac, av);
         if(i < 1)
             i = 1;
     }
@@ -282,9 +282,9 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     if(((argc >= 10)&&(argc <= 13))
        &&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2))
     {
-        a = (int)atom_getintarg(0, argc, argv);
-        w = (int)atom_getintarg(1, argc, argv);
-        h = (int)atom_getintarg(2, argc, argv);
+        a = atom_getintarg(0, argc, argv);
+        w = atom_getintarg(1, argc, argv);
+        h = atom_getintarg(2, argc, argv);
     }
     if((argc >= 12)&&(IS_A_SYMBOL(argv,3)||IS_A_FLOAT(argv,3))&&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4)))
     {
@@ -308,15 +308,15 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
             the slot x_labelbindex) and initialize it specially here. */
         iemgui_new_dogetname(&x->x_gui, i+3, argv);
         x->x_gui.x_labelbindex = i+4;
-        ldx = (int)atom_getintarg(i+4, argc, argv);
-        ldy = (int)atom_getintarg(i+5, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(i+6, argc, argv));
-        fs = (int)atom_getintarg(i+7, argc, argv);
+        ldx = atom_getintarg(i+4, argc, argv);
+        ldy = atom_getintarg(i+5, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(i+6, argc, argv));
+        fs = atom_getintarg(i+7, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+i+8, 0, argv+i+9);
     }
     if((argc == 13)&&IS_A_FLOAT(argv,i+10))
     {
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(i+10, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(i+10, argc, argv));
     }
     x->x_gui.x_draw = (t_iemfunptr)my_canvas_draw;
     x->x_gui.x_fsf.x_snd_able = 1;

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -310,13 +310,13 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
         x->x_gui.x_labelbindex = i+4;
         ldx = (int)atom_getintarg(i+4, argc, argv);
         ldy = (int)atom_getintarg(i+5, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(i+6, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(i+6, argc, argv));
         fs = (int)atom_getintarg(i+7, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+i+8, 0, argv+i+9);
     }
     if((argc == 13)&&IS_A_FLOAT(argv,i+10))
     {
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(i+10, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(i+10, argc, argv));
     }
     x->x_gui.x_draw = (t_iemfunptr)my_canvas_draw;
     x->x_gui.x_fsf.x_snd_able = 1;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -485,12 +485,12 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getintarg(0, argc, argv);
-    int h = (int)atom_getintarg(1, argc, argv);
+    int w = atom_getintarg(0, argc, argv);
+    int h = atom_getintarg(1, argc, argv);
     double min = (double)atom_getfloatarg(2, argc, argv);
     double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getintarg(4, argc, argv);
-    int log_height = (int)atom_getintarg(6, argc, argv);
+    int lilo = atom_getintarg(4, argc, argv);
+    int log_height = atom_getintarg(6, argc, argv);
     int sr_flags;
 
     if(lilo != 0) lilo = 1;
@@ -604,13 +604,13 @@ static void my_numbox_size(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 {
     int h, w;
 
-    w = (int)atom_getintarg(0, ac, av);
+    w = atom_getintarg(0, ac, av);
     if(w < 1)
         w = 1;
     x->x_gui.x_w = w;
     if(ac > 1)
     {
-        h = (int)atom_getintarg(1, ac, av);
+        h = atom_getintarg(1, ac, av);
         if(h < 8)
             h = 8;
         x->x_gui.x_h = h;
@@ -653,12 +653,12 @@ static void my_numbox_label_pos(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 static void my_numbox_label_font(t_my_numbox *x,
     t_symbol *s, int ac, t_atom *av)
 {
-    int f = (int)atom_getintarg(1, ac, av);
+    int f = atom_getintarg(1, ac, av);
 
     if(f < 4)
         f = 4;
     x->x_gui.x_fontsize = f;
-    f = (int)atom_getintarg(0, ac, av);
+    f = atom_getintarg(0, ac, av);
     if((f < 0) || (f > 2))
         f = 0;
     x->x_gui.x_fsf.x_font_style = f;
@@ -775,24 +775,24 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
        &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
     {
-        w = (int)atom_getintarg(0, argc, argv);
-        h = (int)atom_getintarg(1, argc, argv);
+        w = atom_getintarg(0, argc, argv);
+        h = atom_getintarg(1, argc, argv);
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
+        lilo = atom_getintarg(4, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getintarg(9, argc, argv);
-        ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
-        fs = (int)atom_getintarg(12, argc, argv);
+        ldx = atom_getintarg(9, argc, argv);
+        ldy = atom_getintarg(10, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        fs = atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);
     }
     else iemgui_new_getnames(&x->x_gui, 6, 0);
     if((argc == 18)&&IS_A_FLOAT(argv,17))
     {
-        log_height = (int)atom_getintarg(17, argc, argv);
+        log_height = atom_getintarg(17, argc, argv);
     }
     x->x_gui.x_draw = (t_iemfunptr)my_numbox_draw;
     x->x_gui.x_fsf.x_snd_able = 1;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -77,7 +77,7 @@ void my_numbox_ftoa(t_my_numbox *x)
     int bufsize, is_exp=0, i, idecimal;
 
     sprintf(x->x_buf, "%g", f);
-    bufsize = strlen(x->x_buf);
+    bufsize = (int)strlen(x->x_buf);
     if(bufsize >= 5)/* if it is in exponential mode */
     {
         i = bufsize - 4;
@@ -138,7 +138,7 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
             if(x->x_buf[0])
             {
                 char *cp=x->x_buf;
-                int sl = strlen(x->x_buf);
+                int sl = (int)strlen(x->x_buf);
 
                 x->x_buf[sl] = '>';
                 x->x_buf[sl+1] = 0;
@@ -721,8 +721,7 @@ static void my_numbox_key(void *z, t_floatarg fkey)
     }
     else if((c=='\b')||(c==127))
     {
-        int sl=strlen(x->x_buf)-1;
-
+        int sl = (int)strlen(x->x_buf)-1;
         if(sl < 0)
             sl = 0;
         x->x_buf[sl] = 0;
@@ -781,11 +780,11 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
         lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
         ldx = (int)atom_getintarg(9, argc, argv);
         ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
         fs = (int)atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -786,7 +786,7 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
     }
     else
     {
-        int cpy = s1 - s->s_name, got;
+        int cpy = (int)(s1 - s->s_name), got;
         double v1, v2, screen1, screen2, quantum;
         if (cpy > MAXPDSTRING-5)
             cpy = MAXPDSTRING-5;
@@ -2454,7 +2454,7 @@ static void drawnumber_getbuf(t_drawnumber *x, t_word *data,
     {
         strncpy(buf, x->x_label->s_name, DRAWNUMBER_BUFSIZE);
         buf[DRAWNUMBER_BUFSIZE - 1] = 0;
-        nchars = strlen(buf);
+        nchars = (int)strlen(buf);
         if (type == DT_TEXT)
         {
             char *buf2;
@@ -2508,11 +2508,11 @@ static void drawnumber_getrect(t_gobj *z, t_glist *glist,
         startline = newline+1)
     {
         if (newline - startline > width)
-            width = newline - startline;
+            width = (int)(newline - startline);
         height++;
     }
     if (strlen(startline) > (unsigned)width)
-        width = strlen(startline);
+        width = (int)strlen(startline);
     *xp1 = xloc;
     *yp1 = yloc;
     *xp2 = xloc + fontwidth * width;

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -188,8 +188,8 @@ void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     {
         t_binbuf *b = binbuf_new();
         binbuf_restore(b, argc-2, argv+2);
-        canvas_objtext(gl, (int)atom_getintarg(0, argc, argv),
-            (int)atom_getintarg(1, argc, argv), 0, 0, b);
+        canvas_objtext(gl, atom_getintarg(0, argc, argv),
+            atom_getintarg(1, argc, argv), 0, 0, b);
     }
         /* JMZ: don't go into interactive mode in a closed canvas */
     else if (!glist_isvisible(gl))

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -188,8 +188,8 @@ void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     {
         t_binbuf *b = binbuf_new();
         binbuf_restore(b, argc-2, argv+2);
-        canvas_objtext(gl, atom_getintarg(0, argc, argv),
-            atom_getintarg(1, argc, argv), 0, 0, b);
+        canvas_objtext(gl, (int)atom_getintarg(0, argc, argv),
+            (int)atom_getintarg(1, argc, argv), 0, 0, b);
     }
         /* JMZ: don't go into interactive mode in a closed canvas */
     else if (!glist_isvisible(gl))
@@ -676,7 +676,7 @@ static void gatom_key(void *z, t_floatarg f)
 {
     t_gatom *x = (t_gatom *)z;
     int c = f;
-    int len = strlen(x->a_buf);
+    int len = (int)strlen(x->a_buf);
     t_atom at;
     char sbuf[ATOMBUFSIZE + 4];
     if (c == 0)
@@ -832,7 +832,7 @@ static void gatom_getwherelabel(t_gatom *x, t_glist *glist, int *xp, int *yp)
     if (x->a_wherelabel == ATOM_LABELLEFT)
     {
         *xp = x1 - 3 -
-            strlen(canvas_realizedollar(x->a_glist, x->a_label)->s_name) *
+            (int)strlen(canvas_realizedollar(x->a_glist, x->a_label)->s_name) *
             glist_fontwidth(glist);
         *yp = y1 + 2;
     }

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -262,7 +262,7 @@ static void toggle_bang(t_toggle *x)
 static void toggle_dialog(t_toggle *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getintarg(0, argc, argv);
+    int a = atom_getintarg(0, argc, argv);
     t_float nonzero = (t_float)atom_getfloatarg(2, argc, argv);
     int sr_flags;
 
@@ -327,7 +327,7 @@ static void toggle_loadbang(t_toggle *x, t_floatarg action)
 
 static void toggle_size(t_toggle *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -391,13 +391,13 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,5)&&IS_A_FLOAT(argv,6)
        &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)&&IS_A_FLOAT(argv,12))
     {
-        a = (int)atom_getintarg(0, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(1, argc, argv));
+        a = atom_getintarg(0, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(1, argc, argv));
         iemgui_new_getnames(&x->x_gui, 2, argv);
-        ldx = (int)atom_getintarg(5, argc, argv);
-        ldy = (int)atom_getintarg(6, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(7, argc, argv));
-        fs = (int)atom_getintarg(8, argc, argv);
+        ldx = atom_getintarg(5, argc, argv);
+        ldy = atom_getintarg(6, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(7, argc, argv));
+        fs = atom_getintarg(8, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+9, argv+10, argv+11);
         on = (t_float)atom_getfloatarg(12, argc, argv);
     }

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -392,11 +392,11 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)&&IS_A_FLOAT(argv,12))
     {
         a = (int)atom_getintarg(0, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(1, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(1, argc, argv));
         iemgui_new_getnames(&x->x_gui, 2, argv);
         ldx = (int)atom_getintarg(5, argc, argv);
         ldy = (int)atom_getintarg(6, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(7, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(7, argc, argv));
         fs = (int)atom_getintarg(8, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+9, argv+10, argv+11);
         on = (t_float)atom_getfloatarg(12, argc, argv);

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -292,9 +292,9 @@ static void vradio_properties(t_gobj *z, t_glist *owner)
 static void vradio_dialog(t_vradio *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getintarg(0, argc, argv);
-    int chg = (int)atom_getintarg(4, argc, argv);
-    int num = (int)atom_getintarg(6, argc, argv);
+    int a = atom_getintarg(0, argc, argv);
+    int chg = atom_getintarg(4, argc, argv);
+    int num = atom_getintarg(6, argc, argv);
     int sr_flags;
 
     if(chg != 0) chg = 1;
@@ -517,7 +517,7 @@ static void vradio_number(t_vradio *x, t_floatarg num)
 
 static void vradio_size(t_vradio *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -579,15 +579,15 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
        &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)&&IS_A_FLOAT(argv,14))
     {
-        a = (int)atom_getintarg(0, argc, argv);
-        chg = (int)atom_getintarg(1, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(2, argc, argv));
-        num = (int)atom_getintarg(3, argc, argv);
+        a = atom_getintarg(0, argc, argv);
+        chg = atom_getintarg(1, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(2, argc, argv));
+        num = atom_getintarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getintarg(7, argc, argv);
-        ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
-        fs = (int)atom_getintarg(10, argc, argv);
+        ldx = atom_getintarg(7, argc, argv);
+        ldy = atom_getintarg(8, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        fs = atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
         fval = atom_getintarg(14, argc, argv);
     }

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -581,12 +581,12 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     {
         a = (int)atom_getintarg(0, argc, argv);
         chg = (int)atom_getintarg(1, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(2, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(2, argc, argv));
         num = (int)atom_getintarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
         ldx = (int)atom_getintarg(7, argc, argv);
         ldy = (int)atom_getintarg(8, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(9, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(9, argc, argv));
         fs = (int)atom_getintarg(10, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
         fval = atom_getintarg(14, argc, argv);

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -329,12 +329,12 @@ static void vslider_bang(t_vslider *x)
 static void vslider_dialog(t_vslider *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getintarg(0, argc, argv);
-    int h = (int)atom_getintarg(1, argc, argv);
+    int w = atom_getintarg(0, argc, argv);
+    int h = atom_getintarg(1, argc, argv);
     double min = (double)atom_getfloatarg(2, argc, argv);
     double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getintarg(4, argc, argv);
-    int steady = (int)atom_getintarg(17, argc, argv);
+    int lilo = atom_getintarg(4, argc, argv);
+    int steady = atom_getintarg(17, argc, argv);
     int sr_flags;
 
     if(lilo != 0) lilo = 1;
@@ -455,9 +455,9 @@ static void vslider_float(t_vslider *x, t_floatarg f)
 
 static void vslider_size(t_vslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     if(ac > 1)
-        vslider_check_height(x, (int)atom_getintarg(1, ac, av));
+        vslider_check_height(x, atom_getintarg(1, ac, av));
     iemgui_size((void *)x, &x->x_gui);
 }
 
@@ -548,23 +548,23 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
        &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
     {
-        w = (int)atom_getintarg(0, argc, argv);
-        h = (int)atom_getintarg(1, argc, argv);
+        w = atom_getintarg(0, argc, argv);
+        h = atom_getintarg(1, argc, argv);
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
+        lilo = atom_getintarg(4, argc, argv);
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getintarg(9, argc, argv);
-        ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
-        fs = (int)atom_getintarg(12, argc, argv);
+        ldx = atom_getintarg(9, argc, argv);
+        ldy = atom_getintarg(10, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        fs = atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);
     }
     else iemgui_new_getnames(&x->x_gui, 6, 0);
     if((argc == 18)&&IS_A_FLOAT(argv,17))
-        steady = (int)atom_getintarg(17, argc, argv);
+        steady = atom_getintarg(17, argc, argv);
     x->x_gui.x_draw = (t_iemfunptr)vslider_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -553,11 +553,11 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
         min = (double)atom_getfloatarg(2, argc, argv);
         max = (double)atom_getfloatarg(3, argc, argv);
         lilo = (int)atom_getintarg(4, argc, argv);
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(5, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
         ldx = (int)atom_getintarg(9, argc, argv);
         ldy = (int)atom_getintarg(10, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(11, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(11, argc, argv));
         fs = (int)atom_getintarg(12, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -525,9 +525,9 @@ static void vu_properties(t_gobj *z, t_glist *owner)
 static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getintarg(0, argc, argv);
-    int h = (int)atom_getintarg(1, argc, argv);
-    int scale = (int)atom_getintarg(4, argc, argv);
+    int w = atom_getintarg(0, argc, argv);
+    int h = atom_getintarg(1, argc, argv);
+    int scale = atom_getintarg(4, argc, argv);
     int sr_flags;
 
     srl[0] = gensym("empty");
@@ -547,9 +547,9 @@ static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
 
 static void vu_size(t_vu *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getintarg(0, ac, av));
+    x->x_gui.x_w = iemgui_clip_size(atom_getintarg(0, ac, av));
     if(ac > 1)
-        vu_check_height(x, (int)atom_getintarg(1, ac, av));
+        vu_check_height(x, atom_getintarg(1, ac, av));
     if(glist_isvisible(x->x_gui.x_glist))
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
@@ -653,19 +653,19 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
        &&IS_A_FLOAT(argv,6)&&IS_A_FLOAT(argv,7)
        &&IS_A_FLOAT(argv,10))
     {
-        w = (int)atom_getintarg(0, argc, argv);
-        h = (int)atom_getintarg(1, argc, argv);
+        w = atom_getintarg(0, argc, argv);
+        h = atom_getintarg(1, argc, argv);
         iemgui_new_getnames(&x->x_gui, 1, argv);
-        ldx = (int)atom_getintarg(4, argc, argv);
-        ldy = (int)atom_getintarg(5, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(6, argc, argv));
-        fs = (int)atom_getintarg(7, argc, argv);
+        ldx = atom_getintarg(4, argc, argv);
+        ldy = atom_getintarg(5, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(6, argc, argv));
+        fs = atom_getintarg(7, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+8, NULL, argv+9);
-        scale = (int)atom_getintarg(10, argc, argv);
+        scale = atom_getintarg(10, argc, argv);
     }
     else iemgui_new_getnames(&x->x_gui, 1, 0);
     if((argc == 12)&&IS_A_FLOAT(argv,11))
-        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(11, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(11, argc, argv));
     x->x_gui.x_draw = (t_iemfunptr)vu_draw;
 
     x->x_gui.x_fsf.x_snd_able = 0;

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -658,14 +658,14 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
         iemgui_new_getnames(&x->x_gui, 1, argv);
         ldx = (int)atom_getintarg(4, argc, argv);
         ldy = (int)atom_getintarg(5, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getintarg(6, argc, argv));
+        iem_inttofstyle(&x->x_gui.x_fsf, (int)atom_getintarg(6, argc, argv));
         fs = (int)atom_getintarg(7, argc, argv);
         iemgui_all_loadcolors(&x->x_gui, argv+8, NULL, argv+9);
         scale = (int)atom_getintarg(10, argc, argv);
     }
     else iemgui_new_getnames(&x->x_gui, 1, 0);
     if((argc == 12)&&IS_A_FLOAT(argv,11))
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getintarg(11, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, (int)atom_getintarg(11, argc, argv));
     x->x_gui.x_draw = (t_iemfunptr)vu_draw;
 
     x->x_gui.x_fsf.x_snd_able = 0;

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -16,7 +16,7 @@ t_float atom_getfloat(t_atom *a)
     else return (0);
 }
 
-t_int atom_getint(t_atom *a)
+int atom_getint(t_atom *a)
 {
     return (atom_getfloat(a));
 }
@@ -45,7 +45,7 @@ t_float atom_getfloatarg(int which, int argc, t_atom *argv)
     else return (0);
 }
 
-t_int atom_getintarg(int which, int argc, t_atom *argv)
+int atom_getintarg(int which, int argc, t_atom *argv)
 {
     return (atom_getfloatarg(which, argc, argv));
 }

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -216,7 +216,7 @@ void binbuf_gettext(t_binbuf *x, char **bufp, int *lengthp)
         if ((ap->a_type == A_SEMI || ap->a_type == A_COMMA) &&
                 length && buf[length-1] == ' ') length--;
         atom_string(ap, string, MAXPDSTRING);
-        newlength = length + strlen(string) + 1;
+        newlength = length + (int)strlen(string) + 1;
         if (!(newbuf = resizebytes(buf, length, newlength))) break;
         buf = newbuf;
         strcpy(buf + length, string);
@@ -478,7 +478,7 @@ int canvas_getdollarzero( void);
  */
 int binbuf_expanddollsym(char*s, char*buf,t_atom dollar0, int ac, t_atom *av, int tonew)
 {
-  int argno=atol(s);
+  int argno = (int)atol(s);
   int arglen=0;
   char*cs=s;
   char c=*cs;
@@ -819,7 +819,7 @@ int binbuf_read(t_binbuf *b, char *filename, char *dirname, int crflag)
         close(fd);
         return(1);
     }
-    if ((readret = read(fd, buf, length)) < length)
+    if ((readret = (int)read(fd, buf, length)) < length)
     {
         fprintf(stderr, "read (%d %ld) -> %d\n", fd, length, readret);
         perror(namebuf);
@@ -920,7 +920,7 @@ int binbuf_write(t_binbuf *x, char *filename, char *dir, int crflag)
             /* estimate how many characters will be needed.  Printing out
             symbols may need extra characters for inserting backslashes. */
         if (ap->a_type == A_SYMBOL || ap->a_type == A_DOLLSYM)
-            length = 80 + strlen(ap->a_w.w_symbol->s_name);
+            length = 80 + (int)strlen(ap->a_w.w_symbol->s_name);
         else length = 40;
         if (ep - bp < length)
         {
@@ -935,8 +935,8 @@ int binbuf_write(t_binbuf *x, char *filename, char *dir, int crflag)
             bp > sbuf && bp[-1] == ' ') bp--;
         if (!crflag || ap->a_type != A_SEMI)
         {
-            atom_string(ap, bp, (ep-bp)-2);
-            length = strlen(bp);
+            atom_string(ap, bp, (unsigned int)((ep-bp)-2));
+            length = (int)strlen(bp);
             bp += length;
             ncolumn += length;
         }
@@ -990,7 +990,8 @@ static t_binbuf *binbuf_convert(t_binbuf *oldb, int maxtopd)
     t_binbuf *newb = binbuf_new();
     t_atom *vec = oldb->b_vec;
     t_int n = oldb->b_n, nextindex, stackdepth = 0, stack[MAXSTACK] = {0},
-        nobj = 0, i, gotfontsize = 0;
+        nobj = 0, gotfontsize = 0;
+	int i;
     t_atom outmess[MAXSTACK], *nextmess;
     t_float fontsize = 10;
     if (!maxtopd)
@@ -999,7 +1000,7 @@ static t_binbuf *binbuf_convert(t_binbuf *oldb, int maxtopd)
     {
         int endmess, natom;
         char *first, *second, *third;
-        for (endmess = nextindex; endmess < n && vec[endmess].a_type != A_SEMI;
+        for (endmess = (int)nextindex; endmess < n && vec[endmess].a_type != A_SEMI;
             endmess++)
                 ;
         if (endmess == n) break;
@@ -1010,7 +1011,7 @@ static t_binbuf *binbuf_convert(t_binbuf *oldb, int maxtopd)
             nextindex = endmess + 1;
             continue;
         }
-        natom = endmess - nextindex;
+        natom = endmess - (int)nextindex;
         if (natom > MAXSTACK-10) natom = MAXSTACK-10;
         nextmess = vec + nextindex;
         first = nextmess->a_w.w_symbol->s_name;

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -749,7 +749,7 @@ t_symbol *gensym(const char *s)
 static t_symbol *addfileextent(t_symbol *s)
 {
     char namebuf[MAXPDSTRING], *str = s->s_name;
-    int ln = strlen(str);
+    int ln = (int)strlen(str);
     if (!strcmp(str + ln - 3, ".pd")) return (s);
     strcpy(namebuf, str);
     strcpy(namebuf+ln, ".pd");

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -320,11 +320,11 @@ EXTERN void *resizebytes(void *x, size_t oldsize, size_t newsize);
     (atom)->a_w.w_symbol= (s))
 
 EXTERN t_float atom_getfloat(t_atom *a);
-EXTERN t_int atom_getint(t_atom *a);
+EXTERN int atom_getint(t_atom *a);
 EXTERN t_symbol *atom_getsymbol(t_atom *a);
 EXTERN t_symbol *atom_gensym(t_atom *a);
 EXTERN t_float atom_getfloatarg(int which, int argc, t_atom *argv);
-EXTERN t_int atom_getintarg(int which, int argc, t_atom *argv);
+EXTERN int atom_getintarg(int which, int argc, t_atom *argv);
 EXTERN t_symbol *atom_getsymbolarg(int which, int argc, t_atom *argv);
 
 EXTERN void atom_string(t_atom *a, char *buf, unsigned int bufsize);
@@ -650,6 +650,7 @@ EXTERN t_float q8_rsqrt(t_float);
 EXTERN t_float qsqrt(t_float);  /* old names kept for extern compatibility */
 EXTERN t_float qrsqrt(t_float);
 #endif
+
 /* --------------------- data --------------------------------- */
 
     /* graphical arrays */

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -822,17 +822,17 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int newaudioindev[4], newaudioinchan[4],
         newaudiooutdev[4], newaudiooutchan[4];
         /* the new values the dialog came back with: */
-    int newrate = atom_getintarg(16, argc, argv);
-    int newadvance = atom_getintarg(17, argc, argv);
-    int newcallback = atom_getintarg(18, argc, argv);
-    int newblocksize = atom_getintarg(19, argc, argv);
+    int newrate = (int)atom_getintarg(16, argc, argv);
+    int newadvance = (int)atom_getintarg(17, argc, argv);
+    int newcallback = (int)atom_getintarg(18, argc, argv);
+    int newblocksize = (int)atom_getintarg(19, argc, argv);
 
     for (i = 0; i < 4; i++)
     {
-        newaudioindev[i] = atom_getintarg(i, argc, argv);
-        newaudioinchan[i] = atom_getintarg(i+4, argc, argv);
-        newaudiooutdev[i] = atom_getintarg(i+8, argc, argv);
-        newaudiooutchan[i] = atom_getintarg(i+12, argc, argv);
+        newaudioindev[i] = (int)atom_getintarg(i, argc, argv);
+        newaudioinchan[i] = (int)atom_getintarg(i+4, argc, argv);
+        newaudiooutdev[i] = (int)atom_getintarg(i+8, argc, argv);
+        newaudiooutchan[i] = (int)atom_getintarg(i+12, argc, argv);
     }
 
     for (i = 0, nindev = 0; i < 4; i++)
@@ -1089,7 +1089,7 @@ int sys_audiodevnametonumber(int output, const char *name)
     {
         for (i = 0; i < noutdevs; i++)
         {
-            unsigned int comp = strlen(name);
+            unsigned long comp = strlen(name);
             if (comp > strlen(outdevlist + i * DEVDESCSIZE))
                 comp = strlen(outdevlist + i * DEVDESCSIZE);
             if (!strncmp(name, outdevlist + i * DEVDESCSIZE, comp))
@@ -1100,7 +1100,7 @@ int sys_audiodevnametonumber(int output, const char *name)
     {
         for (i = 0; i < nindevs; i++)
         {
-            unsigned int comp = strlen(name);
+            unsigned long comp = strlen(name);
             if (comp > strlen(indevlist + i * DEVDESCSIZE))
                 comp = strlen(indevlist + i * DEVDESCSIZE);
             if (!strncmp(name, indevlist + i * DEVDESCSIZE, comp))

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -822,17 +822,17 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int newaudioindev[4], newaudioinchan[4],
         newaudiooutdev[4], newaudiooutchan[4];
         /* the new values the dialog came back with: */
-    int newrate = (int)atom_getintarg(16, argc, argv);
-    int newadvance = (int)atom_getintarg(17, argc, argv);
-    int newcallback = (int)atom_getintarg(18, argc, argv);
-    int newblocksize = (int)atom_getintarg(19, argc, argv);
+    int newrate = atom_getintarg(16, argc, argv);
+    int newadvance = atom_getintarg(17, argc, argv);
+    int newcallback = atom_getintarg(18, argc, argv);
+    int newblocksize = atom_getintarg(19, argc, argv);
 
     for (i = 0; i < 4; i++)
     {
-        newaudioindev[i] = (int)atom_getintarg(i, argc, argv);
-        newaudioinchan[i] = (int)atom_getintarg(i+4, argc, argv);
-        newaudiooutdev[i] = (int)atom_getintarg(i+8, argc, argv);
-        newaudiooutchan[i] = (int)atom_getintarg(i+12, argc, argv);
+        newaudioindev[i] = atom_getintarg(i, argc, argv);
+        newaudioinchan[i] = atom_getintarg(i+4, argc, argv);
+        newaudiooutdev[i] = atom_getintarg(i+8, argc, argv);
+        newaudiooutchan[i] = atom_getintarg(i+12, argc, argv);
     }
 
     for (i = 0, nindev = 0; i < 4; i++)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -508,7 +508,7 @@ static int socketreceiver_doread(t_socketreceiver *x)
 static void socketreceiver_getudp(t_socketreceiver *x, int fd)
 {
     char buf[INBUFSIZE+1];
-    int ret = recv(fd, buf, INBUFSIZE, 0);
+    int ret = (int)recv(fd, buf, INBUFSIZE, 0);
     if (ret < 0)
     {
         sys_sockerror("recv");
@@ -565,7 +565,7 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
         }
         else
         {
-            ret = recv(fd, x->sr_inbuf + x->sr_inhead,
+            ret = (int)recv(fd, x->sr_inbuf + x->sr_inhead,
                 readto - x->sr_inhead, 0);
             if (ret <= 0)
             {
@@ -655,7 +655,7 @@ static void sys_trytogetmoreguibuf(int newsize)
         int written = 0;
         while (1)
         {
-            int res = send(pd_this->pd_inter->i_guisock,
+            int res = (int)send(pd_this->pd_inter->i_guisock,
                 pd_this->pd_inter->i_guibuf + pd_this->pd_inter->i_guitail +
                     written, bytestowrite, 0);
             if (res < 0)
@@ -747,12 +747,12 @@ void sys_gui(char *s)
     sys_vgui("%s", s);
 }
 
-static int sys_flushtogui( void)
+static int sys_flushtogui(void)
 {
     int writesize = pd_this->pd_inter->i_guihead - pd_this->pd_inter->i_guitail,
         nwrote = 0;
     if (writesize > 0)
-        nwrote = send(pd_this->pd_inter->i_guisock,
+        nwrote =(int) send(pd_this->pd_inter->i_guisock,
             pd_this->pd_inter->i_guibuf + pd_this->pd_inter->i_guitail,
                 writesize, 0);
 

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -752,7 +752,7 @@ static int sys_flushtogui(void)
     int writesize = pd_this->pd_inter->i_guihead - pd_this->pd_inter->i_guitail,
         nwrote = 0;
     if (writesize > 0)
-        nwrote =(int) send(pd_this->pd_inter->i_guisock,
+        nwrote = (int)send(pd_this->pd_inter->i_guisock,
             pd_this->pd_inter->i_guibuf + pd_this->pd_inter->i_guitail,
                 writesize, 0);
 

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -320,7 +320,7 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
         int dirlen;
         if (!z)
             return (0);
-        dirlen = z - classname;
+        dirlen = (int)(z - classname);
         if (dirlen > MAXPDSTRING-1)
             dirlen = MAXPDSTRING-1;
         strncpy(dirbuf, classname, dirlen);

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -236,9 +236,9 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     for (j = 0; j < NZOOM; j++)
         for (i = 0; i < NFONT; i++)
     {
-        int size   = (int)atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
-        int width  = (int)atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
-        int height = (int)atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
+        int size   = atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
+        int width  = atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
+        int height = atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
         if (!(size && width && height))
         {
             size   = (j+1)*sys_fontspec[i].fi_pointsize;

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -236,9 +236,9 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     for (j = 0; j < NZOOM; j++)
         for (i = 0; i < NFONT; i++)
     {
-        int size   = atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
-        int width  = atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
-        int height = atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
+        int size   = (int)atom_getintarg(3 * (i + j * NFONT) + 2, argc, argv);
+        int width  = (int)atom_getintarg(3 * (i + j * NFONT) + 3, argc, argv);
+        int height = (int)atom_getintarg(3 * (i + j * NFONT) + 4, argc, argv);
         if (!(size && width && height))
         {
             size   = (j+1)*sys_fontspec[i].fi_pointsize;
@@ -517,7 +517,7 @@ static void sys_parsedevlist(int *np, int *vecp, int max, char *str)
         else
         {
             char *endp;
-            vecp[n] = strtol(str, &endp, 10);
+            vecp[n] = (int)strtol(str, &endp, 10);
             if (endp == str)
                 break;
             n++;

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -642,8 +642,8 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int i;
     namelist_free(STUFF->st_searchpath);
     STUFF->st_searchpath = 0;
-    sys_usestdpath = (int)atom_getintarg(0, argc, argv);
-    sys_verbose = (int)atom_getintarg(1, argc, argv);
+    sys_usestdpath = atom_getintarg(0, argc, argv);
+    sys_verbose = atom_getintarg(1, argc, argv);
     for (i = 0; i < argc-2; i++)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
@@ -698,7 +698,7 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int i;
     namelist_free(STUFF->st_externlist);
     STUFF->st_externlist = 0;
-    sys_defeatrt = (int)atom_getintarg(0, argc, argv);
+    sys_defeatrt = atom_getintarg(0, argc, argv);
     sys_flags = sys_decodedialog(atom_getsymbolarg(1, argc, argv));
     for (i = 0; i < argc-2; i++)
     {

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -335,7 +335,7 @@ int sys_open_absolute(const char *name, const char* ext,
         int dirlen;
         if (!z)
             return (0);
-        dirlen = z - name;
+        dirlen = (int)(z - name);
         if (dirlen > MAXPDSTRING-1)
             dirlen = MAXPDSTRING-1;
         strncpy(dirbuf, name, dirlen);
@@ -531,7 +531,7 @@ void sys_doflags( void)
     char *rcargv[MAXPDSTRING];
     if (!sys_flags)
         sys_flags = &s_;
-    len = strlen(sys_flags->s_name);
+    len = (int)strlen(sys_flags->s_name);
     if (len > MAXPDSTRING)
     {
         error("flags: %s: too long", sys_flags->s_name);
@@ -642,8 +642,8 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int i;
     namelist_free(STUFF->st_searchpath);
     STUFF->st_searchpath = 0;
-    sys_usestdpath = atom_getintarg(0, argc, argv);
-    sys_verbose = atom_getintarg(1, argc, argv);
+    sys_usestdpath = (int)atom_getintarg(0, argc, argv);
+    sys_verbose = (int)atom_getintarg(1, argc, argv);
     for (i = 0; i < argc-2; i++)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
@@ -698,7 +698,7 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int i;
     namelist_free(STUFF->st_externlist);
     STUFF->st_externlist = 0;
-    sys_defeatrt = atom_getintarg(0, argc, argv);
+    sys_defeatrt = (int)atom_getintarg(0, argc, argv);
     sys_flags = sys_decodedialog(atom_getsymbolarg(1, argc, argv));
     for (i = 0; i < argc-2; i++)
     {

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -558,7 +558,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
     {
         if (argc > 1)       /* 2 or more args: treat as "list" */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_list)
                 {
@@ -572,7 +572,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else if (argc == 0)         /* no args: treat as "bang" */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_bang)
                 {
@@ -583,7 +583,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else if (argv[0].a_type == A_FLOAT)     /* one float arg */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_float)
                 {
@@ -594,7 +594,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_symbol)
                 {

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -398,7 +398,7 @@ typedef struct _sel2
 static void sel2_float(t_sel2 *x, t_float f)
 {
     t_selectelement *e;
-    int nelement;
+    t_int nelement;
     if (x->x_type == A_FLOAT)
     {
         for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
@@ -414,7 +414,7 @@ static void sel2_float(t_sel2 *x, t_float f)
 static void sel2_symbol(t_sel2 *x, t_symbol *s)
 {
     t_selectelement *e;
-    int nelement;
+    t_int nelement;
     if (x->x_type == A_SYMBOL)
     {
         for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
@@ -517,7 +517,7 @@ typedef struct _route
 static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
-    int nelement;
+    t_int nelement;
     if (x->x_type == A_SYMBOL)
     {
         for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
@@ -536,7 +536,7 @@ static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
-    int nelement;
+    t_int nelement;
     if (x->x_type == A_FLOAT)
     {
         t_float f;
@@ -732,10 +732,10 @@ static void *pack_new(t_symbol *s, int argc, t_atom *argv)
 
 static void pack_bang(t_pack *x)
 {
-    int i, reentered = 0, size = x->x_n * sizeof (t_atom);
+    int i, reentered = 0, size = (int)(x->x_n * sizeof(t_atom));
     t_gpointer *gp;
     t_atom *outvec;
-    for (i = x->x_nptr, gp = x->x_gpointer; i--; gp++)
+    for (i = (int)x->x_nptr, gp = x->x_gpointer; i--; gp++)
         if (!gpointer_check(gp, 1))
     {
         pd_error(x, "pack: stale pointer");
@@ -757,7 +757,7 @@ static void pack_bang(t_pack *x)
         x->x_outvec = 0;
     }
     memcpy(outvec, x->x_vec, size);
-    outlet_list(x->x_obj.ob_outlet, &s_list, x->x_n, outvec);
+    outlet_list(x->x_obj.ob_outlet, &s_list, (int)x->x_n, outvec);
     if (reentered)
         t_freebytes(outvec, size);
     else x->x_outvec = outvec;
@@ -815,7 +815,7 @@ static void pack_free(t_pack *x)
 {
     t_gpointer *gp;
     int i;
-    for (gp = x->x_gpointer, i = x->x_nptr; i--; gp++)
+    for (gp = x->x_gpointer, i = (int)x->x_nptr; i--; gp++)
         gpointer_unset(gp);
     freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
     freebytes(x->x_outvec, x->x_n * sizeof(*x->x_outvec));
@@ -904,7 +904,7 @@ static void unpack_list(t_unpack *x, t_symbol *s, int argc, t_atom *argv)
     t_atom *ap;
     t_unpackout *u;
     int i;
-    if (argc > x->x_n) argc = x->x_n;
+    if (argc > x->x_n) argc = (int)x->x_n;
     for (i = argc, u = x->x_vec + i, ap = argv + i; u--, ap--, i--;)
     {
         t_atomtype type = u->u_type;
@@ -1015,7 +1015,7 @@ static void trigger_list(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_triggerout *u;
     int i;
-    for (i = x->x_n, u = x->x_vec + i; u--, i--;)
+    for (i = (int)x->x_n, u = x->x_vec + i; u--, i--;)
     {
         if (u->u_type == TR_FLOAT)
             outlet_float(u->u_outlet, (argc ? atom_getfloat(argv) : 0));
@@ -1038,7 +1038,7 @@ static void trigger_anything(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_triggerout *u;
     int i;
-    for (i = x->x_n, u = x->x_vec + i; u--, i--;)
+    for (i = (int)x->x_n, u = x->x_vec + i; u--, i--;)
     {
         if (u->u_type == TR_BANG)
             outlet_bang(u->u_outlet);

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -398,10 +398,10 @@ typedef struct _sel2
 static void sel2_float(t_sel2 *x, t_float f)
 {
     t_selectelement *e;
-    t_int nelement;
+    int nelement;
     if (x->x_type == A_FLOAT)
     {
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_float == f)
         {
             outlet_bang(e->e_outlet);
@@ -414,10 +414,10 @@ static void sel2_float(t_sel2 *x, t_float f)
 static void sel2_symbol(t_sel2 *x, t_symbol *s)
 {
     t_selectelement *e;
-    t_int nelement;
+    int nelement;
     if (x->x_type == A_SYMBOL)
     {
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_symbol == s)
         {
             outlet_bang(e->e_outlet);
@@ -517,10 +517,10 @@ typedef struct _route
 static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
-    t_int nelement;
+    int nelement;
     if (x->x_type == A_SYMBOL)
     {
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_symbol == sel)
         {
             if (argc > 0 && argv[0].a_type == A_SYMBOL)
@@ -536,7 +536,7 @@ static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
-    t_int nelement;
+    int nelement;
     if (x->x_type == A_FLOAT)
     {
         t_float f;
@@ -544,7 +544,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         if (argv->a_type != A_FLOAT)
             goto rejected;
         f = atom_getfloat(argv);
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_float == f)
         {
             if (argc > 1 && argv[1].a_type == A_SYMBOL)

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -698,7 +698,7 @@ static void *list_fromsymbol_new( void)
 static void list_fromsymbol_symbol(t_list_fromsymbol *x, t_symbol *s)
 {
     t_atom *outv;
-    int n, outc = strlen(s->s_name);
+    int n, outc = (int)strlen(s->s_name);
     ATOMS_ALLOCA(outv, outc);
     for (n = 0; n < outc; n++)
         SETFLOAT(outv + n, (unsigned char)s->s_name[n]);

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -1092,9 +1092,9 @@ static void poly_float(t_poly *x, t_float f)
             serialon = serialoff = 0xffffffff; i < x->x_n; v++, i++)
         {
             if (v->v_used && v->v_serial < serialon)
-                    firston = v, serialon = v->v_serial, onindex = i;
+                    firston = v, serialon = (unsigned int)v->v_serial, onindex = i;
             else if (!v->v_used && v->v_serial < serialoff)
-                    firstoff = v, serialoff = v->v_serial, offindex = i;
+                    firstoff = v, serialoff = (unsigned int)v->v_serial, offindex = i;
         }
         if (firstoff)
         {
@@ -1121,7 +1121,7 @@ static void poly_float(t_poly *x, t_float f)
         for (v = x->x_vec, i = 0, firston = 0, serialon = 0xffffffff;
             i < x->x_n; v++, i++)
                 if (v->v_used && v->v_pitch == f && v->v_serial < serialon)
-                    firston = v, serialon = v->v_serial, onindex = i;
+                    firston = v, serialon = (unsigned int)v->v_serial, onindex = i;
         if (firston)
         {
             firston->v_used = 0;

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -489,8 +489,8 @@ typedef struct _oscformat
 static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
 {
     char buf[MAXPDSTRING];
-	int i;
-	unsigned long newsize;
+    int i;
+    unsigned long newsize;
     *x->x_pathbuf = 0;
     buf[0] = '/';
     for (i = 0; i < argc; i++)
@@ -575,7 +575,7 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
         j++;
         ndata++;
     }
-    datastart = (int) (ROUNDUPTO4(strlen(x->x_pathbuf)+1) + ROUNDUPTO4(ndata + 2));
+    datastart = (int)(ROUNDUPTO4(strlen(x->x_pathbuf)+1) + ROUNDUPTO4(ndata + 2));
     msgsize = datastart + msgindex;
     msg = (t_atom *)alloca(msgsize * sizeof(t_atom));
     putstring(msg, &typeindex, x->x_pathbuf);

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -489,7 +489,8 @@ typedef struct _oscformat
 static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
 {
     char buf[MAXPDSTRING];
-    int i, newsize;
+	int i;
+	unsigned long newsize;
     *x->x_pathbuf = 0;
     buf[0] = '/';
     for (i = 0; i < argc; i++)
@@ -500,7 +501,7 @@ static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
         if ((newsize = strlen(buf) + strlen(x->x_pathbuf) + 1) > x->x_pathsize)
         {
             x->x_pathbuf = resizebytes(x->x_pathbuf, x->x_pathsize, newsize);
-            x->x_pathsize = newsize;
+            x->x_pathsize = (int)newsize;
         }
         strcat(x->x_pathbuf, buf);
     }
@@ -574,7 +575,7 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
         j++;
         ndata++;
     }
-    datastart = ROUNDUPTO4(strlen(x->x_pathbuf)+1) + ROUNDUPTO4(ndata + 2);
+    datastart = (int) (ROUNDUPTO4(strlen(x->x_pathbuf)+1) + ROUNDUPTO4(ndata + 2));
     msgsize = datastart + msgindex;
     msg = (t_atom *)alloca(msgsize * sizeof(t_atom));
     putstring(msg, &typeindex, x->x_pathbuf);

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -91,7 +91,7 @@ static void *netsend_new(t_symbol *s, int argc, t_atom *argv)
 static void netsend_readbin(t_netsend *x, int fd)
 {
     unsigned char inbuf[MAXPDSTRING];
-    int ret = recv(fd, inbuf, MAXPDSTRING, 0), i;
+    int ret = (int)recv(fd, inbuf, MAXPDSTRING, 0), i;
     if (!x->x_msgout)
     {
         bug("netsend_readbin");
@@ -308,7 +308,7 @@ static int netsend_dosend(t_netsend *x, int sockfd,
         static double lastwarntime;
         static double pleasewarn;
         double timebefore = sys_getrealtime();
-        int res = send(sockfd, bp, length-sent, 0);
+        int res = (int)send(sockfd, bp, length-sent, 0);
         double timeafter = sys_getrealtime();
         int late = (timeafter - timebefore > 0.005);
         if (late || pleasewarn)

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -71,7 +71,7 @@ static void textbuf_senditup(t_textbuf *x)
         if (!j) j = txt + ntxt;
         sys_vgui("pdtk_textwindow_append .x%lx {%.*s\n}\n",
             x, j-txt-i, txt+i);
-        i = (int) ((j-txt)+1);
+        i = (int)((j-txt)+1);
     }
     sys_vgui("pdtk_textwindow_setdirty .x%lx 0\n", x);
     t_freebytes(txt, ntxt);

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -71,7 +71,7 @@ static void textbuf_senditup(t_textbuf *x)
         if (!j) j = txt + ntxt;
         sys_vgui("pdtk_textwindow_append .x%lx {%.*s\n}\n",
             x, j-txt-i, txt+i);
-        i = (j-txt)+1;
+        i = (int) ((j-txt)+1);
     }
     sys_vgui("pdtk_textwindow_setdirty .x%lx 0\n", x);
     t_freebytes(txt, ntxt);

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -960,7 +960,7 @@ ex_dzdetect(struct expr *expr)
 {
         char *etype;
 
-        if (!expr->exp_error & EE_DZ) {
+        if ((!expr->exp_error) & EE_DZ) {
                 if (IS_EXPR(expr))
                         etype = "expr";
                 else if (IS_EXPR_TILDE(expr))

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -18,8 +18,9 @@
  *              --sdy
  *
  * Oct 2015
- *                              $x[-1] was not equal $x1[-1], not accessing the previous block
- *                              (bug fix by Dan Ellis)
+ *              $x[-1] was not equal $x1[-1], not accessing the previous block
+ *              (bug fix by Dan Ellis)
+ *
  *  July 2017 --sdy
  *      - Version 0.55
  *
@@ -444,24 +445,23 @@ ex_match(struct ex_ex *eptr, long int op)
                                 ret = ex_match(eptr + 1, OP_RB);
                                 if (!ret)
                                         return (ret);
-                                                                /*
-                                                                 * this is a special case handling
-                                                                 * for $1, $2 processing in Pd
-                                                                 *
-                                                                 * Pure data translates $#[x] (e.g. $1[x]) to 0[x]
-                                                                 * for abstracting patches so that later
-                                                                 * in the instantiation of the abstraction
-                                                                 * the $# is replaced with the proper argument
-                                                                 * of the abstraction
-                                                                 * so we change 0[x] to a special table pointing to null
-                                                                 * and catch errors in execution time
-                                                                 */
-                                                                if (!firstone && (eptr - 1)->ex_type == ET_INT &&
-                                                                                                                ((eptr - 1)->ex_int == 0)) {
-                                                                        (eptr - 1)->ex_type = ET_TBL;
-                                                                        (eptr - 1)->ex_ptr = (char *)0;
-                                                                }
-
+                                /*
+                                 * this is a special case handling
+                                 * for $1, $2 processing in Pd
+                                 *
+                                 * Pure data translates $#[x] (e.g. $1[x]) to 0[x]
+                                 * for abstracting patches so that later
+                                 * in the instantiation of the abstraction
+                                 * the $# is replaced with the proper argument
+                                 * of the abstraction
+                                 * so we change 0[x] to a special table pointing to null
+                                 * and catch errors in execution time
+                                 */
+                                if (!firstone && (eptr - 1)->ex_type == ET_INT &&
+                                    ((eptr - 1)->ex_int == 0)) {
+                                        (eptr - 1)->ex_type = ET_TBL;
+                                        (eptr - 1)->ex_ptr = (char *)0;
+                                }
                                 eptr->ex_type = ET_LB;
                                 eptr->ex_ptr = (char *) ret;
                                 eptr = ret;

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1501,7 +1501,7 @@ eval_sigidx(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
                 rem_i =  arg.ex_flt - i;        /* remains of integer */
         } else if (arg.ex_type == ET_INT) {
                 fi = arg.ex_int;                /* float index */
-                i = arg.ex_int;
+                i = (int) arg.ex_int;           /* integer index */
                 rem_i = 0;
         } else {
                 post("eval_sigidx: bad res type (%d)", arg.ex_type);

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -887,8 +887,8 @@ max_ex_tab(struct expr *expr, fts_symbol_t s, struct ex_ex *arg,
 {
 #ifdef PD
         t_garray *garray;
-		int size;
-		long indx;
+        int size;
+        long indx;
         t_word *wvec;
 
         if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||
@@ -948,8 +948,8 @@ max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
 {
 #ifdef PD
         t_garray *garray;
-		int size;
-		long indx;
+        int size;
+        long indx;
         t_word *wvec;
 
         if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -887,7 +887,8 @@ max_ex_tab(struct expr *expr, fts_symbol_t s, struct ex_ex *arg,
 {
 #ifdef PD
         t_garray *garray;
-        int size, indx;
+		int size;
+		long indx;
         t_word *wvec;
 
         if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||
@@ -947,7 +948,8 @@ max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
 {
 #ifdef PD
         t_garray *garray;
-        int size, indx;
+		int size;
+		long indx;
         t_word *wvec;
 
         if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||
@@ -1110,7 +1112,7 @@ ex_Sum(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
         int size;
         t_word *wvec;
         t_float sum;
-        int indx, n1, n2;
+        long indx, n1, n2;
 
         if (argv->ex_type != ET_SYM)
         {


### PR DESCRIPTION
This PR mostly adds explicit casts to fix conversion warnings in clang:

* long -> int
* t_int -> int
* etc

Some of the warnings come from `atom_getintarg()` returning a t_int but many functions taking int as args. The more complicated update came in d_soundfile.c where I erred on using longs for buffer sizes.