### PR TITLE
Disable macOS Portmidi rate limit

### DIFF
--- a/portmidi/Makefile.am
+++ b/portmidi/Makefile.am
@@ -26,8 +26,9 @@ libportmidi_a_SOURCES += \
     portmidi/pm_linux/pmlinuxalsa.c
 endif
 
+# disable portmidi rate limiting on macos
 if MACOSX
-AM_CPPFLAGS += -I$(top_srcdir)/portmidi/portmidi/pm_mac
+AM_CPPFLAGS += -I$(top_srcdir)/portmidi/portmidi/pm_mac -DLIMIT_RATE=0
 libportmidi_a_SOURCES += \
     portmidi/porttime/ptmacosx_mach.c \
     portmidi/pm_mac/pmmac.c \

--- a/portmidi/README.txt
+++ b/portmidi/README.txt
@@ -1,3 +1,5 @@
+# PortMidi
+
 The cross-platform PortMidi library is included with the PureData distribution
 so that Pd can be built without any main external dependencies.
 
@@ -6,7 +8,11 @@ It is built as a libtool convenience library when using autotools to build Pd:
     ./configure
     make
 
-If you want to update to a newer version of PortAudio, simply use the
+For more info on PortMidi, see http://portmedia.sourceforge.net/portmidi
+
+## Updating
+
+If you want to update to a newer version of PortMidi, simply use the
 "update.sh" script:
 
     cd portmidi
@@ -20,12 +26,14 @@ If you want to update to a newer version of PortAudio, simply use the
 You *may* need to add or remove source file or header lines in the Makefile.am,
 if the source or include files have changed in PortMidi.
 
+## System-installed PortMidi
+
 As a second option, you can build Pd using a system-installed PortMidi via:
 
     ./configure --without-local-portmidi
     make
 
-For more info on PortMidi, see http://portmedia.sourceforge.net/portmidi
+## Patches
 
 There may be custom patches to apply to the PortMidi sources in the "patches"
 directory which are applied by the "update.sh" script automatically using:
@@ -35,3 +43,16 @@ directory which are applied by the "update.sh" script automatically using:
 To generate a patch file from a PortMidi svn checkout:
 
     svn diff > some_newfix.patch
+
+## macOS LIMIT_RATE
+
+Newer versions of Portmidi include automatic message rate limiting for macOS
+which has a rather low buffer size when using the internal IAC virtual device
+for message routing and could lead to messages being dropped. As this limit
+may affect timing and cause issues when sending *large* amounts of MIDI data,
+it is disabled when building the Portmidi sources included with Pd.
+
+If you want to re-enabled the rate limit, set the LIMIT_RATE define before
+building:
+
+    ./configure CFLAGS="-DLIMIT_RATE=1"

--- a/portmidi/README.txt
+++ b/portmidi/README.txt
@@ -52,7 +52,7 @@ for message routing and could lead to messages being dropped. As this limit
 may affect timing and cause issues when sending *large* amounts of MIDI data,
 it is disabled when building the Portmidi sources included with Pd.
 
-If you want to re-enabled the rate limit, set the LIMIT_RATE define before
+If you want to re-enable the rate limit, set the LIMIT_RATE define before
 building:
 
     ./configure CFLAGS="-DLIMIT_RATE=1"

