### PR TITLE
fix error message in s_audio_pa.c

### DIFF
--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -673,10 +673,10 @@ int pa_send_dacs(void)
             if (audio_isopen())
                 error("successfully reopened audio device");
             else
+            {
                 error("audio device not responding - closing audio");
-            #ifdef _WIN32
-                error("reconnect and try reselecting the device in the settings");
-            #endif
+                error("reconnect and reselect it in the settings (or toggle DSP)");
+            }
         #endif
         return SENDDACS_NO;
     } else


### PR DESCRIPTION
* missing braces would put the second call to error() outside the else clause.
* also improve the error message itself.
* I don't think there's a reason to post the last error message only on Windows (and not on Linux for example)