### PR TITLE
Feature/netobject updates

### DIFF
--- a/doc/5.reference/netsend-help.pd
+++ b/doc/5.reference/netsend-help.pd
@@ -70,12 +70,12 @@ request should specify the name or IP address of the other host and
 the port number. There should be a "netreceive" on the remote host
 with a matching port number., f 132;
 #X text 147 12 netsend -- send Pd messages over a network;
-#X msg 447 258 timeout 3;
-#X text 526 251 TCP connect timeout, f 11;
 #X text 35 554 As of 0.50+ \, Pd supports IPv6 addresses \, netsend
 -u (UDP) is fully "connectionless" and no longer closes if no one receives
 a UDP message \, and netsend (TCP) has a settable connect timeout which
 defaults to 10 seconds., f 115;
+#X msg 437 255 timeout 3000;
+#X text 532 250 TCP connect timeout (ms), f 13;
 #X connect 0 0 8 0;
 #X connect 0 1 38 0;
 #X connect 1 0 0 0;
@@ -101,4 +101,4 @@ defaults to 10 seconds., f 115;
 #X connect 34 1 39 0;
 #X connect 35 0 31 0;
 #X connect 44 0 31 0;
-#X connect 54 0 34 0;
+#X connect 55 0 34 0;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -360,7 +360,9 @@ if MINGW
 # To use SetDllDirectory() in s_loader.c, we need a minimum of Windows
 # XP SP1. WINVER isnt' fine-grained enough for that, so we use the
 # next minor version of Windows, 5.2.  That gives us -DWINVER=0x0502
-pd_CFLAGS += -DWINVER=0x0502 -D_WIN32_WINNT=0x0502
+# On the other hand, Msys2 wants a minimum of 0x0600  (Windows Vista)
+# for some necessary defines in <ws2tcpip.h> (for IP6 support).
+pd_CFLAGS += -DWINVER=0x0600 -D_WIN32_WINNT=0x0600
 endif
 
 #########################################

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -14,6 +14,7 @@ that didn't really belong anywhere. */
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -103,10 +103,10 @@ struct _socketreceiver
     int sr_intail;
     void *sr_owner;
     int sr_udp;
-    struct sockaddr_storage *sr_fromaddr; /* optional, UDP only */
+    struct sockaddr_storage *sr_fromaddr; /* optional */
     t_socketnotifier sr_notifier;
     t_socketreceivefn sr_socketreceivefn;
-    t_socketfromaddrfn sr_fromaddrfn; /* optional, UDP only */
+    t_socketfromaddrfn sr_fromaddrfn; /* optional */
 };
 
 typedef struct _guiqueue

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -554,6 +554,8 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
             if (sys_sockerrno())
             {
                 sys_sockerror("recv (udp)");
+                if (x->sr_notifier)
+                    (*x->sr_notifier)(x->sr_owner, fd);
                 sys_rmpollfn(fd);
                 sys_closesocket(fd);
             }

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -423,7 +423,18 @@ int sys_sockerrno()
 void sys_sockerror(char *s)
 {
     int err = sys_sockerrno();
+#ifdef _WIN32
+    char buf[MAXPDSTRING];
+    buf[0] = 0;
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, err,
+                   MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), buf, sizeof(buf), NULL);
+    if (*buf)
+        error("%s: %s (%d)", s, buf, err);
+    else
+        error("%s: unknown error (%d)", s, err);
+#else
     error("%s: %s (%d)", s, strerror(err), err);
+#endif
 }
 
 void sys_addpollfn(int fd, t_fdpollfn fn, void *ptr)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -503,7 +503,11 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 
             /* connect */
             status = connect(sockfd, ai->ai_addr, ai->ai_addrlen);
+        #ifdef _WIN32
+            if (status < 0 && sys_sockerrno() != WSAEWOULDBLOCK)
+        #else
             if (status < 0 && sys_sockerrno() != EINPROGRESS)
