### PR TITLE
improve (verbose) logging

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -126,9 +126,9 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
         nbuf[79] = 0;
         (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
         if (c == pd_objectmaker)
-            verbose(1, "warning: class '%s' overwritten; old one renamed '%s'",
+            verbose(PD_VERBOSE, "warning: class '%s' overwritten; old one renamed '%s'",
                 sel->s_name, nbuf);
-        else verbose(1, "warning: old method '%s' for class '%s' renamed '%s'",
+        else verbose(PD_VERBOSE, "warning: old method '%s' for class '%s' renamed '%s'",
             sel->s_name, c->c_name->s_name, nbuf);
     }
     (*methodlist) = t_resizebytes((*methodlist),

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -532,6 +532,15 @@ EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
 #endif
 
 /* ------------   printing --------------------------------- */
+
+typedef enum {
+    PD_CRITICAL = -3,
+    PD_ERROR,
+    PD_NORMAL,
+    PD_DEBUG,
+    PD_VERBOSE
+} t_loglevel;
+
 EXTERN void post(const char *fmt, ...);
 EXTERN void startpost(const char *fmt, ...);
 EXTERN void poststring(const char *s);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -222,8 +222,7 @@ void sys_setchsr(int chin, int chout, int sr)
     STUFF->st_soundout = (t_sample *)getbytes(outbytes);
     memset(STUFF->st_soundout, 0, outbytes);
 
-    if (sys_verbose)
-        post("input channels = %d, output channels = %d",
+    verbose(PD_VERBOSE, "input channels = %d, output channels = %d",
             STUFF->st_inchannels, STUFF->st_outchannels);
     canvas_resume_dsp(canvas_suspend_dsp());
 }
@@ -1022,7 +1021,7 @@ void sys_set_audio_api(int which)
     }
     sys_audioapi = which;
     if (sys_verbose && ok)
-        post("sys_audioapi set to %d", sys_audioapi);
+        verbose(PD_VERBOSE, "sys_audioapi set to %d", sys_audioapi);
 }
 
 void glob_audio_setapi(void *dummy, t_floatarg f)

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -117,8 +117,7 @@ static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     snd_pcm_hw_params_alloca(&hw_params);
     snd_pcm_sw_params_alloca(&sw_params);
 
-    if (sys_verbose)
-        post((out ? "configuring sound output..." :
+    verbose(PD_VERBOSE, (out ? "configuring sound output..." :
             "configuring sound input..."));
 
         /* set hardware parameters... */
@@ -159,8 +158,7 @@ static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     }
     else dev->a_sampwidth = 4;
 
-    if (sys_verbose)
-        post("Sample width set to %d bytes", dev->a_sampwidth);
+    verbose(PD_VERBOSE, "Sample width set to %d bytes", dev->a_sampwidth);
 
         /* set the subformat */
     err = snd_pcm_hw_params_set_subformat(dev->a_handle,
@@ -286,8 +284,8 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
     alsa_nindev = alsa_noutdev = 0;
     alsa_jittermax = ALSA_DEFJITTERMAX;
 
-    if (sys_verbose)
-        post("audio buffer set to %d", (int)(0.001 * sys_schedadvance));
+    verbose(PD_VERBOSE, "audio buffer set to %d",
+        (int)(0.001 * sys_schedadvance));
 
     for (iodev = 0; iodev < naudioindev; iodev++)
     {
@@ -299,8 +297,7 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
             continue;
         alsa_indev[alsa_nindev].a_devno = audioindev[iodev];
         snd_pcm_nonblock(alsa_indev[alsa_nindev].a_handle, 1);
-        if (sys_verbose)
-            post("opened input device name %s", devname);
+        verbose(PD_VERBOSE, "opened input device name %s", devname);
         alsa_nindev++;
     }
     for (iodev = 0; iodev < naudiooutdev; iodev++)
@@ -789,9 +786,8 @@ static void alsa_checkiosync(void)
             }
             else if (result != SND_PCM_STATE_RUNNING)
             {
-                if (sys_verbose)
-                    post("restarting output device from state %d",
-                        snd_pcm_state(alsa_outdev[iodev].a_handle));
+                verbose(PD_VERBOSE, "restarting output device from state %d",
+                    snd_pcm_state(alsa_outdev[iodev].a_handle));
                 if ((err = snd_pcm_start(alsa_outdev[iodev].a_handle)) < 0)
                     check_error(err, 0, "restart failed");
             }
@@ -829,9 +825,8 @@ static void alsa_checkiosync(void)
             }
             else if (result != SND_PCM_STATE_RUNNING)
             {
-                if (sys_verbose)
-                    post("restarting input device from state %d",
-                        snd_pcm_state(alsa_indev[iodev].a_handle));
+                verbose(PD_VERBOSE, "restarting input device from state %d",
+                    snd_pcm_state(alsa_indev[iodev].a_handle));
                 if ((err = snd_pcm_start(alsa_indev[iodev].a_handle)) < 0)
                     check_error(err, 1, "restart failed");
             }

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -360,7 +360,7 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
           &status, NULL);
         if (status & JackFailure) {
             error("JACK: couldn't connect to server, is JACK running?");
-            verbose(1, "JACK: returned status is: %d", status);
+            verbose(PD_VERBOSE, "JACK: returned status is: %d", status);
             jack_client=NULL;
             /* jack spits out enough messages already, do not warn */
             STUFF->st_inchannels = STUFF->st_outchannels = 0;
@@ -368,7 +368,7 @@ jack_open_audio(int inchans, int outchans, int rate, t_audiocallback callback)
         }
         if (status & JackNameNotUnique)
             jack_client_name(jack_get_client_name(jack_client));
