### PR TITLE
dump tcl source code on error

### DIFF
--- a/tcl/pd_connect.tcl
+++ b/tcl/pd_connect.tcl
@@ -100,6 +100,8 @@ proc ::pd_connect::pd_readsocket {} {
                      ::pdwindow::fatal \
                          [concat [_ "(Tcl) UNHANDLED ERROR: "] $errorInfo "\n"]
                  }
+                 ::pdwindow::fatal \
+                     [concat [_ "(Tcl) COMMAND SOURCE CODE: "] $docmds "\n"]
              }
          }
      }


### PR DESCRIPTION
printing the offending tcl code on error may help developers diagnose the source