### PR TITLE
updates for 0.49 test3

### DIFF
--- a/doc/5.reference/makefilename-help.pd
+++ b/doc/5.reference/makefilename-help.pd
@@ -36,7 +36,7 @@
 #X text 33 266 %X;
 #X text 110 266 unsigned hexadecimal in CAPS;
 #X text 33 286 %p;
-#X text 110 286 unsigned hexadecimal in lowercase preceeded by "0x"
+#X text 110 286 unsigned hexadecimal in lowercase preceded by "0x"
 ;
 #X text 20 37 This is a listing of all possible printf patterns used
 in Pd's [makefilename]:;

--- a/doc/5.reference/midi-help.pd
+++ b/doc/5.reference/midi-help.pd
@@ -109,13 +109,13 @@ from -8192 to 8191 - this won't change.;
 , f 72;
 #X text 530 197 MIDI OUTPUTS: Outputs are set to channel 1 by default
 \, but they also take a channel argument \, but [ctlout] takes control
-and channel arguments. Inlets are not supressed by arguments and change
+and channel arguments. Inlets are not suppressed by arguments and change
 the parameters., f 65;
 #X text 32 41 MIDI INPUTS: Inputs are omni by default \, an optional
-argument sets the channel and removes the rightmost outlet (which ouputs
+argument sets the channel and removes the rightmost outlet (which outputs
 the channel number). For [ctlin] \, a first optional argument sets
-controller number and supresses its corresponding outlet \, and a second
-argument sets the channel and also supresses its corresponding outlet.
+controller number and suppresses its corresponding outlet \, and a second
+argument sets the channel and also suppresses its corresponding outlet.
 ;
 #X text 738 398 value;
 #X connect 0 0 79 0;

--- a/mac/README.txt
+++ b/mac/README.txt
@@ -164,3 +164,12 @@ commandline utility in Terminal:
 
     # set the startup flag in the core settings
     defaults write org.puredata.pd -array-add flags '-lib Gem'
+
+Some important per-application settings required by the GUI include:
+
+* NSRecentDocuments: string array, list of recently opened files
+* NSQuitAlwaysKeepsWindows: false, disables default 10.7+ window state saving
+* ApplePressAndHoldEnabled: false, disables character compose popup,
+                                   enables key repeat for all keys
+
+These are set in `tcl/pd_guiprefs.tcl`.

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -393,7 +393,10 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_snd = snd = canvas_realizedollar(iemgui->x_glist, snd);
     iemgui->x_fsf.x_snd_able = sndable;
     iemgui_verify_snd_ne_rcv(iemgui);
-    (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    if(glist_isvisible(iemgui->x_glist))
+    {
+        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    }
 }
 
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -427,7 +430,10 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
     }
     iemgui->x_fsf.x_rcv_able = rcvable;
     iemgui_verify_snd_ne_rcv(iemgui);
-    (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    if(glist_isvisible(iemgui->x_glist))
+    {
+        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    }
 }
 
 void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -539,8 +545,11 @@ void iemgui_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 
     x->x_obj.te_xpix += dx;
     x->x_obj.te_ypix += dy;
-    (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(glist, (t_text *)z);
+    if(glist_isvisible(glist))
+    {
+        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_MOVE);
+        canvas_fixlinesfor(glist, (t_text *)z);
+    }
 }
 
 void iemgui_select(t_gobj *z, t_glist *glist, int selected)
@@ -548,7 +557,10 @@ void iemgui_select(t_gobj *z, t_glist *glist, int selected)
     t_iemgui *x = (t_iemgui *)z;
 
     x->x_fsf.x_selected = selected;
-    (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_SELECT);
+    if(glist_isvisible(glist))
+    {
+        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_SELECT);
+    }
 }
 
 void iemgui_delete(t_gobj *z, t_glist *glist)
