### PR TITLE
allow negative canvas positions in Tk 8.5+ for multi monitor support

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -365,10 +365,6 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     }
     else x->gl_env = 0;
 
-    if (yloc < GLIST_DEFCANVASYLOC)
-        yloc = GLIST_DEFCANVASYLOC;
-    if (xloc < 0)
-        xloc = 0;
     x->gl_x1 = 0;
     x->gl_y1 = 0;
     x->gl_x2 = 1;

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -114,9 +114,8 @@ set PD_BUGFIX_VERSION 0
 set PD_TEST_VERSION ""
 set done_init 0
 
-set TCL_MAJOR_VERSION 0
-set TCL_MINOR_VERSION 0
-set TCL_BUGFIX_VERSION 0
+# this complements tcl_version by providing the patchlevel version aka #.#.patch
+set TCL_PATCHLEVEL 0
 
 # for testing which platform we are running on ("aqua", "win32", or "x11")
 set windowingsystem ""
@@ -758,6 +757,7 @@ proc main {argc argv} {
     if { $::tcl_platform(platform) eq "windows"} {
        set ::platform W32
     }
+    scan [info patchlevel] "%d.%d.%d" - - ::TCL_PATCHLEVEL
 
     tk appname pd-gui
     load_locale

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -40,20 +40,27 @@ proc pdtk_canvas_place_window {width height geometry} {
 
     # read back the current geometry +posx+posy into variables
     scan $geometry {%[+]%d%[+]%d} - x - y
-    # fit the geometry onto screen
-    set x [ expr $x % $screenwidth - $::windowframex]
-    set y [ expr $y % $screenheight - $::windowframey]
-    if {$x < 0} {set x 0}
-    if {$y < 0} {set y 0}
-    if {$width > $screenwidth} {
-        set width $screenwidth
-        set x 0
+
+    # fit the geometry onto screen for Tk 8.4,
+    # newer versions of Tk can handle multiple monitors so allow negative pos,
+    # also check for Tk Cocoa backend on macOS which is only stable in 8.5.13+
+    if {$::tcl_version < 8.5 || \
+        ($::windowingsystem eq "aqua" && $::tcl_version == 8.5 && $::TCL_PATCHLEVEL < 13)} {
+        set x [ expr $x % $screenwidth - $::windowframex]
+        set y [ expr $y % $screenheight - $::windowframey]
+        if {$x < 0} {set x 0}
+        if {$y < 0} {set y 0}
+        if {$width > $screenwidth} {
+            set width $screenwidth
+            set x 0
+        }
+        if {$height > $screenheight} {
+            # 30 for window framing
+            set height [expr $screenheight - $::menubarsize - 30]
+            set y $::menubarsize
+        }
     }
-    if {$height > $screenheight} {
-        set height [expr $screenheight - $::menubarsize - 30] ;# 30 for window framing
-        set y $::menubarsize
-    }
-    return [list $width $height ${width}x$height+$x+$y]
+    return [list $width $height ${width}x${height}+${x}+${y}]
 }
 
 


### PR DESCRIPTION
As reported on the pd-list, negative canvas window positions are clipped to 0 and/or reflected on the opposite screen border.

This PR fixes that by allowing negative positions to be sent to the window manager in Tk 8.5+ and keeps the clipping for Tk 8.4 as a fallback. Also, versions of Tk < 8.5.13 on macOS keep the clipping due to the buggy nature of the TK Cocoa backend up until that version.

This will need to be tested on all platforms but, from my research, it should be fine as negative positions were added to 8.5 and back ported to 8.4 at some point. I decided to use 8.5 as a hard limit to be conservative.

This also removes the apparently unused TCL_*_VERSION variables and adds the TCL_PATCHLEVEL variable for checking the patchlevel in conjunction with the major.minor number returned by $::tcl_version.

Tested so far on macOS 10.12.6 with Tk 8.4, Tk 8.5.9, Tk 8.7.0a.

You can try a build for newer macs (10.9+) with Tk 8.7a: http://docs.danomatika.com/pdbuilds/Pd-0.48-1-multimonitor.app.zip

Here is a minimal patch which opens sub patches in all 4 directions. Expected behavior: all open on screen, either in expected location or clipped to screen edge if the position is off screen.

~~~
#N canvas 100 300 450 300 10;
#N canvas 400 -800 450 300 top 1;
#X restore 150 50 pd top;
#N canvas 400 1800 450 300 bottom 1;
#X restore 150 250 pd bottom;
#N canvas -1800 400 450 300 left 1;
#X restore 50 150 pd left;
#N canvas 1800 400 450 300 right 1;
#X restore 250 150 pd right;
~~~