### PR TITLE
exitcode

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -141,7 +141,7 @@ void glob_init(void)
         A_SYMBOL, A_SYMBOL, 0);
     class_addmethod(glob_pdobject, (t_method)glob_open, gensym("open"),
         A_SYMBOL, A_SYMBOL, A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_quit, gensym("quit"), 0);
+    class_addmethod(glob_pdobject, (t_method)glob_exit, gensym("quit"), A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_verifyquit,
         gensym("verifyquit"), A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_foo, gensym("foo"), A_GIMME, 0);

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -95,7 +95,8 @@ void pd_globalunlock(void);
 
 EXTERN t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir);
 EXTERN void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv);
-EXTERN void glob_quit(void *dummy);
+EXTERN void glob_quit(void *dummy); /* glob_exit(0); */
+EXTERN void glob_exit(void *dummy, t_float status);
 EXTERN void open_via_helppath(const char *name, const char *dir);
 
 

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1443,7 +1443,7 @@ void sys_bail(int n)
     else _exit(1);
 }
 
-void glob_quit(void *dummy)
+void glob_exit(void *dummy, t_float status)
 {
     sys_close_audio();
     sys_close_midi();
@@ -1452,7 +1452,11 @@ void glob_quit(void *dummy)
         sys_closesocket(pd_this->pd_inter->i_guisock);
         sys_rmpollfn(pd_this->pd_inter->i_guisock);
     }
-    exit(0);
+    exit((int)status);
+}
+void glob_quit(void *dummy)
+{
+    glob_exit(dummy, 0);
 }
 
     /* recursively descend to all canvases and send them "vis" messages


### PR DESCRIPTION
this PR adds an optional argument to the `pd quit` message to allow specifying an exit code.

e.g. `[; pd quit 2(` will make Pd exit with exit-code `2`.
the old `[; pd quit(` will still exit with exit-code `0`.


this can be used to report the success of Pd, and is mostly useful when running in *batchmode* and/or testing