### PR TITLE
running bugfixes branch for 0.48-x

### DIFF
--- a/extra/stdout/stdout.c
+++ b/extra/stdout/stdout.c
@@ -76,7 +76,7 @@ static void stdout_binary(t_stdout *x, int argc, t_atom *argv)
         argc = BUFSIZE;
     for (i=0; i<argc; i++)
         ((unsigned char *)buf)[i] = atom_getfloatarg(i, argc, argv);
-    buf[i>BUFSIZE?BUFSIZE:i] = 0;
+    buf[i>=BUFSIZE?(BUFSIZE-1):i] = 0;
     fwrite(buf, 1, argc, stdout);
 
     if (x->x_flush || !argc)

--- a/linux/cp-to-max.sh
+++ b/linux/cp-to-max.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 cd /home/msp/pd/extra
 tar czf /tmp/z.tgz \
    pd~/pd~.c pd~/pd~-help.pd pd~/pd~-subprocess.pd \

--- a/linux/git-add-pd.sh
+++ b/linux/git-add-pd.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 (cd ~/pd/src; sh ../linux/detab-src.sh)
 
 cd ~/pd

--- a/mac/tcltk-wish.sh
+++ b/mac/tcltk-wish.sh
@@ -18,6 +18,9 @@ set -e
 UNIVERSAL=false
 ARCH=
 GIT=false
+DOWNLOAD=true
+BUILD=true
+LEAVE=false
 
 # set deployment target to enable weak-linking for older macOS version support
 CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
@@ -41,6 +44,14 @@ Options:
 
   --git               clone from tcl/tk git repos at https://github.com/tcltk,
                       any arguments after VERSION are passed to git
+
+  -d,--download       download source to tcl{$VERSION}/tk{$VERSION} paths,
+                      do not build
+
+  -s,--source         (re)build from tcl{$VERSION}/tk{$VERSION} source paths,
+                      do not download
+
+  -l,--leave          leave source paths, do not delete after building
 
 Arguments:
 
@@ -89,6 +100,17 @@ while [ "$1" != "" ] ; do
         --git)
             GIT=true
             ;;
+        -d|--download)
+            DOWNLOAD=true
+            BUILD=false
+            ;;
+        -b|--build)
+            DOWNLOAD=false
+            BUILD=true
+            ;;
+        -l|--leave)
+            LEAVE=true
+            ;;
         *)
             break ;;
     esac
@@ -116,29 +138,46 @@ if [ -d "$WISH" ] ; then
     rm -rf "$WISH"
 fi
 
-echo "==== Creating Tcl/Tk Wish-$TCLTK.app"
+tcldir=tcl${TCLTK}
+tkdir=tk${TCLTK}
 
-if [[ $GIT == true ]] ; then
+if [[ $DOWNLOAD == true ]] ; then
+    echo "==== Downloading Tcl/Tk $TCLTK"
 
-    # shallow clone sources, pass remaining args to git
-    git clone --depth 1 https://github.com/tcltk/tcl.git $@
-    git clone --depth 1 https://github.com/tcltk/tk.git $@
+    if [[ $GIT == true ]] ; then
 
-    tcldir=tcl
-    tkdir=tk
+        # shallow clone sources, pass remaining args to git
+        git clone --depth 1 https://github.com/tcltk/tcl.git tcl${TCLTK} $@
+        git clone --depth 1 https://github.com/tcltk/tk.git tk${TCLTK} $@
+    else
+
+        # download source packages
+        curl -LO http://prdownloads.sourceforge.net/tcl/tcl${TCLTK}-src.tar.gz
+        curl -LO http://prdownloads.sourceforge.net/tcl/tk${TCLTK}-src.tar.gz
+
+        # unpack
+        tar -xzf tcl${TCLTK}-src.tar.gz
+        tar -xzf tk${TCLTK}-src.tar.gz
+    fi
 else
+    echo  "==== Using sources in $tcldir $tkdir"
 
-    # download source packages
-    curl -LO http://prdownloads.sourceforge.net/tcl/tcl${TCLTK}-src.tar.gz
-    curl -LO http://prdownloads.sourceforge.net/tcl/tk${TCLTK}-src.tar.gz
-
-    # unpack
-    tar -xzf tcl${TCLTK}-src.tar.gz
-    tar -xzf tk${TCLTK}-src.tar.gz
-
-    tcldir=tcl${TCLTK}
-    tkdir=tk${TCLTK}
+    # check source directories
+    if [ ! -e "$tcldir" ] ; then
+        echo "$tcldir not found"
+        exit 1
+    fi
+    if [ ! -e "$tkdir" ] ; then
+        echo "$tkdir not found"
+        exit 1
+    fi
 fi
+
+if [[ $BUILD == false ]] ; then
+    echo  "==== Downloaded sources to $tcldir $tkdir"
+    exit 0
+fi
+echo "==== Building Tcl/Tk Wish-$TCLTK.app"
 
 # set a specific arch
 if [ "$ARCH" != "" ] ; then
@@ -168,7 +207,9 @@ make -C ${tkdir}/macosx  install-embedded INSTALL_ROOT=`pwd`/embedded
 mv embedded/Applications/Utilities/Wish.app $WISH
 
 # finish up
-rm -rf ${tcldir} ${tkdir} ${tcldir}-src.tar.gz ${tkdir}-src.tar.gz
-rm -rf build embedded
+if [[ $LEAVE == false ]] ; then
+    rm -rf ${tcldir} ${tkdir} ${tcldir}-src.tar.gz ${tkdir}-src.tar.gz
+    rm -rf build embedded
+fi
 
 echo  "==== Finished Tcl/Tk Wish-$TCLTK.app"

