### PR TITLE
Remove unused variables

### DIFF
--- a/src/d_array.c
+++ b/src/d_array.c
@@ -575,9 +575,7 @@ static t_int *tabosc4_tilde_perform(t_int *w)
     t_float fnpoints = x->x_fnpoints;
     int mask = fnpoints - 1;
     t_float conv = fnpoints * x->x_conv;
-    int maxindex;
     t_word *tab = x->x_vec, *addr;
-    int i;
     double dphase = fnpoints * x->x_phase + UNITBIT32;
 
     if (!tab) goto zero;
@@ -755,7 +753,6 @@ static void tabsend_set(t_tabsend *x, t_symbol *s)
 
 static void tabsend_dsp(t_tabsend *x, t_signal **sp)
 {
-    int i, vecsize;
     int n = sp[0]->s_n;
     int ticksper = sp[0]->s_sr/n;
     tabsend_set(x, x->x_arrayname);
@@ -988,7 +985,7 @@ typedef struct _tabwrite
 
 static void tabwrite_float(t_tabwrite *x, t_float f)
 {
-    int i, vecsize;
+    int vecsize;
     t_garray *a;
     t_word *vec;
 

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -262,7 +262,6 @@ static t_int *vline_tilde_perform(t_int *w)
     double f = x->x_value;
     double inc = x->x_inc;
     double msecpersamp = x->x_msecpersamp;
-    double samppermsec = x->x_samppermsec;
     double timenow, logicaltimenow = clock_gettimesince(x->x_referencetime);
     t_vseg *s = x->x_list;
     if (logicaltimenow != x->x_lastlogicaltime)

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -22,7 +22,7 @@ typedef struct _dac
 static void *dac_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_dac *x = (t_dac *)pd_new(dac_class);
-    t_atom defarg[2], *ap;
+    t_atom defarg[2];
     int i;
     if (!argc)
     {
@@ -92,7 +92,7 @@ typedef struct _adc
 static void *adc_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_adc *x = (t_adc *)pd_new(adc_class);
-    t_atom defarg[2], *ap;
+    t_atom defarg[2];
     int i;
     if (!argc)
     {

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -178,13 +178,11 @@ static void *sigdelread_new(t_symbol *s, t_floatarg f)
 
 static void sigdelread_float(t_sigdelread *x, t_float f)
 {
-    int samps;
     t_sigdelwrite *delwriter =
         (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
     x->x_deltime = f;
     if (delwriter)
     {
-        int delsize = delwriter->x_cspace.c_n;
         x->x_delsamps = (int)(0.5 + x->x_sr * x->x_deltime)
             + x->x_n - x->x_zerodel;
         if (x->x_delsamps < x->x_n) x->x_delsamps = x->x_n;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -260,7 +260,7 @@ static void outlet_soundfile_info(t_outlet *out, t_soundfile_info *info)
 
 int open_soundfile_via_fd(int fd, t_soundfile_info *p_info, long skipframes)
 {
-    int format, nchannels, bigendian, bytespersamp, samprate, swap;
+    int nchannels, bigendian, bytespersamp, samprate, swap;
     int headersize = 0;
     long sysrtn, bytelimit = 0x7fffffff;
     errno = 0;
@@ -1243,7 +1243,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
 {
     t_soundfile_info info;
     int resize = 0, i;
-    long skipframes = 0, finalsize = 0, itemsleft,
+    long skipframes = 0, finalsize = 0,
         maxsize = DEFMAXSIZE, itemsread = 0, j;
     int fd = -1;
     char endianness, *filename;
@@ -1403,7 +1403,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
 
     for (i = 0; i < argc; i++)
     {
-        int nzero, vecsize;
+        int vecsize;
         if (garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
             for (j = itemsread; j < vecsize; j++)
                 vecs[i][j].w_float = 0;
@@ -1440,13 +1440,12 @@ done:
 long soundfiler_dowrite(void *obj, t_canvas *canvas,
     int argc, t_atom *argv, t_soundfile_info *info)
 {
-    int endianness, swap, filetype, normalize, i;
-    long onset, nframes, itemsleft,
-        maxsize = DEFMAXSIZE, itemswritten = 0, j;
+    int swap, filetype, normalize, i;
+    long onset, nframes, itemswritten = 0, j;
     t_garray *garrays[MAXSFCHANS];
     t_word *vectors[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
-    int bufframes, nitems;
+    int bufframes;
     int fd = -1;
     t_sample normfactor, biggest = 0;
     t_float samplerate;
@@ -1520,7 +1519,7 @@ long soundfiler_dowrite(void *obj, t_canvas *canvas,
 
     for (itemswritten = 0; itemswritten < nframes; )
     {
-        long thiswrite = nframes - itemswritten, nitems, nbytes;
+        long thiswrite = nframes - itemswritten, nbytes;
         thiswrite = (thiswrite > bufframes ? bufframes : thiswrite);
         soundfile_xferout_words(argc, vectors, (unsigned char *)sampbuf,
             thiswrite, onset, info->bytespersample, info->bigendian, normfactor);
@@ -2032,7 +2031,7 @@ static t_int *readsf_perform(t_int *w)
     t_sample *fp;
     if (x->x_state == STATE_STREAM)
     {
-        int wantbytes, nchannels, sfchannels = x->x_sfchannels;
+        int wantbytes, sfchannels = x->x_sfchannels;
         pthread_mutex_lock(&x->x_mutex);
         wantbytes = sfchannels * vecsize * bytespersample;
         while (
@@ -2277,9 +2276,6 @@ static void *writesf_child_main(void *zz)
 
                 /* copy file stuff out of the data structure so we can
                 relinquish the mutex while we're in open_soundfile(). */
-            long onsetframes = x->x_onsetframes;
-            long bytelimit = 0x7fffffff;
-            int skipheaderbytes = x->x_skipheaderbytes;
             int bytespersample = x->x_bytespersample;
             int sfchannels = x->x_sfchannels;
             int bigendian = x->x_bigendian;
@@ -2302,7 +2298,6 @@ static void *writesf_child_main(void *zz)
             if (x->x_fd >= 0)
             {
                 int bytesperframe = x->x_bytespersample * x->x_sfchannels;
-                int bigendian = x->x_bigendian;
                 char *filename = x->x_filename;
                 int fd = x->x_fd;
                 int filetype = x->x_filetype;
@@ -2443,7 +2438,6 @@ static void *writesf_child_main(void *zz)
             if (x->x_fd >= 0)
             {
                 int bytesperframe = x->x_bytespersample * x->x_sfchannels;
-                int bigendian = x->x_bigendian;
                 char *filename = x->x_filename;
                 int fd = x->x_fd;
                 int filetype = x->x_filetype;
@@ -2527,10 +2521,9 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 static t_int *writesf_perform(t_int *w)
 {
     t_writesf *x = (t_writesf *)(w[1]);
-    int vecsize = x->x_vecsize, sfchannels = x->x_sfchannels, i, j,
+    int vecsize = x->x_vecsize, sfchannels = x->x_sfchannels,
         bytespersample = x->x_bytespersample,
         bigendian = x->x_bigendian;
-    t_sample *fp;
     if (x->x_state == STATE_STREAM)
     {
         int wantbytes, roominfifo;

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -389,7 +389,7 @@ int ilog2(int n)
     /* call this when DSP is stopped to free all the signals */
 void signal_cleanup(void)
 {
-    t_signal **svec, *sig, *sig2;
+    t_signal *sig;
     int i;
     while ((sig = THIS->u_signals))
     {
@@ -456,9 +456,8 @@ void signal_makereusable(t_signal *sig)
 
 t_signal *signal_new(int n, t_float sr)
 {
-    int logn, n2, vecsize = 0;
+    int logn, vecsize = 0;
     t_signal *ret, **whichlist;
-    t_sample *fp;
     logn = ilog2(n);
     if (n)
     {
@@ -586,8 +585,6 @@ t_signal *signal_newfromcontext(int borrowed)
 
 void ugen_stop(void)
 {
-    t_signal *s;
-    int i;
     if (THIS->u_dspchain)
     {
         freebytes(THIS->u_dspchain,
@@ -644,7 +641,6 @@ t_dspcontext *ugen_start_graph(int toplevel, t_signal **sp,
     int ninlets, int noutlets)
 {
     t_dspcontext *dc = (t_dspcontext *)getbytes(sizeof(*dc));
-    int parent_vecsize, vecsize;
 
     if (THIS->u_loud) post("ugen_start_graph...");
 
@@ -749,7 +745,7 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
 {
     t_sigoutlet *uout;
     t_siginlet *uin;
-    t_sigoutconnect *oc, *oc2;
+    t_sigoutconnect *oc;
     t_class *class = pd_class(&u->u_obj->ob_pd);
     int i, n;
         /* suppress creating new signals for the outputs of signal
@@ -902,7 +898,7 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
 
 void ugen_done_graph(t_dspcontext *dc)
 {
-    t_ugenbox *u, *u2;
+    t_ugenbox *u;
     t_sigoutlet *uout;
     t_siginlet *uin;
     t_sigoutconnect *oc, *oc2;
@@ -1046,7 +1042,7 @@ void ugen_done_graph(t_dspcontext *dc)
     for (u = dc->dc_ugenlist; u; u = u->u_next)
     {
         t_pd *zz = &u->u_obj->ob_pd;
-        t_signal **insigs = dc->dc_iosigs, **outsigs = dc->dc_iosigs;
+        t_signal **outsigs = dc->dc_iosigs;
         if (outsigs) outsigs += dc->dc_ninlets;
 
         if (pd_class(zz) == vinlet_class)

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -378,8 +378,7 @@ void iemgui_all_raute2dollar(t_symbol **srlsym)
 void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 {
     t_symbol *snd;
-    int pargc, tail_len, nth_arg, sndable=1, oldsndrcvable=0;
-    t_atom *pargv;
+    int sndable=1, oldsndrcvable=0;
 
     if(iemgui->x_fsf.x_rcv_able)
         oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
@@ -398,8 +397,7 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
 {
     t_symbol *rcv;
-    int pargc, tail_len, nth_arg, rcvable=1, oldsndrcvable=0;
-    t_atom *pargv;
+    int rcvable=1, oldsndrcvable=0;
 
     if(iemgui->x_fsf.x_rcv_able)
         oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
@@ -433,8 +431,6 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
 void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
 {
     t_symbol *old;
-    int pargc, tail_len, nth_arg;
-    t_atom *pargv;
 
         /* tb: fix for empty label { */
         if (s == gensym(""))

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -23,7 +23,6 @@ t_array *array_new(t_symbol *templatesym, t_gpointer *parent)
 {
     t_array *x = (t_array *)getbytes(sizeof (*x));
     t_template *template;
-    t_gpointer *gp;
     template = template_findbyname(templatesym);
     x->a_templatesym = templatesym;
     x->a_n = 1;
@@ -46,7 +45,6 @@ void garray_arrayviewlist_close(t_garray *x);
 void array_resize(t_array *x, int n)
 {
     int elemsize, oldn;
-    t_gpointer *gp;
     char *tmp;
     t_template *template = template_findbyname(x->a_templatesym);
     if (n < 1)
@@ -161,12 +159,7 @@ to save and create arrays this might get called more directly. */
 static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
     int saveit)
 {
-    int i, zz;
     t_garray *x;
-    t_pd *x2;
-    t_template *template;
-    char *str;
-    t_gpointer gp;
     if (!template_findbyname(templatesym))
         return (0);
     x = (t_garray *)pd_new(garray_class);
@@ -185,7 +178,7 @@ static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
     /* get a garray's "array" structure. */
 t_array *garray_getarray(t_garray *x)
 {
-    int nwords, zonset, ztype;
+    int zonset, ztype;
     t_symbol *zarraytype;
     t_scalar *sc = x->x_scalar;
     t_symbol *templatesym = sc->sc_template;
@@ -280,15 +273,12 @@ by a more coherent (and general) invocation. */
 t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
     t_floatarg fsize, t_floatarg fflags)
 {
-    int n = fsize, i, zz, nwords, zonset, ztype, saveit;
+    int n = fsize, zonset, ztype, saveit;
     t_symbol *zarraytype, *asym = gensym("#A");
     t_garray *x;
-    t_pd *x2;
     t_template *template, *ztemplate;
     t_symbol *templatesym;
-    char *str;
     int flags = fflags;
-    t_gpointer gp;
     int filestyle = ((flags & 6) >> 1);
     int style = (filestyle == 0 ? PLOTSTYLE_POLY :
         (filestyle == 1 ? PLOTSTYLE_POINTS : filestyle));
@@ -425,8 +415,6 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
     else
     {
         long size;
-        int styleonset, styletype;
-        t_symbol *stylearraytype;
         t_symbol *argname = iemgui_raute2dollar(name);
         t_array *a = garray_getarray(x);
         t_template *scalartemplate;
@@ -482,10 +470,9 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
 /* jsarlo { */
 void garray_arrayviewlist_new(t_garray *x)
 {
-    int i, xonset=0, yonset=0, type=0, elemsize=0;
+    int i, yonset=0, elemsize=0;
     t_float yval;
     char cmdbuf[200];
-    t_symbol *arraytype;
     t_array *a = garray_getarray_floatonly(x, &yonset, &elemsize);
 
     if (!a)
@@ -515,10 +502,8 @@ void garray_arrayviewlist_fillpage(t_garray *x,
                                    t_float page,
                                    t_float fTopItem)
 {
-    int i, xonset=0, yonset=0, type=0, elemsize=0, topItem;
+    int i, yonset=0, elemsize=0, topItem;
     t_float yval;
-    char cmdbuf[200];
-    t_symbol *arraytype;
     t_array *a = garray_getarray_floatonly(x, &yonset, &elemsize);
 
     topItem = (int)fTopItem;
@@ -646,7 +631,7 @@ static void array_getrect(t_array *array, t_glist *glist,
         else incr = array->a_n / 300;
         for (i = 0; i < array->a_n; i += incr)
         {
-            t_float pxpix, pypix, pwpix, dx, dy;
+            t_float pxpix, pypix, pwpix;
             array_getcoordinate(glist, (char *)(array->a_vec) +
                 i * elemsize,
                 xonset, yonset, wonset, i, 0, 0, 1,
@@ -840,7 +825,7 @@ char *garray_vec(t_garray *x) /* get the contents */
 
 int garray_getfloatwords(t_garray *x, int *size, t_word **vec)
 {
-    int yonset, type, elemsize;
+    int yonset, elemsize;
     t_array *a = garray_getarray_floatonly(x, &yonset, &elemsize);
     if (!a)
     {
@@ -980,7 +965,7 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 
 static void garray_normalize(t_garray *x, t_float f)
 {
-    int type, i;
+    int i;
     double maxv, renormer;
     int yonset, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
@@ -1173,7 +1158,6 @@ int garray_ambigendian(void)
 void garray_resize_long(t_garray *x, long n)
 {
     t_array *array = garray_getarray(x);
-    t_glist *gl = x->x_glist;
     if (n < 1)
         n = 1;
     garray_fittograph(x, (int)n, template_getfloat(

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -447,7 +447,6 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
     int fs = 10;
     int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
         fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
-    char str[144];
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);
     iem_inttofstyle(&x->x_gui.x_fsf, 0);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -926,7 +926,6 @@ void canvas_loadbangsubpatches(t_canvas *x)
 
 void canvas_loadbang(t_canvas *x)
 {
-    t_gobj *y;
     canvas_loadbangabstractions(x);
     canvas_loadbangsubpatches(x);
 }
@@ -1251,7 +1250,6 @@ static void glist_redrawall(t_glist *gl, int action)
     int vis = glist_isvisible(gl);
     for (g = gl->gl_list; g; g = g->g_next)
     {
-        t_class *cl;
         if (vis && g->g_pd == scalar_class)
         {
             if (action == 1)
@@ -1539,10 +1537,7 @@ static int canvas_open_iter(const char *path, t_canvasopen *co)
 int canvas_open(t_canvas *x, const char *name, const char *ext,
     char *dirresult, char **nameresult, unsigned int size, int bin)
 {
-    t_namelist *nl, thislist;
     int fd = -1;
-    char listbuf[MAXPDSTRING];
-    t_canvas *y;
     t_canvasopen co;
 
         /* first check if "name" is absolute (and if so, try to open) */

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -146,7 +146,7 @@ static void clone_in_vis(t_in *x, t_floatarg fn, t_floatarg vis)
 
 static void clone_out_anything(t_out *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_atom *outv, *ap;
+    t_atom *outv;
     int first =
         1 + (s != &s_list && s != &s_float && s != &s_symbol && s != &s_bang),
             outc = argc + first;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -522,7 +522,6 @@ typedef struct _undo_cut
 static void *canvas_undo_set_cut(t_canvas *x, int mode)
 {
     t_undo_cut *buf;
-    t_gobj *y;
     t_linetraverser t;
     t_outconnect *oc;
     int nnotsel= glist_selectionindex(x, 0, 0);
@@ -847,7 +846,6 @@ int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos,
     int *x1p, int *y1p, int *x2p, int *y2p)
 {
     int x1, y1, x2, y2;
-    t_text *ob;
     if (!gobj_shouldvis(y, x))
         return (0);
     gobj_getrect(y, x, &x1, &y1, &x2, &y2);
@@ -942,8 +940,6 @@ void canvas_create_editor(t_glist *x)
 
 void canvas_destroy_editor(t_glist *x)
 {
-    t_gobj *y;
-    t_object *ob;
     glist_noselect(x);
     if (x->gl_editor)
     {
@@ -963,7 +959,6 @@ void canvas_map(t_canvas *x, t_floatarg f);
     the window. */
 void canvas_vis(t_canvas *x, t_floatarg f)
 {
-    char buf[30];
     int flag = (f != 0);
     if (flag)
     {
@@ -1121,8 +1116,6 @@ void canvas_properties(t_gobj*z, t_glist*unused)
 static void canvas_donecanvasdialog(t_glist *x,
     t_symbol *s, int argc, t_atom *argv)
 {
-
-
     t_float xperpix, yperpix, x1, y1, x2, y2, xpix, ypix, xmargin, ymargin;
     int graphme, redraw = 0, fromgui;
 
@@ -1208,7 +1201,7 @@ static void canvas_donecanvasdialog(t_glist *x,
 static void canvas_done_popup(t_canvas *x, t_float which,
     t_float xpos, t_float ypos)
 {
-    char pathbuf[MAXPDSTRING], namebuf[MAXPDSTRING], *basenamep;
+    char namebuf[MAXPDSTRING], *basenamep;
     t_gobj *y;
     for (y = x->gl_list; y; y = y->g_next)
     {
@@ -1824,7 +1817,6 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
         return;
     if (x && down)
     {
-        t_object *ob;
             /* cancel any dragging action */
         if (x->gl_editor->e_onmotion == MA_MOVE)
             x->gl_editor->e_onmotion = MA_NONE;
@@ -1941,7 +1933,6 @@ void canvas_motion(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
                 &x11, &y11, &x12, &y12)))
         {
             int wantwidth = xpos - x11;
-            t_gotfn sizefn;
             t_object *ob = pd_checkobject(&y1->g_pd);
             if (ob && ((ob->te_pd->c_wb == &text_widgetbehavior) ||
                     (pd_checkglist(&ob->te_pd) &&
@@ -2493,7 +2484,7 @@ static void glist_donewloadbangs(t_glist *x)
 
 static void canvas_dopaste(t_canvas *x, t_binbuf *b)
 {
-    t_gobj *newgobj, *last, *g2;
+    t_gobj *g2;
     int dspstate = canvas_suspend_dsp(), nbox, count;
     t_symbol *asym = gensym("#A");
         /* save and clear bindings to symbols #a, $N, $X; restore when done */
@@ -2581,8 +2572,6 @@ static void canvas_selectall(t_canvas *x)
 static void canvas_reselect(t_canvas *x)
 {
     t_gobj *g, *gwas;
-    t_selection *sel;
-    t_object *ob;
         /* if someone is text editing, and if only one object is
         selected,  deselect everyone and reselect.  */
     if (x->gl_editor->e_textedfor)
@@ -2669,7 +2658,7 @@ bad:
     /* LATER might have to speed this up */
 static void canvas_tidy(t_canvas *x)
 {
-    t_gobj *y, *y2, *y3;
+    t_gobj *y, *y2;
     int ax1, ay1, ax2, ay2, bx1, by1, bx2, by2;
     int histogram[NHIST], *ip, i, besthist, bestdist;
         /* if nobody is selected, this means do it to all boxes;

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -143,7 +143,7 @@ void glist_delete(t_glist *x, t_gobj *y)
     /* remove every object from a glist.  Experimental. */
 void glist_clear(t_glist *x)
 {
-    t_gobj *y, *y2;
+    t_gobj *y;
     int dspstate = 0, suspended = 0;
     t_symbol *dspsym = gensym("dsp");
     while ((y = x->gl_list))
@@ -725,7 +725,6 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         t_float f;
         t_gobj *g;
         t_symbol *arrayname;
-        t_garray *ga;
         char *ylabelanchor =
             (x->gl_ylabelx > 0.5*(x->gl_x1 + x->gl_x2) ? "w" : "e");
         char *xlabelanchor =
@@ -889,7 +888,6 @@ static void graph_getrect(t_gobj *z, t_glist *glist,
     {
         int hadwindow;
         t_gobj *g;
-        t_text *ob;
         int x21, y21, x22, y22;
 
         graph_graphrect(z, glist, &x1, &y1, &x2, &y2);

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -575,11 +575,9 @@ static void hradio_single_change(t_hradio *x)
 static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
 {
     t_hradio *x = (t_hradio *)pd_new(old ? hradio_old_class : hradio_class);
-    int a=IEM_GUI_DEFAULTSIZE, on = 0, f = 0;
+    int a = IEM_GUI_DEFAULTSIZE, on = 0;
     int ldx = 0, ldy = -8, chg = 1, num = 8;
     int fs = 10;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME, fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
-    char str[144];
     float fval = 0;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -545,10 +545,9 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_hslider *x = (t_hslider *)pd_new(hslider_class);
     int w = IEM_SL_DEFAULTSIZE, h = IEM_GUI_DEFAULTSIZE;
-    int lilo = 0, ldx = -2, ldy = -8, f = 0, steady = 1;
+    int lilo = 0, ldx = -2, ldy = -8, steady = 1;
     int fs = 10;
     double min = 0.0, max = (double)(IEM_SL_DEFAULTSIZE-1);
-    char str[144];
     float v = 0;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -158,7 +158,7 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs,
     int myvecsize, int calcsize, int phase, int period, int frequency,
     int downsample, int upsample,  int reblock, int switched)
 {
-    t_signal *insig, *outsig;
+    t_signal *insig;
         /* no buffer means we're not a signal inlet */
     if (!x->x_buf)
         return;
@@ -474,7 +474,7 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs,
     x->x_updown.upsample=upsample;
     if (reblock)
     {
-        t_signal *insig, *outsig;
+        t_signal *outsig;
         int parentvecsize, bufsize, oldbufsize;
         int re_parentvecsize;
         int bigperiod, epilogphase, blockphase;

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -270,7 +270,6 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     int a = IEM_GUI_DEFAULTSIZE, w = 100, h = 60;
     int ldx = 20, ldy = 12, f = 2, i = 0;
     int fs = 14;
-    char str[144];
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);
     iem_inttofstyle(&x->x_gui.x_fsf, 0);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -771,11 +771,10 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_my_numbox *x = (t_my_numbox *)pd_new(my_numbox_class);
     int w = 5, h = 14;
-    int lilo = 0, f = 0, ldx = 0, ldy = -8;
+    int lilo = 0, ldx = 0, ldy = -8;
     int fs = 10;
     int log_height = 256;
     double min = -1.0e+37, max = 1.0e+37, v = 0.0;
-    char str[144];
 
     x->x_gui.x_bcol = 0xFCFCFC;
     x->x_gui.x_fcol = 0x00;

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -25,7 +25,7 @@ void canvas_savedeclarationsto(t_canvas *x, t_binbuf *b);
 static int canvas_scanbinbuf(int natoms, t_atom *vec, int *p_indexout,
     int *p_next)
 {
-    int i, j;
+    int i;
     int indexwas = *p_next;
     *p_indexout = indexwas;
     if (indexwas >= natoms)
@@ -55,7 +55,7 @@ static void canvas_readerror(int natoms, t_atom *vec, int message,
 static void glist_readatoms(t_glist *x, int natoms, t_atom *vec,
     int *p_nextmsg, t_symbol *templatesym, t_word *w, int argc, t_atom *argv)
 {
-    int message, nline, n, i;
+    int message, n, i;
 
     t_template *template = template_findbyname(templatesym);
     if (!template)
@@ -70,7 +70,6 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec,
     {
         if (template->t_vec[i].ds_type == DT_ARRAY)
         {
-            int j;
             t_array *a = w[i].w_array;
             int elemsize = a->a_elemsize, nitems = 0;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
@@ -114,7 +113,7 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec,
 int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
     int *p_nextmsg, int selectit)
 {
-    int message, i, j, nline;
+    int message, nline;
     t_template *template;
     t_symbol *templatesym;
     t_scalar *sc;
@@ -170,9 +169,8 @@ int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
 void glist_readfrombinbuf(t_glist *x, t_binbuf *b, char *filename, int selectem)
 {
     t_canvas *canvas = glist_getcanvas(x);
-    int cr = 0, natoms, nline, message, nextmsg = 0, i, j, nitems;
+    int natoms, nline, message, nextmsg = 0;
     t_atom *vec;
-    t_gobj *gobj;
 
     natoms = binbuf_getnatom(b);
     vec = binbuf_getvec(b);
@@ -256,8 +254,7 @@ static void glist_doread(t_glist *x, t_symbol *filename, t_symbol *format,
     t_binbuf *b = binbuf_new();
     t_canvas *canvas = glist_getcanvas(x);
     int wasvis = glist_isvisible(canvas);
-    int cr = 0, natoms, nline, message, nextmsg = 0, i, j;
-    t_atom *vec;
+    int cr = 0;
 
     if (!strcmp(format->s_name, "cr"))
         cr = 1;
@@ -399,7 +396,6 @@ void binbuf_savetext(t_binbuf *bfrom, t_binbuf *bto);
 void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
     int amarrayelement)
 {
-    t_dataslot *ds;
     t_template *template = template_findbyname(templatesym);
     t_atom *a = (t_atom *)t_getbytes(0);
     int i, n = template?(template->t_n):0, natom = 0;
@@ -566,10 +562,9 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
 
 static void glist_write(t_glist *x, t_symbol *filename, t_symbol *format)
 {
-    int cr = 0, i;
+    int cr = 0;
     t_binbuf *b;
     char buf[MAXPDSTRING];
-    t_gobj *y;
     t_canvas *canvas = glist_getcanvas(x);
     canvas_makefilename(canvas, filename->s_name, buf, MAXPDSTRING);
     if (!strcmp(format->s_name, "cr"))
@@ -699,7 +694,6 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 {
     t_symbol **templatevec = getbytes(0);
     int i, ntemplates = 0;
-    t_gobj *y;
     canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
     for (i = 0; i < ntemplates; i++)
     {

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -157,7 +157,6 @@ static void audio_init( void)
 
 void sys_setchsr(int chin, int chout, int sr)
 {
-    int nblk;
     int inbytes = (chin ? chin : 2) *
                 (DEFDACBLKSIZE*sizeof(t_sample));
     int outbytes = (chout ? chout : 2) *
@@ -201,7 +200,7 @@ void sys_set_audio_settings(int naudioindev, int *audioindev, int nchindev,
     int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
     int *choutdev, int rate, int advance, int callback, int blocksize)
 {
-    int i, *ip;
+    int i;
     int defaultchannels = SYS_DEFAULTCH;
     int inchans, outchans, nrealindev, nrealoutdev;
     int realindev[MAXAUDIOINDEV], realoutdev[MAXAUDIOOUTDEV];
@@ -815,10 +814,7 @@ extern int pa_foo;
     /* new values from dialog window */
 void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int naudioindev, audioindev[MAXAUDIOINDEV], chindev[MAXAUDIOINDEV];
-    int naudiooutdev, audiooutdev[MAXAUDIOOUTDEV], choutdev[MAXAUDIOOUTDEV];
-    int rate, advance, audioon, i, nindev, noutdev;
-    int audioindev1, audioinchan1, audiooutdev1, audiooutchan1;
+    int i, nindev, noutdev;
     int newaudioindev[4], newaudioinchan[4],
         newaudiooutdev[4], newaudiooutchan[4];
         /* the new values the dialog came back with: */
@@ -1117,7 +1113,7 @@ int sys_audiodevnametonumber(int output, const char *name)
 void sys_audiodevnumbertoname(int output, int devno, char *name, int namesize)
 {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i, canmulti, cancallback;
+    int nindevs = 0, noutdevs = 0, canmulti, cancallback;
     if (devno < 0)
     {
         *name = 0;

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -96,7 +96,7 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
     const char *path)
 {
     char symname[MAXPDSTRING], filename[MAXPDSTRING], dirbuf[MAXPDSTRING],
-        *nameptr, altsymname[MAXPDSTRING];
+        *nameptr;
     const char *classname, *cnameptr;
     void *dlobj;
     t_xxx makeout = NULL;

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -550,7 +550,7 @@ static int sys_getmultidevchannels(int n, int *devlist)
     INSTALL_PREFIX.  In MSW, we don't try to use INSTALL_PREFIX. */
 void sys_findprogdir(char *progname)
 {
-    char sbuf[MAXPDSTRING], sbuf2[MAXPDSTRING], *sp;
+    char sbuf[MAXPDSTRING], sbuf2[MAXPDSTRING];
     char *lastslash;
 #ifndef _WIN32
     struct stat statbuf;
@@ -635,7 +635,6 @@ static int sys_mmio = 0;
 
 int sys_argparse(int argc, char **argv)
 {
-    char sbuf[MAXPDSTRING];
     int i;
     while ((argc > 0) && **argv == '-')
     {

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -198,7 +198,7 @@ t_namelist *namelist_append_files(t_namelist *listwas, const char *s)
 {
     const char *npos;
     char temp[MAXPDSTRING];
-    t_namelist *nl = listwas, *rtn = listwas;
+    t_namelist *nl = listwas;
 
     npos = s;
     do
@@ -657,7 +657,6 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     if "saveit" is set, also save all settings.  */
 void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit)
 {
-    int i;
     t_symbol *s = sys_decodedialog(path);
     if (*s->s_name)
     {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -527,10 +527,8 @@ static int array_rangeop_getrange(t_array_rangeop *x,
 {
     t_glist *glist;
     t_array *a = array_client_getbuf(&x->x_tc, &glist);
-    char *elemp;
-    int stride, fieldonset, arrayonset, nitem, i, type;
+    int stride, fieldonset, arrayonset, nitem, type;
     t_symbol *arraytype;
-    double sum;
     t_template *template;
     if (!a)
         return (0);
@@ -714,8 +712,8 @@ static void array_random_seed(t_array_random *x, t_floatarg f)
 
 static void array_random_bang(t_array_random *x)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i;
+    char *firstitem;
+    int stride, nitem, arrayonset;
 
     if (!array_rangeop_getrange(&x->x_r, &firstitem, &nitem, &stride,
         &arrayonset))

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1257,7 +1257,7 @@ typedef struct _makefilename
 } t_makefilename;
 
 static const char* _formatscan(const char*str, t_printtype*typ) {
-    int num=0, infmt=0;
+    int infmt=0;
     for (; *str; str++) {
         if (!infmt && *str=='%') {
             infmt=1;
@@ -1294,9 +1294,7 @@ static const char* _formatscan(const char*str, t_printtype*typ) {
 
 static void makefilename_scanformat(t_makefilename *x)
 {
-    int num=0, infmt=0;
     const char *str;
-    char *chr;
     t_printtype typ;
     if (!x->x_format) return;
     str = x->x_format->s_name;

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -61,7 +61,6 @@ static void print_float(t_print *x, t_float f)
 
 static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     if (argc && argv->a_type != A_SYMBOL) startpost("%s:", x->x_sym->s_name);
     else startpost("%s%s%s", x->x_sym->s_name,
         (*x->x_sym->s_name ? ": " : ""),
@@ -73,7 +72,6 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
 
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     startpost("%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
         s->s_name);
     postatom(argc, argv);

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -963,7 +963,6 @@ static void *stripnote_new(void)
 
 static void stripnote_float(t_stripnote *x, t_float f)
 {
-    t_hang *hang;
     if (!x->x_velo) return;
     outlet_float(x->x_velout, x->x_velo);
     outlet_float(x->x_pitchout, f);

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -127,7 +127,6 @@ static void netsend_readbin(t_netsend *x, int fd)
 
 static void netsend_doit(void *z, t_binbuf *b)
 {
-    t_atom messbuf[1024];
     t_netsend *x = (t_netsend *)z;
     int msg, natom = binbuf_getnatom(b);
     t_atom *at = binbuf_getvec(b);
@@ -165,7 +164,7 @@ static void netsend_doit(void *z, t_binbuf *b)
 static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *hostname;
-    int fportno, sportno, sockfd, portno, srcportno, intarg;
+    int fportno, sportno, sockfd, portno, intarg;
     struct sockaddr_in server = {0};
     struct sockaddr_in srcaddr = {0};
     struct hostent *hp;
@@ -182,7 +181,6 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     fportno = (int)argv[1].a_w.w_float;
     sportno = (argc>2)?(int)argv[2].a_w.w_float:0;
     portno = fportno;
-    srcportno = sportno;
     if (x->x_sockfd >= 0)
     {
         error("netsend_connect: already connected");

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -20,7 +20,6 @@ t_class *scalar_define_class;
 static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_atom a[9];
-    t_glist *gl;
     t_canvas *x, *z = canvas_getcurrent();
     t_symbol *templatesym = &s_float, *asym = gensym("#A");
     t_template *template;

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -212,7 +212,7 @@ static int text_nthline(int n, t_atom *vec, int line, int *startp, int *endp)
     {
         if (cnt == line)
         {
-            int j = i, outc, k;
+            int j = i;
             while (j < n && vec[j].a_type != A_SEMI &&
                 vec[j].a_type != A_COMMA)
                     j++;
@@ -312,7 +312,6 @@ static void text_define_frompointer(t_text_define *x, t_gpointer *gp,
         gp, s, "text_frompointer");
     if (b)
     {
-        t_gstub *gs = gp->gp_stub;
         binbuf_clear(x->x_textbuf.b_binbuf);
         binbuf_add(x->x_textbuf.b_binbuf, binbuf_getnatom(b), binbuf_getvec(b));
     }
@@ -961,8 +960,6 @@ static void *text_tolist_new(t_symbol *s, int argc, t_atom *argv)
 static void text_tolist_bang(t_text_tolist *x)
 {
     t_binbuf *b = text_client_getbuf(x), *b2;
-    int n, i, cnt = 0;
-    t_atom *vec;
     if (!b)
        return;
     b2 = binbuf_new();
@@ -1083,10 +1080,9 @@ static void text_search_list(t_text_search *x,
     t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int i, j, n, lineno, bestline = -1, beststart=-1, bestn, thisstart, thisn,
+    int i, n, lineno, bestline = -1, beststart=-1, bestn, thisstart,
         nkeys = x->x_nkeys, failed = 0;
     t_atom *vec;
-    t_key *kp = x->x_keyvec;
     if (!b)
        return;
     if (argc < nkeys)
@@ -1349,7 +1345,7 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
 
 static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
 {
-    t_binbuf *b = text_client_getbuf(&x->x_tc), *b2;
+    t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n, i, onset, nfield, wait, eatsemi = 1, gotcomma = 0;
     t_atom *vec, *outvec, *ap;
     if (!b)
@@ -1552,7 +1548,7 @@ static void text_sequence_step(t_text_sequence *x)
 
 static void text_sequence_line(t_text_sequence *x, t_floatarg f)
 {
-    t_binbuf *b = text_client_getbuf(&x->x_tc), *b2;
+    t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n, start, end;
     t_atom *vec;
     if (!b)
@@ -1905,7 +1901,7 @@ static void *textfile_new( void)
 static void textfile_bang(t_qlist *x)
 {
     int argc = binbuf_getnatom(x->x_binbuf),
-        count, onset = x->x_onset, onset2;
+        onset = x->x_onset, onset2;
     t_atom *argv = binbuf_getvec(x->x_binbuf);
     t_atom *ap = argv + onset, *ap2;
     while (onset < argc &&

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1324,7 +1324,6 @@ eval_store(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
         struct ex_ex arg;
         struct ex_ex rval;
         struct ex_ex *retp;
-        int isvalue;
         char *tbl = (char *) 0;
         char *var = (char *) 0;
         int badleft = 0;
@@ -1449,7 +1448,6 @@ eval_var(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the operation stack */
 /* the result pointer */
 {
-        struct ex_ex arg;
         char *var = (char *) 0;
         int novar = 0;
 
@@ -1491,10 +1489,9 @@ eval_sigidx(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 {
         struct ex_ex arg;
         struct ex_ex *reteptr;
-        int i = 0, j = 0;
+        int i = 0;
         t_float fi = 0,         /* index in float */
               rem_i = 0;        /* remains of the float */
-        char *tbl;
 
         arg.ex_type = 0;
         arg.ex_int = 0;


### PR DESCRIPTION
I enabled all warnings and saw lots of obvious cases of unused variables that were just declared but never used.
I have removed some of the obvious cases, although I did not have time to fix all of them, also paying attention to the variables not being used in commented-out or deactivated code.
I put the changes in a commit per file to ease partial change acceptance.
