### PR TITLE
Patch file crashes on windows but works on macOS

### DIFF
--- a/src/m_memory.c
+++ b/src/m_memory.c
@@ -50,11 +50,12 @@ void *copybytes(void *src, size_t nbytes)
 void *resizebytes(void *old, size_t oldsize, size_t newsize)
 {
     void *ret;
-    if (newsize < 1) newsize = 1;
-    if (oldsize < 1) oldsize = 1;
-    ret = (void *)realloc((char *)old, newsize);
-    if (newsize > oldsize && ret)
-        memset(((char *)ret) + oldsize, 0, newsize - oldsize);
+    newsize += 1;
+    size_t allocSize = newsize;
+    if (newsize < 1) allocSize = 1;
+    ret = (void *)realloc((char *)old, allocSize);
+    if (allocSize > oldsize && ret)
+        memset(((char *)ret) + oldsize, 0, allocSize - oldsize);
 #ifdef LOUD
     fprintf(stderr, "resize %lx %d --> %lx %d\n", (int)old, oldsize, (int)ret, newsize);
 #endif /* LOUD */


### PR DESCRIPTION
We have experienced some crashes with libpd on Windows when using some patch files which work fine on macOS.

We were able to work around the crash by allocating slightly more memory than required during reallocation. (See commit)
This may not be the best solution but we do not have the time to investigate further.

Originally reported here: https://github.com/libpd/libpd/issues/248

Github does not allow me to update the pd file directly, or a zip file containing it, so here are the contents: (This example patch is not very meaningful but it reliably crashes on Windows)
```
#N canvas 754 469 632 421 10;
#X obj 107 52 vsl 30 200 0 100 0 0 distance init_distance empty 0 -9
0 10 -204800 -1 -1 19900 1;
#X obj 159 52 vsl 30 200 -25 25 0 0 focus init_focus empty 0 -9 0 10
-261234 -1 -1 11100 1;
#X obj 304 54 tgl 30 0 SoundOnOff init_SoundOnOff empty 17 7 0 10 -262144
-1 -1 1 1;
#X obj 304 127 vsl 30 128 0 10 0 0 Volume init_Volume empty 0 -9 0
10 -262144 -1 -1 6350 1;
#X text 302 36 On/Off;
#X text 300 108 Volume;
#X text 100 31 Distance;
#X text 46 51 Far Away;
#N canvas 1172 152 1012 1021 inside 1;
#X obj 316 45 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 1
1;
#X obj 310 82 metro 200;
#X floatatom 375 41 5 0 0 0 - - -, f 5;
#X obj 383 79 s metrotime;
#X obj 300 208 s currcount;
#X obj 642 104 hsl 128 15 0 100 0 0 empty empty empty -2 -8 0 10 -262144
-1 -1 0 1;
#X obj 673 137 s distance;
#X obj 534 33 r distance;
#X floatatom 770 135 5 0 0 0 - - -, f 5;
#N canvas 331 392 782 469 beaters 0;
#X obj 278 135 - 12;
#N canvas 671 298 1411 823 beaterLO 0;
#X obj 418 384 mtof;
#X obj 464 350 + 4;
#X obj 528 363 + 7;
#X floatatom 420 267 5 0 0 0 - - -, f 5;
#X obj 414 577 *~ 0.1;
#X obj 579 369 + 12;
#X obj 149 664 *~ 1;
#X obj 414 658 *~ 1;
#X obj 413 628 *~ 1;
#X obj 152 628 *~ 1;
#X obj 412 447 sig~;
#X obj 414 491 *~;
#X obj 653 310 hsl 128 15 1 1.05 0 0 empty empty empty -2 -8 0 10 -262144
-1 -1 367 1;
#X obj 467 527 osc~;
#X obj 472 390 mtof;
#X obj 466 453 sig~;
#X obj 468 497 *~;
#X obj 520 536 osc~;
#X obj 525 399 mtof;
#X obj 519 462 sig~;
#X obj 521 506 *~;
#X obj 586 407 mtof;
#X obj 580 470 sig~;
#X obj 582 514 *~;
#X obj 413 521 triwave;
#X obj 581 544 triwave;
#X obj 131 387 mtof;
#X obj 177 353 + 4;
#X obj 241 366 + 7;
#X obj 127 580 *~ 0.1;
#X obj 292 372 + 12;
#X obj 125 450 sig~;
#X obj 127 494 *~;
#X obj 180 530 osc~;
#X obj 185 393 mtof;
#X obj 179 456 sig~;
#X obj 181 500 *~;
#X obj 233 539 osc~;
#X obj 238 402 mtof;
#X obj 232 465 sig~;
#X obj 234 509 *~;
#X obj 299 410 mtof;
#X obj 293 473 sig~;
#X obj 295 517 *~;
#X obj 126 524 triwave;
#X obj 294 547 triwave;
#X obj 86 291 hsl 128 15 0.95 1 0 0 empty empty empty -2 -8 0 10 -262144
-1 -1 12333 1;
#X obj 137 747 outlet~;
#X obj 417 204 inlet;
#X obj 715 32 inlet;
#X obj 687 170 expr 1 - $f1;
#X obj 861 204 + 1;
#X obj 717 65 max 0;
#X obj 756 97 / 2000;
#X connect 0 0 10 0;
#X connect 1 0 14 0;
#X connect 2 0 18 0;
#X connect 3 0 0 0;
#X connect 3 0 1 0;
#X connect 3 0 2 0;
#X connect 3 0 5 0;
#X connect 3 0 26 0;
#X connect 3 0 27 0;
#X connect 3 0 28 0;
#X connect 3 0 30 0;
#X connect 4 0 8 0;
#X connect 5 0 21 0;
#X connect 6 0 47 0;
#X connect 7 0 47 0;
#X connect 8 0 7 0;
#X connect 9 0 6 0;
#X connect 10 0 11 0;
#X connect 11 0 24 0;
#X connect 12 0 11 1;
#X connect 12 0 16 1;
#X connect 12 0 20 1;
#X connect 12 0 23 1;
#X connect 13 0 4 0;
#X connect 14 0 15 0;
#X connect 15 0 16 0;
#X connect 16 0 13 0;
#X connect 18 0 19 0;
#X connect 19 0 20 0;
#X connect 20 0 17 0;
#X connect 21 0 22 0;
#X connect 22 0 23 0;
#X connect 23 0 25 0;
#X connect 24 0 4 0;
#X connect 26 0 31 0;
#X connect 27 0 34 0;
#X connect 28 0 38 0;
#X connect 29 0 9 0;
#X connect 30 0 41 0;
#X connect 31 0 32 0;
#X connect 32 0 44 0;
#X connect 33 0 29 0;
#X connect 34 0 35 0;
#X connect 35 0 36 0;
#X connect 36 0 33 0;
#X connect 38 0 39 0;
#X connect 39 0 40 0;
#X connect 40 0 37 0;
#X connect 41 0 42 0;
#X connect 42 0 43 0;
#X connect 43 0 45 0;
#X connect 44 0 29 0;
#X connect 46 0 43 1;
#X connect 46 0 40 1;
#X connect 46 0 36 1;
#X connect 46 0 32 1;
#X connect 48 0 3 0;
#X connect 49 0 52 0;
#X connect 50 0 46 0;
#X connect 51 0 12 0;
#X connect 52 0 53 0;
#X connect 53 0 50 0;
#X connect 53 0 51 0;
#X restore 265 170 pd beaterLO;
#N canvas 1111 224 1411 823 beaterLO 0;
#X obj 418 384 mtof;
#X obj 464 350 + 4;
#X obj 528 363 + 7;
#X floatatom 420 267 5 0 0 0 - - -, f 5;
#X obj 414 577 *~ 0.1;
#X obj 579 369 + 12;
#X obj 149 664 *~ 1;
#X obj 414 658 *~ 1;
#X obj 413 628 *~ 1;
#X obj 152 628 *~ 1;
#X obj 412 447 sig~;
#X obj 414 491 *~;
#X obj 653 310 hsl 128 15 1 1.05 0 0 empty empty empty -2 -8 0 10 -262144
-1 -1 0 1;
#X obj 467 527 osc~;
#X obj 472 390 mtof;
#X obj 466 453 sig~;
#X obj 468 497 *~;
#X obj 520 536 osc~;
#X obj 525 399 mtof;
#X obj 519 462 sig~;
#X obj 521 506 *~;
#X obj 586 407 mtof;
#X obj 580 470 sig~;
#X obj 582 514 *~;
#X obj 413 521 triwave;
#X obj 581 544 triwave;
#X obj 131 387 mtof;
#X obj 177 353 + 4;
#X obj 241 366 + 7;
#X obj 127 580 *~ 0.1;
#X obj 292 372 + 12;
#X obj 125 450 sig~;
#X obj 127 494 *~;
#X obj 180 530 osc~;
#X obj 185 393 mtof;
#X obj 179 456 sig~;
#X obj 181 500 *~;
#X obj 233 539 osc~;
#X obj 238 402 mtof;
#X obj 232 465 sig~;
#X obj 234 509 *~;
#X obj 299 410 mtof;
#X obj 293 473 sig~;
#X obj 295 517 *~;
#X obj 126 524 triwave;
#X obj 294 547 triwave;
#X obj 86 291 hsl 128 15 0.95 1 0 0 empty empty empty -2 -8 0 10 -262144
-1 -1 12700 1;
#X obj 137 747 outlet~;
#X obj 417 204 inlet;
```

