### PR TITLE
disable portmidi rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tcl/pd-gui
 
 # build
 *.o
+*.obj
 lib*.a
 
 # libtool
@@ -55,6 +56,7 @@ src/*.a
 # distribution tarballs
 pd-0.*
 msw/0.*
+msw/pdprototype/*
 
 # gettext
 po/*.msg

--- a/configure.ac
+++ b/configure.ac
@@ -279,6 +279,7 @@ AS_IF([test x$debug = xyes],[
     CFLAGS="$CFLAGS $DEBUG_CFLAGS"
 ],[
     CFLAGS="$CFLAGS $RELEASE_CFLAGS"
+    CPPFLAGS="$CPPFLAGS -DNDEBUG"
 ])
 
 #########################################

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -42,11 +42,11 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 #endif /* EXTERN */
 
     /* On most c compilers, you can just say "struct foo;" to declare a
-    structure whose elements are defined elsewhere.  On MSVC, when compiling
-    C (but not C++) code, you have to say "extern struct foo;".  So we make
-    a stupid macro: */
+    structure whose elements are defined elsewhere.  On very old MSVC versions,
+    when compiling C (but not C++) code, you have to say "extern struct foo;".
+    So we make a stupid macro: */
 #if defined(_MSC_VER) && !defined(_LANGUAGE_C_PLUS_PLUS) \
-    && !defined(__cplusplus)
+    && !defined(__cplusplus) && (_MSC_VER < 1700)
 #define EXTERN_STRUCT extern struct
 #else
 #define EXTERN_STRUCT struct

--- a/src/s_entry.c
+++ b/src/s_entry.c
@@ -11,10 +11,8 @@ int sys_main(int argc, char **argv);
 #include <windows.h>
 #include <stdio.h>
 
-int WINAPI WinMain(HINSTANCE hInstance,
-                               HINSTANCE hPrevInstance,
-                               LPSTR lpCmdLine,
-                               int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+    LPSTR lpCmdLine, int nCmdShow)
 {
     __try {
         sys_main(__argc,__argv);

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1647,6 +1647,9 @@ void s_inter_free(t_instanceinter *inter)
         inter->i_fdpoll = 0;
         inter->i_nfdpoll = 0;
     }
+#if PDTHREADS
+    pthread_mutex_destroy(&INTER->i_mutex);
+#endif
     freebytes(inter, sizeof(*inter));
 }
 

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -225,7 +225,7 @@ void endpost(void)
   /* keep this in the Pd app for binary extern compatibility but don't
   include in libpd because it conflicts with the posix pd_error(0, ) function. */
 #ifdef PD_INTERNAL
-void error(const char *fmt, ...)
+EXTERN void error(const char *fmt, ...)
 {
     char buf[MAXPDSTRING];
     va_list ap;


### PR DESCRIPTION
portmidi added a speed limit for outgoing MIDI messages on macOS to prevent possible data loss because of an inofficial hard-coded 15 kB/s limit in CoreMidi (for feedback protection on the IAC). Unfortunately, this makes it impossible to continously send large amout of MIDI data to USB MIDI devices. It is not entirely clear if CoreMidi only drops messages on the IAC, but it seems so.

See this massive thread for more information: https://github.com/pure-data/pure-data/issues/581

This PR does the following:

a) patch portmidi so we can fully disable the rate limit for macOS with a compile time switch (`-DLIMIT_RATE=0`). the default is `#define LIMIT_RATE 1`
b) compile Pd without the rate limit to get the original behavior before the portmidi update. We might want to add a warning somewhere about possible message loss.