### PR TITLE
Add a 'depth' argument to [namecanvas]

### DIFF
--- a/doc/5.reference/namecanvas-help.pd
+++ b/doc/5.reference/namecanvas-help.pd
@@ -1,13 +1,19 @@
-#N canvas 402 55 524 371 12;
-#X obj 39 20 namecanvas;
-#X obj 39 108 namecanvas bonzo;
-#X text 291 309 updated for Pd version 0.44;
-#X text 131 20 - attach this canvas to a name;
-#X text 34 150 This is sometimes the only way to send a message to
-a canvas when making graph-on-parent abstractions \, but its use in
-making self-editing patches is dangerous since if you use it to edit
-the namecanvas itself away you can cause Pd to crash. Instead \, you
-can just say:;
-#X msg 38 65 \; bonzo msg 280 50 hi there;
-#X msg 38 237 \; pd-namecanvas-help.pd msg 280 80 this is safer but
+#N canvas 590 23 512 472 12;
+#X obj 50 20 namecanvas;
+#X text 135 20 - attach a canvas to a name;
+#X text 275 430 updated for Pd version 0.51;
+#X msg 49 81 \; bonzo msg 280 70 hi there;
+#X text 176 125 first argument sets canvas name;
+#X obj 50 124 namecanvas bonzo;
+#X text 36 223 This is sometimes the only way to send a message to
+a canvas when making graph-on-parent abstractions \, for example. But
+its use in making self-editing patches is dangerous since if you use
+it to edit the namecanvas itself away you can cause Pd to crash. Instead
+\, you can just say:, f 63;
+#X text 44 59 send a message to a canvas:;
+#X msg 40 311 \; pd-namecanvas-help.pd msg 40 370 this is safer but
 only possible if you know the name of the canvas in advance.;
+#X text 36 156 A second optional argument specifies this canvas (0
+- default) \, owning canvas (1) \, its own owner (2) \, and so on.
+The ownership number is silently reduced if owners don't exist \, so
+here anything greater than zero would be ignored., f 63;

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -136,11 +136,15 @@ typedef struct _namecanvas
     t_pd *x_owner;
 } t_namecanvas;
 
-static void *namecanvas_new(t_symbol *s)
+static void *namecanvas_new(t_symbol *s, t_floatarg f)
 {
     t_namecanvas *x = (t_namecanvas *)pd_new(namecanvas_class);
-    x->x_owner = (t_pd *)canvas_getcurrent();
+    t_canvas *cnv = canvas_getcurrent();
     x->x_sym = s;
+    int depth = (int)f < 0 ? 0 : (int)f;
+    while(depth-- && cnv->gl_owner)
+        cnv = cnv->gl_owner;
+    x->x_owner = (t_pd *)cnv;
     if (*s->s_name) pd_bind(x->x_owner, s);
     return (x);
 }
@@ -154,7 +158,7 @@ static void namecanvas_setup(void)
 {
     namecanvas_class = class_new(gensym("namecanvas"),
         (t_newmethod)namecanvas_new, (t_method)namecanvas_free,
-            sizeof(t_namecanvas), CLASS_NOINLET, A_DEFSYM, 0);
+            sizeof(t_namecanvas), CLASS_NOINLET, A_DEFSYM, A_DEFFLOAT, 0);
 }
 
 /* -------------------------- cputime ------------------------------ */

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -126,7 +126,7 @@ static void loadbang_setup(void)
         gensym("loadbang"), A_DEFFLOAT, 0);
 }
 
-/* ------------- namecanvas (delete this later) --------------------- */
+/* ------------- namecanvas --------------------- */
 static t_class *namecanvas_class;
 
 typedef struct _namecanvas


### PR DESCRIPTION
This PR adds a 2nd float argument that sets a name to a parent patch (like with 'dir'/'args' methods in [pdcontrol]). The use case is that sometimes abstractions need to talk to the parent patch. 

This PR closes https://github.com/pure-data/pure-data/issues/835 as it's one of its possible solutions. This feature has recently been requested a couple of times and https://github.com/pure-data/pure-data/issues/835 is where the current discussion is.

I don't mean to impose this solution, and maybe I can close this PR in favor of another one. And, as I mentioned in https://github.com/pure-data/pure-data/issues/835#issuecomment-565108439 I'm not sure how @millerpuckette feels about [namecanvas], so this is my main concern.

The code says "Delete later" in the comments, but obviously it won't be deleted anymore. Therefore, my first commit here only removes that in the comment. The 2nd commit implements the feature.



