### PR TITLE
[feature]: add 'mode' argument to [openpanel]

### DIFF
--- a/doc/5.reference/openpanel-help.pd
+++ b/doc/5.reference/openpanel-help.pd
@@ -1,19 +1,38 @@
-#N canvas 70 117 585 333 12;
-#X obj 128 196 openpanel;
-#X msg 128 108 bang;
-#X obj 128 221 print;
-#X text 31 11 openpanel -- query you for a filename;
-#X text 48 278 see also:;
-#X obj 136 279 savepanel;
-#X text 28 44 When openpanel gets a "bang" an "Open file" browser appears
-on the screen. If you select a file \, its name appears on the outlet.
+#N canvas 70 117 585 433 12;
+#X obj 100 190 openpanel;
+#X msg 100 102 bang;
+#X obj 100 215 print;
+#X text 37 316 see also:;
+#X obj 125 317 savepanel;
+#X text 150 103 Starts open panel in current directory;
+#X msg 116 130 symbol /tmp;
+#X msg 118 155 symbol C:/;
+#X text 210 130 Starts in a specified directory;
+#X text 304 316 updated for Pd version 0.50.;
+#X text 28 44 When openpanel gets a "bang" a file browser appears on
+the screen. If you select a file \, its name appears on the outlet.
 ;
-#X text 285 289 updated for Pd version 0.40.;
-#X text 178 109 Starts open panel in current directory;
-#X msg 144 136 symbol /tmp;
-#X msg 146 161 symbol C:/;
-#X text 252 137 Starts in a specified directory;
+#X text 27 13 openpanel -- query you for files or directories;
+#X obj 334 272 print;
+#X obj 334 245 openpanel 1;
+#X obj 436 273 print;
+#X obj 436 246 openpanel 2;
+#X msg 334 217 bang;
+#X msg 436 220 bang;
+#X text 332 196 directory;
+#X text 436 198 multiple files;
+#X obj 219 272 print;
+#X msg 219 217 bang;
+#X obj 219 245 openpanel 0;
+#X text 217 196 file (default);
+#X text 215 167 openpanel takes an optional mode argument:;
 #X connect 0 0 2 0;
 #X connect 1 0 0 0;
-#X connect 9 0 0 0;
-#X connect 10 0 0 0;
+#X connect 6 0 0 0;
+#X connect 7 0 0 0;
+#X connect 13 0 12 0;
+#X connect 15 0 14 0;
+#X connect 16 0 13 0;
+#X connect 17 0 15 0;
+#X connect 21 0 22 0;
+#X connect 22 0 20 0;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -192,12 +192,14 @@ typedef struct _openpanel
 {
     t_object x_obj;
     t_symbol *x_s;
+    int x_mode;
 } t_openpanel;
 
-static void *openpanel_new(void)
+static void *openpanel_new(t_floatarg mode)
 {
     char buf[50];
     t_openpanel *x = (t_openpanel *)pd_new(openpanel_class);
+    x->x_mode = (int)mode;
     sprintf(buf, "d%lx", (t_int)x);
     x->x_s = gensym(buf);
     pd_bind(&x->x_obj.ob_pd, x->x_s);
@@ -208,7 +210,8 @@ static void *openpanel_new(void)
 static void openpanel_symbol(t_openpanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    sys_vgui("pdtk_openpanel {%s} {%s}\n", x->x_s->s_name, path);
+    sys_vgui("pdtk_openpanel {%s} {%s} %d\n",
+        x->x_s->s_name, path, x->x_mode);
 }
 
 static void openpanel_bang(t_openpanel *x)
@@ -231,7 +234,7 @@ static void openpanel_setup(void)
 {
     openpanel_class = class_new(gensym("openpanel"),
         (t_newmethod)openpanel_new, (t_method)openpanel_free,
-        sizeof(t_openpanel), 0, 0);
+        sizeof(t_openpanel), 0, A_DEFFLOAT, 0);
     class_addbang(openpanel_class, openpanel_bang);
     class_addsymbol(openpanel_class, openpanel_symbol);
     class_addmethod(openpanel_class, (t_method)openpanel_callback,

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -28,7 +28,7 @@ proc open_file {filename} {
 # ------------------------------------------------------------------------------
 # procs for panels (openpanel, savepanel)
 
-proc pdtk_openpanel {target localdir mode} {
+proc pdtk_openpanel {target localdir {mode 0}} {
     if {! [file isdirectory $localdir]} {
         if { ! [file isdirectory $::fileopendir]} {
             set ::fileopendir $::env(HOME)

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -35,14 +35,26 @@ proc pdtk_openpanel {target localdir mode} {
         }
         set localdir $::fileopendir
     }
-    if {$mode == 1} {
-        set result [tk_chooseDirectory -initialdir $localdir]
-    } else {
-        set result [tk_getOpenFile -initialdir $localdir]
+    # 0: file, 1: directory, 2: multiple files
+    switch $mode {
+        0 { set result [tk_getOpenFile -initialdir $localdir] }
+        1 { set result [tk_chooseDirectory -initialdir $localdir] }
+        2 { set result [tk_getOpenFile -multiple 1 -initialdir $localdir] }
+        default { ::pdwindow::error "bad value for 'mode' argument" }
     }
     if {$result ne ""} {
-        set ::fileopendir [file dirname $result]
-        pdsend "$target callback [enquote_path $result]"
+        if { $mode == 2 } {
+            # 'result' is a list
+            set ::fileopendir [file dirname [lindex $result 0]]
+            set args {}
+            foreach path $result {
+                lappend args [enquote_path $path]
+            }
+            pdsend "$target callback [join $args]"
+        } else {
+            set ::fileopendir [expr {$mode == 0 ? [file dirname $result] : $result}]
+            pdsend "$target callback [enquote_path $result]"
+        }
     }
 }
 

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -28,17 +28,21 @@ proc open_file {filename} {
 # ------------------------------------------------------------------------------
 # procs for panels (openpanel, savepanel)
 
-proc pdtk_openpanel {target localdir} {
+proc pdtk_openpanel {target localdir mode} {
     if {! [file isdirectory $localdir]} {
         if { ! [file isdirectory $::fileopendir]} {
             set ::fileopendir $::env(HOME)
         }
         set localdir $::fileopendir
     }
-    set filename [tk_getOpenFile -initialdir $localdir]
-    if {$filename ne ""} {
-        set ::fileopendir [file dirname $filename]
-        pdsend "$target callback [enquote_path $filename]"
+    if {$mode == 1} {
+        set result [tk_chooseDirectory -initialdir $localdir]
+    } else {
+        set result [tk_getOpenFile -initialdir $localdir]
+    }
+    if {$result ne ""} {
+        set ::fileopendir [file dirname $result]
+        pdsend "$target callback [enquote_path $result]"
     }
 }
 


### PR DESCRIPTION
this PR adds an optional 'mode' argument to [openpanel]:

0: choose a single file (the default)
1: choose a directory
2: choose multiple files (output as Pd list)

this feature is fully backwards compatible