--- a/portmidi/patches/mac_limit_rate_override.patch
+++ b/portmidi/patches/mac_limit_rate_override.patch
@@ -1,0 +1,121 @@
+Index: pm_mac/pmmacosxcm.c
+===================================================================
+--- pm_mac/pmmacosxcm.c	(revision 234)
++++ pm_mac/pmmacosxcm.c	(working copy)
+@@ -63,7 +63,9 @@
+ 
+      Note that this distorts accurate timestamps somewhat.
+  */
++#ifndef LIMIT_RATE
+ #define LIMIT_RATE 1
++#endif
+ 
+ #define SYSEX_BUFFER_SIZE 128
+ 
+@@ -107,11 +109,13 @@
+     /* allow for running status (is running status possible here? -rbd): -cpr */
+     unsigned char last_command; 
+     int32_t last_msg_length;
++#if LIMIT_RATE
+     /* limit midi data rate (a CoreMidi requirement): */
+     UInt64 min_next_time; /* when can the next send take place? */
+     int byte_count; /* how many bytes in the next packet list? */
+     Float64 us_per_host_tick; /* host clock frequency, units of min_next_time */
+     UInt64 host_ticks_per_byte; /* host clock units per byte at maximum rate */
++#endif
+ } midi_macosxcm_node, *midi_macosxcm_type;
+ 
+ /* private function declarations */
+@@ -427,11 +431,13 @@
+     m->packet = NULL;
+     m->last_command = 0;
+     m->last_msg_length = 0;
++#if LIMIT_RATE
+     m->min_next_time = 0;
+     m->byte_count = 0;
+     m->us_per_host_tick = 1000000.0 / AudioGetHostClockFrequency();
+     m->host_ticks_per_byte = (UInt64) (1000000.0 / 
+                                        (m->us_per_host_tick * MAX_BYTES_PER_S));
++#endif
+     return pmNoError;
+ }
+ 
+@@ -477,6 +483,7 @@
+     assert(endpoint);
+     if (m->packet != NULL) {
+         /* out of space, send the buffer and start refilling it */
++    #if LIMIT_RATE
+         /* before we can send, maybe delay to limit data rate. OS X allows
+          * 15KB/s. */
+         UInt64 now = AudioGetCurrentHostTime();
+@@ -484,10 +491,11 @@
+             usleep((useconds_t) 
+                    ((m->min_next_time - now) * m->us_per_host_tick));
+         }
++        m->min_next_time = now + m->byte_count * m->host_ticks_per_byte;
++        m->byte_count = 0;
++    #endif
+         macHostError = MIDISend(portOut, endpoint, m->packetList);
+         m->packet = NULL; /* indicate no data in packetList now */
+-        m->min_next_time = now + m->byte_count * m->host_ticks_per_byte;
+-        m->byte_count = 0;
+         if (macHostError != noErr) goto send_packet_error;
+     }
+     return pmNoError;
+@@ -514,7 +522,9 @@
+     m->packet = MIDIPacketListAdd(m->packetList, sizeof(m->packetBuffer), 
+                                   m->packet, timestamp, messageLength, 
+                                   message);
++#if LIMIT_RATE
+     m->byte_count += messageLength;
++#endif
+     if (m->packet == NULL) {
+         /* out of space, send the buffer and start refilling it */
+         /* make midi->packet non-null to fool midi_write_flush into sending */
+@@ -567,13 +577,15 @@
+     messageLength = midi_length(what);
+         
+     /* make sure we go foreward in time */
+-    if (timestamp < m->min_next_time) timestamp = m->min_next_time;
+-
+-    #ifdef LIMIT_RATE
+-        if (timestamp < m->last_time)
+-            timestamp = m->last_time;
++    if (timestamp < m->last_time)
++        timestamp = m->last_time;
++#ifdef LIMIT_RATE
++    if (timestamp < m->min_next_time)
++        timestamp = m->min_next_time;
+ 	m->last_time = timestamp + messageLength * m->host_ticks_per_byte;
+-    #endif
++#else
++    m->last_time = timestamp;
++#endif
+ 
+     /* Add this message to the packet list */
+     return send_packet(midi, message, messageLength, timestamp);
+@@ -613,15 +625,17 @@
+     assert(m);
+     
+     /* make sure we go foreward in time */
++    if (m->sysex_timestamp < m->last_time)
++        m->sysex_timestamp = m->last_time;
++
++#ifdef LIMIT_RATE
+     if (m->sysex_timestamp < m->min_next_time) 
+         m->sysex_timestamp = m->min_next_time;
+-
+-    #ifdef LIMIT_RATE
+-        if (m->sysex_timestamp < m->last_time) 
+-            m->sysex_timestamp = m->last_time;
+-        m->last_time = m->sysex_timestamp + m->sysex_byte_count *
+-                                            m->host_ticks_per_byte;
+-    #endif
++    m->last_time = m->sysex_timestamp + m->sysex_byte_count *
++                                        m->host_ticks_per_byte;
++#else
++    m->last_time = m->sysex_timestamp;
++#endif
+     
+     /* now send what's in the buffer */
+     err = send_packet(midi, m->sysex_buffer, m->sysex_byte_count,

--- a/portmidi/patches/mac_limit_rate_override.patch
+++ b/portmidi/patches/mac_limit_rate_override.patch
@@ -83,7 +83,7 @@ Index: pm_mac/pmmacosxcm.c
 -            timestamp = m->last_time;
 +    if (timestamp < m->last_time)
 +        timestamp = m->last_time;
-+#ifdef LIMIT_RATE
++#if LIMIT_RATE
 +    if (timestamp < m->min_next_time)
 +        timestamp = m->min_next_time;
  	m->last_time = timestamp + messageLength * m->host_ticks_per_byte;
@@ -101,7 +101,7 @@ Index: pm_mac/pmmacosxcm.c
 +    if (m->sysex_timestamp < m->last_time)
 +        m->sysex_timestamp = m->last_time;
 +
-+#ifdef LIMIT_RATE
++#if LIMIT_RATE
      if (m->sysex_timestamp < m->min_next_time) 
          m->sysex_timestamp = m->min_next_time;
 -

--- a/portmidi/portmidi/pm_mac/pmmacosxcm.c
+++ b/portmidi/portmidi/pm_mac/pmmacosxcm.c
@@ -587,7 +587,7 @@ midi_write_short(PmInternal *midi, PmEvent *event)
     /* make sure we go foreward in time */
     if (timestamp < m->last_time)
         timestamp = m->last_time;
-#ifdef LIMIT_RATE
+#if LIMIT_RATE
     if (timestamp < m->min_next_time)
         timestamp = m->min_next_time;
 	m->last_time = timestamp + messageLength * m->host_ticks_per_byte;
@@ -636,7 +636,7 @@ midi_end_sysex(PmInternal *midi, PmTimestamp when)
     if (m->sysex_timestamp < m->last_time)
         m->sysex_timestamp = m->last_time;
 
-#ifdef LIMIT_RATE
+#if LIMIT_RATE
     if (m->sysex_timestamp < m->min_next_time) 
         m->sysex_timestamp = m->min_next_time;
     m->last_time = m->sysex_timestamp + m->sysex_byte_count *

--- a/portmidi/portmidi/pm_mac/pmmacosxcm.c
+++ b/portmidi/portmidi/pm_mac/pmmacosxcm.c
@@ -63,7 +63,9 @@
 
      Note that this distorts accurate timestamps somewhat.
  */
+#ifndef LIMIT_RATE
 #define LIMIT_RATE 1
+#endif
 
 #define SYSEX_BUFFER_SIZE 128
 
@@ -108,11 +110,13 @@ typedef struct midi_macosxcm_struct {
     /* allow for running status (is running status possible here? -rbd): -cpr */
     unsigned char last_command; 
     int32_t last_msg_length;
+#if LIMIT_RATE
     /* limit midi data rate (a CoreMidi requirement): */
     UInt64 min_next_time; /* when can the next send take place? */
     int byte_count; /* how many bytes in the next packet list? */
     Float64 us_per_host_tick; /* host clock frequency, units of min_next_time */
     UInt64 host_ticks_per_byte; /* host clock units per byte at maximum rate */
+#endif
 } midi_macosxcm_node, *midi_macosxcm_type;
 
 /* private function declarations */
@@ -435,11 +439,13 @@ midi_out_open(PmInternal *midi, void *driverInfo)
     m->packet = NULL;
     m->last_command = 0;
     m->last_msg_length = 0;
+#if LIMIT_RATE
     m->min_next_time = 0;
     m->byte_count = 0;
     m->us_per_host_tick = 1000000.0 / AudioGetHostClockFrequency();
     m->host_ticks_per_byte = (UInt64) (1000000.0 / 
                                        (m->us_per_host_tick * MAX_BYTES_PER_S));
+#endif
     return pmNoError;
 }
 
@@ -485,6 +491,7 @@ midi_write_flush(PmInternal *midi, PmTimestamp timestamp)
     assert(endpoint);
     if (m->packet != NULL) {
         /* out of space, send the buffer and start refilling it */
+    #if LIMIT_RATE
         /* before we can send, maybe delay to limit data rate. OS X allows
          * 15KB/s. */
         UInt64 now = AudioGetCurrentHostTime();
@@ -492,10 +499,11 @@ midi_write_flush(PmInternal *midi, PmTimestamp timestamp)
             usleep((useconds_t) 
                    ((m->min_next_time - now) * m->us_per_host_tick));
         }
-        macHostError = MIDISend(portOut, endpoint, m->packetList);
-        m->packet = NULL; /* indicate no data in packetList now */
         m->min_next_time = now + m->byte_count * m->host_ticks_per_byte;
         m->byte_count = 0;
+    #endif
+        macHostError = MIDISend(portOut, endpoint, m->packetList);
+        m->packet = NULL; /* indicate no data in packetList now */
         if (macHostError != noErr) goto send_packet_error;
     }
     return pmNoError;