-        verbose(1, "JACK: registered as '%s'", desired_client_name);
+        verbose(PD_VERBOSE, "JACK: registered as '%s'", desired_client_name);
 
         STUFF->st_inchannels = inchans;
         STUFF->st_outchannels = outchans;

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -123,8 +123,7 @@ int mmio_do_open_audio(void)
     UINT mmresult;
     int nad, nda;
     static int naudioprepped = 0, nindevsprepped = 0, noutdevsprepped = 0;
-    if (sys_verbose)
-        post("%d devices in, %d devices out",
+    verbose(PD_VERBOSE, "%d devices in, %d devices out",
             nt_nwavein, nt_nwaveout);
 
     form.wf.wFormatTag = WAVE_FORMAT_PCM;
@@ -170,7 +169,7 @@ int mmio_do_open_audio(void)
                 (WAVEFORMATEX *)(&form), 0L, 0L, CALLBACK_NULL);
 
         if (sys_verbose)
-            printf("opened adc device %d with return %d\n",
+            fprintf(stderr, "opened adc device %d with return %d\n",
                 nt_whichadc+nad,mmresult);
 
         if (mmresult != MMSYSERR_NOERROR)
@@ -222,8 +221,7 @@ void mmio_close_audio(void)
 {
     int errcode;
     int nda, nad;
-    if (sys_verbose)
-        post("closing audio...");
+    verbose(PD_VERBOSE, "closing audio...");
 
     for (nda=0; nda < nt_nwaveout; nda++) /*if (nt_nwaveout) wini */
     {

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -173,8 +173,8 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
         if (fragbytes != (1 << logfragsize))
             post("warning: OSS takes only power of 2 blocksize; using %d",
                 (1 << logfragsize)/(dev->d_bytespersamp * nchannels));
-        if (sys_verbose)
-            post("setting nfrags = %d, fragsize %d\n", nfragment, fragbytes);
+        verbose(PD_VERBOSE, "setting nfrags = %d, fragsize %d\n",
+            nfragment, fragbytes);
 
         param = orig = (nfragment<<16) + logfragsize;
         if (ioctl(fd,SNDCTL_DSP_SETFRAGMENT, &param) == -1)
@@ -186,8 +186,8 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
             post("warning: actual fragments %d, blocksize %d",
                 nfragment, (1 << logfragsize));
         }
-        if (sys_verbose)
-            post("audiobuffer set to %d msec", (int)(0.001 * sys_schedadvance));
+        verbose(PD_VERBOSE, "audiobuffer set to %d msec",
+            (int)(0.001 * sys_schedadvance));
     }
 
     if (dac)
@@ -223,8 +223,7 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
 static int oss_setchannels(int fd, int wantchannels, char *devname)
 {
     int param;
-    if (sys_verbose)
-        post("setchan %d", wantchannels);
+    verbose(PD_VERBOSE, "setchan %d", wantchannels);
     if (ioctl(fd, SNDCTL_DSP_CHANNELS, &param) == -1)
     {
         if (sys_verbose)
@@ -232,12 +231,10 @@ static int oss_setchannels(int fd, int wantchannels, char *devname)
     }
     else
     {
-        if (sys_verbose)
-            post("channels originally %d for %s", param, devname);
+        verbose(PD_VERBOSE, "channels originally %d for %s", param, devname);
         if (param == wantchannels)
         {
-            if (sys_verbose)
-                post("number of channels doesn't need setting\n");
+            verbose(PD_VERBOSE, "number of channels doesn't need setting\n");
             return (wantchannels);
         }
     }
@@ -316,8 +313,8 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                     post("couldn't get audio device flags");
                 else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                     post("couldn't set audio device flags");
-                if (sys_verbose)
-                    post("opened %s for reading and writing\n", devname);
+                verbose(PD_VERBOSE,
+                    "opened %s for reading and writing\n", devname);
                 linux_adcs[inindex].d_fd = fd;
             }
         }
