### PR TITLE
add missing  [drawtext] / [drawsymbol] objects to documentation

### DIFF
--- a/doc/5.reference/drawtext-help.pd
+++ b/doc/5.reference/drawtext-help.pd
@@ -46,3 +46,4 @@ through "set" objects..;
 #X obj 22 130 struct;
 #X text 275 159 updated for Pd version 0.39;
 #X obj 107 8 drawsymbol;
+#X obj 107 40 drawtext;

--- a/doc/5.reference/help-intro.pd
+++ b/doc/5.reference/help-intro.pd
@@ -1,4 +1,4 @@
-#N canvas 705 42 594 925 12;
+#N canvas 326 23 594 833 12;
 #X declare;
 #X obj 24 150 bang;
 #X text 124 150 - output a bang message;
@@ -252,31 +252,31 @@
 #X text 124 3798 - define a data structure;
 #X obj 24 3822 drawcurve;
 #X obj 112 3822 filledcurve;
-#X text 225 3822 - draw a curve;
+#X text 215 3822 - draw a curve;
 #X obj 24 3846 drawpolygon;
 #X obj 129 3846 filledpolygon;
-#X text 259 3846 - draw a polygon;
-#X obj 24 3870 plot;
-#X text 124 3870 - plot an array field;
-#X obj 24 3894 drawnumber;
-#X text 124 3894 - print a numeric value;
-#X obj 25 3958 pointer;
-#X text 125 3958 - point to an object belonging to a template;
-#X obj 25 3982 get;
-#X text 125 3982 - get numeric fields;
-#X obj 25 4006 set;
-#X text 125 4006 - change numeric fields;
-#X obj 25 4030 element;
-#X text 125 4030 - get an array element;
-#X obj 25 4054 getsize;
-#X text 125 4054 - get the size of an array;
-#X obj 25 4078 setsize;
-#X text 125 4078 - change the size of an array;
-#X obj 25 4102 append;
-#X text 125 4102 - add an element to a list;
-#X obj 25 4126 scalar;
-#X text 130 4448 (use tabwrite~ now);
-#X obj 30 4473 namecanvas;
+#X text 239 3846 - draw a polygon;
+#X obj 24 3897 plot;
+#X text 124 3897 - plot an array field;
+#X obj 24 3921 drawnumber;
+#X text 124 3921 - print a numeric value;
+#X obj 25 3985 pointer;
+#X text 125 3985 - point to an object belonging to a template;
+#X obj 25 4009 get;
+#X text 125 4009 - get numeric fields;
+#X obj 25 4033 set;
+#X text 125 4033 - change numeric fields;
+#X obj 25 4057 element;
+#X text 125 4057 - get an array element;
+#X obj 25 4081 getsize;
+#X text 125 4081 - get the size of an array;
+#X obj 25 4105 setsize;
+#X text 125 4105 - change the size of an array;
+#X obj 25 4129 append;
+#X text 125 4129 - add an element to a list;
+#X obj 25 4153 scalar;
+#X text 130 4475 (use tabwrite~ now);
+#X obj 30 4500 namecanvas;
 #X obj 142 3439 czero_rev~;
 #X obj 26 2568 threshold~;
 #X text 126 2568 - detect signal thresholds;
@@ -290,7 +290,7 @@
 ;
 #X text 18 3768 ---------------------- DATA TEMPLATES ----------------------
 ;
-#X text 18 3928 ---------------------- ACCESSING DATA ----------------------
+#X text 18 3955 ---------------------- ACCESSING DATA ----------------------
 ;
 #X text 17 2840 ------------ AUDIO OSCILLATORS AND TABLES -------------
 ;
@@ -302,7 +302,7 @@
 #X obj 118 909 <;
 #X obj 149 909 >=;
 #X obj 180 909 <=;
-#X text 26 4423 ------------------------ OBSOLETE --------------------------
+#X text 26 4410 ------------------------ OBSOLETE --------------------------
 ;
 #X obj 54 886 -;
 #X obj 87 886 *;
@@ -342,17 +342,17 @@
 #X text 128 1539 - general array creation and manipulation;
 #X text 17 1393 ----------------- ARRAYS/TABLES -------------------
 ;
