### PR TITLE
hide dialogs which resize on creation and raise after sizing to fit

### DIFF
--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -134,6 +134,7 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
     set audio_blocksize $blocksize
 
     toplevel $mytoplevel -class DialogWindow
+    wm withdraw $mytoplevel
     wm title $mytoplevel [_ "Audio Settings"]
     wm group $mytoplevel .
     wm resizable $mytoplevel 0 0
@@ -169,7 +170,7 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
     pack $mytoplevel.settings.bsc.bs_popup -side left
     if {$audio_callback >= 0} {
         checkbutton $mytoplevel.settings.bsc.c_button -variable audio_callback \
-            -text [_ "Use callbacks"] -anchor e
+            -text [_ "Use callbacks"] -anchor w
         pack $mytoplevel.settings.bsc.c_button -side right
     }
 
@@ -402,9 +403,7 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
     # set min size based on widget sizing & pos over pdwindow
     wm minsize $mytoplevel [winfo reqwidth $mytoplevel] [winfo reqheight $mytoplevel]
     position_over_window $mytoplevel .pdwindow
-
-    # wait a little for creation, then raise so it's on top
-    after 100 raise "$mytoplevel"
+    raise $mytoplevel
 }
 
 # for focus handling on OSX

--- a/tcl/dialog_canvas.tcl
+++ b/tcl/dialog_canvas.tcl
@@ -149,7 +149,7 @@ proc ::dialog_canvas::create_dialog {mytoplevel} {
 
     labelframe $mytoplevel.scale -text [_ "Scale"] -borderwidth 1
     pack $mytoplevel.scale -side top -fill x
-    frame $mytoplevel.scale.x -pady 2 -borderwidth 1
+    frame $mytoplevel.scale.x -pady 2
     pack $mytoplevel.scale.x -side top
     label $mytoplevel.scale.x.label -text [_ "X units per pixel:"]
     entry $mytoplevel.scale.x.entry -width 10

--- a/tcl/dialog_midi.tcl
+++ b/tcl/dialog_midi.tcl
@@ -112,6 +112,7 @@ proc ::dialog_midi::pdtk_midi_dialog {id \
     set midi_alsaout [llength $midi_outdevlist]
 
     toplevel $id -class DialogWindow
+    wm withdraw $id
     wm title $id [_ "MIDI Settings"]
     wm group $id .
     wm resizable $id 0 0
@@ -410,9 +411,7 @@ proc ::dialog_midi::pdtk_midi_dialog {id \
     # set min size based on widget sizing & pos over pdwindow
     wm minsize $id [winfo reqwidth $id] [winfo reqheight $id]
     position_over_window $id .pdwindow
-
-    # wait a little for creation, then raise so it's on top
-    after 100 raise "$id"
+    raise $id
 }
 
 proc ::dialog_midi::pdtk_alsa_midi_dialog {id indev1 indev2 indev3 indev4 \
@@ -447,6 +446,7 @@ proc ::dialog_midi::pdtk_alsa_midi_dialog {id indev1 indev2 indev3 indev4 \
     set midi_alsaout [expr [llength $midi_outdevlist] - 1]
 
     toplevel $id -class DialogWindow
+    wm withdraw $id
     wm title $id [_ "ALSA MIDI Settings"]
     wm resizable $id 0 0
     wm transient $id
@@ -487,9 +487,7 @@ proc ::dialog_midi::pdtk_alsa_midi_dialog {id indev1 indev2 indev3 indev4 \
     # set min size based on widget sizing & pos over pdwindow
     wm minsize $id [winfo reqwidth $id] [winfo reqheight $id]
     position_over_window $id .pdwindow
-
-    # wait a little for creation, then raise so it's on top
-    after 100 raise "$id"
+    rase "$id"
 }
 
 # for focus handling on OSX

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -48,7 +48,7 @@ proc ::dialog_path::create_dialog {mytoplevel} {
         dialog_path::add dialog_path::edit dialog_path::commit \
         [_ "Pd search path for objects, help, fonts, and other files"] \
         450 300 1
-    wm geometry $mytoplevel ""
+    wm withdraw $mytoplevel
     ::pd_bindings::dialog_bindings $mytoplevel "path"
     set readonly_color [lindex [$mytoplevel configure -background] end]
 
@@ -140,9 +140,10 @@ proc ::dialog_path::create_dialog {mytoplevel} {
 
     # re-adjust height based on optional sections
     update
-    wm minsize $mytoplevel [winfo width $mytoplevel] [winfo height $mytoplevel]
+    wm minsize $mytoplevel [winfo width $mytoplevel] [winfo reqheight $mytoplevel]
 
     position_over_window $mytoplevel .pdwindow
+    raise $mytoplevel
 }
 
 # browse for a new Pd user docs path

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -86,7 +86,6 @@ proc ::dialog_startup::create_dialog {mytoplevel} {
         [_ "Pd libraries to load on startup"] \
         450 300 0
     wm withdraw $mytoplevel
-    #wm geometry $mytoplevel ""
     ::pd_bindings::dialog_bindings $mytoplevel "startup"
 
     frame $mytoplevel.flags

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -85,7 +85,8 @@ proc ::dialog_startup::create_dialog {mytoplevel} {
         dialog_startup::add dialog_startup::edit dialog_startup::commit \
         [_ "Pd libraries to load on startup"] \
         450 300 0
-    wm geometry $mytoplevel ""
+    wm withdraw $mytoplevel
+    #wm geometry $mytoplevel ""
     ::pd_bindings::dialog_bindings $mytoplevel "startup"
 
     frame $mytoplevel.flags
@@ -132,9 +133,10 @@ proc ::dialog_startup::create_dialog {mytoplevel} {
 
     # set min size based on widget sizing
     update
-    wm minsize $mytoplevel [winfo width $mytoplevel] [winfo height $mytoplevel]
+    wm minsize $mytoplevel [winfo width $mytoplevel] [winfo reqheight $mytoplevel]
 
     position_over_window $mytoplevel .pdwindow
+    raise $mytoplevel
 }
 
 # for focus handling on OSX


### PR DESCRIPTION
This is a quick fix to hide dialogs which resize on creation and raise after sizing to fit, affected dialogs are: audio, midi, path, startup.

Basically, on macOS I'm seeing the dialog window be created, then resized and moved which looks like a jarring visible "jump." it doesn't seem to happen with all versions of Tk, but does with the current Pd 0.48-1 release and my macOS 10.13 system.

The simple fix is to hide the window as after it's created then raise it after it's been sized and moved. There shouldn't be a noticeable change in behavior on other platforms.

Also included are a couple small dialog layout tweaks, including aligning the "Use callbacks" label with it's associated button.