### PR TITLE
check sys_libdir exists before reading it

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1366,7 +1366,7 @@ static void canvas_completepath(char *from, char *to, int bufsize)
     {
         to[0] = '\0';
     }
-    else
+    else if(sys_libdir)
     {   // if not absolute path, append Pd lib dir
         strncpy(to, sys_libdir->s_name, bufsize-10);
         to[bufsize-9] = '\0';


### PR DESCRIPTION
This fixes libpd/libpd#214: libpd crashing when patch contains [declare -stdpath]
