### PR TITLE
Fix how number boxes perform sameness comparison (fix bug due to surprising IEEE754 outcome).

### DIFF
--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include "m_pd.h"
+#include "m_imp.h"
 #include "g_canvas.h"
 
 #include "g_all_guis.h"
@@ -588,7 +589,7 @@ static int my_numbox_newclick(t_gobj *z, struct _glist *glist,
 
 static void my_numbox_set(t_my_numbox *x, t_floatarg f)
 {
-    if(x->x_val != f)
+    if(!float_strict_equal(x->x_val, f))
     {
         x->x_val = f;
         my_numbox_clip(x);

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -584,9 +584,7 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
     if (x->a_atom.a_type == A_FLOAT)
     {
         x->a_atom.a_w.w_float = atom_getfloat(argv);
-        changed = ((x->a_atom.a_w.w_float != oldatom.a_w.w_float));
-        if (isnan(x->a_atom.a_w.w_float) != isnan(oldatom.a_w.w_float))
-            changed = 1;
+        changed = !float_strict_equal(x->a_atom.a_w.w_float, oldatom.a_w.w_float);
     }
     else if (x->a_atom.a_type == A_SYMBOL)
         x->a_atom.a_w.w_symbol = atom_getsymbol(argv),

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -90,6 +90,9 @@ EXTERN int obj_sigoutletindex(const t_object *x, int m);
 void pd_globallock(void);
 void pd_globalunlock(void);
 
+/* x_misc.c */
+EXTERN int float_strict_equal(t_float f1, t_float f2);
+
 /* misc */
 #define SYMTABHASHSIZE 1024
 

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -852,7 +852,18 @@ static void fudiformat_setup(void) {
   class_addanything(fudiformat_class, fudiformat_any);
 }
 
-
+/* This compares two floating point values for "strict equality," in the usual
+sense, that is sameness-of-value rather than mathematical-equality. That is,
+unlike `==` which obeys (by and large) IEEE754 rules for equality and hence
+sometimes leads to surprising results (such as the nonreflexivity of NaN, and
+negative and positive zeros being considered equal to each other), this function
+operates on the bitwise representation of its arguments. */
+int float_strict_equal(t_float f1, t_float f2) {
+    /* Unfortunately, the most reliable way to perform the requisite comparison
+    in C is to use `memcmp()`. Fortunately, many compilers understand this
+    particular idiom, so it's typically reasonably performant (just ugly). */
+    return memcmp(&f1, &f2, sizeof (t_float)) == 0;
+}
 
 void x_misc_setup(void)
 {


### PR DESCRIPTION
This PR fixes issue #790 ("Number box with a zero won't update when given a zero of opposite sign."). I made the equivalent fix for both old- and new-style number boxes, which were both buggy though in somewhat different ways.

What I specifically did was make the "equality" comparison (of old and new values) be based on value-sameness instead of the IEEE754 definition of numeric equality. The most notable reason for doing this is because IEEE754 (a) defines both positive and negative zeros, and (b) considers them to be "equal." Since number boxes (as currently written) _don't_ completely ignore this distinction (e.g. you can type `-0` into a box and it behaves as expected, etc.), it was bad news to ignore the distinction in the value sameness comparison. The other consistent option would of course be to more completely ignore the `+0/-0` distinction in number boxes, but this struck me as inconsistent with the rest of Pd, which seems to (implicitly) fully embrace IEEE754 math (or at least reifies whatever math rules are implemented by the C compiler that compiled it, which by and large will be IEEE754 compliant these days).

In addition to fixing the aforementioned bug, this also improves sameness checking of NaNs (which IEEE754 _also_ treats surprisingly, with respect to the `==` operator). Interestingly enough, the new-style number box already had an apparent attempt to do something special with NaNs, but as it turns out what was written was effectively a no-op, so I removed the code in question.

As part of this PR I wrote a new utility function, which is called `float_strict_equal`. I have questions: (1) Is this a good enough name? (2) I couldn't figure out a good file to put it in, so I made a new file for it. Do (the collective) you have a suggestion for a better place? (3) If it stays in its own file, I presume you'd prefer me to assign copyright to Puckette, as his name seems to appear on the rest of the files. Do you have a form (CLA or what-have-you) for administration of project contribution / copyright?

Final questions:

* I tested this to my satisfaction using the attached patch, but I couldn't spot any unit tests (or similar) to update. Did I miss them? If so, please let me know and I'll edit / augment as necessary.

* I updated all the makefiles, and the auto-builds seem to be passing, but I have no practical way of testing anything but the macOS build locally. Is there something I should do to gain assurance of the build's soundness on other platforms?

Here's the patch I used for testing:
[numbox-test.pd.txt](https://github.com/pure-data/pure-data/files/3867335/numbox-test.pd.txt)

![numbox-test](https://user-images.githubusercontent.com/1090235/69209483-41d1c100-0b0c-11ea-9989-082e030bed05.png)