### PR TITLE
Export obj_findsignalscalar function

### DIFF
--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -17,7 +17,6 @@
 #include <stdarg.h>
 
 extern t_class *vinlet_class, *voutlet_class, *canvas_class, *text_class;
-t_float *obj_findsignalscalar(t_object *x, int m);
 
 EXTERN_STRUCT _vinlet;
 EXTERN_STRUCT _voutlet;

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -84,6 +84,7 @@ EXTERN int obj_nsiginlets(const t_object *x);
 EXTERN int obj_nsigoutlets(const t_object *x);
 EXTERN int obj_siginletindex(const t_object *x, int m);
 EXTERN int obj_sigoutletindex(const t_object *x, int m);
+EXTERN t_float *obj_findsignalscalar(const t_object *x, int m);
 
 /* s_inter.c */
 void pd_globallock( void);

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -422,7 +422,7 @@ EXTERN void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
 EXTERN t_symbol *outlet_getsymbol(t_outlet *x);
 EXTERN void outlet_free(t_outlet *x);
 EXTERN t_object *pd_checkobject(t_pd *x);
-EXTERN t_float *obj_findsignalscalar(t_object *x, int m);
+EXTERN t_float *obj_findsignalscalar(const t_object *x, int m);
 
 
 /* -------------------- canvases -------------- */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -422,6 +422,7 @@ EXTERN void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
 EXTERN t_symbol *outlet_getsymbol(t_outlet *x);
 EXTERN void outlet_free(t_outlet *x);
 EXTERN t_object *pd_checkobject(t_pd *x);
+EXTERN t_float *obj_findsignalscalar(t_object *x, int m);
 
 
 /* -------------------- canvases -------------- */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -422,7 +422,6 @@ EXTERN void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
 EXTERN t_symbol *outlet_getsymbol(t_outlet *x);
 EXTERN void outlet_free(t_outlet *x);
 EXTERN t_object *pd_checkobject(t_pd *x);
-EXTERN t_float *obj_findsignalscalar(const t_object *x, int m);
 
 
 /* -------------------- canvases -------------- */


### PR DESCRIPTION
This exports the `obj_findsignalscalar` function.
This function is currently used by some plugins in [cyclone](https://github.com/porres/pd-cyclone). See [here](https://github.com/porres/pd-cyclone/search?q=obj_findsignalscalar&unscoped_q=obj_findsignalscalar).

I was not sure where to put it in the header file. Please let me know if I should put it somewhere else.