@@ -559,6 +571,8 @@ void iemgui_delete(t_gobj *z, t_glist *glist)
 void iemgui_vis(t_gobj *z, t_glist *glist, int vis)
 {
     t_iemgui *x = (t_iemgui *)z;
+    if(!glist_isvisible(glist))
+        return;
 
     if (vis)
         (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_NEW);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -896,7 +896,7 @@ static void garray_dofo(t_garray *x, long npoints, t_float dcval,
     if (npoints == 0)
         npoints = 512;  /* dunno what a good default would be... */
     if (npoints != (1 << ilog2((int)npoints)))
-        post("%s: rounnding to %d points", array->a_templatesym->s_name,
+        post("%s: rounding to %d points", array->a_templatesym->s_name,
             (npoints = (1<<ilog2((int)npoints))));
     garray_resize_long(x, npoints + 3);
     phaseincr = 2. * 3.14159 / npoints;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1373,11 +1373,10 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
     t_undo_canvas_properties *buf = (t_undo_canvas_properties *)z;
     t_undo_canvas_properties tmp;
 
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
-
     if (action == UNDO_UNDO || action == UNDO_REDO)
     {
+        if (!x->gl_edit)
+            canvas_editmode(x, 1);
 #if 0
             /* close properties window first */
         t_int properties = gfxstub_haveproperties((void *)x);
@@ -1386,7 +1385,6 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
             gfxstub_deleteforkey(x);
         }
 #endif
-
             /* store current canvas values into temporary data holder */
         tmp.gl_pixwidth = x->gl_pixwidth;
         tmp.gl_pixheight = x->gl_pixheight;

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -321,7 +321,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
             /* we add an extra space to the string just in case the last
             character is an unescaped backslash ('\') which would have confused
             tcl/tk by escaping the close brace otherwise.  The GUI code
-            drops the last character in teh string. */
+            drops the last character in the string. */
         sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %f %f {%.*s } %d %s\n",
             canvas, x->x_tag, rtext_gettype(x)->s_name,
             dispx + lmargin, dispy + tmargin,

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -90,9 +90,9 @@ static pthread_cond_t pa_sem;
 #if defined (FAKEBLOCKING) && defined(_WIN32)
 #include <windows.h>    /* for Sleep() */
 #endif
-/* maximum number of ms sleeps before we stop polling and try to reopen the device */
+/* max number of unsuccessful polls before trying to reopen the device */
 #ifndef MAX_NUM_POLLS
-#define MAX_NUM_POLLS 1000 /* maximum number of unsuccessful polls before giving up */
+#define MAX_NUM_POLLS 1000
 #endif
 #endif /* THREADSIGNAL */
 #endif  /* FAKEBLOCKING */

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -226,7 +226,7 @@ void midi_oss_init(void)
     struct stat statbuf;
     char namebuf[80];
          /* we only try to detect devices before trying to open them, because
-         when they're open, they migth not be possible to reopen here */
+         when they're open, they might not be possible to reopen here */
     static int initted = 0;
     if (initted)
         return;

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -564,7 +564,7 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
                 msgindex += ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
             else
             {
-                pd_error(x, "oscformat: expected symbol but got float");
+                pd_error(x, "oscformat: expected symbol for argument %d", j+1);
                 return;
             }
         }

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -559,7 +559,15 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
             typecode = 's';
         else typecode = 'f';
         if (typecode == 's')
-            msgindex += ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
+        {
+            if (argv[j].a_type == A_SYMBOL)
+                msgindex += ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
+            else
+            {
+                pd_error(x, "oscformat: expected symbol but got float");
+                return;
+            }
+        }
         else if (typecode == 'b')
         {
             int blobsize = 0x7fffffff, blobindex;

--- a/src/x_time.c
+++ b/src/x_time.c
@@ -12,7 +12,7 @@
     a form usable by clock_setunit)( and clock_gettimesincewithunits().
     This brute-force search through symbols really ought not to be done on
     the fly for incoming 'tempo' messages, hmm...  This isn't public because
-    its interface migth want to change - but it's used in x_text.c as well
+    its interface might want to change - but it's used in x_text.c as well
     as here. */
 void parsetimeunits(void *x, t_float amount, t_symbol *unitname,
     t_float *unit, int *samps)


### PR DESCRIPTION
Some more running updates:

* catch malformed messages to [oscformat], fixes #379
* fixed spelling error in posted message
* fixed undo-related crashes with `donecanvasdialog`, fixes https://github.com/pure-data/pure-data/pull/467