### PR TITLE
Update vector size after resize

### DIFF
--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -192,6 +192,7 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
                 nalloc * (2*sizeof(*x->b_vec)));
             nalloc = nalloc * 2;
             ap = x->b_vec + natom;
+            x->b_n = nalloc;
         }
         if (textp == etext) break;
     }


### PR DESCRIPTION
The size is updated at the end of the function but I think it would be more correct to update it on every resize.