--- a/msw/build-msw-64.sh
+++ b/msw/build-msw-64.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #usage: ./build-msw-64.sh 0.38-0 or 0.38-0test4
 
-if test x$1 == x
+if test x$1 = x
 then
    echo usage: ./build-msw-64.sh 0.38-0 or 0.38-0test4
    exit 1

--- a/msw/build-msw.sh
+++ b/msw/build-msw.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 if [ ! -d ../drive_c/users/msp ]
   then echo ../drive_c/users/msp: no such directory; exit 1
   else echo -n

--- a/msw/mingw-compile.sh
+++ b/msw/mingw-compile.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 rm -rf ../mingw-build
 mkdir ../mingw-build
 cd ../mingw-build

--- a/msw/send-msw.sh
+++ b/msw/send-msw.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #usage: ./send-mw.sh 0.38-0 or 0.38-0test4
 
 if test x$1 == x

--- a/po/af.po
+++ b/po/af.po
@@ -669,12 +669,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -693,17 +726,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Voorkeure..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Voorkeure..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -720,25 +795,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -769,11 +826,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Volgrote teks soektog..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -834,6 +897,9 @@ msgstr "Onder"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Redigeermodus"
@@ -871,10 +937,6 @@ msgstr "Uitvee Alle"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Maak lys skoon"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Voorkeure..."
 
 msgid "Object"
 msgstr ""

--- a/po/az.po
+++ b/po/az.po
@@ -665,12 +665,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -689,17 +722,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Seçimlər..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Seçimlər..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -716,25 +791,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -765,11 +822,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Mətni Axtar..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -829,6 +892,9 @@ msgstr "Altda"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Təfərruatlar"
@@ -864,10 +930,6 @@ msgstr "Hamısı Sil"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Siyahını təmizlə"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Seçimlər..."
 
 msgid "Object"
 msgstr ""

--- a/po/be.po
+++ b/po/be.po
@@ -665,12 +665,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -689,17 +722,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "_Асаблівасці"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "_Асаблівасці"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -716,25 +791,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -765,11 +822,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "_Пошук"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -828,6 +891,9 @@ msgstr "Ніз"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Рэжым"
@@ -865,10 +931,6 @@ msgstr "Вылучце колер"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Ачысціць спіс"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "_Асаблівасці"
 
 msgid "Object"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -666,12 +666,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -690,17 +723,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Настройки"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Настройки"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -717,25 +792,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -766,11 +823,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Търсене из текста..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -830,6 +893,9 @@ msgstr "Долу"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Режим \"Редакция\""
@@ -865,10 +931,6 @@ msgstr "Изтрива всички"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Изчистване на списъка"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Настройки"
 
 msgid "Object"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -640,12 +640,46 @@ msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 "[deken] die installierte Version ist bereits am neuesten Stand [%1$s == %2$s]"
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr "Erfolgreich %1$s nach %2$s entpackt."
+
+#, fuzzy
+msgid "[deken]: Unable to extract package automatically."
+msgstr "Konnte Paket nicht automatisch entpacken."
+
+msgid "Please perform the following steps manually:"
+msgstr "Bitte führen Sie die folgenden Schritte manuell aus:"
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr "1. Entpacken von %s."
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr "2. Kopieren Sie den Inhalt nach %s."
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr "[deken] Pd Paketmanager vom Pfad %s geladen."
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr "[deken] Plattform gefunden: %s"
+
+#, fuzzy, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr "[deken] Plattform gefunden: %s"
 
 msgid "Show all"
@@ -665,20 +699,66 @@ msgstr "zusätzliche Objekte im Internet finden"
 msgid "Only install externals uploaded by people you trust."
 msgstr "Installieren Sie nur Bibliotheken von Menschen, denen Sie vertrauen."
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Voreinstellungen"
+
+#, fuzzy
+msgid "Installation options:"
+msgstr "Bibliotheken installieren Verzeichnis:"
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Voreinstellungen"
+
+#, fuzzy
+msgid "[deken]: Start searching for externals..."
 msgstr "zusätzliche Objekte im Internet finden..."
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
+msgstr ""
+
+#, fuzzy
+msgid "Unable to perform search."
 msgstr "Die Suche schlug fehl. Sind Sie online?"
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+#, fuzzy
+msgid "Try using the full name e.g. 'freeverb'."
 msgstr ""
 "Konnte keine passenden Pakete finden.\n"
 "Tipp: Suchen Sie nach dem vollen Namen, z.B. 'freeverb'"
+
+#, fuzzy
+msgid "No matching externals found."
+msgstr "zusätzliche Objekte im Internet finden..."
 
 msgid "Please select a (writable) installation directory!"
 msgstr "Bitte wählen Sie ein (schreibbares) Verzeichnis aus!"
@@ -694,26 +774,9 @@ msgid ""
 "Into %2$s..."
 msgstr "Lade %1$s nach %2$s herunter..."
 
-msgid "aborting."
+#, fuzzy
+msgid "aborting.\n"
 msgstr "Abbruch."
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr "Erfolgreich %1$s nach %2$s entpackt."
-
-msgid "Unable to extract package automatically."
-msgstr "Konnte Paket nicht automatisch entpacken."
-
-msgid "Please perform the following steps manually:"
-msgstr "Bitte führen Sie die folgenden Schritte manuell aus:"
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr "1. Entpacken von %s."
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
-msgstr "2. Kopieren Sie den Inhalt nach %s."
 
 #, tcl-format
 msgid "Unable to add %s to search paths"
@@ -743,13 +806,19 @@ msgstr "Konnte heruntergeladene Datei %s nicht umbenennen."
 msgid "searching for '%s'"
 msgstr "Such nach '%s'"
 
