### PR TITLE
prevent double-precision externals from crashing a single-precision Pd (and vice versa)

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -23,6 +23,10 @@
 #define snprintf _snprintf
 #endif
 
+#ifdef class_new
+# undef class_new
+#endif
+
 static t_symbol *class_loadsym;     /* name under which an extern is invoked */
 static void pd_defaultfloat(t_pd *x, t_float f);
 static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv);

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -23,10 +23,6 @@
 #define snprintf _snprintf
 #endif
 
-#ifdef class_new
-# undef class_new
-#endif
-
 static t_symbol *class_loadsym;     /* name under which an extern is invoked */
 static void pd_defaultfloat(t_pd *x, t_float f);
 static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv);
@@ -460,6 +456,9 @@ t_class *class_do_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     return (c);
 }
 
+#ifdef class_new
+# undef class_new
+#endif
 t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     size_t size, int flags, t_atomtype type1, ...)
 {

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -509,9 +509,9 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     va_end(ap);
     return class_do_new(s, newmethod, freemethod, size, flags, count, vec);
 #else
-    static int saidit = 0;
-    logpost(0, saidit, "refusing to load %dbit float external '%s' into %dbit Pd", 32, s->s_name, PD_FLOATSIZE);
-    saidit=3;
+    static int loglevel = 0;
+    logpost(0, loglevel, "refusing to load %d-bit float object '%s' into %d-bit float Pd", 32, s->s_name, PD_FLOATSIZE);
+    loglevel=3;
 
     return 0;
 #endif
@@ -542,9 +542,9 @@ t_class *class_new64(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     va_end(ap);
     return class_do_new(s, newmethod, freemethod, size, flags, count, vec);
 #else
-    static int saidit = 0;
-    logpost(0, saidit, "refusing to load %dbit float external '%s' into %dbit Pd", 64, s->s_name, PD_FLOATSIZE);
-    saidit=3;
+    static int loglevel = 0;
+    logpost(0, loglevel, "refusing to load %d-bit float object '%s' into %d-bit float Pd", 64, s->s_name, PD_FLOATSIZE);
+    loglevel=3;
 
     return 0;
 #endif

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -519,7 +519,8 @@ void class_addmethod(t_class *c, t_method fn, t_symbol *sel,
     t_methodentry *m;
     t_atomtype argtype = arg1;
     int nargs, i;
-
+    if(!c)
+        return;
     va_start(ap, arg1);
         /* "signal" method specifies that we take audio signals but
         that we don't want automatic float to signal conversion.  This
@@ -595,56 +596,78 @@ done:
     /* Instead of these, see the "class_addfloat", etc.,  macros in m_pd.h */
 void class_addbang(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_bangmethod = (t_bangmethod)fn;
 }
 
 void class_addpointer(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_pointermethod = (t_pointermethod)fn;
 }
 
 void class_doaddfloat(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_floatmethod = (t_floatmethod)fn;
 }
 
 void class_addsymbol(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_symbolmethod = (t_symbolmethod)fn;
 }
 
 void class_addlist(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_listmethod = (t_listmethod)fn;
 }
 
 void class_addanything(t_class *c, t_method fn)
 {
+    if(!c)
+        return;
     c->c_anymethod = (t_anymethod)fn;
 }
 
 void class_setwidget(t_class *c, const t_widgetbehavior *w)
 {
+    if(!c)
+        return;
     c->c_wb = w;
 }
 
 void class_setparentwidget(t_class *c, const t_parentwidgetbehavior *pw)
 {
+    if(!c)
+        return;
     c->c_pwb = pw;
 }
 
 char *class_getname(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_name->s_name);
 }
 
 char *class_gethelpname(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_helpname->s_name);
 }
 
 void class_sethelpsymbol(t_class *c, t_symbol *s)
 {
+    if(!c)
+        return;
     c->c_helpname = s;
 }
 
@@ -655,11 +678,15 @@ const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x)
 
 void class_setdrawcommand(t_class *c)
 {
+    if(!c)
+        return;
     c->c_drawcommand = 1;
 }
 
 int class_isdrawcommand(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_drawcommand);
 }
 
@@ -675,6 +702,8 @@ static void pd_floatforsignal(t_pd *x, t_float f)
 
 void class_domainsignalin(t_class *c, int onset)
 {
+    if(!c)
+        return;
     if (onset <= 0) onset = -1;
     else
     {
@@ -692,6 +721,8 @@ void class_set_extern_dir(t_symbol *s)
 
 char *class_gethelpdir(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_externdir->s_name);
 }
 
@@ -702,21 +733,29 @@ static void class_nosavefn(t_gobj *z, t_binbuf *b)
 
 void class_setsavefn(t_class *c, t_savefn f)
 {
+    if(!c)
+        return;
     c->c_savefn = f;
 }
 
 t_savefn class_getsavefn(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_savefn);
 }
 
 void class_setpropertiesfn(t_class *c, t_propertiesfn f)
 {
+    if(!c)
+        return;
     c->c_propertiesfn = f;
 }
 
 t_propertiesfn class_getpropertiesfn(t_class *c)
 {
+    if(!c)
+        return 0;
     return (c->c_propertiesfn);
 }
 

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -459,6 +459,7 @@ t_class *class_do_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
 t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     size_t size, int flags, t_atomtype type1, ...)
 {
+#if PD_FLOATSIZE == 32
     va_list ap;
     t_atomtype vec[MAXPDARG+1], *vp = vec;
     unsigned int count = 0;
@@ -478,7 +479,15 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
         *vp = va_arg(ap, t_atomtype);
     }
     va_end(ap);