@@ -337,19 +334,17 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                 post("couldn't get audio device flags");
             else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                 post("couldn't set audio device flags");
-            if (sys_verbose)
-                post("opened %s for writing only\n", devname);
+            verbose(PD_VERBOSE, "opened %s for writing only\n", devname);
         }
         if (ioctl(fd, SNDCTL_DSP_GETCAPS, &capabilities) == -1)
             error("OSS: SNDCTL_DSP_GETCAPS failed %s", devname);
 
         gotchans = oss_setchannels(fd,
             (wantchannels>OSS_MAXCHPERDEV)?OSS_MAXCHPERDEV:wantchannels,
-                    devname);
+                devname);
 
-        if (sys_verbose)
-            post("opened audio output on %s; got %d channels",
-                 devname, gotchans);
+        verbose(PD_VERBOSE, "opened audio output on %s; got %d channels",
+            devname, gotchans);
 
         if (gotchans < 2)
         {
@@ -398,8 +393,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
         {
             fd = linux_adcs[n].d_fd;
             alreadyopened = 1;
-            if (sys_verbose)
-                post("already opened it");
+            verbose(PD_VERBOSE, "already opened it");
         }
         else
         {
@@ -415,17 +409,15 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                 post("couldn't get audio device flags");
             else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                 post("couldn't set audio device flags");
-            if (sys_verbose)
-                post("opened %s for reading only\n", devname);
+            verbose(PD_VERBOSE, "opened %s for reading only\n", devname);
         }
         linux_adcs[linux_nindevs].d_fd = fd;
 
         gotchans = oss_setchannels(fd,
             (wantchannels>OSS_MAXCHPERDEV)?OSS_MAXCHPERDEV:wantchannels,
                 devname);
-        if (sys_verbose)
-            post("opened audio input device %s; got %d channels",
-                devname, gotchans);
+        verbose(PD_VERBOSE, "opened audio input device %s; got %d channels",
+            devname, gotchans);
 
         if (gotchans < 1)
         {

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -401,13 +401,11 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     if (outchans > 0 && pa_outdev == -1)
         outchans = 0;
 
-    if (sys_verbose)
-    {
-        post("input device %d, channels %d", pa_indev, inchans);
-        post("output device %d, channels %d", pa_outdev, outchans);
-        post("framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
-        post("rate %d", rate);
-    }
+    verbose(PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
+    verbose(PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);
+    verbose(PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
+    verbose(PD_VERBOSE, "rate %d", rate);
+
     pa_inchans = STUFF->st_inchannels = inchans;
     pa_outchans = STUFF->st_outchannels = outchans;
     pa_soundin = soundin;
@@ -464,8 +462,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         /* Pa_Terminate(); */
         return (1);
     }
-    else if (sys_verbose)
-        post("... opened OK.");
+    else verbose(PD_VERBOSE, "... opened OK.");
     return (0);
 }
 

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -77,8 +77,7 @@ static void sys_initloadpreferences_file(const char *filename)
     }
     sys_prefbuf[length+1] = 0;
     close(fd);
-    if (sys_verbose)
-        post("success reading preferences from: %s", filename);
+    verbose(PD_VERBOSE, "success reading preferences from: %s", filename);
 }
 
 static int sys_getpreference_file(const char *key, char *value, int size)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -365,11 +365,11 @@ void sys_set_priority(int mode)
         else post("priority %d scheduling failed; running at normal priority",
                 p3);
     }
-    else if (sys_verbose)
+    else
     {
         if (mode == MODE_RT)
-            post("priority %d scheduling enabled.\n", p3);
-        else post("running at normal (non-real-time) priority.\n");
+            verbose(PD_VERBOSE, "priority %d scheduling enabled.\n", p3);
+        else verbose(PD_VERBOSE, "running at normal (non-real-time) priority.\n");
     }
 #endif
 
@@ -1454,8 +1454,7 @@ void sys_setrealtime(const char *libdir)
                 this is done later when the socket is open. */
         }
     }
