### PR TITLE
[WIP] CAF audio file support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -58,4 +58,4 @@ Lindsay, Karl MacMillan, Thomas Musil, Toshinori Ohkouchi, Winfried Ritsch,
 Vibeke Sorensen, Rand Steiger, Hans-Christoph Steiner, Shahrokh Yadegari, Dan
 Wilcox, David Zicarelli, IOhannes m zmoelnig, and probably many others for
 contributions of code, documentation, ideas, and expertise. This work has
-received support from Intel, Keith Mcmillen Instruments, and UCSD.
+received support from Intel, Keith McMillen Instruments, ZKM, and UCSD.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,7 +54,7 @@ pd_SOURCES_core = \
     d_resample.c \
     d_soundfile.c \
     d_soundfile_aiff.c \
-    d_soundfile_caff.c \
+    d_soundfile_caf.c \
     d_soundfile_next.c \
     d_soundfile_wave.c \
     d_ugen.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,7 @@ pd_SOURCES_core = \
     d_resample.c \
     d_soundfile.c \
     d_soundfile_aiff.c \
+    d_soundfile_caff.c \
     d_soundfile_next.c \
     d_soundfile_wave.c \
     d_ugen.c \

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -29,13 +29,10 @@ objects use Posix-like threads.  */
 
 #ifdef _LARGEFILE64_SOURCE
 #define open open64
-#define lseek lseek64
-#define off_t __off64_t
 #endif
 
 /* Microsoft Visual Studio does not define these... arg */
 #ifdef _MSC_VER
-#define off_t long
 #define O_CREAT   _O_CREAT
 #define O_TRUNC   _O_TRUNC
 #define O_WRONLY  _O_WRONLY

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -54,7 +54,7 @@ typedef enum _soundfile_filetype
     FILETYPE_UNKNOWN = -1,
     FILETYPE_WAVE    =  0,
     FILETYPE_AIFF    =  1,
