### PR TITLE
macOS .app info update

### DIFF
--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -29,6 +29,9 @@ SRC=..
 custom_builddir=false
 BUILD=..
 
+# PlistBuddy command for editing app bundle Info.plist from template
+PLIST_BUDDY=/usr/libexec/PlistBuddy
+
 # the app Get Info string
 GETINFO="Pure Data: a free real-time computer music system"
 
@@ -247,7 +250,8 @@ if [ -e $APP/Contents/version.plist ] ; then
     rm $APP/Contents/version.plist
 fi
 # older "Wish Shell.app" does not have a symlink but a real file
-if [ -f $APP/Contents/MacOS/Wish\ Shell ] && [ ! -L $APP/Contents/MacOS/Wish\ Shell ] ; then
+if [ -f $APP/Contents/MacOS/Wish\ Shell ] && \
+   [ ! -L $APP/Contents/MacOS/Wish\ Shell ] ; then
     mv $APP/Contents/MacOS/Wish\ Shell $APP/Contents/MacOS/Pd
     mv $APP/Contents/Resources/Wish\ Shell.rsrc $APP/Contents/Resources/Pd.rsrc
 else
@@ -268,14 +272,14 @@ cp stuff/pd.icns $APP/Contents/Resources/
 cp stuff/pd-file.icns $APP/Contents/Resources/
 cp -R ../font $APP/Contents/Resources/
 
+INFO_PLIST=$APP/Contents/Info.plist
+
 # set version identifiers & contextual strings in Info.plist,
 # version strings can only use 0-9 and periods, so replace "-" & "test" with "."
-PLIST_BUDDY=/usr/libexec/PlistBuddy
 PLIST_VERSION=${PD_VERSION/-/.}; PLIST_VERSION=${PLIST_VERSION/test/.}
-$PLIST_BUDDY -c "Set:CFBundleVersion \"$PLIST_VERSION\"" $APP/Contents/Info.plist
-$PLIST_BUDDY -c "Add:CFBundleShortVersionString string \"$PLIST_VERSION\"" $APP/Contents/Info.plist
-$PLIST_BUDDY -c "Add:CFBundleGetInfoString string \"$GETINFO\"" $APP/Contents/Info.plist
-$PLIST_BUDDY -c "Add:CFBundleSpokenName string \"Pure Data\"" $APP/Contents/Info.plist
+$PLIST_BUDDY -c "Set:CFBundleVersion \"$PLIST_VERSION\"" $INFO_PLIST
+$PLIST_BUDDY -c "Set:CFBundleShortVersionString \"$PLIST_VERSION\"" $INFO_PLIST
+$PLIST_BUDDY -c "Set:CFBundleGetInfoString \"$GETINFO\"" $INFO_PLIST
 
 # install binaries
 mkdir -p $DEST/bin
@@ -303,6 +307,14 @@ cp $verbose $SRC/LICENSE.txt $DEST/
 if [ -e $BUILD/po/af.msg ] ; then
     mkdir -p $DEST/po
     cp $verbose $BUILD/po/*.msg $DEST/po/
+    # add locale entries to the plist based on available .msg files
+    LOCALES=$(find $BUILD/po -name "*.msg" -exec basename {} .msg \;)
+    $PLIST_BUDDY \
+        -c "Add:CFBundleLocalizations array \"$PLIST_VERSION\"" $INFO_PLIST
+    for locale in $LOCALES ; do
+        $PLIST_BUDDY \
+            -c "Add:CFBundleLocalizations: string \"$locale\"" $INFO_PLIST
+    done
 else
     echo "No localizations found. Skipping po dir..."
 fi

--- a/mac/stuff/Info.plist
+++ b/mac/stuff/Info.plist
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ATSApplicationFontsPath</key>
+	<string>font</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>Pd</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
@@ -14,28 +18,60 @@
 			<key>CFBundleTypeIconFile</key>
 			<string>pd-file.icns</string>
 			<key>CFBundleTypeName</key>
-			<string>Pure Data Patch</string>
+			<string>Pure Data patch</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/plain</string>
+			</array>
 		</dict>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>Pd</string>
+	<key>CFBundleGetInfoString</key>
+	<string>????</string>
+	<key>CFBundleIconFile</key>
+	<string>pd.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.puredata.pd.pd-gui</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Pd</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>????</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleIconFile</key>
-	<string>pd.icns</string>
+	<key>CFBundleSpokenName</key>
+	<string>Pure Data</string>
 	<key>CFBundleVersion</key>
-	<string>0.38</string>
+	<string>????</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
-	<key>ATSApplicationFontsPath</key>
-	<string>font</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Pure Data patch</string>
+			<key>UTTypeIconFile</key>
+			<string>pd-file.icns</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.puredata.pd-patch</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>pd</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the template Info.plist used in the Pd macOS app bundle:

* added UTExportedTypes keys for associated file type
* set UTTypeConfirmsTo so patch preview shows document icon instead of text file contents
* added mimetype info
* osx-app.sh now adds localization entries if .msg files are built
* organize Info.plist template keys alphabetically (they are alphabetized by PlistBuddy anyway)

This brings the vanilla Info.plist up to par with that used in Pd-extended.