-#, fuzzy
-msgid "Unable to perform search."
-msgstr "Die Suche schlug fehl. Sind Sie online?"
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
 msgstr "von %1$s am %2$s hochgeladen"
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Letzte Dateien öffnen"
+
+msgid "_"
+msgstr ""
 
 #, tcl-format
 msgid ""
@@ -802,6 +871,9 @@ msgstr "Verkleinern"
 msgid "Tidy Up"
 msgstr "Aufräumen"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Editiermodus"
 
@@ -831,9 +903,6 @@ msgstr "Alles auswählen"
 
 msgid "Clear Console"
 msgstr "Konsole löschen"
-
-msgid "Preferences"
-msgstr "Voreinstellungen"
 
 msgid "Object"
 msgstr "Objekt"
@@ -1013,8 +1082,8 @@ msgstr "Überspringe '%s': kein Pd-File"
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "Überspringe '%s': kein Pd-File"
 
-#~ msgid "Install externals to:"
-#~ msgstr "Bibliotheken installieren Verzeichnis:"
+#~ msgid "Unable to perform search. Are you online?"
+#~ msgstr "Die Suche schlug fehl. Sind Sie online?"
 
 #~ msgid "for:"
 #~ msgstr "für:"

--- a/po/el.po
+++ b/po/el.po
@@ -645,12 +645,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -669,17 +702,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Προτιμήσεις"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Προτιμήσεις"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -697,26 +771,8 @@ msgid ""
 msgstr ""
 
 #, fuzzy
-msgid "aborting."
+msgid "aborting.\n"
 msgstr "Δρομολόγηση"
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
-msgstr ""
 
 #, tcl-format
 msgid "Unable to add %s to search paths"
@@ -746,11 +802,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Απόρριψη αλλαγών σε '%s';"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Άνοιγμα Πρόσφατου"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -806,6 +869,9 @@ msgstr "Εστίαση"
 msgid "Tidy Up"
 msgstr "Τακτοποίηση"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Κατάσταση Επεξεργασίας"
 
@@ -836,9 +902,6 @@ msgstr "Επιλογή Όλων"
 
 msgid "Clear Console"
 msgstr "Καθαρισμός Κονσόλας"
-
-msgid "Preferences"
-msgstr "Προτιμήσεις"
 
 msgid "Object"
 msgstr ""

--- a/po/en_ca.po
+++ b/po/en_ca.po
@@ -615,12 +615,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -638,17 +671,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr ""
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, tcl-format
+msgid "Deken %s Preferences"
+msgstr ""
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -665,25 +739,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -714,11 +770,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr ""
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -772,6 +834,9 @@ msgstr ""
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr ""
 
@@ -800,9 +865,6 @@ msgid "Select All"
 msgstr ""
 
 msgid "Clear Console"
-msgstr ""
-
-msgid "Preferences"
 msgstr ""
 
 msgid "Object"

--- a/po/es.po
+++ b/po/es.po
@@ -618,6 +618,37 @@ msgstr "[deken]: version instalada [%1$s] < %2$s...sobreescribiendo!"
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr "[deken]: version instalada [%1$s] == %2$s...salteando!"
 
+#, fuzzy
+msgid "[deken]: "
+msgstr "[deken]: ¿Está usted online? %s"
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr "Se ha extraído con éxito %1$s en %2$s."
+
+#, fuzzy
+msgid "[deken]: Unable to extract package automatically."
+msgstr "No se ha podido extraer el paquete automáticamente."
+
+msgid "Please perform the following steps manually:"
+msgstr "Por favor, siga estos pasos manualmente:"
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr "1. Extraer %s."
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr "2. Copiar los contenidos en %s."
+
+#, fuzzy, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr "[deken]: ¿Está usted online? %s"
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
@@ -625,6 +656,10 @@ msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr "[deken] Plataforma detectada: %s"
+
+#, fuzzy, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr "[deken] Plataforma detectada: %s"
 
 msgid "Show all"
@@ -644,20 +679,65 @@ msgstr "Buscar Externos"
 msgid "Only install externals uploaded by people you trust."
 msgstr "Solo instalar externos subidos por gente de confianza."
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Preferencias"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Preferencias"
+
+#, fuzzy
+msgid "[deken]: Start searching for externals..."
 msgstr "Buscando externos..."
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr "[deken]: ¿Está usted online? %s"
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
+msgstr ""
+
+#, fuzzy
+msgid "Unable to perform search."
 msgstr "La búsqueda no pudo ser realizada. ¿Está usted online?"
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+#, fuzzy
+msgid "Try using the full name e.g. 'freeverb'."
 msgstr ""
 "No se han encontrado externos con ese nombre. Prueba usando el nombre "
 "completo, por ejemplo: 'freeverb'."
+
+#, fuzzy
+msgid "No matching externals found."
+msgstr "Buscando externos..."
 
 msgid "Please select a (writable) installation directory!"
 msgstr ""
@@ -677,26 +757,9 @@ msgstr ""
 "%1$s\n"
 "En %2$s..."
 
-msgid "aborting."
+#, fuzzy
+msgid "aborting.\n"
 msgstr "Abortando."
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr "Se ha extraído con éxito %1$s en %2$s."
-
-msgid "Unable to extract package automatically."
-msgstr "No se ha podido extraer el paquete automáticamente."
-
-msgid "Please perform the following steps manually:"
-msgstr "Por favor, siga estos pasos manualmente:"
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr "1. Extraer %s."
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
-msgstr "2. Copiar los contenidos en %s."
 
 #, tcl-format
 msgid "Unable to add %s to search paths"
