### PR TITLE
Windows installer (2  bug-fixes)

### DIFF
--- a/msw/pd.nsi
+++ b/msw/pd.nsi
@@ -131,7 +131,7 @@ Section -Post
   WriteUninstaller "$INSTDIR\uninst.exe"
 
   
-  WriteRegStr HKLM "${PRODUCT_DIR_REGKEY}" "${ARCHI}" "$INSTDIR\bin\pd.exe"
+  WriteRegStr HKLM "${PRODUCT_DIR_REGKEY}" "${ARCHI}" "$INSTDIR"
 
   
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"

--- a/msw/pd.nsi
+++ b/msw/pd.nsi
@@ -115,7 +115,7 @@ SectionGroup /e "${COMPONENT_GROUP_TEXT}"
     WriteRegStr HKCR "PureData\DefaultIcon" "" "$INSTDIR\bin\pd.exe"
     WriteRegStr HKCR "PureData\shell" "" ""
     WriteRegStr HKCR "PureData\shell\open" "" ""
-    WriteRegStr HKCR "PureData\shell\open\command" "" '$INSTDIR\bin\WISHNAME "$INSTDIR\tcl\pd-gui.tcl" %1'
+    WriteRegStr HKCR "PureData\shell\open\command" "" '$INSTDIR\bin\WISHNAME "$INSTDIR\tcl\pd-gui.tcl" "%1"'
   ; Set file ext icon
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.pd" "" ""
     WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.pd\OpenWithList" "a" "pd.exe"


### PR DESCRIPTION
Two bug-fixes for the Windows installer:

- Allow double-click to open .pd files with "white space" in name. Closes #759

- Windows: calling installer multiple times _should not_ change target path. Closes #763

Both tested.