+    return class_do_new(s, newmethod, freemethod, size, flags, count, vec);
+#else
+    static int saidit = 0;
+    logpost(0, saidit, "refusing to load %dbit float external '%s' into %dbit Pd", 32, s->s_name, PD_FLOATSIZE);
+    saidit=3;
 
+    return 0;
+#endif
+}
     return class_do_new(s, newmethod, freemethod, size, flags, count, vec);
 }
     /* add a creation method, which is a function that returns a Pd object

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -85,7 +85,7 @@ typedef unsigned __int64  uint64_t;
 #if !defined(PD_LONGINTTYPE)
 #if defined(_WIN32) && defined(__x86_64__)
 #define PD_LONGINTTYPE long long
-#else 
+#else
 #define PD_LONGINTTYPE long
 #endif
 #endif

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -103,7 +103,6 @@ typedef unsigned __int64  uint64_t;
 #elif PD_FLOATSIZE == 64
 # define PD_FLOATTYPE double
 # define PD_FLOATUINTTYPE unsigned long
-# define class_new class_new64
 #else
 # error invalid FLOATSIZE: must be 32 or 64
 #endif
@@ -513,6 +512,10 @@ EXTERN t_propertiesfn class_getpropertiesfn(t_class *c);
 #define class_addsymbol(x, y) class_addsymbol((x), (t_method)(y))
 #define class_addlist(x, y) class_addlist((x), (t_method)(y))
 #define class_addanything(x, y) class_addanything((x), (t_method)(y))
+#endif
+
+#if PD_FLOATSIZE == 64
+# define class_new class_new64
 #endif
 
 /* ------------   printing --------------------------------- */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -83,7 +83,11 @@ typedef unsigned __int64  uint64_t;
 
 /* signed and unsigned integer types the size of a pointer:  */
 #if !defined(PD_LONGINTTYPE)
+#if defined(_WIN32) && defined(__x86_64__)
+#define PD_LONGINTTYPE long long
+#else 
 #define PD_LONGINTTYPE long
+#endif
 #endif
 
 #if !defined(PD_FLOATSIZE)

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -468,6 +468,9 @@ EXTERN const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x);
 
 EXTERN t_class *class_new(t_symbol *name, t_newmethod newmethod,
     t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
+EXTERN t_class *class_new64(t_symbol *name, t_newmethod newmethod,
+    t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
+
 EXTERN void class_addcreator(t_newmethod newmethod, t_symbol *s,
     t_atomtype type1, ...);
 EXTERN void class_addmethod(t_class *c, t_method fn, t_symbol *sel,

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -103,6 +103,7 @@ typedef unsigned __int64  uint64_t;
 #elif PD_FLOATSIZE == 64
 # define PD_FLOATTYPE double
 # define PD_FLOATUINTTYPE unsigned long
+# define class_new class_new64
 #else
 # error invalid FLOATSIZE: must be 32 or 64
 #endif

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -481,7 +481,6 @@ EXTERN void class_addanything(t_class *c, t_method fn);
 EXTERN void class_sethelpsymbol(t_class *c, t_symbol *s);
 EXTERN void class_setwidget(t_class *c, const t_widgetbehavior *w);
 EXTERN void class_setparentwidget(t_class *c, const t_parentwidgetbehavior *w);
-EXTERN const t_parentwidgetbehavior *class_parentwidget(t_class *c);
 EXTERN char *class_getname(t_class *c);
 EXTERN char *class_gethelpname(t_class *c);
 EXTERN char *class_gethelpdir(t_class *c);


### PR DESCRIPTION
this implements a simple, API-compatible mechanism to prevent double-precision externals from being loaded into a single-precision Pd and vice versa, as [proposed on the mailnglist](https://lists.puredata.info/pipermail/pd-dev/2015-02/020073.html) and mentioned in #299 

## how it works
- single-precision (`PD_FLOATTYPE==32`) externals use `class_new()` to register new classes
- double-precision (`PD_FLOATTYPE==64`) externals use `class_new64()` to register new classes

if an external uses the wrong variant of `class_new` (e.g. `class_new64()` on a single-precision Pd host) will yield an error message and the class will not be registered (with `class_new` returning `NULL`).

API compatibility is kept by using a pre-processor define, so externals keep using `class_new` in their code, but it gets magically replaced with `class_new64`, if `PD_FLOATTYPE==64`.

ABI (binary) compatibility is retained for single-precision externals (since we still use `class_new()`), but not for double-precision externals.

this also adds some NULL-pointer checks to functions with a `t_class*` argument, since practically all externals do not check whether `class_new` returns *NULL*.