@@ -726,13 +789,19 @@ msgstr "No se ha podido renombrar el archivo descargado a %s"
 msgid "searching for '%s'"
 msgstr "Buscando '%s'"
 
-#, fuzzy
-msgid "Unable to perform search."
-msgstr "La búsqueda no pudo ser realizada. ¿Está usted online?"
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
 msgstr "Subido por %1$s @ %2$s"
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Abrir Recientes"
+
+msgid "_"
+msgstr ""
 
 #, tcl-format
 msgid ""
@@ -796,6 +865,9 @@ msgstr "Alejar"
 msgid "Tidy Up"
 msgstr "Ordenar"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Modo Edición"
 
@@ -825,9 +897,6 @@ msgstr "Seleccionar Todo"
 
 msgid "Clear Console"
 msgstr "Limpiar Consola"
-
-msgid "Preferences"
-msgstr "Preferencias"
 
 msgid "Object"
 msgstr "Objeto"
@@ -1005,3 +1074,6 @@ msgstr "Ignorando '%s': archivo no existente."
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "Ignorando '%s': no parece ser un fichero de Pd."
+
+#~ msgid "Unable to perform search. Are you online?"
+#~ msgstr "La búsqueda no pudo ser realizada. ¿Está usted online?"

--- a/po/eu.po
+++ b/po/eu.po
@@ -668,12 +668,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -692,17 +725,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Hobespenak"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Hobespenak"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -719,25 +794,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -768,11 +825,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "'%s'-ren aldaketak utzi"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Azkenaldi Ireki"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -830,6 +894,9 @@ msgstr ""
 msgid "Tidy Up"
 msgstr "Txukuntzea"
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Edizio Modua"
@@ -865,10 +932,6 @@ msgstr "Guztia Aukeratu"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Kontsola Garbitu"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Hobespenak"
 
 msgid "Object"
 msgstr "Objektu"

--- a/po/fr.po
+++ b/po/fr.po
@@ -617,6 +617,37 @@ msgstr "[deken]: version installée [%1$s] < %2$s...remplacer !"
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr "[deken]: version installée [%1$s] == %2$s...ignorer !"
 
+#, fuzzy
+msgid "[deken]: "
+msgstr "[deken]: connecté ? %s"
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr "%1$s décompressé avec succès dans %2$s."
+
+#, fuzzy
+msgid "[deken]: Unable to extract package automatically."
+msgstr "Impossible de décompresser l'archive automatiquement."
+
+msgid "Please perform the following steps manually:"
+msgstr "Effectuez manuellement les étapes suivantes :"
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr "1. Décompresser %s"
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr "2. Copier le dossier obtenu dans %s."
+
+#, fuzzy, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr "[deken]: connecté ? %s"
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr "[deken] deken-plugin.tcl (recherche d'externals) chargé depuis %s."
@@ -646,20 +677,64 @@ msgstr "Installer des objets supplémentaires"
 msgid "Only install externals uploaded by people you trust."
 msgstr "Installer uniquement des objets provenant de sources de confiance."
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Préférences"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Préférences"
+
+#, fuzzy
+msgid "[deken]: Start searching for externals..."
 msgstr "Installer des objets supplémentaires..."
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr "[deken]: connecté ? %s"
 
-msgid "Unable to perform search. Are you online?"
-msgstr "La recherche n'a pu aboutir. Êtes-vous connecté ?"
+msgid "Are you online?"
+msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr "Recherche impossible."
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+#, fuzzy
+msgid "Try using the full name e.g. 'freeverb'."
 msgstr ""
 "Aucun external correspondant. Réessayez avec le nom complet, par exemple "
 "'freeverb'."
+
+#, fuzzy
+msgid "No matching externals found."
+msgstr "Installer des objets supplémentaires..."
 
 msgid "Please select a (writable) installation directory!"
 msgstr "Choisissez un dossier (accessible en écriture) pour l'installation !"
@@ -678,26 +753,9 @@ msgstr ""
 "%1$s\n"
 "Dans %2$s..."
 
-msgid "aborting."
+#, fuzzy
+msgid "aborting.\n"
 msgstr "abandon."
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr "%1$s décompressé avec succès dans %2$s."
-
-msgid "Unable to extract package automatically."
-msgstr "Impossible de décompresser l'archive automatiquement."
-
-msgid "Please perform the following steps manually:"
-msgstr "Effectuez manuellement les étapes suivantes :"
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr "1. Décompresser %s"
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
-msgstr "2. Copier le dossier obtenu dans %s."
 
 #, tcl-format
 msgid "Unable to add %s to search paths"
@@ -727,12 +785,19 @@ msgstr "Impossible de donner au fichier téléchargé le nom %s"
 msgid "searching for '%s'"
 msgstr "recherche de '%s'"
 
-msgid "Unable to perform search."
-msgstr "Recherche impossible."
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
 msgstr "Mis en ligne par '%1$s' le : %2$s"
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Ouvrir un élément récent"
+
+msgid "_"
+msgstr ""
 
 #, tcl-format
 msgid ""
@@ -796,6 +861,9 @@ msgstr "Dézoomer"
 msgid "Tidy Up"
 msgstr "Aligner"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Mode d'édition"
 
@@ -825,9 +893,6 @@ msgstr "Tout sélectionner"
 
 msgid "Clear Console"
 msgstr "Effacer la console"
-
-msgid "Preferences"
-msgstr "Préférences"
 
 msgid "Object"
 msgstr "Objet"
@@ -1005,6 +1070,9 @@ msgstr "'%s' n'existe pas"
 #, tcl-format
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "'%s' ne semble pas être un fichier Pd"
+
+#~ msgid "Unable to perform search. Are you online?"
+#~ msgstr "La recherche n'a pu aboutir. Êtes-vous connecté ?"
 
 #~ msgid "for:"
 #~ msgstr ":"

