### PR TITLE
[poly] features

### DIFF
--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -1037,17 +1037,17 @@ static void poly_resize(t_poly *x, t_float fnvoice)
     x->x_n = n;
 }
 
-static void *poly_new(t_float nvoice, t_float steal, t_float retrigger)
+static void *poly_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_voice *v;
-    int i;
+    int i, nvoice = atom_getfloatarg(0, argc, argv);
     t_poly *x = (t_poly *)pd_new(poly_class);
 
-    x->x_n = (int)nvoice < 1 ? 1 : (int)nvoice;
+    x->x_n = nvoice < 1 ? 1 : nvoice;
     x->x_vel = 0;
     x->x_sustain = 0;
-    x->x_steal = (steal != 0);
-    x->x_retrigger = (int)retrigger; /* for now only 0 and 1 */
+    x->x_steal = (atom_getfloatarg(1, argc, argv) != 0);
+    x->x_retrigger = argc > 2 ? atom_getfloat(argv+2) : 1; /* default: true */
     floatinlet_new(&x->x_obj, &x->x_vel);
     outlet_new(&x->x_obj, &s_float);
     x->x_pitchout = outlet_new(&x->x_obj, &s_float);
@@ -1175,7 +1175,7 @@ void poly_setup(void)
 {
     poly_class = class_new(gensym("poly"),
         (t_newmethod)poly_new, (t_method)poly_free,
-        sizeof(t_poly), 0, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
+        sizeof(t_poly), 0, A_GIMME, 0);
     class_addfloat(poly_class, poly_float);
     class_addmethod(poly_class, (t_method)poly_stop, gensym("stop"), 0);
     class_addmethod(poly_class, (t_method)poly_clear, gensym("clear"), 0);

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -1045,8 +1045,8 @@ static void poly_float(t_poly *x, t_float f)
 
         /* turn off oldest matching voice if
          * a) we got a note-off message
-         * b) note stealing is on */
-    if (x->x_vel <= 0 || x->x_notesteal)
+         * b) sustain is on and note stealing is enabled */
+    if (x->x_vel <= 0 || (x->x_sustain && x->x_notesteal))
     {
         for (v = x->x_vec, i = 0, firston = 0, serialon = 0xffffffff;
             i < x->x_n; v++, i++)


### PR DESCRIPTION
These are my personal patches to the [poly] object. I've found them so useful that I think they could make it into Pd vanilla.

* dynamically set number of voices
if the new number is smaller than the old one, excess voices are flushed, 
otherwise existing voices are left untouched.
* dynamically enable/disable voice stealing
* add `[sustain <f>(` message which mimicks a piano sustain pedal. 
`[sustain 1(` - note-offs are sustained
`[sustain 0(` - all sustained notes are flushed
* add `[stack <f>(` message which enables/disables stacking of sustained notes of the same pitch
`[stack 0(` - can't sustain more than one voice of the same pitch (like a piano)
`[stack 1(` - sustain as many notes of the same pitch as you like (like many polyphonic synthesizers)