### PR TITLE
add object to test gpointers for equality

### DIFF
--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -520,6 +520,49 @@ static void ptrobj_setup(void)
     class_addbang(ptrobj_class, ptrobj_bang);
 }
 
+/*----------------------- compare ------------------------- */
+
+static t_class *compare_class;
+
+typedef struct _compare
+{
+    t_object x_obj;
+    t_gpointer x_gp;
+} t_compare;
+
+static void *compare_new(t_symbol *classname, int argc, t_atom *argv)
+{
+    t_compare *x = (t_compare *)pd_new(compare_class);
+    gpointer_init(&x->x_gp);
+    pointerinlet_new(&x->x_obj, &x->x_gp);
+    outlet_new(&x->x_obj, 0);
+    return (x);
+}
+
+static void compare_free(t_compare *x)
+{
+    gpointer_unset(&x->x_gp);
+}
+
+static void compare_pointer(t_compare *x, t_gpointer *gp)
+{
+    if (!gpointer_check(&x->x_gp, 1))
+    {
+        pd_error(x, "compare: empty pointer");
+        return;
+    }
+    /* we don't care for the actual type in the union because they are all pointers */
+    outlet_float(x->x_obj.ob_outlet, gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
+}
+
+static void compare_setup(void)
+{
+    compare_class = class_new(gensym("compare"), (t_newmethod)compare_new,
+        (t_method)compare_free, sizeof(t_compare), 0, 0);
+    class_addpointer(compare_class, (t_method)compare_pointer);
+}
+
+
 /* ---------------------- get ----------------------------- */
 
 static t_class *get_class;
@@ -1339,6 +1382,7 @@ static void append_setup(void)
 void g_traversal_setup(void)
 {
     ptrobj_setup();
+    compare_setup();
     get_setup();
     set_setup();
     elem_setup();

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -520,46 +520,46 @@ static void ptrobj_setup(void)
     class_addbang(ptrobj_class, ptrobj_bang);
 }
 
-/*----------------------- compare ------------------------- */
+/*----------------------- equal ------------------------- */
 
-static t_class *compare_class;
+static t_class *equal_class;
 
-typedef struct _compare
+typedef struct _equal
 {
     t_object x_obj;
     t_gpointer x_gp;
-} t_compare;
+} t_equal;
 
-static void *compare_new(t_symbol *classname, int argc, t_atom *argv)
+static void *equal_new(t_symbol *classname, int argc, t_atom *argv)
 {
-    t_compare *x = (t_compare *)pd_new(compare_class);
+    t_equal *x = (t_equal *)pd_new(equal_class);
     gpointer_init(&x->x_gp);
     pointerinlet_new(&x->x_obj, &x->x_gp);
     outlet_new(&x->x_obj, 0);
     return (x);
 }
 
-static void compare_free(t_compare *x)
+static void equal_free(t_equal *x)
 {
     gpointer_unset(&x->x_gp);
 }
 
-static void compare_pointer(t_compare *x, t_gpointer *gp)
+static void equal_pointer(t_equal *x, t_gpointer *gp)
 {
     if (!gpointer_check(&x->x_gp, 1))
     {
-        pd_error(x, "compare: empty pointer");
+        pd_error(x, "equal: empty pointer");
         return;
     }
     /* we don't care for the actual type in the union because they are all pointers */
     outlet_float(x->x_obj.ob_outlet, gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
 }
 
-static void compare_setup(void)
+static void equal_setup(void)
 {
-    compare_class = class_new(gensym("compare"), (t_newmethod)compare_new,
-        (t_method)compare_free, sizeof(t_compare), 0, 0);
-    class_addpointer(compare_class, (t_method)compare_pointer);
+    equal_class = class_new(gensym("equal"), (t_newmethod)equal_new,
+        (t_method)equal_free, sizeof(t_equal), 0, 0);
+    class_addpointer(equal_class, (t_method)equal_pointer);
 }
 
 
@@ -1382,7 +1382,7 @@ static void append_setup(void)
 void g_traversal_setup(void)
 {
     ptrobj_setup();
-    compare_setup();
+    equal_setup();
     get_setup();
     set_setup();
     elem_setup();

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -546,13 +546,16 @@ static void equal_free(t_equal *x)
 
 static void equal_pointer(t_equal *x, t_gpointer *gp)
 {
+    int result;
     if (!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "equal: empty pointer");
         return;
     }
     /* we don't care for the actual type in the union because they are all pointers */
-    outlet_float(x->x_obj.ob_outlet, gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
+    result = (gp->gp_stub->gs_un.gs_glist == x->x_gp.gp_stub->gs_un.gs_glist) &&
+        (gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
+    outlet_float(x->x_obj.ob_outlet, result);
 }
 
 static void equal_setup(void)


### PR DESCRIPTION
output 1 if pointer to left inlet and stored pointer (right inlet) point to the same thing.
otherwise output 0.

alternative implementation: https://github.com/pure-data/pure-data/pull/436

EDIT: we could also create this object via a special constructor argument to [pointer], e.g. [pointer ==]. the thing is that this would break patches which have a struct called "==". maybe it is so unlikely that we can ignore it. after all, Miller reserved "text" for [text], accepting that it *might* cause a regression in someone's patch.