### PR TITLE
make openpanel/savepanel + "save as" dialogs window modal

### DIFF
--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -240,6 +240,7 @@ static t_class *openpanel_class;
 typedef struct _openpanel
 {
     t_object x_obj;
+    t_canvas *x_canvas;
     t_symbol *x_s;
     int x_mode; /* 0: file, 1: folder, 2: multiple files */
 } t_openpanel;
@@ -252,6 +253,7 @@ static void *openpanel_new(t_floatarg mode)
     x->x_mode = (mode < 0 || mode > 2) ? 0 : mode;
     sprintf(buf, "d%lx", (t_int)x);
     x->x_s = gensym(buf);
+    x->x_canvas = canvas_getcurrent();
     pd_bind(&x->x_obj.ob_pd, x->x_s);
     outlet_new(&x->x_obj, &s_symbol);
     return (x);
@@ -260,8 +262,8 @@ static void *openpanel_new(t_floatarg mode)
 static void openpanel_symbol(t_openpanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    pdgui_vmess("pdtk_openpanel", "ssi",
-        x->x_s->s_name, path, x->x_mode);
+    pdgui_vmess("pdtk_openpanel", "ssic",
+        x->x_s->s_name, path, x->x_mode, glist_getcanvas(x->x_canvas));
 }
 
 static void openpanel_bang(t_openpanel *x)
@@ -324,8 +326,8 @@ static void *savepanel_new(void)
 static void savepanel_symbol(t_savepanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    pdgui_vmess("pdtk_savepanel", "ss",
-        x->x_s->s_name, path);
+    pdgui_vmess("pdtk_savepanel", "ssc",
+        x->x_s->s_name, path, glist_getcanvas(x->x_canvas));
 }
 
 static void savepanel_bang(t_savepanel *x)

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -172,7 +172,8 @@ proc pdtk_canvas_saveas {mytoplevel initialfile initialdir destroyflag} {
     if { ! [file isdirectory $initialdir]} {set initialdir $::filenewdir}
     set filename [tk_getSaveFile -initialdir $initialdir \
                       -initialfile [::pdtk_canvas::cleanname "$initialfile"] \
-                      -defaultextension .pd -filetypes $::filetypes]
+                      -defaultextension .pd -filetypes $::filetypes \
+                      -parent $mytoplevel]
     if {$filename eq ""} return; # they clicked cancel
 
     set extension [file extension $filename]

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -208,7 +208,7 @@ proc ::pdwindow::clear_console {} {
 # save the contents of the pdwindow::logbuffer to a file
 proc ::pdwindow::save_logbuffer_to_file {} {
     variable logbuffer
-    set filename [tk_getSaveFile -initialfile "pdwindow.txt" -defaultextension .txt]
+    set filename [tk_getSaveFile -initialfile "pdwindow.txt" -defaultextension .txt -parent .pdwindow]
     if {$filename eq ""} return; # they clicked cancel
     set f [open $filename w]
     puts $f "Pd $::PD_MAJOR_VERSION.$::PD_MINOR_VERSION-$::PD_BUGFIX_VERSION$::PD_TEST_VERSION on $::tcl_platform(os) $::tcl_platform(machine)"

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -36,7 +36,7 @@ proc open_file {filename} {
 # ------------------------------------------------------------------------------
 # procs for panels (openpanel, savepanel)
 
-proc pdtk_openpanel {target localdir {mode 0}} {
+proc pdtk_openpanel {target localdir {mode 0} {parent .pdwindow}} {
     if { $::pd::private::lastopendir == "" } {
         if { ! [file isdirectory $::fileopendir]} {
             set ::fileopendir $::env(HOME)
@@ -49,9 +49,12 @@ proc pdtk_openpanel {target localdir {mode 0}} {
 
     # 0: file, 1: directory, 2: multiple files
     switch $mode {
-        0 { set result [tk_getOpenFile -initialdir $localdir] }
-        1 { set result [tk_chooseDirectory -initialdir $localdir] }
-        2 { set result [tk_getOpenFile -multiple 1 -initialdir $localdir] }
+        0 { set result [tk_getOpenFile -initialdir $localdir \
+            -parent $parent] }
+        1 { set result [tk_chooseDirectory -initialdir $localdir \
+            -parent $parent] }
+        2 { set result [tk_getOpenFile -multiple 1 -initialdir $localdir \
+            -parent $parent] }
         default { ::pdwindow::error "bad value for 'mode' argument" }
     }
     if {$result ne ""} {
@@ -73,7 +76,7 @@ proc pdtk_openpanel {target localdir {mode 0}} {
 }
 
 
-proc pdtk_savepanel {target localdir} {
+proc pdtk_savepanel {target localdir {parent .pdwindow}} {
     if { $::pd::private::lastsavedir == "" } {
         if { ! [file isdirectory $::filenewdir]} {
             set ::filenewdir $::env(HOME)
@@ -84,7 +87,7 @@ proc pdtk_savepanel {target localdir} {
         set localdir $::pd::private::lastsavedir
     }
 
-    set filename [tk_getSaveFile -initialdir $localdir]
+    set filename [tk_getSaveFile -initialdir $localdir -parent $parent]
     if {$filename ne ""} {
         set ::pd::private::lastsavedir [file dirname $filename]
         pdsend "$target callback [enquote_path $filename]"


### PR DESCRIPTION
On Windows, the Tk dialogs are non-modal which means that they can get hidden by the parent window and the user can open the same dialog more than once. This PR makes those dialogs window-modal, so they always stay on top of the parent. They only block interaction with the parent window, other windows are not affected. As a long-time Windows user, this is the behavior I would expect of such dialogs. Fixes https://github.com/pure-data/pure-data/issues/751

I've tested on OSX 10.11 and Debian 9 + GNOME and there's practically no difference in behavior because dialogs already seem to be *application-modal* by default. There's one subtle difference on OSX: dialogs show up in front of the parent window, which I find rather nice, but I'm not a regular OSX user (@danomatika probably has something to say). 

I'm not sure about the implications for Linux + other desktop environments... (@umlaeute: what is the current behavior on your desktop?) If this change is too risky, I could set the parent window only on Windows (and maybe also OSX).

