### PR TITLE
fix 'multiply defined' error in help of [array]

### DIFF
--- a/doc/5.reference/array-object-help.pd
+++ b/doc/5.reference/array-object-help.pd
@@ -7,7 +7,7 @@
 #X obj 208 496 list;
 #X text 34 496 see also:;
 #X text 485 171 (click for details:), f 11;
-#N canvas 490 70 900 759 define 0;
+#N canvas 490 89 900 759 define 0;
 #X text 332 562 creation arguments:;
 #X text 362 633 optional name;
 #X text 322 164 read from a file;
@@ -286,9 +286,8 @@ of the array are dropped.;
 #X obj 90 356 array random;
 #N canvas 102 243 816 629 quantile+random 0;
 #X floatatom 75 177 5 0 100 0 - - -;
-#X obj 39 251 array quantile array-help-3, f 14;
 #N canvas 0 50 450 250 (subpatch) 0;
-#X array array-help-3 100 float 3;
+#X array array-help-5 100 float 3;
 #A 0 0 0 0 0 0 0 0 0 0 0 0 0.00715053 0.00715053 0.0285789 0.0500072
 0.0714356 0.100007 0.128578 0.164292 0.207148 0.478574 0.628573 0.678572
 0.721429 0.717857 0.714286 0.707143 0.7 0.692857 0.685715 0.678572
@@ -301,12 +300,10 @@ of the array are dropped.;
 #X coords 0 1 99 0 200 140 1 0 0;
 #X restore 37 375 graph;
 #X floatatom 111 198 5 -1 100 0 - - -;
-#X msg 43 524 \; array-help-3 const 0;
 #X floatatom 39 131 5 -1 100 0 - - -;
 #X obj 39 152 / 100;
 #X floatatom 39 295 5 0 100 0 - - -;
 #X floatatom 368 599 5 0 100 0 - - -;
-#X obj 370 555 array random array-help-3, f 13;
 #X obj 370 435 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
 -1 -1;
 #X floatatom 383 484 5 0 0 0 - - -;
@@ -340,24 +337,27 @@ the range 0-1 output the x values at the two extremes of the array
 #X text 313 217 set name or pointer;
 #X msg 471 529 symbol array-help-2;
 #X text 635 528 set name or pointer;
-#X connect 0 0 1 1;
-#X connect 1 0 7 0;
-#X connect 3 0 1 2;
-#X connect 5 0 6 0;
-#X connect 6 0 1 0;
-#X connect 9 0 8 0;
-#X connect 10 0 9 0;
-#X connect 11 0 9 0;
-#X connect 12 0 9 1;
-#X connect 15 0 9 0;
-#X connect 27 0 1 3;
-#X connect 29 0 9 2;
+#X obj 39 251 array quantile array-help-5, f 14;
+#X msg 43 524 \; array-help-5 const 0;
+#X obj 370 555 array random array-help-5, f 13;
+#X connect 0 0 28 1;
+#X connect 2 0 28 2;
+#X connect 3 0 4 0;
+#X connect 4 0 28 0;
+#X connect 7 0 30 0;
+#X connect 8 0 30 0;
+#X connect 9 0 30 1;
+#X connect 12 0 30 0;
+#X connect 24 0 28 3;
+#X connect 26 0 30 2;
+#X connect 28 0 5 0;
+#X connect 30 0 6 0;
 #X restore 485 346 pd quantile+random;
 #X text 195 356 - random - array as probabilities;
 #X obj 90 379 array max;
 #N canvas 727 168 744 595 min+max 0;
 #N canvas 0 50 450 250 (subpatch) 0;
-#X array array-help-4 100 float 3;
+#X array array-help-6 100 float 3;
 #A 0 0.335714 0.37857 0.421427 0.442855 0.478569 0.521426 0.535711
 0.55714 0.585711 0.599997 0.614282 0.63571 0.649996 0.664282 0.671424
 0.699995 0.699995 0.714281 0.721424 0.707138 0.699995 0.692853 0.68571
@@ -373,7 +373,7 @@ the range 0-1 output the x values at the two extremes of the array
 0.50714 0.514283 0.521426 0.528569;
 #X coords 0 1 99 0 200 140 1 0 0;
 #X restore 382 386 graph;
-#X floatatom 55 275 7 0 100 0 - - -;
+#X floatatom 57 275 7 0 100 0 - - -;
 #X obj 57 136 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
 -1;
 #X floatatom 70 159 5 0 0 0 - - -;
@@ -387,7 +387,6 @@ default -1, f 61;
 #X text 153 180 number of points;
 #X msg 158 204 symbol array-help-2;
 #X text 322 205 set name or pointer;
-#X obj 57 230 array max array-help-4, f 13;
 #X floatatom 123 275 5 0 100 0 - - -;
 #X text 79 133 bang to find maximum;
 #X text 130 5 "array max" and "array min" find the maximum and minimum
@@ -395,7 +394,7 @@ values in the array \, respectively. The first outlet is the value
 and the second is the index (the x location where the value was found).
 The search may be restricted to a sub-domain of the array by specifying
 the "onset" and "number of points".;
-#X floatatom 52 497 7 0 100 0 - - -;
+#X floatatom 54 497 7 0 100 0 - - -;
 #X obj 54 358 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144 -1
 -1;
 #X floatatom 67 381 5 0 0 0 - - -;
@@ -404,20 +403,21 @@ the "onset" and "number of points".;
 #X floatatom 120 497 5 0 100 0 - - -;
 #X text 76 355 bang to find minimum;
 #X text 153 402 number of points;
-#X obj 54 452 array min array-help-4, f 13;
-#X text 54 298 value;
+#X text 56 298 value;
 #X text 118 299 index;
-#X connect 2 0 12 0;
-#X connect 3 0 12 0;
-#X connect 4 0 12 1;
-#X connect 10 0 12 2;
-#X connect 12 0 1 0;
-#X connect 12 1 13 0;
-#X connect 17 0 24 0;
-#X connect 18 0 24 0;
-#X connect 19 0 24 1;
-#X connect 24 0 16 0;
-#X connect 24 1 21 0;
+#X obj 54 452 array min array-help-6, f 13;
+#X obj 57 230 array max array-help-6, f 13;
+#X connect 2 0 26 0;
+#X connect 3 0 26 0;
+#X connect 4 0 26 1;
+#X connect 10 0 26 2;
+#X connect 16 0 25 0;
+#X connect 17 0 25 0;
+#X connect 18 0 25 1;
+#X connect 25 0 15 0;
+#X connect 25 1 20 0;
+#X connect 26 0 1 0;
+#X connect 26 1 12 0;
 #X restore 480 392 pd min+max;
 #X obj 90 402 array min;
 #X text 194 403 - min - find lowest value;


### PR DESCRIPTION
by renaming arrays in the [pd quantile+random] and [pd min+max] subpatches.