### PR TITLE
t_curve: implement missing "-n" flag, add error messages for unknown flags and add new flags for more selective mouse interaction

### DIFF
--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1017,20 +1017,29 @@ static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
     else classname += 4;
     if (classname[0] == 'c') flags |= BEZ;
     fielddesc_setfloat_const(&x->x_vis, 1);
-    while (1)
+    while (argc && argv->a_type == A_SYMBOL &&
+        *argv->a_w.w_symbol->s_name == '-')
     {
-        t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-        if (!strcmp(firstarg->s_name, "-v") && argc > 1)
+        const char *flag = argv->a_w.w_symbol->s_name;
+        if (!strcmp(flag, "-n"))
+        {
+            fielddesc_setfloat_const(&x->x_vis, 0);
+        }
+        else if (!strcmp(flag, "-v") && argc > 1)
         {
             fielddesc_setfloatarg(&x->x_vis, 1, argv+1);
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(firstarg->s_name, "-x"))
-        {
-            flags |= NOMOUSE;
             argc -= 1; argv += 1;
         }
-        else break;
+        else if (!strcmp(flag, "-x"))
+        {
+            flags |= NOMOUSE;
+        }
+        else
+        {
+            pd_error(x, "%s: unknown flag '%s'...", classsym->s_name,
+                flag);
+        }
+        argc--; argv++;
     }
     x->x_flags = flags;
     if ((flags & CLOSED) && argc)


### PR DESCRIPTION
1) 
drawpolygon-help.pd mentions a "-n" flag but it's not implemented in the source code. 
moreover, curve_new() doesn't complain about unknown flags and just interprets them as field descripters instead of eating them and issue a warning.

I went ahead and implemented it - although it's not so useful since you can just do [loadbang]-->[0( -->[drawpolygon],  if this is supposed to be the desired behaviour... 
another possibility would be to just get rid of it and fix the documentation.

the more relevant part of this PR is the better and more verbose error handling in curve_new().

this fixes: https://sourceforge.net/p/pure-data/bugs/1281/

2) 
new flags ("-s" and "-g") for more selective mouse interaction with the t_curve objects.

while the existing "-x" flag inhibits *all* mouse interactions in both interactive and edit mode, I often want more fine grained control. therefore I implemented two more flags which can also be combined:
* "-s" disables selecting and moving/cutting the object in edit mode.
* "-g" disables grabbing and moving vertices of the polygon.

with these flags you can achieve the following UI interaction schemes:
* only select/move scalars but don't change their shape.
* change their shape but don't select/move/them.
* neither select/move scalars nor change their shape (but still report mouse clicks)

note that with "-g" mouse clicks within the bounding rect are still reported (they can be filtered out easily on patch level).
LATER we might add more flags, e.g. to inhibit moving selected scalars.
