### PR TITLE
Remove additional "standard paths" in conflict with Pd's documentation

### DIFF
--- a/src/s_path.c
+++ b/src/s_path.c
@@ -235,9 +235,9 @@ int sys_usestdpath = 1;
 
 void sys_setextrapath(const char *p)
 {
-    char pathbuf[MAXPDSTRING];
+//    char pathbuf[MAXPDSTRING];
     namelist_free(STUFF->st_staticpath);
-    /* add standard place for users to install stuff first */
+/* remove extra standard paths 
 #ifdef __gnu_linux__
     sys_expandpath("~/.local/lib/pd/extra/", pathbuf, MAXPDSTRING);
     STUFF->st_staticpath = namelist_append(0, pathbuf, 0);
@@ -259,7 +259,7 @@ void sys_setextrapath(const char *p)
     sys_expandpath("%CommonProgramFiles%/Pd", pathbuf, MAXPDSTRING);
     STUFF->st_staticpath = namelist_append(STUFF->st_staticpath, pathbuf, 0);
 #endif
-    /* add built-in "extra" path last so its checked last */
+*/
     STUFF->st_staticpath = namelist_append(STUFF->st_staticpath, p, 0);
 }
 


### PR DESCRIPTION
This is a reboot of https://github.com/pure-data/pure-data/pull/183

I just commented out additional "standard paths" that are not the "extra" folder. There's a long discussion that led to this proposal of mine in an earlier Pull Request that got rejected - see #139

I wanted to add a better additional "standard path" than what we had (~/Documents/Pd besides ~/Library). As I understand, the rejection came from the notion that "Standard Path" should only refer to the "extra" folder and not anything else, but somehow these additional paths are here. Pd's manual actually makes it clear that the "standard path" is only the "extra" folder, and teaches you how to use the Path mechanism to add other "paths" to Pd and says nothing about these folders.

From the discussion in that earlier Pull Request, the ~/Documents/Pd folder has actually been included as a conventional location for externals, but not as a "Standard Path", reinforcing the notion that we should not have another "Standard Path" other than the "extra" folder.

Thus, in order to avoid confusion and better sort Pd's path mechanism, I propose we get rid of these additional "Standard Paths" that are not even mentioned in Pd's manual and in fact present themselves in a conflicting matter to Pd's Manual and all the reasoning behind earlier discussions that did not lead to add yet another "Standard Path" location.