--- a/po/gu.po
+++ b/po/gu.po
@@ -667,12 +667,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -691,17 +724,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "પસંદગીઓ..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "પસંદગીઓ..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -718,25 +793,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -767,11 +824,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "લખાણ શોધો..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -831,6 +894,9 @@ msgstr "નીચે"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "સ્થિતિ"
@@ -866,10 +932,6 @@ msgstr "રંગ પસંદ કરો"
 #, fuzzy
 msgid "Clear Console"
 msgstr "યાદી સાફ કરો"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "પસંદગીઓ..."
 
 msgid "Object"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -653,12 +653,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -677,17 +710,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "איקס-צ'אט: הגדרות"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "איקס-צ'אט: הגדרות"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -704,25 +779,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -753,11 +810,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "חפש בבאפר.."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -815,6 +878,9 @@ msgstr "תחתון"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "עריכת תפריט משתמש"
@@ -848,10 +914,6 @@ msgstr "בחר גופן"
 
 msgid "Clear Console"
 msgstr ""
-
-#, fuzzy
-msgid "Preferences"
-msgstr "איקס-צ'אט: הגדרות"
 
 msgid "Object"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -664,12 +664,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -688,17 +721,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "प्राथमिकताएं..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "प्राथमिकताएं..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -715,25 +790,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -764,11 +821,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "पाठ खोजें..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -828,6 +891,9 @@ msgstr "नीचे"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "मोड"
@@ -863,10 +929,6 @@ msgstr "रंग चुनें"
 #, fuzzy
 msgid "Clear Console"
 msgstr "सूची साफ करें"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "प्राथमिकताएं..."
 
 msgid "Object"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -647,12 +647,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -671,17 +704,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Beállítások"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Beállítások"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -698,25 +772,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -747,11 +803,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Elveti '%s' változtatásait?"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Legutóbbi fájlok"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -807,6 +870,9 @@ msgstr "Nagyító"
 msgid "Tidy Up"
 msgstr "Elrendez"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Szerkesztő üzemmód"
 
@@ -837,9 +903,6 @@ msgstr "Mindent kijelöl"
 
 msgid "Clear Console"
 msgstr "Konzolt ürít"
-
-msgid "Preferences"
-msgstr "Beállítások"
 
 msgid "Object"
 msgstr "Object"

--- a/po/it.po
+++ b/po/it.po
@@ -645,12 +645,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -669,17 +702,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Preferenze"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Preferenze"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -696,25 +770,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -745,11 +801,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Cestinare le modifiche apportate a '%s'?"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Apri recenti"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -803,6 +866,9 @@ msgstr ""
 msgid "Tidy Up"
 msgstr "Allinea elementi"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Modalità modifica"
 
@@ -833,9 +899,6 @@ msgstr "Seleziona tutto"
 
 msgid "Clear Console"
 msgstr "Pulisci console"
-
-msgid "Preferences"
-msgstr "Preferenze"
 
 msgid "Object"
 msgstr "Oggetto"

--- a/po/pa.po
+++ b/po/pa.po
@@ -666,12 +666,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -690,17 +723,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "ਮੇਰੀ ਪਸੰਦ..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "ਮੇਰੀ ਪਸੰਦ..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -717,25 +792,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -766,11 +823,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "ਪਾਠ ਖੋਜ..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -829,6 +892,9 @@ msgstr "ਹੇਠਾਂ"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "ਮੋਡ"
@@ -865,10 +931,6 @@ msgstr "ਚੋਣ ਰੰਗ"
 #, fuzzy
 msgid "Clear Console"
 msgstr "ਸੂਚੀ ਸਾਫ਼"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "ਮੇਰੀ ਪਸੰਦ..."
 
 msgid "Object"
 msgstr ""

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -647,12 +647,47 @@ msgstr "[deken]: versão instalada [%1$s] < %2$s...sobrescrevendo!"
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr "[deken]: versão instalada [%1$s] == %2$s...pulando!"
 
+#, fuzzy
+msgid "[deken]: "
+msgstr "[deken]: online? %s"
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr "%1$s descompactado em %2$s com sucesso."
+
+#, fuzzy
+msgid "[deken]: Unable to extract package automatically."
+msgstr "Incapaz de extrair o pacote automaticamente."
+
+msgid "Please perform the following steps manually:"
+msgstr "Por favor realize os seguintes passos manualmente:"
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr "1. Descompactar %s."
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr "2. Copiar o conteúdo para %s."
+
+#, fuzzy, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr "[deken]: online? %s"
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr "[deken] deken-plugin.tcl (busca de externals Pd) carregado de %s."
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr "[deken] Platforma detectada: %s"
+
+#, fuzzy, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr "[deken] Platforma detectada: %s"
 
 msgid "Show all"
@@ -672,19 +707,65 @@ msgstr "Procurar por externals"
 msgid "Only install externals uploaded by people you trust."
 msgstr "Instale apenas externals enviados por quem você confia."
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Preferências"
+
+#, fuzzy
+msgid "Installation options:"
+msgstr "Instalar externals em:"
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Preferências"
+
+#, fuzzy
+msgid "[deken]: Start searching for externals..."
 msgstr "Procurando por externals"
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr "[deken]: online? %s"
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
+msgstr ""
+
+#, fuzzy
+msgid "Unable to perform search."
 msgstr "Incapaz de realizar busca. Você está online?"
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+#, fuzzy
+msgid "Try using the full name e.g. 'freeverb'."
 msgstr ""
 "Nenhum external encontrado. Tente usar o nome completo (como 'freeverb')."
