### PR TITLE
closebang bug fixes

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -897,7 +897,7 @@ int glist_fontheight(t_glist *x)
     return (sys_zoomfontheight(glist_getfont(x), glist_getzoom(x), 0));
 }
 
-void glist_dodelete(t_glist *x, t_gobj *y, int close);
+void glist_dodelete(t_glist *x, t_gobj *y);
 
 void canvas_free(t_canvas *x)
 {
@@ -909,7 +909,7 @@ void canvas_free(t_canvas *x)
         canvas_whichfind = 0;
     glist_noselect(x);
     while ((y = x->gl_list))
-        glist_dodelete(x, y, 0);
+        glist_dodelete(x, y);
     if (x == glist_getcanvas(x))
         canvas_vis(x, 0);
     if (x->gl_editor)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -897,6 +897,8 @@ int glist_fontheight(t_glist *x)
     return (sys_zoomfontheight(glist_getfont(x), glist_getzoom(x), 0));
 }
 
+void glist_dodelete(t_glist *x, t_gobj *y, int close);
+
 void canvas_free(t_canvas *x)
 {
     t_gobj *y;
@@ -907,7 +909,7 @@ void canvas_free(t_canvas *x)
         canvas_whichfind = 0;
     glist_noselect(x);
     while ((y = x->gl_list))
-        glist_delete(x, y);
+        glist_dodelete(x, y, 0);
     if (x == glist_getcanvas(x))
         canvas_vis(x, 0);
     if (x->gl_editor)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1078,7 +1078,7 @@ static void canvas_loadbangabstractions(t_canvas *x)
         }
 }
 
-void canvas_loadbangsubpatches(t_canvas *x)
+static void canvas_loadbangsubpatches(t_canvas *x)
 {
     t_gobj *y;
     t_symbol *s = gensym("loadbang");

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -177,8 +177,6 @@ static void clone_out_anything(t_outproxy *x, t_symbol *s, int argc, t_atom *arg
     FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
-static PERTHREAD int clone_voicetovis = -1;
-
 static t_canvas *clone_makeone(t_symbol *s, int argc, t_atom *argv)
 {
     t_canvas *retval;
@@ -472,6 +470,8 @@ static void clone_dsp(t_clone *x, t_signal **sp)
             bug("clone 3 %d", sp[i]->s_refcount);
     }
 }
+
+static PERTHREAD int clone_voicetovis = -1;
 
 static void *clone_new(t_symbol *s, int argc, t_atom *argv)
 {

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -3312,6 +3312,12 @@ void glob_verifyquit(void *dummy, t_floatarg f)
     else glob_quit(0);
 }
 
+static void canvas_doclose(t_canvas *x)
+{
+    canvas_closebang(x);
+    pd_free(&x->gl_pd);
+}
+
     /* close a window (or possibly quit Pd), checking for dirty flags.
        The "force" parameter is interpreted as follows:
        0 - request from GUI to close, verifying whether clean or dirty
@@ -3354,10 +3360,10 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                 gensym(buf), 2, backmsg,
                 "yes");
         }
-        else pd_free(&x->gl_pd);
+        else canvas_doclose(x);
     }
     else if (force == 1)
-        pd_free(&x->gl_pd);
+        canvas_doclose(x);
     else if (force == 2)
     {
         canvas_dirty(x, 0);
@@ -3374,7 +3380,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                         canvas_getrootfor(g), gensym(buf), 2, backmsg);
             return;
         }
-        else pd_free(&x->gl_pd);
+        else canvas_doclose(x);
     }
     else if (force == 3)
     {

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -1030,7 +1030,7 @@ static void graph_delete(t_gobj *z, t_glist *glist)
     t_glist *x = (t_glist *)z;
     t_gobj *y;
     while ((y = x->gl_list))
-        glist_delete(x, y);
+        glist_dodelete(x, y, 0);
     if (glist_isvisible(x))
         text_widgetbehavior.w_deletefn(z, glist);
             /* if we have connections to the actual 'canvas' object, zap


### PR DESCRIPTION
* send closebangs *before any object is actually removed* and in the same order as loadbang and initbang:
1) abstractions / clone objects (recursively)
2) subpatches (recursively)
3) remaining objects on the canvas

the current ordering is messy because when an object receives a closebang, other objects might have already been destroyed. so if you want to save a table with [closebang] for example, you have to put it into the right place in the glist (the details are complicated). here's a patch which demonstrates the problem:
[closebang-issue.zip](https://github.com/pure-data/pure-data/files/3130537/closebang-issue.zip)
what I would want instead is that no object is actually deleted unless all closebang messages have been sent, so I don't have worry about where I put my [closebang] objects.

* don't send closebang twice to cloned abstractions

* fix a bug where non-canvas objects on the root canvas wouldn't receive a closebang message.

---

externals which use `glist_delete` from the private canvas API still work as expected. 
the `[clear(` message also works. 
cutting objects is ok but `canvas_closebang` is called *on every selected canvas in series* - which means the closebang order is only correct for each selected canvas. otoh, it's the same with loadbang and initbang when pasting multiple canvases, so at least its consistent. later we might want to fix the initialization order for cut&paste...

here's a test patch (needs [iemguts] with a version **before 2018**):
[closebang-test.zip](https://github.com/pure-data/pure-data/files/3121633/closebang-test.zip)

needs review from @umlaeute (see also https://git.iem.at/pd/iemguts/issues/8)