### PR TITLE
make pd_unbind safe and improve stack overflow protection

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -299,6 +299,7 @@ void obj_init(void)
 /* --------------------------- outlets ------------------------------ */
 
 static PERTHREAD int stackcount = 0; /* iteration counter */
+static PERTHREAD int overflow = 0;
 #define STACKITER 1000 /* maximum iterations allowed */
 
 static PERTHREAD int outlet_eventno;
@@ -306,6 +307,26 @@ static PERTHREAD int outlet_eventno;
     /* set a stack limit (on each incoming event that can set off messages)
     for the outlet functions to check to prevent stack overflow from message
     recursion */
+
+int stackcount_increase(void)
+{
+    if (++stackcount >= STACKITER)
+    {
+            /* set overflow flag to prevent any further messaging */
+        overflow = 1;
+        return 0;
+    }
+    else
+        return !overflow;
+}
+
+void stackcount_release(void)
+{
+    stackcount--;
+        /* once the stack got completely unwound, we can clear the overflow flag */
+    if (stackcount == 0)
+        overflow = 0;
+}
 
 void outlet_setstacklim(void)
 {
@@ -356,19 +377,19 @@ static void outlet_stackerror(t_outlet *x)
 void outlet_bang(t_outlet *x)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_bang(oc->oc_to);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_pointer(t_outlet *x, t_gpointer *gp)
 {
     t_outconnect *oc;
     t_gpointer gpointer;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     {
@@ -376,51 +397,51 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
         for (oc = x->o_connections; oc; oc = oc->oc_next)
             pd_pointer(oc->oc_to, &gpointer);
     }
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_float(t_outlet *x, t_float f)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_float(oc->oc_to, f);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_symbol(t_outlet *x, t_symbol *s)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_symbol(oc->oc_to, s);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_list(oc->oc_to, s, argc, argv);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_increase())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         typedmess(oc->oc_to, s, argc, argv);
-    --stackcount;
+    stackcount_release();
 }
 
     /* get the outlet's declared symbol */

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -123,8 +123,8 @@ static t_bindelem * bs_pop()
     }
 }
 
-/* if "e" is about to be unbound, check and update the bind stack */
-static void bs_check(t_bindelem *e)
+/* "e" is about to be unbound - check and update the bind element stack */
+static void bs_update(t_bindelem *e)
 {
     int i;
     for (i = bs_head; i > 0; i--)
@@ -290,14 +290,14 @@ void pd_unbind(t_pd *x, t_symbol *s)
         t_bindelem *e, *e2;
         if ((e = b->b_list)->e_who == x)
         {
-            bs_check(e);
+            bs_update(e);
             b->b_list = e->e_next;
             freebytes(e, sizeof(t_bindelem));
         }
         else for (e = b->b_list; (e2 = e->e_next); e = e2)
             if (e2->e_who == x)
         {
-            bs_check(e2);
+            bs_update(e2);
             e->e_next = e2->e_next;
             freebytes(e2, sizeof(t_bindelem));
             break;

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -83,13 +83,15 @@ static PERTHREAD t_bindelem **bindstack = 0;
 static PERTHREAD int bs_size = 0;
 static PERTHREAD int bs_head = 0;
 
+#define DEFBINDSTACKSIZE 64
+
 /* push the next element on the stack */
 static void bs_push(t_bindelem *e)
 {
     if (!bindstack)
     {
-        bindstack = getbytes(sizeof(t_bindelem *) * 64);
-        bs_size = 16;
+        bindstack = getbytes(sizeof(t_bindelem *) * DEFBINDSTACKSIZE);
+        bs_size = DEFBINDSTACKSIZE;
     }
     bs_head++;
     if (bs_head >= bs_size)


### PR DESCRIPTION
#### Problem:

the Pd GUI objects and some externals (e.g. [iem_receive] from iemlib) allow to bind/unbind symbols on the fly. this is dangerous in case the bound/unbound symbol is the same we're currently receiving messages from because the bind list can get modified (or even deleted) while iterating over it.

[value] theoretically also has this issue ~~although I couldn't get it to crash in practice - but I've observed situations where a bind element or the whole bind list gets deleted right before or after it receives a message (it only doesn't crash because the freed memory hasn't been overwritten or returned to the OS yet).~~

EDIT: here's a test patch which demonstrates the issue with value: [value-crash.zip](https://github.com/pure-data/pure-data/files/3139523/value-crash.zip) (for me this only crashes when I run Pd in a debugger.)

Also, the current overflow protection only works for a *single* recursion path; for more than one path (e. g. several outlets feeding back to the same inlet), Pd would end up in an infinite loop. The same problem applies to bind lists if more than one target sends back to the bound symbol.

#### Solution:

I added a (thread-local) stack of `t_bindelem` pointers. When sending a message to a symbol, I do the following for each bind list element:
1) put the *next* element on the stack
2) message the object
3) get the next element from the stack

The trick is that when `pd_unbind()` is asked to unbind an object from a symbol, it tries to locate the bind element in the stack and - if necessary - sets it to the next valid element (or 0). This means we can iterate over the bind list even recursively while removing elements (not that it's a good idea to do so). 

Also, t_bindlist has to be reference counted to avoid segfaults.

To improve the stack overflow protection, I set a flag when a stack overflow is detected so that no outlets or bind lists are messaged until the stack is completely unwound.

There is a tiny performance overhead but judging from the benchmarks I did it's pretty much neglectible.

---

Here's a crude testpatch using [iem_receive] from iemlib: [bindlist-test.zip](https://github.com/pure-data/pure-data/files/3145507/bindlist-test.zip)
Here you can test the improved stack overflow protection: [stackoverflow.zip](https://github.com/pure-data/pure-data/files/3145508/stackoverflow.zip)

Try both patches with and without this PR to see the difference!

This PR is needed by https://github.com/pure-data/pure-data/pull/604.