+
+#, fuzzy
+msgid "No matching externals found."
+msgstr "Procurando por externals"
 
 msgid "Please select a (writable) installation directory!"
 msgstr "Por favor escolha um diretório de instalação com permissão de escrita!"
@@ -703,26 +784,9 @@ msgstr ""
 "%1$s\n"
 "Em %2$s..."
 
-msgid "aborting."
+#, fuzzy
+msgid "aborting.\n"
 msgstr "abortando."
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr "%1$s descompactado em %2$s com sucesso."
-
-msgid "Unable to extract package automatically."
-msgstr "Incapaz de extrair o pacote automaticamente."
-
-msgid "Please perform the following steps manually:"
-msgstr "Por favor realize os seguintes passos manualmente:"
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr "1. Descompactar %s."
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
-msgstr "2. Copiar o conteúdo para %s."
 
 #, tcl-format
 msgid "Unable to add %s to search paths"
@@ -752,13 +816,19 @@ msgstr "Incapaz de renomear o arquivo baixado para %s"
 msgid "searching for '%s'"
 msgstr "procurando por '%s'"
 
-#, fuzzy
-msgid "Unable to perform search."
-msgstr "Incapaz de realizar busca. Você está online?"
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
 msgstr "Enviado por '%1$s' em %2$s"
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Abrir Recente"
+
+msgid "_"
+msgstr ""
 
 #, tcl-format
 msgid ""
@@ -823,6 +893,9 @@ msgstr "Reduzir Zoom"
 msgid "Tidy Up"
 msgstr "Organizar"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Modo de Edição"
 
@@ -852,9 +925,6 @@ msgstr "Selecionar Tudo"
 
 msgid "Clear Console"
 msgstr "Limpar Console"
-
-msgid "Preferences"
-msgstr "Preferências"
 
 msgid "Object"
 msgstr "Objeto"
@@ -1033,8 +1103,8 @@ msgstr "Ignorando '%s': não existe"
 msgid "Ignoring '%s': doesn't look like a Pd-file"
 msgstr "Ignorando '%s': não parece ser um arquivo de Pd válido"
 
-#~ msgid "Install externals to:"
-#~ msgstr "Instalar externals em:"
+#~ msgid "Unable to perform search. Are you online?"
+#~ msgstr "Incapaz de realizar busca. Você está online?"
 
 #~ msgid "for:"
 #~ msgstr "por:"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -641,12 +641,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -665,17 +698,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Preferências"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Preferências"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -692,25 +766,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -741,11 +797,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Rejeitar modificações em '%s'?"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Abrir recente"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -801,6 +864,9 @@ msgstr "Zoom"
 msgid "Tidy Up"
 msgstr "Arrumar"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Modo de edição"
 
@@ -831,9 +897,6 @@ msgstr "Escolher tudo"
 
 msgid "Clear Console"
 msgstr "Limpar consola"
-
-msgid "Preferences"
-msgstr "Preferências"
 
 msgid "Object"
 msgstr "Object"

--- a/po/sq.po
+++ b/po/sq.po
@@ -665,12 +665,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -689,17 +722,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Parapëlqime..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Parapëlqime..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -716,25 +791,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -765,11 +822,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Kërko Tekst..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -829,6 +892,9 @@ msgstr "Poshtë"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Mënyrë"
@@ -864,10 +930,6 @@ msgstr "Fshij Tërë"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Fshij listë"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Parapëlqime..."
 
 msgid "Object"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -654,12 +654,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -678,17 +711,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr "Inställningar"
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Inställningar"
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -705,25 +779,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -754,11 +810,18 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Förkasta ändringar i '%s'?"
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+#, fuzzy
+msgid "Open webpage"
+msgstr "Öppna senaste"
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -814,6 +877,9 @@ msgstr "Zooma"
 msgid "Tidy Up"
 msgstr "Städa upp"
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr "Redigeringsläge"
 
@@ -845,9 +911,6 @@ msgstr "Markera allt"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Rensa konsoll"
-
-msgid "Preferences"
-msgstr "Inställningar"
 
 msgid "Object"
 msgstr "Objekt"

--- a/po/template.pot
+++ b/po/template.pot
@@ -5,7 +5,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Pure Data 0.48.0\n"
+"Project-Id-Version: Pure Data 0.48.2\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -615,12 +615,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -638,17 +671,58 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+msgid "Preferences"
+msgstr ""
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, tcl-format
+msgid "Deken %s Preferences"
+msgstr ""
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -665,25 +739,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -714,11 +770,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr ""
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -772,6 +834,9 @@ msgstr ""
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 msgid "Edit Mode"
 msgstr ""
 
@@ -800,9 +865,6 @@ msgid "Select All"
 msgstr ""
 
 msgid "Clear Console"
-msgstr ""
-
-msgid "Preferences"
 msgstr ""
 
 msgid "Object"

--- a/po/vi.po
+++ b/po/vi.po
@@ -665,12 +665,45 @@ msgstr ""
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
 
+msgid "[deken]: "
+msgstr ""
+
+#, tcl-format
+msgid "Successfully unzipped %1$s into %2$s."
+msgstr ""
+
+msgid "[deken]: Unable to extract package automatically."
+msgstr ""
+
+msgid "Please perform the following steps manually:"
+msgstr ""
+
+#, tcl-format
+msgid "1. Unzip %s."
+msgstr ""
+
+#, tcl-format
+msgid "2. Copy the contents into %s."
+msgstr ""
+
+#, tcl-format
+msgid "[deken] uninstalling '%s'"
+msgstr ""
+
+#, tcl-format
+msgid "Uninstalling %1$s from %2$s failed!"
+msgstr ""
+
 #, tcl-format
 msgid "[deken] deken-plugin.tcl (Pd externals search) loaded from %s."
 msgstr ""
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
+msgstr ""
+
+#, tcl-format
+msgid "[deken] Platform re-detected: %s"
 msgstr ""
 
 msgid "Show all"
