### PR TITLE
escape curlies

### DIFF
--- a/src/s_print.c
+++ b/src/s_print.c
@@ -18,25 +18,34 @@ t_printhook sys_printhook;
 int sys_printtostderr;
 
 /* escape characters for tcl/tk */
-static char* strnescape(char *dest, const char *src, size_t len)
+char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
 {
-    int ptin = 0;
-    unsigned ptout = 0;
-    for(; ptout < len; ptin++, ptout++)
+    unsigned ptin = 0, ptout = 0;
+    if(!dst || !src)return 0;
+    while(1)
     {
         int c = src[ptin];
-        if (c == '\\' || c == '{' || c == '}')
-            dest[ptout++] = '\\';
-        dest[ptout] = src[ptin];
+        if (c == '\\' || c == '{' || c == '}') {
+            dst[ptout++] = '\\';
+            if (dstlen && ptout >= dstlen){
+                dst[ptout-1] = 0;
+                break;
+            }
+        }
+        dst[ptout] = c;
+        ptin++;
+        ptout++;
         if (c==0) break;
+        if (srclen && ptin  >= srclen) break;
+        if (dstlen && ptout >= dstlen) break;
     }
 
-    if(ptout < len)
-        dest[ptout]=0;
+    if(!dstlen || ptout < dstlen)
+        dst[ptout]=0;
     else
-        dest[len-1]=0;
+        dst[dstlen-1]=0;
 
-    return dest;
+    return dst;
 }
 
 static char* strnpointerid(char *dest, const void *pointer, size_t len)
@@ -60,7 +69,7 @@ static void dopost(const char *s)
     else
     {
         char upbuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::post {%s}\n", strnescape(upbuf, s, MAXPDSTRING));
+        sys_vgui("::pdwindow::post {%s}\n", pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
     }
 }
 
@@ -82,7 +91,7 @@ static void doerror(const void *object, const char *s)
         char obuf[MAXPDSTRING];
         sys_vgui("::pdwindow::logpost {%s} 1 {%s}\n",
                  strnpointerid(obuf, object, MAXPDSTRING),
-                 strnescape(upbuf, s, MAXPDSTRING));
+                 pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
     }
 }
 
@@ -106,7 +115,7 @@ static void dologpost(const void *object, const int level, const char *s)
         char obuf[MAXPDSTRING];
         sys_vgui("::pdwindow::logpost {%s} %d {%s}\n",
                  strnpointerid(obuf, object, MAXPDSTRING),
-                 level, strnescape(upbuf, s, MAXPDSTRING));
+                 level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
     }
 }
 

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -412,3 +412,13 @@ struct _instancestuff
 };
 
 #define STUFF (pd_this->pd_stuff)
+
+/* escape characters for tcl/tk
+ * escapes special characters ("{}\") in the string 'src', which
+ * has a maximum length of 'srclen' and might be 0-terminated,
+ * and writes them into the 'dstlen' sized output buffer 'dst'
+ * the result is zero-terminated; if the 'dst' buffer cannot hold the
+ * fully escaped 'src' string, the result might be incomplete.
+ * 'srclen' can be 0, in which case the 'src' string must be 0-terminated.
+ */
+EXTERN char*pdgui_strnescape(char* dst, size_t dstlen, const char*src, size_t srclen);

