### PR TITLE
fix obscure bug with [donecanvasdialog(

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1373,11 +1373,10 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
     t_undo_canvas_properties *buf = (t_undo_canvas_properties *)z;
     t_undo_canvas_properties tmp;
 
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
-
     if (action == UNDO_UNDO || action == UNDO_REDO)
     {
+        if (!x->gl_edit)
+            canvas_editmode(x, 1);
 #if 0
             /* close properties window first */
         t_int properties = gfxstub_haveproperties((void *)x);
@@ -1386,7 +1385,6 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
             gfxstub_deleteforkey(x);
         }
 #endif
-
             /* store current canvas values into temporary data holder */
         tmp.gl_pixwidth = x->gl_pixwidth;
         tmp.gl_pixheight = x->gl_pixheight;


### PR DESCRIPTION
Pd 0.49 introduced a weird bug with the [donecanvasdialog( message.

if you send this message to a canvas and this canvas has GOP enabled, deleting the canvas will
a) show a Tcl error if its a subpatch
b) segfault if its an abstraction

here's the backtrace:

~~~
Thread 1 received signal SIGSEGV, Segmentation fault.
0x675a6a09 in atom_string (a=0xfeeefeee, buf=0x28f012 "", bufsize=500)
    at m_atom.c:70
70          switch(a->a_type)
(gdb) bt
#0  0x675a6a09 in atom_string (a=0xfeeefeee, buf=0x28f012 "", bufsize=500)
    at m_atom.c:70
#1  0x67562a1b in canvas_reflecttitle (x=0x37896c8) at g_canvas.c:607
#2  0x67573d0a in canvas_editmode (x=0x37896c8, state=1) at g_editor.c:4603
#3  0x6756a506 in canvas_undo_canvas_apply (x=0x37896c8, z=0x377e1a0,
    action=0) at g_editor.c:1377
#4  0x6759cbb5 in canvas_undo_doit (x=0x37896c8, udo=0x377e1f0, action=0,
    funname=0x676378c8 <__FUNCTION__.4674> "canvas_undo_free") at g_undo.c:146
#5  0x6759d197 in canvas_undo_free (x=0x37896c8) at g_undo.c:326
#6  0x675631ab in canvas_free (x=0x37896c8) at g_canvas.c:787
#7  0x675afd87 in pd_free (x=0x37896c8) at m_pd.c:31
#8  0x67576bfb in glist_delete (x=0x3778078, y=0x37896c8) at g_graph.c:134
#9  0x6757118f in canvas_doclear (x=0x3778078) at g_editor.c:3698
#10 0x6756f4e6 in canvas_key (x=0x3778078, s=0x50bdd0, ac=3, av=0x28f8b4)
    at g_editor.c:3122
#11 0x675ad1f2 in pd_typedmess (x=0x3778078, s=0x50bdd0, argc=3,
    argv=0x28f8b4) at m_class.c:949
#12 0x6757a0c5 in guiconnect_anything (x=0x37783c0, s=0x50bdd0, ac=3,
    av=0x28f8b4) at g_guiconnect.c:73
#13 0x675ad5d9 in pd_typedmess (x=0x37783c0, s=0x50bdd0, argc=3,
    argv=0x28f8b4) at m_class.c:1036
#14 0x675a85d1 in binbuf_eval (x=0x2224b18, target=0x37783c0, argc=0,
    argv=0x0) at m_binbuf.c:792
~~~

somehow, [donecanvasdialog( messes with the canvas invariants so that after` canvas_free(),` `glist_isvisible(x) `will still return true. the result is that `canvas_editmode()` will call `canvas_reflecttitle()` which leads to the crash/error. I've tried to understand what is happening but I couldn't find the reason. I made a change to canvas_undo_canvas_apply (@umlaeute is this ok?) which avoids calling `canvas_editmode` for UNDO_FREE. this fixes the crash but I think we should look for the real problem.

here's a Pd patch which shows the problem: 
[donecanvasdialog-crash.zip](https://github.com/pure-data/pure-data/files/2383704/donecanvasdialog-crash.zip)

UPDATE: this also happens when the message gets sent by the actual dialog, so it's not only a dynamic patching problem!
