### PR TITLE
Enabling IEMGuis autoconnect

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -234,6 +234,15 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     // enable autoconnect
     int connectme, indx, nobj;
     canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
+    // align vsl and hsl like others objects
+    if (guiobjname== gensym("hsl"))
+    {
+        xpix+=3;
+    }
+    else if (guiobjname== gensym("vsl"))
+    {
+        ypix+=3;
+    }
 
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
 
@@ -247,7 +256,7 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     }
     else 
     {
-	canvas_startmotion(glist_getcanvas(gl));
+        canvas_startmotion(glist_getcanvas(gl));
     }
     if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
 	canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -231,15 +231,32 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     t_binbuf *b = binbuf_new();
     int xpix, ypix;
 
+    // enable autoconnect
+    int connectme, indx, nobj;
+    canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
+
+
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
-    glist_noselect(gl);
+ //   glist_noselect(gl);
+
     SETSYMBOL(&at, guiobjname);
     binbuf_restore(b, 1, &at);
-    glist_getnextxy(gl, &xpix, &ypix);
-    canvas_objtext(gl, xpix/gl->gl_zoom, ypix/gl->gl_zoom, 0, 1, b);
-    canvas_startmotion(glist_getcanvas(gl));
-    canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-        (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+    if (connectme)
+    {
+	canvas_objtext(gl,  xpix, ypix, 0, 1, b);
+        canvas_connect(gl, indx, 0, nobj, 0);
+    }
+    else 
+    {
+	glist_getnextxy(gl, &xpix, &ypix);
+        // glist_getnextxy gives mouse pixel coords, that need to be "dezoomed"
+	canvas_objtext(gl,  xpix/gl->gl_zoom, ypix/gl->gl_zoom, 0, 1, b);
+	canvas_startmotion(glist_getcanvas(gl));
+    }
+    if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+	canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
+           (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+
 }
 
 void canvas_bng(t_glist *gl, t_symbol *s, int argc, t_atom *argv)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -235,27 +235,23 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     int connectme, indx, nobj;
     canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
 
-
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
 
     SETSYMBOL(&at, guiobjname);
     binbuf_restore(b, 1, &at);
+    canvas_objtext(gl,  xpix, ypix, 0, 1, b);
+
     if (connectme)
     {
-	canvas_objtext(gl,  xpix, ypix, 0, 1, b);
         canvas_connect(gl, indx, 0, nobj, 0);
     }
     else 
     {
-	glist_getnextxy(gl, &xpix, &ypix);
-        // glist_getnextxy gives mouse pixel coords, that need to be "dezoomed"
-	canvas_objtext(gl,  xpix/gl->gl_zoom, ypix/gl->gl_zoom, 0, 1, b);
 	canvas_startmotion(glist_getcanvas(gl));
     }
     if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
 	canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
            (void *)canvas_undo_set_create(glist_getcanvas(gl)));
-
 }
 
 void canvas_bng(t_glist *gl, t_symbol *s, int argc, t_atom *argv)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -237,7 +237,6 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
 
 
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
- //   glist_noselect(gl);
 
     SETSYMBOL(&at, guiobjname);
     binbuf_restore(b, 1, &at);


### PR DESCRIPTION
The autoconnect feature enables new objects and messages  to be  automatically connected to any previously created (and selected) object.
This patch enables other gui's (vsl, hsl, bang, toogle, hradio, etc...) to get this feature.
I also checked the behaviour with zoom = 2.

PS: Sorry for my misuse of git :  g_text.c only is concerned by this pull request, I don't know how to mask po/template.pot that is not related to this change


EDIT(@umlaeute):
- Closes:https://github.com/pure-data/pure-data/issues/826