### PR TITLE
array editing features

### DIFF
--- a/doc/2.control.examples/16.more.arrays.pd
+++ b/doc/2.control.examples/16.more.arrays.pd
@@ -1,4 +1,4 @@
-#N canvas 288 82 910 618 12;
+#N canvas 288 82 910 642 12;
 #N canvas 0 50 450 250 (subpatch) 0;
 #X array array99 5 float 1;
 #A 0 0.32 0.499999 -0.406667 -0.753333 0.00666714;
@@ -42,9 +42,18 @@ dialog. Note that information about size and ranges is saved \, but
 ticks and labels are lost between Pd sessions. The contents of the
 array may be saved as part of the patch or discarded., f 46;
 #X text 510 118 This is set in the "properties" dialog.;
-#X text 60 528 enable/disable mouse editing:;
-#X obj 37 528 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+#X text 283 529 enable/disable mouse editing:, f 30;
+#X obj 285 551 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
 1;
-#X msg 37 550 \; array98 edit \$1 \; array99 edit \$1;
+#X msg 285 575 \; array98 edit \$1 \; array99 edit \$1;
 #X text 654 493 last updated for release 0.51;
+#X text 37 526 show/hide arrays:;
+#X obj 162 550 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X msg 162 570 \; array99 vis \$1;
+#X obj 40 550 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X msg 40 570 \; array98 vis \$1;
 #X connect 21 0 22 0;
+#X connect 25 0 26 0;
+#X connect 27 0 28 0;

--- a/doc/2.control.examples/16.more.arrays.pd
+++ b/doc/2.control.examples/16.more.arrays.pd
@@ -1,4 +1,4 @@
-#N canvas 288 82 910 558 12;
+#N canvas 288 82 910 618 12;
 #N canvas 0 50 450 250 (subpatch) 0;
 #X array array99 5 float 1;
 #A 0 0.32 0.499999 -0.406667 -0.753333 0.00666714;
@@ -37,9 +37,14 @@ for "canvas".) Arrays' sizes need not match the bounds of the containing
 graph. But if you resize an array \, and if it is the only array contained
 in a graph \, then the graph automaticallly resets its bounds to match.
 , f 51;
-#X text 654 493 last updated for release 0.48;
 #X text 508 27 You can also change x and y range and size in the "properties"
 dialog. Note that information about size and ranges is saved \, but
 ticks and labels are lost between Pd sessions. The contents of the
 array may be saved as part of the patch or discarded., f 46;
 #X text 510 118 This is set in the "properties" dialog.;
+#X text 60 528 enable/disable mouse editing:;
+#X obj 37 528 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
+#X msg 37 550 \; array98 edit \$1 \; array99 edit \$1;
+#X text 654 493 last updated for release 0.51;
+#X connect 21 0 22 0;

--- a/doc/5.reference/plot-help.pd
+++ b/doc/5.reference/plot-help.pd
@@ -5,45 +5,47 @@ array array2 help-plot-array2-template array array3 help-plot-array3-template
 #N struct help-plot-array2-template float x float y;
 #N struct help-plot-array3-template float y float w;
 #N canvas 568 102 513 268 12;
-#N canvas 621 90 523 734 help-plot-template 0;
+#N canvas 593 51 523 734 help-plot-template 0;
 #X text 30 44 creation arguments:;
-#X text 50 251 - RGB color (0=black \, 999=white \, 900=red \, 90=green
+#X text 50 269 - RGB color (0=black \, 999=white \, 900=red \, 90=green
 \, 9=blue \, 555=grey \, etc.);
-#X text 48 281 - line width;
-#X text 48 300 - relative x and y location;
-#X text 49 320 - x spacing;
-#X obj 41 413 plot curve array2 70 3 100 0;
-#X obj 32 504 plot curve array3 9 1 120 50 20;
+#X text 48 299 - line width;
+#X text 48 318 - relative x and y location;
+#X text 49 338 - x spacing;
+#X obj 41 430 plot curve array2 70 3 100 0;
+#X obj 32 521 plot curve array3 9 1 120 50 20;
 #X obj 45 14 plot array1 500 1 10 15 20;
