### PR TITLE
move 'verbose' setting from path dialog to startup dialog

### DIFF
--- a/src/s_path.c
+++ b/src/s_path.c
@@ -632,7 +632,7 @@ void glob_start_path_dialog(t_pd *dummy)
      char buf[MAXPDSTRING];
 
     sys_set_searchpath();
-    sprintf(buf, "pdtk_path_dialog %%s %d %d\n", sys_usestdpath, sys_verbose);
+    sprintf(buf, "pdtk_path_dialog %%s %d\n", sys_usestdpath);
     gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
 }
 
@@ -643,10 +643,9 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     namelist_free(STUFF->st_searchpath);
     STUFF->st_searchpath = 0;
     sys_usestdpath = atom_getintarg(0, argc, argv);
-    sys_verbose = atom_getintarg(1, argc, argv);
-    for (i = 0; i < argc-2; i++)
+    for (i = 0; i < argc-1; i++)
     {
-        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
+        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+1, argc, argv));
         if (*s->s_name)
             STUFF->st_searchpath =
                 namelist_append_files(STUFF->st_searchpath, s->s_name);
@@ -687,7 +686,8 @@ void glob_start_startup_dialog(t_pd *dummy)
     char buf[MAXPDSTRING];
 
     sys_set_startup();
-    sprintf(buf, "pdtk_startup_dialog %%s %d \"%s\"\n", sys_defeatrt,
+    sprintf(buf, "pdtk_startup_dialog %%s %d %d \"%s\"\n", sys_defeatrt,
+        sys_verbose,
         (sys_flags? sys_flags->s_name : ""));
     gfxstub_new(&glob_pdobject, (void *)glob_start_startup_dialog, buf);
 }
@@ -699,10 +699,11 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     namelist_free(STUFF->st_externlist);
     STUFF->st_externlist = 0;
     sys_defeatrt = atom_getintarg(0, argc, argv);
