### PR TITLE
better error messages for portaudio hotplug fix

### DIFF
--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -667,6 +667,12 @@ int pa_send_dacs(void)
             error("successfully reopened audio device");
         else
             error("audio device not responding - closing audio.");
+        #ifdef _WIN32
+            error("check your hardware connection and reopen the device from the menu");
+        #else
+            /* TODO: find out why we can't reopen a hotplugged device on OSX */
+            error("please restart Pd");
+        #endif
         return SENDDACS_NO;
     } else
         return (rtnval);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -671,7 +671,7 @@ int pa_send_dacs(void)
             error("check your hardware connection and reopen the device from the menu");
         #else
             /* TODO: find out why we can't reopen a hotplugged device on OSX */
-            error("please restart Pd");
+            error("you may need to save and restart Pd");
         #endif
         return SENDDACS_NO;
     } else


### PR DESCRIPTION
make error message platform specific

* on Windows we can plug the device back in and reopen it from the menu
* on OSX we have to restart Pd