### PR TITLE
intelligent patching amendments

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -81,6 +81,19 @@ script settings on the commandline:
     # build Pd using a system installed PortAudio
     ./configure --without-local-portaudio
 
+An important configure option for some platforms is --enable-universal which
+allows you to specify the desired architecture(s) when building Pd. For Intel
+and AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". By default,
+Pd is built for the architecture of the current system, however you may want a
+32 bit Pd to work with existing 32 bit externals on a 64 bit system. You can
+override the defaults with --enable-universal:
+
+    # build 32 bit Pd
+    ./configure --enable-universal=i386
+
+    # build 64 bit Pd
+    ./configure --with-universal=x86_64
+
 The full list of available configuration options can printed by running:
 
     ./configure --help
@@ -184,18 +197,16 @@ need. For example, to install the autotools & gettext using Homebrew:
     brew link --force gettext
 
 By default, Pd is built for the current system architecture, usually 64 bit. If
-you want to override this you can use the --enable-universal configure option 
-which allows you to specify the desired architecture(s) when building Pd. For
-Intel/AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". By
-default, Pd is built for the architecture of the current system, however you may
-want a 32 bit Pd to work with existing 32 bit externals on a 64 bit system. You
-can override the defaults with --enable-universal:
+you want to override this you can use the --enable-universal configure option,
+as mentioned in the main Autotools Build section. On macOS, running this option
+without arguments will build a "fat" Pd for all architectures supported by the
+compiler:
 
-    # build 32 bit Pd
-    ./configure --enable-universal=i386
+* macOS 10.6: i386, x86_64, ppc
+* macOS 10.7+: i386, x86_64
 
-    # build 64 bit Pd
-    ./configure --with-universal=x86_64
+Note: a "fat" Pd may not work on all systems and/or be able to load both 32 or
+64 bit externals. Additonally, you can specify multiple architectures directly:
 
     # build a "fat" Pd for both 32 and 64 bit
     # may not work on all systems
@@ -204,12 +215,6 @@ can override the defaults with --enable-universal:
     # build a "fat" Pd for all detected architectures (macOS: i386, x86_64, ppc)
     # may not work on all systems
     ./configure --enable-universal
-
-On macOS, running this option without arguments will build Pd for all of the
-architectures supported by the compiler:
-
-* 10.6: i386, x86_64, ppc
-* 10.7+: i386, x86_64
 
 The JACK audio server is supported by Pd on macOS. By default, Pd can use the
 Jack OS X runtime framework from http://www.jackosx.com if it is installed on

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -81,25 +81,6 @@ script settings on the commandline:
     # build Pd using a system installed PortAudio
     ./configure --without-local-portaudio
 
-An important configure option is --enable-universal which allows you to specify
-the desired architecture(s) when building Pd. For Intel/AMD processors, 32 bit
-is called "i386" and 64 bit is "x86_64". By default, Pd is built for the
-architecture of the current system, however you may want a 32 bit Pd to work
-with existing 32 bit externals on a 64 bit system. You can override the defaults
-with --enable-universal:
-
-    # build 32 bit Pd
-    ./configure --enable-universal=i386
-
-    # build 64 bit Pd
-    ./configure --with-universal=x86_64
-
-    # build a "fat" Pd for both 32 and 64 bit (not useful on all platforms)
-    ./configure --enable-universal=i386,x86_64
-
-    # build a "fat" Pd for all detected architectures (macOS: i386, x86_64, ppc)
-    ./configure --enable-universal
-
 The full list of available configuration options can printed by running:
 
     ./configure --help
@@ -203,9 +184,29 @@ need. For example, to install the autotools & gettext using Homebrew:
     brew link --force gettext
 
 By default, Pd is built for the current system architecture, usually 64 bit. If
-you want to override this you can use the --enable-universal configure option,
-as mentioned in the main Autotools Build section. On macOS, running this option
-without arguments will build Pd for all architectures supported by the compiler:
+you want to override this you can use the --enable-universal configure option 
+which allows you to specify the desired architecture(s) when building Pd. For
+Intel/AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". By
+default, Pd is built for the architecture of the current system, however you may
+want a 32 bit Pd to work with existing 32 bit externals on a 64 bit system. You
+can override the defaults with --enable-universal:
+
+    # build 32 bit Pd
+    ./configure --enable-universal=i386
+
+    # build 64 bit Pd
+    ./configure --with-universal=x86_64
+
+    # build a "fat" Pd for both 32 and 64 bit
+    # may not work on all systems
+    ./configure --enable-universal=i386,x86_64
+
+    # build a "fat" Pd for all detected architectures (macOS: i386, x86_64, ppc)
+    # may not work on all systems
+    ./configure --enable-universal
+
+On macOS, running this option without arguments will build Pd for all of the
+architectures supported by the compiler:
 
 * 10.6: i386, x86_64, ppc
 * 10.7+: i386, x86_64

--- a/configure.ac
+++ b/configure.ac
@@ -279,7 +279,7 @@ else
     CFLAGS="$CFLAGS $RELEASE_CFLAGS"
 fi
 
-##### Universal/multi architecture build on OSX #####
+##### Universal/multi architecture build on macOS #####
 PD_CHECK_UNIVERSAL(ARCH, [universal=yes], [universal=no])
 AM_CONDITIONAL(UNIVERSAL, test x$universal = xyes)
 if test x$universal = xyes ; then
@@ -290,7 +290,8 @@ fi
 ##### Gettext #####
 # Gettext is needed to build language localizations.
 AC_ARG_ENABLE([locales],
-    [AS_HELP_STRING([--disable-locales], [do not compile localizations (requires gettext)])],
+    [AS_HELP_STRING([--disable-locales],
+        [do not compile localizations (requires gettext)])],
     [locales=$enableval])
 if test x$locales = xyes ; then
     AC_CHECK_PROG(HAVE_MSGFMT, [msgfmt], yes, no)
@@ -325,7 +326,8 @@ fi
 # on macOS, use the JackOSX.com Jackmp.framework not the jack lib by default
 # this is set in src/Makefile.am based on the JACK & JACK_FRAMEWORK vars
 AC_ARG_ENABLE([jack-framework],
-    [AS_HELP_STRING([--disable-jack-framework], [do not weak link to Jackmp.framework on macOS])],
+    [AS_HELP_STRING([--disable-jack-framework],
+        [do not weak link to Jackmp.framework on macOS])],
     [jack_framework=$enableval])
 test x$MACOSX = xyes || jack_framework=no
 if test x$jack_framework = xyes ; then
