### PR TITLE
Fix implicit functions and definitions for msvc

### DIFF
--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -26,11 +26,6 @@ typedef double t_floatarg;
 and usable in other contexts.  The one external requirement is a real
 single-precision FFT, invoked as in the Mayer one: */
 
-#ifdef _MSC_VER /* this is only needed with Microsoft's compiler */
-__declspec(dllimport) extern
-#endif
-void mayer_realfft(int npoints, t_sample *buf);
-
 /* this routine is passed a buffer of npoints values, and returns the
 N/2+1 real parts of the DFT (frequency zero through Nyquist), followed
 by the N/2-1 imaginary points, in order of decreasing frequency.  Pd 0.41,

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -10,6 +10,7 @@ to be different but are now unified except for some fossilized names.) */
 #include "m_pd.h"
 #include "m_imp.h"
 #include "s_stuff.h"
+#include "s_utf8.h"
 #include "g_canvas.h"
 #include <string.h>
 #include "g_all_guis.h"

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -16,6 +16,7 @@ to be different but are now unified except for some fossilized names.) */
 #include "g_all_guis.h"
 
 #ifdef _MSC_VER
+#include <io.h>
 #define snprintf _snprintf
 #endif
 

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -95,7 +95,7 @@ static void pdfloat_float(t_pdfloat *x, t_float f)
 }
 
 #ifdef _MSC_VER
-#define strtof _atoldbl
+#define strtof(a,b) _atoldbl(a,*b)
 #endif
 
 static void pdfloat_symbol(t_pdfloat *x, t_symbol *s)

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -76,7 +76,7 @@
 #endif
 
 #ifdef _MSC_VER
-#define strtof _atoldbl
+#define strtof(a, b) _atoldbl(a, *b)
 #endif
 
 

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -77,7 +77,6 @@
 #include <math.h>
 #undef __STRICT_BSD__
 
-
 #include "x_vexp.h"
 
 struct ex_ex *ex_eval(struct expr *expr, struct ex_ex *eptr,
@@ -537,17 +536,6 @@ ex_toint(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 #define toint(x)        ((int)(x))
                 FUNC_EVAL_UNARY(left, toint, (int), optr, 0);
         }
-
-#ifdef _WIN32
-/* No rint in NT land ??? */
-double rint(double x);
-
-double
-rint(double x)
-{
-        return (floor(x + 0.5));
-}
-#endif
 
 /*
  * ex_rint -- rint() round to the nearest int according to the common


### PR DESCRIPTION
b90f5cc: s_utf8.h is necessary for `u8_utf8toucs2()` [L. 1393](https://github.com/pierreguillot/pure-data/blob/8c40ab48edf8e2f6899cdc7ad68645a652d649cd/src/g_canvas.c#L1393) of g_canvas.c

8c40ab4: io.h is necessary for `_waccess()` [L. 1394](https://github.com/pierreguillot/pure-data/blob/8c40ab48edf8e2f6899cdc7ad68645a652d649cd/src/g_canvas.c#L1394) of g_canvas.c


c738415 & 4eaf62b: `_atoldbl` takes a `char*` for the 2nd arg and not `char**` the macro fix this.
 
b29dcc5:  `mayer_realfft()` is already declared in m_pd.h.

fcdabfe: `rint()` is already declared with math.h 