### PR TITLE
improve portaudio scheduler

### DIFF
--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -436,6 +436,7 @@ the audio I/O system is still busy with previous transfers.
 
 void sys_pollmidiqueue(void);
 void sys_initmidiqueue(void);
+int sys_pollsockets(void);
 
  /* sys_idlehook is a hook the user can fill in to grab idle time.  Return
 nonzero if you actually used the time; otherwise we're really really idle and
@@ -520,7 +521,7 @@ static void m_pollingscheduler(void)
 
         sys_addhist(2);
         sys_pollmidiqueue();
-        if (sys_pollgui())
+        if (sys_pollsockets())
         {
             if (!didsomething)
                 sched_didpoll++;
@@ -530,6 +531,8 @@ static void m_pollingscheduler(void)
             /* test for idle; if so, do graphics updates. */
         if (!didsomething)
         {
+            if (timeforward != SENDDACS_SLEPT)
+                sys_pollgui();
             sched_pollformeters();
             sys_reportidle();
             sys_unlock();   /* unlock while we idle */

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -496,6 +496,7 @@ int pa_send_dacs(void)
     int j, k;
     int rtnval =  SENDDACS_YES;
     int locked = 0;
+    int didsomething;
 #ifdef FAKEBLOCKING
 #ifdef THREADSIGNAL
     struct timespec ts;
@@ -547,11 +548,11 @@ int pa_send_dacs(void)
                 locked = 1;
                 break;
             }
-#ifdef _WIN32
-            Sleep(1);
-#else
-            usleep(1000);
-#endif /* _WIN32 */
+            sys_lock();
+            didsomething = sys_pollgui();
+            sys_unlock();
+            if (!didsomething)
+                sys_microsleep(1000);
 #endif /* THREADSIGNAL */
         }
 #ifdef THREADSIGNAL
@@ -592,11 +593,11 @@ int pa_send_dacs(void)
                 locked = 1;
                 break;
             }
-#ifdef _WIN32
-            Sleep(1);
-#else
-            usleep(1000);
-#endif /* _WIN32 */
+            sys_lock();
+            didsomething = sys_pollgui();
+            sys_unlock();
+            if (!didsomething)
+                sys_microsleep(1000);
 #endif /* THREADSIGNAL */
         }
 #ifdef THREADSIGNAL

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -552,6 +552,9 @@ int pa_send_dacs(void)
             sys_unlock();
             if (!didsomething)
                 sys_microsleep(1000);
+                /* polling sockets might close the audio device! */
+            else if (!pa_stream)
+                return SENDDACS_NO;
 #endif /* THREADSIGNAL */
         }
 #ifdef THREADSIGNAL
@@ -596,6 +599,9 @@ int pa_send_dacs(void)
             sys_unlock();
             if (!didsomething)
                 sys_microsleep(1000);
+                /* polling sockets might close the audio device! */
+            else if (!pa_stream)
+                return SENDDACS_NO;
 #endif /* THREADSIGNAL */
         }
 #ifdef THREADSIGNAL

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -255,7 +255,11 @@ static int sys_domicrosleep(int microsec, int pollem)
 
 void sys_microsleep(int microsec)
 {
-    sys_domicrosleep(microsec, 1);
+#ifdef _WIN32
+    Sleep(microsec/1000);
+#else
+    usleep(microsec);
+#endif /* _WIN32 */
 }
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -201,7 +201,7 @@ double sys_getrealtime(void)
 
 extern int sys_nosleep;
 
-static int sys_pollsockets(void)
+int sys_pollsockets(void)
 {
     struct timeval timout;
     int i, didsomething = 0;
@@ -811,7 +811,7 @@ static int sys_flushqueue(void)
 }
 
     /* flush output buffer and update queue to gui in small time slices */
-static int sys_poll_togui(void) /* returns 1 if did anything */
+int sys_poll_togui(void) /* returns 1 if did anything */
 {
     if (!sys_havegui())
         return (0);


### PR DESCRIPTION
* `sys_microsleep` only sleeps (because it is called in contexts where Pd is not locked)
* `sys_domicrosleep` -> `sys_pollsockets` - only polls sockets
* `pa_send_dacs`: first try `sys_pollgui()` before going to sleep. This makes sure we actually use the idle time! 

This PR implicitly fixes a problem where excessive incoming network traffic would freeze the GUI (when DSP is on): https://github.com/pure-data/pure-data/issues/55 