### PR TITLE
Fix for issue with t_int on 64-bit Windows for d_math objects

### DIFF
--- a/src/d_math.c
+++ b/src/d_math.c
@@ -138,7 +138,7 @@ static void *sigrsqrt_new(void)
 static t_int *sigrsqrt_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = *(int *)(w+3);
+    int n = (int)w[3];
     while (n--)
     {
         t_sample f = *in++;
@@ -197,7 +197,7 @@ static void *sigsqrt_new(void)
 t_int *sigsqrt_perform(t_int *w)    /* not static; also used in d_fft.c */
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = *(int *)(w+3);
+    int n = (int)w[3];
     while (n--)
     {
         t_sample f = *in++;

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -138,7 +138,7 @@ static void *sigrsqrt_new(void)
 static t_int *sigrsqrt_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = *(t_int *)(w+3);
+    int n = *(int *)(w+3);
     while (n--)
     {
         t_sample f = *in++;
@@ -197,7 +197,7 @@ static void *sigsqrt_new(void)
 t_int *sigsqrt_perform(t_int *w)    /* not static; also used in d_fft.c */
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = *(t_int *)(w+3);
+    int n = *(int *)(w+3);
     while (n--)
     {
         t_sample f = *in++;
@@ -253,7 +253,7 @@ static void *sigwrap_new(void)
 static t_int *sigwrap_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     while (n--)
     {
         t_sample f = *in++;
@@ -268,7 +268,7 @@ static t_int *sigwrap_perform(t_int *w)
 static t_int *sigwrap_old_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     while (n--)
     {
         t_sample f = *in++;
@@ -316,7 +316,7 @@ static void *mtof_tilde_new(void)
 static t_int *mtof_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;
@@ -365,7 +365,7 @@ static void *ftom_tilde_new(void)
 static t_int *ftom_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;
@@ -409,7 +409,7 @@ static void *dbtorms_tilde_new(void)
 static t_int *dbtorms_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;
@@ -459,7 +459,7 @@ static void *rmstodb_tilde_new(void)
 static t_int *rmstodb_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;
@@ -508,7 +508,7 @@ static void *dbtopow_tilde_new(void)
 static t_int *dbtopow_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;
@@ -558,7 +558,7 @@ static void *powtodb_tilde_new(void)
 static t_int *powtodb_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    t_int n = (t_int)w[3];
+    int n = (int)w[3];
     for (; n--; in++, out++)
     {
         t_sample f = *in;


### PR DESCRIPTION
This is a fix for an issue I encountered when using libpd in my own [Unity wrapper](https://github.com/LibPdIntegration/LibPdIntegration) for the library (you can read the original issue [here](https://github.com/LibPdIntegration/LibPdIntegration/issues/6)).

In d_math.c there are a number of objects which, in their perform function, define the block size as a t_int variable. This causes problems on 64-bit Windows binaries, because the block size is originally defined as an int (32-bits on Windows). Because t_int is defined as a long long (64-bits) this results in the perform function of these objects reading a junk value in the upper 32 bits of the t_int and attempting to process the wrong number of samples.

The affected objects are:
rsqrt~
sqrt~
wrap~
mtof~
ftom~
dbtorms~
rmstodb~
dbtopow~
powtodb~

Without the fix, any patches running via my wrapper in Unity (that use one of these objects) crash. For reasons that aren't clear to me, the currently-available 64-bit Windows executable of Pure Data seems to work fine without the fix.