### PR TITLE
fix for soundfiler truncating higher wave file samplerate values

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -371,7 +371,7 @@ int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
                     else if (format == 32)
                         bytespersamp = 4;
                     else goto badheader;
-                    samprate = swap2(buf.b_fmt.f_samplespersec, swap);
+                    samprate = swap4(buf.b_fmt.f_samplespersec, swap);
                 }
                 seekout = lseek(fd, seekto, SEEK_SET);
                 if (seekout != seekto)


### PR DESCRIPTION
As reported by [Philipp Schmalfuß on the pd-list](https://lists.puredata.info/pipermail/pd-list/2017-10/120846.html):

>i ran into some trouble with the new features of [soundfiler]  
recently. It does not output the samplerate of .wave files correctly  
(haven't tried .aiff yet). With 96kHz files i got 30464, with 192kHz  
files 60928. Iemlib/soundfile_info did gave me the correct samplerate  
of the same soundfiles. So, is this a bug?

It seams using swap2() to convert the wave header sample rate byte values inadvertently drops some MSBs leading incorrect values for larger sample rate values. I've changed to using swap(4) which seems to work in my testing, but perhaps someone can double check the sample rate byte size in the WAVE format spec as I don't have time today.

EDIT: I just checked [here](http://www.topherlee.com/software/pcm-tut-wavformat.html) and the sample rate value is indeed 4 bytes, so this fix should be fine. Reading AIFF's already uses swap4() so it should be fine as well.
