### PR TITLE
ensure iemgui labels are on top of controls and io

### DIFF
--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -141,20 +141,26 @@ void bng_draw_io(t_bng* x, t_glist* glist, int old_snd_rcv_flags)
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
              canvas,
              xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
              xpos + iow, ypos + x->x_gui.x_h,
              x, 0);
+        /* keep above outlet */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 0);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
              canvas,
              xpos, ypos,
              xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+        /* keep above inlet */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 0);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -180,8 +180,11 @@ void hradio_draw_io(t_hradio* x, t_glist* glist, int old_snd_rcv_flags)
                  xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
                  xpos + iow, ypos + x->x_gui.x_h,
                  x, 0);
-        if(x->x_on == 0) /* keep button above outlet */
+        /* keep these above outlet */
+        if(x->x_on == 0) {
             sys_vgui(".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
@@ -192,8 +195,11 @@ void hradio_draw_io(t_hradio* x, t_glist* glist, int old_snd_rcv_flags)
                  xpos, ypos,
                  xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
                  x, 0);
-        if(x->x_on == 0) /* keep button above inlet */
+        /* keep these above inlet */
+        if(x->x_on == 0) {
             sys_vgui(".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -71,6 +71,10 @@ static void hslider_draw_new(t_hslider *x, t_glist *glist)
              xpos - lmargin, ypos,
              xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
+             canvas, r, ypos + IEMGUI_ZOOM(x),
+             r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x),
+             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
              canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -78,10 +82,6 @@ static void hslider_draw_new(t_hslider *x, t_glist *glist)
              (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
              x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
              x->x_gui.x_lcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
-             canvas, r, ypos + IEMGUI_ZOOM(x),
-             r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x),
-             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
 }
 
 static void hslider_draw_move(t_hslider *x, t_glist *glist)
@@ -107,12 +107,12 @@ static void hslider_draw_move(t_hslider *x, t_glist *glist)
              canvas, x, 0,
              xpos - lmargin, ypos,
              xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
              canvas, x, r, ypos + IEMGUI_ZOOM(x),
              r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
+             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
 static void hslider_draw_erase(t_hslider* x, t_glist* glist)
@@ -155,8 +155,9 @@ static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
              xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
              xpos - lmargin + iow, ypos + x->x_gui.x_h,
              x, 0);
-        /* keep knob above outlet */
+        /* keep these above outlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxOUT%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
@@ -167,8 +168,9 @@ static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
              xpos - lmargin, ypos,
              xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
-        /* keep label and knob above inlet */
+        /* keep these above inlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxIN%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -208,17 +208,17 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
              xpos, ypos,
              xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+    my_numbox_ftoa(x);
+    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags %lxNUMBER\n",
+             canvas, xpos + half + 2*IEMGUI_ZOOM(x), ypos + half + d,
+             x->x_buf, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+             sys_fontweight, (x->x_gui.x_fsf.x_change ? IEM_GUI_COLOR_EDITED : x->x_gui.x_fcol), x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
              canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
              ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
              (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
              x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
              x->x_gui.x_lcol, x);
-    my_numbox_ftoa(x);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags %lxNUMBER\n",
-             canvas, xpos + half + 2*IEMGUI_ZOOM(x), ypos + half + d,
-             x->x_buf, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
-             sys_fontweight, (x->x_gui.x_fsf.x_change ? IEM_GUI_COLOR_EDITED : x->x_gui.x_fcol), x);
 }
 
 static void my_numbox_draw_move(t_my_numbox *x, t_glist *glist)
@@ -300,20 +300,28 @@ static void my_numbox_draw_io(t_my_numbox* x,t_glist* glist, int old_snd_rcv_fla
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
              canvas,
              xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
              xpos + iow, ypos + x->x_gui.x_h,
              x, 0);
+        /* keep these above outlet */
+        sys_vgui(".x%lx.c raise %lxNUMBER %lxOUT%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxNUMBER\n", canvas, x, x);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
              canvas,
              xpos, ypos,
              xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+        /* keep these above inlet */
