### PR TITLE
disallow creating an object with the name "anything"

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -778,6 +778,10 @@ void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv)
       error("maximum object loading depth %d reached", MAXOBJDEPTH);
       return;
     }
+    if (s == &s_anything){
+      error("object name \"%s\" not allowed", s->s_name);
+      return;
+    }
     pd_this->pd_newest = 0;
     class_loadsym = s;
     pd_globallock();


### PR DESCRIPTION
...because this would eventually override pd_objectmakers's anything method, essentially breaking the abstraction/external loading mechanism. 
fixes https://github.com/pure-data/pure-data/issues/372