### PR TITLE
re-fix portaudio unplug regression with patch

### DIFF
--- a/mac/README.txt
+++ b/mac/README.txt
@@ -111,7 +111,12 @@ tcltk-wish.sh --git commandline option. Oftentimes, these kinds of issues will
 appear with a newer version of macOS before they have been fixed by the open
 source community.
 
-Additionally, Pd uses an older version of Tcl/Tk for backwards compatibility on macOS. As such, small bugfixes from newer versions may need to be backported for the Pd GUI. Currently, this is handled in the tcltk-wish.sh script by applying custom patches to either the Tcl and/or Tk source trees. To skip applying patches, use the tcltk-wish.sh --no-patches commandline option. See mac/patches/README.txt for more info.
+Additionally, Pd uses an older version of Tcl/Tk for backwards compatibility on
+macOS. As such, small bugfixes from newer versions may need to be backported for
+the Pd GUI. Currently, this is handled in the tcltk-wish.sh script by applying
+custom patches to either the Tcl and/or Tk source trees. To skip applying
+patches, use the tcltk-wish.sh --no-patches commandline option. See
+mac/patches/README.txt for more info.
 
 ## Supplementary Build Scripts
 

--- a/portaudio/README.txt
+++ b/portaudio/README.txt
@@ -27,3 +27,12 @@ As a second option, you can build Pd using a system-installed PortAudio via:
     make
 
 For more info on PortAudio, see http://portaudio.com
+
+There may be custom patches to apply to the PortAudio sources in the "patches"
+directory which are applied by the "update.sh" script automatically using:
+
+    patch -p1 < ../patches/some_unreleased_fix.patch
+
+To generate a patch file from a PortAudio git clone:
+
+    git diff > some_newfix.patch

--- a/portaudio/patches/mac_deviceisalive_listener.patch
+++ b/portaudio/patches/mac_deviceisalive_listener.patch
@@ -1,0 +1,113 @@
+diff --git a/src/hostapi/coreaudio/pa_mac_core.c b/src/hostapi/coreaudio/pa_mac_core.c
+index 257e9de..361d281 100644
+--- a/src/hostapi/coreaudio/pa_mac_core.c
++++ b/src/hostapi/coreaudio/pa_mac_core.c
+@@ -1117,6 +1117,34 @@ static OSStatus AudioDevicePropertyGenericListenerProc( AudioDeviceID inDevice,
+     return osErr;
+ }
+ 
++/* this is called when a device unexpectedly disappears, ie. is unplugged while streaming */
++static OSStatus AudioDevicePropertyIsAliveListenerProc( AudioObjectID inDevice, UInt32 inNumberAddresses, const AudioObjectPropertyAddress inAddresses[], void* inClientData )
++{
++    OSStatus osErr = noErr;
++    PaMacCoreStream *stream = (PaMacCoreStream*)inClientData;
++    Boolean isInput = (inDevice == stream->inputDevice);
++
++    // Make sure the callback is operating on a stream that is still valid!
++    assert( stream->streamRepresentation.magic == PA_STREAM_MAGIC );
++
++    AudioObjectPropertyAddress currentAddress = inAddresses[0];
++    if( currentAddress.mSelector == kAudioDevicePropertyDeviceIsAlive )
++    {
++        UInt32 alive = 1;
++        osErr = QueryUInt32DeviceProperty( inDevice, isInput, kAudioDevicePropertyDeviceIsAlive, &alive );
++        if( osErr == noErr && alive == 0 )
++        {
++            // abort the stream so the audio unit(s) are cleaned up,
++            // inDevice may no longer be valid & retrieving kAudioDevicePropertyDeviceName
++            // doesn't seem to work here, too bad we can't print the device name
++            DBUG( ( "WARNING: Device no longer alive, aborting Stream.\n" ) );
++            AbortStream(stream);
++        }
++    }
++
++    return osErr;
++}
++
+ /* ================================================================================= */
+ /*
+  * Setup listeners in case device properties change during the run. */
+@@ -1142,6 +1170,15 @@ static OSStatus SetupDevicePropertyListeners( PaMacCoreStream *stream, AudioDevi
+     AudioDeviceAddPropertyListener( deviceID, 0, isInput, kAudioDevicePropertySafetyOffset, 
+                                    AudioDevicePropertyGenericListenerProc, stream );
+     
++    // listener for detecting when a device is removed
++    const AudioObjectPropertyAddress aliveAddress = {
++         kAudioDevicePropertyDeviceIsAlive,
++         kAudioObjectPropertyScopeGlobal,
++         kAudioObjectPropertyElementMaster
++     };
++     AudioObjectAddPropertyListener( deviceID, &aliveAddress,
++                                   AudioDevicePropertyIsAliveListenerProc, stream);
++
+     return osErr;
+ }
+ 
+@@ -1156,6 +1193,13 @@ static void CleanupDevicePropertyListeners( PaMacCoreStream *stream, AudioDevice
+                                    AudioDevicePropertyGenericListenerProc );
+     AudioDeviceRemovePropertyListener( deviceID, 0, isInput, kAudioDevicePropertySafetyOffset, 
+                                    AudioDevicePropertyGenericListenerProc );
++
++    const AudioObjectPropertyAddress aliveAddress = {
++        kAudioDevicePropertyDeviceIsAlive,
++        kAudioObjectPropertyScopeGlobal,
++        kAudioObjectPropertyElementMaster
++    };
++    AudioObjectRemovePropertyListener( deviceID, &aliveAddress, AudioDevicePropertyIsAliveListenerProc, stream );
+ }
+ 
+ /* ================================================================================= */
+@@ -2283,7 +2327,9 @@ static OSStatus AudioIOProc( void *inRefCon,
+                     INPUT_ELEMENT,
+                     inNumberFrames,
+                     &stream->inputAudioBufferList );
+-      if(err != noErr)
++      /* allow err == -50 on unexpected device unplug to be caught by
++         DeviceIsAlive property listener */
++      if(err != noErr && err != -50)
+       {
+         goto stop_stream;
+       }
+@@ -2377,7 +2423,9 @@ static OSStatus AudioIOProc( void *inRefCon,
+                   }
+                }
+                ERR( err );
+-               if(err != noErr)
++               /* allow err == -50 on unexpected device unplug to be caught by
++                  DeviceIsAlive property listener */
++               if(err != noErr && err != -50)
+                {
+                  goto stop_stream;
+                }
+@@ -2488,7 +2536,9 @@ static OSStatus AudioIOProc( void *inRefCon,
+             inNumberFrames /= 2;
+       } while( err == -10874 && inNumberFrames > 1 );
+       ERR( err );
+-      if(err != noErr)
++      /* allow err == -50 on unexpected device unplug to be caught by
++         DeviceIsAlive property listener */
++      if(err != noErr && err != -50)
+       {
+           goto stop_stream;
+       }
+@@ -2552,7 +2602,9 @@ static OSStatus AudioIOProc( void *inRefCon,
+                           (void *)data );
+             if( err != RING_BUFFER_EMPTY )
+                ERR( err );
+-            if( err != noErr && err != RING_BUFFER_EMPTY )
++            /* allow err == -50 on unexpected device unplug to be caught by
++               DeviceIsAlive property listener */
++            if( err != noErr && err != -50 && err != RING_BUFFER_EMPTY )
+             {
+                 goto stop_stream;
+             }