--- a/tcl/pdtk_text.tcl
+++ b/tcl/pdtk_text.tcl
@@ -10,6 +10,7 @@ package provide pdtk_text 0.1
 # had the effect of escaping the closing brace.  We trim off the last
 # character in the string to compensate via [string range].
 proc pdtk_text_new {tkcanvas tags x y text font_size color} {
+    set text [subst -nocommands -novariables $text]
     $tkcanvas create text $x $y -tags $tags \
         -text [string range $text 0 end-1] \
             -fill $color -anchor nw -font [get_font_for_size $font_size]
@@ -27,6 +28,7 @@ proc pdtk_text_new {tkcanvas tags x y text font_size color} {
 
 # change the text in an existing text box
 proc pdtk_text_set {tkcanvas tag text} {
+    set text [subst -nocommands -novariables $text]
     $tkcanvas itemconfig $tag -text [string range $text 0 end-1]
 }
 

--- a/tcl/pdtk_text.tcl
+++ b/tcl/pdtk_text.tcl
@@ -4,15 +4,21 @@ package provide pdtk_text 0.1
 # these procs are currently all in the global namespace because all of them
 # are used by 'pd' and therefore need to be in the global namespace.
 
+namespace eval ::pdtk_text:: {
+# proc to sanitize the 'text'
+    proc unescape {text} {
+        return [string trimright [subst -nocommands -novariables $text] { }]
+    }
+}
+
 # create a new text object (ie. obj, msg, comment)
 # the initializing string ends in an extra space.  This is done in case
 # the last character should have been a backslash ('\') which would have
 # had the effect of escaping the closing brace.  We trim off the last
 # character in the string to compensate via [string range].
 proc pdtk_text_new {tkcanvas tags x y text font_size color} {
-    set text [subst -nocommands -novariables $text]
     $tkcanvas create text $x $y -tags $tags \
-        -text [string range $text 0 end-1] \
+        -text [::pdtk_text::unescape $text] \
             -fill $color -anchor nw -font [get_font_for_size $font_size]
     set mytag [lindex $tags 0]
     $tkcanvas bind $mytag <Home> "$tkcanvas icursor $mytag 0"
@@ -28,8 +34,7 @@ proc pdtk_text_new {tkcanvas tags x y text font_size color} {
 
 # change the text in an existing text box
 proc pdtk_text_set {tkcanvas tag text} {
-    set text [subst -nocommands -novariables $text]
-    $tkcanvas itemconfig $tag -text [string range $text 0 end-1]
+    $tkcanvas itemconfig $tag -text [::pdtk_text::unescape $text]
 }
 
 # paste into an existing text box by literally "typing" the contents of the

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -60,6 +60,7 @@ proc ::pdwindow::buffer_message {object_id level message} {
 }
 
 proc ::pdwindow::insert_log_line {object_id level message} {
+    set message [subst -nocommands -novariables $message]
     if {$object_id eq ""} {
         .pdwindow.text.internal insert end $message log$level
     } else {


### PR DESCRIPTION
this PR is to allow the printout of objects/msgboxes/comments/symbolboxes that contain curly braces without locking up Pd.

A simple test-patch to lock up Pd is like this:

~~~
[123(
|
[list tosymbol]
|
[symbol\
~~~

this (displaying an open curly "`{`" on a patch-canvas) locks up the receiving thread in the GUI, until a matching `}` is received.
to the user it just locks up Pd.
if the patch is currently "dirty", Pd won't react on <kbd>Ctrl</kbd>-<kbd>Q</kbd> anymore (as this requires the GUI to pop up a window), although it would react on <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>Q</kbd> (but not everybody knows about this).

what the patch does:
- make the already existing `pdgui_strnescape()` non-static, so it can be used for escaping object-labels.
  - this also adds a new argument to the `strnescape()` function for the size of the destination buffer (rather than just assuming that the destionation buffer is big enough; you can still pass `0` as the size for the old behaviour)
 - as a quick recap: the `strnescape` function replaces `('{', '}', '\')` with `('\{', '\}', '\\')` and is already used for escaping curlies and backslashes for Pd-console messages.
- use this `pdgui_strnescape()` when creating/renaming objects (via `rtext_senditup()`)
   - i'm sure this could be done more efficiently, as `rtext_senditup` already mangles the buffer.
- once the label has been received successfully on the GUI-side, it is unescaped
   - this now also happens for messages to the Pd-console (prior, printouts where escaped before sending them up, but never unescaped; Closes #615).