### PR TITLE
Fix object noise~ new method argument

### DIFF
--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -503,7 +503,7 @@ static void noise_float(t_noise *x, t_float f)
 static void noise_setup(void)
 {
     noise_class = class_new(gensym("noise~"), (t_newmethod)noise_new, 0,
-        sizeof(t_noise), 0, A_DEFFLOAT);
+        sizeof(t_noise), 0, A_DEFFLOAT, 0);
     class_addmethod(noise_class, (t_method)noise_dsp,
         gensym("dsp"), A_CANT, 0);
     class_addmethod(noise_class, (t_method)noise_float,


### PR DESCRIPTION
This fix the bug `bad arguments for message "noise~" to objectmaker...` generated by the PR **noise~ inlet now sets random seed** (https://github.com/pure-data/pure-data/pull/264) due to missing `0` at the end of `class_new()`.
