### PR TITLE
add message to [pointer] to test gpointers for equality

### DIFF
--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -396,6 +396,34 @@ static void ptrobj_delete(t_ptrobj *x)
     }
 }
 
+static void ptrobj_equal(t_ptrobj *x, t_gpointer *gp)
+{
+    t_symbol *templatesym;
+    int n, which;
+    t_typedout *to;
+    if (!gpointer_check(&x->x_gp, 1))
+    {
+        pd_error(x, "pointer_bang: empty pointer");
+        return;
+    }
+    /* we don't care for the actual union type because they are all pointers */
+    if (x->x_gp.gp_un.gp_scalar != gp->gp_un.gp_scalar)
+    {
+        outlet_bang(x->x_bangout);
+        return;
+    }
+    templatesym = gpointer_gettemplatesym(&x->x_gp);
+    for (n = x->x_ntypedout, to = x->x_typedout; n--; to++)
+    {
+        if (to->to_type == templatesym)
+        {
+            outlet_pointer(to->to_outlet, &x->x_gp);
+            return;
+        }
+    }
+    outlet_pointer(x->x_otherout, &x->x_gp);
+}
+
     /* send a message to the window containing the object pointed to */
 static void ptrobj_sendwindow(t_ptrobj *x, t_symbol *s, int argc, t_atom *argv)
 {
@@ -512,6 +540,7 @@ static void ptrobj_setup(void)
     class_addmethod(ptrobj_class, (t_method)ptrobj_vnext, gensym("vnext"),
         A_DEFFLOAT, 0);
     class_addmethod(ptrobj_class, (t_method)ptrobj_delete, gensym("delete"), 0);
+    class_addmethod(ptrobj_class, (t_method)ptrobj_equal, gensym("equal"), A_POINTER, 0);
     class_addmethod(ptrobj_class, (t_method)ptrobj_sendwindow,
         gensym("send-window"), A_GIMME, 0);
     class_addmethod(ptrobj_class, (t_method)ptrobj_rewind,

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -399,15 +399,17 @@ static void ptrobj_delete(t_ptrobj *x)
 static void ptrobj_equal(t_ptrobj *x, t_gpointer *gp)
 {
     t_symbol *templatesym;
-    int n, which;
+    int n, which, result;
     t_typedout *to;
     if (!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "pointer_bang: empty pointer");
         return;
     }
-    /* we don't care for the actual union type because they are all pointers */
-    if (x->x_gp.gp_un.gp_scalar != gp->gp_un.gp_scalar)
+    /* we don't care for the actual type in the union because they are all pointers */
+    result = (gp->gp_stub->gs_un.gs_glist == x->x_gp.gp_stub->gs_un.gs_glist) &&
+        (gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
+    if (!result)
     {
         outlet_bang(x->x_bangout);
         return;


### PR DESCRIPTION
if the gpointer of the message points to the same thing (scalar or word) as the stored pointer,
output the pointer.
if they are not equal, send a bang through the last outlet.

EDIT: the result could also be sent as float (0 or 1) to the last outlet. I'm starting to like this better because it wouldn't interfere with the rest of the interface (the user can use [route bang float] on the last outlet)

alternative implementation: https://github.com/pure-data/pure-data/pull/435