### PR TITLE
revert the portaudio polling limit for non-Windows systems

### DIFF
--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -92,12 +92,9 @@ static pthread_cond_t pa_sem;
 #endif
 /* maximum number of ms sleeps before we stop polling and try to reopen the device */
 #ifndef MAX_NUM_POLLS
-#ifdef _WIN32
-#define MAX_NUM_POLLS 1000
-#else
-#define MAX_NUM_POLLS 0x7fffffff /* polling limit doesn't work on non-Windows systems yet */
-#endif /* WIN32 */
-#endif /* MAX_NUM_POLLS */
+#define MAX_NUM_POLLS 1000 /* maximum number of unsuccessful polls before giving up */
+PaError PaUtil_ValidateStreamPointer(PaStream * stream);
+#endif
 #endif /* THREADSIGNAL */
 #endif  /* FAKEBLOCKING */
 
@@ -544,7 +541,9 @@ int pa_send_dacs(void)
                 break;
             }
 #else
-            if (!--counter)
+            if (PaUtil_ValidateStreamPointer(&pa_stream) < 0)
+                counter--;
+            if (!counter)
             {
                 locked = 1;
                 break;
@@ -587,7 +586,9 @@ int pa_send_dacs(void)
                 break;
             }
 #else
-            if (!--counter)
+            if (PaUtil_ValidateStreamPointer(&pa_stream) < 0)
+                counter--;
+            if (!counter)
             {
                 locked = 1;
                 break;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -92,8 +92,12 @@ static pthread_cond_t pa_sem;
 #endif
 /* maximum number of ms sleeps before we stop polling and try to reopen the device */
 #ifndef MAX_NUM_POLLS
+#ifdef _WIN32
 #define MAX_NUM_POLLS 1000
-#endif
+#else
+#define MAX_NUM_POLLS 0x7fffffff /* polling limit doesn't work on non-Windows systems yet */
+#endif /* WIN32 */
+#endif /* MAX_NUM_POLLS */
 #endif /* THREADSIGNAL */
 #endif  /* FAKEBLOCKING */
 


### PR DESCRIPTION
because it seems to cause weirdness as reported by https://github.com/pure-data/pure-data/issues/443#issuecomment-420425508
I'll work on it when I have access to a Mac. In the mean, keep it Windows only.