### PR TITLE
[WIP] Array features: dynamically set color, width, style and visibility

### DIFF
--- a/doc/2.control.examples/16.more.arrays.pd
+++ b/doc/2.control.examples/16.more.arrays.pd
@@ -1,4 +1,4 @@
-#N canvas 288 82 910 558 12;
+#N canvas 288 82 910 685 12;
 #N canvas 0 50 450 250 (subpatch) 0;
 #X array array99 5 float 1;
 #A 0 0.32 0.499999 -0.406667 -0.753333 0.00666714;
@@ -6,40 +6,70 @@
 #A 0 -0.0933342 0.306665 0.0266657 0.239999 0.573332 -0.200001 0.533332
 ;
 #X coords 0 1 5 -1 200 150 1;
-#X restore 554 183 graph;
-#X text 177 17 MORE ON ARRAYS;
-#X msg 39 237 \; array99 rename george;
-#X msg 222 237 \; george rename array99;
-#X msg 289 170 \; array99 3 -0.5 0.5;
-#X text 39 215 renaming an array:;
-#X text 38 287 setting the bounds rectangle:;
-#X msg 40 307 \; array99 bounds 0 -2 10 2;
-#X msg 256 305 \; array99 bounds 0 -1 5 1;
-#X msg 41 407 \; array99 xticks 0 1 1;
-#X msg 234 406 \; array99 yticks 0 0.1 5;
-#X text 37 354 adding x and y labels: give a point to put a tick \,
-the interval between ticks \, and the number of ticks overall per large
-tick., f 51;
-#X msg 37 484 \; array99 xlabel -1.1 0 1 2 3 4 5;
-#X text 38 448 adding labels. Give a y value and a bunch of x values
-or vice versa:, f 40;
-#X msg 39 170 \; array98 0 -1 1 -1 1 -1 1 -1 1 -1;
-#X msg 277 484 \; array99 ylabel 5.15 -1 0 1;
-#X text 32 45 Arrays have methods to set their values explicitly \;
+#X restore 510 51 graph;
+#X text 155 15 MORE ON ARRAYS;
+#X msg 17 229 \; array99 rename george;
+#X msg 221 229 \; george rename array99;
+#X msg 317 166 \; array99 3 -0.5 0.5;
+#X text 17 207 renaming an array:;
+#X text 16 276 setting the bounds rectangle:;
+#X msg 18 296 \; array99 bounds 0 -2 10 2;
+#X msg 245 294 \; array99 bounds 0 -1 5 1;
+#X msg 19 395 \; array99 xticks 0 1 1;
+#X msg 212 394 \; array99 yticks 0 0.1 5;
+#X msg 15 472 \; array99 xlabel -1.1 0 1 2 3 4 5;
+#X text 12 436 adding labels. Give a y value and a bunch of x values
+or vice versa:;
+#X msg 17 166 \; array98 0 -1 1 -1 1 -1 1 -1 1 -1;
+#X msg 256 472 \; array99 ylabel 5.15 -1 0 1;
+#X text 10 39 Arrays have methods to set their values explicitly \;
 to set their "bounds" rectangles \, to rename them (but if you have
 two with the same name this won't necessarily do what you want) and
 to add markings. To set values by message \, send a list whose first
 element gives the index to start at. The second example sets two values
 starting at index three. Indices count up from zero.;
-#X text 507 364 you can put more than one array in a single "graph"
+#X obj 482 403 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X msg 482 427 \; array98 vis \$1;
+#X obj 602 401 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X msg 602 426 \; array99 vis \$1;
+#X msg 483 632 \; array98 style \$1;
+#X obj 483 611 hradio 15 1 0 3 empty empty empty 0 -8 0 10 -262144
+-1 -1 0;
+#X msg 633 547 \; array98 width \$1;
+#X floatatom 632 524 5 0 0 0 - - -;
+#X text 482 588 point \, line \, bezier;
+#X text 629 501 line width;
+#X floatatom 483 521 5 0 0 0 - - -;
+#X text 480 498 color;
+#X msg 527 521 9;
+#X text 480 361 You can selectively show/hide arrays with the "vis"
+message:, f 37;
+#X text 479 474 Change the visual appearance:;
+#X msg 558 521 90;
+#X msg 591 520 900;
+#X msg 483 547 \; array98 color \$1;
+#X text 14 522 You can also change x and y range and size in the "properties"
+dialog. Note that information about size and ranges is saved \, but
+ticks and labels are lost between Pd sessions. The contents of the
+array may be saved as part of the patch or discarded. This is set in
+the 'properties" dialog.;
+#X text 480 211 You can put more than one array in a single "graph"
 (which is Pd's name for the bounding rectangle \, and is a synonym
 for "canvas".) Arrays' sizes need not match the bounds of the containing
 graph. But if you resize an array \, and if it is the only array contained
 in a graph \, then the graph automaticallly resets its bounds to match.
-, f 51;
-#X text 654 493 last updated for release 0.48;
-#X text 508 27 You can also change x and y range and size in the "properties"
-dialog. Note that information about size and ranges is saved \, but
-ticks and labels are lost between Pd sessions. The contents of the
-array may be saved as part of the patch or discarded., f 46;
-#X text 510 118 This is set in the "properties" dialog.;
+, f 36;
+#X text 15 342 Adding x and y labels: give a point to put a tick \,
+the interval between ticks \, and the number of ticks overall per large
+tick.;
+#X text 636 632 last updated for release 0.52.;
+#X connect 16 0 17 0;
+#X connect 18 0 19 0;
+#X connect 21 0 20 0;
+#X connect 23 0 22 0;
+#X connect 26 0 33 0;
+#X connect 28 0 33 0;
+#X connect 31 0 33 0;
+#X connect 32 0 33 0;

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1096,9 +1096,6 @@ static void garray_style(t_garray *x, t_floatarg fstyle)
             ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
     #endif
         garray_redraw(x);
-    #if 0
-        canvas_dirty(x->x_glist, 1);
-    #endif
     }
 }
 
