### PR TITLE
don't concatenate absolute paths when searching for a lib to load

### DIFF
--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -348,7 +348,7 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
         sys_loadlib_iter(dirbuf, &data);
     }
     data.classname = classname;
-    if(!data.ok)
+    if(!data.ok && !sys_isabsolutepath(classname)) /* don't iterate if classname is absolute */
         canvas_path_iterate(canvas, (t_canvas_path_iterator)sys_loadlib_iter,
             &data);
 


### PR DESCRIPTION
When searching for a library to load (through `[declare -(std)lib]` for example), the canvas paths are concatenated with the name of the wanted library.

If no success, the library name is first appended after each of the canvas paths, and the previous process is retried for each new version (if I understand correctly); this allows to find e.g `/usr/lib/pd/extra/foo/bar.pd_linux` with a `[declare -path foo -lib bar]`.

Unfortunately this process also tries many absurd paths. A simple `[declare -stdlib bar]`, with no path configured in the Pd preferences, leads to 329 different attempts (visible with -verbose), for e.g: 
```
/home/me/.local/lib/pd/extra//usr/local/lib/pd/extra/bar//usr/local/lib/pd/extra/bar.pd

/usr/local/lib/pd/extra//usr/local/lib/pd/extra/bar//usr/local/lib/pd/extra/bar.pd

```
The current PR reduces the number of trials from 329 to 54, by avoiding to run this iteration when the tested path is already absolute.