@@ -339,7 +341,9 @@ AC_ARG_ENABLE([jack],
 if [ test x$jack_framework != xyes ] && [ test x$jack = xyes ] ; then
     AC_CHECK_LIB([rt], [shm_open], [LIBS="$LIBS -lrt"])
     AC_CHECK_LIB([jack], [jack_set_xrun_callback], [JACK_LIBS="-ljack" ; jack=xrun])
-    AC_CHECK_LIB([jack], [jack_set_error_function], [JACK_LIBS="-ljack" ; jack=yes], [jack=no])
+    AC_CHECK_LIB([jack], [jack_set_error_function], [JACK_LIBS="-ljack" ; jack=yes],
+        [AC_MSG_WARN([JACK development files not found... skipping (See INSTALL.txt)])
+        jack=no])
 fi
 
 ##### MMIO #####
@@ -355,7 +359,8 @@ AC_ARG_ENABLE([asio],
 test x$WINDOWS = xyes || asio=no
 AS_IF([test x$asio = xyes],
     test -f "${srcdir}"/asio/ASIOSDK/common/asio.h || asio=no
-    AS_IF([test x$asio = xno], AC_MSG_WARN([ASIO SDK not found! See asio/README.txt]))
+    AS_IF([test x$asio = xno],
+        AC_MSG_WARN([ASIO SDK not found... skipping (See asio/README.txt)]))
 )
 
 ##### PortAudio #####
@@ -363,7 +368,8 @@ AC_ARG_ENABLE([portaudio],
     [AS_HELP_STRING([--disable-portaudio], [do not use portaudio])],
     [portaudio=$enableval])
 AC_ARG_WITH([local-portaudio],
-    [AS_HELP_STRING([--without-local-portaudio], [do not use the portaudio included with pd])],
+    [AS_HELP_STRING([--without-local-portaudio],
+        [do not use the portaudio included with pd])],
     [local_portaudio=$withval])
 if test x$portaudio = xyes ; then
     if test x$local_portaudio = xno ; then
@@ -386,11 +392,12 @@ AC_ARG_ENABLE([portmidi],
     [AS_HELP_STRING([--enable-portmidi], [use portmidi])],
     [portmidi=$enableval])
 AC_ARG_WITH([local-portmidi],
-    [AS_HELP_STRING([--without-local-portmidi], [do not use the portmidi included with pd])],
+    [AS_HELP_STRING([--without-local-portmidi],
+        [do not use the portmidi included with pd])],
     [local_portmidi=$withval])
 # don't allow portmidi if already using oss
 AS_IF([test x$oss = xyes -a x$portmidi != xno],
-  [AC_MSG_WARN([Cannot enable both OSS-midi and PortMidi..preferring OSS])
+  [AC_MSG_WARN([Cannot enable both OSS-midi and PortMidi... preferring OSS])
   portmidi=no])
 if test x$portmidi = xyes ; then
     if test x$local_portmidi = xno ; then
@@ -415,13 +422,15 @@ AC_ARG_ENABLE([fftw],
 if test x$fftw = xyes; then
     AC_CHECK_LIB([fftw3f], [fftwf_execute],
         [LIBS="$LIBS -lfftw3f"],
-        [AC_MSG_NOTICE([fftw package not found, using built-in FFT]) ; fftw=no])
+        [AC_MSG_WARN([FFTW development files not found... using built-in FFT])
+        fftw=no])
 fi
 AM_CONDITIONAL(FFTW, test x$fftw = xyes)
 
 ##### Wish #####
 AC_ARG_WITH([wish],
-    [AS_HELP_STRING([--with-wish=WISH], [which Tk Wish application to use for the Pd GUI])],
+    [AS_HELP_STRING([--with-wish=WISH],
+        [which Tk Wish application to use for the Pd GUI])],
     [WISH=$withval])
 AS_IF([test "x${WISH}" = "xyes" -o "x${WISH}" = "xno"],
     [AC_MSG_NOTICE([--with-wish requires an application, ignoring '${WISH}'])
@@ -435,8 +444,7 @@ AC_SUBST([WISH])
 # Cygwin has a function OSS /dev/dsp, but not MIDI,
 # and Pd is only set up to handle a single MIDI API
 AS_IF([test x$WINDOW = xyes -a x$oss != xno],
-  [AC_MSG_WARN([OSS not working on W32..disabling])
-  oss=no])
+  [AC_MSG_WARN([OSS not working on W32... disabling]) ; oss=no])
 AM_CONDITIONAL(OSS, test x$oss = xyes)
 AS_IF([test x$oss = xyes], [audio_backends="OSS ${audio_backends}"])
 AS_IF([test x$oss = xyes], [midi_backends="OSS ${midi_backends}"])
@@ -461,9 +469,9 @@ AM_CONDITIONAL(ASIO, test x$asio = xyes)
 AS_IF([test x$asio = xyes], [audio_backends="ASIO ${audio_backends}"])
 
 ##### CoreAudio #####
-# portaudio doesn't work with iPhone, so don't bother with CoreAudio
+# portaudio doesn't work with iOS, so don't bother with CoreAudio
 AS_IF([test x$IPHONEOS = xyes -a x$coreaudio != xno],
-  [AC_MSG_WARN([PortAudio not working on iPhone..disabling CoreAudio])
+  [AC_MSG_WARN([PortAudio not working on iOS... disabling CoreAudio])
   coreaudio=no])
 AM_CONDITIONAL(COREAUDIO, test x$coreaudio = xyes)
 

--- a/configure.ac
+++ b/configure.ac
@@ -369,7 +369,7 @@ AC_ARG_ENABLE([portaudio],
     [portaudio=$enableval])
 AC_ARG_WITH([local-portaudio],
     [AS_HELP_STRING([--without-local-portaudio],
-        [do not use the portaudio included with pd])],
+        [do not use the portaudio included with Pd])],
     [local_portaudio=$withval])
 if test x$portaudio = xyes ; then
     if test x$local_portaudio = xno ; then
@@ -381,7 +381,7 @@ if test x$portaudio = xyes ; then
         if test -d "$srcdir/portaudio" ; then
             AC_MSG_NOTICE([Using included PortAudio])
         else
-            AC_MSG_WARN([PortAudio not found in pd source directory])
+            AC_MSG_WARN([PortAudio not found in Pd source directory])
             portaudio=no
         fi
     fi
@@ -393,7 +393,7 @@ AC_ARG_ENABLE([portmidi],
     [portmidi=$enableval])
 AC_ARG_WITH([local-portmidi],
     [AS_HELP_STRING([--without-local-portmidi],
-        [do not use the portmidi included with pd])],
+        [do not use the portmidi included with Pd])],
     [local_portmidi=$withval])
 # don't allow portmidi if already using oss
 AS_IF([test x$oss = xyes -a x$portmidi != xno],
@@ -409,7 +409,7 @@ if test x$portmidi = xyes ; then
         if test -d "$srcdir/portmidi" ; then
             AC_MSG_NOTICE([Using included PortMidi])
         else
-            AC_MSG_WARN([PortMidi not found in pd source directory])
+            AC_MSG_WARN([PortMidi not found in Pd source directory])
             portmidi=no
         fi
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -576,3 +576,24 @@ AC_MSG_NOTICE([
     audio APIs:           $audio_backends
     midi APIs:            $midi_backends
 ])
+
+
+AS_IF([test x$enable_locales = xyes -a x$locales = xno ],
+ AC_MSG_WARN([localization requested but no GNU gettext with msgfmt found... disabled]))
+AS_IF([test x$enable_oss = xyes -a x$oss = xno ],
+ AC_MSG_WARN([OSS requested but no development files found... disabled]))
+AS_IF([test x$enable_alsa = xyes -a x$alsa = xno ],
+ AC_MSG_WARN([ALSA requested but no development files found... disabled (See INSTALL.txt)]))
+AS_IF([test x$enable_jack = xyes -a x$jack = xno ],
+ AC_MSG_WARN([JACK requested but no development files found... disabled (See INSTALL.txt)]))
+AS_IF([test x$enable_jack_framework = xyes -a x$jack_jack != xyes ],
+ AC_MSG_WARN([JACK-Framework requested but no development files found... disabled (See INSTALL.txt)]))
+AS_IF([test x$enable_mmio = xyes -a x$mmio = xno ],
+ AC_MSG_WARN([MMIO requested but not available... disabled (requires Windows)]))
+AS_IF([test x$enable_asio = xyes -a x$asio = xno ],
+ AC_MSG_WARN([ASIO requested but no SDK found... disabled (see asio/README.txt)]))
+
+# TODO portaudio
+
+AS_IF([test x$enable_fftw = xyes -a x$fftw = xno ],
+ AC_MSG_WARN([FFTW requested but no development files found... disabled]))

--- a/doc/1.manual/x5.htm
+++ b/doc/1.manual/x5.htm
@@ -42,8 +42,11 @@ save state information as part of the calling patch.
 <P> "Text", "array", and "scalar" objects have the same methods (bang and "send")
 for outputting pointers to themselves
 
-<P> Opening patches from menu, command line, or messages to "pd" first check
-of the file is already open and if so only bring the existing patch to front.
+<P> An optional argument was added to the "pd open" message, to allow opening
+a file only if it is not currently open; to get this behavior send "pd open
+<file> <directory> 1".  It is still under discussion whether this would be the
+appropriate response when the user clicks on a patch to open it in the file
+browser.
 
 <P> 4 million point default limit on resizing soundfile read to array changed to
 2^31-1 (about 2 billion) samples.  If invoked without an array name,  soundfiler

--- a/doc/6.externs/0.README.txt
+++ b/doc/6.externs/0.README.txt
@@ -1,9 +1,23 @@
-EXTERNAL OBJECTS in Pd.
+Examples of external objects for Pd.
 
-Here are the sources for three simple external objects in Pd.
-To compile, type "make pd_linux", "make pd_linux32", "nmake pd_nt", or
-"make pd_darwin"
+Here are the sources for a few simple external objects in Pd, along with patches
+to test them.  There is a makefile included that should help compile them
+using the "make" (Mac or linux) or "nmake" (Windows) shell commands.
 
-The objects "foo1" and "foo2" are intended as very simple control objects, and
-"dspobj" is a tilde object.
+This relies on having installed a development environment for whatever computer
+is in use.  For Windows, this should be Microsoft Visual C (it's also possible
+to compile externs using mingw but this makefile doesn't support that).
 
+To compile, type "make pd_linux", "nmake pd_nt" (for windows), or
+"make pd_darwin" (for Mac OSX).
+
+If you have saved these files to a new location (other than the Pd distrubution
+itself), it will probably be necessary to customize the makefile by changing the
+definition of "PDNTINCLUDE" (windows) or "LINUXINCLUDE" (linux or Mac)
+to point back to the PD source directory.
+
+Mac users who haven't installed a 32-bit compilation chain will also have to
+edit the makefile to delete the phrase "-arch i386" in two places.
+
+Windows users will most likely have to update the makefile to point correctly to
+the current version of Microsoft Visual C.

--- a/po/de.po
+++ b/po/de.po
@@ -271,7 +271,7 @@ msgid "Delay (msec):"
 msgstr "Verzögerung (msec):"
 
 msgid "Block size:"
-msgstr "Bocklänge:"
+msgstr "Blocklänge:"
 
 msgid "Use callbacks"
 msgstr "Rückfragen verwenden"

--- a/po/de.po
+++ b/po/de.po
@@ -7,14 +7,14 @@ msgstr ""
 "Project-Id-Version: Pure Data 0.48\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
 "POT-Creation-Date: 2017-07-06 18:10+0200\n"
-"PO-Revision-Date: 2018-12-12 17:27+0100\n"
+"PO-Revision-Date: 2019-01-05 21:25+0100\n"
 "Last-Translator: Winfried Ritsch\n"
 "Language-Team: Deutsch <LL@li.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.11\n"
+"X-Generator: Poedit 2.2\n"
 
 # iemgui
 msgid "-------dimensions(digits)(pix):-------"
@@ -168,8 +168,8 @@ msgstr "keine Pd Einstellungen zum Löschen"
 
 msgid "skipping loading preferences... Pd seems to have crashed on startup."
 msgstr ""
-"überspringe das Laden der Einstellungen...Pd ist scheinbar beim letzten "
-"Start abgestürzt."
+"überspringe das Laden der Einstellungen...es scheint, als wäre Pd beim "
+"letzten Start abgestürzt."
 
 msgid "(re-save preferences to reinstate them)"
 msgstr "(speichern Sie die Einstellungen um sie wiederherzustellen)"
@@ -277,13 +277,13 @@ msgid "Use callbacks"
 msgstr "Callbacks"
 
 msgid "Input Devices"
-msgstr "Eingabegerät"
+msgstr "Eingabegeräte"
 
 msgid "Channels:"
 msgstr "Kanäle:"
 
 msgid "Output Devices"
-msgstr "Ausgabegerät"
+msgstr "Ausgabegeräte"
 
 msgid "(same as input device)..."
 msgstr "(wie Eingabegerät) .............."
@@ -404,7 +404,7 @@ msgid "Upper:"
 msgstr "Oberer:"
 
 msgid "Label"
-msgstr "Aufschrift"
+msgstr "Beschriftung"
 
 msgid "Left"
 msgstr "Links"
@@ -434,7 +434,7 @@ msgid "Foreground color"
 msgstr "Vordergrundfarbe"
 
 msgid "Label color"
-msgstr "Etikettenfarbe"
+msgstr "Beschriftungsfarbe"
 
 msgid "Init"
 msgstr "Init"
@@ -581,9 +581,8 @@ msgstr "Deaktivieren"
 msgid "Externals Install Directory"
 msgstr "Installationsverzeichnis für Bibliotheken"
 
-#, fuzzy
 msgid "Clear"
-msgstr "Menü löschen"
+msgstr "Löschen"
 
 msgid "Choose Pd documents directory:"
 msgstr "Wählen Sie ein Verzeichnis für Pd-Dokumente:"
@@ -634,7 +633,8 @@ msgstr "[deken]: überschreibe die installierte Version [%1$s] mit %2$s!"
 #, tcl-format
 msgid "[deken]: installed version [%1$s] == %2$s...skipping!"
 msgstr ""
-"[deken] die installierte Version ist bereits am neuesten Stand [%1$s == %2$s]"
+"[deken]: die installierte Version ist bereits am neuesten Stand [%1$s == "
+"%2$s]"
 
 msgid "[deken]: "
 msgstr ""
@@ -671,11 +671,11 @@ msgstr "[deken] Pd Paketmanager vom Pfad %s geladen."
 
 #, tcl-format
 msgid "[deken] Platform detected: %s"
-msgstr "[deken] Plattform gefunden: %s"
+msgstr "[deken] Architektur gefunden: %s"
 
-#, fuzzy, tcl-format
+#, tcl-format
 msgid "[deken] Platform re-detected: %s"
-msgstr "[deken] Plattform gefunden: %s"
+msgstr "[deken] Architektur aktualisiert: %s"
 
 msgid "Show all"
 msgstr "Alle anzeigen"
@@ -704,7 +704,7 @@ msgstr "Installationsoptionen:"
 
 msgid "Try to remove libraries before (re)installing them?"
 msgstr ""
-"Sollte versucht werden, Externals vor der (Neu)Installation zu entfernen?"
+"Soll versucht werden, Externals vor der (Neu)Installation zu entfernen?"
 
 msgid "Show README of newly installed libraries (if present)?"
 msgstr ""
@@ -712,11 +712,10 @@ msgstr ""
 "werden?"
 
 msgid "Should newly installed libraries be added to Pd's search path?"
-msgstr ""
-"Sollen neu installierte Bibliotheken zu Pds Suchpfad hinzugefügt werden?"
+msgstr "Sollen neu installierte Externals zu Pds Suchpfad hinzugefügt werden?"
 
 msgid "Platform settings:"
-msgstr "Architektureinstellungen:"
+msgstr "Kompatibilitätseinstellungen:"
 
 #, tcl-format
 msgid "Default platform: %s"
@@ -749,7 +748,7 @@ msgid "[deken]: No matching externals found."
 msgstr "[deken]: Konnte keine passenden Externals finden."
 
 msgid "Try using the full name e.g. 'freeverb'."
-msgstr "Tipp: Suchen Sie nach dem vollen Namen, z.B. 'freeverb'"
+msgstr "Tipp: Suchen Sie nach dem vollen Namen, z.B. 'freeverb'."
 
 msgid "No matching externals found."
 msgstr "Keine passenden Externals gefunden."
@@ -847,9 +846,10 @@ msgstr ""
 msgid "Couldn't create Pd documents directory: %s\n"
 msgstr "Konnte das Verzeichnis für Pd-Dokumente nicht erzeugen: %s\n"
 
+# "externals" is a literal (a folder name to be created)
 #, tcl-format
 msgid "Couldn't create \"externals\" directory in: %s\n"
-msgstr "Konnte kein \"Externals\" Verzeichnis in '%s' erstellen.\n"
+msgstr "Konnte kein \"externals\" Verzeichnis in '%s' erstellen.\n"
 
 msgid "About Pd"
 msgstr "Über Pd"
@@ -1018,14 +1018,13 @@ msgid "Save All Preferences"
 msgstr "Alle Einstellungen speichern"
 
 msgid "Save to..."
-msgstr "Speichern als..."
+msgstr "Einstellungen in Datei speichern..."
 
 msgid "Load from..."
-msgstr "Laden von..."
+msgstr "Einstellungen von Datei laden..."
 
-#, fuzzy
 msgid "Forget All..."
-msgstr "Zurücksetzen..."
+msgstr "Alle Einstellungen zurücksetzen..."
 
 msgid "Open Recent"
 msgstr "Letzte Dateien öffnen"

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -690,7 +690,7 @@ static void env_tilde_ff(t_sigenv *x)           /* cleanup on free */
 }
 
 
-void env_tilde_setup(void )
+void env_tilde_setup(void)
 {
     env_tilde_class = class_new(gensym("env~"), (t_newmethod)env_tilde_new,
         (t_method)env_tilde_ff, sizeof(t_sigenv), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
@@ -819,7 +819,7 @@ static void threshold_tilde_ff(t_threshold_tilde *x)
     clock_free(x->x_clock);
 }
 
-static void threshold_tilde_setup( void)
+static void threshold_tilde_setup(void)
 {
     threshold_tilde_class = class_new(gensym("threshold~"),
         (t_newmethod)threshold_tilde_new, (t_method)threshold_tilde_ff,

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -12,8 +12,8 @@ linked in.  The configure script can be used to select which one.
 */
 
 /* ------------------ initialization and cleanup -------------------------- */
-void mayer_init( void);
-void mayer_term( void);
+void mayer_init(void);
+void mayer_term(void);
 
 static void fftclass_cleanup(t_class *c)
 {

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -645,7 +645,7 @@ typedef struct _exp_tilde
     t_float x_f;
 } t_exp_tilde;
 
-static void *exp_tilde_new( void)
+static void *exp_tilde_new(void)
 {
     t_exp_tilde *x = (t_exp_tilde *)pd_new(exp_tilde_class);
     outlet_new(&x->x_obj, &s_signal);
@@ -739,7 +739,7 @@ typedef struct _abs_tilde
     t_float x_f;
 } t_abs_tilde;
 
-static void *abs_tilde_new( void)
+static void *abs_tilde_new(void)
 {
     t_abs_tilde *x = (t_abs_tilde *)pd_new(abs_tilde_class);
     outlet_new(&x->x_obj, &s_signal);

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -49,7 +49,7 @@ struct _instanceugen
 
 #define THIS (pd_this->pd_ugen)
 
-void d_ugen_newpdinstance( void)
+void d_ugen_newpdinstance(void)
 {
     THIS = getbytes(sizeof(*THIS));
     THIS->u_dspchain = 0;
@@ -57,7 +57,7 @@ void d_ugen_newpdinstance( void)
     THIS->u_signals = 0;
 }
 
-void d_ugen_freepdinstance( void)
+void d_ugen_freepdinstance(void)
 {
     freebytes(THIS, sizeof(*THIS));
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -131,7 +131,7 @@ canvas 0 0 458 153 10;\n\
 /* create invisible, built-in canvases to supply templates for floats
 and float-arrays. */
 
-void garray_init( void)
+void garray_init(void)
 {
     t_binbuf *b;
     b = binbuf_new();

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -70,7 +70,7 @@ void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
 
 
     /* maintain the list of visible toplevels for the GUI's "windows" menu */
-void canvas_updatewindowlist( void)
+void canvas_updatewindowlist(void)
 {
             /* not if we're in a reload */
     if (!THISGUI->i_reloadingabstraction)
@@ -146,7 +146,7 @@ t_canvasenvironment *canvas_getenv(const t_canvas *x)
     return (x->gl_env);
 }
 
-int canvas_getdollarzero( void)
+int canvas_getdollarzero(void)
 {
     t_canvas *x = canvas_getcurrent();
     t_canvasenvironment *env = (x ? canvas_getenv(x) : 0);
@@ -2002,7 +2002,7 @@ void canvas_add_for_class(t_class *c)
     /* g_graph_setup_class(c); */
 }
 
-void g_canvas_newpdinstance( void)
+void g_canvas_newpdinstance(void)
 {
     THISGUI = getbytes(sizeof(*THISGUI));
     THISGUI->i_newfilename = THISGUI->i_newdirectory = &s_;
@@ -2015,7 +2015,7 @@ void g_canvas_newpdinstance( void)
     g_template_newpdinstance();
 }
 
-void g_canvas_freepdinstance( void)
+void g_canvas_freepdinstance(void)
 {
     g_editor_freepdinstance();
     g_template_freepdinstance();

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -216,13 +216,13 @@ void canvas_rename(t_canvas *x, t_symbol *s, t_symbol *dir)
     canvas_unbind(x);
     x->gl_name = s;
     canvas_bind(x);
-    if (x->gl_havewindow)
-        canvas_reflecttitle(x);
     if (dir && dir != &s_)
     {
         t_canvasenvironment *e = canvas_getenv(x);
         e->ce_dir = dir;
     }
+    if (x->gl_havewindow)
+        canvas_reflecttitle(x);
 }
 
 /* --------------- traversing the set of lines in a canvas ----------- */

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1466,7 +1466,7 @@ static void canvas_completepath(const char *from, char *to, int bufsize,
     {
         /* append canvas dir */
         const char *dir = canvas_getdir(x)->s_name;
-        int dirlen = strlen(dir);
+        int dirlen = (int)strlen(dir);
         strncpy(to, dir, bufsize-dirlen);
         to[bufsize-dirlen-1] = '\0';
         strcat(to, "/");

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -270,10 +270,10 @@ struct _instancecanvas
     t_float i_graph_lastxpix, i_graph_lastypix;
 };
 
-void g_editor_newpdinstance( void);
-void g_template_newpdinstance( void);
-void g_editor_freepdinstance( void);
-void g_template_freepdinstance( void);
+void g_editor_newpdinstance(void);
+void g_template_newpdinstance(void);
+void g_editor_freepdinstance(void);
+void g_template_freepdinstance(void);
 
 #define THISGUI (pd_this->pd_gui)
 #define EDITOR (pd_this->pd_gui->i_editor)
@@ -502,7 +502,7 @@ typedef int (*t_canvasapply)(t_canvas *x, t_int x1, t_int x2, t_int x3);
 EXTERN void canvas_resortinlets(t_canvas *x);
 EXTERN void canvas_resortoutlets(t_canvas *x);
 EXTERN void canvas_free(t_canvas *x);
-EXTERN void canvas_updatewindowlist( void);
+EXTERN void canvas_updatewindowlist(void);
 EXTERN void canvas_editmode(t_canvas *x, t_floatarg state);
 EXTERN int canvas_isabstraction(const t_canvas *x);
 EXTERN int canvas_istable(const t_canvas *x);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1771,6 +1771,7 @@ static void glist_doreload(t_glist *gl, t_symbol *name, t_symbol *dir,
     {
         canvas_cut(gl);
         canvas_undo_undo(gl);
+        canvas_undo_rebranch(gl);
         glist_noselect(gl);
     }
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4218,7 +4218,7 @@ static void canvas_tidy(t_canvas *x)
            othewise just the selection */
     int all = (x->gl_editor ? (x->gl_editor->e_selection == 0) : 1);
 
-    canvas_undo_add(x, UNDO_MOTION, "motion", canvas_undo_set_move(x, 1));
+    canvas_undo_add(x, UNDO_MOTION, "{tidy up}", canvas_undo_set_move(x, !all));
 
         /* tidy horizontally */
     for (y = x->gl_list; y; y = y->g_next)

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2892,11 +2892,13 @@ static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
 }
 
 void canvas_mouseup(t_canvas *x,
-    t_floatarg fxpos, t_floatarg fypos, t_floatarg fwhich)
+    t_floatarg fxpos, t_floatarg fypos, t_floatarg fwhich,
+    t_floatarg fmod)
 {
     int xpos = fxpos, ypos = fypos, which = fwhich;
+    int mod = fmod;
 #if 0
-    post("mouseup %d %d %d", xpos, ypos, which);
+    post("mouseup %d %d %d %d", xpos, ypos, which, mod);
 #endif
     if (!x->gl_editor)
     {
@@ -4675,7 +4677,7 @@ void g_editor_setup(void)
     class_addmethod(canvas_class, (t_method)canvas_mouse, gensym("mouse"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_mouseup, gensym("mouseup"),
-        A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+        A_FLOAT, A_FLOAT, A_FLOAT, A_DEFFLOAT, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_key, gensym("key"),
         A_GIMME, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_motion, gensym("motion"),
@@ -4753,7 +4755,7 @@ void canvas_editor_for_class(t_class *c)
     class_addmethod(c, (t_method)canvas_key, gensym("key"),
         A_GIMME, A_NULL);
     class_addmethod(c, (t_method)canvas_motion, gensym("motion"),
-        A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+        A_FLOAT, A_FLOAT, A_FLOAT, A_DEFFLOAT, A_NULL);
 
 /* ------------------------ menu actions ---------------------------- */
     class_addmethod(c, (t_method)canvas_menuclose,

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1793,11 +1793,21 @@ void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except)
 {
     t_canvas *x;
     int dspwas = canvas_suspend_dsp();
+    t_binbuf*b = 0;
+    if(EDITOR->copy_binbuf)
+        b = binbuf_duplicate(EDITOR->copy_binbuf);
+
     THISGUI->i_reloadingabstraction = except;
         /* find all root canvases */
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
         glist_doreload(x, name, dir, &except->gl_gobj);
     THISGUI->i_reloadingabstraction = 0;
+    if(b)
+    {
+        if(EDITOR->copy_binbuf)
+            binbuf_free(EDITOR->copy_binbuf);
+        EDITOR->copy_binbuf = b;
+    }
     canvas_resume_dsp(dspwas);
 }
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2283,7 +2283,7 @@ static void canvas_done_popup(t_canvas *x, t_float which,
 #define DCLICKINTERVAL 0.25
 
     /* mouse click */
-void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
+static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
     int mod, int doit)
 {
     t_gobj *y;
@@ -2652,7 +2652,7 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
     return 0;
 }
 
-void canvas_doconnect(t_canvas *x, int xpos, int ypos, int which, int doit)
+static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int which, int doit)
 {
     int x11=0, y11=0, x12=0, y12=0;
     t_gobj *y1;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4097,6 +4097,9 @@ static void canvas_duplicate(t_canvas *x)
     if (x->gl_editor->e_onmotion == MA_NONE && x->gl_editor->e_selection)
     {
         t_selection *y;
+        t_binbuf*b = 0;
+        if(EDITOR->copy_binbuf)
+            b = binbuf_duplicate(EDITOR->copy_binbuf);
         canvas_copy(x);
         canvas_undo_add(x, UNDO_PASTE, "duplicate",
             (void *)canvas_undo_set_paste(x, 0, 1, PASTE_OFFSET));
@@ -4104,6 +4107,12 @@ static void canvas_duplicate(t_canvas *x)
         for (y = x->gl_editor->e_selection; y; y = y->sel_next)
             gobj_displace(y->sel_what, x,
                 PASTE_OFFSET, PASTE_OFFSET);
+        if(b)
+        {
+            if(EDITOR->copy_binbuf)
+                binbuf_free(EDITOR->copy_binbuf);
+            EDITOR->copy_binbuf = b;
+        }
         canvas_dirty(x, 1);
     }
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4556,18 +4556,23 @@ static void canvas_connect_selection(t_canvas *x)
             objsink = objsrc;
             objsrc = obj;
         }
-
+        if (!objsrc || !objsink)
+            return;
         if (obj_noutlets(objsrc))
         {
-            int out = 0, in=0;
+            int noutlets = obj_noutlets(objsrc);
+            int ninlets = obj_ninlets(objsink);
+            int fanout = (noutlets == 1) && obj_issignaloutlet(objsrc, 0);
+            int out = 0, in = 0;
             while(!tryconnect(x, objsrc, out, objsink, in))
             {
-                if (!objsrc  || obj_noutlets(objsrc ) <= out)
+                if (noutlets <= out)
                     return;
-                if (!objsink || obj_ninlets (objsink) <= in )
+                if (ninlets <= in )
                     return;
                 in++;
-                out++;
+                if(!fanout)
+                    out++;
             }
         }
         return;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4762,12 +4762,12 @@ void canvas_editor_for_class(t_class *c)
         gensym("findparent"), A_NULL);
 }
 
-void g_editor_newpdinstance( void)
+void g_editor_newpdinstance(void)
 {
     EDITOR = getbytes(sizeof(*EDITOR));
 }
 
-void g_editor_freepdinstance( void)
+void g_editor_freepdinstance(void)
 {
     if (EDITOR->copy_binbuf)
         binbuf_free(EDITOR->copy_binbuf);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4190,10 +4190,8 @@ static void canvas_cycleselect(t_canvas*x, t_float foffset)
             closest = ((xpos-snkX1) * (nios-1) + width/2)/width;
             closest = ((closest + offset) % nios + nios) % nios;
             hotspot = snkX1 + (width - IOWIDTH) * closest / (nios-1.0) + IOWIDTH*0.5;
-            xpos = hotspot;
-                /* moving the mouse doesn't seem to work on macOS... */
-            sys_vgui("event generate .x%lx.c <Motion> -warp 1 -x %d -y %d\n",
-                glist_getcanvas(x), xpos, ypos);
+            sys_vgui("::pdtk_canvas::setmouse .x%lx.c %d %d\n",
+                glist_getcanvas(x), hotspot, ypos);
         } else {
                 /* cycle outlets */
             int width = srcX2 - srcX1, hotspot, closest;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2652,7 +2652,7 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
     return 0;
 }
 
-static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int which, int doit)
+static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 {
     int x11=0, y11=0, x12=0, y12=0;
     t_gobj *y1;
@@ -2661,7 +2661,7 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int which, int doi
     int xwas = x->gl_editor->e_xwas,
         ywas = x->gl_editor->e_ywas;
 #if 0
-    post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, which, doit);
+    post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, mod, doit);
 #endif
     if (doit) sys_vgui(".x%lx.c delete x\n", x);
     else sys_vgui(".x%lx.c coords x %d %d %d %d\n",
@@ -2718,13 +2718,14 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int which, int doi
             if (doit)
             {
                 t_selection *sel;
-                int selmode;
+                int selmode = 0;
                 canvas_undo_add(x, UNDO_SEQUENCE_START, "connect", 0);
                 tryconnect(x, ob1, closest1, ob2, closest2);
                 canvas_dirty(x, 1);
                     /* now find out if either ob1 xor ob2 are part of the selection,
                      * and if so, connect the rest of the selection as well */
-                selmode = glist_isselected(x, &ob1->ob_g) + 2 * glist_isselected(x, &ob2->ob_g);
+                if(mod & SHIFTMOD) /* intelligent patching needs to be activated by modifier key */
+                    selmode = glist_isselected(x, &ob1->ob_g) + 2 * glist_isselected(x, &ob2->ob_g);
                 switch(selmode) {
                 case 3: /* both source and sink are selected */
                         /* if only the source & sink are selected, keep connecting them */
@@ -2911,7 +2912,7 @@ void canvas_mouseup(t_canvas *x,
     EDITOR->canvas_upy = ypos;
 
     if (x->gl_editor->e_onmotion == MA_CONNECT)
-        canvas_doconnect(x, xpos, ypos, which, 1);
+        canvas_doconnect(x, xpos, ypos, mod, 1);
     else if (x->gl_editor->e_onmotion == MA_REGION)
         canvas_doregion(x, xpos, ypos, 1);
     else if (x->gl_editor->e_onmotion == MA_MOVE ||
@@ -3186,7 +3187,7 @@ void canvas_motion(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
         canvas_doregion(x, xpos, ypos, 0);
     else if (x->gl_editor->e_onmotion == MA_CONNECT)
     {
-        canvas_doconnect(x, xpos, ypos, 0, 0);
+        canvas_doconnect(x, xpos, ypos, mod, 0);
         x->gl_editor->e_xnew = xpos;
         x->gl_editor->e_ynew = ypos;
     }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4125,6 +4125,12 @@ static void canvas_selectall(t_canvas *x)
          }
 }
 
+static void canvas_deselectall(t_canvas *x)
+{
+    if(x)glist_noselect(x);
+}
+
+
 static void canvas_reselect(t_canvas *x)
 {
     t_gobj *g, *gwas;
@@ -4699,6 +4705,8 @@ void g_editor_setup(void)
         gensym("duplicate"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_selectall,
         gensym("selectall"), A_NULL);
+    class_addmethod(canvas_class, (t_method)canvas_deselectall,
+        gensym("deselectall"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_reselect,
         gensym("reselect"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_undo_undo,

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -760,7 +760,8 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
                 }
             }
                 /* LATER disable redrawing here */
-            canvas_redraw(x);
+            if (x->gl_havewindow)
+                canvas_redraw(x);
             if (x->gl_owner && glist_isvisible(x->gl_owner))
             {
                 gobj_vis((t_gobj *)x, x->gl_owner, 0);
@@ -1085,7 +1086,7 @@ int canvas_undo_apply(t_canvas *x, void *z, int action)
             /* connections should stay the same */
         canvas_applybinbuf(x, buf->u_reconnectbuf);
             /* now we need to reposition the object to its original place */
-        if (canvas_apply_restore_original_position(x, buf->u_index))
+        if (canvas_apply_restore_original_position(x, buf->u_index) && x->gl_havewindow)
             canvas_redraw(x);
     }
     else if (action == UNDO_FREE)
@@ -1263,9 +1264,6 @@ int canvas_undo_arrange(t_canvas *x, void *z, int action)
                 y->g_next = next;
                 x->gl_list = y;
             }
-
-                /* and finally redraw canvas */
-            canvas_redraw(x);
         }
         else {
                 /* if it is the first object */
@@ -1283,10 +1281,10 @@ int canvas_undo_arrange(t_canvas *x, void *z, int action)
                 /* now readjust pointers */
             prev->g_next = y;
             y->g_next = next;
-
-                /* and finally redraw canvas */
-            canvas_redraw(x);
         }
+            /* and finally redraw canvas */
+        if (x->gl_havewindow)
+            canvas_redraw(x);
         break;
     case UNDO_REDO:
     {
@@ -1450,7 +1448,8 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
             glist_noselect(x);
             gobj_vis(&x->gl_gobj, x->gl_owner, 0);
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
-            canvas_redraw(x->gl_owner);
+            if (x->gl_havewindow)
+                canvas_redraw(x->gl_owner);
         }
     }
 
@@ -1633,7 +1632,7 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 
             /* reposition object to its original place */
         if (action == UNDO_UNDO)
-            if (canvas_apply_restore_original_position(x, buf->u_index))
+            if (canvas_apply_restore_original_position(x, buf->u_index) && x->gl_havewindow)
                 canvas_redraw(x);
 
             /* send a loadbang */
@@ -4747,7 +4746,7 @@ void canvas_editmode(t_canvas *x, t_floatarg state)
             sys_vgui(".x%lx.c delete commentbar\n", glist_getcanvas(x));
         }
     }
-    if (glist_isvisible(x))
+    if (glist_isvisible(x) && x->gl_havewindow)
     {
         sys_vgui("pdtk_canvas_editmode .x%lx %d\n",
             glist_getcanvas(x), x->gl_edit);

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -303,8 +303,8 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
             canvas_undo_add(x, UNDO_CONNECT, "connect",
                 canvas_undo_set_connect(x, obj_i, nout, stub_i, 0));
             glist_select(x, o2g(stub));
+            didit++;
         }
-        didit++;
     }
     return didit;
 }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -588,7 +588,11 @@ static void canvas_do_triggerize(t_glist*cnv)
 void canvas_triggerize(t_glist*cnv)
 {
     int dspstate;
-    if(NULL == cnv)return;
+
+    if(!cnv || !cnv->gl_editor)
+        return;
+    if(!cnv->gl_editor->e_selection && !cnv->gl_editor->e_selectedline)
+        return;
 
         /* suspend system */
     dspstate = canvas_suspend_dsp();

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -524,6 +524,8 @@ static int expand_trigger(t_glist*cnv, t_object*obj)
     binbuf_add(b, 1, argv);
     binbuf_addv(b, "s", gensym("a"));
     binbuf_add(b, argc-1, argv+1);
+    canvas_undo_add(cnv, UNDO_PASTE, "paste",
+        canvas_undo_set_pastebinbuf(cnv, b, 0, 0, 0));
     stub=triggerize_createobj(cnv, b);
     stub_i = canvas_getindex(cnv, o2g(stub));
     for(nout=0; nout<obj_nout; nout++)

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -577,7 +577,7 @@ static int triggerize_triggers(t_glist*cnv)
     return 0;
 }
 
-static void canvas_do_triggerize(t_glist*cnv)
+static int canvas_do_triggerize(t_glist*cnv)
 {
         /*
          * selected msg-connection: insert [t a] (->triggerize_line)
@@ -588,10 +588,9 @@ static void canvas_do_triggerize(t_glist*cnv)
          * selected [trigger]: else, add left-most "a" outlet (->triggerize_triggers)
          */
 
-    if(triggerize_line(cnv)
-       || triggerize_fanouts(cnv)
-       || triggerize_triggers(cnv))
-    canvas_dirty(cnv, 1);
+    return(triggerize_line(cnv)
+        || triggerize_fanouts(cnv)
+        || triggerize_triggers(cnv));
 }
 void canvas_triggerize(t_glist*cnv)
 {

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -314,11 +314,13 @@ static int triggerize_fanouts(t_glist*cnv)
     t_gobj*gobj = NULL;
     int count=0;
     canvas_undo_add(cnv, UNDO_SEQUENCE_START, "triggerize", 0);
-    for(gobj=cnv->gl_list; gobj; gobj=gobj->g_next)
+    for(gobj=cnv->gl_list; gobj; )
     {
+        t_gobj*next=gobj->g_next;
         t_object*obj=g2o(gobj);
         if(obj && glist_isselected(cnv, gobj) && triggerize_fanout(cnv, obj))
             count++;
+        gobj = next;
     }
     canvas_undo_add(cnv, UNDO_SEQUENCE_END, "triggerize", 0);
     return count;
@@ -524,8 +526,9 @@ static int with_triggers(t_glist*cnv, t_fun_withobject fun)
     const t_symbol*s_trigger=gensym("trigger");
     int count=0;
     t_gobj*gobj = NULL;
-    for(gobj=cnv->gl_list; gobj; gobj=gobj->g_next)
+    for(gobj=cnv->gl_list; gobj;)
     {
+        t_gobj*next=gobj->g_next;
         t_object*obj=g2o(gobj);
         if(obj && glist_isselected(cnv, gobj))
         {
@@ -533,6 +536,7 @@ static int with_triggers(t_glist*cnv, t_fun_withobject fun)
             if((s_trigger == c_name) && fun(cnv, obj))
                 count++;
         }
+        gobj=next;
     }
     return count;
 }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -364,7 +364,22 @@ static int triggerize_line(t_glist*x, t_triggerize_return*tr)
         t_object*obj2=g2o(dst);
         if(obj1 && obj2)
         {
-            posx=(obj1->te_xpix+obj2->te_xpix)>>1;
+            float posSource, posSink;
+            int nio;
+            int _x; /* dummy variable */
+            int posLeft, posRight;
+
+                /* get real x-position of the outlet */
+            gobj_getrect(src, x, &posLeft, &_x, &posRight, &_x);
+            nio = obj_noutlets(obj1);
+            posSource = posLeft + (posRight - posLeft - IOWIDTH * x->gl_zoom) * src_out / ((nio==1)?1.:(nio-1.));
+
+                /* get real x-position of the inlet */
+            gobj_getrect(dst, x, &posLeft, &_x, &posRight, &_x);
+            nio = obj_ninlets(obj2);
+            posSink = posLeft + (posRight - posLeft - IOWIDTH * x->gl_zoom) * dst_in / ((nio==1)?1.:(nio-1.));
+
+            posx=(posSource + posSink)*0.5;
             posy=(obj1->te_ypix+obj2->te_ypix)>>1;
         }
     }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -14,6 +14,12 @@ void *canvas_undo_set_pastebinbuf(t_canvas *x, t_binbuf *b,
     int numpasted, int duplicate, int d_offset);
 
 /* ------------ utilities ---------- */
+typedef struct _triggerize_return {
+        /* data to return from triggerize */
+    t_gobj*tr_editgobj; /* if set, immediately switch this object to being edited */
+} t_triggerize_return;
+
+
 static t_gobj*o2g(t_object*obj)
 {
     return &(obj->te_g);
@@ -326,7 +332,7 @@ static int triggerize_fanouts(t_glist*cnv)
     return count;
 }
 
-static int triggerize_line(t_glist*x)
+static int triggerize_line(t_glist*x, t_triggerize_return*tr)
 {
         /* triggerize a single selected line, by inserting a [t a] object
          * (or it's signal equivalent) */
@@ -408,6 +414,9 @@ static int triggerize_line(t_glist*x)
     glist_select(x, o2g(stub));
 
     canvas_undo_add(x, UNDO_SEQUENCE_END, "{insert object}", 0);
+        /* remember the inserted object, so we can select/edit it later */
+    if(tr)
+        tr->tr_editgobj = o2g(stub);
     if(sigline)
         canvas_resume_dsp(dspstate);
     return 1;
@@ -577,7 +586,7 @@ static int triggerize_triggers(t_glist*cnv)
     return 0;
 }
 
-static int canvas_do_triggerize(t_glist*cnv)
+static int canvas_do_triggerize(t_glist*cnv, t_triggerize_return*tr)
 {
         /*
          * selected msg-connection: insert [t a] (->triggerize_line)
@@ -588,21 +597,27 @@ static int canvas_do_triggerize(t_glist*cnv)
          * selected [trigger]: else, add left-most "a" outlet (->triggerize_triggers)
          */
 
-    return(triggerize_line(cnv)
+    return(triggerize_line(cnv, tr)
         || triggerize_fanouts(cnv)
         || triggerize_triggers(cnv));
 }
 void canvas_triggerize(t_glist*cnv)
 {
+    int count = 0;
+    t_triggerize_return*tr;
     if(!cnv || !cnv->gl_editor)
         return;
     if(!cnv->gl_editor->e_selection && !cnv->gl_editor->e_selectedline)
         return;
-    int count = 0;
-    if(count = canvas_do_triggerize(cnv)) {
+    tr = getbytes(sizeof(*tr));
+    if(count = canvas_do_triggerize(cnv, tr)) {
         canvas_dirty(cnv, 1);
             /* fix display of connections, objects,... */
         canvas_redraw(cnv);
         glist_redraw(cnv);
+            /* if we inserted an object, allow the user to change it now */
+        if(tr->tr_editgobj)
+            gobj_activate(tr->tr_editgobj, cnv, 1);
     }
+    freebytes(tr, sizeof(*tr));
 }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -598,10 +598,11 @@ void canvas_triggerize(t_glist*cnv)
         return;
     if(!cnv->gl_editor->e_selection && !cnv->gl_editor->e_selectedline)
         return;
-
-    canvas_do_triggerize(cnv);
-
-        /* fix display of connections, objects,... */
-    canvas_redraw(cnv);
-    glist_redraw(cnv);
+    int count = 0;
+    if(count = canvas_do_triggerize(cnv)) {
+        canvas_dirty(cnv, 1);
+            /* fix display of connections, objects,... */
+        canvas_redraw(cnv);
+        glist_redraw(cnv);
+    }
 }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -236,7 +236,6 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
     int obj_nout=obj_noutlets(obj);
     int nout;
     int posX, posY;
-    t_binbuf*b=binbuf_new();
     int didit=0;
 
     int _x; /* dummy variable */
@@ -273,6 +272,7 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
 
                 /* need to get the coordinates of the fanning outlet */
             t_linetraverser t;
+            t_binbuf*b=binbuf_new();
             linetraverser_start(&t, x);
             while((conn = linetraverser_next(&t)))
             {
@@ -295,6 +295,7 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
             canvas_undo_add(x, UNDO_PASTE, "paste",
                 canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
             stub=triggerize_createobj(x, b);
+            binbuf_free(b);
             stub_i = canvas_getindex(x, o2g(stub));
             conn=obj_starttraverseoutlet(obj, &out, nout);
             triggerize_defanout(x, count-1, conn, obj, stub, nout);
@@ -305,7 +306,6 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
         }
         didit++;
     }
-    binbuf_free(b);
     return didit;
 }
 static int triggerize_fanouts(t_glist*cnv)

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2809,12 +2809,12 @@ void g_template_setup(void)
     drawnumber_setup();
 }
 
-void g_template_newpdinstance( void)
+void g_template_newpdinstance(void)
 {
     TEMPLATE = getbytes(sizeof(*TEMPLATE));
 }
 
-void g_template_freepdinstance( void)
+void g_template_freepdinstance(void)
 {
     freebytes(TEMPLATE, sizeof(*TEMPLATE));
 }

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -14,6 +14,13 @@
 
 void canvas_undo_set_name(const char*name);
 
+
+static void canvas_show_undomenu(t_canvas*x, const char* undo_action, const char* redo_action)
+{
+    if (glist_isvisible(x) && glist_istoplevel(x))
+        sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, undo_action, redo_action);
+}
+
 static void canvas_undo_docleardirty(t_canvas *x)
 {
     t_undo *udo = canvas_undo_get(x);
@@ -79,8 +86,7 @@ t_undo_action *canvas_undo_init(t_canvas *x)
 
         a->prev = NULL;
         a->name = "no";
-        if (glist_isvisible(x) && glist_istoplevel(x))
-            sys_vgui("pdtk_undomenu .x%lx no no\n", x);
+        canvas_show_undomenu(x, "no", "no");
     }
     else
     {
@@ -112,8 +118,7 @@ t_undo_action *canvas_undo_add(t_canvas *x, t_undo_type type, const char *name,
         canvas_undo_rebranch(x);
         udo->u_last->next = 0;
         canvas_undo_set_name(udo->u_last->name);
-        if (glist_isvisible(x) && glist_istoplevel(x))
-            sys_vgui("pdtk_undomenu .x%lx %s no\n", x, udo->u_last->name);
+        canvas_show_undomenu(x, udo->u_last->name, "no");
         return 0;
     }
 
@@ -123,9 +128,7 @@ t_undo_action *canvas_undo_add(t_canvas *x, t_undo_type type, const char *name,
     a->data = (void *)data;
     a->name = (char *)name;
     canvas_undo_set_name(name);
-    if (glist_isvisible(x) && glist_istoplevel(x))
-        sys_vgui("pdtk_undomenu .x%lx %s no\n", x, a->name);
-
+    canvas_show_undomenu(x, a->name, "no");
     DEBUG_UNDO(post("%s: done!", __FUNCTION__));
     return(a);
 }
@@ -210,11 +213,7 @@ void canvas_undo_undo(t_canvas *x)
                 /* here we call updating of all unpaired hubs and nodes since
                    their regular call will fail in case their position needed
                    to be updated by undo/redo first to reflect the old one */
-            if (glist_isvisible(x) && glist_istoplevel(x))
-            {
-                if (glist_isvisible(x) && glist_istoplevel(x))
-                    sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, undo_action, redo_action);
-            }
+            canvas_show_undomenu(x, undo_action, redo_action);
             canvas_dirty(x, canvas_undo_isdirty(x));
         }
     }
@@ -269,11 +268,7 @@ void canvas_undo_redo(t_canvas *x)
         /* here we call updating of all unpaired hubs and nodes since their
            regular call will fail in case their position needed to be updated
            by undo/redo first to reflect the old one */
-        if (glist_isvisible(x) && glist_istoplevel(x))
-        {
-            if (glist_isvisible(x) && glist_istoplevel(x))
-                sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, undo_action, redo_action);
-        }
+        canvas_show_undomenu(x, undo_action, redo_action);
         canvas_dirty(x, canvas_undo_isdirty(x));
     }
     canvas_resume_dsp(dspwas);
