### PR TITLE
remove *edit* suffix when displaying canvas menuclose dialog

### DIFF
--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -12,6 +12,10 @@ namespace eval ::pdtk_canvas:: {
     namespace export pdtk_canvas_menuclose
 }
 
+# store the filename associated with this window,
+# so we can use it during menuclose
+array set ::pdtk_canvas::::window_fullname {}
+
 # One thing that is tricky to understand is the difference between a Tk
 # 'canvas' and a 'canvas' in terms of Pd's implementation.  They are similar,
 # but not the same thing.  In Pd code, a 'canvas' is basically a patch, while
@@ -179,7 +183,7 @@ proc pdtk_canvas_saveas {name initialfile initialdir destroyflag} {
 ##### ask user Save? Discard? Cancel?, and if so, send a message on to Pd ######
 proc ::pdtk_canvas::pdtk_canvas_menuclose {mytoplevel reply_to_pd} {
     raise $mytoplevel
-    set filename [wm title $mytoplevel]
+    set filename [lindex [array get ::pdtk_canvas::::window_fullname $mytoplevel] 1]
     set message [format {Do you want to save the changes you made in "%s"?} $filename]
     set answer [tk_messageBox -message $message -type yesnocancel -default "yes" \
                     -parent $mytoplevel -icon question]
@@ -396,7 +400,8 @@ proc ::pdtk_canvas::pdtk_canvas_setparents {mytoplevel args} {
 # receive information for setting the info the the title bar of the window
 proc ::pdtk_canvas::pdtk_canvas_reflecttitle {mytoplevel \
                                               path name arguments dirty} {
-    set ::windowname($mytoplevel) $name ;# TODO add path to this
+    set ::windowname($mytoplevel) $name
+    set ::pdtk_canvas::::window_fullname($mytoplevel) "$path/$name"
     if {$::windowingsystem eq "aqua"} {
         wm attributes $mytoplevel -modified $dirty
         if {[file exists "$path/$name"]} {


### PR DESCRIPTION
The new " \*edit\*" suffix is sent added to the filename which is set as the canvas window title. When closing a dirty canvas window, the dialog text is

    Do you want to save the changes you made in "SomePatch *edit*"?

when it should probably be the filename without the suffix

    Do you want to save the changes you made in "SomePatch"?

This PR simply removes the suffix using regsub if the filename is long enough to contain it. As far as I can tell, this is the only place in the gui where the window title is used to grab the filename. If not, this could probably be rolled into a new canvas procedure and reused ala

    proc ::pdtk_canvas::pdtk_canvas_cleanfilename {mytoplevel}