### PR TITLE
several gpointer bugfixes

### DIFF
--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -791,7 +791,12 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                 if (nargs == 1) pd_float(target, mstack->a_w.w_float);
                 else pd_list(target, 0, nargs, mstack);
                 break;
+            case A_POINTER:
+                if (nargs == 1) pd_pointer(target, mstack->a_w.w_gpointer);
+                else pd_list(target, 0, nargs, mstack);
+                break;
             default:
+                bug("bad selector");
                 break;
             }
         }

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -948,8 +948,7 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     t_pd *bonzo;
 
         /* check for messages that are handled by fixed slots in the class
-        structure.  We don't catch "pointer" though so that sending "pointer"
-        to pd_objectmaker doesn't require that we supply a pointer value. */
+        structure. */
     if (s == &s_float)
     {
         if (!argc) (*c->c_floatmethod)(x, 0.);
@@ -974,6 +973,15 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
             (*c->c_symbolmethod)(x, argv->a_w.w_symbol);
         else
             (*c->c_symbolmethod)(x, &s_);
+        return;
+    }
+        /* pd_objectmaker doesn't require
+        an actual pointer value */
+    if (s == &s_pointer && x != &pd_objectmaker)
+    {
+        if (argc && argv->a_type == A_POINTER)
+            (*c->c_pointermethod)(x, argv->a_w.w_gpointer);
+        else goto badarg;
         return;
     }
 #ifdef PDINSTANCE

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -509,7 +509,7 @@ typedef struct _route
 {
     t_object x_obj;
     t_atomtype x_type;
-    t_int x_nelement;
+    int x_nelement;
     t_routeelement *x_vec;
     t_outlet *x_rejectout;
 } t_route;
@@ -520,7 +520,7 @@ static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
     int nelement;
     if (x->x_type == A_SYMBOL)
     {
-        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_symbol == sel)
         {
             if (argc > 0 && argv[0].a_type == A_SYMBOL)
@@ -544,7 +544,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         if (argv->a_type != A_FLOAT)
             goto rejected;
         f = atom_getfloat(argv);
-        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             if (e->e_w.w_float == f)
         {
             if (argc > 1 && argv[1].a_type == A_SYMBOL)
@@ -558,7 +558,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
     {
         if (argc > 1)       /* 2 or more args: treat as "list" */
         {
-            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_list)
                 {
@@ -572,7 +572,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else if (argc == 0)         /* no args: treat as "bang" */
         {
-            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_bang)
                 {
@@ -583,7 +583,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else if (argv[0].a_type == A_FLOAT)     /* one float arg */
         {
-            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_float)
                 {
@@ -594,7 +594,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         }
         else
         {
-            for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
+            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
                 if (e->e_w.w_symbol == &s_symbol)
                 {

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -581,7 +581,7 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
                 }
             }
         }
-        else if (argv[0].a_type == A_FLOAT)     /* one float arg */
+        else if (argv[0].a_type == A_FLOAT)    /* one float arg */
         {
             for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
@@ -592,7 +592,18 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
                 }
             }
         }
-        else
+        else if (argv[0].a_type == A_POINTER)    /* one pointer arg */
+        {
+            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            {
+                if (e->e_w.w_symbol == &s_pointer)
+                {
+                    outlet_pointer(e->e_outlet, argv[0].a_w.w_gpointer);
+                    return;
+                }
+            }
+        }
+        else                                     /* one symbol arg */
         {
             for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1038,7 +1038,7 @@ static void trigger_list(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
         else if (u->u_type == TR_POINTER)
         {
             if (!argc || argv->a_type != TR_POINTER)
-                pd_error(x, "unpack: bad pointer");
+                pd_error(x, "trigger: bad pointer");
             else outlet_pointer(u->u_outlet, argv->a_w.w_gpointer);
         }
         else outlet_list(u->u_outlet, &s_list, argc, argv);

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -51,7 +51,7 @@ static void print_bang(t_print *x)
 
 static void print_pointer(t_print *x, t_gpointer *gp)
 {
-    post("%s%s(gpointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    post("%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
 }
 
 static void print_float(t_print *x, t_float f)

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -59,32 +59,51 @@ static void print_float(t_print *x, t_float f)
     post("%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
 }
 
-static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
-{
-    if (argc && argv->a_type == A_FLOAT)
-    {
-        if(*x->x_sym->s_name)
-            startpost("%s:", x->x_sym->s_name);
-        else {
-                /* print first (numeric) atom, to avoid a trailing space */
-            startpost("%g", atom_getfloat(argv));
-            argc--; argv++;
-        }
-    }
-    else startpost("%s%s%s", x->x_sym->s_name,
-        (*x->x_sym->s_name ? ": " : ""),
-        (argc > 1 ? s_list.s_name : (argc == 1 ? s_symbol.s_name :
-            s_bang.s_name)));
-    postatom(argc, argv);
-    endpost();
-}
-
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
     startpost("%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
         s->s_name);
     postatom(argc, argv);
     endpost();
+}
+
+static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
+{
+    if (!argc)
+        print_bang(x);
+    else if (argc == 1)
+    {
+        switch (argv->a_type)
+        {
+        case A_FLOAT:
+            print_float(x, argv->a_w.w_float);
+            break;
+        case A_SYMBOL:
+            print_anything(x, &s_symbol, 1, argv);
+            break;
+        case A_POINTER:
+            print_pointer(x, argv->a_w.w_gpointer);
+            break;
+        default:
+            bug("print");
+            break;
+        }
+    }
+    else if (argv->a_type == A_FLOAT)
+    {
+        if (*x->x_sym->s_name)
+            startpost("%s: ", x->x_sym->s_name);
+        else
+        {
+            /* print first (numeric) atom, to avoid a trailing space */
+            startpost("%g", atom_getfloat(argv));
+            argc--; argv++;
+        }
+        postatom(argc, argv);
+        endpost();
+    }
+    else
+        print_anything(x, &s_list, argc, argv);
 }
 
 static void print_setup(void)


### PR DESCRIPTION
* `[print]`: print a single gpointer as `(pointer)` for consistency with all other objects
* `[print]`: correctly print a list containing a single gpointer (the current code accidentally prints a symbol selector)
* `[route]`: correctly forward a single gpointer (the current code accidentally sends the gpointer as a symbol!)
* `[trigger]`: fix gpointer error message
* `pd_typedmess`: check for gpointer, so we can't type bogus messages like `[pointer foo(`, just like we can't type `[float foo(`. This also ensures that `gpointer -> [pointer $1(` stays a gpointer message.
* `binbuf_eval`: check for gpointer selector, so we can pass a gpointer to `[$1 ...(` (the current code just silently ignores the message).