### PR TITLE
make sys_lock/sys_unlock recursive

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -125,7 +125,7 @@ struct _instanceinter
     LARGE_INTEGER i_inittime;
     double i_freq;
 #endif
-#if PDTHREADS
+#if PDTHREADS && PDINSTANCE
     pthread_mutex_t i_mutex;
 #endif
 };
@@ -1551,7 +1551,14 @@ void s_inter_newpdinstance(void)
 {
     pd_this->pd_inter = getbytes(sizeof(*pd_this->pd_inter));
 #if PDTHREADS
-    pthread_mutex_init(&pd_this->pd_inter->i_mutex, NULL);
+#if PDINSTANCE
+    {
+        pthread_mutexattr_t attr;
+        pthread_mutexattr_init(&attr);
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+        pthread_mutex_init(&pd_this->pd_inter->i_mutex, &attr);
+    }
+#endif
     pd_this->pd_islocked = 0;
 #endif
 #ifdef _WIN32
@@ -1582,7 +1589,7 @@ void s_inter_freepdinstance(void)
 #ifdef PDINSTANCE
 static pthread_rwlock_t sys_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 #else /* PDINSTANCE */
-static pthread_mutex_t sys_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t sys_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 #endif /* PDINSTANCE */
 #endif /* PDTHREADS */
 


### PR DESCRIPTION
Currently, `sys_lock()/sys_unlock()` uses a simple non-recursive mutex which is prone to dead locking. 

This causes problems in libpd (https://github.com/libpd/libpd/issues/274). Although libpd could use its own recursive (per-instance) mutex instead of `sys_lock() / sys_unlock()`, I guess the easiest solution is to use a recursive mutex in Pd itself.

It would also help to simplify the Pd scheduler, where we have to be very careful not to deadlock.

I've tested my changes with both single-instance Pd and multi-instance Pd (`-DPDINSTANCE`), using a custom external which calls `sys_lock() / sys_unlock()` in one of its methods (while the message system is being locked) and I could verify that it doesn't deadlock.

I also had a quick look at the winpthreads implementation and the overhead of a recursive `pthread_mutex_t` over a non-recursive one is very small.