@@ -1120,9 +1117,6 @@ static void garray_width(t_garray *x, t_floatarg width)
         template_setfloat(scalartemplate, gensym("linewidth"),
             x->x_scalar->sc_vec, width, 0);
         garray_redraw(x);
-    #if 0
-        canvas_dirty(x->x_glist, 1);
-    #endif
     }
 }
 
@@ -1143,9 +1137,6 @@ static void garray_color(t_garray *x, t_floatarg color)
         template_setfloat(scalartemplate, gensym("color"),
             x->x_scalar->sc_vec, color, 0);
         garray_redraw(x);
-    #if 0
-        canvas_dirty(x->x_glist, 1);
-    #endif
     }
 }
 

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1066,6 +1066,89 @@ static void garray_ylabel(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
     typedmess(&x->x_glist->gl_pd, s, argc, argv);
 }
+
+static void garray_style(t_garray *x, t_floatarg fstyle)
+{
+    int stylewas, style = fstyle;
+    t_template *scalartemplate;
+    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    {
+        error("array: no template of type %s",
+            x->x_scalar->sc_template->s_name);
+        return;
+    }
+    stylewas = template_getfloat(
+        scalartemplate, gensym("style"), x->x_scalar->sc_vec, 1);
+    if (style != stylewas)
+    {
+        t_array *a = garray_getarray(x);
+        if (!a)
+        {
+            pd_error(x, "can't find array\n");
+            return;
+        }
+        if (style == PLOTSTYLE_POINTS || stylewas == PLOTSTYLE_POINTS)
+            garray_fittograph(x, a->a_n, style);
+        template_setfloat(scalartemplate, gensym("style"),
+            x->x_scalar->sc_vec, (t_float)style, 0);
+    #if 1
+        template_setfloat(scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec,
+            ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
+    #endif
+        garray_redraw(x);
+    #if 0
+        canvas_dirty(x->x_glist, 1);
+    #endif
+    }
+}
+
+static void garray_width(t_garray *x, t_floatarg width)
+{
+    t_float widthwas;
+    t_template *scalartemplate;
+    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    {
+        error("array: no template of type %s",
+            x->x_scalar->sc_template->s_name);
+        return;
+    }
+    widthwas = template_getfloat(
+        scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, 1);
+    if (width < 1) width = 1;
+    if (width != widthwas)
+    {
+        template_setfloat(scalartemplate, gensym("linewidth"),
+            x->x_scalar->sc_vec, width, 0);
+        garray_redraw(x);
+    #if 0
+        canvas_dirty(x->x_glist, 1);
+    #endif
+    }
+}
+
+static void garray_color(t_garray *x, t_floatarg color)
+{
+    t_float colorwas;
+    t_template *scalartemplate;
+    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    {
+        error("array: no template of type %s",
+            x->x_scalar->sc_template->s_name);
+        return;
+    }
+    colorwas = template_getfloat(
+        scalartemplate, gensym("color"), x->x_scalar->sc_vec, 1);
+    if (color != colorwas)
+    {
+        template_setfloat(scalartemplate, gensym("color"),
+            x->x_scalar->sc_vec, color, 0);
+        garray_redraw(x);
+    #if 0
+        canvas_dirty(x->x_glist, 1);
+    #endif
+    }
+}
+
     /* change the name of a garray. */
 static void garray_rename(t_garray *x, t_symbol *s)
 {
@@ -1208,6 +1291,12 @@ void g_array_setup(void)
         A_FLOAT, A_FLOAT, A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_ylabel, gensym("ylabel"),
         A_GIMME, 0);
+    class_addmethod(garray_class, (t_method)garray_style, gensym("style"),
+        A_FLOAT, 0);
+    class_addmethod(garray_class, (t_method)garray_width, gensym("width"),
+        A_FLOAT, 0);
+    class_addmethod(garray_class, (t_method)garray_color, gensym("color"),
+        A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_rename, gensym("rename"),
         A_SYMBOL, 0);
     class_addmethod(garray_class, (t_method)garray_read, gensym("read"),

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -120,8 +120,8 @@ static t_pd *garray_arraytemplatecanvas;  /* written at setup w/ global lock */
 static const char garray_arraytemplatefile[] = "\
 canvas 0 0 458 153 10;\n\
 #X obj 43 31 struct float-array array z float float style\n\
-float linewidth float color;\n\
-#X obj 43 70 plot z color linewidth 0 0 1 style;\n\
+float linewidth float color float v;\n\
+#X obj 43 70 plot -v v z color linewidth 0 0 1 style;\n\
 ";
 static const char garray_floattemplatefile[] = "\
 canvas 0 0 458 153 10;\n\
@@ -323,6 +323,7 @@ t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
         style, 1);
     template_setfloat(template, gensym("linewidth"), x->x_scalar->sc_vec,
         ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
+    template_setfloat(template, gensym("v"), x->x_scalar->sc_vec, 1, 1);
 
            /* bashily unbind #A -- this would create garbage if #A were
            multiply bound but we believe in this context it's at most
@@ -1140,6 +1141,26 @@ static void garray_color(t_garray *x, t_floatarg color)
     }
 }
 
+static void garray_vis_msg(t_garray *x, t_floatarg fvis)
+{
+    int viswas, vis = fvis != 0;
+    t_template *scalartemplate;
+    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    {
+        error("array: no template of type %s",
+            x->x_scalar->sc_template->s_name);
+        return;
+    }
+    viswas = template_getfloat(
+        scalartemplate, gensym("v"), x->x_scalar->sc_vec, 1);
+    if (vis != viswas)
+    {
+        template_setfloat(scalartemplate, gensym("v"),
+            x->x_scalar->sc_vec, vis, 0);
+        garray_redraw(x);
+    }
+}
+
     /* change the name of a garray. */
 static void garray_rename(t_garray *x, t_symbol *s)
 {
@@ -1287,6 +1308,8 @@ void g_array_setup(void)
     class_addmethod(garray_class, (t_method)garray_width, gensym("width"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_color, gensym("color"),
+        A_FLOAT, 0);
+    class_addmethod(garray_class, (t_method)garray_vis_msg, gensym("vis"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_rename, gensym("rename"),
         A_SYMBOL, 0);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -460,6 +460,8 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
             garray_fittograph(x, (int)size, style);
         template_setfloat(scalartemplate, gensym("style"),
             x->x_scalar->sc_vec, (t_float)style, 0);
+        template_setfloat(scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec,
+            ((style == PLOTSTYLE_POINTS) ? 2 : 1), 0);
 
         garray_setsaveit(x, (saveit != 0));
         garray_redraw(x);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -333,7 +333,7 @@ t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
         saved file or copy buffer */
     pd_bind(&x->x_gobj.g_pd, asym);
 
-    garray_redraw(x);
+    garray_fittograph(x, n, style);
     canvas_update_dsp();
     return (x);
 }

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1780,6 +1780,9 @@ static void plot_vis(t_gobj *z, t_glist *glist,
         {
             t_float minyval = 1e20, maxyval = -1e20;
             int ndrawn = 0;
+            char color[20];
+            numbertocolor(fielddesc_getfloat(&x->x_outlinecolor, template,
+                data, 1), color);
             for (xsum = basex + xloc, i = 0; i < nelem; i++)
             {
                 t_float yval, xpix, ypix, nextxloc;
@@ -1814,13 +1817,13 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                 if (i == nelem-1 || inextx != ixpix)
                 {
                     sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                        "-fill black -width 0 -tags [list plot%lx array]\n",
+                        "-fill %s -width 0 -tags [list plot%lx array]\n",
                         glist_getcanvas(glist),
                         ixpix, (int)glist_ytopixels(glist,
                             basey + fielddesc_cvttocoord(yfielddesc, minyval)),
                         inextx, (int)(glist_ytopixels(glist,
                             basey + fielddesc_cvttocoord(yfielddesc, maxyval))
-                                + linewidth), data);
+                                + linewidth), color, data);
                     ndrawn++;
                     minyval = 1e20;
                     maxyval = -1e20;


### PR DESCRIPTION
This PR adds the following messages for garrays:

* `[color <f>(` - set line/point color (in data structure color format)
* `[width <f>(` - set line/point width
* `[style <f>(`- switch between point, line and bezier style
* `[vis <f>(` - show/hide array. Very useful if there's more than 1 array in a graph!

I've documented these features in `2.control.examples/16.more.arrays.pd`.

Small example:
![graph](https://user-images.githubusercontent.com/16126632/62556180-aaa26f80-b874-11e9-9cec-ad710bb4427b.png)




