### PR TITLE
No need of alloca.h for *BSD

### DIFF
--- a/extra/bonk~/bonk~.c
+++ b/extra/bonk~/bonk~.c
@@ -83,9 +83,11 @@ static t_class *bonk_class;
 #endif
 
 #ifdef _WIN32
-#include <malloc.h>
-#elif ! defined(_MSC_VER)
-#include <alloca.h>
+# include <malloc.h> /* MSVC or mingw on windows */
+#elif defined(__linux__) || defined(__APPLE__)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
+#else
+# include <stdlib.h> /* BSDs for example */
 #endif
 
 /* ------------------------ bonk~ ----------------------------- */

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -40,9 +40,9 @@ for example, defines this in the file d_fft_mayer.c or d_fft_fftsg.c. */
 #include <stdio.h>
 #include <string.h>
 #ifdef _WIN32
-#include <malloc.h>
-#elif ! defined(_MSC_VER)
-#include <alloca.h>
+# include <malloc.h> /* MSVC or mingw on windows */
+#elif defined(__linux__) || defined(__APPLE__)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
 #endif
 #include <stdlib.h>
 #ifdef _MSC_VER
@@ -1300,8 +1300,8 @@ static void *sigmund_new(t_symbol *s, int argc, t_atom *argv)
 static void sigmund_list(t_sigmund *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *syminput = atom_getsymbolarg(0, argc, argv);
-    int npts = atom_getfloatarg(1, argc, argv);
-    int onset = atom_getfloatarg(2, argc, argv);
+    int npts = atom_getintarg(1, argc, argv);
+    int onset = atom_getintarg(2, argc, argv);
     t_float srate = atom_getfloatarg(3, argc, argv);
     int loud = atom_getfloatarg(4, argc, argv);
     int arraysize, totstorage, nfound, i;


### PR DESCRIPTION
As said, there is no need of alloca.h on *BSD. These was the two last source files that do not compile on *BSD.