### PR TITLE
Msw installer updates

### DIFF
--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -115,6 +115,10 @@ if [  "x$PDARCH" = "x" ]; then
     cleanup 1
 fi
 
+# autodetect TCL interpreter 
+
+PDWISH=$(find "$PDWINDIR" -name "wish**.exe" -printf "%f")
+
 #### WRITE INSTALL LIST #########################################
 find "$PDWINDIR" \
   -mindepth 0 \
@@ -174,7 +178,7 @@ case $nsis_exit in
 esac
 
 # run the build
-if makensis -DARCHI=${PDARCH} ${NSIFILE}
+if makensis -DARCHI=${PDARCH} -DWISHI=${PDWISH} ${NSIFILE}
 then
   echo "Build successful"
 else

--- a/msw/pd.nsi
+++ b/msw/pd.nsi
@@ -99,11 +99,11 @@ SectionGroup /e "${COMPONENT_GROUP_TEXT}"
     CreateDirectory "$SMPROGRAMS\${PRODUCT_NAME}"
     CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Website.lnk" "$INSTDIR\${PRODUCT_NAME}.url"
     CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\Uninstall.lnk" "$INSTDIR\uninst.exe"
-    CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\bin\wish85.exe" '"$INSTDIR\tcl\pd-gui.tcl"' "$INSTDIR\bin\pd.exe" 0
+    CreateShortCut "$SMPROGRAMS\${PRODUCT_NAME}\${PRODUCT_NAME}.lnk" "$INSTDIR\bin\${WISHI}" '"$INSTDIR\tcl\pd-gui.tcl"' "$INSTDIR\bin\pd.exe" 0
   SectionEnd
 
   Section "${COMPONENT_DESKTOPSHORTCUT_TEXT}" DesktopShortcut
-    CreateShortCut "$Desktop\${PRODUCT_NAME}.lnk" "$INSTDIR\bin\wish85.exe" '"$INSTDIR\tcl\pd-gui.tcl"' "$INSTDIR\bin\pd.exe" 0
+    CreateShortCut "$Desktop\${PRODUCT_NAME}.lnk" "$INSTDIR\bin\${WISHI}" '"$INSTDIR\tcl\pd-gui.tcl"' "$INSTDIR\bin\pd.exe" 0
   SectionEnd
 
   Section "${COMPONENT_FILEASSOC_TEXT}" SetFileAssociations
@@ -113,7 +113,7 @@ SectionGroup /e "${COMPONENT_GROUP_TEXT}"
     WriteRegStr HKCR "PureData\DefaultIcon" "" "$INSTDIR\bin\pd.exe"
     WriteRegStr HKCR "PureData\shell" "" ""
     WriteRegStr HKCR "PureData\shell\open" "" ""
-    WriteRegStr HKCR "PureData\shell\open\command" "" '$INSTDIR\bin\wish85.exe "$INSTDIR\tcl\pd-gui.tcl" %1'
+    WriteRegStr HKCR "PureData\shell\open\command" "" '$INSTDIR\bin\${WISHI} "$INSTDIR\tcl\pd-gui.tcl" %1'
   ; Set file ext icon
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.pd" "" ""
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.pd\OpenWithList" "a" "pd.exe"


### PR DESCRIPTION
This PR finds the `wish**.exe` that we are currently using when building the Pd-installer so that `wish85.exe` does not have to be hard-coded in `pd.nsi`. 
This allows to build the installer with whatever wish**.exe we are using (`wish85.exe`, `wish86.exe`, ...).