### PR TITLE
Fix pointer cast in perform functions of d_math.c

### DIFF
--- a/src/d_math.c
+++ b/src/d_math.c
@@ -252,7 +252,7 @@ static void *sigwrap_new(void)
 
 static t_int *sigwrap_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     while (n--)
     {
@@ -267,7 +267,7 @@ static t_int *sigwrap_perform(t_int *w)
      /* old buggy version that sometimes output 1 instead of 0 */
 static t_int *sigwrap_old_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     while (n--)
     {
@@ -315,7 +315,7 @@ static void *mtof_tilde_new(void)
 
 static t_int *mtof_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {
@@ -364,7 +364,7 @@ static void *ftom_tilde_new(void)
 
 static t_int *ftom_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {
@@ -408,7 +408,7 @@ static void *dbtorms_tilde_new(void)
 
 static t_int *dbtorms_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {
@@ -458,7 +458,7 @@ static void *rmstodb_tilde_new(void)
 
 static t_int *rmstodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {
@@ -507,7 +507,7 @@ static void *dbtopow_tilde_new(void)
 
 static t_int *dbtopow_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {
@@ -557,7 +557,7 @@ static void *powtodb_tilde_new(void)
 
 static t_int *powtodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = w[2];
+    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
     t_int n = (t_int)w[3];
     for (; n--; in++, out++)
     {


### PR DESCRIPTION
`t_sample *in = (t_sample *)w[1], *out = w[2];`
to
`t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];`