### PR TITLE
offset patch cord y pos to center within io

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -801,13 +801,14 @@ static void canvas_drawlines(t_canvas *x)
 {
     t_linetraverser t;
     t_outconnect *oc;
+    int iyoffset = (IHEIGHT/2)*x->gl_zoom, oyoffset = (OHEIGHT/2)*x->gl_zoom;
     {
         linetraverser_start(&t, x);
         while ((oc = linetraverser_next(&t)))
             sys_vgui(
         ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
                 glist_getcanvas(x),
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
+                t.tr_lx1, t.tr_ly1-iyoffset, t.tr_lx2, t.tr_ly2+oyoffset,
                 (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
                 oc);
     }
@@ -817,6 +818,7 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
 {
     t_linetraverser t;
     t_outconnect *oc;
+    int iyoffset = (IHEIGHT/2)*x->gl_zoom, oyoffset = (OHEIGHT/2)*x->gl_zoom;
 
     linetraverser_start(&t, x);
     while ((oc = linetraverser_next(&t)))
@@ -825,7 +827,7 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
         {
             sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
                 glist_getcanvas(x), oc,
-                    t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
+                    t.tr_lx1, t.tr_ly1-iyoffset, t.tr_lx2, t.tr_ly2+oyoffset);
         }
     }
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -801,14 +801,14 @@ static void canvas_drawlines(t_canvas *x)
 {
     t_linetraverser t;
     t_outconnect *oc;
-    int iyoffset = (IHEIGHT/2)*x->gl_zoom, oyoffset = (OHEIGHT/2)*x->gl_zoom;
+    int yoffset = x->gl_zoom; /* slight offset to hide thick line corners */
     {
         linetraverser_start(&t, x);
         while ((oc = linetraverser_next(&t)))
             sys_vgui(
         ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
                 glist_getcanvas(x),
-                t.tr_lx1, t.tr_ly1-iyoffset, t.tr_lx2, t.tr_ly2+oyoffset,
+                t.tr_lx1, t.tr_ly1 - yoffset, t.tr_lx2, t.tr_ly2 + yoffset,
                 (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
                 oc);
     }
@@ -818,8 +818,8 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
 {
     t_linetraverser t;
     t_outconnect *oc;
-    int iyoffset = (IHEIGHT/2)*x->gl_zoom, oyoffset = (OHEIGHT/2)*x->gl_zoom;
-
+    int yoffset = x->gl_zoom; /* slight offset to hide thick line corners */
+    
     linetraverser_start(&t, x);
     while ((oc = linetraverser_next(&t)))
     {
@@ -827,7 +827,7 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
         {
             sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
                 glist_getcanvas(x), oc,
-                    t.tr_lx1, t.tr_ly1-iyoffset, t.tr_lx2, t.tr_ly2+oyoffset);
+                t.tr_lx1, t.tr_ly1 - yoffset, t.tr_lx2, t.tr_ly2 + yoffset);
         }
     }
 }


### PR DESCRIPTION
This fixes a display "bug" where signal patch cord corners can be seen at certain patch cord angles between objects. The fix basically introduces a y offset based on the inlet/outlet height and zoom setting.

The only downside I can see is that the current PR introduces some extra math when updating the canvas io. This could probably be avoided by precomputing the offset and storing it somewhere.

Quick examples at zoom 2. Notice the corner of the [osc~] outlet cord showing beyond the object border.

![screen shot 2018-09-03 at 2 04 50 pm](https://user-images.githubusercontent.com/480637/44988684-d8f43c80-af8b-11e8-9d71-0d1e58f66461.png)

![screen shot 2018-09-03 at 2 06 18 pm](https://user-images.githubusercontent.com/480637/44988692-ddb8f080-af8b-11e8-8e2e-67e1969d1074.png)