### PR TITLE
ad-hoc code sign to set library loading entitlements for macOS 10.15+

### DIFF
--- a/mac/Makefile.am
+++ b/mac/Makefile.am
@@ -7,6 +7,7 @@ EXTRA_DIST = \
     osx-app.sh \
     tcltk-wish.sh \
     stuff/Info.plist \
+    stuff/pd.entitlements \
     stuff/pd-file.icns \
     stuff/pd.icns \
     stuff/wish-shell.tgz

--- a/mac/README.txt
+++ b/mac/README.txt
@@ -178,3 +178,12 @@ Some important per-application settings required by the GUI include:
                                    enables key repeat for all keys
 
 These are set in `tcl/pd_guiprefs.tcl`.
+
+## Code Signing
+
+As of Pd 0.51, the mac/osx-app.sh script performs "ad-hoc code signing" in order
+to set entitlements to open un-validated dynamic libraries on macOS 10.15+. This
+is required due to the new security settings. Note: ad-hoc signing doesn't
+actually sign the .app bundle with an account certificate, so the unidentified
+developer warning is still shown when the downloaded .app is run for the first
+time.

--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -358,6 +358,12 @@ cd $DEST
 ln -s tcl Scripts
 cd - > /dev/null # quiet
 
+# "code signing" which also sets entitlements
+# note: "-" identity results in "ad-hoc signing" aka no signing is performed
+# for one, this allows loading un-validated external libraries on macOS 10.15+:
+# https://cutecoder.org/programming/shared-framework-hardened-runtime
+codesign -v --deep -s "-" --entitlements stuff/pd.entitlements $APP
+
 # finish up
 touch $APP
 

--- a/mac/stuff/pd.entitlements
+++ b/mac/stuff/pd.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds a code signing step when building the macOS .app bundle in order to set an entitlement to allow un-validated dynamic libraries to be loaded:

https://cutecoder.org/programming/shared-framework-hardened-runtime

This is required in order for Pd to load older externals (built with min macOS deployment version < 10.9) without a validation warning and manual steps to allow loading in the Security & Privacy preferences panel on macOS Catalina 10.15+.

The signing identity is "-" which performs an "ad-hoc code sign" aka the bundle is not actually signed with a developer certificate. This means the first run "unidentified developer" warning remains. We could add a developer identity later, if needed.

EDIT: From the original pd-list post by Kevin Haywood:

> I just discovered the huge headache of the notarization system under Catalina: the OS will prevent loading of every non-notarized *external* that you try to load. This appears to be a 3-part ordeal per external:
> 
> macOS’ first message is thrown the first time you open a patch with a non-notarized external:
> 
>     “myexternal~.pd_darwin” cannot be opened because the developer cannot be verified. macOS cannot verify that this app is free from malware.
> 
> The buttons accompanying this message are Move to Trash (!) and Cancel.
> 
> There are probably other ways, but to fix this, I had to go to System Preferences > Security & Privacy and click the button that allows authorization for the last binary that was prevented from launching.
> 
> I then had to quit and restart Pd. Opening a patch containing the offending external, I’m greeted with an error message similar to the first:
> 
>     macOS cannot verify the developer of “myexternal~.pd_darwin”. Are you sure you want to open it? By opening this app, you will be overriding system security which can expose your computer and personal information to malware that may harm your Mac or compromise your privacy.
> 
> You get Move to Trash, Open, and Cancel buttons this time. If you say Open, your external is allowed to load from this point on. But note that you have to do this 3-step process for every external, and only at the time that they’re first loaded, meaning we’re going to have to go through this whenever we first load up some old patch with a (64-bit) external we haven’t used in a while : \