### PR TITLE
Search for hex-munged filenames when hexmunge is true

### DIFF
--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -122,7 +122,7 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
     const char *classname, *cnameptr;
     void *dlobj;
     t_xxx makeout = NULL;
-    int i, hexmunge = 0, fd;
+    int i, hexmunge = 0, tilde = 0, fd;
 #ifdef _WIN32
     HINSTANCE ntdll;
 #endif
@@ -149,6 +149,7 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
         {
             strcpy(symname+i, "_tilde");
             i += strlen(symname+i);
+            tilde = 1;
         }
         else /* anything you can't put in a C symbol is sprintf'ed in hex */
         {
@@ -162,7 +163,15 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
     const char *name;
     if (hexmunge)
     {
-        name = gensym(symname)->s_name;
+        if (tilde)
+        {
+            i -= 6;
+            filename[i] = '~';
+        }
+        strncpy(filename, symname, i);
+        filename[i+tilde] = 0;
+
+        name = filename;
         memmove(symname+6, symname, strlen(symname)+1);
         strncpy(symname, "setup_", 6);
     }

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -130,7 +130,8 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
            but we have already tried all paths */
     if(!path)return (0);
 
-    if ((classname = strrchr(objectname, '/')))
+    char *last = objectname + (strlen(objectname)-1);
+    if ((classname = strrchr(objectname, '/')) && classname != last)
         classname++;
     else classname = objectname;
     for (i = 0, cnameptr = classname; i < MAXPDSTRING-7 && *cnameptr;
@@ -157,12 +158,19 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
         }
     }
     symname[i] = 0;
+
+    const char *name;
     if (hexmunge)
     {
+        name = gensym(symname)->s_name;
         memmove(symname+6, symname, strlen(symname)+1);
         strncpy(symname, "setup_", 6);
     }
-    else strcat(symname, "_setup");
+    else
+    {
+        name = objectname;
+        strcat(symname, "_setup");
+    }
 
 #if 0
     fprintf(stderr, "lib: %s\n", classname);
@@ -170,7 +178,7 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
         /* try looking in the path for (objectname).(sys_dllextent) ... */
     for(dllextent=sys_dllextent; *dllextent; dllextent++)
     {
-        if ((fd = sys_trytoopenone(path, objectname, *dllextent,
+        if ((fd = sys_trytoopenone(path, name, *dllextent,
             dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
                 goto gotone;
     }

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -145,7 +145,7 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
             i++;
         }
             /* trailing tilde becomes "_tilde" */
-        else if (c == '~' && cnameptr[1] == 0)
+        else if (c == '~' && cnameptr[1] == 0 && cnameptr != classname)
         {
             strcpy(symname+i, "_tilde");
             i += strlen(symname+i);

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -79,11 +79,11 @@ void sys_unbashfilename(const char *from, char *to)
 /* test if path is absolute or relative, based on leading /, env vars, ~, etc */
 int sys_isabsolutepath(const char *dir)
 {
-    if (dir[0] == '/' || dir[0] == '~'
+    if (dir[0] == '/' || (dir[0] == '~' && strlen(dir) > 1)
 #ifdef _WIN32
         || dir[0] == '%' || (dir[1] == ':' && dir[2] == '/')
 #endif
-        )
+       )
     {
         return 1;
     }


### PR DESCRIPTION
While the setup methods for special-character objects are hex-munged, the raw object name still gets passed to the method sys_trytoopenone, which means that it searches for a filename with the special characters still intact. Here, the hex-munged name is passed instead, with the assumption that the filename is also going to be hex-munged.

A couple of extra conditions for special cases have been added. One allows for a single tilde by itself to be seen as an object name rather than part of a path name, and another allows for a forward slash to be seen as part of an object name if it's the last character in the name.