### PR TITLE
fix [text get] out of range behavior

### DIFF
--- a/src/x_text.c
+++ b/src/x_text.c
@@ -638,7 +638,7 @@ static void text_get_float(t_text_get *x, t_floatarg f)
             ATOMS_FREEA(outv, nfield);
         }
     }
-    else if (x->x_f1 < 0)   /* whole line but out of range: empty list and 2 */
+    else /* line number out of range: empty list and 2 */
     {
         outlet_float(x->x_out2, 2);         /* 2 for out of range */
         outlet_list(x->x_out1, 0, 0, 0);    /* ... and empty list */


### PR DESCRIPTION
Always output empty list + 2 if line number is out of range (not only for whole lines).

@millerpuckette I was wondering about the purpose of that explicit `else if` clause because I can't really see a reason to handle out-of-range errors for whole lines only.