+        #endif
             {
                 sys_sockerror("connecting stream socket");
                 sys_closesocket(sockfd);

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -709,12 +709,12 @@ static void netreceive_notify(t_netreceive *x, int fd)
             x->x_connections = (int *)t_resizebytes(x->x_connections,
                 x->x_nconnections * sizeof(int),
                     (x->x_nconnections-1) * sizeof(int));
-            memmove(x->x_receivers+i, x->x_receivers+(i+1),
-                sizeof(t_socketreceiver*) * (x->x_nconnections - (i+1)));
 
             if (x->x_receivers[i])
                 socketreceiver_free(x->x_receivers[i]);
-            x->x_receivers[i] = NULL;
+            memmove(x->x_receivers+i, x->x_receivers+(i+1),
+                sizeof(t_socketreceiver*) * (x->x_nconnections - (i+1)));
+
             x->x_receivers = (t_socketreceiver **)t_resizebytes(x->x_receivers,
                 x->x_nconnections * sizeof(t_socketreceiver*),
                     (x->x_nconnections-1) * sizeof(t_socketreceiver*));

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -39,6 +39,8 @@
 /* print addrinfo lists for debugging */
 //#define POST_ADDRINFO
 
+#define INBUFSIZE 4096
+
 /* ----------------------------- helpers ------------------------- */
 
 /* Windows XP winsock doesn't provide inet_ntop */
@@ -283,7 +285,7 @@ static void *netsend_new(t_symbol *s, int argc, t_atom *argv)
 
 static void netsend_readbin(t_netsend *x, int fd)
 {
-    unsigned char inbuf[MAXPDSTRING];
+    unsigned char inbuf[INBUFSIZE];
     int ret = 0, i;
     struct sockaddr_storage fromaddr = {0};
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
@@ -293,10 +295,10 @@ static void netsend_readbin(t_netsend *x, int fd)
         return;
     }
     if (x->x_protocol == SOCK_DGRAM)
-        ret = (int)recvfrom(fd, inbuf, MAXPDSTRING, 0,
+        ret = (int)recvfrom(fd, inbuf, INBUFSIZE, 0,
             (struct sockaddr *)&fromaddr, &fromaddrlen);
     else
-        ret = (int)recv(fd, inbuf, MAXPDSTRING, 0);
+        ret = (int)recv(fd, inbuf, INBUFSIZE, 0);
     if (ret <= 0)
     {
         if (ret < 0)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -579,7 +579,6 @@ static void netsend_disconnect(t_netsend *x)
         if (x->x_receiver)
             socketreceiver_free(x->x_receiver);
         x->x_receiver = NULL;
-        memset(&x->x_receiver, 0, sizeof(x->x_receiver));
         memset(&x->x_server, 0, sizeof(struct sockaddr_storage));
         outlet_float(x->x_obj.ob_outlet, 0);
     }

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -49,8 +49,8 @@
 const char* INET_NTOP(int af, const void *src, char *dst, socklen_t size) {
     struct sockaddr_storage addr;
     socklen_t addrlen;
-    addr.ss_family = af;
     memset(&addr, 0, sizeof(struct sockaddr_storage));
+    addr.ss_family = af;
     if (af == AF_INET6)
     {
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&addr;
@@ -65,12 +65,12 @@ const char* INET_NTOP(int af, const void *src, char *dst, socklen_t size) {
     }
     else
         return NULL;
-    if (WSAAddressToString((struct sockaddr *)&addr, addrlen, 0, dst,
+    if (WSAAddressToStringA((struct sockaddr *)&addr, addrlen, 0, dst,
         (LPDWORD)&size) != 0)
         return NULL;
     return dst;
 }
-#else
+#else /* _WIN32 */
 #define INET_NTOP inet_ntop
 #endif
 

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -14,6 +14,9 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#if defined(_MSC_VER) && _WIN32_WINNT == 0x0601
+#include <ws2def.h>
+#endif /* MSVC + Windows 7 */
 #else
 #include <arpa/inet.h>
 #include <sys/socket.h>

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -305,7 +305,13 @@ static void netsend_readbin(t_netsend *x, int fd)
         if (ret <= 0)
         {
             if (ret < 0)
+            {
+                /* only close the socket if there really was an error.
+                (sys_sockerrno() ignores some error codes) */
+                if (!sys_sockerrno())
+                    return;
                 sys_sockerror("recv (bin)");
+            }
             sys_rmpollfn(fd);
             sys_closesocket(fd);
             if (x->x_obj.ob_pd == netreceive_class)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -666,7 +666,7 @@ static void netsend_send(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 static void netsend_timeout(t_netsend *x, t_float timeout)
 {
     if (timeout >= 0)
-        x->x_timeout = timeout;
+        x->x_timeout = timeout * 0.001;
 }
 
 static void netsend_free(t_netsend *x)


### PR DESCRIPTION
mostly minor bugfixes but also two "features":

* allow to receive more than 1 UDP packet per scheduler tick to match the behavior of TCP. With this fix, receiving 1000 short UDP packets (with DSP on) only takes ~1 ms instead of ~1.5 seconds (!)

* properly notify TCP clients when a socket has been closed, i.e. `[listen 0( -> [netreceive]` will cause all connected `[netsend]`s to close and output a 0. 
(currently, `[netsend]` is not notified when its connection is closed from the other side, so you get a cryptic socket error when you send it a message.)

successfully tested on Windows 7 and Debian 9. @danomatika @umlaeute 
