### PR TITLE
remove lib "already loaded" error printing

### DIFF
--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -329,7 +329,7 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
 
     if (sys_onloadlist(classname))
     {
-        error("%s: already loaded", classname);
+        /*error("%s: already loaded", classname);*/
         return (1);
     }
         /* if classname is absolute, try this first */

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -327,11 +327,8 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
     data.canvas = canvas;
     data.ok = 0;
 
-    if (sys_onloadlist(classname))
-    {
-        /*error("%s: already loaded", classname);*/
-        return (1);
-    }
+    if (sys_onloadlist(classname)) return (1); // if lib is already loaded, dismiss.
+
         /* if classname is absolute, try this first */
     if (sys_isabsolutepath(classname))
     {


### PR DESCRIPTION
to avoid cluttering the Pd console, e.g when many abstractions are declaring the
same library.

I have chosen to simply comment the error out, for memory.