@@ -689,17 +722,59 @@ msgstr ""
 msgid "Only install externals uploaded by people you trust."
 msgstr ""
 
-msgid "Searching for externals..."
+#, fuzzy
+msgid "Preferences"
+msgstr "Sở thích..."
+
+msgid "Installation options:"
+msgstr ""
+
+msgid "Try to remove libraries before (re)installing them?"
+msgstr ""
+
+msgid "Show README of newly installed libraries (if present)?"
+msgstr ""
+
+msgid "Should newly installed libraries be added to Pd's search path?"
+msgstr ""
+
+msgid "Platform settings:"
+msgstr ""
+
+#, tcl-format
+msgid "Default platform: %s"
+msgstr ""
+
+msgid "User-defined platform:"
+msgstr ""
+
+msgid "Hide foreign architectures?"
+msgstr ""
+
+#, fuzzy, tcl-format
+msgid "Deken %s Preferences"
+msgstr "Sở thích..."
+
+msgid "[deken]: Start searching for externals..."
 msgstr ""
 
 #, tcl-format
 msgid "[deken]: online? %s"
 msgstr ""
 
-msgid "Unable to perform search. Are you online?"
+msgid "Are you online?"
 msgstr ""
 
-msgid "No matching externals found. Try using the full name e.g. 'freeverb'."
+msgid "Unable to perform search."
+msgstr ""
+
+msgid "[deken]: No matching externals found."
+msgstr ""
+
+msgid "Try using the full name e.g. 'freeverb'."
+msgstr ""
+
+msgid "No matching externals found."
 msgstr ""
 
 msgid "Please select a (writable) installation directory!"
@@ -716,25 +791,7 @@ msgid ""
 "Into %2$s..."
 msgstr ""
 
-msgid "aborting."
-msgstr ""
-
-#, tcl-format
-msgid "Successfully unzipped %1$s into %2$s."
-msgstr ""
-
-msgid "Unable to extract package automatically."
-msgstr ""
-
-msgid "Please perform the following steps manually:"
-msgstr ""
-
-#, tcl-format
-msgid "1. Unzip %s."
-msgstr ""
-
-#, tcl-format
-msgid "2. Copy the contents into %s."
+msgid "aborting.\n"
 msgstr ""
 
 #, tcl-format
@@ -765,11 +822,17 @@ msgstr ""
 msgid "searching for '%s'"
 msgstr "Tìm kiếm trong văn bản..."
 
-msgid "Unable to perform search."
-msgstr ""
-
 #, tcl-format
 msgid "Uploaded by %1$s @ %2$s"
+msgstr ""
+
+msgid "Install package"
+msgstr ""
+
+msgid "Open webpage"
+msgstr ""
+
+msgid "_"
 msgstr ""
 
 #, tcl-format
@@ -829,6 +892,9 @@ msgstr "Đáy"
 msgid "Tidy Up"
 msgstr ""
 
+msgid "Connect Selection"
+msgstr ""
+
 #, fuzzy
 msgid "Edit Mode"
 msgstr "Chế độ"
@@ -864,10 +930,6 @@ msgstr "Chọn màu"
 #, fuzzy
 msgid "Clear Console"
 msgstr "Xóa danh sách"
