### PR TITLE
value right inlet

### DIFF
--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1567,8 +1567,7 @@ void value_release(t_symbol *s)
  * value_getfloat -- obtain the float value of a "value" object
  *                  return 0 on success, 1 otherwise
  */
-int
-value_getfloat(t_symbol *s, t_float *f)
+int value_getfloat(t_symbol *s, t_float *f)
 {
     t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
     if (!c)
@@ -1581,8 +1580,7 @@ value_getfloat(t_symbol *s, t_float *f)
  * value_setfloat -- set the float value of a "value" object
  *                  return 0 on success, 1 otherwise
  */
-int
-value_setfloat(t_symbol *s, t_float f)
+int value_setfloat(t_symbol *s, t_float f)
 {
     t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
     if (!c)
@@ -1615,6 +1613,13 @@ static void value_float(t_value *x, t_float f)
     *x->x_floatstar = f;
 }
 
+static void value_set(t_value *x, t_symbol *s)
+{
+    value_release(x->x_sym);
+    x->x_sym = s;
+    x->x_floatstar = value_get(s);
+}
+
 static void value_ff(t_value *x)
 {
     value_release(x->x_sym);
@@ -1628,6 +1633,8 @@ static void value_setup(void)
     class_addcreator((t_newmethod)value_new, gensym("v"), A_DEFSYM, 0);
     class_addbang(value_class, value_bang);
     class_addfloat(value_class, value_float);
+    class_addmethod(value_class, (t_method)value_set, gensym("set"),
+        A_DEFSYM, 0);
     vcommon_class = class_new(gensym("value"), 0, 0,
         sizeof(t_vcommon), CLASS_PD, 0);
     class_addfloat(vcommon_class, vcommon_float);

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1597,6 +1597,8 @@ static void vcommon_float(t_vcommon *x, t_float f)
 static void *value_new(t_symbol *s)
 {
     t_value *x = (t_value *)pd_new(value_class);
+    if (!*s->s_name)
+        inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("symbol"), gensym("symbol2"));
     x->x_sym = s;
     x->x_floatstar = value_get(s);
     outlet_new(&x->x_obj, &s_float);
@@ -1613,7 +1615,8 @@ static void value_float(t_value *x, t_float f)
     *x->x_floatstar = f;
 }
 
-static void value_set(t_value *x, t_symbol *s)
+/* set method */
+static void value_symbol2(t_value *x, t_symbol *s)
 {
     value_release(x->x_sym);
     x->x_sym = s;
@@ -1633,7 +1636,7 @@ static void value_setup(void)
     class_addcreator((t_newmethod)value_new, gensym("v"), A_DEFSYM, 0);
     class_addbang(value_class, value_bang);
     class_addfloat(value_class, value_float);
-    class_addmethod(value_class, (t_method)value_set, gensym("set"),
+    class_addmethod(value_class, (t_method)value_symbol2, gensym("symbol2"),
         A_DEFSYM, 0);
     vcommon_class = class_new(gensym("value"), 0, 0,
         sizeof(t_vcommon), CLASS_PD, 0);


### PR DESCRIPTION
This PR adds a right inlet to the [value] object as [suggested on the pd-list](https://lists.puredata.info/pipermail/pd-list/2017-10/120875.html).

Here's a test patch:

![screen shot 2017-10-31 at 2 14 16 pm](https://user-images.githubusercontent.com/480637/32225570-edeea4c8-be45-11e7-9340-65140e1ee4c3.png)

~~~
#N canvas 169 142 450 300 10;
#X obj 306 159 value b;
#X obj 86 132 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
-1;
#X obj 86 132 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
-1;
#X obj 306 130 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
-1 -1;
#X obj 306 130 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
-1 -1;
#X floatatom 86 190 5 0 0 0 - - -, f 5;
#X floatatom 306 189 5 0 0 0 - - -, f 5;
#X floatatom 185 39 5 0 0 0 - - -, f 5;
#X floatatom 185 137 5 0 0 0 - - -, f 5;
#X obj 159 57 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
-1;
#X obj 159 57 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
-1;
#X obj 86 160 value a;
#X obj 185 105 value;
#X msg 232 37 symbol a;
#X msg 238 59 symbol b;
#X msg 245 81 symbol c;
#X connect 0 0 6 0;
#X connect 1 0 11 0;
#X connect 3 0 0 0;
#X connect 7 0 12 0;
#X connect 9 0 12 0;
#X connect 11 0 5 0;
#X connect 12 0 8 0;
#X connect 13 0 12 1;
#X connect 14 0 12 1;
#X connect 15 0 12 1;
~~~