### PR TITLE
add flag to [drawpolygon] to only disable changing vertices

### DIFF
--- a/doc/5.reference/drawpolygon-help.pd
+++ b/doc/5.reference/drawpolygon-help.pd
@@ -11,36 +11,38 @@ dog float weasel;
 #X text 225 10 -- draw shapes for data structures;
 #N canvas 418 85 546 629 help-drawpolygon-template 1;
 #X obj 19 24 drawpolygon 0 2 0 0 0 weasel;
-#X obj 17 367 filledpolygon 900 dog 3 10 0 20 cat 30 0;
-#X text 29 389 filledpolygon and filledcurve take the same arguments
+#X obj 17 404 filledpolygon 900 dog 3 10 0 20 cat 30 0;
+#X text 29 426 filledpolygon and filledcurve take the same arguments
 \, except that a new first argument is added to specify interior color.
 Here the interior color is red (900) \, the outline color is controlled
 by the "dog" field \, and the three points describe a triangle of altitude
 "cat". The fields x and y automatically govern the placement of the
 object as a whole.;
-#X text 37 228 - RGB color (0=black \, 999=white \, 900=red \, 90=green
+#X text 37 265 - RGB color (0=black \, 999=white \, 900=red \, 90=green
 \, 9=blue \, 555=grey \, etc.);
-#X text 35 268 - line width;
-#X text 35 289 - two or more (x \, y) pairs giving coordinates.;
-#X text 24 552 This object defines the fields for this template. You
+#X text 35 305 - line width;
+#X text 35 326 - two or more (x \, y) pairs giving coordinates.;
+#X text 24 589 This object defines the fields for this template. You
 can see the fields' values by right-clicking on the object in the "data"
 window and selecting "properties.";
-#X obj 12 508 struct help-drawpolygon-template float x float y float
+#X obj 12 545 struct help-drawpolygon-template float x float y float
 cat float dog float weasel;
 #X text 26 44 drawpolygon and drawcurve take these arguments:;
 #X text 40 67 - optional "-n" flag to make invisible initially;
 #X text 38 88 - alternatively \, an optional "-v [variable]" flag to
 assign a variable to make this visible/invisible.;
-#X text 26 310 Any of these (except the flags) can be numbers or field
+#X text 26 347 Any of these (except the flags) can be numbers or field
 names \, like "weasel" here. The example above draws a vertical black
 line of height "weasel".;
 #X text 37 129 - optional "-xr" flag to disable mouse actions when
 in "run" mode, f 65;
-#X text 37 189 - optional "-x" flag to set both "-xr" and "-xe" \,
+#X text 37 226 - optional "-x" flag to set both "-xr" and "-xe" \,
 disabling all mouse actions;
 #X text 36 152 - optional "-xe" flag to disable mouse actions when
 in "edit" mode (so don't stretch the bounding rectangle to include
 this item), f 66;
+#X text 34 188 - optional "-xv" flag to disable dragging vertices when
+in "run" mode (keep reporting mouse clicks), f 66;
 #X restore 240 92 pd help-drawpolygon-template;
 #N canvas 11 270 384 178 help-drawpolygon-data 1;
 #X scalar help-drawpolygon-template 50 40 30 9 80 \;;

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -852,6 +852,7 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
 #define BEZ 2         /* bezier shape */
 #define NOMOUSERUN 4  /* disable mouse interaction when in run mode  */
 #define NOMOUSEEDIT 8 /* same in edit mode */
+#define NOVERTICES 16 /* disable only vertex grabbing in run mode */
 #define A_ARRAY 55      /* LATER decide whether to enshrine this in m_pd.h */
 
 static void fielddesc_setfloatarg(t_fielddesc *fd, int argc, t_atom *argv)
@@ -1070,6 +1071,11 @@ static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
         {
             /* disable mouse actions in edit mode */
             flags |= NOMOUSEEDIT;
+        }
+        else if (!strcmp(flag, "-xv"))
+        {
+            /* disable changing vertices in run mode */
+            flags |= NOVERTICES;
         }
         else
         {
@@ -1318,7 +1324,7 @@ static int curve_click(t_gobj *z, t_glist *glist,
     int bestn = -1;
     int besterror = 0x7fffffff;
     t_fielddesc *f;
-    if ((x->x_flags & NOMOUSERUN) ||
+    if ((x->x_flags & NOMOUSERUN) || (x->x_flags & NOVERTICES) ||
         !fielddesc_getfloat(&x->x_vis, template, data, 0))
             return (0);
     for (i = 0, f = x->x_vec; i < n; i++, f += 2)


### PR DESCRIPTION
while "-xr" disables *all* mouse actions in run mode, "-xv" only disables changing vertices while still reporting mouse clicks to the struct.

example use case: build a GUI with data structures but prevent the user from accidentally change the shape of the widgets.