### PR TITLE
Feature/netobject updates

### DIFF
--- a/src/s_net.c
+++ b/src/s_net.c
@@ -369,6 +369,29 @@ int socket_join_multicast_group(int socket, const struct sockaddr *sa)
     return -1;
 }
 
+int socket_leave_multicast_group(int socket, const struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET6)
+    {
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct ipv6_mreq mreq6 = {0};
+        memcpy(&mreq6.ipv6mr_multiaddr, &sa6->sin6_addr,
+            sizeof(struct in6_addr));
+        return setsockopt(socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
+            (char *)&mreq6, sizeof(mreq6));
+    }
+    else if (sa->sa_family == AF_INET)
+    {
+        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct ip_mreq mreq = {0};
+        mreq.imr_multiaddr.s_addr = sa4->sin_addr.s_addr;
+        mreq.imr_interface.s_addr = INADDR_ANY;
+        return setsockopt(socket, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+            (char *)&mreq, sizeof(mreq));
+    }
+    return -1;
+}
+
 int socket_errno(void)
 {
 #ifdef _WIN32

--- a/src/s_net.h
+++ b/src/s_net.h
@@ -125,6 +125,9 @@ int socket_set_nonblocking(int socket, int nonblocking);
 /// join a multicast group address, returns < 0 on error
 int socket_join_multicast_group(int socket, const struct sockaddr *sa);
 
+/// leave a multicast group address, returns < 0 on error
+int socket_leave_multicast_group(int socket, const struct sockaddr *sa);
+
 /// cross-platform socket errno() which catches WSAESOCKTNOSUPPORT on Windows
 int socket_errno(void);
 

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -801,6 +801,11 @@ static void netreceive_send(t_netreceive *x,
     t_symbol *s, int argc, t_atom *argv)
 {
     int i;
+    if (x->x_ns.x_protocol != SOCK_STREAM)
+    {
+        pd_error(x, "netreceive: 'send' only works for TCP");
+        return;
+    }
     for (i = 0; i < x->x_nconnections; i++)
     {
         if (netsend_dosend(&x->x_ns, x->x_connections[i], s, argc, argv))


### PR DESCRIPTION
@danomatika the thing is that you're not supposed to bind to the multicast address. bind only determines which interfaces you listen to. binding to the multicast address causes an error (at least on Windows).

here's a reference: https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_71/rzab6/xmulticast.htm

also, it's possible to join more than 1 multicast group. you can also leave them.
so my suggestion is:
1) use `[listen <port> <host>(` only to select the interface (TCP and UDP), e.g. to only allow traffic from "localhost"
2) add [multicast_join( and [multicast_leave( methods to join/leave multicast groups

With this PR I can successfully join/leave several multicast groups. I've tested locally and with another machine in the local network.

The only caveat is that the IP family of `[listen(` and `[multicast_*(` must match. This means you might have to explicitly do `[listen 0.0.0.0(` if you want to join IPv4 multicast groups. I don't like this but I don't see an easy way around this. FWIW, I post a warning if the IP family doesn't match and suggest to bind to the correct "any" address.

Need to update the docs, but only if you're happy with the implementation.
