### PR TITLE
fix MIDI overflow handling for portmidi

### DIFF
--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -273,11 +273,10 @@ void sys_poll_midi(void)
     PmEvent buffer;
     for (i = 0; i < mac_nmidiindev; i++)
     {
-        while(Pm_Poll(mac_midiindevlist[i]))
+        while((nmess = Pm_Read(mac_midiindevlist[i], &buffer, 1)))
         {
             if (!throttle--)
                 goto overload;
-            nmess = Pm_Read(mac_midiindevlist[i], &buffer, 1);
             if (nmess > 0)
             {
                 int status = Pm_MessageStatus(buffer.message);
@@ -328,7 +327,7 @@ void sys_poll_midi(void)
             }
             else
             {
-                error("portmidi: %s", Pm_GetErrorText(nmess));
+                error("%s", Pm_GetErrorText(nmess));
                 if (nmess != pmBufferOverflow)
                     break;
             }

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -64,7 +64,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
                 if (devno == midiinvec[i])
                 {
                     err = Pm_OpenInput(&mac_midiindevlist[mac_nmidiindev],
-                        j, NULL, 100, NULL, NULL);
+                        j, NULL, 1024, NULL, NULL);
                     if (err)
                         post("could not open midi input %d (%s): %s",
                             j, info->name, Pm_GetErrorText(err));

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -326,8 +326,12 @@ void sys_poll_midi(void)
                         break;
                 }
             }
-            else if (nmess != pmBufferOverflow)
-                break;
+            else
+            {
+                error("portmidi: %s", Pm_GetErrorText(nmess));
+                if (nmess != pmBufferOverflow)
+                    break;
+            }
         }
     }
     overload: ;

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -273,7 +273,7 @@ void sys_poll_midi(void)
     PmEvent buffer;
     for (i = 0; i < mac_nmidiindev; i++)
     {
-        if(Pm_Poll(mac_midiindevlist[i]))
+        while(Pm_Poll(mac_midiindevlist[i]))
         {
             if (!throttle--)
                 goto overload;


### PR DESCRIPTION
currently, [midiin] and related objects stop responding if too many MIDI messages are sent in short time intervals and you have to reset the MIDI device in the MIDI dialog. I've tested this with a MIDI loopback and it already happens after sending 3 MIDI bytes every 1 ms.

there were two problems in the Pd code: 
* sys_poll_midi used an if clause instead of a while loop so the midi queue doesn't get flushed properly (and the `throttle` variable was useless)
* the call to Pa_Poll is redundant and also doesn't report overflow errors. this means that sys_poll_midi would stop reading midi messages once an overflow occured.

fixes https://github.com/pure-data/pure-data/issues/554

