### PR TITLE
updated the make app target to build Tcl/Tk 8.5 frameworks

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -228,9 +228,9 @@ To build the Pd macOS application, simply run:
 
     make app
 
-This builds Pd-#.#.#.app in the Pd source directory which can be then be
-double-clicked and/or copied to /Applications. For more info &
-options regarding the Pd .app bundle, see mac/README.txt
+This builds a Pd-#.#.#.app with embedded Tcl/Tk frameworks in the Pd source
+directory which can be then be double-clicked and/or copied to /Applications.
+For more info & options regarding the Pd .app bundle, see mac/README.txt.
 
 If you want to have both the Pd application *and* use Pd from the commandline,
 add command aliases to the binaries inside the .app to your ~/.bash_profile:
@@ -255,9 +255,9 @@ Tk version log line in the Pd window.
 
 Another option is to set the Tk Wish command Pd uses to launch the GUI. At
 start, Pd does a quick search in the "usual places" for Wish and chooses the
-first path that exists. Currently, macOS also ships with Tcl/Tk 8.4 which works
-fine and this wish can be invoked by Pd using the full path "/usr/bin/wish8.4".
-You can configure Pd to use this search path first with:
+first path that exists. macOS versions before 10.13 also ship with Tcl/Tk 8.4
+which works fine and this wish can be invoked by Pd using the full path
+"/usr/bin/wish8.4". You can configure Pd to use this search path first with:
 
     ./configure --with-wish=/usr/bin/wish8.4
 

--- a/mac/Makefile.am
+++ b/mac/Makefile.am
@@ -18,22 +18,29 @@ EXTRA_DIST = \
 
 if MACOSX
 
-# build an app bundle on OSX
+TK_VERSION=8.5.19
+
+# build an app bundle on macOS,
+# downloads and builds Tk frameworks using ARCH_CFLAGS set by --enable-universal
 app:
 	rm -rf $(top_builddir)/Pd-$(VERSION).app
-	$(SH) $(top_srcdir)/mac/osx-app.sh --builddir $(top_builddir) $(VERSION)
+	test -e Wish-$(TK_VERSION).app || CFLAGS="$(ARCH_CFLAGS)" \
+		$(SH) $(top_srcdir)/mac/tcltk-wish.sh $(TK_VERSION)
+	$(SH) $(top_srcdir)/mac/osx-app.sh \
+		--wish Wish-$(TK_VERSION).app \
+		--builddir $(top_builddir) $(VERSION)
 	mv $(top_builddir)/mac/Pd-$(VERSION).app $(top_builddir)
 
 else
 
 # don't bother on other platforms
 app:
-	echo "app bundle only supported when building on OS X"
+	echo "app bundle only supported when building on macOS"
 
 endif
 
 # kludge that relies on this Makefile being called *before* the src/Makefile
-# since we remove empty folders in $(libdir)/pd last in the main Makefile,
-# make sure multiple calls to `make uninstall` do not fail due to missing bin dir
+# since we remove empty folders in $(libdir)/pd last in the main Makefile, make
+# sure multiple calls to `make uninstall` do not fail due to missing bin dir
 uninstall-local:
 	$(MKDIR_P) $(DESTDIR)$(pkglibdir)/bin

--- a/mac/tcltk-wish.sh
+++ b/mac/tcltk-wish.sh
@@ -156,6 +156,7 @@ fi
 
 # set any custom flags
 export CFLAGS
+echo "CFLAGS: $CFLAGS"
 
 # build Tcl and Tk
 # outputs into local "build" & "embedded" directories 


### PR DESCRIPTION
This PR updates the `make app` autotools make target to download and build the Tcl/TK 8.5 frameworks to match that of the current Pd release builds.

This makes building an equivalent build to the releases require only a few steps, namely:

    ./autogen.sh
    ./configure
    make
    make app

The ARCH_CFLAGS used when configuring are passed to the `mac/tcltk-wish.sh` script to ensure Wish is built with the same architecture that Pd was configured for.

An existing Wish is checked for before building to ensure a prebuilt Wish is re-used. One thing to note is if someone is scripting different architecture builds, the Wish app should be re(moved)/renamed before running `make app` to make sure the wrong Wish architecture is not used.