### PR TITLE
fix iem gop again

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -393,7 +393,8 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_snd = snd = canvas_realizedollar(iemgui->x_glist, snd);
     iemgui->x_fsf.x_snd_able = sndable;
     iemgui_verify_snd_ne_rcv(iemgui);
-    (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    if(glist_isvisible(iemgui->x_glist))
+        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
 }
 
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -427,7 +428,8 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
     }
     iemgui->x_fsf.x_rcv_able = rcvable;
     iemgui_verify_snd_ne_rcv(iemgui);
-    (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    if(glist_isvisible(iemgui->x_glist))
+        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
 }
 
 void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -539,8 +541,11 @@ void iemgui_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 
     x->x_obj.te_xpix += dx;
     x->x_obj.te_ypix += dy;
-    (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(glist, (t_text *)z);
+    if(glist_isvisible(x->x_glist))
+    {
+        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_MOVE);
+        canvas_fixlinesfor(glist, (t_text *)z);
+    }
 }
 
 void iemgui_select(t_gobj *z, t_glist *glist, int selected)
@@ -548,7 +553,8 @@ void iemgui_select(t_gobj *z, t_glist *glist, int selected)
     t_iemgui *x = (t_iemgui *)z;
 
     x->x_fsf.x_selected = selected;
-    (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_SELECT);
+    if(glist_isvisible(x->x_glist))
+        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_SELECT);
 }
 
 void iemgui_delete(t_gobj *z, t_glist *glist)


### PR DESCRIPTION
Restore `glist_isvisible()` protection for `send()`, `receive()`, `displace()` and `select()` methods.

Closes #477, that was happening again, when loadbang-setting a receive/send name of an iemgui located inside of a GOP, itself contained into a non-GOP patch.