@@ -297,9 +292,7 @@ void canvas_undo_rebranch(t_canvas *x)
         }
         udo->u_last->next = 0;
     }
-    if (glist_isvisible(x) && glist_istoplevel(x))
-        sys_vgui("pdtk_undomenu .x%lx %s no\n", x, udo->u_last->name);
-
+    canvas_show_undomenu(x, udo->u_last->name, "no");
     canvas_resume_dsp(dspwas);
 }
 

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -295,7 +295,11 @@ void canvas_undo_rebranch(t_canvas *x)
             freebytes(a1, sizeof(*a1));
             a1 = a2;
         }
+        udo->u_last->next = 0;
     }
+    if (glist_isvisible(x) && glist_istoplevel(x))
+        sys_vgui("pdtk_undomenu .x%lx %s no\n", x, udo->u_last->name);
+
     canvas_resume_dsp(dspwas);
 }
 

--- a/src/g_undo.h
+++ b/src/g_undo.h
@@ -4,6 +4,7 @@
 
 /*
 Infinite undo by Ivica Ico Bukvic <ico@vt.edu> Dec. 2011
+Modified for Pd-vanilla by IOhannes m zmölnig <zmoelnig@iem.at> Jun. 2018
 
 This is the home of infinite undo queue. Each root canvas has one of these.
 Only canvas that is root will instantiate the pointer to t_undo_action struct.
@@ -80,7 +81,7 @@ struct _undo
     t_undo_action *u_queue;
     t_undo_action *u_last;
     void *u_cleanstate; /* pointer to non-dirty state */