+        sys_vgui(".x%lx.c raise %lxNUMBER %lxIN%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxNUMBER\n", canvas, x, x);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -170,20 +170,26 @@ void toggle_draw_io(t_toggle* x, t_glist* glist, int old_snd_rcv_flags)
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
              canvas,
              xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
              xpos + iow, ypos + x->x_gui.x_h,
              x, 0);
+        /* keep above outlet */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 0);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
              canvas,
              xpos, ypos,
              xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+        /* keep above inlet */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 0);
+    }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -109,9 +109,6 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
         yy21 += dy;
         yy22 += dy;
     }
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
              canvas, x, 0,
@@ -122,6 +119,9 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
              canvas, x, 0,
              xx11, yy11b,
              xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
+             canvas, x, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+             yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
 void vradio_draw_erase(t_vradio* x, t_glist* glist)
@@ -174,8 +174,11 @@ void vradio_draw_io(t_vradio* x, t_glist* glist, int old_snd_rcv_flags)
                  xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
                  xpos + iow, ypos + x->x_gui.x_h,
                  x, 0);
-        if(x->x_on == 0) /* keep button above outlet */
+        /* keep these above outlet */
+        if(x->x_on == 0) {
             sys_vgui(".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
@@ -186,8 +189,11 @@ void vradio_draw_io(t_vradio* x, t_glist* glist, int old_snd_rcv_flags)
                  xpos, ypos,
                  xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
                  x, 0);
-        if(x->x_on == 0) /* keep button above inlet */
+        /* keep these above inlet */
+        if(x->x_on == 0) {
             sys_vgui(".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -72,6 +72,10 @@ static void vslider_draw_new(t_vslider *x, t_glist *glist)
              xpos, ypos - tmargin,
              xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh,
              x, 0);
+    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
+             canvas, xpos + IEMGUI_ZOOM(x), r,
+             xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r,
+             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
              canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -79,10 +83,6 @@ static void vslider_draw_new(t_vslider *x, t_glist *glist)
              (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
              x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
              x->x_gui.x_lcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
-             canvas, xpos + IEMGUI_ZOOM(x), r,
-             xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r,
-             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
 }
 
 static void vslider_draw_move(t_vslider *x, t_glist *glist)
@@ -108,12 +108,12 @@ static void vslider_draw_move(t_vslider *x, t_glist *glist)
              canvas, x, 0,
              xpos, ypos - tmargin,
              xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
              canvas, x, xpos + IEMGUI_ZOOM(x), r,
              xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
+             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
 static void vslider_draw_erase(t_vslider* x, t_glist* glist)
@@ -158,8 +158,9 @@ static void vslider_draw_io(t_vslider* x, t_glist* glist, int old_snd_rcv_flags)
              xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
              xpos + iow, ypos + x->x_gui.x_h + bmargin,
              x, 0);
-        /* keep knob above outlet */
+        /* keep these above outlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxOUT%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
@@ -170,8 +171,9 @@ static void vslider_draw_io(t_vslider* x, t_glist* glist, int old_snd_rcv_flags)
              xpos, ypos - tmargin,
              xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh,
              x, 0);
-        /* keep label and knob above inlet */
+        /* keep these above inlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxIN%d\n", canvas, x, x, 0);
+        sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -331,6 +331,8 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
              xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
              xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin,
              x, 1);
+        /* keep above outlets */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 1);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
     {
@@ -349,6 +351,8 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
              xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
              xpos + x->x_gui.x_w + hmargin, ypos - vmargin - IEMGUI_ZOOM(x) + ioh,
              x, 1);
+        /* keep above inlets */
+        sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 1);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
     {


### PR DESCRIPTION
This PR updates the iemguis to ensure that labels are *always* on top. Previous work for 0.48-1 raised controls above labels but this was pointed out as a bug on the pd-list by Roman Haefeli:

>Up until 0.48, the label text of any gui widgets (sliders, etc.) appeared above the front. Since 0.48, the front covers the label text, changing the appearance of patches that have overlapping front and label.
>
>See here:
>![front_above_label](https://user-images.githubusercontent.com/480637/35737163-e18718a8-082a-11e8-96e6-0f5e91fa1530.png)

This PR reverts to labels above controls and fixes a bug where label draw order would be lost after configuring send/receive names.