### PR TITLE
[soundfiler] - remove tiny default value of "maxsize" and prevent signed integer overflow

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1441,8 +1441,7 @@ long soundfiler_dowrite(void *obj, t_canvas *canvas,
     int argc, t_atom *argv, t_soundfile_info *info)
 {
     int endianness, swap, filetype, normalize, i;
-    long onset, nframes, itemsleft,
-        maxsize = DEFMAXSIZE, itemswritten = 0, j;
+    long onset, nframes, itemsleft, itemswritten = 0, j;
     t_garray *garrays[MAXSFCHANS];
     t_word *vectors[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -23,6 +23,7 @@ objects use Posix-like threads.  */
 #include <string.h>
 #include <errno.h>
 #include <math.h>
+#include <limits.h>
 
 #include "m_pd.h"
 
@@ -1205,7 +1206,6 @@ static void soundfile_xferout_words(int nchannels, t_word **vecs,
 }
 
 /* ------- soundfiler - reads and writes soundfiles to/from "garrays" ---- */
-#define DEFMAXSIZE 4000000      /* default maximum 16 MB per channel */
 #define SAMPBUFSIZE 1024
 
 
@@ -1244,7 +1244,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     t_soundfile_info info;
     int resize = 0, i;
     long skipframes = 0, finalsize = 0, itemsleft,
-        maxsize = DEFMAXSIZE, itemsread = 0, j;
+        maxsize = LONG_MAX, itemsread = 0, j;
     int fd = -1;
     char endianness, *filename;
     t_garray *garrays[MAXSFCHANS];

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1302,7 +1302,8 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
         else if (!strcmp(flag, "maxsize"))
         {
             if (argc < 2 || argv[1].a_type != A_FLOAT ||
-                ((maxsize = argv[1].a_w.w_float) < 0))
+                ((maxsize = (argv[1].a_w.w_float > LONG_MAX ? 
+                LONG_MAX : argv[1].a_w.w_float)) < 0))
                     goto usage;
             resize = 1;     /* maxsize implies resize. */
             argc -= 2; argv += 2;


### PR DESCRIPTION
1)
the default value for maxsize has been 4000000 samples which IMHO is not necessary. I basically end up always doing [read -resize -maxsize 1e007 ...( when loading soundfiles... 
I think "maxsize" should be opt-in so I've set the default value to LONG_MAX. 

EDIT: I could've also used a magic number like -1 instead of LONG_MAX and test against it to avoid including "limits.h"

2)
users would often do something like "-maxsize HUGENUMBER" to practically circumvent the default value. on Windows, however, `long `is always 32 bit, and something like "1e010" will lead to integer overflow, most likely resulting in a negative number and making soundfiler_read fail. I added a simple check to prevent this. this fixes #380 