### PR TITLE
[WIP] bugfixes/improvements for pd~

### DIFF
--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -22,7 +22,7 @@ AUTOMAKE_OPTIONS = foreign
 AM_CFLAGS = @EXTERNAL_CFLAGS@
 AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
 AM_LIBS = $(LIBM)
-AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
+AM_LDFLAGS = -lpthread -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
     -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
 
 externaldir = $(pkglibdir)/extra/$(NAME)

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -584,6 +584,13 @@ static void pd_tilde_donew(t_pd_tilde *x, char *pddir, char *schedlibdir,
         execv(cmdbuf, execargv);
         _exit(1);
     }
+    do {
+      unsigned int i;
+      for(i=FIXEDARG; execargv[i]; i++) {
+        free(execargv[i]);
+      }
+    } while(0);
+
 #endif /* _WIN32 */
         /* done with fork/exec or spawn; parent continues here */
     close(pipe1[0]);

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -144,7 +144,7 @@ static void pd_tilde_close(t_pd_tilde *x)
     x->x_childpid = -1;
 }
 
-static void pd_tilde_readmessages(t_pd_tilde *x)
+static int pd_tilde_readmessages(t_pd_tilde *x)
 {
     t_atom at;
     binbuf_clear(x->x_binbuf);
@@ -153,7 +153,8 @@ static void pd_tilde_readmessages(t_pd_tilde *x)
         int nonempty = 0;
         while (1)
         {
-            pd_tilde_getatom(&at, x->x_infd);
+            if (!pd_tilde_getatom(&at, x->x_infd))
+                return 0;
             if (!nonempty && at.a_type == A_SEMI)
                 break;
             nonempty = (at.a_type != A_SEMI);
@@ -171,7 +172,7 @@ static void pd_tilde_readmessages(t_pd_tilde *x)
             while (isspace((c = getc(x->x_infd))) && c != EOF)
                 ;
             if (c == EOF)
-                return;
+                return 0;
             do
                 msgbuf[infill++] = c;
             while (!isspace((c = getc(x->x_infd))) && c != ';' && c != EOF) ;
@@ -192,6 +193,7 @@ static void pd_tilde_readmessages(t_pd_tilde *x)
             binbuf_print(x->x_binbuf); */
     }
     clock_delay(x->x_clock, 0);
+    return 1;
 }
 
 #define FIXEDARG 13

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -552,7 +552,13 @@ static t_int *pd_tilde_perform(t_int *w)
         for (; j < DEFDACBLKSIZE; j++)
             x->x_outsig[nsigs][j] = 0;
     }
-    pd_tilde_readmessages(x);
+    if (!pd_tilde_readmessages(x))
+    {
+        if (errno)
+            PDERROR "pd~: %s", strerror(errno));
+        else PDERROR "pd~: subprocess exited");
+        pd_tilde_close(x);
+    }
     return (w+3);
 zeroit:
     for (i = 0; i < x->x_noutsig; i++)

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -238,7 +238,8 @@ static void pd_tilde_donew(t_pd_tilde *x, char *pddir, char *schedlibdir,
             }
         }
     }
-        /* check that the scheduler dynamic linkable exists w either sffix */
+
+        /* check that the scheduler dynamic linkable exists w either suffix */
     snprintf(tmpbuf, MAXPDSTRING, "%s/pdsched%s", schedlibdir, 
         pd_tilde_dllextent);
     sys_bashfilename(tmpbuf, schedbuf);

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -350,7 +350,7 @@ static void pd_tilde_donew(t_pd_tilde *x, char *pddir, char *schedlibdir,
             _dup2(pipe1[0], 0);
         if (pipe2[1] != 1)
             _dup2(pipe2[1], 1);
-        pid = _spawnv(P_NOWAIT, cmdbuf, execargv);
+        pid = _spawnv(P_NOWAIT, cmdbuf, (const char * const *)execargv);
         if (pid < 0)
         {
             post("%s: couldn't start subprocess (%s)\n", execargv[0],

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -317,7 +317,8 @@ void sys_loadpreferences(const char *filename, int startingup)
         sys_initloadpreferences_file(filename);
     else sys_initloadpreferences();
         /* load audio preferences */
-    if (sys_getpreference("audioapi", prefbuf, MAXPDSTRING)
+    if (!sys_externalschedlib
+        && sys_getpreference("audioapi", prefbuf, MAXPDSTRING)
         && sscanf(prefbuf, "%d", &api) > 0)
             sys_set_audio_api(api);
             /* JMZ/MB: brackets for initializing */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -351,12 +351,16 @@ int sys_main(int argc, char **argv)
 #endif  /* _WIN32 */
     pd_init();                                  /* start the message system */
     sys_findprogdir(argv[0]);                   /* set sys_progname, guipath */
-    for (i = noprefs = 0; i < argc; i++)    /* prescan for prefs override */
+    for (i = noprefs = 0; i < argc; i++)    /* prescan ... */
     {
+        /* for prefs override */
         if (!strcmp(argv[i], "-noprefs"))
             noprefs = 1;
         else if (!strcmp(argv[i], "-prefsfile") && i < argc-1)
             prefsfile = argv[i+1];
+        /* for external scheduler (to ignore audio api in sys_loadpreferences) */
+        else if (!strcmp(argv[i], "-schedlib") && i < argc-1)
+            sys_externalschedlib = 1;
     }
     if (!noprefs)       /* load preferences before parsing args to allow ... */
         sys_loadpreferences(prefsfile, 1);  /* args to override prefs */


### PR DESCRIPTION
* fix errors with path names containing whitespace. On Windows, Pd is usually installed in C:\Program Files (x86) and such a path would be treated as several arguments, messing up the argument parsing in the subprocess. This fixes https://github.com/pure-data/pure-data/issues/251

* return from pd_tilde_readmessage if no binary message could be received instead of going into an infinite loop. I also added a return code to the function so we can call pd_tilde_close on failure. this gracefully handles the case where the subprocess is closed from within, preventing the parent process from freezing.

* ignore audio API in sys_loadpreferences when an external scheduler is used. the idea is to prevent unnecessary scanning of audio devices (which can take some time on some systems for various reasons) so that the subprocess is opened instantly. the "-schedlib" flag will set the audio api to 0 in sys_argparse anyway.

EDIT:

* the parent process keeps reading from the pipe in a child thread, preventing possible deadlocks.