### PR TITLE
reimplemented "allow negative canvas positions in Tk 8.5+ for multi monitor support"

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -365,10 +365,6 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     }
     else x->gl_env = 0;
 
-    if (yloc < GLIST_DEFCANVASYLOC)
-        yloc = GLIST_DEFCANVASYLOC;
-    if (xloc < 0)
-        xloc = 0;
     x->gl_x1 = 0;
     x->gl_y1 = 0;
     x->gl_x2 = 1;

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -114,10 +114,6 @@ set PD_BUGFIX_VERSION 0
 set PD_TEST_VERSION ""
 set done_init 0
 
-set TCL_MAJOR_VERSION 0
-set TCL_MINOR_VERSION 0
-set TCL_BUGFIX_VERSION 0
-
 # for testing which platform we are running on ("aqua", "win32", or "x11")
 set windowingsystem ""
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -29,31 +29,54 @@ namespace eval ::pdtk_canvas:: {
 #winfo rooty . returns contentsTop
 #winfo rootx . returns contentsLeftEdge
 
+if {$::tcl_version < 8.5 || \
+        ($::tcl_version == 8.5 && \
+             [tk windowingsystem] eq "aqua" && \
+             [lindex [split [info patchlevel] "."] 2] < 13) } {
+    # fit the geometry onto screen for Tk 8.4,
+    #  also check for Tk Cocoa backend on macOS which is only stable in 8.5.13+;
+    # newer versions of Tk can handle multiple monitors so allow negative pos
+    proc pdtk_canvas_wrap_window {x y w h} {
+        set width [lindex [wm maxsize .] 0]
+        set height [lindex [wm maxsize .] 1]
+
+        if {$w > $width} {
+            set w $width
+            set x 0
+        }
+        if {$h > $height} {
+            # 30 for window framing
+            set h [expr $height - $::menubarsize - $::windowframey]
+            set y $::menubarsize
+        }
+
+        set x [ expr $x % $width]
+        set y [ expr $y % $height]
+        if {$x < 0} {set x 0}
+        if {$y < 0} {set y 0}
+
+        return [list ${x} ${y} ${w} ${h}]
+    }
+} {
+    proc pdtk_canvas_wrap_window {x y w h} {
+        return [list ${x} ${y} ${w} ${h}]
+    }
+}
 
 # this proc is split out on its own to make it easy to override. This makes it
 # easy for people to customize these calculations based on their Window
 # Manager, desires, etc.
 proc pdtk_canvas_place_window {width height geometry} {
     ::pdwindow::configure_window_offset
-    set screenwidth [lindex [wm maxsize .] 0]
-    set screenheight [lindex [wm maxsize .] 1]
 
     # read back the current geometry +posx+posy into variables
     scan $geometry {%[+]%d%[+]%d} - x - y
-    # fit the geometry onto screen
-    set x [ expr $x % $screenwidth - $::windowframex]
-    set y [ expr $y % $screenheight - $::windowframey]
-    if {$x < 0} {set x 0}
-    if {$y < 0} {set y 0}
-    if {$width > $screenwidth} {
-        set width $screenwidth
-        set x 0
-    }
-    if {$height > $screenheight} {
-        set height [expr $screenheight - $::menubarsize - 30] ;# 30 for window framing
-        set y $::menubarsize
-    }
-    return [list $width $height ${width}x$height+$x+$y]
+    set xywh [pdtk_canvas_wrap_window [expr $x - $::windowframex] [expr $y - $::windowframey] $width $height]
+    set x [lindex $xywh 0]
+    set y [lindex $xywh 1]
+    set w [lindex $xywh 2]
+    set h [lindex $xywh 3]
+    return [list ${w} ${h} ${w}x${h}+${x}+${y}]
 }
 
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -34,7 +34,7 @@ if {$::tcl_version < 8.5 || \
              [tk windowingsystem] eq "aqua" && \
              [lindex [split [info patchlevel] "."] 2] < 13) } {
     # fit the geometry onto screen for Tk 8.4,
-    #  also check for Tk Cocoa backend on macOS which is only stable in 8.5.13+;
+    # also check for Tk Cocoa backend on macOS which is only stable in 8.5.13+;
     # newer versions of Tk can handle multiple monitors so allow negative pos
     proc pdtk_canvas_wrap_window {x y w h} {
         set width [lindex [wm maxsize .] 0]
@@ -71,7 +71,8 @@ proc pdtk_canvas_place_window {width height geometry} {
 
     # read back the current geometry +posx+posy into variables
     scan $geometry {%[+]%d%[+]%d} - x - y
-    set xywh [pdtk_canvas_wrap_window [expr $x - $::windowframex] [expr $y - $::windowframey] $width $height]
+    set xywh [pdtk_canvas_wrap_window \
+        [expr $x - $::windowframex] [expr $y - $::windowframey] $width $height]
     set x [lindex $xywh 0]
     set y [lindex $xywh 1]
     set w [lindex $xywh 2]


### PR DESCRIPTION
this is a re-implementation of PR #224, which:
- keeps the window-positions on X11
- is more optimized (check for hacks is only done on boot time (and therefore drops the `TCL_PATCHLEVEL` variable)

i've tested this on Debian but only with a standard dual-screen setup (main monitor to the left of right-monitor)

### original PR text

As reported on the pd-list, negative canvas window positions are clipped to 0 and/or reflected on the opposite screen border.

This PR fixes that by allowing negative positions to be sent to the window manager in Tk 8.5+ and keeps the clipping for Tk 8.4 as a fallback. Also, versions of Tk < 8.5.13 on macOS keep the clipping due to the buggy nature of the TK Cocoa backend up until that version.

This will need to be tested on all platforms but, from my research, it should be fine as negative positions were added to 8.5 and back ported to 8.4 at some point. I decided to use 8.5 as a hard limit to be conservative.

This also removes the apparently unused TCL_*_VERSION variables

Tested so far on macOS 10.12.6 with Tk 8.4, Tk 8.5.9, Tk 8.7.0a.

You can try a build for newer macs (10.9+) with Tk 8.7a: http://docs.danomatika.com/pdbuilds/Pd-0.48-1-multimonitor.app.zip

Here is a minimal patch which opens sub patches in all 4 directions. Expected behavior: all open on screen, either in expected location or clipped to screen edge if the position is off screen.

~~~
#N canvas 100 300 450 300 10;
#N canvas 400 -800 450 300 top 1;
#X restore 150 50 pd top;
#N canvas 400 1800 450 300 bottom 1;
#X restore 150 250 pd bottom;
#N canvas -1800 400 450 300 left 1;
#X restore 50 150 pd left;
#N canvas 1800 400 450 300 right 1;
#X restore 250 150 pd right;
~~~