### PR TITLE
more simple bugfixes for Pd-0.49

### DIFF
--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -383,9 +383,6 @@ proc init_for_platform {} {
             option add *DialogWindow*font menufont startupFile
             option add *PdWindow*font menufont startupFile
             option add *ErrorDialog*font menufont startupFile
-            # initial dir is home
-            set ::filenewdir $::env(HOME)
-            set ::fileopendir $::env(HOME)
             # set file types that open/save recognize
             set ::filetypes \
                 [list \


### PR DESCRIPTION
trying to keep bugfixes even simpler than last time...

- [x] on windows, when starting Pd via pd.exe (or pd.com), use the current-directory as the starting point for fileopendir/filenewdir (as is already the case with the other OSs); Closes #478