### PR TITLE
zoom bugfixes

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -407,6 +407,11 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     x->gl_edit = !strncmp(x->gl_name->s_name, "Untitled", 8);
     x->gl_font = sys_nearestfontsize(font);
     x->gl_zoom = 1;
+
+/////zoomfix
+    if(owner)
+	x->gl_zoom=owner->gl_zoom;
+
     pd_pushsym(&x->gl_pd);
     return(x);
 }
@@ -415,6 +420,8 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
 static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
+///// zoomfix    
+    x->gl_zoom=x->gl_owner->gl_zoom;
     x->gl_x1 = atom_getfloatarg(0, argc, argv);
     x->gl_y1 = atom_getfloatarg(1, argc, argv);
     x->gl_x2 = atom_getfloatarg(2, argc, argv);
@@ -484,7 +491,10 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_pixheight = py2 - py1;
     x->gl_font =  (canvas_getcurrent() ?
         canvas_getcurrent()->gl_font : sys_defaultfont);
-    x->gl_zoom = 1;
+
+/////zoom fix
+    x->gl_zoom = g->gl_zoom;
+
     x->gl_screenx1 = 0;
     x->gl_screeny1 = GLIST_DEFCANVASYLOC;
     x->gl_screenx2 = 450;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2952,7 +2952,8 @@ void canvas_mouseup(t_canvas *x,
     /* displace the selection by (dx, dy) pixels */
 static void canvas_displaceselection(t_canvas *x, int dx, int dy)
 {
-    t_selection *y;
+    
+     t_selection *y;
     int resortin = 0, resortout = 0;
     if (!EDITOR->canvas_undo_already_set_move)
     {
@@ -3157,7 +3158,7 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 static void delay_move(t_canvas *x)
 {
     int incx = (x->gl_editor->e_xnew - x->gl_editor->e_xwas)/x->gl_zoom,
-        incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas)/x->gl_zoom;
+    incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas)/x->gl_zoom;
     if (incx || incy)
         canvas_displaceselection(x, incx, incy);
     x->gl_editor->e_xwas += incx * x->gl_zoom;
@@ -3258,8 +3259,11 @@ void canvas_startmotion(t_canvas *x)
     glist_getnextxy(x, &xval, &yval);
     if (xval == 0 && yval == 0) return;
     x->gl_editor->e_onmotion = MA_MOVE;
-    x->gl_editor->e_xwas = xval;
-    x->gl_editor->e_ywas = yval;
+
+/////zoomfix
+	
+    x->gl_editor->e_xwas = xval*x->gl_zoom;
+    x->gl_editor->e_ywas = yval*x->gl_zoom;
 }
 
 /* ----------------------------- window stuff ----------------------- */
@@ -4798,6 +4802,10 @@ void glist_getnextxy(t_glist *gl, int *xpix, int *ypix)
         *xpix = EDITOR->canvas_last_glist_x,
         *ypix = EDITOR->canvas_last_glist_y;
     else *xpix = *ypix = 40;
+
+/////zoomfix
+    *xpix /= gl->gl_zoom;
+    *ypix /= gl->gl_zoom;	
 }
 
 static void glist_setlastxy(t_glist *gl, int xval, int yval)

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -610,7 +610,7 @@ t_float glist_dpixtody(t_glist *x, t_float dypix)
 int text_xpix(t_text *x, t_glist *glist)
 {
     if (glist->gl_havewindow || !glist->gl_isgraph)
-        return (x->te_xpix * glist->gl_zoom);
+	return (x->te_xpix * glist->gl_zoom);
     else if (glist->gl_goprect)
         return (glist_xtopixels(glist, glist->gl_x1) +
             glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -129,7 +129,6 @@ void my_canvas_draw(t_my_canvas *x, t_glist *glist, int mode)
 static void my_canvas_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_my_canvas *x = (t_my_canvas *)z;
-
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
     *xp2 = *xp1 + x->x_gui.x_w;

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2033,7 +2033,7 @@ static void array_motion(void *z, t_floatarg dx, t_floatarg dy)
                     TEMPLATE->array_motion_template, thisword, 1) : 0);
             fielddesc_setcoord(TEMPLATE->array_motion_xfield,
                 TEMPLATE->array_motion_template, thisword,
-                    xwas + dx * TEMPLATE->array_motion_yperpix, 1);
+                    xwas + dx * TEMPLATE->array_motion_xperpix, 1);
             if (TEMPLATE->array_motion_yfield)
             {
                 if (TEMPLATE->array_motion_fatten)
@@ -2619,8 +2619,9 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist,
         drawnumber_getbuf(x, data, template, buf);
         sys_vgui(".x%lx.c create text %d %d -anchor nw -fill %s -text {%s}",
                 glist_getcanvas(glist), xloc, yloc, colorstring, buf);
+/////zoomfix
         sys_vgui(" -font {{%s} -%d %s}", sys_font,
-            sys_hostfontsize(glist_getfont(glist), 1),
+            sys_hostfontsize(glist_getfont(glist), 1)*glist->gl_zoom,
                 sys_fontweight);
         sys_vgui(" -tags [list drawnumber%lx label]\n", data);
     }

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -159,8 +159,11 @@ static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
         {
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
             indx = nobj;
-            *xpixp = x1;
-            *ypixp = y2 + 5;
+
+/////zoomfix
+        *xpixp = x1 / x->gl_zoom ;
+        *ypixp = (int)(0.5 + (float)y2 / x->gl_zoom + 5);
+
         }
         glist_noselect(x);
             /* search back for 'selected' and if it isn't on the list,


### PR DESCRIPTION
Some fixes (in a try-and-error approach) for enabling patch editing with zoom x 2.
Due to changes in xtopixels, ytopixels, pixelstox, pixelstoy fonctions, we loosed the ability to editing patch with zoom x2, resulting in huge differences  between mouse cursor position and created object position. (the same for bng, hsl, hdial, etc.)
In this fix proposal, I modified g_editor.c/glist_getnextxy(), g_editor.c/canvas_startmotion() and g_text.c/canvas_howputnew() functions to take care of those changes.
Further, I modified g_canvas.c/*canvas_new() and g_canvas.c/canvas_coords() in order to enable creating and displaying  a GOP abstraction( or a graph) with correct scale in a patch that is already with zoom mode = 2.
At least, I made a change in drawnumber_vis() to display correctly font size in datastructures with zoomx2 and integrated a bugfix mentionned here (https://github.com/pure-data/pure-data/pull/563#issuecomment-519444185) and here (https://github.com/pure-data/pure-data/commit/f1516d89c133791f6bfd5f444bf41496058a35d0#commitcomment-34674313)