### PR TITLE
Fix thread concurrency issues and multi-instance issues

### DIFF
--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -36,10 +36,10 @@ void rdft(int, int, FFTFLT *, int *, FFTFLT *);
 
 int ilog2(int n);
 
-static int ooura_maxn;
-static int *ooura_bitrev;
-static int ooura_bitrevsize;
-static FFTFLT *ooura_costab;
+static PERTHREAD int ooura_maxn;
+static PERTHREAD int *ooura_bitrev;
+static PERTHREAD int ooura_bitrevsize;
+static PERTHREAD FFTFLT *ooura_costab;
 
 static int ooura_init( int n)
 {
@@ -48,7 +48,6 @@ static int ooura_init( int n)
         return (0);
     if (n > ooura_maxn)
     {
-        pd_globallock();
         if (n > ooura_maxn)    /* recheck in case it got set while we waited */
         {
             if (ooura_maxn)
@@ -63,7 +62,6 @@ static int ooura_init( int n)
             {
                 error("out of memory allocating FFT buffer");
                 ooura_maxn = 0;
-                pd_globalunlock();
                 return (0);
             }
             ooura_costab = (FFTFLT *)t_getbytes(n * sizeof(FFTFLT)/2);
@@ -72,13 +70,11 @@ static int ooura_init( int n)
                 error("out of memory allocating FFT buffer");
                 t_freebytes(ooura_bitrev, ooura_bitrevsize);
                 ooura_maxn = 0;
-                pd_globalunlock();
                 return (0);
             }
             ooura_maxn = n;
             ooura_bitrev[0] = 0;
         }
-        pd_globalunlock();
     }
     return (1);
 }

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -301,7 +301,7 @@ void obj_init(void)
 static PERTHREAD int stackcount = 0; /* iteration counter */
 #define STACKITER 1000 /* maximum iterations allowed */
 
-static int outlet_eventno;
+static PERTHREAD int outlet_eventno;
 
     /* set a stack limit (on each incoming event that can set off messages)
     for the outlet functions to check to prevent stack overflow from message

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -298,7 +298,7 @@ void obj_init(void)
 
 /* --------------------------- outlets ------------------------------ */
 
-static int stackcount = 0; /* iteration counter */
+static PERTHREAD int stackcount = 0; /* iteration counter */
 #define STACKITER 1000 /* maximum iterations allowed */
 
 static int outlet_eventno;

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -32,14 +32,11 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 #ifdef _WIN32
 #ifdef PD_INTERNAL
 #define EXTERN __declspec(dllexport) extern
-#define EXTERN_NOAPI extern
 #else
 #define EXTERN __declspec(dllimport) extern
-#define EXTERN_NOAPI extern
 #endif /* PD_INTERNAL */
 #else
 #define EXTERN extern
-#define EXTERN_NOAPI extern
 #endif /* _WIN32 */
 
     /* On most c compilers, you can just say "struct foo;" to declare a
@@ -857,7 +854,7 @@ EXTERN void pdinstance_free(t_pdinstance *x);
 #endif
 
 #ifdef PDINSTANCE
-EXTERN_NOAPI PERTHREAD t_pdinstance *pd_this;
+extern PERTHREAD t_pdinstance *pd_this;
 EXTERN t_pdinstance **pd_instances;
 EXTERN int pd_ninstances;
 #else

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -291,7 +291,6 @@ static void savepanel_setup(void)
 
 /* ---------------------- key and its relatives ------------------ */
 
-static t_symbol *key_sym, *keyup_sym, *keyname_sym;
 static t_class *key_class, *keyup_class, *keyname_class;
 
 typedef struct _key
@@ -303,7 +302,7 @@ static void *key_new( void)
 {
     t_key *x = (t_key *)pd_new(key_class);
     outlet_new(&x->x_obj, &s_float);
-    pd_bind(&x->x_obj.ob_pd, key_sym);
+    pd_bind(&x->x_obj.ob_pd, gensym("#key"));
     return (x);
 }
 
