### PR TITLE
settable stackdepth via pd message

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -40,6 +40,7 @@ void glob_watchdog(t_pd *dummy);
 void glob_loadpreferences(t_pd *dummy, t_symbol *s);
 void glob_savepreferences(t_pd *dummy, t_symbol *s);
 void glob_forgetpreferences(t_pd *dummy);
+void glob_stackdepth(void *dummy, t_symbol *s, int argc, t_atom *argv);
 
 static void glob_helpintro(t_pd *dummy)
 {
@@ -199,6 +200,8 @@ void glob_init(void)
     class_addmethod(glob_pdobject, (t_method)glob_watchdog,
         gensym("watchdog"), 0);
 #endif
+    class_addmethod(glob_pdobject, (t_method)glob_stackdepth,
+        gensym("stackdepth"), A_GIMME, 0);
     class_addanything(glob_pdobject, max_default);
     pd_bind(&glob_pdobject, gensym("pd"));
 }

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -299,9 +299,23 @@ void obj_init(void)
 /* --------------------------- outlets ------------------------------ */
 
 static PERTHREAD int stackcount = 0; /* iteration counter */
-#define STACKITER 1000 /* maximum iterations allowed */
+static PERTHREAD int stackdepth = 1000; /* maximum iterations allowed */
 
 static PERTHREAD int outlet_eventno;
+
+    /* the "stackdepth" message to sets the max allowed stack iterations */
+
+void glob_stackdepth(void *dummy, t_symbol *s, int argc, t_atom *argv)
+{
+    int depth;
+    if (argc)
+    {
+        depth = atom_getfloatarg(0, argc, argv);
+        if(depth > 0) stackdepth = depth;
+        else post("warning: stackdepth must be greater than 0");
+    }
+    else post("stackdepth %d", stackdepth);
+}
 
     /* set a stack limit (on each incoming event that can set off messages)
     for the outlet functions to check to prevent stack overflow from message
@@ -356,7 +370,7 @@ static void outlet_stackerror(t_outlet *x)
 void outlet_bang(t_outlet *x)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
@@ -368,7 +382,7 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
 {
     t_outconnect *oc;
     t_gpointer gpointer;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     {
@@ -382,7 +396,7 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
 void outlet_float(t_outlet *x, t_float f)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
@@ -393,7 +407,7 @@ void outlet_float(t_outlet *x, t_float f)
 void outlet_symbol(t_outlet *x, t_symbol *s)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
@@ -404,7 +418,7 @@ void outlet_symbol(t_outlet *x, t_symbol *s)
 void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
@@ -415,7 +429,7 @@ void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(++stackcount >= stackdepth)
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)


### PR DESCRIPTION
This PR adds a settable max stack depth before throwing a stack overflow error. A new "pd stackdepth" message can set the value with a float > 0 or print the current value to the console.

This is an implementation of #482.

One thing missing is a help patch for the manual explaining how/why you would need this. 

Screenshot with stackdepth at 1000:

![screen shot 2018-09-22 at 1 55 43 am](https://user-images.githubusercontent.com/480637/45910677-639dbe00-be0b-11e8-83a3-fe180bff48e7.png)

and stackdepth at 10000:

![screen shot 2018-09-22 at 1 55 50 am](https://user-images.githubusercontent.com/480637/45910680-6b5d6280-be0b-11e8-9c14-84a0e6113c6c.png)
