### PR TITLE
pdcontrol args method

### DIFF
--- a/doc/5.reference/pdcontrol-abs.pd
+++ b/doc/5.reference/pdcontrol-abs.pd
@@ -1,0 +1,9 @@
+#N canvas 674 311 471 296 12;
+#X obj 149 108 inlet;
+#X obj 149 228 outlet;
+#X obj 149 165 pdcontrol;
+#X text 78 28 This is the abstraction for the pdcontrol help patch.
+It serves an example on how it gets the arguments of an abstraction.
+, f 41;
+#X connect 0 0 2 0;
+#X connect 2 0 1 0;

--- a/doc/5.reference/pdcontrol-help.pd
+++ b/doc/5.reference/pdcontrol-help.pd
@@ -1,46 +1,67 @@
-#N canvas 398 86 779 629 12;
-#X obj 21 10 pdcontrol;
-#X text 100 10 -- communicate with pd and/or this patch;
-#X text 390 593 updated for Pd version 0.50.;
-#X obj 35 271 pdcontrol;
-#X obj 35 296 print;
-#X msg 43 146 isvisible;
-#X msg 51 358 isvisible;
+#N canvas 404 92 779 665 12;
+#X obj 21 14 pdcontrol;
+#X text 100 14 -- communicate with pd and/or this patch;
+#X text 390 617 updated for Pd version 0.50.;
+#X obj 35 275 pdcontrol;
+#X obj 35 300 print;
+#X msg 43 150 isvisible;
+#X msg 51 382 isvisible;
 #N canvas 898 272 450 300 subpatch 0;
 #X obj 37 37 inlet;
 #X obj 37 62 pdcontrol;
 #X obj 37 87 print;
 #X connect 0 0 1 0;
 #X connect 1 0 2 0;
-#X restore 51 383 pd subpatch;
-#X text 138 357 open and shut the subpatch to test "isvisible" message
+#X restore 51 407 pd subpatch;
+#X text 138 381 open and shut the subpatch to test "isvisible" message
 ;
-#X text 131 144 1 if this patch is visible \, 0 if not;
-#X msg 35 116 gui ::pd_menucommands::menu_aboutpd;
-#X msg 51 172 dir;
-#X text 98 172 get directory this patch is in;
-#X text 306 202 optional argument to specify this patch (0) \, owning
+#X text 131 148 1 if this patch is visible \, 0 if not;
+#X msg 35 120 gui ::pd_menucommands::menu_aboutpd;
+#X msg 51 176 dir;
+#X text 98 176 get directory this patch is in;
+#X text 306 206 optional argument to specify this patch (0) \, owning
 patch (1) \, its own owner (2) \, and so on \, and optionally also
 a filename relative to the patch's directory. (Ownership number is
 silently reduced if owners don't exist \, so here anything greater
 than zero is ignored.), f 42;
-#X msg 57 210 dir 0 ../3.audio-examples/A00.intro.pd, f 32;
-#X obj 46 511 pdcontrol;
-#X obj 322 481 r bazoo;
-#X obj 322 506 print bazoo;
-#X msg 46 479 gui pdsend [concat bazoo [exec date]];
-#X text 31 37 pdcontrol lets you communicate with the patch to get
-its owning directory \, its visible/invisible state \, or to send a
-command directly to the tcl/tk interpreter used for Pd's gui.;
-#X text 296 118 run a tcl/tk command in the gui;
-#X text 45 422 You can run system commands via the gui. What commands
+#X msg 57 214 dir 0 ../3.audio-examples/A00.intro.pd, f 32;
+#X obj 46 535 pdcontrol;
+#X obj 322 505 r bazoo;
+#X obj 322 530 print bazoo;
+#X msg 46 503 gui pdsend [concat bazoo [exec date]];
+#X text 296 122 run a tcl/tk command in the gui;
+#X text 45 446 You can run system commands via the gui. What commands
 you can run depends on your operating system. If you're in linux or
 Mac OS you can get the time and date like this:;
-#X text 494 416 (note: because you can't use open and close braces
+#X text 494 440 (note: because you can't use open and close braces
 in Pd \, this can be very awkward. It is perhaps best to define tcl/tk
 functions in a "gui plug-in" that can be called eastil from Pd. Also
 \, O/S variations will make it hard to make perfectly portable patches
 using system commands.), f 36;
+#N canvas 689 91 529 365 args 0;
+#X obj 127 209 print;
+#X text 185 140 <= get arguments;
+#X obj 127 174 pdcontrol-abs foo 100 \$0-x \\\$0 \$1 \$2-x;
+#X msg 127 140 args 0;
+#X text 59 247 Above there's a aimple abstraction to show how it works.
+Note how dollar signs (such as "\$0" \, "\$1" or "\$2-x") get expanded
+unless you escape them with a backlash ("\$2-x" may appear as an unexpanded
+symbol \, but it actually gets expanded if this abstraction is called
+inside another that contains arguments).;
+#X text 40 23 This is useful for managing a variable number of arguments.
+When it receives the 'args' message \, [pdcontrol] outputs the loaded
+arguments. An optional argument specifies this patch (0) \, owning
+patch (1) \, its own owner (2) \, and so on. (Ownership number is silently
+reduced if owners don't exist \, so here anything greater than zero
+is ignored.), f 65;
+#X connect 2 0 0 0;
+#X connect 3 0 2 0;
+#X restore 64 338 pd args;
+#X text 31 41 pdcontrol lets you communicate with the patch to get
+its owning directory \, arguments \, its visible/invisible state \,
+or to send a command directly to the tcl/tk interpreter used for Pd's
+gui.;
+#X text 127 338 get the patch's arguments;
 #X connect 3 0 4 0;
 #X connect 5 0 3 0;
 #X connect 6 0 7 0;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -435,6 +435,25 @@ static void pdcontrol_dir(t_pdcontrol *x, t_symbol *s, t_floatarg f)
     else outlet_symbol(x->x_outlet, canvas_getdir(x->x_canvas));
 }
 
+static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
+{
+    t_canvas *c = x->x_canvas;
+    int i;
+    for (i = 0; i < (int)f; i++)
+    {
+        while (!c->gl_env)  /* back up to containing canvas or abstraction */
+            c = c->gl_owner;
+        if (c->gl_owner)    /* back up one more into an owner if any */
+            c = c->gl_owner;
+    }
+    int argc;
+    t_atom *argv;
+    canvas_setcurrent(c);
+    canvas_getargs(&argc, &argv);
+    canvas_unsetcurrent(c);
+    outlet_list(x->x_outlet, &s_list, argc, argv);
+}
+
 static void pdcontrol_gui(t_pdcontrol *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = binbuf_new();
@@ -466,6 +485,8 @@ static void pdcontrol_setup(void)
         (t_newmethod)pdcontrol_new, 0, sizeof(t_pdcontrol), 0, 0);
     class_addmethod(pdcontrol_class, (t_method)pdcontrol_dir,
         gensym("dir"), A_DEFFLOAT, A_DEFSYMBOL, 0);
+    class_addmethod(pdcontrol_class, (t_method)pdcontrol_args,
+        gensym("args"), A_DEFFLOAT, 0);
     class_addmethod(pdcontrol_class, (t_method)pdcontrol_gui,
         gensym("gui"), A_GIMME, 0);
     class_addmethod(pdcontrol_class, (t_method)pdcontrol_isvisible,


### PR DESCRIPTION
here's a suggestion to get the patch's arguments as a list with a new 'args' method with the new [pdcontrol] object.

