### PR TITLE
Fix potential segfault overflow in [vd~]

### DIFF
--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -277,6 +277,12 @@ static t_int *sigvd_perform(t_int *w)
     t_sample fn = n-1;
     t_sample *vp = ctl->c_vec, *bp, *wp = vp + ctl->c_phase;
     t_sample zerodel = x->x_zerodel;
+    if (limit < 0) /* blocksize is larger than delread~ buffer size */
+    {
+        while (n--)
+            *out++ = 0;
+        return (w+6);
+    }
     while (n--)
     {
         t_sample delsamps = x->x_sr * *in++ - zerodel, frac;

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -282,7 +282,7 @@ static t_int *sigvd_perform(t_int *w)
         t_sample delsamps = x->x_sr * *in++ - zerodel, frac;
         int idelsamps;
         t_sample a, b, c, d, cminusb;
-        if (!(delsamps >= 1.00001f))    /* too small or NAN */
+        if (delsamps < 1.00001f)    /* too small or NAN */
             delsamps = 1.00001f;
         if (delsamps > limit)           /* too big */
             delsamps = limit;
@@ -291,7 +291,7 @@ static t_int *sigvd_perform(t_int *w)
         idelsamps = delsamps;
         frac = delsamps - (t_sample)idelsamps;
         bp = wp - idelsamps;
-        if (bp < vp + 4) bp += nsamps;
+        if (bp < vp + XTRASAMPS) bp += nsamps;
         d = bp[-3];
         c = bp[-2];
         b = bp[-1];

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -225,6 +225,8 @@ static void sigdelread_dsp(t_sigdelread *x, t_signal **sp)
         sigdelread_float(x, x->x_deltime);
         dsp_add(sigdelread_perform, 4,
             sp[0]->s_vec, &delwriter->x_cspace, &x->x_delsamps, sp[0]->s_n);
+        if (sp[0]->s_n > delwriter->x_cspace.c_n)
+            error("delread~ %s: blocksize larger than delread~ buffer", x->x_sym->s_name);
     }
     else if (*x->x_sym->s_name)
         error("delread~: %s: no such delwrite~",x->x_sym->s_name);
@@ -325,6 +327,8 @@ static void sigvd_dsp(t_sigvd *x, t_signal **sp)
         dsp_add(sigvd_perform, 5,
             sp[0]->s_vec, sp[1]->s_vec,
                 &delwriter->x_cspace, x, sp[0]->s_n);
+        if (sp[0]->s_n > delwriter->x_cspace.c_n)
+            error("vd~ %s: blocksize larger than delread~ buffer", x->x_sym->s_name);
     }
     else if (*x->x_sym->s_name)
         error("vd~: %s: no such delwrite~",x->x_sym->s_name);


### PR DESCRIPTION
if the blocksize of [vd~] is larger than the buffer size of the corresponding [delwrite~], there will be a buffer overflow which might lead to a segfault (happened to me).

[delread~], however, is safe and only produces garbage output (because it goes in cycles).

I simply flush the output of [vd~] to zero in case of a bad blocksize. (Don't know if should also do that for [delread~]?) Both objects will print an error to console.

Here's a Pd patch which shows the problem: 
[delay-crash.zip](https://github.com/pure-data/pure-data/files/2364301/delay-crash.zip)
