### PR TITLE
increase portaudio max poll

### DIFF
--- a/mac/README.txt
+++ b/mac/README.txt
@@ -111,7 +111,12 @@ tcltk-wish.sh --git commandline option. Oftentimes, these kinds of issues will
 appear with a newer version of macOS before they have been fixed by the open
 source community.
 
-Additionally, Pd uses an older version of Tcl/Tk for backwards compatibility on macOS. As such, small bugfixes from newer versions may need to be backported for the Pd GUI. Currently, this is handled in the tcltk-wish.sh script by applying custom patches to either the Tcl and/or Tk source trees. To skip applying patches, use the tcltk-wish.sh --no-patches commandline option. See mac/patches/README.txt for more info.
+Additionally, Pd uses an older version of Tcl/Tk for backwards compatibility on
+macOS. As such, small bugfixes from newer versions may need to be backported for
+the Pd GUI. Currently, this is handled in the tcltk-wish.sh script by applying
+custom patches to either the Tcl and/or Tk source trees. To skip applying
+patches, use the tcltk-wish.sh --no-patches commandline option. See
+mac/patches/README.txt for more info.
 
 ## Supplementary Build Scripts
 

--- a/portaudio/update.sh
+++ b/portaudio/update.sh
@@ -1,4 +1,4 @@
-##! /bin/bash
+#! /bin/bash
 #
 # this script automatically downloads and copies the portaudio library for Pd
 #
@@ -29,31 +29,35 @@ VERSION=""
 
 # copy .h & .c files from $SRC to $DEST, ignore missing file errors
 function copysrc {
-	mkdir -p $DEST/$1
-	cp -v $SRC/$1/*.h $DEST/$1 2>/dev/null || :
-	cp -v $SRC/$1/*.c $DEST/$1 2>/dev/null || :
+    mkdir -p $DEST/$1
+    cp -v $SRC/$1/*.h $DEST/$1 2>/dev/null || :
+    cp -v $SRC/$1/*.c $DEST/$1 2>/dev/null || :
 }
 
 ##### GO
 
 if [ $# -gt 0 ] ; then
-	VERSION="$1"
+    VERSION="$1"
 fi
 
 # move to this scripts dir
 cd $(dirname $0)
 
 # clone source
+echo "==== Downloading portaudio $VERSION"
 if [ -d $SRC ] ; then
-	rm -rf $SRC
+    rm -rf $SRC
 fi
 git clone https://git.assembla.com/portaudio.git $SRC
-if [ "$VERSION" -ne "" ] ; then
-	cd $SRC && git checkout $VERSION && cd -
+if [[ "$VERSION" != "" ]] ; then
+    cd $SRC && git checkout $VERSION && cd -
 fi
 
 # set git revision
+echo "==== Set git revision"
 cd $SRC && ./update_gitrevision.sh && cd -
+
+echo "==== Copying"
 
 # remove stuff we don't need
 rm $SRC/include/pa_jack.h

--- a/portmidi/update.sh
+++ b/portmidi/update.sh
@@ -1,4 +1,4 @@
-##! /bin/bash
+#! /bin/bash
 #
 # this script automatically downloads and copies the portmidi library for Pd
 #
@@ -25,39 +25,43 @@ VERSION=""
 
 # copy .h & .c files from $SRC to $DEST, ignore missing file errors
 function copysrc {
-	mkdir -p $DEST/$1
-	cp -v $SRC/$1/*.h $DEST/$1 2>/dev/null || :
-	cp -v $SRC/$1/*.c $DEST/$1 2>/dev/null || :
+    mkdir -p $DEST/$1
+    cp -v $SRC/$1/*.h $DEST/$1 2>/dev/null || :
+    cp -v $SRC/$1/*.c $DEST/$1 2>/dev/null || :
 }
 
 ##### GO
 
 # append revision number to checkout rule ala @###
 if [ $# -gt 0 ] ; then
-	VERSION="@$1"
+    VERSION="@$1"
 fi
 
 # move to this scripts dir
 cd $(dirname $0)
 
 # checkout source
+echo "==== Downloading portmidi $VERSION"
 if [ -d $SRC ] ; then
-	rm -rf $SRC
+    rm -rf $SRC
 fi
 svn checkout https://svn.code.sf.net/p/portmedia/code/portmidi/trunk${VERSION} $SRC
 
 # apply patches, note: this probably can't handle filenames with spaces
 # temp disable exit on error since the exit value of patch --dry-run is used
-set +e
+echo "==== Applying any patches"
 for p in $(find ./patches -type f -name "*.patch") ; do
     cd $SRC
+    set +e
     (patch -p0 -N --silent --dry-run --input "../${p}" > /dev/null 2>&1)
+    set -e
     if [[ $? == 0 ]] ; then
         patch -p0 < "../${p}"
     fi
     cd ../
 done
-set -e
+
+echo "==== Copying"
 
 # copy what we need, namely the main headers and relevant sources
 copysrc pm_common

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -92,7 +92,7 @@ static pthread_cond_t pa_sem;
 #endif
 /* max number of unsuccessful polls before trying to reopen the device */
 #ifndef MAX_NUM_POLLS
-#define MAX_NUM_POLLS 1000
+#define MAX_NUM_POLLS 2000
 #endif
 #endif /* THREADSIGNAL */
 #endif  /* FAKEBLOCKING */


### PR DESCRIPTION
This PR increases the portaudio max poll to 2000 to fix #470. This detail was used in a test build but not actually committed. This is a replacement for #490 as it no longer seems necessary to patch the portaudio sources (yay!).

A test build for this approach is: 
http://docs.danomatika.com/pdbuilds/Pd-0.49-0test4-unplugfix4-nopatch.zip

There are also a few updates to the portaudio/portmidi scripts.
