### PR TITLE
key, keyup, & keyname ignore events in edit mode

### DIFF
--- a/doc/5.reference/key-help.pd
+++ b/doc/5.reference/key-help.pd
@@ -1,24 +1,30 @@
-#N canvas 146 45 546 288 12;
+#N canvas 146 45 509 365 12;
 #X obj 21 10 key;
-#X obj 54 9 keyup;
-#X obj 105 9 keyname;
+#X obj 54 10 keyup;
+#X obj 105 10 keyname;
 #X text 173 8 -- grab keyboard;
 #X obj 38 67 key;
 #X floatatom 38 95 3 0 0 0 - - -;
-#X floatatom 77 93 3 0 0 0 - - -;
+#X floatatom 77 95 3 0 0 0 - - -;
 #X obj 77 67 keyup;
-#X floatatom 128 93 3 0 0 0 - - -;
+#X floatatom 128 95 3 0 0 0 - - -;
 #X obj 128 67 keyname;
-#X symbolatom 172 94 10 0 0 0 - - -;
-#X text 280 262 updated for Pd version 0.32.;
+#X symbolatom 174 95 10 0 0 0 - - -;
 #X text 26 133 Key and keyup report the (system dependent) numbers
 of "printing" keys of the keyboard. Keyname gives the symbolic name
 of the key \, with a 1 or 0 if it's up or down \, and works with non-printing
 keys like shift or "F1".;
-#X text 18 200 Caveat -- this only works if Pd actually gets the key
+#X text 26 200 Caveat -- this only works if Pd actually gets the key
 events which can depend on the stacking order of windows and/or the
 pointer location \, depending on the system.;
+#X obj 38 262 key 1;
+#X floatatom 38 292 3 0 0 0 - - -;
+#X text 93 263 As of Pd 0.5 \, the key objects take an optional creation
+argument to ignore events when the patch is in edit mode. Set to 1
+to ignore and 0 to accept all events (default).;
+#X text 280 325 updated for Pd version 0.50.;
 #X connect 4 0 5 0;
 #X connect 7 0 6 0;
 #X connect 9 0 8 0;
 #X connect 9 1 10 0;
+#X connect 13 0 14 0;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -297,15 +297,13 @@ static t_class *key_class, *keyup_class, *keyname_class;
 typedef struct _key
 {
     t_object x_obj;
-    unsigned int x_ignore:1; /* ignore edit mode key events? */
-    t_canvas *x_canvas;
+    t_canvas *x_canvas; /* set if ignoring edit mode key events */
 } t_key;
 
 static void *key_new(t_floatarg ignore)
 {
     t_key *x = (t_key *)pd_new(key_class);
-    x->x_ignore = (unsigned int)ignore;
-    if (ignore) x->x_canvas = canvas_getcurrent();
+    x->x_canvas = (ignore == 1 ? canvas_getcurrent() : NULL);
     outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, gensym("#key"));
     return (x);
@@ -313,7 +311,7 @@ static void *key_new(t_floatarg ignore)
 
 static void key_float(t_key *x, t_floatarg f)
 {
-    if (x->x_ignore && x->x_canvas->gl_edit)
+    if (x->x_canvas && x->x_canvas->gl_edit)
         return;
     outlet_float(x->x_obj.ob_outlet, f);
 }
@@ -326,15 +324,13 @@ static void key_free(t_key *x)
 typedef struct _keyup
 {
     t_object x_obj;
-    unsigned int x_ignore:1; /* ignore edit mode key events? */
-    t_canvas *x_canvas;
+    t_canvas *x_canvas; /* set if ignoring edit mode key events */
 } t_keyup;
 
 static void *keyup_new(t_floatarg ignore)
 {
     t_keyup *x = (t_keyup *)pd_new(keyup_class);
-    x->x_ignore = (unsigned int)ignore;
-    if (ignore) x->x_canvas = canvas_getcurrent();
+    x->x_canvas = (ignore == 1 ? canvas_getcurrent() : NULL);
     outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, gensym("#keyup"));
     return (x);
@@ -342,7 +338,7 @@ static void *keyup_new(t_floatarg ignore)
 
 static void keyup_float(t_keyup *x, t_floatarg f)
 {
-    if (x->x_ignore && x->x_canvas->gl_edit)
+    if (x->x_canvas && x->x_canvas->gl_edit)
         return;
     outlet_float(x->x_obj.ob_outlet, f);
 }
@@ -355,8 +351,7 @@ static void keyup_free(t_keyup *x)
 typedef struct _keyname
 {
     t_object x_obj;
-    unsigned int x_ignore:1; /* ignore edit mode key events? */
-    t_canvas *x_canvas;
+    t_canvas *x_canvas; /* set if ignoring edit mode key events */
     t_outlet *x_outlet1;
     t_outlet *x_outlet2;
 } t_keyname;
@@ -364,8 +359,7 @@ typedef struct _keyname
 static void *keyname_new(t_floatarg ignore)
 {
     t_keyname *x = (t_keyname *)pd_new(keyname_class);
-    x->x_ignore = (unsigned int)ignore;
-    if (ignore) x->x_canvas = canvas_getcurrent();
+    x->x_canvas = (ignore == 1 ? canvas_getcurrent() : NULL);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_symbol);
     pd_bind(&x->x_obj.ob_pd, gensym("#keyname"));
@@ -374,7 +368,7 @@ static void *keyname_new(t_floatarg ignore)
 
 static void keyname_list(t_keyname *x, t_symbol *s, int ac, t_atom *av)
 {
-    if (x->x_ignore && x->x_canvas->gl_edit)
+    if (x->x_canvas && x->x_canvas->gl_edit)
         return;
     outlet_symbol(x->x_outlet2, atom_getsymbolarg(1, ac, av));
     outlet_float(x->x_outlet1, atom_getfloatarg(0, ac, av));


### PR DESCRIPTION
This PR adds an optional creation argument to [key], [keyup], & [keyname] to ignore events if canvas is in edit mode. Basically, this allows you to edit without triggering what you are editing.

This is creation argument is just a boolean using the first float:
- 0 : allow key events in both run & edit mode (default, current behavior)
- 1 : allow events in run mode, ignore in edit mode