### PR TITLE
Feature/netobject updates4

### DIFF
--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -106,20 +106,20 @@ int main(int argc, char **argv)
         {
             /* stream (TCP) sockets are set NODELAY */
             if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
-                fprintf(stderr, "netreceive: setsockopt (TCP_NODELAY) failed\n");
+                fprintf(stderr, "setsockopt (TCP_NODELAY) failed\n");
         }
         else if (protocol == SOCK_DGRAM && ai->ai_family == AF_INET)
         {
             /* enable IPv4 UDP broadcasting */
             if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
-                fprintf(stderr, "netreceive: setsockopt (SO_BROADCAST) failed\n");
+                fprintf(stderr, "setsockopt (SO_BROADCAST) failed\n");
         }
         /* if this is an IPv6 address, also listen to IPv4 adapters
            (if not supported, fall back to IPv4) */
         if (ai->ai_family == AF_INET6 &&
                 socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
         {
-            /* post("netreceive: setsockopt (IPV6_V6ONLY) failed"); */
+            /* fprintf(stderr, "setsockopt (IPV6_V6ONLY) failed\n"); */
             socket_close(sockfd);
             sockfd = -1;
             continue;

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
                     "getting \"any\" address for multicast failed %s (%d)",
                     gai_strerror(status), status);
                 socket_close(sockfd);
-                return;
+                return EXIT_FAILURE;
             }
             /* name the socket */
             status = bind(sockfd, any->ai_addr, any->ai_addrlen);

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -53,23 +53,18 @@ int main(int argc, char **argv)
     struct addrinfo *ailist = NULL, *ai;
     if (argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
         goto usage;
-    if (argc >= 3)
+    if (argc > 2)
     {
-        int index = (argc > 3 ? 3 : 2);
-        if (!strcmp(argv[index], "tcp"))
+        if (!strcmp(argv[2], "tcp"))
             protocol = SOCK_STREAM;
-        else if (!strcmp(argv[index], "udp"))
+        else if (!strcmp(argv[2], "udp"))
             protocol = SOCK_DGRAM;
         else goto usage;
-        if (index == 3)
-            hostname = argv[2];
     }
-    else protocol = SOCK_STREAM;
-    if (hostname && protocol == SOCK_STREAM)
-    {
-        fprintf(stderr, "ignoring host: %s\n", hostname);
-        hostname = NULL;
-    }
+    else
+        protocol = SOCK_STREAM; /* default */
+    if (argc > 3)
+        hostname = argv[3];
     if (socket_init())
     {
         sockerror("socket_init()");
@@ -220,7 +215,7 @@ int main(int argc, char **argv)
         dopoll();
 
 usage:
-    fprintf(stderr, "usage: pdreceive <portnumber> [udphost] [udp|tcp]\n");
+    fprintf(stderr, "usage: pdreceive <portnumber> [udp|tcp] [host]\n");
     fprintf(stderr, "(default is tcp)\n");
     exit(EXIT_FAILURE);
 }

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -131,11 +131,12 @@ int main(int argc, char **argv)
             continue;
         }
         multicast = sockaddr_is_multicast(ai->ai_addr);
-#ifdef _WIN32
+#if 1
         if (multicast)
         {
-            /* Windows we can't bind to the multicast address,
-               so we bind to the "any" address instead */
+            /* binding to the multicast address doesn't work on Windows and on Linux
+               it doesn't seem to work for IPv6 multicast addresses, so we bind to
+               the "any" address instead */
             struct addrinfo *any;
             int status = addrinfo_get_list(&any,
                 (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno, protocol);

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -22,7 +22,7 @@ static void sockerror(char *s);
 
 int main(int argc, char **argv)
 {
-    int sockfd, portno, protocol, status;
+    int sockfd, portno, protocol, status, multicast;
     struct sockaddr_storage server;
     struct addrinfo *ailist = NULL, *ai;
     float timeout = 10;
@@ -79,6 +79,7 @@ int main(int argc, char **argv)
             if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
                 fprintf(stderr, "setsockopt (SO_BROADCAST) failed\n");
         }
+        multicast = sockaddr_is_multicast(ai->ai_addr);
         if (protocol == SOCK_STREAM)
         {
             status = socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen,
@@ -95,7 +96,10 @@ int main(int argc, char **argv)
         /* print address */
         sockaddr_get_addrstr((struct sockaddr *)&server,
                              addrstr, sizeof(addrstr));
-        fprintf(stderr, "connected to %s\n", addrstr);
+        if (multicast)
+            fprintf(stderr, "connected to %s (multicast)\n", addrstr);
+        else
+            fprintf(stderr, "connected to %s\n", addrstr);
         break;
     }
     freeaddrinfo(ailist);

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -22,7 +22,7 @@ static void sockerror(char *s);
 
 int main(int argc, char **argv)
 {
-    int sockfd, portno, protocol, status, multicast;
+    int sockfd = -1, portno, protocol, status, multicast;
     struct sockaddr_storage server;
     struct addrinfo *ailist = NULL, *ai;
     float timeout = 10;

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -715,11 +715,12 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
             continue;
         }
         multicast = sockaddr_is_multicast(ai->ai_addr);
-#ifdef _WIN32
+#if 1
         if (multicast)
         {
-            /* Windows we can't bind to the multicast address,
-               so we bind to the "any" address instead */
+            /* binding to the multicast address doesn't work on Windows and on Linux
+               it doesn't seem to work for IPv6 multicast addresses, so we bind to
+               the "any" address instead */
             struct addrinfo *any;
             int status = addrinfo_get_list(&any,
                 (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno, protocol);


### PR DESCRIPTION
1) multicast: always bind to "any" address. Binding to an IPv6 multicast address doesn't work on Linux, either, so I think it's another indicator that this isn't good practice. Feel free to change `#if 1` to `#ifndef __APPLE__` if this reliably works on macOS, though!
2) improve pdsend/pdreceive print out
3) pdreceive: allow TCP hostname and move "host" argument *after* tcp/udp (it's less confusing)