--- a/portaudio/update.sh
+++ b/portaudio/update.sh
@@ -60,16 +60,16 @@ cd $SRC && ./update_gitrevision.sh && cd -
 # apply patches, note: this probably can't handle filenames with spaces
 # temp disable exit on error since the exit value of patch --dry-run is used
 echo "==== Applying any patches"
-set +e
 for p in $(find ./patches -type f -name "*.patch") ; do
     cd $SRC
+    set +e
     (patch -p1 -N --silent --dry-run --input "../${p}" > /dev/null 2>&1)
+    set -e
     if [[ $? == 0 ]] ; then
         patch -p1 < "../${p}"
     fi
     cd ../
 done
-set -e
 
 echo "==== Copying"
 

--- a/portmidi/update.sh
+++ b/portmidi/update.sh
@@ -41,6 +41,7 @@ fi
 cd $(dirname $0)
 
 # checkout source
+echo "==== Downloading portmidi $VERSION"
 if [ -d $SRC ] ; then
 	rm -rf $SRC
 fi
@@ -48,6 +49,7 @@ svn checkout https://svn.code.sf.net/p/portmedia/code/portmidi/trunk${VERSION} $
 
 # apply patches, note: this probably can't handle filenames with spaces
 # temp disable exit on error since the exit value of patch --dry-run is used
+echo "==== Applying any patches"
 set +e
 for p in $(find ./patches -type f -name "*.patch") ; do
     cd $SRC
@@ -58,6 +60,8 @@ for p in $(find ./patches -type f -name "*.patch") ; do
     cd ../
 done
 set -e
+
+echo "==== Copying"
 
 # copy what we need, namely the main headers and relevant sources
 copysrc pm_common

--- a/portmidi/update.sh
+++ b/portmidi/update.sh
@@ -50,16 +50,16 @@ svn checkout https://svn.code.sf.net/p/portmedia/code/portmidi/trunk${VERSION} $
 # apply patches, note: this probably can't handle filenames with spaces
 # temp disable exit on error since the exit value of patch --dry-run is used
 echo "==== Applying any patches"
-set +e
 for p in $(find ./patches -type f -name "*.patch") ; do
     cd $SRC
+    set +e
     (patch -p0 -N --silent --dry-run --input "../${p}" > /dev/null 2>&1)
+    set -e
     if [[ $? == 0 ]] ; then
         patch -p0 < "../${p}"
     fi
     cd ../
 done
-set -e
 
 echo "==== Copying"
 


### PR DESCRIPTION
This PR readds 73ea12f6ae43c0ba7b134574a88c15f707e26f43 as a patch against the current portaudio version. This should also fix #470 again for test4.

Basically, some basic error handling was added to the upstream portaudio sources, but the real fix for this is to catch the Coreaudio notification when a device is no longer "alive." I will forward this patch upstream now that it's relatively clean.

*whack a mole*

This also updates the scripts to make it easier to see what's going on and to halt when a patch can't be applied.