@@ -314,7 +313,7 @@ static void key_float(t_key *x, t_floatarg f)
 
 static void key_free(t_key *x)
 {
-    pd_unbind(&x->x_obj.ob_pd, key_sym);
+    pd_unbind(&x->x_obj.ob_pd, gensym("#key"));
 }
 
 typedef struct _keyup
@@ -326,7 +325,7 @@ static void *keyup_new( void)
 {
     t_keyup *x = (t_keyup *)pd_new(keyup_class);
     outlet_new(&x->x_obj, &s_float);
-    pd_bind(&x->x_obj.ob_pd, keyup_sym);
+    pd_bind(&x->x_obj.ob_pd, gensym("#keyup"));
     return (x);
 }
 
@@ -337,7 +336,7 @@ static void keyup_float(t_keyup *x, t_floatarg f)
 
 static void keyup_free(t_keyup *x)
 {
-    pd_unbind(&x->x_obj.ob_pd, keyup_sym);
+    pd_unbind(&x->x_obj.ob_pd, gensym("#keyup"));
 }
 
 typedef struct _keyname
@@ -352,7 +351,7 @@ static void *keyname_new( void)
     t_keyname *x = (t_keyname *)pd_new(keyname_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_symbol);
-    pd_bind(&x->x_obj.ob_pd, keyname_sym);
+    pd_bind(&x->x_obj.ob_pd, gensym("#keyname"));
     return (x);
 }
 
@@ -364,7 +363,7 @@ static void keyname_list(t_keyname *x, t_symbol *s, int ac, t_atom *av)
 
 static void keyname_free(t_keyname *x)
 {
-    pd_unbind(&x->x_obj.ob_pd, keyname_sym);
+    pd_unbind(&x->x_obj.ob_pd, gensym("#keyname"));
 }
 
 static void key_setup(void)
@@ -373,20 +372,17 @@ static void key_setup(void)
         (t_newmethod)key_new, (t_method)key_free,
         sizeof(t_key), CLASS_NOINLET, 0);
     class_addfloat(key_class, key_float);
-    key_sym = gensym("#key");
 
     keyup_class = class_new(gensym("keyup"),
         (t_newmethod)keyup_new, (t_method)keyup_free,
         sizeof(t_keyup), CLASS_NOINLET, 0);
     class_addfloat(keyup_class, keyup_float);
-    keyup_sym = gensym("#keyup");
     class_sethelpsymbol(keyup_class, gensym("key"));
 
     keyname_class = class_new(gensym("keyname"),
         (t_newmethod)keyname_new, (t_method)keyname_free,
         sizeof(t_keyname), CLASS_NOINLET, 0);
     class_addlist(keyname_class, keyname_list);
-    keyname_sym = gensym("#keyname");
     class_sethelpsymbol(keyname_class, gensym("key"));
 }
 


### PR DESCRIPTION
- 0c38ada & c7ae002: set **PERTHREAD** (TLS) the variables **stackcount** and **outlet_eventno**  because if these variables are increased or decreased in a concurrency context the behavior is undefined and results mostly to a stack overflow for the **stackcount**. **outlet_eventno** doesn't seems to have any influence on the program but an ounce of prevention is worth a pound of cure. (and sorry for TSL instead of TLS in the commits names...)
- 8f3eec1: The objects **key**, **keyup** and **keyname** are bound to **static** symbols - that breaks the multi-instance support. To fix this the symbols are generated in the **new** and **free** methods of the objects with **gensym()** - ensure that the symbols correspond to the current pd instance. 
- cb2e44f: set **PERTHREAD** (TLS) the FFT static variables from d_fft_fftsg.c to support FFT objects in a multithread context. We can also add [this](https://github.com/pure-data/pure-data/pull/288) if you want to fix size the problem of the FFT. 

Instead of using **PERTHREAD**, another solution would be to put the variable in the pd instance structure. I started to do it for the FFT (see [this](https://github.com/pierreguillot/pure-data/commit/b8671dfc8bbb1f3328feced7133939dee0d4a3a9)) but it can also be done for  **stackcount**. anyway, the **PERTHREAD** works fine.

- ddb167e & 1f0f6a2: add multi-instance support for MSVC (by @eldruin)