-    int            u_doing; /* currently undoing */
+    int u_doing; /* currently undoing */
 };
 #define t_undo struct _undo
 

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -475,7 +475,7 @@ int binbuf_resize(t_binbuf *x, int newsize)
     return (new != 0);
 }
 
-int canvas_getdollarzero( void);
+int canvas_getdollarzero(void);
 
 /* JMZ:
  * s points to the first character after the $

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -574,7 +574,7 @@ t_symbol *binbuf_realizedollsym(t_symbol *s, int ac, const t_atom *av, int tonew
         substr=strchr(str, '$');
         if(substr)
         {
-            int n = substr-str;
+            long n = substr-str;
             if(n>MAXPDSTRING-strlen(buf2)-1) n=MAXPDSTRING-strlen(buf2)-1;
             strncat(buf2, str, n);
             str=substr+1;

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -44,17 +44,17 @@ t_pdinstance pd_maininstance;
 
 static t_symbol *dogensym(const char *s, t_symbol *oldsym,
     t_pdinstance *pdinstance);
-void x_midi_newpdinstance( void);
-void x_midi_freepdinstance( void);
-void s_inter_newpdinstance( void);
-void s_inter_freepdinstance( void);
-void g_canvas_newpdinstance( void);
-void g_canvas_freepdinstance( void);
-void d_ugen_newpdinstance( void);
-void d_ugen_freepdinstance( void);
+void x_midi_newpdinstance(void);
+void x_midi_freepdinstance(void);
+void s_inter_newpdinstance(void);
+void s_inter_freepdinstance(void);
+void g_canvas_newpdinstance(void);
+void g_canvas_freepdinstance(void);
+void d_ugen_newpdinstance(void);
+void d_ugen_freepdinstance(void);
 void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv);
 
-void s_stuff_newpdinstance( void)
+void s_stuff_newpdinstance(void)
 {
     STUFF = getbytes(sizeof(*STUFF));
     STUFF->st_externlist = STUFF->st_searchpath =
@@ -62,7 +62,7 @@ void s_stuff_newpdinstance( void)
     STUFF->st_schedblocksize = STUFF->st_blocksize = DEFDACBLKSIZE;
 }
 
-void s_stuff_freepdinstance( void)
+void s_stuff_freepdinstance(void)
 {
     freebytes(STUFF, sizeof(*STUFF));
 }

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -65,7 +65,7 @@ void glob_foo(void *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_foo(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
 #ifdef USEAPI_ALSA
-    void alsa_printstate( void);
+    void alsa_printstate(void);
     alsa_printstate();
 #endif
 }

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -86,8 +86,8 @@ EXTERN int obj_siginletindex(const t_object *x, int m);
 EXTERN int obj_sigoutletindex(const t_object *x, int m);
 
 /* s_inter.c */