-    FILETYPE_NEXT    =  2
+    FILETYPE_NEXT    =  2,
     FILETYPE_CAFF    =  3
 } t_soundfile_filetype;
 

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -324,7 +324,6 @@ static void soundfile_xferin_sample(const t_soundfile_info *info, int nvecs,
     size_t j;
     unsigned char *sp, *sp2;
     t_sample *fp;
-    t_floatuint alias;
     for (i = 0, sp = buf; i < nchannels; i++, sp += info->i_bytespersample)
     {
         if (info->i_bytespersample == 2)
@@ -361,6 +360,7 @@ static void soundfile_xferin_sample(const t_soundfile_info *info, int nvecs,
         }
         else if (info->i_bytespersample == 4)
         {
+            t_floatuint alias;
             if (info->i_bigendian)
             {
                 for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
@@ -394,7 +394,6 @@ static void soundfile_xferin_words(const t_soundfile_info *info, int nvecs,
 {
     unsigned char *sp, *sp2;
     t_word *wp;
-    t_floatuint alias;
     int nchannels = (info->i_nchannels < nvecs ? info->i_nchannels : nvecs), i;
     size_t j;
     for (i = 0, sp = buf; i < nchannels; i++, sp += info->i_bytespersample)
@@ -433,6 +432,7 @@ static void soundfile_xferin_words(const t_soundfile_info *info, int nvecs,
         }
         else if (info->i_bytespersample == 4)
         {
+            t_floatuint alias;
             if (info->i_bigendian)
             {
                 for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
@@ -807,12 +807,12 @@ static void soundfile_xferout_sample(const t_soundfile_info *info,
         }
         else if (info->i_bytespersample == 4)
         {
+            t_floatuint f2;
             if (info->i_bigendian)
             {
                 for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
                     j < nframes; j++, sp2 += info->i_bytesperframe, fp++)
                 {
-                    t_floatuint f2;
                     f2.f = *fp * normalfactor;
                     sp2[0] = (f2.ui >> 24); sp2[1] = (f2.ui >> 16);
                     sp2[2] = (f2.ui >> 8);  sp2[3] = f2.ui;
@@ -823,7 +823,6 @@ static void soundfile_xferout_sample(const t_soundfile_info *info,
                 for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
                     j < nframes; j++, sp2 += info->i_bytesperframe, fp++)
                 {
-                    t_floatuint f2;
                     f2.f = *fp * normalfactor;
                     sp2[3] = (f2.ui >> 24); sp2[2] = (f2.ui >> 16);
                     sp2[1] = (f2.ui >> 8);  sp2[0] = f2.ui;
@@ -916,12 +915,12 @@ static void soundfile_xferout_words(const t_soundfile_info *info, t_word **vecs,
         }
         else if (info->i_bytespersample == 4)
         {
+            t_floatuint f2;
             if (info->i_bigendian)
             {
                 for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
                     j < nframes; j++, sp2 += info->i_bytesperframe, wp++)
                 {
-                    t_floatuint f2;
                     f2.f = wp->w_float * normalfactor;
                     sp2[0] = (f2.ui >> 24); sp2[1] = (f2.ui >> 16);
                     sp2[2] = (f2.ui >> 8);  sp2[3] = f2.ui;
@@ -932,7 +931,6 @@ static void soundfile_xferout_words(const t_soundfile_info *info, t_word **vecs,
                 for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
                     j < nframes; j++, sp2 += info->i_bytesperframe, wp++)
                 {
-                    t_floatuint f2;
                     f2.f = wp->w_float * normalfactor;
                     sp2[3] = (f2.ui >> 24); sp2[2] = (f2.ui >> 16);
                     sp2[1] = (f2.ui >> 8);  sp2[0] = f2.ui;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -182,14 +182,14 @@ int32_t swap4s(int32_t n, int doit)
     return n;
 }
 
-uint16_t swap2(uint32_t n, int doit)
+uint16_t swap2(uint16_t n, int doit)
 {
     if (doit)
         return (((n & 0x00ff) << 8) | ((n & 0xff00) >> 8));
     return n;
 }
 
-void swapstring(char *foo, int doit)
+void swapstring4(char *foo, int doit)
 {
     if (doit)
     {
@@ -207,13 +207,6 @@ void swapstring8(char *foo, int doit)
         foo[0] = h; foo[1] = g; foo[2] = f; foo[3] = e;
         foo[4] = d; foo[5] = c; foo[6] = b; foo[7] = a;
     }
-}
-
-double swapdouble(double n, int doit) {
-    if (doit) {
-        swapstring8((char *)&n, 1);
-    }
-    return n;
 }
 
 /* ----------------------- soundfile access routines ----------------------- */

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -606,20 +606,8 @@ static int soundfiler_writeargs_parse(void *obj, int *p_argc, t_atom **p_argv,
     else if (filetype == FILETYPE_AIFF) /* default to big endian */
     {
         bigendian = 1;
-        if (pd_compatibilitylevel < 51)
-        {
-                /* older versions can't read AIFF-C needed for little endian */
-            if (endianness == 1)
-                pd_error(obj, "AIFF file forced to big endian");
-                 /* older versions can't read float */
-            if (bytespersample == 4)
-            {
-                pd_error(obj, "AIFF writing 32 bit float not available");
-                goto usage;
-            }
-        }
-        else if (endianness == 0)
-            bigendian = 0;
+        if (endianness == 0)
+            bigendian = 0; /* manual override */
     }
     else if (filetype == FILETYPE_CAF) /* default to big endian */
     {

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -164,29 +164,30 @@ int soundfile_aiff_hasextension(const char *filename, size_t size);
 
 /* ------------------------- CAFF ------------------------- */
 
-/// returns min CAFF header size in bytes
+    /** returns min CAFF header size in bytes */
 int soundfile_caff_headersize();
 
-/// returns 1 if buffer is the beginning of an CAFF header
-int soundfile_caff_isheader(const char *buf, long size);
+    /** returns 1 if buffer is the beginning of an CAFF header */
+int soundfile_caff_isheader(const char *buf, size_t size);
 
-/// read CAFF header from a file into info, assumes fd is at the beginning
-/// result should place fd at beginning of audio data
-/// returns 1 on success or 0 on error
+    /** read CAFF header from a file into info, assumes fd is at the beginning
+        result should place fd at beginning of audio data
+        returns 1 on success or 0 on error */
 int soundfile_caff_readheader(int fd, t_soundfile_info *info);
 
-/// write header to beginning of an open file from an info struct
-/// returns header bytes written or -1 on error
+    /** write header to beginning of an open file from an info struct
+        returns header bytes written or -1 on error */
 int soundfile_caff_writeheader(int fd, const t_soundfile_info *info,
-    long nframes);
+    size_t nframes);
 
-/// update file header data size, assumes fd is at the beginning
-/// returns 1 on success or 0 on error
+    /** update file header data size, assumes fd is at the beginning
+        returns 1 on success or 0 on error */
 int soundfile_caff_updateheader(int fd, const t_soundfile_info *info,
-    long nframes);
+    size_t nframes);
 
-/// returns 1 if the filename has an CAFF extension (.caf, .CAF) otherwise 0
-int soundfile_caff_hasextension(const char *filename, long size);
+    /** returns 1 if the filename has a CAFF extension
+        (.caf, .CAF) otherwise 0 */
+int soundfile_caff_hasextension(const char *filename, size_t size);
 
 /* ------------------------- NEXT ------------------------- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -99,16 +99,13 @@ uint32_t swap4(uint32_t n, int doit);
 int32_t swap4s(int32_t n, int doit);
 
     /** swap 2 bytes and return if doit = 1, otherwise return n */
-uint16_t swap2(uint32_t n, int doit);
+uint16_t swap2(uint16_t n, int doit);
 
     /** swap a 4 byte string in place if do it = 1, otherewise do nothing */
-void swapstring(char *foo, int doit);
+void swapstring4(char *foo, int doit);
 
     /** swap an 8 byte string in place if do it = 1, otherwise do nothing */
 void swapstring8(char *foo, int doit);
-
-    /** swap an 8 byte double and return if doit = 1, otherwise return n */
-double swapdouble(double n, int doit);
 
 /* ------------------------- WAVE ------------------------- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -188,7 +188,7 @@ int soundfile_caf_hasextension(const char *filename, size_t size);
 
 /* ------------------------- NEXT ------------------------- */
 
-/// returns min NEXT header size in bytes
+    /** returns min NEXT header size in bytes */
 int soundfile_next_headersize();
 
     /** returns 1 if buffer is the beginning of a NEXT header */

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -159,32 +159,32 @@ int soundfile_aiff_updateheader(int fd, const t_soundfile_info *info,
             (.aif, .aiff, .aifc, .AIF, .AIFF, or .AIFC) otherwise 0 */
 int soundfile_aiff_hasextension(const char *filename, size_t size);
 
-/* ------------------------- CAFF ------------------------- */
+/* ------------------------- CAF -------------------------- */
 
-    /** returns min CAFF header size in bytes */
-int soundfile_caff_headersize();
+    /** returns min CAF header size in bytes */
+int soundfile_caf_headersize();
 
-    /** returns 1 if buffer is the beginning of an CAFF header */
-int soundfile_caff_isheader(const char *buf, size_t size);
+    /** returns 1 if buffer is the beginning of an CAF header */
+int soundfile_caf_isheader(const char *buf, size_t size);
 
-    /** read CAFF header from a file into info, assumes fd is at the beginning
+    /** read CAF header from a file into info, assumes fd is at the beginning
         result should place fd at beginning of audio data
         returns 1 on success or 0 on error */
-int soundfile_caff_readheader(int fd, t_soundfile_info *info);
+int soundfile_caf_readheader(int fd, t_soundfile_info *info);
 
     /** write header to beginning of an open file from an info struct
         returns header bytes written or -1 on error */
-int soundfile_caff_writeheader(int fd, const t_soundfile_info *info,
+int soundfile_caf_writeheader(int fd, const t_soundfile_info *info,
     size_t nframes);
 
     /** update file header data size, assumes fd is at the beginning
         returns 1 on success or 0 on error */
-int soundfile_caff_updateheader(int fd, const t_soundfile_info *info,
+int soundfile_caf_updateheader(int fd, const t_soundfile_info *info,
     size_t nframes);
 
-    /** returns 1 if the filename has a CAFF extension
+    /** returns 1 if the filename has a CAF extension
         (.caf, .CAF) otherwise 0 */
-int soundfile_caff_hasextension(const char *filename, size_t size);
+int soundfile_caf_hasextension(const char *filename, size_t size);
 
 /* ------------------------- NEXT ------------------------- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -13,6 +13,13 @@
 #include <string.h>
 #include <limits.h>
 
+#ifdef _LARGEFILE64_SOURCE
+#define lseek lseek64
+#define off_t __off64_t
+#elif defined(_MSC_VER)
+#define off_t long
+#endif
+
 // should be large enough for all file type min sizes
 #define SFHDRBUFSIZE 128
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -27,12 +27,12 @@
 /// soundfile format info
 typedef struct _soundfile_info
 {
-    int i_samplerate;     ///< read: file sr, write: pd sr
-    int i_nchannels;      ///< number of channels
-    int i_bytespersample; ///< 2: 16 bit, 3: 24 bit, 4: 32 bit
-    int i_headersize;     ///< header size in bytes
-    int i_bigendian;      ///< 1: big : 1, 0: little
-    long i_bytelimit;     ///< max number of data bytes to read/write
+    int i_samplerate;      ///< read: file sr, write: pd sr
+    int i_nchannels;       ///< number of channels
+    int i_bytespersample;  ///< 2: 16 bit, 3: 24 bit, 4: 32 bit
+    int i_headersize;      ///< header size in bytes
+    int i_bigendian;       ///< 1: big : 1, 0: little
+    long long i_bytelimit; ///< max number of data bytes to read/write
 } t_soundfile_info;
 
 /// clear soundfile info struct to defaults
@@ -56,14 +56,26 @@ int soundfile_info_swap(const t_soundfile_info *src);
 /// FIXME: should this be renamed or moved?
 int sys_isbigendian(void);
 
+/// swap 8 bytes and return if doit = 1, otherwise return n
+uint64_t swap8(uint64_t n, int doit);
+
+/// swap a 64 bit signed int and return if do it = 1, otherwise return n
+int64_t swap8s(int64_t n, int doit);
+
 /// swap 4 bytes and return if doit = 1, otherwise return n
 uint32_t swap4(uint32_t n, int doit);
 
 /// swap 2 bytes and return if doit = 1, otherwise return n
 uint16_t swap2(uint32_t n, int doit);
 
-/// swap a 4 byte string in place if do it = 1, otherewise do nothing
+/// swap a 4 byte string in place if do it = 1, otherwise do nothing
 void swapstring(char *foo, int doit);
+
+/// swap an 8 byte string in place if do it = 1, otherwise do nothing
+void swapstring8(char *foo, int doit);
+
+/// swap an 8 byte double and return if doit = 1, otherwise return n
+double swapdouble(double n, int doit);
 
 /* WAVE */
 
@@ -74,6 +86,7 @@ int soundfile_wave_headersize();
 int soundfile_wave_isheader(const char *buf, long size);
 
 /// read WAVE header from a file into info, assumes fd is at the beginning
+/// result should place fd at beginning of audio data
 /// returns 1 on success or 0 on error
 int soundfile_wave_readheader(int fd, t_soundfile_info *info);
 
@@ -100,6 +113,7 @@ int soundfile_aiff_headersize();
 int soundfile_aiff_isheader(const char *buf, long size);
 
 /// read AIFF header from a file into info, assumes fd is at the beginning
+/// result should place fd at beginning of audio data
 /// returns 1 on success or 0 on error
 int soundfile_aiff_readheader(int fd, t_soundfile_info *info);
 
@@ -117,6 +131,32 @@ int soundfile_aiff_updateheader(int fd, const t_soundfile_info *info,
 /// .AIFF) otherwise 0
 int soundfile_aiff_hasextension(const char *filename, long size);
 
+/* CAFF */
+
+/// returns min CAFF header size in bytes
+int soundfile_caff_headersize();
+
+/// returns 1 if buffer is the beginning of an CAFF header
+int soundfile_caff_isheader(const char *buf, long size);
+
+/// read CAFF header from a file into info, assumes fd is at the beginning
+/// result should place fd at beginning of audio data
+/// returns 1 on success or 0 on error
+int soundfile_caff_readheader(int fd, t_soundfile_info *info);
+
+/// write header to beginning of an open file from an info struct
+/// returns header bytes written or -1 on error
+int soundfile_caff_writeheader(int fd, const t_soundfile_info *info,
+    long nframes);
+
+/// update file header data size, assumes fd is at the beginning
+/// returns 1 on success or 0 on error
+int soundfile_caff_updateheader(int fd, const t_soundfile_info *info,
+    long nframes);
+
+/// returns 1 if the filename has an CAFF extension (.caf, .CAF) otherwise 0
+int soundfile_caff_hasextension(const char *filename, long size);
+
 /* NEXT */
 
 /// returns min NEXT header size in bytes
@@ -126,6 +166,7 @@ int soundfile_next_headersize();
 int soundfile_next_isheader(const char *buf, long size);
 
 /// read NEXT header from a file into info, assumes fd is at the beginning
+/// result should place fd at beginning of audio data
 /// returns 1 on success or 0 on error
 int soundfile_next_readheader(int fd, t_soundfile_info *info);
 

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -29,7 +29,7 @@
   this implementation:
 
   * supports AIFF and AIFF-C
-  * writes AIFF-C header for 32 bit float, unless pd compatibility < 0.51
+  * implicitly writes AIFF-C header for 32 bit float (see below)
   * implements chunks: common, data, version (AIFF-C)
   * ignores chunks: marker, instrument, comment, name, author, copyright,
                     annotation, audio recording, MIDI data, application, ID3
@@ -39,9 +39,10 @@
   * does not block align sound data
   * sample format: 16 and 24 bit lpcm, 32 bit float, no 32 bit lpcm
 
-*/
+  Pd versions < 0.51 did *not* read or write AIFF files with a 32 bit float
+  sample format.
 
-/* TODO: allow explicit AIFF-C format via some option? */
+*/
 
     /* explicit byte sizes, sizeof(struct) may return alignment-padded values */
 #define AIFFCHUNKSIZE  8 /**< chunk header only */
@@ -408,10 +409,6 @@ int soundfile_aiff_writeheader(int fd, const t_soundfile_info *info,
     };
     t_datachunk data = {"SSND", swap4s(8, swap), 0, 0};
 
-        /* older versions can't read AIFF-C */
-    if (isaiffc && pd_compatibilitylevel < 51)
-        isaiffc = 0;
-
         /* file header */
     if (isaiffc)
         strncpy(head.h_formtype, "AIFC", 4);
@@ -485,10 +482,6 @@ int soundfile_aiff_updateheader(int fd, const t_soundfile_info *info,
            headersize = AIFFHEADSIZE, commsize = AIFFCOMMSIZE;
     uint32_t uinttmp;
     int32_t inttmp;
-
-        /* older versions can't read AIFF-C */
-    if (isaiffc && pd_compatibilitylevel < 51)
-        isaiffc = 0;
 
     if (isaiffc)
     {

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -30,6 +30,8 @@
   * ignores any chunks after finding the data chunk
   * sample format: 16 and 24 bit lpcm, 32 bit float, no 32 bit lpcm
 
+  Pd versions < 0.51 did *not* read or write CAF files.
+
 */
 
     /* explicit byte sizes, sizeof(struct) can return alignment padded values */

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -243,10 +243,10 @@ int soundfile_caf_readheader(int fd, t_soundfile_info *info)
     while (1)
     {
         int64_t chunksize = caf_getchunksize(chunk, swap);
-        off_t seekto = headersize + chunksize, seekout;
+        off_t seekto = headersize + CAFCHUNKSIZE + chunksize, seekout;
         if (seekto & 1) /* pad up to even number of bytes */
             seekto++;
-         post("chunk %.4s seek %d", chunk->c_id, seekto); 
+        /* post("chunk %.4s seek %d", chunk->c_id, seekto); */
         if (!strncmp(chunk->c_id, "data", 4))
         {
                 /* sound data chunk */

--- a/src/d_soundfile_caff.c
+++ b/src/d_soundfile_caff.c
@@ -14,111 +14,145 @@
   * RIFF variant with sections split into data "chunks"
   * chunk data is big-endian
   * sound data can be big or little endian (set in desc fmtflags)
-  * header is immediately followed by audio description chunk
-  * audio data chunk:
-     - size > 0: can be anywhere after audio description chunk
+  * header is immediately followed by description chunk
+  * data chunk:
+     - size > 0: can be anywhere after the description chunk
      - size -1: last chunk in the file,
-                size = file size - (audio data chunk pos + 12)
+                size = file size - (data chunk pos + 12)
 
   this implementation:
 
   * supports CAFF version 1 only
-  * implements chunks: audio description, audio data 
+  * implements chunks: description, data
   * ignores chunks: packet table, magic cookie, strings, marker, region,
                     instrument, MIDI, overview, peak, edit comments,
                     information, unique material identifier, user-defined
-  * ignores any chunks after finding the audio data chunk
+  * ignores any chunks after finding the data chunk
   * sample format: 16 and 24 bit lpcm, 32 bit float, no 32 bit lpcm
 
 */
 
     /* explicit byte sizes, sizeof(struct) can return alignment padded values */
-#define CAFFHDRSIZE      8 /**< chunk header only */
-#define CAFFCHUNKSIZE   12 /**< sizeof(t_caff) returns 16 on 64 systems... */
-#define CAFFDESCSIZE    32 /**< chunk data only */
-#define CAFFDATASIZEMIN  4 /** chunk edit count data */
+#define CAFFHEADSIZE     8 /**< chunk header only */
+#define CAFFCHUNKSIZE   12 /**< chunk header and format */
+#define CAFFDESCSIZE    44 /**< chunk header and data */
+#define CAFFDATASIZE    16 /**< chunk header and edit count data */
 
-    /** Apple-style audio description format flags */
+#define CAFFMAXBYTES SFMAXBYTES /** max signed 64 bit size */
+
+    /** Apple-style description format flags */
 enum {
     kCAFLinearPCMFormatFlagIsFloat        = (1L << 0),
     kCAFLinearPCMFormatFlagIsLittleEndian = (1L << 1)
 };
 
+    /** basic chunk header, 12 bytes
+        note: size is split to avoid struct alignment padding */
+typedef struct _chunk {
+    char c_id[4];                /**< chunk id                        */
+    uint8_t c_size[8];           /**< chunk data length, int64_t      */
+} t_chunk;
+
     /** file header, 8 bytes */
-typedef struct _caff {
-    char c_type[4];                /**< file type "caff"                */
-    uint16_t c_version;            /**< file version, probably 1        */
-    uint16_t c_flags;              /**< format flags, 0 for CAF v1      */
-} t_caff;
+typedef struct _head {
+    char h_id[4];                /**< file id "caff"                  */
+    uint16_t h_version;          /**< file version, probably 1        */
+    uint16_t h_flags;            /**< format flags, 0 for CAF v1      */
+} t_head;
 
-    /** chunk, 12 bytes */
-typedef struct _caff_chunk {
-    char cc_type[4];               /**< chunk type, 4 letter char code  */
-    int64_t cc_size;               /**< length of chunk data in bytes   */
-} t_caff_chunk;
+    /** description chunk, 44 bytes
+        note: size and samplerate are split to avoid struct alignment padding */
+typedef struct _descchunk {
+    char ds_id[4];               /**< chunk id "desc"                 */
+    uint8_t ds_size[8];          /**< chunk data length, int64_t      */
+    uint8_t ds_samplerate[8];    /**< sample rate, double             */
+    char ds_fmtid[4];            /**< format id, 4 letter char code   */
+    uint32_t ds_fmtflags;        /**< format flags, set 0 for "none"  */
+    uint32_t ds_bytesperpacket;  /**< bytes per packet                */
+    uint32_t ds_framesperpacket; /**< for lpcm, 1 packet = 1 frame    */
+    uint32_t ds_nchannels;       /**< number of channels              */
+    uint32_t ds_bitsperchannel;  /**< bits per chan in 1 sample frame */
+} t_descchunk;
 
-    /** audio description chunk data section, 32 bytes */
-typedef struct _caff_desc {
-    double cd_samplerate;          /**< sample rate, 64 bit float       */
-    char cd_fmtid[4];              /**< format id, 4 letter char code   */
-    uint32_t cd_fmtflags;          /**< format flags, set 0 for "none"  */
-    uint32_t cd_bytesperpacket;    /**< bytes per packet                */
-    uint32_t cd_framesperpacket;   /**< for lpcm, 1 packet = 1 frame    */
-    uint32_t cd_nchannels;         /**< number of channels              */
-    uint32_t cd_bitsperchannel;    /**< bits per chan in 1 sample frame */
-} t_caff_desc;
-
-    /** audio data chunk data section, min 4 bytes */
-typedef struct _caff_data {
-    uint32_t cd_editcount;         /**< edit count, set 0 for none      */
-    uint8_t cd_data[0];            /**< sound data starts here          */
-} t_caff_data;
+    /** data chunk, min 16 bytes
+        note: size is split to avoid struct alignment padding */
+typedef struct _datachunk {
+    char dc_id[4];               /**< chunk id "data"                 */ 
+    uint8_t dc_size[8];          /**< chunk data length, int64_t      */
+    uint32_t dc_editcount;       /**< edit count, set 0 for none      */
+} t_datachunk;
 
 /* ----- helpers ----- */
 
-    /** read raw byte buf into head */
-static void caff_readhead(const char *buf, t_caff *head, int swap);
+static int64_t caff_getchunksize(const t_chunk *chunk, int swap)
+{
+    int64_t size = 0;
+    memcpy(&size, chunk->c_size, 8);
+    return swap8s(size, swap);
+}
 
-    /** write head into raw byte buf */
-static void caff_writehead(char *buf, const t_caff *head, int swap);
+static void caff_setchunksize(t_chunk *chunk, int64_t size, int swap)
+{
+    size = swap8s(size, swap);
+    memcpy(chunk->c_size, &size, 8);
+}
+
+static double caff_getsamplerate(const t_descchunk *desc, int swap)
+{
+    double sr = 0;
+    memcpy(&sr, desc->ds_samplerate, 8);
+    swapstring8((char *)&sr, swap);
+    return sr;
+}
+
+static void caff_setsamplerate(t_descchunk *desc, double sr, int swap)
+{
+    memcpy(desc->ds_samplerate, &sr, 8);
+    swapstring8((char *)desc->ds_samplerate, swap);
+}
 
     /** post head info for debugging */
-static void caff_posthead(const t_caff *head);
-
-    /** read raw byte buf into chunk */
-static void caff_readchunk(const char *buf, t_caff_chunk *chunk, int swap);
-
-    /** write chunk into raw byte buf */
-static void caff_writechunk(char *buf, const t_caff_chunk *chunk, int swap);
+static void caff_posthead(const t_head *head, int swap)
+{
+    post("%.4s", head->h_id);
+    post("  version %d", swap2(head->h_version, swap));
+    post("  flags %d", swap2(head->h_flags, swap));
+}
 
     /** post chunk info for debugging */
-static void caff_postchunk(const t_caff_chunk *chunk);
-
-    /** read raw byte buf into desc */
-static void caff_readdesc(const char *buf, t_caff_desc *desc, int swap);
-
-    /** write desc into raw byte buf */
-static void caff_writedesc(char *buf, const t_caff_desc *desc, int swap);
+static void caff_postchunk(const t_chunk *chunk, int swap)
+{
+    post("%.4s %" PRId64, chunk->c_id, caff_getchunksize(chunk, swap));
+}
 
     /** post desc info for debugging */
-static void caff_postdesc(const t_caff_desc *desc);
-
-    /** read raw byte buf into data header, currently edit count only */
-static void caff_readdata(const char *buf, t_caff_data *data, int swap);
-
-    /** write data header into raw byte buf, currently edit count only */
-static void caff_writedata(char *buf, const t_caff_data *data, int swap);
+static void caff_postdesc(const t_descchunk *desc, int swap)
+{
+    uint32_t fmtflags = swap4(desc->ds_fmtflags, swap);
+    caff_postchunk((t_chunk *)desc, swap);
+    post("  sample rate %g", caff_getsamplerate(desc, swap));
+    post("  fmt id %.4s", desc->ds_fmtid);
+    post("  fmt flags %d (%s %s)", fmtflags,
+        (fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian ? "little" : "big"),
+        (fmtflags & kCAFLinearPCMFormatFlagIsFloat ? "float" : "int"));
+    post("  bytes per packet %d", swap4(desc->ds_bytesperpacket, swap));
+    post("  frames per packet %d", swap4(desc->ds_framesperpacket, swap));
+    post("  channels %d", swap4(desc->ds_nchannels, swap));
+    post("  bits per channel %d", swap4(desc->ds_bitsperchannel, swap));
+}
 
     /** post data header info for debugging, currently edit count only */
-static void caff_postdata(const t_caff_data *data);
+static void caff_postdata(const t_datachunk *data, int swap)
+{
+    caff_postchunk((t_chunk *)data, swap);
+    post("  edit count %d", swap4(data->dc_editcount, swap));
+}
 
 /* ------------------------- CAFF ------------------------- */
 
 int soundfile_caff_headersize()
 {
-    return CAFFHDRSIZE +                    /* file header */
-           CAFFCHUNKSIZE + CAFFDESCSIZE +   /* audio desc chunk */
-           CAFFCHUNKSIZE + CAFFDATASIZEMIN; /* audio data chunk */
+    return CAFFHEADSIZE + CAFFDESCSIZE + CAFFDATASIZE;
 }
 
 int soundfile_caff_isheader(const char *buf, size_t size)
@@ -129,98 +163,115 @@ int soundfile_caff_isheader(const char *buf, size_t size)
 
 int soundfile_caff_readheader(int fd, t_soundfile_info *info)
 {
-    int nchannels = 1, bytespersample = 2, samplerate = 44100,
-        bigendian = 1, swap = !sys_isbigendian();
-    off_t headersize = CAFFHDRSIZE;
-    ssize_t bytesread = 0, bytelimit = SFMAXBYTES;
-    char buf[SFHDRBUFSIZE];
-    t_caff head = {0};
-    t_caff_chunk chunk = {0};
-    t_caff_desc desc = {0};
+    int nchannels = 1, bytespersample = 2, bigendian = 1,
+        fmtflags, bitspersample, swap = !sys_isbigendian();
+    double samplerate = 44100;
+    off_t headersize = CAFFHEADSIZE + CAFFDESCSIZE;
+    ssize_t bytelimit = CAFFMAXBYTES;
+    union
+    {
+        char b_c[SFHDRBUFSIZE];
+        t_head b_head;
+        t_chunk b_chunk;
+        t_descchunk b_descchunk;
+        t_datachunk b_datachunk;
+    } buf = {0};
+    t_head *head = &buf.b_head;
+    t_chunk *chunk = &buf.b_chunk;
+    t_descchunk *desc = &buf.b_descchunk;
 
         /* file header */
-    if (read(fd, buf, soundfile_caff_headersize()) < headersize)
+    if (soundfile_readbytes(fd, 0, buf.b_c, headersize) < headersize)
         return 0;
-    caff_readhead(buf, &head, swap);
-    if (strncmp(head.c_type, "caff", 4))
+    if (strncmp(head->h_id, "caff", 4))
         return 0;
-    if (head.c_version != 1)
+    if (swap2(head->h_version, swap) != 1)
     {
-        error("CAFF version %d unsupported", head.c_version);
+        error("CAFF version %d unsupported", swap2(head->h_version, swap));
         return 0;
     }
-    if (head.c_version == 1 && head.c_flags != 0)
+    if (swap2(head->h_flags, swap) != 0)
     {
+            /* current spec says these should be empty */
         error("CAFF version 1 format flags invalid");
         return 0;
     }
     if (sys_verbose)
-        caff_posthead(&head);  
+        caff_posthead(head, swap);
 
-        /* first chunk must be audio description */
-    caff_readchunk(buf + headersize, &chunk, swap);
-    if (sys_verbose)
-        caff_postchunk(&chunk);
-    if (strncmp(chunk.cc_type, "desc", 4))
+        /* copy the first chunk header to beginning of buffer */
+    memcpy(buf.b_c, buf.b_c + CAFFHEADSIZE, CAFFDESCSIZE);
+    headersize = CAFFHEADSIZE;
+
+        /* first chunk must be description */
+    if (strncmp(desc->ds_id, "desc", 4))
         return 0;
-    headersize += CAFFCHUNKSIZE;
-    caff_readdesc(buf + headersize, &desc, swap);
     if (sys_verbose)
-        caff_postdesc(&desc);
-    headersize += CAFFDESCSIZE;
-    if (strncmp(desc.cd_fmtid, "lpcm", 4))
+        caff_postdesc(desc, swap);
+    if (strncmp(desc->ds_fmtid, "lpcm", 4))
     {
-        error("CAFF format \"%.4s\" not supported", desc.cd_fmtid);
+        error("CAFF format \"%.4s\" not supported", desc->ds_fmtid);
         return 0;
     }
-    nchannels = desc.cd_nchannels;
-    switch(desc.cd_bitsperchannel)
+    nchannels = swap4(desc->ds_nchannels, swap);
+    fmtflags = swap4(desc->ds_fmtflags, swap);
+    bitspersample = swap4(desc->ds_bitsperchannel, swap);
+    switch (bitspersample)
     {
         case 16: bytespersample = 2; break;
         case 24: bytespersample = 3; break;
         case 32: bytespersample = 4; break;
-        default: return 0;
+        default:
+            error("CAFF %d bit samples not supported ", bitspersample);
+            return 0;
     }
-    if (bytespersample == 4 &&
-        !(desc.cd_fmtflags & kCAFLinearPCMFormatFlagIsFloat))
+    if (bytespersample == 4 && !(fmtflags & kCAFLinearPCMFormatFlagIsFloat))
     {
         error("CAFF 32 bit int not supported");
         return 0;
     }
-    bigendian = !(desc.cd_fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian);
-    samplerate = desc.cd_samplerate;
+    bigendian = !(fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian);
+    samplerate = caff_getsamplerate(desc, swap);
+    headersize += CAFFDESCSIZE;
 
-        /* read chunks in loop until we get to the audio data */
+        /* prepare second chunk */
+    if (soundfile_readbytes(fd, headersize, buf.b_c,
+                            CAFFCHUNKSIZE) < CAFFCHUNKSIZE)
+        return 0;
+
+        /* read chunks in loop until we find the sound data chunk */
     while (1)
     {
-        long long seekto = headersize, seekout;
+        int64_t chunksize = caff_getchunksize(chunk, swap);
+        off_t seekto = headersize + chunksize, seekout;
         if (seekto & 1) /* pad up to even number of bytes */
             seekto++;
-        seekout = (long)lseek(fd, seekto, SEEK_SET);
-        if (seekout != seekto)
-            return 0;
-        if (read(fd, buf, CAFFCHUNKSIZE) < CAFFCHUNKSIZE)
-            return 0;
-        caff_readchunk(buf, &chunk, swap);
-        if (chunk.cc_size == 0)
-            return 0;
-        if (sys_verbose)
-            caff_postchunk(&chunk);
-        if (!strncmp(chunk.cc_type, "data", 4))
+         post("chunk %.4s seek %d", chunk->c_id, seekto); 
+        if (!strncmp(chunk->c_id, "data", 4))
         {
-            /* audio data chunk data section starts with 4 byte edit count */
+                /* sound data chunk */
             if (sys_verbose)
             {
-                t_caff_data data;
-                caff_readdata(buf + CAFFCHUNKSIZE, &data, swap);
-                caff_postdata(&data);
+                t_datachunk *data = &buf.b_datachunk;
+                if (soundfile_readbytes(fd, headersize + CAFFCHUNKSIZE,
+                                        buf.b_c + CAFFCHUNKSIZE, 4) < 4)
+                    return 0;
+                caff_postdata(data, swap);
             }
-            bytelimit = chunk.cc_size - CAFFDATASIZEMIN;
-            headersize += CAFFCHUNKSIZE + CAFFDATASIZEMIN;
+            bytelimit = chunksize - 4; /* subtract edit count */
+            headersize += CAFFDATASIZE;
             break;
         }
         else
-            headersize += CAFFCHUNKSIZE + chunk.cc_size;
+        {
+                /* everything else */
+            if (sys_verbose)
+                caff_postchunk(chunk, swap);
+        }
+        headersize = seekto;
+        if (soundfile_readbytes(fd, seekto, buf.b_c,
+                                CAFFCHUNKSIZE) < CAFFCHUNKSIZE)
+            return 0;
     }
 
         /* copy sample format back to caller */
@@ -240,71 +291,67 @@ int soundfile_caff_writeheader(int fd, const t_soundfile_info *info,
 {
     int swap = !sys_isbigendian();
     size_t datasize = nframes * info->i_bytesperframe;
-    off_t headersize = CAFFHDRSIZE;
+    off_t headersize = 0;
     ssize_t byteswritten = 0;
+    uint32_t uinttmp = 0;
     char buf[SFHDRBUFSIZE] = {0};
-
-    t_caff head = { "caff", 1, 0 };
-    t_caff_chunk chunk = { "desc", (int64_t)CAFFDESCSIZE };
-    t_caff_desc desc = {
-        (double)info->i_samplerate,          /* sample rate */
-        "lpcm",                              /* format id */
-        0,                                   /* format flags */
-        (uint32_t)info->i_bytesperframe,     /* bytes per packet */
-        1,                                   /* frames per packet */
-        (uint32_t)info->i_nchannels,         /* channels */
-        (uint32_t)info->i_bytespersample * 8 /* bits per channel */
-    };
-    t_caff_data data = {0};
+    t_head head = {"caff", swap2(1, swap), 0};
+    t_descchunk desc = {"desc", 0, 0};
+    t_datachunk data = {"data", 0, 0};
 
         /* file header */
-    caff_writehead(buf, &head, swap);
-    if (sys_verbose)
-        caff_posthead(&head);
+    memcpy(buf + headersize, &head, CAFFHEADSIZE);
+    headersize += CAFFHEADSIZE;
 
-        /* audio description chunk */
-    caff_writechunk(buf + headersize, &chunk, swap);
-    if (sys_verbose)
-        caff_postchunk(&chunk);
-    headersize += CAFFCHUNKSIZE;
+        /* description chunk */
+    caff_setchunksize((t_chunk *)&desc, CAFFDESCSIZE, swap);
+    caff_setsamplerate(&desc, info->i_samplerate, swap);
+    strncpy(desc.ds_fmtid, "lpcm", 4);
     if (info->i_bytespersample == 4)
-        desc.cd_fmtflags |= kCAFLinearPCMFormatFlagIsFloat;
+        uinttmp |= kCAFLinearPCMFormatFlagIsFloat;
     if (!info->i_bigendian)
-        desc.cd_fmtflags |= kCAFLinearPCMFormatFlagIsLittleEndian;
-    caff_writedesc(buf + headersize, &desc, swap);
-    if (sys_verbose)
-        caff_postdesc(&desc);
+        uinttmp |= kCAFLinearPCMFormatFlagIsLittleEndian;
+    desc.ds_fmtflags = swap4(uinttmp, swap);
+    desc.ds_bytesperpacket = swap4(info->i_bytesperframe, swap);
+    desc.ds_framesperpacket = swap4(1, swap);
+    desc.ds_nchannels = swap4(info->i_nchannels, swap);
+    desc.ds_bitsperchannel = swap4(info->i_bytespersample * 8, swap);
+    memcpy(buf + headersize, &desc, CAFFDESCSIZE);
     headersize += CAFFDESCSIZE;
 
-        /* audio data chunk */
-    strncpy(chunk.cc_type, "data", 4);
-    chunk.cc_size = CAFFDATASIZEMIN + datasize;
-    caff_writechunk(buf + headersize, &chunk, swap);
-    if (sys_verbose)
-        caff_postchunk(&chunk);
-    headersize += CAFFCHUNKSIZE;
-    caff_writedata(buf + headersize, &data, swap);
-    if (sys_verbose)
-        caff_postdata(&data);
-    headersize += CAFFDATASIZEMIN;
+        /* data chunk */
+    caff_setchunksize((t_chunk *)&data, datasize + 4, swap);
+    memcpy(buf + headersize, &data, CAFFDATASIZE);
+    headersize += CAFFDATASIZE;
 
-    byteswritten = (int)write(fd, buf, headersize);
+    if (sys_verbose)
+    {
+        caff_posthead(&head, swap);
+        caff_postdesc(&desc, swap);
+        caff_postdata(&data, swap);
+    }
+
+    byteswritten = soundfile_writebytes(fd, 0, buf, headersize);
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
+    /** assumes chunk order: head desc data */
 int soundfile_caff_updateheader(int fd, const t_soundfile_info *info,
     size_t nframes)
 {
     int swap = !sys_isbigendian();
-    size_t datasize = (nframes *info->i_bytesperframe) + CAFFDATASIZEMIN;
-    off_t seekto = CAFFHDRSIZE + CAFFCHUNKSIZE + CAFFDESCSIZE + 4; /* cc_type */
+    int64_t datasize = swap8s((nframes * info->i_bytesperframe) + 4, swap);
 
-        /* audio data chunk data size */
-    if (lseek(fd, seekto, SEEK_SET) == 0)
+        /* data chunk size */
+    if (soundfile_writebytes(fd, CAFFHEADSIZE + CAFFDESCSIZE + 4, /* dc_id */
+                             (char *)&datasize, 8) < 8)
         return 0;
-    datasize = swap8s(datasize, swap);
-    if (write(fd, (char *)&datasize, 8) < 8)
-        return 0;
+
+    if (sys_verbose)
+    {
+        post("caff");
+        post("data %" PRId64, swap8s(datasize, swap));
+    }
 
     return 1;
 }
@@ -317,135 +364,4 @@ int soundfile_caff_hasextension(const char *filename, size_t size)
          !strncmp(filename + (len - 4), ".CAF", 4)))
         return 1;
     return 0;
-}
-
-/* ----- helpers ----- */
-
-static void caff_readhead(const char *buf, t_caff *head, int swap)
-{
-    memcpy(&head->c_type,    buf,     4);
-    memcpy(&head->c_version, buf + 4, 2);
-    memcpy(&head->c_flags,   buf + 6, 2);
-    if (swap)
-    {
-        head->c_version = swap2(head->c_version, 1);
-        head->c_flags = swap2(head->c_flags, 1);
-    }
-}
-
-static void caff_writehead(char *buf, const t_caff *head, int swap)
-{
-    uint16_t inttmp;
-    memcpy(buf, &head->c_type, 4);
-    
-    inttmp = swap2(head->c_version, swap);
-    memcpy(buf + 4, &inttmp, 2);
-
-    inttmp = swap2(head->c_flags, swap);
-    memcpy(buf + 6, &inttmp, 2);
-}
-
-static void caff_posthead(const t_caff *head)
-{
-    post("%.4s", head->c_type);
-    post("  version %d", head->c_version);
-    post("  flags %d", head->c_flags);
-}
-
-static void caff_readchunk(const char *buf, t_caff_chunk *chunk, int swap)
-{
-    memcpy(&chunk->cc_type, buf,     4);
-    memcpy(&chunk->cc_size, buf + 4, 8);
-    chunk->cc_size = swap8s(chunk->cc_size, swap);
-}
-
-static void caff_writechunk(char *buf, const t_caff_chunk *chunk, int swap)
-{
-    int64_t longtmp;
-
-    memcpy(buf, &chunk->cc_type, 4);
-
-    longtmp = swap8s(chunk->cc_size, swap);
-    memcpy(buf + 4, &longtmp, 8);
-}
-
-static void caff_postchunk(const t_caff_chunk *chunk)
-{
-    post("%.4s %" PRId64, chunk->cc_type, chunk->cc_size);
-}
-
-static void caff_readdesc(const char *buf, t_caff_desc *desc, int swap)
-{
-    memcpy(&desc->cd_samplerate,      buf,      8);
-    memcpy(&desc->cd_fmtid,           buf +  8, 4);
-    memcpy(&desc->cd_fmtflags,        buf + 12, 4);
-    memcpy(&desc->cd_bytesperpacket,  buf + 16, 4);
-    memcpy(&desc->cd_framesperpacket, buf + 20, 4);
-    memcpy(&desc->cd_nchannels,       buf + 24, 4);
-    memcpy(&desc->cd_bitsperchannel,  buf + 28, 4);
-    if (swap) 
-    {
-        desc->cd_samplerate = swapdouble(desc->cd_samplerate, 1);
-        desc->cd_fmtflags = swap4(desc->cd_fmtflags, 1);
-        desc->cd_bytesperpacket = swap4(desc->cd_bytesperpacket, 1);
-        desc->cd_framesperpacket = swap4(desc->cd_framesperpacket, 1);
-        desc->cd_nchannels = swap4(desc->cd_nchannels, 1);
-        desc->cd_bitsperchannel = swap4(desc->cd_bitsperchannel, 1);
-    }
-}
-
-static void caff_writedesc(char *buf, const t_caff_desc *desc, int swap)
-{
-    double doubletmp;
-    uint32_t inttmp;
-
-    doubletmp = swapdouble(desc->cd_samplerate, swap);
-    memcpy(buf, &doubletmp, 8);
-
-    memcpy(buf + 8, &desc->cd_fmtid, 4);
-
-    inttmp = swap4(desc->cd_fmtflags, swap);
-    memcpy(buf + 12, &inttmp, 4);
-
-    inttmp = swap4(desc->cd_bytesperpacket, swap);
-    memcpy(buf + 16, &inttmp, 4);
-
-    inttmp = swap4(desc->cd_framesperpacket, swap);
-    memcpy(buf + 20, &inttmp, 4);
-
-    inttmp = swap4(desc->cd_nchannels, swap);
-    memcpy(buf + 24, &inttmp, 4);
-
-    inttmp = swap4(desc->cd_bitsperchannel, swap);
-    memcpy(buf + 28, &inttmp, 4);
-}
-
-static void caff_postdesc(const t_caff_desc *desc)
-{
-    post("  sample rate %g", desc->cd_samplerate);
-    post("  fmt id %.4s", desc->cd_fmtid);
-    post("  fmt flags %u", desc->cd_fmtflags);
-    post("  bytes per packet %u", desc->cd_bytesperpacket);
-    post("  frames per packet %u", desc->cd_framesperpacket);
-    post("  channels %u", desc->cd_nchannels);
-    post("  bits per channel %u", desc->cd_bitsperchannel);
-}
-
-static void caff_readdata(const char *buf, t_caff_data *data, int swap)
-{
-    memcpy(&data->cd_editcount, buf, 4);
-    if (swap)
-        data->cd_editcount = swap4(data->cd_editcount, 1);
-}
-
-static void caff_writedata(char *buf, const t_caff_data *data, int swap)
-{
-    uint32_t inttmp;
-    inttmp = swap4(data->cd_editcount, swap);
-    memcpy(buf, &inttmp, 4);
-}
-
-static void caff_postdata(const t_caff_data *data)
-{
-    post("  edit count %u", data->cd_editcount);
 }

--- a/src/d_soundfile_caff.c
+++ b/src/d_soundfile_caff.c
@@ -1,0 +1,445 @@
+/* Copyright (c) 2020 Dan Wilcox.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* ref: https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_spec/CAF_spec.html */
+
+#include "d_soundfile.h"
+#include "s_stuff.h" /* for sys_verbose */
+#include <math.h>
+#include <inttypes.h>
+
+/* the CAFF header (Core Audio Format File)
+
+  * chunk data is big-endian
+  * audio data can be big or little endian (set in desc fmt_flags)
+  * header is immediately followed by audio description chunk
+  * audio data chunk:
+     - size > 0: can be anywhere after audio description chunk
+     - size -1: last chunk in the file,
+                size = file size - (audio data chunk pos + 12)
+
+  this implementation:
+
+  * supports CAFF version 1 only
+  * implements chunks: audio description, audio data 
+  * ignores chunks: packet table, magic cookie, strings, marker, region,
+                    instrument, MIDI, overview, peak, edit comments,
+                    information, unique material identifier, user-defined
+  * ignores any chunks after finding the audio data chunk
+  * lpcm samples only, no 32 bit int samples
+
+*/
+
+/* file header, 8 bytes */
+typedef struct _caff {
+    char c_type[4];                /* file type "caff"                */
+    uint16_t c_version;            /* file version, probably 1        */
+    uint16_t c_flags;              /* format flags, 0 for CAF v1      */
+} t_caff;
+
+/* chunk, 12 bytes */
+typedef struct _caff_chunk {
+    char cc_type[4];               /* chunk type, 4 letter char code  */
+    int64_t cc_size;               /* length of chunk data in bytes   */
+} t_caff_chunk;
+
+/* audio description chunk data section, 32 bytes */
+typedef struct _caff_desc {
+    double cd_samplerate;          /* sample rate, 64 bit float       */
+    char cd_fmtid[4];              /* format id, 4 letter char code   */
+    uint32_t cd_fmtflags;          /* format flags, set 0 for "none"  */
+    uint32_t cd_bytesperpacket;    /* bytes per packet                */
+    uint32_t cd_framesperpacket;   /* for lpcm, 1 packet = 1 frame    */
+    uint32_t cd_nchannels;         /* number of channels              */
+    uint32_t cd_bitsperchannel;    /* bits per chan in 1 sample frame */
+} t_caff_desc;
+
+/* audio data chunk data section, min 4 bytes */
+typedef struct _caff_data {
+    uint32_t cd_editcount;         /* edit count, set 0 for none      */
+    uint8_t cd_data[0];            /* audio data starts here          */
+} t_caff_data;
+
+/* explicit byte sizes as sizeof(struct) can return alignment padded values */
+#define CAFFHDRSIZE      8
+#define CAFFCHUNKSIZE   12 /* sizeof(t_caff) returns 16 on 64 systems... */
+#define CAFFDESCSIZE    32
+#define CAFFDATASIZEMIN  4 /* edit count only */
+
+/* audio description format flags, Apple-style */
+enum {
+    kCAFLinearPCMFormatFlagIsFloat        = (1L << 0),
+    kCAFLinearPCMFormatFlagIsLittleEndian = (1L << 1)
+};
+
+/* helpers */
+
+/// read raw byte buf into head
+static void caff_readhead(const uint8_t *buf, t_caff *head, int swap);
+
+/// write head into raw byte buf
+static void caff_writehead(uint8_t *buf, const t_caff *head, int swap);
+
+/// post head info for debugging
+static void caff_posthead(const t_caff *head);
+
+/// read raw byte buf into chunk
+static void caff_readchunk(const uint8_t *buf, t_caff_chunk *chunk, int swap);
+
+/// write chunk into raw byte buf
+static void caff_writechunk(uint8_t *buf, const t_caff_chunk *chunk, int swap);
+
+/// post chunk info for debugging
+static void caff_postchunk(const t_caff_chunk *chunk);
+
+/// read raw byte buf into desc
+static void caff_readdesc(const uint8_t *buf, t_caff_desc *desc, int swap);
+
+/// write desc into raw byte buf
+static void caff_writedesc(uint8_t *buf, const t_caff_desc *desc, int swap);
+
+/// post desc info for debugging
+static void caff_postdesc(const t_caff_desc *desc);
+
+/// read raw byte buf into data header, currently edit count only
+static void caff_readdata(const uint8_t *buf, t_caff_data *data, int swap);
+
+/// write data header into raw byte buf, currently edit count only
+static void caff_writedata(uint8_t *buf, const t_caff_data *data, int swap);
+
+/// post data header info for debugging, currently edit count only
+static void caff_postdata(const t_caff_data *data);
+
+/* main functions */
+
+int soundfile_caff_headersize()
+{
+    return CAFFHDRSIZE +                    /* file header */
+           CAFFCHUNKSIZE + CAFFDESCSIZE +   /* audio desc chunk */
+           CAFFCHUNKSIZE + CAFFDATASIZEMIN; /* audio data chunk */
+}
+
+int soundfile_caff_isheader(const char *buf, long size)
+{
+    if (size < 4) return 0;
+    return !strncmp(buf, "caff", 4);
+}
+
+int soundfile_caff_readheader(int fd, t_soundfile_info *info)
+{
+    int nchannels = 1, bytespersample = 2, samplerate = 44100, bigendian = 1,
+        headersize = CAFFHDRSIZE, swap = !sys_isbigendian();
+    long bytesread = 0, bytelimit = SFMAXBYTES;
+    unsigned char buf[SFHDRBUFSIZE];
+    t_caff head = {0};
+    t_caff_chunk chunk = {0};
+    t_caff_desc desc = {0};
+
+        /* file header */
+    if (read(fd, buf, soundfile_caff_headersize()) < headersize)
+        return 0;
+    caff_readhead(buf, &head, swap);
+    if (strncmp(head.c_type, "caff", 4))
+        return 0;
+    if (head.c_version != 1)
+    {
+        error("CAFF version %d unsupported", head.c_version);
+        return 0;
+    }
+    if (head.c_version == 1 && head.c_flags != 0)
+    {
+        error("CAFF version 1 format flags invalid");
+        return 0;
+    }
+    if (sys_verbose)
+        caff_posthead(&head);  
+
+        /* first chunk must be audio description */
+    caff_readchunk(buf + headersize, &chunk, swap);
+    if (sys_verbose)
+        caff_postchunk(&chunk);
+    if (strncmp(chunk.cc_type, "desc", 4))
+        return 0;
+    headersize += CAFFCHUNKSIZE;
+    caff_readdesc(buf + headersize, &desc, swap);
+    if (sys_verbose)
+        caff_postdesc(&desc);
+    headersize += CAFFDESCSIZE;
+    if (strncmp(desc.cd_fmtid, "lpcm", 4)) {
+        error("CAFF format \"%.4s\" not supported", desc.cd_fmtid);
+        return 0;
+    }
+    nchannels = desc.cd_nchannels;
+    switch(desc.cd_bitsperchannel)
+    {
+        case 16: bytespersample = 2; break;
+        case 24: bytespersample = 3; break;
+        case 32: bytespersample = 4; break;
+        default: return 0;
+    }
+    if (bytespersample == 4 &&
+        !(desc.cd_fmtflags & kCAFLinearPCMFormatFlagIsFloat)) {
+        error("CAFF 32 bit int not supported");
+        return 0;
+    }
+    bigendian = !(desc.cd_fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian);
+    samplerate = desc.cd_samplerate;
+
+        /* read chunks in loop until we get to the audio data */
+    while (1)
+    {
+        long long seekto = headersize, seekout;
+        if (seekto & 1) /* pad up to even number of bytes */
+            seekto++;
+        seekout = (long)lseek(fd, seekto, SEEK_SET);
+        if (seekout != seekto)
+            return 0;
+        if (read(fd, buf, CAFFCHUNKSIZE) < CAFFCHUNKSIZE)
+            return 0;
+        caff_readchunk(buf, &chunk, swap);
+        if (chunk.cc_size == 0)
+            return 0;
+        if (sys_verbose)
+            caff_postchunk(&chunk);
+        if (!strncmp(chunk.cc_type, "data", 4))
+        {
+            // audio data chunk data section starts with 4 byte edit count
+            if (sys_verbose)
+            {
+                t_caff_data data;
+                caff_readdata(buf + CAFFCHUNKSIZE, &data, swap);
+                caff_postdata(&data);
+            }
+            bytelimit = chunk.cc_size - CAFFDATASIZEMIN;
+            headersize += CAFFCHUNKSIZE + CAFFDATASIZEMIN;
+            break;
+        }
+        else
+            headersize += CAFFCHUNKSIZE + chunk.cc_size;
+    }
+
+        /* copy sample format back to caller */
+    info->i_samplerate = samplerate;
+    info->i_nchannels = nchannels;
+    info->i_bytespersample = bytespersample;
+    info->i_headersize = headersize;
+    info->i_bytelimit = bytelimit;
+    info->i_bigendian = bigendian;
+
+    return 1;
+}
+
+int soundfile_caff_writeheader(int fd, const t_soundfile_info *info,
+    long nframes)
+{
+    int byteswritten = 0, headersize = CAFFHDRSIZE, swap = !sys_isbigendian(),
+        bytesperframe = soundfile_info_bytesperframe(info);
+    int64_t datasize = nframes * bytesperframe;
+    uint8_t buf[SFHDRBUFSIZE] = {0};
+
+    t_caff head = { "caff", 1, 0 };
+    t_caff_chunk chunk = { "desc", (int64_t)CAFFDESCSIZE };
+    t_caff_desc desc = {
+        (double)info->i_samplerate,          /* sample rate */
+        "lpcm",                              /* format id */
+        0,                                   /* format flags */
+        (uint32_t)bytesperframe,             /* bytes per packet */
+        1,                                   /* frames per packet */
+        (uint32_t)info->i_nchannels,         /* channels */
+        (uint32_t)info->i_bytespersample * 8 /* bits per channel */
+    };
+    t_caff_data data = {0};
+
+        /* file header */
+    caff_writehead(buf, &head, swap);
+    if (sys_verbose)
+        caff_posthead(&head);
+
+        /* audio description chunk */
+    caff_writechunk(buf + headersize, &chunk, swap);
+    if (sys_verbose)
+        caff_postchunk(&chunk);
+    headersize += CAFFCHUNKSIZE;
+    if (info->i_bytespersample == 4)
+        desc.cd_fmtflags |= kCAFLinearPCMFormatFlagIsFloat;
+    if (!info->i_bigendian)
+        desc.cd_fmtflags |= kCAFLinearPCMFormatFlagIsLittleEndian;
+    caff_writedesc(buf + headersize, &desc, swap);
+    if (sys_verbose)
+        caff_postdesc(&desc);
+    headersize += CAFFDESCSIZE;
+
+        /* audio data chunk */
+    strncpy(chunk.cc_type, "data", 4);
+    chunk.cc_size = CAFFDATASIZEMIN + datasize;
+    caff_writechunk(buf + headersize, &chunk, swap);
+    if (sys_verbose)
+        caff_postchunk(&chunk);
+    headersize += CAFFCHUNKSIZE;
+    caff_writedata(buf + headersize, &data, swap);
+    if (sys_verbose)
+        caff_postdata(&data);
+    headersize += CAFFDATASIZEMIN;
+
+    byteswritten = (int)write(fd, buf, headersize);
+    return (byteswritten < headersize ? -1 : byteswritten);
+}
+
+int soundfile_caff_updateheader(int fd, const t_soundfile_info *info,
+    long nframes)
+{
+    int swap = !sys_isbigendian();
+    int64_t datasize = (nframes * soundfile_info_bytesperframe(info)) +
+                       CAFFDATASIZEMIN;
+    off_t seekto = CAFFHDRSIZE + CAFFCHUNKSIZE + CAFFDESCSIZE + 4; /* cc_type */
+
+        /* audio data chunk data size */
+    if (lseek(fd, seekto, SEEK_SET) == 0)
+        return 0;
+    datasize = swap8s(datasize, swap);
+    if (write(fd, (char *)&datasize, 8) < 8)
+        return 0;
+
+    return 1;
+}
+
+int soundfile_caff_hasextension(const char *filename, long size)
+{
+    int len = strnlen(filename, size);
+    if (len >= 5 &&
+        (!strncmp(filename + (len - 4), ".caf", 4) ||
+         !strncmp(filename + (len - 4), ".CAF", 4)))
+        return 1;
+    return 0;
+}
+
+/* helpers */
+
+static void caff_readhead(const uint8_t *buf, t_caff *head, int swap)
+{
+    memcpy(&head->c_type,    buf,     4);
+    memcpy(&head->c_version, buf + 4, 2);
+    memcpy(&head->c_flags,   buf + 6, 2);
+    if (swap)
+    {
+        head->c_version = swap2(head->c_version, 1);
+        head->c_flags = swap2(head->c_flags, 1);
+    }
+}
+
+static void caff_writehead(uint8_t *buf, const t_caff *head, int swap)
+{
+    uint16_t inttmp;
+    memcpy(buf, &head->c_type, 4);
+    
+    inttmp = swap2(head->c_version, swap);
+    memcpy(buf + 4, &inttmp, 2);
+
+    inttmp = swap2(head->c_flags, swap);
+    memcpy(buf + 6, &inttmp, 2);
+}
+
+static void caff_posthead(const t_caff *head)
+{
+    post("%.4s", head->c_type);
+    post("  version %d", head->c_version);
+    post("  flags %d", head->c_flags);
+}
+
+static void caff_readchunk(const uint8_t *buf, t_caff_chunk *chunk, int swap)
+{
+    memcpy(&chunk->cc_type, buf,     4);
+    memcpy(&chunk->cc_size, buf + 4, 8);
+    chunk->cc_size = swap8s(chunk->cc_size, swap);
+}
+
+static void caff_writechunk(uint8_t *buf, const t_caff_chunk *chunk, int swap)
+{
+    int64_t longtmp;
+
+    memcpy(buf, &chunk->cc_type, 4);
+
+    longtmp = swap8s(chunk->cc_size, swap);
+    memcpy(buf + 4, &longtmp, 8);
+}
+
+static void caff_postchunk(const t_caff_chunk *chunk)
+{
+    post("%.4s %" PRId64, chunk->cc_type, chunk->cc_size);
+}
+
+static void caff_readdesc(const uint8_t *buf, t_caff_desc *desc, int swap)
+{
+    memcpy(&desc->cd_samplerate,      buf,      8);
+    memcpy(&desc->cd_fmtid,           buf +  8, 4);
+    memcpy(&desc->cd_fmtflags,        buf + 12, 4);
+    memcpy(&desc->cd_bytesperpacket,  buf + 16, 4);
+    memcpy(&desc->cd_framesperpacket, buf + 20, 4);
+    memcpy(&desc->cd_nchannels,       buf + 24, 4);
+    memcpy(&desc->cd_bitsperchannel,  buf + 28, 4);
+    if (swap) 
+    {
+        desc->cd_samplerate = swapdouble(desc->cd_samplerate, 1);
+        desc->cd_fmtflags = swap4(desc->cd_fmtflags, 1);
+        desc->cd_bytesperpacket = swap4(desc->cd_bytesperpacket, 1);
+        desc->cd_framesperpacket = swap4(desc->cd_framesperpacket, 1);
+        desc->cd_nchannels = swap4(desc->cd_nchannels, 1);
+        desc->cd_bitsperchannel = swap4(desc->cd_bitsperchannel, 1);
+    }
+}
+
+static void caff_writedesc(uint8_t *buf, const t_caff_desc *desc, int swap)
+{
+    double doubletmp;
+    uint32_t inttmp;
+
+    doubletmp = swapdouble(desc->cd_samplerate, swap);
+    memcpy(buf, &doubletmp, 8);
+
+    memcpy(buf + 8, &desc->cd_fmtid, 4);
+
+    inttmp = swap4(desc->cd_fmtflags, swap);
+    memcpy(buf + 12, &inttmp, 4);
+
+    inttmp = swap4(desc->cd_bytesperpacket, swap);
+    memcpy(buf + 16, &inttmp, 4);
+
+    inttmp = swap4(desc->cd_framesperpacket, swap);
+    memcpy(buf + 20, &inttmp, 4);
+
+    inttmp = swap4(desc->cd_nchannels, swap);
+    memcpy(buf + 24, &inttmp, 4);
+
+    inttmp = swap4(desc->cd_bitsperchannel, swap);
+    memcpy(buf + 28, &inttmp, 4);
+}
+
+static void caff_postdesc(const t_caff_desc *desc)
+{
+    post("  sample rate %g", desc->cd_samplerate);
+    post("  fmt id %.4s", desc->cd_fmtid);
+    post("  fmt flags %u", desc->cd_fmtflags);
+    post("  bytes per packet %u", desc->cd_bytesperpacket);
+    post("  frames per packet %u", desc->cd_framesperpacket);
+    post("  channels %u", desc->cd_nchannels);
+    post("  bits per channel %u", desc->cd_bitsperchannel);
+}
+
+static void caff_readdata(const uint8_t *buf, t_caff_data *data, int swap) {
+    memcpy(&data->cd_editcount, buf, 4);
+    if (swap)
+        data->cd_editcount = swap4(data->cd_editcount, 1);
+}
+
+static void caff_writedata(uint8_t *buf, const t_caff_data *data, int swap) {
+    uint32_t inttmp;
+
+    inttmp = swap4(data->cd_editcount, swap);
+    memcpy(buf, &inttmp, 4);
+}
+
+static void caff_postdata(const t_caff_data *data)
+{
+    post("  edit count %u", data->cd_editcount);
+}

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -32,9 +32,10 @@
     * tries to set sound data length, otherwise falls back to "unknown size"
     * sample format: 16 and 24 bit lpcm, 32 bit float, no 32 bit lpcm
 
-*/
+    Pd versions < 0.51 did *not* write the actual data chunk size when updating
+    the header, but set "unknown size" instead.
 
-/* TODO: support 32 bit int format? */
+*/
 
     /* explicit byte sizes, sizeof(struct) may return alignment padded values */
 #define NEXTHEADSIZE 28 /**< min valid header size + info string */

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -196,7 +196,7 @@ int soundfile_next_writeheader(int fd, const t_soundfile_info *info,
     };
 
     if (!info->i_bigendian)
-        swapstring(next.ns_id, 1);
+        swapstring4(next.ns_id, 1);
     switch (info->i_bytespersample)
     {
         case 2:

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -121,8 +121,8 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_audio_paring.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c \
-    d_soundfile_aiff.c d_soundfile_next.c d_soundfile_wave.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -121,7 +121,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_audio_paring.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -92,8 +92,8 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c \
-    d_soundfile_aiff.c d_soundfile_next.c d_soundfile_wave.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -92,7 +92,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -126,8 +126,8 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c \
-    d_soundfile_aiff.c d_soundfile_next.c d_soundfile_wave.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -126,7 +126,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -91,7 +91,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -91,8 +91,8 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
-    d_delay.c d_resample.c d_soundfile.c \
-    d_soundfile_aiff.c d_soundfile_next.c d_soundfile_wave.c \
+    d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caff.c \
+    d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \


### PR DESCRIPTION
This PR is built upon #855 and adds CAF File support (Core Audio Format File).

CAF was designed by Apple but the [specification is open](https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_intro/CAF_intro.html#//apple_ref/doc/uid/TP40001862-CH203-TPXREF101) and there is support for it in other software and systems beyond the Apple sphere. It supports 64 bit chunk sizes so audio data > 4 GB can be handled and samples can be either little or big endian. The layout is similar to AIFF, so it was not too difficult to implement.

I have tested both reading and writing 16 bit, 24 bit, and 32 bit float, mono and 4 channels and have compared the header info with that displayed by `soxi -V4`:

~~~
$ soxi -V4 test4.caf
soxi INFO formats: detected file format type `caf'
soxi DBUG sndfile: `test4.caf': Length : 326724
soxi DBUG sndfile: `test4.caf': caff
soxi DBUG sndfile: `test4.caf':   Version : 1
soxi DBUG sndfile: `test4.caf':   Flags   : 0
soxi DBUG sndfile: `test4.caf': desc : 32
soxi DBUG sndfile: `test4.caf':   Sample rate  : 44100.000
soxi DBUG sndfile: `test4.caf':   Format id    : lpcm
soxi DBUG sndfile: `test4.caf':   Format flags : 3
soxi DBUG sndfile: `test4.caf':   Bytes / packet   : 4
soxi DBUG sndfile: `test4.caf':   Frames / packet  : 1
soxi DBUG sndfile: `test4.caf':   Channels / frame : 1
soxi DBUG sndfile: `test4.caf':   Bits / channel   : 32
soxi DBUG sndfile: `test4.caf': data : 326660
soxi DBUG sndfile: `test4.caf':   edit : 0
soxi DBUG sndfile: `test4.caf': Request for header allocation of 653312 denined.
soxi DBUG sndfile: `test4.caf': End


Input File     : 'test4.caf'
Channels       : 1
Sample Rate    : 44100
Precision      : 25-bit
Duration       : 00:00:01.85 = 81664 samples = 138.884 CDDA sectors
File Size      : 327k
Bit Rate       : 1.41M
Sample Encoding: 32-bit Floating Point PCM

~~~

I have also generated valid files with `sox` for testing in Pd, ex:

~~~
sox -n -r 44100 -b 16 -c 4 sine4_16.caf synth 3 sine 440
~~~

Notes:

* I was having trouble with the reading struct data in a union with the buffer due to struct alignment issues, so this approach separates the buffer from the struct data via read/write functions which also handle the byte swapping. This introduces another copy step but I feel the code is far more readable as a result. I could probably refactor this to use the union again, if desired.
* Header & chunk info is posted when sys_verbose = 1. I think this would be great to add as a debugging feature to the other audio file formats.
* The potentially large data sizes will probably necessitate changing some data types to larger versions in d_soundfile.c. @umlaeute suggests using `size_t` instead of `long` and I think it would be good to transition uses of `long` for the `lseek()` function to `off_t`.
* Naturally, *huge* files can only be completely addressed via Pd compiled with double support.
