### PR TITLE
fix regression in portaudio

### DIFF
--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -93,7 +93,6 @@ static pthread_cond_t pa_sem;
 /* maximum number of ms sleeps before we stop polling and try to reopen the device */
 #ifndef MAX_NUM_POLLS
 #define MAX_NUM_POLLS 1000 /* maximum number of unsuccessful polls before giving up */
-PaError PaUtil_ValidateStreamPointer(PaStream * stream);
 #endif
 #endif /* THREADSIGNAL */
 #endif  /* FAKEBLOCKING */
@@ -541,7 +540,7 @@ int pa_send_dacs(void)
                 break;
             }
 #else
-            if (PaUtil_ValidateStreamPointer(&pa_stream) < 0)
+            if (Pa_IsStreamActive(&pa_stream) < 0)
                 counter--;
             if (!counter)
             {
@@ -586,7 +585,7 @@ int pa_send_dacs(void)
                 break;
             }
 #else
-            if (PaUtil_ValidateStreamPointer(&pa_stream) < 0)
+            if (Pa_IsStreamActive(&pa_stream) < 0)
                 counter--;
             if (!counter)
             {


### PR DESCRIPTION
replace the private PaUtil_ValidateStreamPointer with the public Pa_IsStreamActive. 

solves https://github.com/pure-data/pure-data/issues/450#issuecomment-420761829

lesson learned: stay away from private headers