-#X text 31 341 This first example plots the red trace (500) \, width
+#X text 31 358 This first example plots the red trace (500) \, width
 1 \, at point (10 \, 15) \, with horizontal spacing 20 The black diamonds
 come from the template of the array1 element itself.;
-#X text 52 524 If a "w" variable is present in the template as for
+#X text 52 541 If a "w" variable is present in the template as for
 array3 \, it is added to the line width.;
-#X obj 25 688 filledpolygon 509 509 0 -10 -10 10 -10 10 10 -10 10;
-#X text 29 650 To see the data itself \, select "properties" for the
+#X obj 25 705 filledpolygon 509 509 0 -10 -10 10 -10 10 10 -10 10;
+#X text 29 667 To see the data itself \, select "properties" for the
 scalar by right clicking on the purple square.;
-#X obj 26 583 struct help-plot-template float x float y array array1
+#X obj 26 600 struct help-plot-template float x float y array array1
 help-plot-array1-template array array2 help-plot-array2-template array
 array3 help-plot-array3-template;
-#X text 35 562 here's the "struct" for all this:;
-#X text 47 230 - field to plot (the array);
+#X text 35 579 here's the "struct" for all this:;
+#X text 47 248 - field to plot (the array);
 #X text 49 61 - optional "-n" flag to make invisible initially;
 #X text 48 80 - alternatively \, an optional "-v [variable]" flag to
 assign a variable to make this visible/invisible.;
 #X text 52 111 - optional "-vs [constant or variable]" to set visibility
 of scalars along the path of the plot.;
-#X text 48 209 - optional word "curve" to specify Bézier curve;
-#X text 48 142 - optional "-x [variable]" flag to use different x variable
+#X text 48 227 - optional word "curve" to specify Bézier curve;
+#X text 47 166 - optional "-x [variable]" flag to use different x variable
 ;
-#X text 49 163 - optional "-y [variable]" flag to use different y variable
+#X text 48 187 - optional "-y [variable]" flag to use different y variable
 ;
-#X text 49 183 - optional "-w [variable]" flag to use different w variable
+#X text 48 207 - optional "-w [variable]" flag to use different w variable
 ;
-#X text 64 435 This is the green spiral (color 70 \, line width 3 \,
+#X text 64 452 This is the green spiral (color 70 \, line width 3 \,
 location (100 \, 0). Since the template for array2 contains an "x"
 variable \, plot ignores x spacing requests and takes x from the data
 itself.;
+#X text 47 144 - optional "-e [const or variable]" to enable/disable
+editing, f 62;
 #X restore 243 78 pd help-plot-template;
 #N canvas 754 260 353 124 help-plot-array1-template 0;
 #X obj 30 71 filledpolygon 0 0 0 -5 0 0 5 5 0 0 -5;
@@ -65,6 +67,6 @@ itself.;
 #N canvas 599 270 419 104 help-plot-array3-template 0;
 #X obj 43 32 struct help-plot-array3-template float y float w;
 #X restore 242 144 pd help-plot-array3-template;
-#X text 241 210 updated for Pd version 0.35;
 #X obj 57 157 struct;
 #X text 34 90 explanation is in here ==>;
+#X text 241 210 updated for Pd version 0.51;

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -114,6 +114,7 @@ struct _garray
     char x_saveit;          /* true if we should save this with parent */
     char x_listviewing;     /* true if list view window is open */
     char x_hidename;        /* don't print name above graph */
+    char x_edit;            /* true if we can edit the array */
 };
 
 static t_pd *garray_arraytemplatecanvas;  /* written at setup w/ global lock */
@@ -170,6 +171,7 @@ static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
     x->x_usedindsp = 0;
     x->x_saveit = saveit;
     x->x_listviewing = 0;
