### PR TITLE
Add command for connecting selected objects

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2770,6 +2770,68 @@ static void canvas_tidy(t_canvas *x)
     canvas_dirty(x, 1);
 }
 
+    /* If we have two selected objects on the canvas, try to connect
+       the first outlet of the upper object to the first inlet with
+       a compatible type in the lower one. */
+static void canvas_connect_selection(t_canvas *x)
+{
+    t_gobj *y, *a, *b;
+    t_selection *sel;
+    t_object *objsrc, *objsink;
+    int ax1, ay1, ax2, ay2, bx1, by1, bx2, by2;
+
+    a = b = NULL;
+    sel = x->gl_editor ? x->gl_editor->e_selection : NULL;
+    for (; sel; sel = sel->sel_next)
+    {
+        if (!a)
+            gobj_getrect((a = sel->sel_what), x, &ax1, &ay1, &ax2, &ay2);
+        else if (!b)
+            gobj_getrect((b = sel->sel_what), x, &bx1, &by1, &bx2, &by2);
+        else
+            return;
+    }
+
+    if (!a || !b) return;
+
+    if (by1 < ay1) { y = a; a = b; b = y; }
+
+        /* check they're both patchable objects */
+    if (!(objsrc = pd_checkobject(&a->g_pd)) ||
+        !(objsink = pd_checkobject(&b->g_pd)))
+        return;
+
+    if (obj_noutlets(objsrc))
+    {
+        int out = 0, in;
+        int outsig = obj_issignaloutlet(objsrc, out);
+        int nin = obj_ninlets(objsink);
+
+        for (in = 0; in < nin; in++)
+            if (!(canvas_isconnected(x, objsrc, out, objsink, in)) &&
+                !(outsig && !obj_issignalinlet(objsink, in)))
+        {
+            t_outconnect *oc;
+
+            if (!(oc = obj_connect(objsrc, out, objsink, in))) return;
+
+            sys_vgui(
+                ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
+                glist_getcanvas(x), 0, 0, 0, 0,
+                (obj_issignaloutlet(objsrc, out) ? 2 : 1) * x->gl_zoom, oc);
+            canvas_fixlinesfor(x, objsrc);
+            canvas_dirty(x, 1);
+            canvas_setundo(x, canvas_undo_connect,
+                canvas_undo_set_connect(x,
+                    canvas_getindex(x, &objsrc->ob_g), out,
+                    canvas_getindex(x, &objsink->ob_g), in),
+                    "connect");
+
+            return;
+        }
+    }
+}
+
 static void canvas_texteditor(t_canvas *x)
 {
     t_rtext *foo;
@@ -2915,6 +2977,8 @@ void g_editor_setup(void)
         gensym("redo"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_tidy,
         gensym("tidy"), A_NULL);
+    class_addmethod(canvas_class, (t_method)canvas_connect_selection,
+        gensym("connect_selection"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_texteditor,
         gensym("texteditor"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_editmode,

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -45,6 +45,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Key-e>      {menu_toggle_editmode}
     bind all <$::modifier-Key-f>      {menu_find_dialog}
     bind all <$::modifier-Key-g>      {menu_send %W findagain}
+    bind all <$::modifier-Key-k>      {menu_send %W connect_selection}
     bind all <$::modifier-Key-n>      {menu_new}
     bind all <$::modifier-Key-o>      {menu_open}
     bind all <$::modifier-Key-p>      {menu_print $::focused_window}

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -68,6 +68,7 @@ proc ::pd_menus::configure_for_pdwindow {} {
     $menubar.edit entryconfigure [_ "Zoom In"] -state disabled
     $menubar.edit entryconfigure [_ "Zoom Out"] -state disabled
     $menubar.edit entryconfigure [_ "Tidy Up"] -state disabled
+    $menubar.edit entryconfigure [_ "Connect Selection"] -state disabled
     $menubar.edit entryconfigure [_ "Edit Mode"] -state disabled
     pdtk_canvas_editmode .pdwindow 0
     # Undo/Redo change names, they need to have the asterisk (*) after
@@ -96,6 +97,7 @@ proc ::pd_menus::configure_for_canvas {mytoplevel} {
     $menubar.edit entryconfigure [_ "Zoom In"] -state normal
     $menubar.edit entryconfigure [_ "Zoom Out"] -state normal
     $menubar.edit entryconfigure [_ "Tidy Up"] -state normal
+    $menubar.edit entryconfigure [_ "Connect Selection"] -state normal
     $menubar.edit entryconfigure [_ "Edit Mode"] -state normal
     pdtk_canvas_editmode $mytoplevel $::editmode($mytoplevel)
     # Put menu
@@ -137,6 +139,7 @@ proc ::pd_menus::configure_for_dialog {mytoplevel} {
     $menubar.edit entryconfigure [_ "Zoom In"] -state disabled
     $menubar.edit entryconfigure [_ "Zoom Out"] -state disabled
     $menubar.edit entryconfigure [_ "Tidy Up"] -state disabled
+    $menubar.edit entryconfigure [_ "Connect Selection"] -state disabled
     $menubar.edit entryconfigure [_ "Edit Mode"] -state disabled
     pdtk_canvas_editmode $mytoplevel 0
     # Undo/Redo change names, they need to have the asterisk (*) after
@@ -198,6 +201,8 @@ proc ::pd_menus::build_edit_menu {mymenu} {
         -command {menu_send_float $::focused_window zoom 1}
     $mymenu add command -label [_ "Tidy Up"]    -accelerator "$accelerator+Shift+R" \
         -command {menu_send $::focused_window tidy}
+    $mymenu add command -label [_ "Connect Selection"]    -accelerator "$accelerator+K" \
+        -command {menu_send $::focused_window connect_selection}
     $mymenu add command -label [_ "Clear Console"] \
         -accelerator "Shift+$accelerator+L" -command {menu_clear_console}
     $mymenu add  separator


### PR DESCRIPTION
Add a "Connect Selection" Edit menu item (shortcut "$accelerator-K")
that will heuristically attempt to connect selected objects.

The current implementation checks to see if there are only two
selected objects; if so, it connects the first outlet of the upper
object to the first inlet with a compatible type in the lower one.