-    sys_flags = sys_decodedialog(atom_getsymbolarg(1, argc, argv));
-    for (i = 0; i < argc-2; i++)
+    sys_verbose = atom_getintarg(1, argc, argv);
+    sys_flags = sys_decodedialog(atom_getsymbolarg(2, argc, argv));
+    for (i = 0; i < argc-3; i++)
     {
-        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
+        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+3, argc, argv));
         if (*s->s_name)
             STUFF->st_externlist =
                 namelist_append_files(STUFF->st_externlist, s->s_name);

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -5,7 +5,6 @@ package require scrollboxwindow
 
 namespace eval ::dialog_path:: {
     variable use_standard_paths_button 1
-    variable verbose_button 0
     variable docspath ""
     variable installpath ""
     namespace export pdtk_path_dialog
@@ -22,13 +21,11 @@ proc ::dialog_path::ok {mytoplevel} {
 }
 
 # set up the panel with the info from pd
-proc ::dialog_path::pdtk_path_dialog {mytoplevel extrapath verbose} {
+proc ::dialog_path::pdtk_path_dialog {mytoplevel extrapath} {
     global use_standard_paths_button
-    global verbose_button
     global docspath
     global installpath
     set use_standard_paths_button $extrapath
-    set verbose_button $verbose
     if {[namespace exists ::pd_docsdir]} {set docspath $::pd_docsdir::docspath}
     if {[namespace exists ::deken]} {set installpath $::deken::installpath}
     if {[winfo exists $mytoplevel]} {
@@ -57,10 +54,7 @@ proc ::dialog_path::create_dialog {mytoplevel} {
     pack $mytoplevel.extraframe -side top -anchor s -fill x
     checkbutton $mytoplevel.extraframe.extra -text [_ "Use standard paths"] \
         -variable use_standard_paths_button -anchor w
-    checkbutton $mytoplevel.extraframe.verbose -text [_ "Verbose"] \
-        -variable verbose_button -anchor w
     pack $mytoplevel.extraframe.extra -side left -expand 1
-    pack $mytoplevel.extraframe.verbose -side right -expand 1
 
     # add docsdir path widgets if pd_docsdir is loaded
     if {[namespace exists ::pd_docsdir]} {
@@ -240,7 +234,6 @@ proc ::dialog_path::edit {currentpath} {
 
 proc ::dialog_path::commit {new_path} {
     global use_standard_paths_button
-    global verbose_button
     global docspath
     global installpath
 
@@ -248,7 +241,7 @@ proc ::dialog_path::commit {new_path} {
     set changed false
     if {"$new_path" ne "$::sys_searchpath"} {set changed true}
     set ::sys_searchpath $new_path
-    pdsend "pd path-dialog $use_standard_paths_button $verbose_button [pdtk_encode $::sys_searchpath]"
+    pdsend "pd path-dialog $use_standard_paths_button [pdtk_encode $::sys_searchpath]"
     if {$changed} {::helpbrowser::refresh}
 
     # save installpath

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -5,6 +5,7 @@ package require scrollboxwindow
 
 namespace eval dialog_startup {
     variable defeatrt_flag 0
+    variable verbose_flag 0
 
     namespace export pdtk_startup_dialog
 }
@@ -62,13 +63,15 @@ proc ::dialog_startup::edit { current_library } {
 
 proc ::dialog_startup::commit { new_startup } {
     variable defeatrt_button
+    variable verbose_button
     set ::startup_libraries $new_startup
-    pdsend "pd startup-dialog $defeatrt_button [pdtk_encodedialog $::startup_flags] [pdtk_encode $::startup_libraries]"
+    pdsend "pd startup-dialog $defeatrt_button $verbose_button [pdtk_encodedialog $::startup_flags] [pdtk_encode $::startup_libraries]"
 }
 
 # set up the panel with the info from pd
-proc ::dialog_startup::pdtk_startup_dialog {mytoplevel defeatrt flags} {
+proc ::dialog_startup::pdtk_startup_dialog {mytoplevel defeatrt verbose flags} {
     variable defeatrt_button $defeatrt
+    variable verbose_button $verbose
     if {$flags ne ""} {variable ::startup_flags $flags}
 
     if {[winfo exists $mytoplevel]} {
@@ -95,13 +98,19 @@ proc ::dialog_startup::create_dialog {mytoplevel} {
     pack $mytoplevel.flags.entry -side right -expand 1 -fill x
     pack $mytoplevel.flags.entryname -side right
 
+    frame $mytoplevel.checksframe
+    pack $mytoplevel.checksframe -side top -anchor s -fill x -padx 2m -pady 5
+
+    checkbutton $mytoplevel.checksframe.verbose -anchor w \
+            -text [_ "Verbose"] \
+            -variable ::dialog_startup::verbose_button
+    pack $mytoplevel.checksframe.verbose -side left -expand 1
+
     if {$::windowingsystem ne "win32"} {
-        frame $mytoplevel.defeatrtframe
-        pack $mytoplevel.defeatrtframe -side top -anchor s -fill x -padx 2m -pady 5
-        checkbutton $mytoplevel.defeatrtframe.defeatrt -anchor w \
+        checkbutton $mytoplevel.checksframe.defeatrt -anchor w \
             -text [_ "Defeat real-time scheduling"] \
             -variable ::dialog_startup::defeatrt_button
-        pack $mytoplevel.defeatrtframe.defeatrt
+        pack $mytoplevel.checksframe.defeatrt -side right -expand 1
     }
 
     # focus handling on OSX


### PR DESCRIPTION
IMHO 'verbose' flag is more a startup flag than a path related setting.
This is only a GUI change, and doesn't modify any variable name for e.g, so it shouldn't impact compatibility, excepting patches or plugins or externals directly calling pdtk_path_dialog or pdtk_startup_dialog (but are they numerous?).