### PR TITLE
Fix audio issues related to portaudio

### DIFF
--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -435,11 +435,13 @@ void sys_reopen_audio( void)
     if (sys_audioapi == API_PORTAUDIO)
     {
         int blksize = (audio_blocksize ? audio_blocksize : 64);
+        int nbufs = sys_advance_samples / blksize;
+        if (nbufs < 1) nbufs = 1;
         if (sys_verbose)
-            fprintf(stderr, "blksize %d, advance %d\n", blksize, sys_advance_samples/blksize);
+            fprintf(stderr, "blksize %d, advance %d\n", blksize, nbufs);
         outcome = pa_open_audio((naudioindev > 0 ? chindev[0] : 0),
         (naudiooutdev > 0 ? choutdev[0] : 0), rate, STUFF->st_soundin,
-            STUFF->st_soundout, blksize, sys_advance_samples/blksize,
+            STUFF->st_soundout, blksize, nbufs,
              (naudioindev > 0 ? audioindev[0] : 0),
               (naudiooutdev > 0 ? audiooutdev[0] : 0),
                (callback ? sched_audio_callbackfn : 0));

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -404,6 +404,10 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         free((char *)pa_inbuf), pa_inbuf = 0;
     if (pa_outbuf)
         free((char *)pa_outbuf), pa_outbuf = 0;
+#ifdef THREADSIGNAL
+    pthread_mutex_init(&pa_mutex, 0);
+    pthread_cond_init(&pa_sem, 0);
+#endif
 #endif
 
     if (! inchans && !outchans)
@@ -464,6 +468,10 @@ void pa_close_audio( void)
         free((char *)pa_inbuf), pa_inbuf = 0;
     if (pa_outbuf)
         free((char *)pa_outbuf), pa_outbuf = 0;
+#ifdef THREADSIGNAL
+    pthread_mutex_destroy(&pa_mutex);
+    pthread_cond_destroy(&pa_sem);
+#endif
 #endif
 }
 

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -627,12 +627,16 @@ int pa_send_dacs(void)
                 for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
                     k++, fp++, fp3 += STUFF->st_outchannels)
                         *fp3 = *fp;
-        Pa_WriteStream(pa_stream, conversionbuf, DEFDACBLKSIZE);
+        if (Pa_WriteStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
+            if (Pa_IsStreamActive(&pa_stream) < 0)
+                locked = 1;
     }
 
     if (STUFF->st_inchannels)
     {
-        Pa_ReadStream(pa_stream, conversionbuf, DEFDACBLKSIZE);
+        if (Pa_ReadStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
+            if (Pa_IsStreamActive(&pa_stream) < 0)
+                locked = 1;
         for (j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
             j < STUFF->st_inchannels; j++, fp2++)
                 for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -495,8 +495,8 @@ int pa_send_dacs(void)
     float *conversionbuf;
     int j, k;
     int rtnval =  SENDDACS_YES;
-#ifdef FAKEBLOCKING
     int locked = 0;
+#ifdef FAKEBLOCKING
 #ifdef THREADSIGNAL
     struct timespec ts;
     double timeout;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -468,7 +468,7 @@ void pa_close_audio( void)
 }
 
 /* maximum number of sleeps before we stop polling and try to reopen the device */
-#define PA_MAXSLEEP 2000
+#define PA_MAXSLEEP 1000
 
 int pa_send_dacs(void)
 {
@@ -607,13 +607,15 @@ int pa_send_dacs(void)
         DEFDACBLKSIZE*sizeof(t_sample)*STUFF->st_outchannels);
     if (locked)
     {
+        PaError err = Pa_IsStreamActive(&pa_stream);
+        error("audio device error: %s", Pa_GetErrorText(err));
         sys_close_audio();
-        error("audio device not responsive, trying to reopen it");
+        error("trying to reopen audio device");
         sys_reopen_audio(); /* try to reopen it */
         if (audio_isopen())
             error("successfully reopened audio device");
         else
-            error("audio device not responsive! check your hardware connection and reopen it from the menu");
+            error("audio device unresponsive! check your hardware connection and reopen it from the menu");
         return SENDDACS_NO;
     } else
         return (rtnval);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -608,7 +608,7 @@ int pa_send_dacs(void)
     if (locked)
     {
         PaError err = Pa_IsStreamActive(&pa_stream);
-        error("audio device error: %s", Pa_GetErrorText(err));
+        error("error %d: %s", err, Pa_GetErrorText(err));
         sys_close_audio();
         error("trying to reopen audio device");
         sys_reopen_audio(); /* try to reopen it */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -315,6 +315,7 @@ static void sys_fakefromgui(void)
 }
 
 static void sys_afterargparse(void);
+static void sys_printusage(void);
 
 /* this is called from main() in s_entry.c */
 int sys_main(int argc, char **argv)
@@ -366,6 +367,11 @@ int sys_main(int argc, char **argv)
         /* for external scheduler (to ignore audio api in sys_loadpreferences) */
         else if (!strcmp(argv[i], "-schedlib") && i < argc-1)
             sys_externalschedlib = 1;
+        else if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help"))
+        {
+            sys_printusage();
+            return (1);
+        }
     }
     if (!noprefs)       /* load preferences before parsing args to allow ... */
         sys_loadpreferences(prefsfile, 1);  /* args to override prefs */
@@ -522,6 +528,13 @@ static char *(usagemessage[]) = {
 "-compatibility <f> -- set back-compatibility to version <f>\n",
 };
 
+static void sys_printusage(void)
+{
+    unsigned int i;
+    for (i = 0; i < sizeof(usagemessage)/sizeof(*usagemessage); i++)
+        fprintf(stderr, "%s", usagemessage[i]);
+}
+
 static void sys_parsedevlist(int *np, int *vecp, int max, char *str)
 {
     int n = 0;
@@ -644,7 +657,6 @@ static int sys_mmio = 0;
 
 int sys_argparse(int argc, char **argv)
 {
-    int i;
     while ((argc > 0) && **argv == '-')
     {
         if (!strcmp(*argv, "-r") && argc > 1 &&
@@ -1341,10 +1353,8 @@ int sys_argparse(int argc, char **argv)
             argc -= 2, argv +=2;
         else
         {
-            unsigned int i;
         usage:
-            for (i = 0; i < sizeof(usagemessage)/sizeof(*usagemessage); i++)
-                fprintf(stderr, "%s", usagemessage[i]);
+            sys_printusage();
             return (1);
         }
     }


### PR DESCRIPTION
* prevent Pd from hanging when you choose an audio device blocksize larger than 64 and accidentally set a delay which is shorter than your block size
* check for "-h" and "-help" early on, before opening audio devices because this might take some seconds when you have Jack on Windows (and the server isn't started). this can be a bit unnerving when you only want to see the help
* prevent Pd from hanging when a device gets disconnected. we set a timeout for polling/waiting after which Pd prints an error and tries to reopen the audio device. if that fails, Pd closes the device and the user can later reopen it from the menu. this works for FAKEBLOCKING with and without THREADSIGNAL. I also added the error handling to the blocking mode (which didn't really hang Pd)