### PR TITLE
Feature/netobject updates2

### DIFF
--- a/src/s_net.c
+++ b/src/s_net.c
@@ -369,6 +369,29 @@ int socket_join_multicast_group(int socket, const struct sockaddr *sa)
     return -1;
 }
 
+int socket_leave_multicast_group(int socket, const struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET6)
+    {
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct ipv6_mreq mreq6 = {0};
+        memcpy(&mreq6.ipv6mr_multiaddr, &sa6->sin6_addr,
+            sizeof(struct in6_addr));
+        return setsockopt(socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
+            (char *)&mreq6, sizeof(mreq6));
+    }
+    else if (sa->sa_family == AF_INET)
+    {
+        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct ip_mreq mreq = {0};
+        mreq.imr_multiaddr.s_addr = sa4->sin_addr.s_addr;
+        mreq.imr_interface.s_addr = INADDR_ANY;
+        return setsockopt(socket, IPPROTO_IP, IP_DROP_MEMBERSHIP,
+            (char *)&mreq, sizeof(mreq));
+    }
+    return -1;
+}
+
 int socket_errno(void)
 {
 #ifdef _WIN32

--- a/src/s_net.h
+++ b/src/s_net.h
@@ -125,6 +125,9 @@ int socket_set_nonblocking(int socket, int nonblocking);
 /// join a multicast group address, returns < 0 on error
 int socket_join_multicast_group(int socket, const struct sockaddr *sa);
 
+/// leave a multicast group address, returns < 0 on error
+int socket_leave_multicast_group(int socket, const struct sockaddr *sa);
+
 /// cross-platform socket errno() which catches WSAESOCKTNOSUPPORT on Windows
 int socket_errno(void);
 

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -807,6 +807,11 @@ static void netreceive_send(t_netreceive *x,
     t_symbol *s, int argc, t_atom *argv)
 {
     int i;
+    if (x->x_ns.x_protocol != SOCK_STREAM)
+    {
+        pd_error(x, "netreceive: 'send' only works for TCP");
+        return;
+    }
     for (i = 0; i < x->x_nconnections; i++)
     {
         if (netsend_dosend(&x->x_ns, x->x_connections[i], s, argc, argv))

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -630,10 +630,8 @@ static void netreceive_closeall(t_netreceive *x)
 
 static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int portno = 0, sockfd, status, protocol = x->x_ns.x_protocol,
-        multicast = 0;
+    int portno = 0, sockfd, status, protocol = x->x_ns.x_protocol, multicast = 0;
     struct addrinfo *ailist = NULL, *ai;
-    struct sockaddr_storage server;
     const char *hostname = NULL; /* allowed or UDP multicast hostname */
 
     netreceive_closeall(x);
@@ -716,16 +714,65 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
             sockfd = -1;
             continue;
         }
-        /* name the socket */
-        if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
+        multicast = sockaddr_is_multicast(ai->ai_addr);
+#ifdef _WIN32
+        if (multicast)
         {
-            sys_closesocket(sockfd);
-            sockfd = -1;
-            continue;
+            /* Windows we can't bind to the multicast address,
+               so we bind to the "any" address instead */
+            struct addrinfo *any;
+            int status = addrinfo_get_list(&any,
+                (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno, protocol);
+            if (status != 0)
+            {
+                pd_error(x, "netreceive: bad host or port? %s (%d)",
+                    gai_strerror(status), status);
+                return;
+            }
+            /* name the socket */
+            status = bind(sockfd, any->ai_addr, any->ai_addrlen);
+            freeaddrinfo(any);
+            if (status < 0)
+            {
+                sys_sockerror("bind"); /* bind shouldn't fail */
+                sys_closesocket(sockfd);
+                sockfd = -1;
+                continue;
+            }
         }
-
+        else
+#endif
+        {
+            /* name the socket */
+            if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
+            {
+                sys_sockerror("bind"); /* bind shouldn't fail */
+                sys_closesocket(sockfd);
+                sockfd = -1;
+                continue;
+            }
+        }
+        /* join multicast group */
+        if (multicast && socket_join_multicast_group(sockfd, ai->ai_addr) < 0)
+        {
+            int err = socket_errno();
+            char buf[MAXPDSTRING];
+            socket_strerror(err, buf, sizeof(buf));
+            pd_error(x,
+                "netreceive: joining multicast group %s failed: %s (%d)",
+                hostname, buf, err);
+        }
         /* this addr worked */
-        memcpy(&server, ai->ai_addr, ai->ai_addrlen);
+        if (hostname)
+        {
+            char hostbuf[256];
+            sockaddr_get_addrstr(ai->ai_addr,
+                hostbuf, sizeof(hostbuf));
+            post("listening on %s %d%s", hostbuf, portno,
+                (multicast ? " (multicast)" : ""));
+        }
+        else
+            post("listening on %d", portno);
         break;
     }
     freeaddrinfo(ailist);
@@ -744,23 +791,6 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
 
     if (protocol == SOCK_DGRAM) /* datagram protocol */
     {
-        /* join multicast group */
-        if (sockaddr_is_multicast((struct sockaddr *)&server))
-        {
-            if (socket_join_multicast_group(x->x_ns.x_sockfd,
-                (struct sockaddr *)&server) < 0)
-            {
-                int err = socket_errno();
-                char buf[MAXPDSTRING];
-                socket_strerror(err, buf, sizeof(buf));
-                pd_error(x,
-                    "netreceive: joining multicast group %s failed: %s (%d)",
-                    hostname, buf, err);
-            }
-            else
-                multicast = 1;
-        }
-
         if (x->x_ns.x_bin)
             sys_addpollfn(x->x_ns.x_sockfd, (t_fdpollfn)netsend_readbin, x);
         else
@@ -790,17 +820,6 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
                 (t_fdpollfn)netreceive_connectpoll,x);
         }
     }
-
-    if (hostname)
-    {
-        char hostbuf[256];
-        sockaddr_get_addrstr((const struct sockaddr *)&server,
-            hostbuf, sizeof(hostbuf));
-        post("listening on %s %d%s", hostbuf, portno,
-            (multicast ? " (multicast)" : ""));
-    }
-    else
-        post("listening on %d", portno);
 }
 
 static void netreceive_send(t_netreceive *x,


### PR DESCRIPTION
This fixes multicast for Windows. Basically, we can't bind to the multicast address (https://stackoverflow.com/questions/6140734/cannot-bind-to-multicast-address-windows) so we bind to the "any" address instead.

This is a lightweight alternative to https://github.com/pure-data/pure-data/pull/715