-    else if (sys_verbose)
-        post("not setting real-time priority");
+    else verbose(PD_VERBOSE, "not setting real-time priority");
 #endif /* __linux__ */
 
 #ifdef _WIN32

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -247,7 +247,7 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
             height = (j+1)*sys_fontspec[i].fi_height;
             if (!did_fontwarning)
             {
-                verbose(1, "ignoring invalid font-metrics from GUI");
+                verbose(PD_VERBOSE, "ignoring invalid font-metrics from GUI");
                 did_fontwarning = 1;
             }
         }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -661,14 +661,12 @@ void sys_set_midi_api(int which)
     case(API_DEFAULTMIDI): break;
 #endif
     default:
-        if (sys_verbose)
-            post("ignoring unknown MIDI API %d", which);
+        verbose(PD_VERBOSE, "ignoring unknown MIDI API %d", which);
         return;
     }
 
     sys_midiapi = which;
-    if (sys_verbose)
-        post("sys_midiapi %d", sys_midiapi);
+    verbose(PD_VERBOSE, "sys_midiapi %d", sys_midiapi);
 }
 
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform);

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -86,9 +86,8 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_devnames[devno], O_RDWR | O_MIDIFLAG);
-            if (sys_verbose)
-                post("tried to open %s read/write; got %d\n",
-                    oss_devnames[devno], fd);
+            verbose(PD_VERBOSE, "tried to open %s read/write; got %d\n",
+                oss_devnames[devno], fd);
             if (outdevindex >= 0 && fd >= 0)
                 oss_midioutfd[outdevindex] = fd;
         }
@@ -97,9 +96,8 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_devnames[devno], O_RDONLY | O_MIDIFLAG);
-            if (sys_verbose)
-                post("tried to open %s read-only; got %d\n",
-                    oss_devnames[devno], fd);
+            verbose(PD_VERBOSE, "tried to open %s read-only; got %d\n",
+                oss_devnames[devno], fd);
         }
         if (fd >= 0)
             oss_midiinfd[oss_nmidiin++] = fd;
@@ -116,9 +114,8 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_devnames[devno], O_WRONLY | O_MIDIFLAG);
-            if (sys_verbose)
-                post("tried to open %s write-only; got %d\n",
-                    oss_devnames[devno], fd);
+            verbose(PD_VERBOSE, "tried to open %s write-only; got %d\n",
+                oss_devnames[devno], fd);
         }
         if (fd >= 0)
             oss_midioutfd[oss_nmidiout++] = fd;

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -72,9 +72,8 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
                     {
                         /* disable default active sense filtering */
                         Pm_SetFilter(mac_midiindevlist[mac_nmidiindev], 0);
-                        if (sys_verbose)
-                            post("MIDI input (%s) opened.",
-                                info->name);
+                        verbose(PD_VERBOSE, "MIDI input (%s) opened.",
+                            info->name);
                         mac_nmidiindev++;
                     }
                 }
@@ -101,9 +100,8 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
                             j, info->name, Pm_GetErrorText(err));
                     else
                     {
-                        if (sys_verbose)
-                            post("MIDI output (%s) opened.",
-                                info->name);
+                        verbose(PD_VERBOSE, "MIDI output (%s) opened.",
+                            info->name);
                         mac_nmidioutdev++;
                     }
                 }

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -298,7 +298,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
             !S_ISDIR(statbuf.st_mode));
         if (!ok)
         {
-            if (sys_verbose) post("tried %s; stat failed or directory",
+            verbose(PD_VERBOSE, "tried %s; stat failed or directory",
                 dirresult);
             close (fd);
             fd = -1;
@@ -307,7 +307,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
 #endif
         {
             char *slash;
-            if (sys_verbose) post("tried %s and succeeded", dirresult);
+            verbose(PD_VERBOSE, "tried %s and succeeded", dirresult);
             sys_unbashfilename(dirresult, dirresult);
             slash = strrchr(dirresult, '/');
             if (slash)
@@ -322,7 +322,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
     }
     else
     {
-        if (sys_verbose) post("tried %s and failed", dirresult);
+        verbose(PD_VERBOSE, "tried %s and failed", dirresult);
     }
     return (-1);
 }


### PR DESCRIPTION
* add `t_loglevel` enum for `verbose()` in `m_pd.h`.
* replace all `verbose(1, ...)` calls with `verbose(PD_VERBOSE, ...)`
* replace all `if (sys_verbose) post(...)` occurences with `verbose(PD_VERBOSE, ...)`