### PR TITLE
[value] symbol support

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -689,10 +689,13 @@ EXTERN t_glist *garray_getglist(t_garray *x);
 EXTERN t_array *garray_getarray(t_garray *x);
 EXTERN t_class *scalar_class;
 
-EXTERN t_float *value_get(t_symbol *s);
+EXTERN t_float *value_get(t_symbol *s); /* original: get float only */
+EXTERN t_atom *value_getatom(t_symbol *s); /* updated: float or symbol */
 EXTERN void value_release(t_symbol *s);
 EXTERN int value_getfloat(t_symbol *s, t_float *f);
 EXTERN int value_setfloat(t_symbol *s, t_float f);
+EXTERN int value_getsymbol(t_symbol *s, t_symbol *s2);
+EXTERN int value_setsymbol(t_symbol *s, t_symbol *s2);
 
 /* ------- GUI interface - functions to send strings to TK --------- */
 typedef void (*t_guicallbackfn)(t_gobj *client, t_glist *glist);


### PR DESCRIPTION
This PR changes the value object backing type from t_float to t_atom and adds support for symbol values. Types can be changed on the fly based on what is sent to the left inlet: float or symbol.

As suggested by @Spacechild1 on the pd-list, it ended up being simpler than my first implantation which used explicit type checking and a "-s" flag.

I can't imagine this breaking existing patches.