### PR TITLE
don't increment gl_valid when deleting non-scalar objects

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -129,6 +129,8 @@ void glist_delete(t_glist *x, t_gobj *y)
         g->g_next = y->g_next;
         break;
     }
+    if (y->g_pd == scalar_class)
+        x->gl_valid = ++glist_valid;
     pd_free(&y->g_pd);
     if (rtext)
         rtext_free(rtext);
@@ -137,7 +139,6 @@ void glist_delete(t_glist *x, t_gobj *y)
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
             glist_getcanvas(x)->gl_name)), 1);
     canvas_setdeleting(canvas, wasdeleting);
-    x->gl_valid = ++glist_valid;
 }
 
     /* remove every object from a glist.  Experimental. */

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -384,6 +384,7 @@ static void text_define_free(t_text_define *x)
     if (x->x_bindsym != &s_)
         pd_unbind(&x->x_ob.ob_pd, x->x_bindsym);
     gpointer_unset(&x->x_gp);
+    pd_free(&x->x_scalar->sc_gobj.g_pd);
 }
 
 /* ---  text_client - common code for objects that refer to text buffers -- */

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -385,6 +385,7 @@ static void text_define_free(t_text_define *x)
         pd_unbind(&x->x_ob.ob_pd, x->x_bindsym);
     gpointer_unset(&x->x_gp);
     pd_free(&x->x_scalar->sc_gobj.g_pd);
+    x->x_canvas->gl_valid = ++glist_valid; /* invalidate pointers */
 }
 
 /* ---  text_client - common code for objects that refer to text buffers -- */


### PR DESCRIPTION
currently, gl_valid is incremented whenever you delete any gobject. this means that pointers to scalars become stale even when you add/delete non-scalar objects to the same canvas (adding an object means deleting the temporary object). 

I run into this problem in a large personal Pd project which combines data structures and abstractions on the same canvas.

this PR enables adding/deleting non-scalar objects to the same canvas without affecting pointers.
it also fixes a memory leak where text_define_free wouldn't delete the scalar.

note that [text define] has to be handled specially because it owns the scalar and uses the parent canvas only as a stub, so deleting a [text define] wouldn't automatically free the scalar and increment gl_valid - this has to be done manually in text_define_free.

here's a test patch:

[gl_valid_test.zip](https://github.com/pure-data/pure-data/files/2123458/gl_valid_test.zip)

