### PR TITLE
Use .gitignore trick to include empty 'm4/generated' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ configure
 config.log
 config.status
 libtool
-m4/generated
 m4/config
 makefile.dependencies
 dist

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,12 +2,6 @@
 
 PATH=/sw/bin:$PATH
 
-PWD=${0%/*}
-
-## git cannot really handle empty directories
-## so let's create the missing ones
-mkdir -p ${PWD}/m4/generated
-
 case `uname -s` in
     MINGW*)
         # autoreconf doesn't always work on MinGW

--- a/m4/generated/.gitignore
+++ b/m4/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This allows the project to be built using autotools without running autogen.sh.
This makes it easier to package Pure Data for Buildroot (for example) without having
to define post-extraction hooks to manually create the 'm4/generated' directory.

Tested on Ubuntu 18.04, normal build with autogen.sh works.