+    x->x_edit = 1;
     glist_add(gl, &x->x_gobj);
     x->x_glist = gl;
     return (x);
@@ -694,8 +696,11 @@ static int garray_click(t_gobj *z, t_glist *glist,
     int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
     t_garray *x = (t_garray *)z;
-    return (gobj_click(&x->x_scalar->sc_gobj, glist,
-        xpix, ypix, shift, alt, dbl, doit));
+    if (x->x_edit)
+        return (gobj_click(&x->x_scalar->sc_gobj, glist,
+            xpix, ypix, shift, alt, dbl, doit));
+    else
+        return (0);
 }
 
 #define ARRAYWRITECHUNKSIZE 1000
@@ -1181,6 +1186,11 @@ static void garray_zoom(t_garray *x, t_floatarg f)
 {
 }
 
+static void garray_edit(t_garray *x, t_floatarg f)
+{
+    x->x_edit = (int)f;
+}
+
 static void garray_print(t_garray *x)
 {
     t_array *array = garray_getarray(x);
@@ -1215,6 +1225,8 @@ void g_array_setup(void)
     class_addmethod(garray_class, (t_method)garray_resize, gensym("resize"),
         A_FLOAT, A_NULL);
     class_addmethod(garray_class, (t_method)garray_zoom, gensym("zoom"),
+        A_FLOAT, 0);
+    class_addmethod(garray_class, (t_method)garray_edit, gensym("edit"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_print, gensym("print"),
         A_NULL);

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1429,6 +1429,7 @@ typedef struct _plot
     t_fielddesc x_wpoints;
     t_fielddesc x_vis;          /* visible */
     t_fielddesc x_scalarvis;    /* true if drawing the scalar at each point */
+    t_fielddesc x_edit;         /* enable/disable mouse editing */
 } t_plot;
 
 static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
@@ -1443,6 +1444,7 @@ static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
 
     fielddesc_setfloat_const(&x->x_vis, 1);
     fielddesc_setfloat_const(&x->x_scalarvis, 1);
+    fielddesc_setfloat_const(&x->x_edit, 1);
     while (1)
     {
         t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
@@ -1476,6 +1478,17 @@ static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
         {
             fielddesc_setfloatarg(&x->x_wpoints, 1, argv+1);
             argc -= 2; argv += 2;
+        }
+        else if (!strcmp(firstarg->s_name, "-e") && argc > 1)
+        {
+            fielddesc_setfloatarg(&x->x_edit, 1, argv+1);
+            argc -= 2; argv += 2;
+        }
+        else if (*firstarg->s_name == '-')
+        {
+            pd_error(x, "%s: unknown flag '%s'...", classsym->s_name,
+                firstarg->s_name);
+            argc--; argv++;
         }
         else break;
     }
@@ -1522,7 +1535,7 @@ static int plot_readownertemplate(t_plot *x,
     t_word *data, t_template *ownertemplate,
     t_symbol **elemtemplatesymp, t_array **arrayp,
     t_float *linewidthp, t_float *xlocp, t_float *xincp, t_float *ylocp,
-    t_float *stylep, t_float *visp, t_float *scalarvisp,
+    t_float *stylep, t_float *visp, t_float *scalarvisp, t_float *editp,
     t_fielddesc **xfield, t_fielddesc **yfield, t_fielddesc **wfield)
 {
     int arrayonset, type;
@@ -1554,6 +1567,7 @@ static int plot_readownertemplate(t_plot *x,
     *stylep = fielddesc_getfloat(&x->x_style, ownertemplate, data, 1);
     *visp = fielddesc_getfloat(&x->x_vis, ownertemplate, data, 1);
     *scalarvisp = fielddesc_getfloat(&x->x_scalarvis, ownertemplate, data, 1);
+    *editp = fielddesc_getfloat(&x->x_edit, ownertemplate, data, 1);
     *elemtemplatesymp = elemtemplatesym;
     *arrayp = array;
     *xfield = &x->x_xpoints;
@@ -1629,7 +1643,7 @@ static void plot_getrect(t_gobj *z, t_glist *glist,
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, yval, vis, scalarvis;
+    t_float linewidth, xloc, xinc, yloc, style, yval, vis, scalarvis, edit;
     double xsum;
     t_array *array;
     int x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff, y2 = -0x7fffffff;
@@ -1645,7 +1659,7 @@ static void plot_getrect(t_gobj *z, t_glist *glist,
     }
     if (!plot_readownertemplate(x, data, template,
         &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-            &vis, &scalarvis, &xfielddesc, &yfielddesc, &wfielddesc) &&
+            &vis, &scalarvis, &edit, &xfielddesc, &yfielddesc, &wfielddesc) &&
                 (vis != 0) &&
             !array_getfields(elemtemplatesym, &elemtemplatecanvas,
                 &elemtemplate, &elemsize,
@@ -1745,7 +1759,8 @@ static void plot_vis(t_gobj *z, t_glist *glist,
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval, vis, scalarvis;
+    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval,
+        vis, scalarvis, edit;
     double xsum;
     t_array *array;
     int nelem;
@@ -1762,7 +1777,7 @@ static void plot_vis(t_gobj *z, t_glist *glist,
 
     if (plot_readownertemplate(x, data, template,
         &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-        &vis, &scalarvis, &xfielddesc, &yfielddesc, &wfielddesc) ||
+        &vis, &scalarvis, &edit, &xfielddesc, &yfielddesc, &wfielddesc) ||
             ((vis == 0) && tovis) /* see above for 'tovis' */
             || array_getfields(elemtemplatesym, &elemtemplatecanvas,
                 &elemtemplate, &elemsize, xfielddesc, yfielddesc, wfielddesc,
@@ -2157,7 +2172,8 @@ static int array_doclick_element(t_array *array, t_glist *glist,
 
 static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
     t_array *ap, t_symbol *elemtemplatesym,
-    t_float xloc, t_float xinc, t_float yloc, t_float scalarvis,
+    t_float xloc, t_float xinc, t_float yloc,
+    t_float scalarvis, t_float edit,
     t_fielddesc *xfield, t_fielddesc *yfield, t_fielddesc *wfield,
     int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
@@ -2263,6 +2279,9 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                 a) grab an element, b) change the line width,
                 c) delete an element or d) add a new element */
             best += 0.001;  /* add truncation error margin */
+             /* otherwise we try to grab a vertex */
+            if (!edit)
+                return (0);
             for (i = 0; i < array->a_n; i += incr)
             {
                 t_float pxpix, pypix, pwpix, dx, dy, dy2, dy3;
@@ -2393,17 +2412,17 @@ static int plot_click(t_gobj *z, t_glist *glist,
 {
     t_plot *x = (t_plot *)z;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, vis, scalarvis;
+    t_float linewidth, xloc, xinc, yloc, style, vis, scalarvis, edit;
     t_array *array;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
 
     if (!plot_readownertemplate(x, data, template,
         &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-        &vis, &scalarvis,
+        &vis, &scalarvis, &edit,
         &xfielddesc, &yfielddesc, &wfielddesc) && (vis != 0))
     {
         return (array_doclick(array, glist, sc, ap, elemtemplatesym,
-            basex + xloc, xinc, basey + yloc, scalarvis,
+            basex + xloc, xinc, basey + yloc, scalarvis, edit,
             xfielddesc, yfielddesc, wfielddesc,
             xpix, ypix, shift, alt, dbl, doit));
     }


### PR DESCRIPTION
* add `-e [constant or field]` to `[plot]` to (dynamically) enable/disable mouse editing
* add `[edit <f>(` message to `t_garray` to enable/disable mouse editing
* add `[vis <f>(` message to `t_garray` to show/hide array

implements https://github.com/pure-data/pure-data/issues/839#issuecomment-566247716

This is particularly useful when dealing with several arrays in a single graph, because you can selectively show/hide resp. enable/disable them.