-
-#, fuzzy
-msgid "Preferences"
-msgstr "Sở thích..."
 
 msgid "Object"
 msgstr ""

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -654,7 +654,7 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         {
             t_gobj *y1, *y2;
             glist_noselect(x);
-            for (y1 = x->gl_list; y2 = y1->g_next; y1 = y2)
+            for (y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
             if (y1)
             {
@@ -749,7 +749,7 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         else if (mode == UCUT_TEXT)
         {
             t_gobj *y1, *y2;
-            for (y1 = x->gl_list; y2 = y1->g_next; y1 = y2)
+            for (y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
             if (y1)
                 glist_delete(x, y1);
@@ -987,7 +987,7 @@ void *canvas_undo_set_apply(t_canvas *x, int n)
         /* store connections into/out of the selection */
     buf->u_reconnectbuf = binbuf_new();
     linetraverser_start(&t, x);
-    while (oc = linetraverser_next(&t))
+    while ((oc = linetraverser_next(&t)))
     {
         int issel1 = glist_isselected(x, &t.tr_ob->ob_g);
         int issel2 = glist_isselected(x, &t.tr_ob2->ob_g);
@@ -1446,7 +1446,7 @@ void *canvas_undo_set_create(t_canvas *x)
         }
         buf->u_reconnectbuf = binbuf_new();
         linetraverser_start(&t, x);
-        while (oc = linetraverser_next(&t))
+        while ((oc = linetraverser_next(&t)))
         {
             int issel1, issel2;
             issel1 = ( &t.tr_ob->ob_g == y ? 1 : 0);
@@ -1518,7 +1518,7 @@ void *canvas_undo_set_recreate(t_canvas *x, t_gobj *y, int pos)
 
     buf->u_reconnectbuf = binbuf_new();
     linetraverser_start(&t, x);
-    while (oc = linetraverser_next(&t))
+    while ((oc = linetraverser_next(&t)))
     {
         int issel1, issel2;
         issel1 = ( &t.tr_ob->ob_g == y ? 1 : 0);

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1185,6 +1185,8 @@ void text_save(t_gobj *z, t_binbuf *b)
             mess1(&x->te_pd, gensym("saveto"), b);
             binbuf_addv(b, "ssii", gensym("#X"), gensym("restore"),
                 (int)x->te_xpix, (int)x->te_ypix);
+            binbuf_addbinbuf(b, x->te_binbuf);
+            binbuf_addv(b, ";");
             if (x->te_width)
                 binbuf_addv(b, "ssi;",
                     gensym("#X"), gensym("f"), (int)x->te_width);

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -208,11 +208,15 @@ static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     {
         if (alsa_snd_bufsize < bufsizeforthis)
         {
-            if (!(alsa_snd_buf = realloc(alsa_snd_buf, bufsizeforthis)))
+            char *tmp_snd_buf = realloc(alsa_snd_buf, bufsizeforthis);
+            if (!tmp_snd_buf)
             {
+                free(alsa_snd_buf);
+                alsa_snd_buf=0;
                 post("out of memory");
                 return (-1);
             }
+            alsa_snd_buf = tmp_snd_buf;
             memset(alsa_snd_buf, 0, bufsizeforthis);
             alsa_snd_bufsize = bufsizeforthis;
         }

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1153,19 +1153,26 @@ static int sys_do_startgui(const char *libdir)
                 sprintf(cmdbuf, "\"%s\" %d\n", glob_buffer.gl_pathv[0], portno);
             else
             {
+                int wish_paths_count = sizeof(wish_paths)/sizeof(*wish_paths);
                 #ifdef WISH
                     wish_paths[0] = WISH;
                 #endif
                 sprintf(home_filename,
                         "%s/Applications/Wish.app/Contents/MacOS/Wish",homedir);
                 wish_paths[1] = home_filename;
-                for(i=0; i<11; i++)
+                for(i=0; i<wish_paths_count; i++)
                 {
                     if (sys_verbose)
                         fprintf(stderr, "Trying Wish at \"%s\"\n",
                             wish_paths[i]);
                     if (stat(wish_paths[i], &statbuf) >= 0)
                         break;
+                }
+                if(i>=wish_paths_count)
+                {
+                    fprintf(stderr, "sys_startgui couldn't find tcl/tk\n");
+                    sys_closesocket(xsock);
+                    return (1);
                 }
                 sprintf(cmdbuf, "\"%s\" \"%s/%spd-gui.tcl\" %d\n",
                         wish_paths[i], libdir, PDGUIDIR, portno);

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -115,8 +115,15 @@ static void addport(int fd)
 {
     int nfd = nfdpoll;
     t_fdpoll *fp;
-    fdpoll = (t_fdpoll *)realloc(fdpoll,
+    t_fdpoll *fdtmp = (t_fdpoll *)realloc(fdpoll,
         (nfdpoll+1) * sizeof(t_fdpoll));
+    if (!fdtmp)
+    {
+        free(fdpoll);
+        fprintf(stderr, "out of memory!");
+        exit(1);
+    }
+    fdpoll = fdtmp;
     fp = fdpoll + nfdpoll;
     fp->fdp_fd = fd;
     nfdpoll++;

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1329,6 +1329,9 @@ eval_store(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
         int badleft = 0;
         int notable = 0;
 
+        arg.ex_type = ET_INT;
+        arg.ex_int = 0;
+
         switch (eptr->ex_type) {
         case ET_VAR:
                 var = (char *) eptr->ex_ptr;

--- a/tcl/dialog_midi.tcl
+++ b/tcl/dialog_midi.tcl
@@ -487,7 +487,7 @@ proc ::dialog_midi::pdtk_alsa_midi_dialog {id indev1 indev2 indev3 indev4 \
     # set min size based on widget sizing & pos over pdwindow
     wm minsize $id [winfo reqwidth $id] [winfo reqheight $id]
     position_over_window $id .pdwindow
-    rase "$id"
+    raise "$id"
 }
 
 # for focus handling on OSX

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -210,11 +210,6 @@ proc ::pd_menus::build_edit_menu {mymenu} {
     $mymenu add check -label [_ "Edit Mode"]    -accelerator "$accelerator+E" \
         -variable ::editmode_button \
         -command {menu_editmode $::editmode_button}
-    if {$::windowingsystem ne "aqua"} {
-        $mymenu add  separator
-        create_preferences_menu $mymenu.preferences
-        $mymenu add cascade -label [_ "Preferences"] -menu $mymenu.preferences
-    }
 }
 
 proc ::pd_menus::build_put_menu {mymenu} {


### PR DESCRIPTION
this is a curated branch that only contains trivial bug fixes, translation updates and documentation updates.

rules for inclusion in the PR:

- only bugfixes
- the patch is trivial
- the patch is "unanimous" (no protests, "buts" or second thoughts have been (ever) voiced)

## included fixes

- [x] [expr~ crash due to un initialiized value](https://sourceforge.net/p/pure-data/bugs/1315/)
- [x] typo (`rase` instead of `raise` for raising a dialog window) resulting in backtraces in the Pd-console #407 
- [x] regression that would not properly `restore` subpatches when saving a patch (thus leading to all kind of weirdnesses, starting from empty objectboxes...)
- [x] a couple of potential buffer-overflows (detected by codacy)
- [x] handling of failed `realloc()` (detected by codacy)
- [x] adding hashbangs to the build-scripts so the terminal knows which interpreter to choose (rather than relying on miller's login-shell)
- [x] removed double entry for `Preferences` from the `Edit`-menu (it's already in the `File`-menu)
- [x] fixed some warning when doing assignments within conditionals
- [x] re-generated translations
- [x] improved `mac/tcltk-wish.sh` to not enforce (re)downloading of TclTk sources