### PR TITLE
Save size in [array define]

### DIFF
--- a/src/g_array.c
+++ b/src/g_array.c
@@ -700,6 +700,16 @@ static int garray_click(t_gobj *z, t_glist *glist,
 
 #define ARRAYWRITECHUNKSIZE 1000
 
+void garray_savesizeto(t_garray *x, t_binbuf *b)
+{
+    if (x->x_saveit)
+    {
+        t_array *array = garray_getarray(x);
+        binbuf_addv(b, "ssi", gensym("#A"), gensym("resize"), array->a_n);
+        binbuf_addsemi(b);
+    }
+}
+
 void garray_savecontentsto(t_garray *x, t_binbuf *b)
 {
     if (x->x_saveit)

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1168,7 +1168,9 @@ int garray_ambigendian(void)
 void garray_resize_long(t_garray *x, long n)
 {
     t_array *array = garray_getarray(x);
-    if (n < 1)
+    if (n == array->a_n)
+        return;
+    else if (n < 1)
         n = 1;
     garray_fittograph(x, (int)n, template_getfloat(
         template_findbyname(x->x_scalar->sc_template),

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -179,6 +179,7 @@ static void *array_define_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
+void garray_savesizeto(t_garray *x, t_binbuf *b);
 void garray_savecontentsto(t_garray *x, t_binbuf *b);
 
 void array_define_save(t_gobj *z, t_binbuf *bb)
@@ -192,6 +193,7 @@ void array_define_save(t_gobj *z, t_binbuf *bb)
 
     if (gl)
     {
+        garray_savesizeto((t_garray *)gl->gl_list, bb);
         garray_savecontentsto((t_garray *)gl->gl_list, bb);
         obj_saveformat(&x->gl_obj, bb);
     }


### PR DESCRIPTION
[array define -k foo] doesn't save the *actual* size of the array but only the initial size. This is especially confusing when no size is given as a creation argument (in which case the initial size is 100). 

For cases like `[array define -k foo]` (no initial size given), my solution is to simply add a `resize` message to the save binbuf.

For cases like `[array define -k foo 64]`, I replace the initial size argument in the saved obj binbuf and issue a notice (e.g. "array define: saving foo with size 1000") - but only if the size has actually changed, of course.

this fixes https://github.com/pure-data/pure-data/issues/567