### PR TITLE
make pd_unbind safe (+ improve stack overflow protection)

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -351,6 +351,7 @@ int backtracer_tracing;
 t_class *backtracer_class;
 
 static PERTHREAD int stackcount = 0; /* iteration counter */
+static PERTHREAD int overflow = 0;
 #define STACKITER 1000 /* maximum iterations allowed */
 
 static PERTHREAD int outlet_eventno;
@@ -358,6 +359,21 @@ static PERTHREAD int outlet_eventno;
     /* initialize stack depth count on each incoming event that can set off
     messages so that  the outlet functions can check to prevent stack overflow]
     from message recursion.  Also count message initiations. */
+
+int stackcount_add(void)
+{
+        /* set overflow flag to prevent any further messaging */
+    if (++stackcount >= STACKITER)
+        overflow = 1;
+    return !overflow;
+}
+
+void stackcount_release(void)
+{
+        /* once the stack is completely unwound, we can clear the overflow flag */
+    if (--stackcount == 0)
+        overflow = 0;
+}
 
 void outlet_setstacklim(void)
 {
@@ -555,19 +571,19 @@ static void outlet_stackerror(t_outlet *x)
 void outlet_bang(t_outlet *x)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_bang(oc->oc_to);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_pointer(t_outlet *x, t_gpointer *gp)
 {
     t_outconnect *oc;
     t_gpointer gpointer;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     {
@@ -575,51 +591,51 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
         for (oc = x->o_connections; oc; oc = oc->oc_next)
             pd_pointer(oc->oc_to, &gpointer);
     }
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_float(t_outlet *x, t_float f)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_float(oc->oc_to, f);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_symbol(t_outlet *x, t_symbol *s)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_symbol(oc->oc_to, s);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         pd_list(oc->oc_to, s, argc, argv);
-    --stackcount;
+    stackcount_release();
 }
 
 void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
-    if(++stackcount >= STACKITER)
+    if(!stackcount_add())
         outlet_stackerror(x);
     else
     for (oc = x->o_connections; oc; oc = oc->oc_next)
         typedmess(oc->oc_to, s, argc, argv);
-    --stackcount;
+    stackcount_release();
 }
 
     /* get the outlet's declared symbol */


### PR DESCRIPTION
### a) make `pd_unbind` safe

Currently, it is unsafe to dynamically unbind symbols because some other object could be sending to them.

The solution is to simply make a copy of the bind list before iterating over it. A counter keeps track of the total number of items. We use stack allocation up to a certain limit and then switch to heap allocation to avoid a stack overflow.

To make copying as fast as possible, I changed the bind list implementation to a dynamically sized array instead of a linked list. (This is also better for cache coherency).

In a way, this not much different than how `[list]` has to output a *copy* of the stored list to prevent other objects to modify the list while iterating over it.

This PR would finally make it possible to safely implement dyamically settable `[receive]` objects (https://github.com/pure-data/pure-data/pull/604), and make existing similar objects safe, for example iemgui's `[receive(` method.

---

### b) improve stack overflow protection

The current overflow protection only works for a *single* recursion path. For more than 1 path (e.g. several outlets feeding back to the same inlet), Pd would end up in an infinite loop. Once the stacklimit is reached, I set an overflow flag to prevent any further messaging until the stack got completely unwound.