### PR TITLE
avoid undefined behavior in 'dsp_add'

### DIFF
--- a/doc/6.externs/dspobj~.c
+++ b/doc/6.externs/dspobj~.c
@@ -40,7 +40,7 @@ static t_int *dspobj_perform(t_int *w)
     out the samples. */
 static void dspobj_dsp(t_dspobj *x, t_signal **sp)
 {
-    dsp_add(dspobj_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(dspobj_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void *dspobj_new(void)

--- a/extra/bob~/bob~.c
+++ b/extra/bob~/bob~.c
@@ -234,7 +234,7 @@ static void bob_dsp(t_bob *x, t_signal **sp)
 {
     x->x_sr = sp[0]->s_sr;
     dsp_add(bob_perform, 6, x, sp[0]->s_vec, sp[1]->s_vec,
-        sp[2]->s_vec, sp[3]->s_vec, sp[0]->s_n);
+        sp[2]->s_vec, sp[3]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void bob_tilde_setup(void)

--- a/extra/bonk~/bonk~.c
+++ b/extra/bonk~/bonk~.c
@@ -820,7 +820,7 @@ static void bonk_dsp(t_bonk *x, t_signal **sp)
     for (i = 0, gp = x->x_insig; i < ninsig; i++, gp++)
         gp->g_invec = (*(sp++))->s_vec;
     
-    dsp_add(bonk_perform, 2, x, n);
+    dsp_add(bonk_perform, 2, x, (t_int)n);
 }
 
 static void bonk_thresh(t_bonk *x, t_floatarg f1, t_floatarg f2)

--- a/extra/fiddle~/fiddle~.c
+++ b/extra/fiddle~/fiddle~.c
@@ -1416,7 +1416,7 @@ void sigfiddle_dsp(t_sigfiddle *x, t_signal **sp)
     x->x_sr = sp[0]->s_sr;
     sigfiddle_reattack(x, x->x_attacktime, x->x_attackthresh);
     sigfiddle_vibrato(x, x->x_vibtime, x->x_vibdepth);
-    dsp_add(fiddle_perform, 3, sp[0]->s_vec, x, sp[0]->s_n);
+    dsp_add(fiddle_perform, 3, sp[0]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
     /* This is the callback function for the clock, but also acts as
@@ -1676,7 +1676,7 @@ void sigfiddle_dsp(t_sigfiddle *x, t_signal **sp)
         }
         sigfiddle_reattack(x, x->x_attacktime, x->x_attackthresh);
     sigfiddle_vibrato(x, x->x_vibtime, x->x_vibdepth);
-    dsp_add(fiddle_perform, 3, sp[0]->s_vec, x, sp[0]->s_n);
+    dsp_add(fiddle_perform, 3, sp[0]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
 void sigfiddle_tick(t_sigfiddle *x)     /* callback function for the clock MSP*/

--- a/extra/loop~/loop~.c
+++ b/extra/loop~/loop~.c
@@ -142,7 +142,7 @@ static void loop_dsp(t_loop *x, t_signal **sp)
 {
     dsp_add(loop_perform, 6,
         &x->x_loopctl, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-            sp[0]->s_n);
+            (t_int)sp[0]->s_n);
 }
 
 static void loop_set(t_loop *x, t_floatarg val)

--- a/extra/lrshift~/lrshift~.c
+++ b/extra/lrshift~/lrshift~.c
@@ -51,9 +51,9 @@ static void lrshift_tilde_dsp(t_lrshift_tilde *x, t_signal **sp)
         shift = -n;
     if (shift < 0)
         dsp_add(rightshift_perform, 4,
-            sp[0]->s_vec + n, sp[1]->s_vec + n, n, -shift);
+            sp[0]->s_vec + n, sp[1]->s_vec + n, (t_int)n, (t_int)(-shift));
     else dsp_add(leftshift_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, n, shift);
+            sp[0]->s_vec, sp[1]->s_vec, (t_int)n, (t_int)shift);
 }
 
 static void *lrshift_tilde_new(t_floatarg f)

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -607,7 +607,7 @@ static void pd_tilde_dsp(t_pd_tilde *x, t_signal **sp)
     for (i = 0, g = x->x_outsig; i < x->x_noutsig; i++, g++)
         *g = (*(sp++))->s_vec;
     
