### PR TITLE
fix GOP-Canvas Properties dialog issues when zoom = 2 (and fix another zoom bug)

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2098,15 +2098,15 @@ void canvas_properties(t_gobj*z, t_glist*unused)
                 0., 0.,
                 glist_isgraph(x) ,
                 x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
-                (int)x->gl_pixwidth/x->gl_zoom, (int)x->gl_pixheight/x->gl_zoom,
-                (int)x->gl_xmargin/x->gl_zoom, (int)x->gl_ymargin/x->gl_zoom);
+                (int)x->gl_pixwidth, (int)x->gl_pixheight,
+                (int)x->gl_xmargin, (int)x->gl_ymargin);
     else sprintf(graphbuf,
             "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n",
                 glist_dpixtodx(x, 1), -glist_dpixtody(x, 1),
                 0,
                 0., -1., 1., 1.,
-                (int)x->gl_pixwidth/x->gl_zoom, (int)x->gl_pixheight/x->gl_zoom,
-                (int)x->gl_xmargin/x->gl_zoom, (int)x->gl_ymargin/x->gl_zoom);
+                (int)x->gl_pixwidth, (int)x->gl_pixheight,
+                (int)x->gl_xmargin, (int)x->gl_ymargin);
     gfxstub_new(&x->gl_pd, x, graphbuf);
         /* if any arrays are in the graph, put out their dialogs too */
     for (y = x->gl_list; y; y = y->g_next)
@@ -2146,10 +2146,10 @@ static void canvas_donecanvasdialog(t_glist *x,
            applies to individual objects */
     canvas_undo_add(x, UNDO_CANVAS_APPLY, "apply", canvas_undo_set_canvas(x));
 
-    x->gl_pixwidth = xpix * x->gl_zoom;
-    x->gl_pixheight = ypix * x->gl_zoom;
-    x->gl_xmargin = xmargin * x->gl_zoom;
-    x->gl_ymargin = ymargin * x->gl_zoom;
+    x->gl_pixwidth = xpix;
+    x->gl_pixheight = ypix;
+    x->gl_xmargin = xmargin;
+    x->gl_ymargin = ymargin;
 
     yperpix = -yperpix;
     if (xperpix == 0)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -879,7 +879,7 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
     t_gatom *x = (t_gatom*)z;
     text_displace(z, glist, dx, dy);
     sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
-        x, dx, dy);
+        x, dx*  glist->gl_zoom, dy*  glist->gl_zoom);
 }
 
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -879,7 +879,7 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
     t_gatom *x = (t_gatom*)z;
     text_displace(z, glist, dx, dy);
     sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
-        x, dx*  glist->gl_zoom, dy*  glist->gl_zoom);
+        x, dx * glist->gl_zoom, dy * glist->gl_zoom);
 }
 
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)


### PR DESCRIPTION
With pd 0.50, Canvas Properties dialog values are inconsistent whether you open it  with zooming = 1 or with zooming = 2 (the margins and offset are halfened with zoom = 2).
The proposed fix restores consistent displaying of the margins and offset values in canvas properties dialog box, when gop enabled, independently of zoom displaying factor.
This fix may also restore consistent behaviour of donecanvasdialog message between pd 0.49 and pd 0.50, with zoom = 2.