### PR TITLE
Fixed documentation 16.more.array.pd

### DIFF
--- a/doc/2.control.examples/16.more.arrays.pd
+++ b/doc/2.control.examples/16.more.arrays.pd
@@ -1,8 +1,8 @@
 #N canvas 19 83 830 601 12;
-#X graph graph1 0 -1 5 1 569 304 769 154;
-#X array array99 5 float;
-#X array array98 7 float;
-#X pop;
+#N canvas 0 22 450 278 (subpatch) 0;
+#X array array99 7 float 0;
+#X coords 0 1 6 -1 200 150 1;
+#X restore 569 154 graph;
 #X text 135 18 MORE ON ARRAYS;
 #X msg 17 229 \; array99 rename george;
 #X msg 221 229 \; george rename array99;
@@ -13,11 +13,22 @@
 #X msg 245 294 \; array99 bounds 0 -1 5 1;
 #X msg 19 395 \; array99 xticks 0 1 1;
 #X msg 212 394 \; array99 yticks 0 0.1 5;
-#X text 15 342 adding x and y labels: give a point to put a tick \, the interval between ticks \, and the number of ticks overall per large tick.;
+#X text 15 342 adding x and y labels: give a point to put a tick \,
+the interval between ticks \, and the number of ticks overall per large
+tick.;
 #X msg 15 472 \; array99 xlabel -1.1 0 1 2 3 4 5;
-#X text 12 436 adding labels. Give a y value and a bunch of x values or vice versa:;
-#X msg 17 166 \; array98 0 -1 1 -1 1 -1 1 -1 1 -1;
+#X text 12 436 adding labels. Give a y value and a bunch of x values
+or vice versa:;
+#X msg 17 166 \; array99 0 -1 1 -1 1 -1 1 -1 1 -1;
 #X msg 305 472 \; array99 ylabel 5.15 -1 0 1;
 #X text 556 575 last updated for release 0.33;
-#X text 10 39 Arrays have methods to set their values explicitly \; to set their "bounds" rectangles \, to rename them (but if you have two with the same name this won't necessarily do what you want) and to add markings. To set values by message \, send a list whose first element gives the index to start at. The second example sets two values starting at index three. Indices count up from zero.;
-#X text 11 522 You can also change x and y range and size in the "properties" dialog. Note that information about size and ranges is saved \, but ticks \, labels \, and the actual data are lost between Pd sessions.;
+#X text 10 39 Arrays have methods to set their values explicitly \;
+to set their "bounds" rectangles \, to rename them (but if you have
+two with the same name this won't necessarily do what you want) and
+to add markings. To set values by message \, send a list whose first
+element gives the index to start at. The second example sets two values
+starting at index three. Indices count up from zero.;
+#X text 11 522 You can also change x and y range and size in the "properties"
+dialog. Note that information about size and ranges is saved \, but
+ticks \, labels \, and the actual data are lost between Pd sessions.
+;


### PR DESCRIPTION
- There were two arrays (array98 & array99) that were strangely merged together (perhaps due to an incompatiblity with the patch format of previous versions?). I removed the array 98 and the only message associated with it. 
- I changed the size of the array99 to 6, this way it is coherent with the GOP bounds associated with the array.

I tried to change the minimum of things but I'm not sure it's the best fix. But I guess that the patch must be updated in a way or another.

Using the patch revealed one bug:
- Renaming an array doesn't rename it graphically (you have to update the window in a way or another).

And I have two suggestions:
- Using the message bounds should also resize the array
- Using a list to change the elements of an array should also resize the array if needed or at least notifying if the elements are out of bounds.