-#X text 125 4125 - create a single scalar;
-#X text 129 4474 (potentially dangerous but no substitute exists yet)
+#X text 125 4152 - create a single scalar;
+#X text 129 4501 (potentially dangerous but no substitute exists yet)
 ;
 #X text 23 22 The following is a list of built-in objects in Pd. (Not
 included in this list are messages \, atoms \, graphs \, etc. which
 aren't typed into object boxes but come straight off the "add" menu.)
 Right-click (or control-click on a Macintosh) on any object to get
 its "help window".;
-#X msg 30 4446 scope~;
-#X msg 30 4498 template;
-#X text 129 4499 (use struct now);
+#X msg 30 4473 scope~;
+#X msg 30 4525 template;
+#X text 129 4486 (use struct now);
 #X obj 25 1713 textfile;
 #X obj 25 1737 text;
 #X obj 180 932 <<;
@@ -360,30 +360,30 @@ its "help window".;
 #X obj 26 2126 sqrt~;
 #X obj 22 1339 oscparse;
 #X obj 96 1339 oscformat;
-#X text 18 4157 -------- "EXTRA" (patches and externs in pd/extra)
+#X text 18 4184 -------- "EXTRA" (patches and externs in pd/extra)
 ---------;
-#X obj 26 4186 sigmund~;
-#X text 126 4186 - pitch tracker;
-#X obj 26 4211 bonk~;
-#X text 126 4211 - attack detector;
-#X obj 26 4236 choice;
-#X text 126 4236 - best match of list to templates;
-#X obj 26 4260 hilbert~;
-#X obj 104 4260 complex-mod~;
-#X text 218 4261 - phase quadrature / frequency shifting;
-#X obj 26 4289 loop~;
-#X text 122 4292 - phasor~ with S/H on its frequency input;
-#X obj 26 4314 lrshift~;
-#X text 122 4317 - left and right shift (useful with FFT objects);
-#X obj 27 4340 pd~;
-#X text 124 4338 - run another copy of Pd (for multiprocessing);
-#X obj 27 4367 rev1~;
-#X obj 79 4367 rev2~;
-#X obj 128 4367 rev3~;
-#X text 188 4367 - reverberators;
-#X obj 60 4340 stdout;
-#X obj 27 4394 bob~;
-#X text 123 4396 - Moog resonant filter model;
+#X obj 26 4213 sigmund~;
+#X text 126 4213 - pitch tracker;
+#X obj 26 4238 bonk~;
+#X text 126 4238 - attack detector;
+#X obj 26 4263 choice;
+#X text 126 4263 - best match of list to templates;
+#X obj 26 4287 hilbert~;
+#X obj 104 4287 complex-mod~;
+#X text 218 4288 - phase quadrature / frequency shifting;
+#X obj 26 4316 loop~;
+#X text 122 4319 - phasor~ with S/H on its frequency input;
+#X obj 26 4341 lrshift~;
+#X text 122 4344 - left and right shift (useful with FFT objects);
+#X obj 27 4367 pd~;
+#X text 124 4365 - run another copy of Pd (for multiprocessing);
+#X obj 27 4394 rev1~;
+#X obj 79 4394 rev2~;
+#X obj 128 4394 rev3~;
+#X text 188 4394 - reverberators;
+#X obj 60 4367 stdout;
+#X obj 27 4421 bob~;
+#X text 123 4423 - Moog resonant filter model;
 #X text 116 3697 - make copies of a subpatch;
 #X obj 24 3697 clone;
 #X obj 194 1204 midirealtimein;
@@ -410,3 +410,6 @@ its "help window".;
 #X msg 76 3722 switch;
 #X text 138 3720 - specify block size and overlap \, or \, if invoked
 as "switch" \, also switch subpatches on and off;
+#X obj 129 3871 drawsymbol;
+#X obj 24 3871 drawtext;
+#X text 224 3870 - draw text;


### PR DESCRIPTION
added references to [drawtext] and [drawsymbol] into help-intro.pd

added [drawtext] in drawtext-help.pd file as it wasn't mentioned anywhere in any help file... and seems like it could be into drawtext-help.pd if any :) - but I didn't add any information on what it does or what's different about, because I just have no idea!