@@ -522,7 +530,9 @@ send_packet(PmInternal *midi, Byte *message, unsigned int messageLength,
     m->packet = MIDIPacketListAdd(m->packetList, sizeof(m->packetBuffer), 
                                   m->packet, timestamp, messageLength, 
                                   message);
+#if LIMIT_RATE
     m->byte_count += messageLength;
+#endif
     if (m->packet == NULL) {
         /* out of space, send the buffer and start refilling it */
         /* make midi->packet non-null to fool midi_write_flush into sending */
@@ -575,13 +585,15 @@ midi_write_short(PmInternal *midi, PmEvent *event)
     messageLength = midi_length(what);
         
     /* make sure we go foreward in time */
-    if (timestamp < m->min_next_time) timestamp = m->min_next_time;
-
-    #ifdef LIMIT_RATE
-        if (timestamp < m->last_time)
-            timestamp = m->last_time;
+    if (timestamp < m->last_time)
+        timestamp = m->last_time;
+#ifdef LIMIT_RATE
+    if (timestamp < m->min_next_time)
+        timestamp = m->min_next_time;
 	m->last_time = timestamp + messageLength * m->host_ticks_per_byte;
-    #endif
+#else
+    m->last_time = timestamp;
+#endif
 
     /* Add this message to the packet list */
     return send_packet(midi, message, messageLength, timestamp);
@@ -621,15 +633,17 @@ midi_end_sysex(PmInternal *midi, PmTimestamp when)
     assert(m);
     
     /* make sure we go foreward in time */
+    if (m->sysex_timestamp < m->last_time)
+        m->sysex_timestamp = m->last_time;
+
+#ifdef LIMIT_RATE
     if (m->sysex_timestamp < m->min_next_time) 
         m->sysex_timestamp = m->min_next_time;
-
-    #ifdef LIMIT_RATE
-        if (m->sysex_timestamp < m->last_time) 
-            m->sysex_timestamp = m->last_time;
-        m->last_time = m->sysex_timestamp + m->sysex_byte_count *
-                                            m->host_ticks_per_byte;
-    #endif
+    m->last_time = m->sysex_timestamp + m->sysex_byte_count *
+                                        m->host_ticks_per_byte;
+#else
+    m->last_time = m->sysex_timestamp;
+#endif
     
     /* now send what's in the buffer */
     err = send_packet(midi, m->sysex_buffer, m->sysex_byte_count,


### PR DESCRIPTION
This PR is an updated version of #639 and is included as a patch to the Portmidi sources:

> portmidi added a speed limit for outgoing MIDI messages on macOS to prevent possible data loss because of an inofficial hard-coded 15 kB/s limit in CoreMidi (for feedback protection on the IAC). Unfortunately, this makes it impossible to continously send large amout of MIDI data to USB MIDI devices. It is not entirely clear if CoreMidi only drops messages on the IAC, but it seems so.
> 
> See this massive thread for more information: #581
> 
> This PR does the following:
> 
> a) patch portmidi so we can fully disable the rate limit for macOS with a compile time switch (-DLIMIT_RATE=0). the default is #define LIMIT_RATE 1
> b) compile Pd without the rate limit to get the original behavior before the portmidi update. We might want to add a warning somewhere about possible message loss.