-    dsp_add(pd_tilde_perform, 2, x, n);
+    dsp_add(pd_tilde_perform, 2, x, (t_int)n);
 }
 
 static void pd_tilde_pdtilde(t_pd_tilde *x, t_symbol *s,

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -1051,7 +1051,7 @@ static void sigmund_dsp(t_sigmund *x, t_signal **sp)
             post("sigmund: adjusting hop size to %d",
                 (x->x_hop = sp[0]->s_n * (x->x_hop / sp[0]->s_n)));
         x->x_sr = sp[0]->s_sr;
-        dsp_add(sigmund_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+        dsp_add(sigmund_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     }
 }
 

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -108,24 +108,24 @@ t_int *scalarplus_perf8(t_int *w)
 void dsp_add_plus(t_sample *in1, t_sample *in2, t_sample *out, int n)
 {
     if (n&7)
-        dsp_add(plus_perform, 4, in1, in2, out, n);
+        dsp_add(plus_perform, 4, in1, in2, out, (t_int)n);
     else
-        dsp_add(plus_perf8, 4, in1, in2, out, n);
+        dsp_add(plus_perf8, 4, in1, in2, out, (t_int)n);
 }
 
 static void plus_dsp(t_plus *x, t_signal **sp)
 {
-    dsp_add_plus(sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+    dsp_add_plus(sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalarplus_dsp(t_scalarplus *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalarplus_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalarplus_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void plus_setup(void)
@@ -242,20 +242,20 @@ static void minus_dsp(t_minus *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(minus_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(minus_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalarminus_dsp(t_scalarminus *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalarminus_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalarminus_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void minus_setup(void)
@@ -373,20 +373,20 @@ static void times_dsp(t_times *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(times_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(times_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalartimes_dsp(t_scalartimes *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalartimes_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalartimes_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void times_setup(void)
@@ -515,20 +515,20 @@ static void over_dsp(t_over *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(over_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(over_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalarover_dsp(t_scalarover *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalarover_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalarover_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void over_setup(void)
@@ -657,20 +657,20 @@ static void max_dsp(t_max *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(max_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(max_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalarmax_dsp(t_scalarmax *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalarmax_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalarmax_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void max_setup(void)
@@ -799,20 +799,20 @@ static void min_dsp(t_min *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(min_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(min_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void scalarmin_dsp(t_scalarmin *x, t_signal **sp)
 {
     if (sp[0]->s_n&7)
         dsp_add(scalarmin_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
     else
         dsp_add(scalarmin_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, sp[0]->s_n);
+            sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void min_setup(void)

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -96,7 +96,7 @@ static void tabwrite_tilde_set(t_tabwrite_tilde *x, t_symbol *s)
 static void tabwrite_tilde_dsp(t_tabwrite_tilde *x, t_signal **sp)
 {
     tabwrite_tilde_set(x, x->x_arrayname);
-    dsp_add(tabwrite_tilde_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(tabwrite_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void tabwrite_tilde_bang(t_tabwrite_tilde *x)
@@ -221,7 +221,7 @@ static void tabplay_tilde_set(t_tabplay_tilde *x, t_symbol *s)
 static void tabplay_tilde_dsp(t_tabplay_tilde *x, t_signal **sp)
 {
     tabplay_tilde_set(x, x->x_arrayname);
-    dsp_add(tabplay_tilde_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(tabplay_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void tabplay_tilde_list(t_tabplay_tilde *x, t_symbol *s,
@@ -343,7 +343,7 @@ static void tabread_tilde_dsp(t_tabread_tilde *x, t_signal **sp)
     tabread_tilde_set(x, x->x_arrayname);
 
     dsp_add(tabread_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 
 }
 
@@ -474,7 +474,7 @@ static void tabread4_tilde_dsp(t_tabread4_tilde *x, t_signal **sp)
     tabread4_tilde_set(x, x->x_arrayname);
 
     dsp_add(tabread4_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 
 }
 
@@ -659,7 +659,7 @@ static void tabosc4_tilde_dsp(t_tabosc4_tilde *x, t_signal **sp)
     tabosc4_tilde_set(x, x->x_arrayname);
 
     dsp_add(tabosc4_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void tabosc4_tilde_setup(void)
@@ -759,7 +759,7 @@ static void tabsend_dsp(t_tabsend *x, t_signal **sp)
     if (ticksper < 1) ticksper = 1;
     x->x_graphperiod = ticksper;
     if (x->x_graphcount > ticksper) x->x_graphcount = ticksper;
-    dsp_add(tabsend_perform, 3, x, sp[0]->s_vec, n);
+    dsp_add(tabsend_perform, 3, x, sp[0]->s_vec, (t_int)n);
 }
 
 static void tabsend_setup(void)
@@ -831,7 +831,7 @@ static void tabreceive_set(t_tabreceive *x, t_symbol *s)
 static void tabreceive_dsp(t_tabreceive *x, t_signal **sp)
 {
     tabreceive_set(x, x->x_arrayname);
-    dsp_add(tabreceive_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(tabreceive_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void *tabreceive_new(t_symbol *s)

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -51,9 +51,9 @@ static t_int *sig_tilde_perf8(t_int *w)
 void dsp_add_scalarcopy(t_float *in, t_sample *out, int n)
 {
     if (n&7)
-        dsp_add(sig_tilde_perform, 3, in, out, n);
+        dsp_add(sig_tilde_perform, 3, in, out, (t_int)n);
     else
-        dsp_add(sig_tilde_perf8, 3, in, out, n);
+        dsp_add(sig_tilde_perf8, 3, in, out, (t_int)n);
 }
 
 static void sig_tilde_float(t_sig *x, t_float f)
@@ -63,7 +63,7 @@ static void sig_tilde_float(t_sig *x, t_float f)
 
 static void sig_tilde_dsp(t_sig *x, t_signal **sp)
 {
-    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void *sig_tilde_new(t_floatarg f)
@@ -198,9 +198,9 @@ static void line_tilde_stop(t_line *x)
 static void line_tilde_dsp(t_line *x, t_signal **sp)
 {
     if(sp[0]->s_n&7)
-        dsp_add(line_tilde_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+        dsp_add(line_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     else
-        dsp_add(line_tilde_perf8, 3, x, sp[0]->s_vec, sp[0]->s_n);
+        dsp_add(line_tilde_perf8, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     x->x_1overn = 1./sp[0]->s_n;
     x->x_dspticktomsec = sp[0]->s_sr / (1000 * sp[0]->s_n);
 }
@@ -388,7 +388,7 @@ static void vline_tilde_float(t_vline *x, t_float f)
 
 static void vline_tilde_dsp(t_vline *x, t_signal **sp)
 {
-    dsp_add(vline_tilde_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(vline_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     x->x_samppermsec = ((double)(sp[0]->s_sr)) / 1000;
     x->x_msecpersamp = ((double)1000) / sp[0]->s_sr;
 }
@@ -675,7 +675,7 @@ static void env_tilde_dsp(t_sigenv *x, t_signal **sp)
         x->x_buf = (t_sample *)xx;
         x->x_allocforvs = sp[0]->s_n;
     }
-    dsp_add(env_tilde_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(env_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void env_tilde_tick(t_sigenv *x) /* callback function for the clock */
@@ -811,7 +811,7 @@ done:
 void threshold_tilde_dsp(t_threshold_tilde *x, t_signal **sp)
 {
     x->x_msecpertick = 1000. * sp[0]->s_n / sp[0]->s_sr;
-    dsp_add(threshold_tilde_perform, 3, sp[0]->s_vec, x, sp[0]->s_n);
+    dsp_add(threshold_tilde_perform, 3, sp[0]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
 static void threshold_tilde_ff(t_threshold_tilde *x)

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -52,7 +52,7 @@ static void dac_dsp(t_dac *x, t_signal **sp)
             error("dac~: bad vector size");
         else if (ch >= 0 && ch < sys_get_outchannels())
             dsp_add(plus_perform, 4, STUFF->st_soundout + DEFDACBLKSIZE*ch,
-                (*sp2)->s_vec, STUFF->st_soundout + DEFDACBLKSIZE*ch, DEFDACBLKSIZE);
+                (*sp2)->s_vec, STUFF->st_soundout + DEFDACBLKSIZE*ch, (t_int)DEFDACBLKSIZE);
     }
 }
 
@@ -151,9 +151,9 @@ static t_int *copy_perf8(t_int *w)
 void dsp_add_copy(t_sample *in, t_sample *out, int n)
 {
     if (n&7)
-        dsp_add(copy_perform, 3, in, out, n);
+        dsp_add(copy_perform, 3, in, out, (t_int)n);
     else
-        dsp_add(copy_perf8, 3, in, out, n);
+        dsp_add(copy_perf8, 3, in, out, (t_int)n);
 }
 
 static void adc_dsp(t_adc *x, t_signal **sp)

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -123,7 +123,7 @@ static t_int *sigdelwrite_perform(t_int *w)
 
 static void sigdelwrite_dsp(t_sigdelwrite *x, t_signal **sp)
 {
-    dsp_add(sigdelwrite_perform, 3, sp[0]->s_vec, &x->x_cspace, sp[0]->s_n);
+    dsp_add(sigdelwrite_perform, 3, sp[0]->s_vec, &x->x_cspace, (t_int)sp[0]->s_n);
     x->x_sortno = ugen_getsortno();
     sigdelwrite_checkvecsize(x, sp[0]->s_n);
     sigdelwrite_updatesr(x, sp[0]->s_sr);
@@ -224,7 +224,7 @@ static void sigdelread_dsp(t_sigdelread *x, t_signal **sp)
             0 : delwriter->x_vecsize);
         sigdelread_float(x, x->x_deltime);
         dsp_add(sigdelread_perform, 4,
-            sp[0]->s_vec, &delwriter->x_cspace, &x->x_delsamps, sp[0]->s_n);
+            sp[0]->s_vec, &delwriter->x_cspace, &x->x_delsamps, (t_int)sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
         if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
             pd_error(x, "delread~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);
@@ -327,7 +327,7 @@ static void sigvd_dsp(t_sigvd *x, t_signal **sp)
             0 : delwriter->x_vecsize);
         dsp_add(sigvd_perform, 5,
             sp[0]->s_vec, sp[1]->s_vec,
-                &delwriter->x_cspace, x, sp[0]->s_n);
+                &delwriter->x_cspace, x, (t_int)sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
         if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
             pd_error(x, "delread4~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -107,18 +107,18 @@ static void sigfft_dspx(t_sigfft *x, t_signal **sp, t_int *(*f)(t_int *w))
     t_sample *out1 = sp[2]->s_vec;
     t_sample *out2 = sp[3]->s_vec;
     if (out1 == in2 && out2 == in1)
-        dsp_add(sigfft_swap, 3, out1, out2, n);
+        dsp_add(sigfft_swap, 3, out1, out2, (t_int)n);
     else if (out1 == in2)
     {
-        dsp_add(copy_perform, 3, in2, out2, n);
-        dsp_add(copy_perform, 3, in1, out1, n);
+        dsp_add(copy_perform, 3, in2, out2, (t_int)n);
+        dsp_add(copy_perform, 3, in1, out1, (t_int)n);
     }
     else
     {
-        if (out1 != in1) dsp_add(copy_perform, 3, in1, out1, n);
-        if (out2 != in2) dsp_add(copy_perform, 3, in2, out2, n);
+        if (out1 != in1) dsp_add(copy_perform, 3, in1, out1, (t_int)n);
+        if (out2 != in2) dsp_add(copy_perform, 3, in2, out2, (t_int)n);
     }
-    dsp_add(f, 3, sp[2]->s_vec, sp[3]->s_vec, n);
+    dsp_add(f, 3, sp[2]->s_vec, sp[3]->s_vec, (t_int)n);
 }
 
 static void sigfft_dsp(t_sigfft *x, t_signal **sp)
@@ -190,9 +190,9 @@ static void sigrfft_dsp(t_sigrfft *x, t_signal **sp)
         return;
     }
     if (in1 != out1)
-        dsp_add(copy_perform, 3, in1, out1, n);
-    dsp_add(sigrfft_perform, 2, out1, n);
-    dsp_add(sigrfft_flip, 3, out1 + (n2+1), out2 + n2, n2-1);
+        dsp_add(copy_perform, 3, in1, out1, (t_int)n);
+    dsp_add(sigrfft_perform, 2, out1, (t_int)n);
+    dsp_add(sigrfft_flip, 3, out1 + (n2+1), out2 + n2, (t_int)(n2-1));
     dsp_add_zero(out1 + (n2+1), ((n2-1)&(~7)));
     dsp_add_zero(out1 + (n2+1) + ((n2-1)&(~7)), ((n2-1)&7));
     dsp_add_zero(out2 + n2, n2);
@@ -251,15 +251,15 @@ static void sigrifft_dsp(t_sigrifft *x, t_signal **sp)
     }
     if (in2 == out1)
     {
-        dsp_add(sigrfft_flip, 3, out1+1, out1 + n, n2-1);
-        dsp_add(copy_perform, 3, in1, out1, n2+1);
+        dsp_add(sigrfft_flip, 3, out1+1, out1 + n, (t_int)(n2-1));
+        dsp_add(copy_perform, 3, in1, out1, (t_int)(n2+1));
     }
     else
     {
-        if (in1 != out1) dsp_add(copy_perform, 3, in1, out1, n2+1);
-        dsp_add(sigrfft_flip, 3, in2+1, out1 + n, n2-1);
+        if (in1 != out1) dsp_add(copy_perform, 3, in1, out1, (t_int)(n2+1));
+        dsp_add(sigrfft_flip, 3, in2+1, out1 + n, (t_int)(n2-1));
     }
-    dsp_add(sigrifft_perform, 2, out1, n);
+    dsp_add(sigrifft_perform, 2, out1, (t_int)n);
 }
 
 static void sigrifft_setup(void)
@@ -349,8 +349,8 @@ static void sigframp_dsp(t_sigframp *x, t_signal **sp)
         return;
     }
     dsp_add(sigframp_perform, 5, sp[0]->s_vec, sp[1]->s_vec,
-        sp[2]->s_vec, sp[3]->s_vec, n2);
-    dsp_add(sigsqrt_perform, 3, sp[3]->s_vec, sp[3]->s_vec, n2);
+        sp[2]->s_vec, sp[3]->s_vec, (t_int)n2);
+    dsp_add(sigsqrt_perform, 3, sp[3]->s_vec, sp[3]->s_vec, (t_int)n2);
 }
 
 static void sigframp_setup(void)

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -119,7 +119,7 @@ static void sighip_dsp(t_sighip *x, t_signal **sp)
     sighip_ft1(x,  x->x_hz);
     dsp_add((pd_compatibilitylevel > 43 ?
         sighip_perform : sighip_perform_old),
-            4, sp[0]->s_vec, sp[1]->s_vec, x->x_ctl, sp[0]->s_n);
+            4, sp[0]->s_vec, sp[1]->s_vec, x->x_ctl, (t_int)sp[0]->s_n);
 }
 
 static void sighip_clear(t_sighip *x, t_floatarg q)
@@ -214,7 +214,7 @@ static void siglop_dsp(t_siglop *x, t_signal **sp)
     siglop_ft1(x,  x->x_hz);
     dsp_add(siglop_perform, 4,
         sp[0]->s_vec, sp[1]->s_vec,
-            x->x_ctl, sp[0]->s_n);
+            x->x_ctl, (t_int)sp[0]->s_n);
 
 }
 
@@ -349,7 +349,7 @@ static void sigbp_dsp(t_sigbp *x, t_signal **sp)
     sigbp_docoef(x, x->x_freq, x->x_q);
     dsp_add(sigbp_perform, 4,
         sp[0]->s_vec, sp[1]->s_vec,
-            x->x_ctl, sp[0]->s_n);
+            x->x_ctl, (t_int)sp[0]->s_n);
 
 }
 
@@ -476,7 +476,7 @@ static void sigbiquad_dsp(t_sigbiquad *x, t_signal **sp)
 {
     dsp_add(sigbiquad_perform, 4,
         sp[0]->s_vec, sp[1]->s_vec,
-            x->x_ctl, sp[0]->s_n);
+            x->x_ctl, (t_int)sp[0]->s_n);
 
 }
 
@@ -543,7 +543,7 @@ static void sigsamphold_dsp(t_sigsamphold *x, t_signal **sp)
 {
     dsp_add(sigsamphold_perform, 5,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, sp[0]->s_n);
+            x, (t_int)sp[0]->s_n);
 }
 
 static void sigsamphold_reset(t_sigsamphold *x, t_symbol *s, int argc,
@@ -618,7 +618,7 @@ static void sigrpole_dsp(t_sigrpole *x, t_signal **sp)
 {
     dsp_add(sigrpole_perform, 5,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, sp[0]->s_n);
+            x, (t_int)sp[0]->s_n);
 }
 
 static void sigrpole_clear(t_sigrpole *x)
@@ -690,7 +690,7 @@ static void sigrzero_dsp(t_sigrzero *x, t_signal **sp)
 {
     dsp_add(sigrzero_perform, 5,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, sp[0]->s_n);
+            x, (t_int)sp[0]->s_n);
 }
 
 static void sigrzero_clear(t_sigrzero *x)
@@ -762,7 +762,7 @@ static void sigrzero_rev_dsp(t_sigrzero_rev *x, t_signal **sp)
 {
     dsp_add(sigrzero_rev_perform, 5,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, sp[0]->s_n);
+            x, (t_int)sp[0]->s_n);
 }
 
 static void sigrzero_rev_clear(t_sigrzero_rev *x)
@@ -854,7 +854,7 @@ static void sigcpole_dsp(t_sigcpole *x, t_signal **sp)
 {
     dsp_add(sigcpole_perform, 8,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, sp[0]->s_n);
+        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
 static void sigcpole_clear(t_sigcpole *x)
@@ -944,7 +944,7 @@ static void sigczero_dsp(t_sigczero *x, t_signal **sp)
 {
     dsp_add(sigczero_perform, 8,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, sp[0]->s_n);
+        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
 static void sigczero_clear(t_sigczero *x)
@@ -1036,7 +1036,7 @@ static void sigczero_rev_dsp(t_sigczero_rev *x, t_signal **sp)
 {
     dsp_add(sigczero_rev_perform, 8,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, sp[0]->s_n);
+        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
 }
 
 static void sigczero_rev_clear(t_sigczero_rev *x)
@@ -1156,7 +1156,7 @@ static void slop_tilde_dsp(t_slop_tilde *x, t_signal **sp)
     x->x_coef = (2 * 3.14159) / sp[0]->s_sr;
     dsp_add(slop_tilde_perform, 9,
         x, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec, sp[4]->s_vec,
-            sp[5]->s_vec, sp[6]->s_vec, sp[0]->s_n);
+            sp[5]->s_vec, sp[6]->s_vec, (t_int)sp[0]->s_n);
 
 }
 

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -50,7 +50,7 @@ static t_int *sigsend_perform(t_int *w)
 static void sigsend_dsp(t_sigsend *x, t_signal **sp)
 {
     if (x->x_n == sp[0]->s_n)
-        dsp_add(sigsend_perform, 3, sp[0]->s_vec, x->x_vec, sp[0]->s_n);
+        dsp_add(sigsend_perform, 3, sp[0]->s_vec, x->x_vec, (t_int)sp[0]->s_n);
     else error("sigsend %s: unexpected vector size", x->x_sym->s_name);
 }
 
@@ -168,9 +168,9 @@ static void sigreceive_dsp(t_sigreceive *x, t_signal **sp)
         sigreceive_set(x, x->x_sym);
         if (sp[0]->s_n&7)
             dsp_add(sigreceive_perform, 3,
-                x, sp[0]->s_vec, sp[0]->s_n);
+                x, sp[0]->s_vec, (t_int)sp[0]->s_n);
         else dsp_add(sigreceive_perf8, 3,
-            x, sp[0]->s_vec, sp[0]->s_n);
+            x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     }
 }
 
@@ -241,9 +241,9 @@ static void sigcatch_dsp(t_sigcatch *x, t_signal **sp)
     if (x->x_n == sp[0]->s_n)
     {
         if(sp[0]->s_n&7)
-        dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec, sp[0]->s_n);
+            dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec, (t_int)sp[0]->s_n);
         else
-        dsp_add(sigcatch_perf8, 3, x->x_vec, sp[0]->s_vec, sp[0]->s_n);
+            dsp_add(sigcatch_perf8, 3, x->x_vec, sp[0]->s_vec, (t_int)sp[0]->s_n);
     }
     else error("sigcatch %s: unexpected vector size", x->x_sym->s_name);
 }
@@ -330,7 +330,7 @@ static void sigthrow_dsp(t_sigthrow *x, t_signal **sp)
     {
         sigthrow_set(x, x->x_sym);
         dsp_add(sigthrow_perform, 3,
-            x, sp[0]->s_vec, sp[0]->s_n);
+            x, sp[0]->s_vec, (t_int)sp[0]->s_n);
     }
 }
 

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -51,7 +51,7 @@ static t_int *clip_perform(t_int *w)
 
 static void clip_dsp(t_clip *x, t_signal **sp)
 {
-    dsp_add(clip_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(clip_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void clip_setup(void)
@@ -160,7 +160,7 @@ static t_int *sigrsqrt_perform(t_int *w)
 
 static void sigrsqrt_dsp(t_sigrsqrt *x, t_signal **sp)
 {
-    dsp_add(sigrsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(sigrsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void sigrsqrt_setup(void)
@@ -219,7 +219,7 @@ t_int *sigsqrt_perform(t_int *w)    /* not static; also used in d_fft.c */
 
 static void sigsqrt_dsp(t_sigsqrt *x, t_signal **sp)
 {
-    dsp_add(sigsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(sigsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void sigsqrt_setup(void)
@@ -283,7 +283,7 @@ static void sigwrap_dsp(t_sigwrap *x, t_signal **sp)
 {
     dsp_add((pd_compatibilitylevel < 48 ?
         sigwrap_old_perform : sigwrap_perform),
-            3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+            3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void sigwrap_setup(void)
@@ -332,7 +332,7 @@ static t_int *mtof_tilde_perform(t_int *w)
 
 static void mtof_tilde_dsp(t_mtof_tilde *x, t_signal **sp)
 {
-    dsp_add(mtof_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(mtof_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void mtof_tilde_setup(void)
@@ -376,7 +376,7 @@ static t_int *ftom_tilde_perform(t_int *w)
 
 static void ftom_tilde_dsp(t_ftom_tilde *x, t_signal **sp)
 {
-    dsp_add(ftom_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(ftom_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void ftom_tilde_setup(void)
@@ -426,7 +426,7 @@ static t_int *dbtorms_tilde_perform(t_int *w)
 
 static void dbtorms_tilde_dsp(t_dbtorms_tilde *x, t_signal **sp)
 {
-    dsp_add(dbtorms_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(dbtorms_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void dbtorms_tilde_setup(void)
@@ -475,7 +475,7 @@ static t_int *rmstodb_tilde_perform(t_int *w)
 
 static void rmstodb_tilde_dsp(t_rmstodb_tilde *x, t_signal **sp)
 {
-    dsp_add(rmstodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(rmstodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void rmstodb_tilde_setup(void)
@@ -525,7 +525,7 @@ static t_int *dbtopow_tilde_perform(t_int *w)
 
 static void dbtopow_tilde_dsp(t_dbtopow_tilde *x, t_signal **sp)
 {
-    dsp_add(dbtopow_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(dbtopow_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void dbtopow_tilde_setup(void)
@@ -574,7 +574,7 @@ static t_int *powtodb_tilde_perform(t_int *w)
 
 static void powtodb_tilde_dsp(t_powtodb_tilde *x, t_signal **sp)
 {
-    dsp_add(powtodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(powtodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 void powtodb_tilde_setup(void)
@@ -624,7 +624,7 @@ t_int *pow_tilde_perform(t_int *w)
 static void pow_tilde_dsp(t_pow_tilde *x, t_signal **sp)
 {
     dsp_add(pow_tilde_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void pow_tilde_setup(void)
@@ -665,7 +665,7 @@ t_int *exp_tilde_perform(t_int *w)
 static void exp_tilde_dsp(t_exp_tilde *x, t_signal **sp)
 {
     dsp_add(exp_tilde_perform, 3,
-        sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void exp_tilde_setup(void)
@@ -718,7 +718,7 @@ t_int *log_tilde_perform(t_int *w)
 static void log_tilde_dsp(t_log_tilde *x, t_signal **sp)
 {
     dsp_add(log_tilde_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void log_tilde_setup(void)
@@ -762,7 +762,7 @@ t_int *abs_tilde_perform(t_int *w)
 static void abs_tilde_dsp(t_abs_tilde *x, t_signal **sp)
 {
     dsp_add(abs_tilde_perform, 3,
-        sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void abs_tilde_setup(void)

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -41,7 +41,7 @@ static t_int *print_perform(t_int *w)
 
 static void print_dsp(t_print *x, t_signal **sp)
 {
-    dsp_add(print_perform, 3, x, sp[0]->s_vec, sp[0]->s_n);
+    dsp_add(print_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void print_float(t_print *x, t_float f)

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -103,7 +103,7 @@ static t_int *phasor_perform(t_int *w)
 static void phasor_dsp(t_phasor *x, t_signal **sp)
 {
     x->x_conv = 1./sp[0]->s_sr;
-    dsp_add(phasor_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(phasor_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void phasor_ft1(t_phasor *x, t_float f)
@@ -196,7 +196,7 @@ static t_int *cos_perform(t_int *w)
 
 static void cos_dsp(t_cos *x, t_signal **sp)
 {
-    dsp_add(cos_perform, 3, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(cos_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void cos_maketable(void)
@@ -318,7 +318,7 @@ static t_int *osc_perform(t_int *w)
 static void osc_dsp(t_osc *x, t_signal **sp)
 {
     x->x_conv = COSTABSIZE/sp[0]->s_sr;
-    dsp_add(osc_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_n);
+    dsp_add(osc_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void osc_ft1(t_osc *x, t_float f)
@@ -446,7 +446,7 @@ static void sigvcf_dsp(t_sigvcf *x, t_signal **sp)
     x->x_ctl->c_isr = 6.28318f/sp[0]->s_sr;
     dsp_add(sigvcf_perform, 6,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-            x->x_ctl, sp[0]->s_n);
+            x->x_ctl, (t_int)sp[0]->s_n);
 }
 
 void sigvcf_setup(void)
@@ -498,7 +498,7 @@ static t_int *noise_perform(t_int *w)
 
 static void noise_dsp(t_noise *x, t_signal **sp)
 {
-    dsp_add(noise_perform, 3, sp[0]->s_vec, &x->x_val, sp[0]->s_n);
+    dsp_add(noise_perform, 3, sp[0]->s_vec, &x->x_val, (t_int)sp[0]->s_n);
 }
 
 static void noise_float(t_noise *x, t_float f)

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -141,7 +141,7 @@ void resample_dsp(t_resample *x,
     }
     switch (method) {
     default:
-      dsp_add(downsampling_perform_0, 4, in, out, insize/outsize, insize);
+      dsp_add(downsampling_perform_0, 4, in, out, (t_int)(insize/outsize), (t_int)insize);
     }
 
 
@@ -152,7 +152,7 @@ void resample_dsp(t_resample *x,
     }
     switch (method) {
     case 1:
-      dsp_add(upsampling_perform_hold, 4, in, out, outsize/insize, insize);
+      dsp_add(upsampling_perform_hold, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
       break;
     case 2:
       if (x->bufsize != 1) {
@@ -160,10 +160,10 @@ void resample_dsp(t_resample *x,
         x->bufsize = 1;
         x->buffer = t_getbytes(x->bufsize*sizeof(*x->buffer));
       }
-      dsp_add(upsampling_perform_linear, 5, x, in, out, outsize/insize, insize);
+      dsp_add(upsampling_perform_linear, 5, x, in, out, (t_int)(outsize/insize), (t_int)insize);
       break;
     default:
-      dsp_add(upsampling_perform_0, 4, in, out, outsize/insize, insize);
+      dsp_add(upsampling_perform_0, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
     }
   }
 }

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -92,9 +92,9 @@ t_int *zero_perf8(t_int *w)
 void dsp_add_zero(t_sample *out, int n)
 {
     if (n&7)
-        dsp_add(zero_perform, 2, out, n);
+        dsp_add(zero_perform, 2, out, (t_int)n);
     else
-        dsp_add(zero_perf8, 2, out, n);
+        dsp_add(zero_perf8, 2, out, (t_int)n);
 }
 
 /* ---------------------------- block~ ----------------------------- */

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -126,7 +126,7 @@ static void vinlet_dsp(t_vinlet *x, t_signal **sp)
     }
     else
     {
-        dsp_add(vinlet_perform, 3, x, outsig->s_vec, outsig->s_vecsize);
+        dsp_add(vinlet_perform, 3, x, outsig->s_vec, (t_int)outsig->s_vecsize);
         x->x_read = x->x_buf;
     }
 }
@@ -213,14 +213,14 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs,
 
             if (upsample * downsample == 1)
                     dsp_add(vinlet_doprolog, 3, x, insig->s_vec,
-                        re_parentvecsize);
+                        (t_int)re_parentvecsize);
             else {
               int method = (x->x_updown.method == 3?
-                (pd_compatibilitylevel < 44 ? 0 : 1) : x->x_updown.method);
+                  (pd_compatibilitylevel < 44 ? 0 : 1) : x->x_updown.method);
               resamplefrom_dsp(&x->x_updown, insig->s_vec, parentvecsize,
-                re_parentvecsize, method);
+                  re_parentvecsize, method);
               dsp_add(vinlet_doprolog, 3, x, x->x_updown.s_vec,
-                re_parentvecsize);
+                  (t_int)re_parentvecsize);
         }
 
             /* if the input signal's reference count is zero, we have
@@ -451,7 +451,7 @@ static void voutlet_dsp(t_voutlet *x, t_signal **sp)
     if (!x->x_buf) return;
     insig = sp[0];
     if (x->x_justcopyout)
-        dsp_add_copy(insig->s_vec, x->x_directsignal->s_vec, insig->s_n);
+        dsp_add_copy(insig->s_vec, x->x_directsignal->s_vec, (t_int)insig->s_n);
     else if (x->x_directsignal)
     {
             /* if we're just going to make the signal available on the
@@ -460,7 +460,7 @@ static void voutlet_dsp(t_voutlet *x, t_signal **sp)
         signal_setborrowed(x->x_directsignal, sp[0]);
     }
     else
-        dsp_add(voutlet_perform, 3, x, insig->s_vec, insig->s_n);
+        dsp_add(voutlet_perform, 3, x, insig->s_vec, (t_int)insig->s_n);
 }
 
         /* set up epilog DSP code.  If we're reblocking, this is the
@@ -521,12 +521,12 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs,
             x->x_empty = x->x_buf + re_parentvecsize * epilogphase;
             if (upsample * downsample == 1)
                 dsp_add(voutlet_doepilog, 3, x, outsig->s_vec,
-                    re_parentvecsize);
+                    (t_int)re_parentvecsize);
             else
             {
                 int method = (x->x_updown.method == 3?
                     (pd_compatibilitylevel < 44 ? 0 : 1) : x->x_updown.method);
-                dsp_add(voutlet_doepilog_resampling, 2, x, re_parentvecsize);
+                dsp_add(voutlet_doepilog_resampling, 2, x, (t_int)re_parentvecsize);
                 resampleto_dsp(&x->x_updown, outsig->s_vec, re_parentvecsize,
                     parentvecsize, method);
             }


### PR DESCRIPTION
`dsp_add` is a variadic function which expects all arguments to be of type `t_int`; pushing arguments of a different size, e.g. `int` on a 64-bit platform, is undefined behavior. This has caused actual problems with 64-bit MSVC builds on Windows. For a more detailed explanation, see https://github.com/pure-data/pure-data/pull/673#issuecomment-508223766.

This PR makes sure to cast every integer to `t_int` before pushing it to `dsp_add.`