-void pd_globallock( void);
-void pd_globalunlock( void);
+void pd_globallock(void);
+void pd_globalunlock(void);
 
 /* misc */
 #define SYMTABHASHSIZE 1024

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -313,7 +313,7 @@ void outlet_setstacklim(void)
 }
 
     /* get a number unique to the (clock, MIDI, GUI, etc.) event we're on */
-int sched_geteventno( void)
+int sched_geteventno(void)
 {
     return (outlet_eventno);
 }

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -256,7 +256,7 @@ void pd_popsym(t_pd *x)
     }
 }
 
-void pd_doloadbang( void)
+void pd_doloadbang(void)
 {
     if (lastpopped)
         pd_vmess(lastpopped, gensym("loadbang"), "f", LB_LOAD);

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -11,7 +11,7 @@ extern "C" {
 #define PD_MAJOR_VERSION 0
 #define PD_MINOR_VERSION 49
 #define PD_BUGFIX_VERSION 0
-#define PD_TEST_VERSION "test5"
+#define PD_TEST_VERSION ""
 extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 
 /* old name for "MSW" flag -- we have to take it for the sake of many old

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -255,7 +255,7 @@ typedef struct _text t_object;
 #define ob_g te_g
 
 typedef void (*t_method)(void);
-typedef void *(*t_newmethod)( void);
+typedef void *(*t_newmethod)(void);
 
 /* in ARM 64 a varargs prototype generates a different function call sequence
 from a fixed one, so in that special case we make a more restrictive
@@ -848,7 +848,7 @@ EXTERN t_pdinstance pd_maininstance;
 
 /* m_pd.c */
 #ifdef PDINSTANCE
-EXTERN t_pdinstance *pdinstance_new( void);
+EXTERN t_pdinstance *pdinstance_new(void);
 EXTERN void pd_setinstance(t_pdinstance *x);
 EXTERN void pdinstance_free(t_pdinstance *x);
 #endif /* PDINSTANCE */

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -125,13 +125,13 @@ void clock_setunit(t_clock *x, double timeunit, int sampflag)
 
     /* get current logical time.  We don't specify what units this is in;
     use clock_gettimesince() to measure intervals from time of this call. */
-double clock_getlogicaltime( void)
+double clock_getlogicaltime(void)
 {
     return (pd_this->pd_systime);
 }
 
     /* OBSOLETE (misleading) function name kept for compatibility */
-double clock_getsystime( void) { return (pd_this->pd_systime); }
+double clock_getsystime(void) { return (pd_this->pd_systime); }
 
     /* elapsed time in milliseconds since the given system time */
 double clock_gettimesince(double prevsystime)
@@ -175,7 +175,7 @@ static int sys_histogram[NHIST][NBIN];
 static double sys_histtime;
 static int sched_diddsp, sched_didpoll, sched_didnothing;
 
-void sys_clearhist( void)
+void sys_clearhist(void)
 {
     unsigned int i, j;
     for (i = 0; i < NHIST; i++)
@@ -184,7 +184,7 @@ void sys_clearhist( void)
     sched_diddsp = sched_didpoll = sched_didnothing = 0;
 }
 
-void sys_printhist( void)
+void sys_printhist(void)
 {
     unsigned int i, j;
     for (i = 0; i < NHIST; i++)
@@ -298,7 +298,7 @@ static int sched_lastinclip, sched_lastoutclip,
 
 void glob_watchdog(t_pd *dummy);
 
-static void sched_pollformeters( void)
+static void sched_pollformeters(void)
 {
     int inclip, outclip, indb, outdb;
     static int sched_nextmeterpolltime, sched_nextpingtime;
@@ -397,7 +397,7 @@ void sched_set_using_audio(int flag)
 }
 
     /* take the scheduler forward one DSP tick, also handling clock timeouts */
-void sched_tick( void)
+void sched_tick(void)
 {
     double next_sys_time = pd_this->pd_systime +
         (STUFF->st_schedblocksize/STUFF->st_dacsr) * TIMEUNITPERSECOND;
@@ -434,15 +434,15 @@ call.  This call returns true if samples were transferred; false means that
 the audio I/O system is still busy with previous transfers.
 */
 
-void sys_pollmidiqueue( void);
-void sys_initmidiqueue( void);
+void sys_pollmidiqueue(void);
+void sys_initmidiqueue(void);
 
  /* sys_idlehook is a hook the user can fill in to grab idle time.  Return
 nonzero if you actually used the time; otherwise we're really really idle and
 will now sleep. */
 int (*sys_idlehook)(void);
 
-static void m_pollingscheduler( void)
+static void m_pollingscheduler(void)
 {
     int idlecount = 0;
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -142,7 +142,7 @@ void sys_save_audio_params(
 void oss_init(void);
 #endif
 
-static void audio_init( void)
+static void audio_init(void)
 {
     static int initted = 0;
     if (initted)
@@ -417,7 +417,7 @@ void sys_close_audio(void)
 }
 
     /* open audio using whatever parameters were last used */
-void sys_reopen_audio( void)
+void sys_reopen_audio(void)
 {
     int naudioindev, audioindev[MAXAUDIOINDEV], chindev[MAXAUDIOINDEV];
     int naudiooutdev, audiooutdev[MAXAUDIOOUTDEV], choutdev[MAXAUDIOOUTDEV];
@@ -620,7 +620,7 @@ void sys_reportidle(void)
 
 /* this could later be set by a preference but for now it seems OK to just
 keep jack audio open but close unused audio devices for any other API */
-int audio_shouldkeepopen( void)
+int audio_shouldkeepopen(void)
 {
     return (sys_audioapi == API_JACK);
 }
@@ -709,7 +709,7 @@ static void audio_getdevs(char *indevlist, int *nindevs,
 }
 
 
-static void sys_listaudiodevs(void )
+static void sys_listaudiodevs(void)
 {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i, canmulti = 0, cancallback = 0;
@@ -881,7 +881,7 @@ void sys_set_audio_settings_reopen(int naudioindev, int *audioindev, int nchinde
     else sched_reopenmeplease();
 }
 
-void sys_listdevs(void )
+void sys_listdevs(void)
 {
 #ifdef USEAPI_PORTAUDIO
     if (sys_audioapi == API_PORTAUDIO)
@@ -1069,7 +1069,7 @@ void sys_get_audio_apis(char *buf)
 #ifdef USEAPI_ALSA
 void alsa_putzeros(int n);
 void alsa_getzeros(int n);
-void alsa_printstate( void);
+void alsa_printstate(void);
 #endif
 
 /* convert a device name to a (1-based) device number.  (Output device if

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -36,7 +36,7 @@
 #define ALSAAPI9
 #endif
 
-static void alsa_checkiosync( void);
+static void alsa_checkiosync(void);
 static void alsa_numbertoname(int iodev, char *devname, int nchar);
 static int alsa_jittermax;
 #define ALSA_DEFJITTERMAX 5
@@ -692,7 +692,7 @@ int alsa_send_dacs(void)
     return (SENDDACS_YES);
 }
 
-void alsa_printstate( void)
+void alsa_printstate(void)
 {
     int i, result, iodev = 0;
     snd_pcm_sframes_t indelay = 0, inavail = 0, outdelay = 0, outavail = 0;
@@ -757,7 +757,7 @@ void alsa_getzeros(int iodev, int n)
 }
 
     /* call this only if both input and output are open */
-static void alsa_checkiosync( void)
+static void alsa_checkiosync(void)
 {
     int i, result, giveup = 50, alreadylogged = 0, iodev = 0, err;
     snd_pcm_sframes_t minphase, maxphase, thisphase, outdelay;

--- a/src/s_audio_audiounit.c
+++ b/src/s_audio_audiounit.c
@@ -35,7 +35,7 @@ void audiounit_getdevs(char *indevlist, int *nindevs,
     post("device getting not implemented for AudioUnit yet\n");
 }
 
-void audiounit_listdevs( void)
+void audiounit_listdevs(void)
 {
     post("device listing not implemented for AudioUnit yet\n");
 }

--- a/src/s_audio_dummy.c
+++ b/src/s_audio_dummy.c
@@ -13,11 +13,11 @@ int dummy_open_audio(int nin, int nout, int sr) {
   return 0;
 }
 
-int dummy_close_audio( void) {
+int dummy_close_audio(void) {
   return 0;
 }
 
-int dummy_send_dacs( void) {
+int dummy_send_dacs(void) {
   return 0;
 }
 
@@ -29,7 +29,7 @@ void dummy_getdevs(char *indevlist, int *nindevs, char *outdevlist,
   *canmulti = 0;
 }
 
-void dummy_listdevs( void) {
+void dummy_listdevs(void) {
   // do nothing
 }
 

--- a/src/s_audio_esd.c
+++ b/src/s_audio_esd.c
@@ -58,7 +58,7 @@ int esd_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
     return (0);
 }
 
-void esd_close_audio( void)
+void esd_close_audio(void)
 {
   close(esd_socket_out);
   close(esd_socket_in);
@@ -113,7 +113,7 @@ int esd_send_dacs(void)
   return (SENDDACS_YES);
 }
 
-void esd_listdevs( void)
+void esd_listdevs(void)
 {
     post("device listing not implemented for ESD yet\n");
 }

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -547,7 +547,7 @@ void jack_getdevs(char *indevlist, int *nindevs,
     *nindevs = *noutdevs = ndev;
 }
 
-void jack_listdevs( void)
+void jack_listdevs(void)
 {
     post("device listing not implemented for jack yet\n");
 }

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -16,7 +16,7 @@
 /* ------------------------- audio -------------------------- */
 
 static void nt_close_midiin(void);
-static void nt_noresync( void);
+static void nt_noresync(void);
 
 static void postflags(void);
 
@@ -218,7 +218,7 @@ int mmio_do_open_audio(void)
     return (0);
 }
 
-void mmio_close_audio( void)
+void mmio_close_audio(void)
 {
     int errcode;
     int nda, nad;
@@ -395,7 +395,7 @@ reason the sync testing below gives false positives. */
 
 static int nt_resync_cancelled;
 
-static void nt_noresync( void)
+static void nt_noresync(void)
 {
     nt_resync_cancelled = 1;
 }

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -481,7 +481,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
     return (0);
 }
 
-void oss_close_audio( void)
+void oss_close_audio(void)
 {
      int i;
      for (i=0;i<linux_nindevs;i++)
@@ -542,7 +542,7 @@ void linux_audiostatus(void)
 /* this call resyncs audio output and input which will cause discontinuities
 in audio output and/or input. */
 
-static void oss_doresync( void)
+static void oss_doresync(void)
 {
     int dev, zeroed = 0, wantsize;
     char buf[OSS_MAXSAMPLEWIDTH * DEFDACBLKSIZE * OSS_MAXCHPERDEV];

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -468,7 +468,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     return (0);
 }
 
-void pa_close_audio( void)
+void pa_close_audio(void)
 {
     if (pa_stream)
     {

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -33,7 +33,7 @@
 #define snprintf _snprintf
 #endif
 
-void sys_doflags( void);
+void sys_doflags(void);
 
 static PERTHREAD char *sys_prefbuf;
 static PERTHREAD int sys_prefbufsize;
@@ -101,7 +101,7 @@ static int sys_getpreference_file(const char *key, char *value, int size)
     return (1);
 }
 
-static void sys_doneloadpreferences_file( void)
+static void sys_doneloadpreferences_file(void)
 {
     if (sys_prefbuf)
         free(sys_prefbuf);
@@ -120,7 +120,7 @@ static void sys_putpreference_file(const char *key, const char *value)
             key, value);
 }
 
-static void sys_donesavepreferences_file( void)
+static void sys_donesavepreferences_file(void)
 {
     if (sys_prefsavefp)
     {
@@ -133,7 +133,7 @@ static void sys_donesavepreferences_file( void)
 /*****  linux/android/BSD etc: read and write to ~/.pdsettings file ******/
 #if !defined(_WIN32) && !defined(__APPLE__)
 
-static void sys_initloadpreferences( void)
+static void sys_initloadpreferences(void)
 {
     char filenamebuf[MAXPDSTRING], *homedir = getenv("HOME");
     int fd, length;
@@ -160,12 +160,12 @@ static int sys_getpreference(const char *key, char *value, int size)
     return (sys_getpreference_file(key, value, size));
 }
 
-static void sys_doneloadpreferences( void)
+static void sys_doneloadpreferences(void)
 {
     sys_doneloadpreferences_file();
 }
 
-static void sys_initsavepreferences( void)
+static void sys_initsavepreferences(void)
 {
     char filenamebuf[MAXPDSTRING],
         *homedir = getenv("HOME");
@@ -183,29 +183,29 @@ static void sys_putpreference(const char *key, const char *value)
     sys_putpreference_file(key, value);
 }
 
-static void sys_donesavepreferences( void)
+static void sys_donesavepreferences(void)
 {
     sys_donesavepreferences_file();
 }
 
 #else  /* !defined(_WIN32) && !defined(__APPLE__) */
 
-static void sys_initloadpreferences( void)
+static void sys_initloadpreferences(void)
 {
     if (sys_prefbuf)
         bug("sys_initloadpreferences");
 }
-static void sys_doneloadpreferences( void)
+static void sys_doneloadpreferences(void)
 {
     if (sys_prefbuf)
         sys_doneloadpreferences_file();
 }
-static void sys_initsavepreferences( void)
+static void sys_initsavepreferences(void)
 {
     if (sys_prefsavefp)
         bug("sys_initsavepreferences");
 }
-static void sys_donesavepreferences( void)
+static void sys_donesavepreferences(void)
 {
     if (sys_prefsavefp)
         sys_donesavepreferences_file();

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -145,7 +145,7 @@ void sys_set_searchpath(void);
 void sys_set_temppath(void);
 void sys_set_extrapath(void);
 void sys_set_startup(void);
-void sys_stopgui( void);
+void sys_stopgui(void);
 
 /* ----------- functions for timing, signals, priorities, etc  --------- */
 
@@ -318,7 +318,7 @@ void sys_setalarm(int microsec)
 #endif /* NOT _WIN32 && NOT __CYGWIN__ */
 
     /* on startup, set various signal handlers */
-void sys_setsignalhandlers( void)
+void sys_setsignalhandlers(void)
 {
 #if !defined(_WIN32) && !defined(__CYGWIN__)
     signal(SIGHUP, sys_huphandler);
@@ -683,7 +683,7 @@ static void sys_trytogetmoreguibuf(int newsize)
     }
 }
 
-int sys_havegui( void)
+int sys_havegui(void)
 {
     return (pd_this->pd_inter->i_havegui);
 }
@@ -797,7 +797,7 @@ void glob_ping(t_pd *dummy)
     pd_this->pd_inter->i_waitingforping = 0;
 }
 
-static int sys_flushqueue(void )
+static int sys_flushqueue(void)
 {
     int wherestop = pd_this->pd_inter->i_bytessincelastping + GUI_UPDATESLICE;
     if (wherestop + (GUI_UPDATESLICE >> 1) > GUI_BYTESPERPING)
@@ -931,7 +931,7 @@ void glob_watchdog(t_pd *dummy)
 }
 #endif
 
-static void sys_init_deken( void)
+static void sys_init_deken(void)
 {
     const char*os =
 #if defined __linux__
@@ -1483,7 +1483,7 @@ int sys_startgui(const char *libdir)
  /* more work needed here - for some reason we can't restart the gui after
  shutting it down this way.  I think the second 'init' message never makes
  it because the to-gui buffer isn't re-initialized. */
-void sys_stopgui( void)
+void sys_stopgui(void)
 {
     t_canvas *x;
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
@@ -1500,7 +1500,7 @@ void sys_stopgui( void)
 
 /* ----------- mutexes for thread safety --------------- */
 
-void s_inter_newpdinstance( void)
+void s_inter_newpdinstance(void)
 {
     pd_this->pd_inter = getbytes(sizeof(*pd_this->pd_inter));
 #if PDTHREADS
@@ -1525,7 +1525,7 @@ void s_inter_free(t_instanceinter *inter)
     freebytes(inter, sizeof(*inter));
 }
 
-void s_inter_freepdinstance( void)
+void s_inter_freepdinstance(void)
 {
     s_inter_free(pd_this->pd_inter);
 }
@@ -1548,7 +1548,7 @@ current instance of Pd is currently locked via sys_lock() below; this gains
 read access to the class and instance lists which must be released for the
 write-lock to be available. */
 
-void pd_globallock( void)
+void pd_globallock(void)
 {
 #ifdef PDINSTANCE
     if (!pd_this->pd_islocked)
@@ -1558,7 +1558,7 @@ void pd_globallock( void)
 #endif /* PDINSTANCE */
 }
 
-void pd_globalunlock( void)
+void pd_globalunlock(void)
 {
 #ifdef PDINSTANCE
     pthread_rwlock_unlock(&sys_rwlock);
@@ -1569,7 +1569,7 @@ void pd_globalunlock( void)
 /* routines to lock/unlock a Pd instance for thread safety.  Call pd_setinsance
 first.  The "pd_this"  variable can be written and read thread-safely as it
 is defined as per-thread storage. */
-void sys_lock( void)
+void sys_lock(void)
 {
 #ifdef PDINSTANCE
     pthread_mutex_lock(&pd_this->pd_inter->i_mutex);
@@ -1580,7 +1580,7 @@ void sys_lock( void)
 #endif
 }
 
-void sys_unlock( void)
+void sys_unlock(void)
 {
 #ifdef PDINSTANCE
     pd_this->pd_islocked = 0;
@@ -1591,7 +1591,7 @@ void sys_unlock( void)
 #endif
 }
 
-int sys_trylock( void)
+int sys_trylock(void)
 {
 #ifdef PDINSTANCE
     int ret;
@@ -1613,9 +1613,9 @@ int sys_trylock( void)
 
 #else /* PDTHREADS */
 
-void sys_lock( void) {}
-void sys_unlock( void) {}
-void pd_globallock( void) {}
-void pd_globalunlock( void) {}
+void sys_lock(void) {}
+void sys_unlock(void) {}
+void pd_globallock(void) {}
+void pd_globalunlock(void) {}
 
 #endif /* PDTHREADS */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -38,7 +38,7 @@ char pd_compiledate[] = __DATE__;
 void pd_init(void);
 int sys_argparse(int argc, char **argv);
 void sys_findprogdir(char *progname);
-void sys_setsignalhandlers( void);
+void sys_setsignalhandlers(void);
 int sys_startgui(const char *guipath);
 void sys_setrealtime(const char *guipath);
 int m_mainloop(void);

--- a/src/s_midi_dummy.c
+++ b/src/s_midi_dummy.c
@@ -12,7 +12,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
 {
 }
 
-void sys_close_midi( void)
+void sys_close_midi(void)
 {
 }
 

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -113,7 +113,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
     }
 }
 
-void sys_close_midi( void)
+void sys_close_midi(void)
 {
     int i;
     for (i = 0; i < mac_nmidiindev; i++)

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -528,7 +528,7 @@ gotone:
 }
 
 int sys_argparse(int argc, char **argv);
-void sys_doflags( void)
+void sys_doflags(void)
 {
     int i, beginstring = 0, state = 0, len;
     int rcargc = 0;
@@ -608,7 +608,7 @@ t_symbol *sys_decodedialog(t_symbol *s)
 }
 
     /* send the user-specified search path to pd-gui */
-void sys_set_searchpath( void)
+void sys_set_searchpath(void)
 {
     int i;
     t_namelist *nl;
@@ -632,7 +632,7 @@ void sys_set_temppath(void)
 }
 
     /* send the hard-coded search path to pd-gui */
-void sys_set_extrapath( void)
+void sys_set_extrapath(void)
 {
     int i;
     t_namelist *nl;
@@ -685,7 +685,7 @@ void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit)
 }
 
     /* set the global list vars for startup libraries and flags */
-void sys_set_startup( void)
+void sys_set_startup(void)
 {
     int i;
     t_namelist *nl;

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -39,7 +39,7 @@ extern t_symbol *sys_flags;
 extern int sys_debuglevel;
 extern int sys_verbose;
 extern int sys_noloadbang;
-EXTERN int sys_havegui( void);
+EXTERN int sys_havegui(void);
 extern char *sys_guicmd;
 
 EXTERN int sys_nearestfontsize(int fontsize);
@@ -73,11 +73,11 @@ EXTERN void sys_set_audio_settings_reopen(int naudioindev, int *audioindev,
     int nchindev, int *chindev,
     int naudiooutdev, int *audiooutdev, int nchoutdev, int *choutdev,
     int srate, int advance, int callback, int blocksize);
-EXTERN void sys_reopen_audio( void);
+EXTERN void sys_reopen_audio(void);
 EXTERN void sys_close_audio(void);
     /* return true if the interface prefers always being open (ala jack) : */
-EXTERN int audio_shouldkeepopen( void);
-EXTERN int audio_isopen( void);     /* true if audio interface is open */
+EXTERN int audio_shouldkeepopen(void);
+EXTERN int audio_isopen(void);     /* true if audio interface is open */
 EXTERN int sys_audiodevnametonumber(int output, const char *name);
 EXTERN void sys_audiodevnumbertoname(int output, int devno, char *name,
     int namesize);
@@ -117,8 +117,8 @@ EXTERN int sys_mididevnametonumber(int output, const char *name);
 EXTERN void sys_mididevnumbertoname(int output, int devno, char *name,
     int namesize);
 
-EXTERN void sys_reopen_midi( void);
-EXTERN void sys_close_midi( void);
+EXTERN void sys_reopen_midi(void);
+EXTERN void sys_close_midi(void);
 EXTERN void sys_putmidimess(int portno, int a, int b, int c);
 EXTERN void sys_putmidibyte(int portno, int a);
 EXTERN void sys_poll_midi(void);
@@ -135,7 +135,7 @@ void sys_do_open_midi(int nmidiindev, int *midiindev,
 EXTERN void sys_alsa_putmidimess(int portno, int a, int b, int c);
 EXTERN void sys_alsa_putmidibyte(int portno, int a);
 EXTERN void sys_alsa_poll_midi(void);
-EXTERN void sys_alsa_close_midi( void);
+EXTERN void sys_alsa_close_midi(void);
 
 
     /* implemented in the system dependent MIDI code (s_midi_pm.c, etc. ) */
@@ -296,7 +296,7 @@ void jack_autoconnect(int);
 int mmio_open_audio(int naudioindev, int *audioindev,
     int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,
     int nchoutdev, int *choutdev, int rate, int blocksize);
-void mmio_close_audio( void);
+void mmio_close_audio(void);
 void mmio_reportidle(void);
 int mmio_send_dacs(void);
 void mmio_getdevs(char *indevlist, int *nindevs,
@@ -324,11 +324,11 @@ void esd_getdevs(char *indevlist, int *nindevs,
         int maxndev, int devdescsize);
 
 int dummy_open_audio(int nin, int nout, int sr);
-int dummy_close_audio( void);
-int dummy_send_dacs( void);
+int dummy_close_audio(void);
+int dummy_send_dacs(void);
 void dummy_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int *canmulti, int maxndev, int devdescsize);
-void dummy_listdevs( void);
+void dummy_listdevs(void);
 
 void sys_listmididevs(void);
 EXTERN void sys_set_midi_api(int whichapi);
@@ -337,7 +337,7 @@ EXTERN int sys_audioapi;
 EXTERN void sys_set_audio_state(int onoff);
 
 /* API dependent audio flags and settings */
-void oss_set32bit( void);
+void oss_set32bit(void);
 void linux_alsa_devname(char *devname);
 
 EXTERN void sys_get_audio_params(
@@ -359,21 +359,21 @@ extern int sys_printtostderr;
 
 EXTERN int sys_externalschedlib;
 
-EXTERN t_sample* get_sys_soundout(void ) ;
-EXTERN t_sample* get_sys_soundin(void ) ;
-EXTERN int* get_sys_main_advance(void ) ;
-EXTERN double* get_sys_time_per_dsp_tick(void ) ;
-EXTERN int* get_sys_schedblocksize(void ) ;
-EXTERN double* get_sys_time(void ) ;
-EXTERN t_float* get_sys_dacsr(void ) ;
-EXTERN int* get_sys_sleepgrain(void ) ;
-EXTERN int* get_sys_schedadvance(void ) ;
+EXTERN t_sample* get_sys_soundout(void);
+EXTERN t_sample* get_sys_soundin(void);
+EXTERN int* get_sys_main_advance(void);
+EXTERN double* get_sys_time_per_dsp_tick(void);
+EXTERN int* get_sys_schedblocksize(void);
+EXTERN double* get_sys_time(void);
+EXTERN t_float* get_sys_dacsr(void);
+EXTERN int* get_sys_sleepgrain(void);
+EXTERN int* get_sys_schedadvance(void);
 
-EXTERN void sys_clearhist(void );
-EXTERN void sys_initmidiqueue(void );
+EXTERN void sys_clearhist(void);
+EXTERN void sys_initmidiqueue(void);
 EXTERN int sys_addhist(int phase);
-EXTERN void sched_tick( void);
-EXTERN void sys_pollmidiqueue(void );
+EXTERN void sched_tick(void);
+EXTERN void sys_pollmidiqueue(void);
 EXTERN void sys_setchsr(int chin, int chout, int sr);
 
 EXTERN void inmidi_realtimein(int portno, int cmd);

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -865,7 +865,7 @@ void canvas_add_for_class(t_class *c);
 
 /* ---------------- global setup function -------------------- */
 
-void x_array_setup(void )
+void x_array_setup(void)
 {
     array_define_class = class_new(gensym("array define"), 0,
         (t_method)canvas_free, sizeof(t_canvas), 0, 0);

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -190,7 +190,7 @@ typedef struct _openpanel
     t_symbol *x_s;
 } t_openpanel;
 
-static void *openpanel_new( void)
+static void *openpanel_new(void)
 {
     char buf[50];
     t_openpanel *x = (t_openpanel *)pd_new(openpanel_class);
@@ -245,7 +245,7 @@ typedef struct _savepanel
     t_symbol *x_s;
 } t_savepanel;
 
-static void *savepanel_new( void)
+static void *savepanel_new(void)
 {
     char buf[50];
     t_savepanel *x = (t_savepanel *)pd_new(savepanel_class);
@@ -298,7 +298,7 @@ typedef struct _key
     t_object x_obj;
 } t_key;
 
-static void *key_new( void)
+static void *key_new(void)
 {
     t_key *x = (t_key *)pd_new(key_class);
     outlet_new(&x->x_obj, &s_float);
@@ -321,7 +321,7 @@ typedef struct _keyup
     t_object x_obj;
 } t_keyup;
 
-static void *keyup_new( void)
+static void *keyup_new(void)
 {
     t_keyup *x = (t_keyup *)pd_new(keyup_class);
     outlet_new(&x->x_obj, &s_float);
@@ -346,7 +346,7 @@ typedef struct _keyname
     t_outlet *x_outlet2;
 } t_keyname;
 
-static void *keyname_new( void)
+static void *keyname_new(void)
 {
     t_keyname *x = (t_keyname *)pd_new(keyname_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -609,7 +609,7 @@ typedef struct _list_trim
     t_object x_obj;
 } t_list_trim;
 
-static void *list_trim_new( void)
+static void *list_trim_new(void)
 {
     t_list_trim *x = (t_list_trim *)pd_new(list_trim_class);
     outlet_new(&x->x_obj, &s_list);
@@ -650,7 +650,7 @@ typedef struct _list_length
     t_object x_obj;
 } t_list_length;
 
-static void *list_length_new( void)
+static void *list_length_new(void)
 {
     t_list_length *x = (t_list_length *)pd_new(list_length_class);
     outlet_new(&x->x_obj, &s_float);
@@ -688,7 +688,7 @@ typedef struct _list_fromsymbol
     t_object x_obj;
 } t_list_fromsymbol;
 
-static void *list_fromsymbol_new( void)
+static void *list_fromsymbol_new(void)
 {
     t_list_fromsymbol *x = (t_list_fromsymbol *)pd_new(list_fromsymbol_class);
     outlet_new(&x->x_obj, &s_list);
@@ -723,7 +723,7 @@ typedef struct _list_tosymbol
     t_object x_obj;
 } t_list_tosymbol;
 
-static void *list_tosymbol_new( void)
+static void *list_tosymbol_new(void)
 {
     t_list_tosymbol *x = (t_list_tosymbol *)pd_new(list_tosymbol_class);
     outlet_new(&x->x_obj, &s_symbol);

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -185,7 +185,7 @@ void canvas_add_for_class(t_class *c);
 
 /* ---------------- global setup function -------------------- */
 
-void x_scalar_setup(void )
+void x_scalar_setup(void)
 {
     scalar_define_class = class_new(gensym("scalar define"), 0,
         (t_method)canvas_free, sizeof(t_canvas), 0, 0);
@@ -199,5 +199,4 @@ void x_scalar_setup(void )
     class_setsavefn(scalar_define_class, scalar_define_save);
 
     class_addcreator((t_newmethod)scalarobj_new, gensym("scalar"), A_GIMME, 0);
-
 }

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -1667,7 +1667,7 @@ static void qlist_tick(t_qlist *x);
 
 static t_class *qlist_class;
 
-static void *qlist_new( void)
+static void *qlist_new(void)
 {
     t_qlist *x = (t_qlist *)pd_new(qlist_class);
     textbuf_init(&x->x_textbuf, gensym("qlist"));
@@ -1895,7 +1895,7 @@ static void qlist_free(t_qlist *x)
 
 static t_class *textfile_class;
 
-static void *textfile_new( void)
+static void *textfile_new(void)
 {
     t_qlist *x = (t_qlist *)pd_new(textfile_class);
     textbuf_init(&x->x_textbuf, gensym("textfile"));
@@ -1957,7 +1957,7 @@ field named 't'.  I don't know how to make this not break
 pre-0.45 patches using templates named 'text'... perhaps this is a minor
 enough incompatibility that I'll just get away with it. */
 
-void text_template_init( void)
+void text_template_init(void)
 {
     t_binbuf *b;
     b = binbuf_new();
@@ -1971,7 +1971,7 @@ void text_template_init( void)
     binbuf_free(b);
 }
 
-void x_qlist_setup(void )
+void x_qlist_setup(void)
 {
     text_template_init();
     text_define_class = class_new(gensym("text define"),

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -2198,5 +2198,5 @@ ex_print(struct ex_ex *eptr)
 }
 
 #ifdef _WIN32
-void ABORT( void) {bug("expr");}
+void ABORT(void) {bug("expr");}
 #endif

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -383,9 +383,6 @@ proc init_for_platform {} {
             option add *DialogWindow*font menufont startupFile
             option add *PdWindow*font menufont startupFile
             option add *ErrorDialog*font menufont startupFile
-            # initial dir is home
-            set ::filenewdir $::env(HOME)
-            set ::fileopendir $::env(HOME)
             # set file types that open/save recognize
             set ::filetypes \
                 [list \

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -116,8 +116,11 @@ proc ::pd_bindings::global_bindings {} {
     bind all <KeyPress-Escape>         {menu_send %W deselectall}
     bind all <KeyPress-Tab>            {menu_send_float %W cycleselect  1; ::pd_bindings::sendkey %W 1 %K %A 0}
     bind all <Shift-Tab>               {menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1}
-    # on X11, <Shift-Tab> is different key by the name 'ISO_Left_Tab'...
-    bind all <KeyPress-ISO_Left_Tab>   {menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1}
+    # on X11, <Shift-Tab> is a different key by the name 'ISO_Left_Tab'...
+    # other systems (at least aqua) do not like this name, so we 'catch' any errors
+    catch {bind all <KeyPress-ISO_Left_Tab> {
+        menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1
+    } } stderr
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -114,9 +114,10 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
     bind all <KeyPress-Escape>         {menu_send %W deselectall}
-    bind all <KeyPress-Tab>            {menu_send_float %W cycleselect  1}
-    bind all <Shift-Tab>               {menu_send_float %W cycleselect -1}
-    bind all <KeyPress-ISO_Left_Tab>   {menu_send_float %W cycleselect -1}
+    bind all <KeyPress-Tab>            {menu_send_float %W cycleselect  1; ::pd_bindings::sendkey %W 1 %K %A 0}
+    bind all <Shift-Tab>               {menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1}
+    # on X11, <Shift-Tab> is different key by the name 'ISO_Left_Tab'...
+    bind all <KeyPress-ISO_Left_Tab>   {menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -114,6 +114,9 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
     bind all <KeyPress-Escape>         {menu_send %W deselectall}
+    bind all <KeyPress-Tab>            {menu_send_float %W cycleselect  1}
+    bind all <Shift-Tab>               {menu_send_float %W cycleselect -1}
+    bind all <KeyPress-ISO_Left_Tab>   {menu_send_float %W cycleselect -1}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -160,7 +160,7 @@ proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
     bind $mytoplevel <$::modifier-Key-w> "dialog_${dialogname}::cancel $mytoplevel"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
-    if {$mytoplevel ne".find"} {
+    if {$mytoplevel ne ".find"} {
         bind $mytoplevel <$::modifier-Key-s>       {bell; break}
         bind $mytoplevel <$::modifier-Shift-Key-s> {bell; break}
         bind $mytoplevel <$::modifier-Shift-Key-S> {bell; break}
@@ -249,7 +249,7 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     bind $tkcanvas <Shift-MouseWheel> {::pdtk_canvas::scroll %W x %D}
 
     # "right clicks" are defined differently on each platform
-    switch -- $::windowingsystem { 
+    switch -- $::windowingsystem {
         "aqua" {
             bind $tkcanvas <ButtonPress-2>    "pdtk_canvas_rightclick %W %x %y %b"
             # on Mac OS X, make a rightclick with Ctrl-click for 1 button mice
@@ -281,7 +281,7 @@ proc ::pd_bindings::window_focusin {mytoplevel} {
     ::pd_menucommands::set_filenewdir $mytoplevel
     ::dialog_font::update_font_dialog $mytoplevel
     if {$mytoplevel eq ".pdwindow"} {
-        ::pd_menus::configure_for_pdwindow 
+        ::pd_menus::configure_for_pdwindow
     } else {
         ::pd_menus::configure_for_canvas $mytoplevel
     }
@@ -329,7 +329,7 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     #    left top right bottom
     pdsend "$mytoplevel setbounds $x $y [expr $x + $width] [expr $y + $height]"
 }
-    
+
 proc ::pd_bindings::patch_destroy {window} {
     set mytoplevel [winfo toplevel $window]
     unset ::editmode($mytoplevel)

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -209,7 +209,22 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     bind $tkcanvas <$::modifier-$alt-Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 7"
 
-    bind $tkcanvas <ButtonRelease-1>          "pdtk_canvas_mouseup %W %x %y %b"
+    bind $tkcanvas <ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 0"
+    bind $tkcanvas <Shift-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 1"
+    bind $tkcanvas <$::modifier-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 2"
+    bind $tkcanvas <$::modifier-Shift-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 3"
+    bind $tkcanvas <$alt-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 4"
+    bind $tkcanvas <$alt-Shift-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 5"
+    bind $tkcanvas <$::modifier-$alt-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 6"
+    bind $tkcanvas <$::modifier-$alt-Shift-ButtonRelease-1> \
+        "pdtk_canvas_mouseup %W %x %y %b 7"
 
     if {$::windowingsystem eq "x11"} {
         # from http://wiki.tcl.tk/3893

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -113,6 +113,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
     bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
+    bind all <KeyPress-Escape>         {menu_send %W deselectall}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -113,7 +113,7 @@ proc ::pd_bindings::global_bindings {} {
     bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
     bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
     bind all <$::modifier-Shift-Key-z> {menu_redo}
-    bind all <KeyPress-Escape>         {menu_send %W deselectall}
+    bind all <KeyPress-Escape>         {menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1}
     bind all <KeyPress-Tab>            {menu_send_float %W cycleselect  1; ::pd_bindings::sendkey %W 1 %K %A 0}
     bind all <Shift-Tab>               {menu_send_float %W cycleselect -1; ::pd_bindings::sendkey %W 1 %K %A 1}
     # on X11, <Shift-Tab> is a different key by the name 'ISO_Left_Tab'...

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -285,6 +285,16 @@ proc ::pdtk_canvas::pdtk_canvas_popup {mytoplevel xcanvas ycanvas hasproperties 
     tk_popup .popup $xpopup $ypopup 0
 }
 
+if {[tk windowingsystem] eq "aqua" } {
+    # I don't know how to move the mouse on OSX, so skip it
+    proc ::pdtk_canvas::setmouse {tkcanvas x y} { }
+} else {
+    proc ::pdtk_canvas::setmouse {tkcanvas x y} {
+        # set the mouse to the given position
+        # (same coordinate system as reported by pdtk_canvas_motion)
+        event generate $tkcanvas <Motion> -warp 1 -x $x -y $y
+    }
+}
 
 #------------------------------------------------------------------------------#
 # procs for when file loading starts/finishes

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -210,9 +210,9 @@ proc pdtk_canvas_mouse {tkcanvas x y b f} {
     pdsend "$mytoplevel mouse [$tkcanvas canvasx $x] [$tkcanvas canvasy $y] $b $f"
 }
 
-proc pdtk_canvas_mouseup {tkcanvas x y b} {
+proc pdtk_canvas_mouseup {tkcanvas x y b {f 0}} {
     set mytoplevel [winfo toplevel $tkcanvas]
-    pdsend "$mytoplevel mouseup [$tkcanvas canvasx $x] [$tkcanvas canvasy $y] $b"
+    pdsend "$mytoplevel mouseup [$tkcanvas canvasx $x] [$tkcanvas canvasy $y] $b $f"
 }
 
 proc pdtk_canvas_rightclick {tkcanvas x y b} {
@@ -223,7 +223,7 @@ proc pdtk_canvas_rightclick {tkcanvas x y b} {
 # on X11, button 2 pastes from X11 clipboard, so simulate normal paste actions
 proc pdtk_canvas_clickpaste {tkcanvas x y b} {
     pdtk_canvas_mouse $tkcanvas $x $y $b 0
-    pdtk_canvas_mouseup $tkcanvas $x $y $b
+    pdtk_canvas_mouseup $tkcanvas $x $y $b 0
     if { [catch {set pdtk_pastebuffer [selection get]}] } {
         # no selection... do nothing
     } else {


### PR DESCRIPTION
some people are a bit unhappy with intelligent patching (#568, #574,...).

this PR is attempting to fix those concerns (and probably add new ones).
the PR is based on [`updates/0.50`](#508).

### fixes and features
 (this list is being updated as new things are added)
- [x] only do multi-connections when pressing a modifier-key (<kbd>Shift</kbd>); Closes:#568
- [x] allow to "deselect all" by pressing <kbd>Esc</kbd>; Closes: #547
- [x] fix insert-object for non-first connections; Closes: #573
- [x] use iolet-positions to better calculate the position of the inserted object; Closes #648 
- [x] made inserted object to be immediately editable; Closes #548 
- [x] have *Duplicate* and *Save-Abstractions* not interfere with the Copy-Paste Buffer; Closes: #644 #643 
- [x] allow fan-out of signal-outlets when connecting objects with <kbd>Ctrl</kbd>-<kbd>k</kbd>; Closes: #501 
- [x] use <kbd>Tab</kbd> to cycle the selected object/line (and <kbd>Shift</kbd>+<kbd>Tab</kbd> for reverse cycling)
- [x] while connecting, the <kbd>Tab</kbd> key cycles the outlets of the source object, resp. the inlets of the sink object (if there *is* a sink object under the mouse; inlet-cycling doesn't work on OSX yet)
- [x] fixed re-doing triggerized [trigger] (#649)
- [x] Regression: <kbd>Tab</kbd>-cycling broken in properties

### demos

https://vimeo.com/showcase/5289665/video/340437816

### experimental builds

those who cannot (or don't want to) compile Pd themselves, can try the experimental [CI-builds](https://git.iem.at/pd/pure-data/pipelines):
- [Win/32bit](https://git.iem.at/pd/pure-data/builds/artifacts/intellipatch2/download?job=w32_snapshot)
- [Win/64bit](https://git.iem.at/pd/pure-data/builds/artifacts/intellipatch2/download?job=w64_snapshot)
- [OSX/64bit](https://git.iem.at/pd/pure-data/builds/artifacts/intellipatch2/download?job=Darwin_snapshot)

these builds include some more features, including the recent changes to the `master` and the `update/0.50` branches.