### PR TITLE
only send rtext-data if there's an actual window to send it to

### DIFF
--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -313,6 +313,10 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
     }
     escbuf = (tempbuf == smallbuf)?smallescbuf:t_getbytes(2 * outchars_b + 1);
     pdgui_strnescape(escbuf, 2 * outchars_b + 1, tempbuf, outchars_b);
+
+    if (action && !canvas->gl_havewindow)
+        action = 0;
+
     if (action == SEND_FIRST)
     {
         int lmargin = LMARGIN, tmargin = TMARGIN;


### PR DESCRIPTION
fixes a problem with updating GOP display just before closing the window containing the GOP.

Closes: https://github.com/pure-data/pure-data/issues/814



