### PR TITLE
fix PD_LONGINTTYPE for 64-bit windows

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -83,7 +83,7 @@ typedef unsigned __int64  uint64_t;
 
 /* signed and unsigned integer types the size of a pointer:  */
 #if !defined(PD_LONGINTTYPE)
-#if defined(_WIN32) && defined(__x86_64__)
+#if defined(_WIN32) && defined(_WIN64)
 #define PD_LONGINTTYPE long long
 #else
 #define PD_LONGINTTYPE long


### PR DESCRIPTION
The correct check for 64-bit Windows is `_WIN64`, not  `__x86_64__` which just happens to be defined by MinGW. 

Yesterday I've been scratching my head why my 64-bit MSVC build of a external would crash Pd (with a wiped out stack) while the MinGW build would not...