### PR TITLE
send st_temppath to GUI

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -142,6 +142,7 @@ struct _instanceinter
 extern int sys_guisetportnumber;
 extern int sys_addhist(int phase);
 void sys_set_searchpath(void);
+void sys_set_temppath(void);
 void sys_set_extrapath(void);
 void sys_set_startup(void);
 void sys_stopgui( void);
@@ -1285,6 +1286,7 @@ static int sys_do_startgui(const char *libdir)
     sys_get_audio_apis(apibuf);
     sys_get_midi_apis(apibuf2);
     sys_set_searchpath();     /* tell GUI about path and startup flags */
+    sys_set_temppath();
     sys_set_extrapath();
     sys_set_startup();
                        /* ... and about font, medio APIS, etc */

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -619,6 +619,18 @@ void sys_set_searchpath( void)
     sys_gui("set ::sys_searchpath $::tmp_path\n");
 }
 
+    /* send the temp paths from the commandline to pd-gui */
+void sys_set_temppath(void)
+{
+    int i;
+    t_namelist *nl;
+
+    sys_gui("set ::tmp_path {}\n");
+    for (nl = STUFF->st_temppath, i = 0; nl; nl = nl->nl_next, i++)
+        sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
+    sys_gui("set ::sys_temppath $::tmp_path\n");
+}
+
     /* send the hard-coded search path to pd-gui */
 void sys_set_extrapath( void)
 {

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -461,6 +461,12 @@ proc ::helpbrowser::build_references {} {
         lappend searchpaths $dir
     }
 
+    # sys_temppath (aka -path on commandline)
+    foreach pathdir $::sys_temppath {
+        set dir [string trimright [file normalize $pathdir]]
+        lappend searchpaths $dir
+    }
+
     # remove any *exact* duplicates between user search paths and system paths
     set searchpaths [lsort -unique $searchpaths]
 

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -155,9 +155,11 @@ set font_zoom2_measured {}
 set sys_libdir {}
 # root path where the pd-gui.tcl GUI script is located
 set sys_guidir {}
-# user-specified search path for objects, help, fonts, etc.
+# user-specified search paths for objects, help, fonts, etc.
 set sys_searchpath {}
-# hard-coded search patch for objects, help, plugins, etc.
+# user-specified search paths from the commandline -path option
+set sys_temppath {}
+# hard-coded search patchs for objects, help, plugins, etc.
 set sys_staticpath {}
 # the path to the folder where the current plugin is being loaded from
 set current_plugin_loadpath {}
@@ -774,7 +776,7 @@ proc load_startup_plugins {} {
     load_plugin_script [file join $::sys_guidir pd_docsdir.tcl]
 
     # load other installed plugins
-    foreach pathdir [concat $::sys_searchpath $::sys_staticpath] {
+    foreach pathdir [concat $::sys_searchpath $::sys_temppath $::sys_staticpath] {
         set dir [file normalize $pathdir]
         if { ! [file isdirectory $dir]} {continue}
         foreach filename [glob -directory $dir -nocomplain -types {f} -- \

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -844,6 +844,13 @@ proc ::deken::preferences::create {mytoplevel} {
         ::deken::preferences::create_pathentry ${pathsframe} ${row} ::deken::preferences::installpath $p
         incr row
     }
+    ::deken::preferences::create_pathpad ${pathsframe} ${row}
+    incr row
+
+    foreach p $::sys_temppath {
+        ::deken::preferences::create_pathentry ${pathsframe} ${row} ::deken::preferences::installpath $p
+        incr row
+    }
 
     pack $pathsframe -fill x
     $mytoplevel.installdir.cnv create window 0 0 -anchor nw -window $pathsframe


### PR DESCRIPTION
This PR adds sending of the `st_temppath` core paths from the commandline `-path` option to GUI so it they be used for plugins, helpbrowser, and deken. This is accomplished by adding a new GUI variable ` $::sys_temppath`. This should fix the regression of `-path` not be used for loading GUI plugins.

This is a fix for #483 which was introduced when separating the `-path` temporary paths from the savable `st_searchpaths`.