### PR TITLE
[feature]: add [send( method to [value] object

### DIFF
--- a/doc/5.reference/value-help.pd
+++ b/doc/5.reference/value-help.pd
@@ -1,58 +1,70 @@
-#N canvas 673 23 541 568 12;
-#X floatatom 21 59 5 0 0 0 - - -, f 5;
+#N canvas 673 23 541 623 12;
+#X floatatom 21 59 5 0 0 0 - - -;
 #X text 383 15 abbreviation:;
 #X text 69 14 -- nonlocal shared value (named variable);
-#X floatatom 21 134 5 0 0 0 - - -, f 5;
+#X floatatom 21 134 5 0 0 0 - - -;
 #X msg 31 82 bang;
 #X obj 18 14 value;
 #X obj 21 109 value help-value1;
 #X obj 493 14 v;
-#X floatatom 163 59 5 0 0 0 - - -, f 5;
-#X floatatom 163 134 5 0 0 0 - - -, f 5;
+#X floatatom 163 59 5 0 0 0 - - -;
+#X floatatom 163 134 5 0 0 0 - - -;
 #X msg 173 82 bang;
 #X obj 163 109 value help-value1;
-#X floatatom 313 59 5 0 0 0 - - -, f 5;
-#X floatatom 313 134 5 0 0 0 - - -, f 5;
+#X floatatom 313 59 5 0 0 0 - - -;
+#X floatatom 313 135 5 0 0 0 - - -;
 #X msg 323 82 bang;
-#X obj 313 109 value help-value2;
+#X obj 313 110 value help-value2;
 #X text 27 173 "Value" stores a numeric value which is shared between
 all values with the same name (which need not be in the same Pd window.)
 ;
 #X text 367 58 numbers set the value;
 #X text 371 81 bang retrieves it;
-#X text 26 516 see also:;
-#X obj 102 516 expr;
+#X text 26 585 see also:;
+#X obj 102 585 expr;
 #X obj 309 266 value z;
 #X obj 388 255 expr z;
-#X floatatom 388 284 5 0 0 0 - - -, f 5;
+#X floatatom 388 284 5 0 0 0 - - -;
 #X obj 388 228 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
 -1 -1;
-#X floatatom 309 237 5 0 0 0 - - -, f 5;
-#X obj 359 341 value y;
-#X obj 278 354 send y;
-#X floatatom 278 326 5 0 0 0 - - -, f 5;
-#X obj 359 319 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+#X floatatom 309 237 5 0 0 0 - - -;
+#X obj 359 337 value y;
+#X obj 278 350 send y;
+#X floatatom 278 322 5 0 0 0 - - -;
+#X obj 359 315 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
 -1 -1;
-#X floatatom 359 369 5 0 0 0 - - -, f 5;
-#X msg 437 334 \; y 5;
-#X obj 140 516 send;
-#X obj 179 516 float;
+#X floatatom 359 365 5 0 0 0 - - -;
+#X msg 437 330 \; y 5;
+#X obj 140 585 send;
+#X obj 179 585 float;
 #X text 28 235 The value may also be stored or recalled in expressions
 via the expr \, expr~ \, and fexpr~ objects., f 34;
-#X floatatom 286 479 5 0 0 0 - - -, f 5;
-#X obj 286 453 value;
-#X msg 318 418 symbol help-value1;
-#X msg 337 452 symbol help-value2;
-#X text 28 317 The value object can also receive float values sent
+#X floatatom 272 553 5 0 0 0 - - -;
+#X obj 272 527 value;
+#X msg 304 492 symbol help-value1;
+#X msg 323 526 symbol help-value2;
+#X text 28 313 The value object can also receive float values sent
 via a [send] object or a message if it has a variable with the same
 name., f 31;
-#X text 29 411 if invoked without a creation argument \, the value
+#X text 29 480 if invoked without a creation argument \, the value
 object adds a right inlet for setting the variable name with a "symbol"
 message:, f 30;
-#X obj 286 418 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+#X obj 272 492 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
 -1 -1;
-#X text 296 527 updated for Pd version 0.48-1;
-#X obj 224 516 int;
+#X obj 224 585 int;
+#X text 296 596 updated for Pd version 0.50.;
+#X obj 272 452 v help-value1;
+#X msg 318 401 send x;
+#X text 27 398 You can sent to the stored value to a named object such
+as a receive or another value:, f 33;
+#X msg 330 425 send y;
+#X floatatom 391 450 5 0 0 0 - - -;
+#X obj 391 426 receive x;
+#X obj 470 427 value y;
+#X floatatom 470 451 5 0 0 0 - - -;
+#X obj 470 403 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
+#X floatatom 272 401 5 0 0 0 - - -;
 #X connect 0 0 6 0;
 #X connect 4 0 6 0;
 #X connect 6 0 3 0;
@@ -72,3 +84,9 @@ message:, f 30;
 #X connect 37 0 36 1;
 #X connect 38 0 36 1;
 #X connect 41 0 36 0;
+#X connect 45 0 44 0;
+#X connect 47 0 44 0;
+#X connect 49 0 48 0;
+#X connect 50 0 51 0;
+#X connect 52 0 50 0;
+#X connect 53 0 44 0;

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1621,6 +1621,13 @@ static void value_symbol2(t_value *x, t_symbol *s)
     x->x_floatstar = value_get(s);
 }
 
+static void value_send(t_value *x, t_symbol *s)
+{
+    if (s->s_thing)
+        pd_float(s->s_thing, *x->x_floatstar);
+    else pd_error(x, "%s: no such object", s->s_name);
+}
+
 static void value_ff(t_value *x)
 {
     value_release(x->x_sym);
@@ -1636,6 +1643,7 @@ static void value_setup(void)
     class_addfloat(value_class, value_float);
     class_addmethod(value_class, (t_method)value_symbol2, gensym("symbol2"),
         A_DEFSYM, 0);
+    class_addmethod(value_class, (t_method)value_send, gensym("send"), A_SYMBOL, 0);
     vcommon_class = class_new(gensym("value"), 0, 0,
         sizeof(t_vcommon), CLASS_PD, 0);
     class_addfloat(vcommon_class, vcommon_float);


### PR DESCRIPTION
this method allows to directly send the stored value to a named object (e.g. [receive] or another [value]), analogous to the [send( method of [float], [int] and [pointer].