### PR TITLE
have "donecanvasdialog" add 'Undo' to the affected canvas

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2131,18 +2131,9 @@ static void canvas_donecanvasdialog(t_glist *x,
            argument supplied. */
     if (fromgui && (!(graphme & 1)))
         graphme = 0;
-        /* parent windows are treated differently than applies to
-           individual objects */
-    if (glist_getcanvas(x) != x && !canvas_isabstraction(x))
-    {
-            /* JMZ: i don't know how to trigger this path */
-        t_canvas*x2 = glist_getcanvas(x);
-        canvas_undo_add(x2, UNDO_APPLY, "apply", canvas_undo_set_apply(x2, glist_getindex(x2, &x->gl_gobj)));
-    }
-    else
-    {
-        canvas_undo_add(x, UNDO_CANVAS_APPLY, "apply", canvas_undo_set_canvas(x));
-    }
+        /* parent windows are treated the same as
+           applies to individual objects */
+    canvas_undo_add(x, UNDO_CANVAS_APPLY, "apply", canvas_undo_set_canvas(x));
 
     x->gl_pixwidth = xpix * x->gl_zoom;
     x->gl_pixheight = ypix * x->gl_zoom;


### PR DESCRIPTION
the canvas-properties can be called
- from the canvas itself (by right-clicking on the empty canvas, and selecting "Properties")
- OR from the parent canvas (by right-clicking the object,...)
unfortunately, there's no way to find out how the canvas-properties have been changed.

because of this, there's some confusion about where the <kbd>Undo</kbd> should be added (the canvas itself or the parent canvas).
the original <kbd>Undo</kbd> implementation (as ported from Pd-l2ork), tried adding the <kbd>Undo</kbd> to the parent-canvas, but this lead to all kinds of unexpected situations 
- the parent canvas would go to <kbd>Edit</kbd>-mode if the GOP-state inside a GOP would 
be changed (#623 and it's dupe #624)
- the parent canvas would also get a new <kbd>Undo</kbd> entry, which - when triggered - would crash Pd :-( (the [relevant source code](https://github.com/pure-data/pure-data/blob/0.49-0/src/g_editor.c#L2138) makes it pretty clear that this was never tested)

The suggested fix for all these problems is to handle the <kbd>Undo</kbd> of the `donecanvasdialog` entirely inside the directly affected canvas.

This means that changing the canvas-properties via the parent-patch can only be undone inside the canvas.
So far, changing the size of a GOPified object (by dragging it's right corner in the parent canvas) is still attached to the parent canvas' <kbd>Undo</kbd> queue.

Closes: https://github.com/pure-data/pure-data/issues/623