### PR TITLE
remove declaration of nonexistent functions

### DIFF
--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -446,8 +446,6 @@ EXTERN void text_setto(t_text *x, t_glist *glist, char *buf, int bufsize);
 EXTERN void text_drawborder(t_text *x, t_glist *glist, char *tag,
     int width, int height, int firsttime);
 EXTERN void text_eraseborder(t_text *x, t_glist *glist, char *tag);
-EXTERN int text_xcoord(t_text *x, t_glist *glist);
-EXTERN int text_ycoord(t_text *x, t_glist *glist);
 EXTERN int text_xpix(t_text *x, t_glist *glist);
 EXTERN int text_ypix(t_text *x, t_glist *glist);
 extern const t_widgetbehavior text_widgetbehavior;


### PR DESCRIPTION
 The commit only remove the declaration of two nonexistent functions `text_xcoord()` and `text_ycoord()`in g_canvas.h