### PR TITLE
[WIP] soundfile plugin architecture

### DIFF
--- a/doc/5.reference/soundfiler-help.pd
+++ b/doc/5.reference/soundfiler-help.pd
@@ -59,8 +59,7 @@ soundfile need not match the number of arrays given (extras are dropped
 and unsupplied channels are zeroed out.), f 64;
 #X text 330 184 optionally resize;
 #X text 436 214 override header;
-#X msg 66 241 read -ascii table.txt array1;
-#X text 279 240 ... read from an ascii file, f 32;
+#X text 331 240 ... read from an ascii file, f 28;
 #X text 44 454 Left outlet outputs the number of samples. Right outlet
 outputs info as a list: samplerate \, headersize \, num channels \,
 bytespersample \, & endianness ("b" or "l"). If no array name is given
@@ -71,6 +70,7 @@ fields are replaced by zero. If multiple arrays are specified \, the
 first elements of each array should come first in the file \, followed
 by all the second elements and so on., f 61;
 #X text 787 635 updated for Pd version 0.51;
+#X msg 66 241 read -ascii -resize table.txt array1;
 #X connect 2 0 9 0;
 #X connect 2 1 33 0;
 #X connect 3 0 2 0;
@@ -79,4 +79,4 @@ by all the second elements and so on., f 61;
 #X connect 10 0 2 0;
 #X connect 11 0 2 0;
 #X connect 12 0 2 0;
-#X connect 41 0 2 0;
+#X connect 45 0 2 0;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,6 +56,7 @@ pd_SOURCES_core = \
     d_soundfile_aiff.c \
     d_soundfile_caf.c \
     d_soundfile_next.c \
+    d_soundfile_raw.c \
     d_soundfile_wave.c \
     d_ugen.c \
     g_all_guis.c \

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -817,7 +817,7 @@ static int create_soundfile(t_canvas *canvas, const char *filename,
             return -1;
     filenamebuf[MAXPDSTRING-10] = 0; /* FIXME: what is the 10 for? */
     canvas_makefilename(canvas, filenamebuf, pathbuf, MAXPDSTRING);
-    if ((fd = sys_open(pathbuf, O_WRONLY | O_CREAT | O_TRUNC, 0666)) < 0)
+    if ((fd = sys_open(pathbuf, O_RDWR | O_CREAT | O_TRUNC, 0666)) < 0)
         return -1;
     if (!sf->sf_type->t_openfn(sf, fd))
         goto badcreate;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1035,14 +1035,14 @@ static t_soundfiler *soundfiler_new(void)
     return x;
 }
 
-static void soundfiler_readascii(t_soundfiler *x, const char *filename,
+static int soundfiler_readascii(t_soundfiler *x, const char *filename,
     int narray, t_garray **garrays, t_word **vecs, int resize, int finalsize)
 {
     t_binbuf *b = binbuf_new();
     int n, i, j, nframes, vecsize;
     t_atom *atoms, *ap;
     if (binbuf_read_via_canvas(b, filename, x->x_canvas, 0))
-        return;
+        return 0;
     n = binbuf_getnatom(b);
     atoms = binbuf_getvec(b);
     nframes = n / narray;
@@ -1052,7 +1052,7 @@ static void soundfiler_readascii(t_soundfiler *x, const char *filename,
     if (nframes < 1)
     {
         pd_error(x, "soundfiler_read: %s: empty or very short file", filename);
-        return;
+        return 0;
     }
     if (resize)
     {
@@ -1083,7 +1083,7 @@ static void soundfiler_readascii(t_soundfiler *x, const char *filename,
 #ifdef DEBUG_SOUNDFILE
     post("read 3");
 #endif
-    
+    return nframes;
 }
 
     /* soundfiler_read ...
@@ -1095,6 +1095,7 @@ static void soundfiler_readascii(t_soundfiler *x, const char *filename,
            -raw <headersize channels bytes endian>
            -resize
            -maxsize <max-size>
+           -ascii
     */
 
 static void soundfiler_read(t_soundfiler *x, t_symbol *s,
@@ -1223,8 +1224,9 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     }
     if (ascii)
     {
-        soundfiler_readascii(x, filename,
+        framesread = soundfiler_readascii(x, filename,
             argc, garrays, vecs, resize, finalsize);
+        outlet_float(x->x_obj.ob_outlet, (t_float)framesread);
         return;
     }
 

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1800,9 +1800,9 @@ static void *readsf_child_main(void *zz)
         }
         else if (x->x_requestcode == REQUEST_CLOSE)
         {
-            if (x->x_sf.sf_fd >= 0)
+            if (sf.sf_fd >= 0)
             {
-                soundfile_copy(&sf, &x->x_sf);
+                    /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sf.sf_filetype->ft_closefn(&sf);
                 pthread_mutex_lock(&x->x_mutex);
@@ -1815,9 +1815,9 @@ static void *readsf_child_main(void *zz)
         }
         else if (x->x_requestcode == REQUEST_QUIT)
         {
-            if (x->x_sf.sf_fd >= 0)
+            if (sf.sf_fd >= 0)
             {
-                soundfile_copy(&sf, &x->x_sf);
+                    /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sf.sf_filetype->ft_closefn(&sf);
                 pthread_mutex_lock(&x->x_mutex);

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1570,6 +1570,7 @@ static void *readsf_child_main(void *zz)
 {
     t_readsf *x = zz;
     t_soundfile sf = {0};
+    soundfile_clear(&sf);
 #ifdef DEBUG_SOUNDFILE
     pute("1\n");
 #endif
@@ -2153,6 +2154,7 @@ static void *writesf_child_main(void *zz)
 {
     t_writesf *x = zz;
     t_soundfile sf = {0};
+    soundfile_clear(&sf);
 #ifdef DEBUG_SOUNDFILE
     pute("1\n");
 #endif

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -218,14 +218,14 @@ ssize_t soundfile_filetype_writesamples(t_soundfile *sf,
 
 /* ----- read write ----- */
 
-ssize_t soundfile_readbytes(int fd, off_t offset, char *dst, size_t size)
+ssize_t fd_read(int fd, off_t offset, char *dst, size_t size)
 {
     if (lseek(fd, offset, SEEK_SET) != offset)
         return -1;
     return read(fd, dst, size);
 }
 
-ssize_t soundfile_writebytes(int fd, off_t offset, const char *src, size_t size)
+ssize_t fd_write(int fd, off_t offset, const char *src, size_t size)
 {
     if (lseek(fd, offset, SEEK_SET) != offset)
         return -1;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -218,14 +218,14 @@ ssize_t soundfile_filetype_writesamples(t_soundfile *sf,
 
 /* ----- read write ----- */
 
-ssize_t fd_read(int fd, off_t offset, char *dst, size_t size)
+ssize_t fd_read(int fd, off_t offset, void *dst, size_t size)
 {
     if (lseek(fd, offset, SEEK_SET) != offset)
         return -1;
     return read(fd, dst, size);
 }
 
-ssize_t fd_write(int fd, off_t offset, const char *src, size_t size)
+ssize_t fd_write(int fd, off_t offset, const void *src, size_t size)
 {
     if (lseek(fd, offset, SEEK_SET) != offset)
         return -1;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1596,7 +1596,6 @@ static void *readsf_child_main(void *zz)
             size_t onsetframes = x->x_onsetframes;
             const char *filename = x->x_filename;
             const char *dirname = canvas_getdir(x->x_canvas)->s_name;
-            soundfile_copy(&sf, &x->x_sf);
 
 #ifdef DEBUG_SOUNDFILE
             pute("4\n");
@@ -1617,6 +1616,10 @@ static void *readsf_child_main(void *zz)
                 if (x->x_requestcode != REQUEST_BUSY)
                     goto lost;
             }
+                /* cache sf *after* closing as x->sf's fd, filetype, & data
+                    may have changed in readsf_open() */
+            soundfile_copy(&sf, &x->x_sf);
+
                 /* open the soundfile with the mutex unlocked */
             pthread_mutex_unlock(&x->x_mutex);
             open_soundfile_via_path(dirname, filename, &sf, onsetframes);

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -167,7 +167,7 @@ int soundfile_addfiletype(t_soundfile_filetype *ft)
     return 1;
 }
 
-    /** return file types head */
+    /** return file type list head */
 static t_soundfile_filetype *soundfile_firstfiletype() {
     return &sf_filetypes[0];
 }
@@ -1200,8 +1200,6 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
             argc, garrays, vecs, resize, finalsize);
         return;
     }
-    if (meta) /* pass outlet to filetype readheaderfn for meta data output */
-        sf.sf_metaout = x->x_out2;
 
     fd = open_soundfile_via_canvas(x->x_canvas, filename, &sf, skipframes);
     if (fd < 0)
@@ -1210,6 +1208,11 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
         goto done;
     }
     framesinfile = sf.sf_bytelimit / sf.sf_bytesperframe;
+
+        /* read meta data to outlet */
+     if (meta && sf.sf_filetype->ft_readmetafn)
+         if (!sf.sf_filetype->ft_readmetafn(&sf, x->x_out2))
+             pd_error(x, "soundfiler_read: reading meta data failed");
 
     if (resize)
     {

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1369,7 +1369,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     goto done;
 usage:
     pd_error(x, "usage: read [flags] filename [tablename]...");
-    post("flags: -skip <n> -resize -maxsize <n> %s...", sf_typeargs);
+    post("flags: -skip <n> -resize -maxsize <n> %s --...", sf_typeargs);
     post("-raw <headerbytes> <channels> <bytespersample> "
          "<endian (b, l, or n)>");
 done:
@@ -2189,7 +2189,7 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
 usage:
     pd_error(x, "usage: open [flags] filename [onset] [headersize]...");
     error("[nchannels] [bytespersample] [endian (b or l)]");
-    post("flags: %s", sf_typeargs);
+    post("flags: %s --", sf_typeargs);
 }
 
 static void readsf_dsp(t_readsf *x, t_signal **sp)
@@ -2605,7 +2605,7 @@ static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
     {
         pd_error(x, "usage: open [flags] filename...");
         post("flags: -bytes <n> %s ...", sf_typeargs);
-        post("-big -little -rate <n>");
+        post("-big -little -rate <n> --");
         return;
     }
     if (wa.wa_normalize || wa.wa_onsetframes || (wa.wa_nframes != SFMAXFRAMES))

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -103,7 +103,8 @@ typedef int (*t_soundfile_closefn)(t_soundfile *sf);
     /** read format info from soundfile header,
         returns 1 on success or 0 on error
         note: set sf_bytelimit = sound data size
-        this may be called in a background thread */
+        this may be called in a background thread, but
+        sf_metaout is only set when called on main thread */
 typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
 
     /** write header to beginning of an open file from an info struct

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -129,11 +129,13 @@ typedef int (*t_soundfile_endiannessfn)(int endianness);
 typedef int (*t_soundfile_seektoframefn)(t_soundfile *sf, size_t frame);
 
     /** read samples from the soundfile into the dst buffer,
+        dst is interleaved and is signed int (16 or 24 bit) or 32 bit float
         returns bytes read or < 0 on failure */
 typedef ssize_t (*t_soundfile_readsamplesfn)(t_soundfile *sf,
     unsigned char *dst, size_t size);
 
     /** write samples from the src buffer into the soundfile,
+        src is interleaved and is signed int (16 or 24 bit) or 32 bit float
         returns bytes written or < 0 on failure */
 typedef ssize_t (*t_soundfile_writesamplesfn)(t_soundfile *sf,
     const unsigned char *src, size_t size);

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -47,8 +47,7 @@ typedef struct _soundfile_filetype t_soundfile_filetype;
     /** soundfile file descriptor, backend type, and format info
         note: headersize and bytelimit are signed as they are used for < 0
               comparisons, hopefully ssize_t is large enough
-        "headersize" can also be thought of as the audio data byte offset
-        TODO: should bytelimit (bytes) be framelimit (sample frames)? */
+        "headersize" can also be thought of as the audio data byte offset */
 typedef struct _soundfile
 {
     int sf_fd;             /**< file descriptor, >= 0 : open, -1 : closed */

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -103,8 +103,8 @@ typedef int (*t_soundfile_isheaderfn)(const char *buf, size_t size);
 
     /** open a sound file with a file descriptor and allocate sf_data,
         returns 1 on success and 0 on failure
-        note: fd is already valid and open when this function is called,
-              so set sf->sf_fd here
+        note: fd is already open when this function is called so set
+              sf->sf_fd here, fd will be closed if 0 is returned
         this may be called in a background thread */
 typedef int (*t_soundfile_openfn)(t_soundfile *sf, int fd);
 
@@ -139,11 +139,6 @@ typedef int (*t_soundfile_hasextensionfn)(const char *filename, size_t size);
         this may be called in a background thread */
 typedef int (*t_soundfile_addextensionfn)(char *filename, size_t size);
 
-    /** returns the type's preferred sample endianness based on the
-        requested endianness (0 little, 1 big, -1 unspecified)
-        returns 1 for big endian, 0 for little endian */
-typedef int (*t_soundfile_endiannessfn)(int endianness);
-
     /** seek to a specified sample frame in an open file,
         returns 1 on success or 0 on failure
         this may be called in a background thread */
@@ -162,6 +157,11 @@ typedef ssize_t (*t_soundfile_readsamplesfn)(t_soundfile *sf,
         this may be called in a background thread */
 typedef ssize_t (*t_soundfile_writesamplesfn)(t_soundfile *sf,
     const unsigned char *src, size_t size);
+
+    /** returns the type's preferred sample endianness based on the
+        requested endianness (0 little, 1 big, -1 unspecified)
+        returns 1 for big endian, 0 for little endian */
+typedef int (*t_soundfile_endiannessfn)(int endianness);
 
     /** read meta data from the soundfile header to the given outlet
         returns 1 on success or 0 on failure */
@@ -190,10 +190,10 @@ typedef struct _soundfile_type
     t_soundfile_updateheaderfn t_updateheaderfn; /**< must be non-NULL      */
     t_soundfile_hasextensionfn t_hasextensionfn; /**< must be non-NULL      */
     t_soundfile_addextensionfn t_addextensionfn; /**< must be non-NULL      */
-    t_soundfile_endiannessfn t_endiannessfn;     /**< must be non-NULL      */
     t_soundfile_seektoframefn t_seektoframefn;   /**< must be non-NULL      */
     t_soundfile_readsamplesfn t_readsamplesfn;   /**< must be non-NULL      */
     t_soundfile_writesamplesfn t_writesamplesfn; /**< must be non-NULL      */
+    t_soundfile_endiannessfn t_endiannessfn;     /**< NULL if not relevant  */
     t_soundfile_readmetafn t_readmetafn;         /**< NULL if not supported */
     t_soundfile_writemetafn t_writemetafn;       /**< NULL if not supported */
     t_soundfile_strerrorfn t_strerrorfn;         /**< NULL if not supported */
@@ -216,11 +216,11 @@ int soundfile_type_seektoframe(t_soundfile *sf, size_t frame);
 
     /** default t_soundfile_readsamplesfn implementation */
 ssize_t soundfile_type_readsamples(t_soundfile *sf,
-    unsigned char *buf, size_t size);
+    unsigned char *dst, size_t size);
 
     /** default t_soundfile_writesamplesfn implementation */
 ssize_t soundfile_type_writesamples(t_soundfile *sf,
-    const unsigned char *buf, size_t size);
+    const unsigned char *src, size_t size);
 
 /* ----- read/write helpers ----- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -208,12 +208,12 @@ ssize_t soundfile_filetype_writesamples(t_soundfile *sf,
 
     /** seek to offset in file fd and read size bytes into dst,
         returns bytes written on success or -1 on failure */
-ssize_t fd_read(int fd, off_t offset, char *dst, size_t size);
+ssize_t fd_read(int fd, off_t offset, void *dst, size_t size);
 
     /** seek to offset in file fd and write size bytes from dst,
         returns number of bytes written on success or -1 if seek or write
         failed */
-ssize_t fd_write(int fd, off_t offset, const char *src, size_t size);
+ssize_t fd_write(int fd, off_t offset, const void *src, size_t size);
 
 /* ----- byte swappers ----- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -83,40 +83,48 @@ int soundfile_needsbyteswap(const t_soundfile *sf);
 /* ----- soundfile file type ----- */
 
     /** returns 1 if buffer is the beginning of a file type header,
-        size will be at least minheadersize */
+        size will be at least minheadersize
+        this may be called in a background thread */
 typedef int (*t_soundfile_isheaderfn)(const char *buf, size_t size);
 
     /** open a sound file with a file descriptor and allocate sf_data,
         returns 1 on success and 0 on failure
         note: fd is already valid and open when this function is called,
-              so set sf->sf_fd here  */
+              so set sf->sf_fd here
+        this may be called in a background thread */
 typedef int (*t_soundfile_openfn)(t_soundfile *sf, int fd);
 
     /** close a soundfile and free sf_data,
         returns 1 on success and 0 on failure
-        note: close sf_fd here, set sf_fd = -1 & sf_data = NULL */
+        note: close sf_fd here, set sf_fd = -1 & sf_data = NULL
+        this may be called in a background thread */
 typedef int (*t_soundfile_closefn)(t_soundfile *sf);
 
     /** read format info from soundfile header,
         returns 1 on success or 0 on error
-        note: set sf_bytelimit = sound data size  */
+        note: set sf_bytelimit = sound data size
+        this may be called in a background thread */
 typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
 
     /** write header to beginning of an open file from an info struct
-        returns header bytes written or -1 on error */
+        returns header bytes written or -1 on error
+        this may be called in a background thread */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 
     /** write meta data to the soundfile header and updates headersize
         returns 1 on success or 0 on failure */
 typedef int (*t_soundfile_writemetafn)(t_soundfile *sf, int argc, t_atom *argv);
 
-    /** update file header data size, returns 1 on success or 0 on error */
+    /** update file header data size, returns 1 on success or 0 on error
+        this may be called in a background thread */
 typedef int (*t_soundfile_updateheaderfn)(t_soundfile *sf, size_t nframes);
 
-    /** returns 1 if the filename has a file type extension, otherwise 0 */
+    /** returns 1 if the filename has a file type extension, otherwise 0
+        this may be called in a background thread */
 typedef int (*t_soundfile_hasextensionfn)(const char *filename, size_t size);
 
-    /** appends the default file type extension, returns 1 on success */
+    /** appends the default file type extension, returns 1 on success
+        this may be called in a background thread */
 typedef int (*t_soundfile_addextensionfn)(char *filename, size_t size);
 
     /** returns 1 if file type prefers big endian samples based on
@@ -125,18 +133,21 @@ typedef int (*t_soundfile_addextensionfn)(char *filename, size_t size);
 typedef int (*t_soundfile_endiannessfn)(int endianness);
 
     /** seek to a specified sample frame in an open file,
-        returns 1 on success or 0 on failure */
+        returns 1 on success or 0 on failure
+        this may be called in a background thread */
 typedef int (*t_soundfile_seektoframefn)(t_soundfile *sf, size_t frame);
 
     /** read samples from the soundfile into the dst buffer,
         dst is interleaved and is signed int (16 or 24 bit) or 32 bit float
-        returns bytes read or < 0 on failure */
+        returns bytes read or < 0 on failure
+        this may be called in a background thread */
 typedef ssize_t (*t_soundfile_readsamplesfn)(t_soundfile *sf,
     unsigned char *dst, size_t size);
 
     /** write samples from the src buffer into the soundfile,
         src is interleaved and is signed int (16 or 24 bit) or 32 bit float
-        returns bytes written or < 0 on failure */
+        returns bytes written or < 0 on failure
+        this may be called in a background thread */
 typedef ssize_t (*t_soundfile_writesamplesfn)(t_soundfile *sf,
     const unsigned char *src, size_t size);
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -113,13 +113,14 @@ typedef int (*t_soundfile_closefn)(t_soundfile *sf);
 
     /** read format info from soundfile header,
         returns 1 on success or 0 on error
-        note: set sf_bytelimit = sound data size, optionaly set errno for
+        note: set sf_bytelimit = sound data size, optionaly set errno
               for descriptive type error read via strerrorfn
         this may be called in a background thread */
 typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
 
     /** write header to beginning of an open file from an info struct
         returns header bytes written or < 0 on error
+        note: optionaly set errno for descriptive type error read via strerrorfn
         this may be called in a background thread */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 
@@ -168,8 +169,8 @@ typedef int (*t_soundfile_readmetafn)(t_soundfile *sf, t_outlet *out);
 typedef int (*t_soundfile_writemetafn)(t_soundfile *sf, int argc, t_atom *argv);
 
     /** returns an error string for a type implemenrtation error otherwise
-        calls soundfile_strerror, currently only used for descriptive
-        readheaderfn errors */
+        calls soundfile_strerror, currently used for descriptive readheaderfn
+        and writeheaderfn errors */
 typedef const char* (*t_soundfile_strerrorfn)(int errnum);
 
     /* type implementation, this could be for single or multiple file formats */

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -51,8 +51,10 @@ typedef struct _soundfile_filetype t_soundfile_filetype;
 typedef struct _soundfile
 {
     int sf_fd;             /**< file descriptor, >= 0 : open, -1 : closed */
+    /* implementation */
     t_soundfile_filetype *sf_filetype; /**< implementation type           */
-    void *sf_data;                     /**< implementation-specific data  */
+    t_outlet *sf_metaout;  /**< read: meta data outlet, if meta supported */
+    void *sf_data;         /**< implementation-specific data              */
     /* format info */
     int sf_samplerate;     /**< read: file sr, write: pd sr               */
     int sf_nchannels;      /**< number of channels                        */
@@ -104,6 +106,10 @@ typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
         returns header bytes written or -1 on error */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 
+    /** write meta data to the soundfile header and updates headersize
+        returns 1 on success or 0 on failure */
+typedef int (*t_soundfile_writemetafn)(t_soundfile *sf, int argc, t_atom *argv);
+
     /** update file header data size, returns 1 on success or 0 on error */
 typedef int (*t_soundfile_updateheaderfn)(t_soundfile *sf, size_t nframes);
 
@@ -142,6 +148,7 @@ typedef struct _soundfile_filetype
     t_soundfile_closefn ft_closefn;               /**< must be non-NULL */
     t_soundfile_readheaderfn ft_readheaderfn;     /**< must be non-NULL */
     t_soundfile_writeheaderfn ft_writeheaderfn;   /**< must be non-NULL */
+    t_soundfile_writemetafn ft_writemetafn;       /**< NULL if not supported */
     t_soundfile_updateheaderfn ft_updateheaderfn; /**< must be non-NULL */
     t_soundfile_hasextensionfn ft_hasextensionfn; /**< must be non-NULL */
     t_soundfile_addextensionfn ft_addextensionfn; /**< must be non-NULL */

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -208,14 +208,12 @@ ssize_t soundfile_filetype_writesamples(t_soundfile *sf,
 
     /** seek to offset in file fd and read size bytes into dst,
         returns bytes written on success or -1 on failure */
-ssize_t soundfile_readbytes(int fd, off_t offset,
-    char *dst, size_t size);
+ssize_t fd_read(int fd, off_t offset, char *dst, size_t size);
 
     /** seek to offset in file fd and write size bytes from dst,
         returns number of bytes written on success or -1 if seek or write
         failed */
-ssize_t soundfile_writebytes(int fd, off_t offset,
-    const char *src, size_t size);
+ssize_t fd_write(int fd, off_t offset, const char *src, size_t size);
 
 /* ----- byte swappers ----- */
 

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -41,6 +41,9 @@ typedef SSIZE_T ssize_t;
 #define SFMAXFRAMES SIZE_MAX  /**< default max sample frames, unsigned */
 #define SFMAXBYTES  SSIZE_MAX /**< default max sample bytes, signed */
 
+    /** sound file read/write debug posts */
+//#define DEBUG_SOUNDFILE
+
 /* ----- soundfile ----- */
 
 typedef struct _soundfile_type t_soundfile_type;

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -79,7 +79,7 @@ typedef struct _chunk
     int32_t c_size;                  /**< chunk data length            */
 } t_chunk;
 
-    /** file header, 12 bytes */
+    /** file head container chunk, 12 bytes */
 typedef struct _head
 {
     char h_id[4];                    /**< chunk id "FORM"              */
@@ -608,7 +608,7 @@ void soundfile_aiff_setup()
     t_soundfile_type aiff = {
         gensym("aiff"),
         AIFFHEADSIZE + AIFFCOMMSIZE + AIFFDATASIZE,
-        NULL,  /* data */
+        NULL, /* data */
         aiff_isheader,
         soundfile_type_open,
         soundfile_type_close,

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -605,25 +605,25 @@ static const char* aiff_strerror(int errnum)
 
 void soundfile_aiff_setup()
 {
-    t_soundfile_filetype aiff = {
+    t_soundfile_type aiff = {
         gensym("aiff"),
         AIFFHEADSIZE + AIFFCOMMSIZE + AIFFDATASIZE,
         NULL,  /* data */
         aiff_isheader,
-        soundfile_filetype_open,
-        soundfile_filetype_close,
+        soundfile_type_open,
+        soundfile_type_close,
         aiff_readheader,
         aiff_writeheader,
         aiff_updateheader,
         aiff_hasextension,
         aiff_addextension,
         aiff_endianness,
-        soundfile_filetype_seektoframe,
-        soundfile_filetype_readsamples,
-        soundfile_filetype_writesamples,
+        soundfile_type_seektoframe,
+        soundfile_type_readsamples,
+        soundfile_type_writesamples,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         aiff_strerror
     };
-    soundfile_addfiletype(&aiff);
+    soundfile_addtype(&aiff);
 }

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -567,6 +567,7 @@ void soundfile_aiff_setup()
         soundfile_filetype_close,
         aiff_readheader,
         aiff_writeheader,
+        NULL,
         aiff_updateheader,
         aiff_hasextension,
         aiff_addextension,

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -636,10 +636,10 @@ void soundfile_aiff_setup()
         aiff_updateheader,
         aiff_hasextension,
         aiff_addextension,
-        aiff_endianness,
         soundfile_type_seektoframe,
         soundfile_type_readsamples,
         soundfile_type_writesamples,
+        aiff_endianness,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         aiff_strerror

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -261,7 +261,7 @@ static int aiff_readheader(t_soundfile *sf)
                 /* AIFF-C format version chunk */
             if (!isaiffc)
             {
-                error("AIFF found FVER chunk, but not AIFF-C");
+                error("aiff: found FVER chunk, but not AIFF-C");
                 return 0;
             }
             if (soundfile_readbytes(sf->sf_fd, headersize + AIFFCHUNKSIZE,
@@ -270,7 +270,7 @@ static int aiff_readheader(t_soundfile *sf)
                 return 0;
             if (swap4(buf.b_verchunk.vc_timestamp, swap) != AIFFCVER1)
             {
-                error("AIFF unsupported AIFF-C version");
+                error("aiff: unsupported AIFF-C version");
                 return 0;
             }
         }
@@ -293,7 +293,7 @@ static int aiff_readheader(t_soundfile *sf)
                 case 24: bytespersample = 3; break;
                 case 32: bytespersample = 4; break;
                 default:
-                    error("AIFF %d bit samples not supported", bitspersample);
+                    error("aiff: %d bit samples not supported", bitspersample);
                     return 0;
             }
             samplerate = aiff_getsamplerate(comm, swap);
@@ -313,7 +313,7 @@ static int aiff_readheader(t_soundfile *sf)
                 {
                     if (bytespersample != 4)
                     {
-                        error("AIFF wrong byte size for format %.4s",
+                        error("aiff: wrong byte size for format %.4s",
                               comm->cc_comptype);
                         return 0;
                     }
@@ -321,14 +321,14 @@ static int aiff_readheader(t_soundfile *sf)
                 }
                 else
                 {
-                    error("AIFF format \"%.4s\" not supported",
+                    error("aiff: format \"%.4s\" not supported",
                           comm->cc_comptype);
                     return 0;
                 }
             }
             if (bytespersample == 4 && !isfloat)
             {
-                error("AIFF 32 bit int not supported");
+                error("aiff: 32 bit int not supported");
                 return 0;
             }
             commfound = 1;
@@ -352,7 +352,7 @@ static int aiff_readheader(t_soundfile *sf)
         else if (!strncmp(chunk->c_id, "CSND", 4))
         {
                 /* AIFF-C compressed sound data chunk */
-            error("AIFF compressed format not support");
+            error("aiff: compressed format not support");
             return 0;
         }
         else
@@ -368,7 +368,7 @@ static int aiff_readheader(t_soundfile *sf)
     }
     if (!commfound)
     {
-        error("AIFF common chunk not found");
+        error("aiff: common chunk not found");
         return 0;
     }
 

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -265,7 +265,7 @@ static int caf_readheader(t_soundfile *sf)
                     bytelimit = CAFMAXBYTES;
             }
             else
-                bytelimit = chunksize - 4; /* subtract edit count */
+                bytelimit = chunksize - 4; /* - edit count */
             break;
         }
         else
@@ -324,8 +324,8 @@ static int caf_writeheader(t_soundfile *sf, size_t nframes)
     memcpy(buf + headersize, &desc, CAFDESCSIZE);
     headersize += CAFDESCSIZE;
 
-        /* data chunk */
-    caf_setchunksize((t_chunk *)&data, datasize + 4, swap); /* + edit count */
+        /* data chunk (+ edit count) */
+    caf_setchunksize((t_chunk *)&data, datasize + 4, swap);
     memcpy(buf + headersize, &data, CAFDATASIZE);
     headersize += CAFDATASIZE;
 
@@ -346,9 +346,8 @@ static int caf_updateheader(t_soundfile *sf, size_t nframes)
     int swap = !sys_isbigendian();
     int64_t datasize = swap8s((nframes * sf->sf_bytesperframe) + 4, swap);
 
-        /* data chunk size */
-    if (fd_write(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4,
-            (char *)&datasize, 8) < 8) /* + edit count */
+        /* data chunk size (+ edit count) */
+    if (fd_write(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4, &datasize, 8) < 8)
         return 0;
 
     if (sys_verbose)

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -408,25 +408,25 @@ static const char* caf_strerror(int errnum)
 
 void soundfile_caf_setup()
 {
-    t_soundfile_filetype caf = {
+    t_soundfile_type caf = {
         gensym("caf"),
         CAFHEADSIZE + CAFDESCSIZE + CAFDATASIZE,
         NULL,  /* data */
         caf_isheader,
-        soundfile_filetype_open,
-        soundfile_filetype_close,
+        soundfile_type_open,
+        soundfile_type_close,
         caf_readheader,
         caf_writeheader,
         caf_updateheader,
         caf_hasextension,
         caf_addextension,
         caf_endianness,
-        soundfile_filetype_seektoframe,
-        soundfile_filetype_readsamples,
-        soundfile_filetype_writesamples,
+        soundfile_type_seektoframe,
+        soundfile_type_readsamples,
+        soundfile_type_writesamples,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         caf_strerror
     };
-    soundfile_addfiletype(&caf);
+    soundfile_addtype(&caf);
 }

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -12,6 +12,7 @@
 /* CAF (Core Audio Format)
 
   * RIFF variant with sections split into data "chunks"
+  * chunk sizes do not include the chunk id or size (- 12)
   * chunk data is big-endian
   * sound data can be big or little endian (set in desc fmtflags)
   * header is immediately followed by description chunk
@@ -393,12 +394,12 @@ void soundfile_caf_setup()
     t_soundfile_filetype caf = {
         gensym("caf"),
         CAFHEADSIZE + CAFDESCSIZE + CAFDATASIZE,
+        NULL,  /* data */
         caf_isheader,
         soundfile_filetype_open,
         soundfile_filetype_close,
         caf_readheader,
         caf_writeheader,
-        NULL, /* writemetafn */
         caf_updateheader,
         caf_hasextension,
         caf_addextension,
@@ -406,7 +407,8 @@ void soundfile_caf_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL  /* writemetafn */
     };
     soundfile_addfiletype(&caf);
 }

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -398,6 +398,7 @@ void soundfile_caf_setup()
         soundfile_filetype_close,
         caf_readheader,
         caf_writeheader,
+        NULL, /* writemetafn */
         caf_updateheader,
         caf_hasextension,
         caf_addextension,

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -65,7 +65,7 @@ typedef struct _chunk {
     uint8_t c_size[8];           /**< chunk data length, int64_t      */
 } t_chunk;
 
-    /** file header, 8 bytes */
+    /** file head container chunk, 8 bytes */
 typedef struct _head {
     char h_id[4];                /**< file id "caff"                  */
     uint16_t h_version;          /**< file version, probably 1        */
@@ -411,7 +411,7 @@ void soundfile_caf_setup()
     t_soundfile_type caf = {
         gensym("caf"),
         CAFHEADSIZE + CAFDESCSIZE + CAFDATASIZE,
-        NULL,  /* data */
+        NULL, /* data */
         caf_isheader,
         soundfile_type_open,
         soundfile_type_close,

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -442,10 +442,10 @@ void soundfile_caf_setup()
         caf_updateheader,
         caf_hasextension,
         caf_addextension,
-        caf_endianness,
         soundfile_type_seektoframe,
         soundfile_type_readsamples,
         soundfile_type_writesamples,
+        caf_endianness,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         caf_strerror

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -180,7 +180,7 @@ static int caf_readheader(t_soundfile *sf)
     t_descchunk *desc = &buf.b_descchunk;
 
         /* file header */
-    if (soundfile_readbytes(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
+    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
         return 0;
     if (strncmp(head->h_id, "caff", 4))
         return 0;
@@ -234,8 +234,7 @@ static int caf_readheader(t_soundfile *sf)
     headersize += CAFDESCSIZE;
 
         /* prepare second chunk */
-    if (soundfile_readbytes(sf->sf_fd, headersize, buf.b_c,
-                            CAFCHUNKSIZE) < CAFCHUNKSIZE)
+    if (fd_read(sf->sf_fd, headersize, buf.b_c, CAFCHUNKSIZE) < CAFCHUNKSIZE)
         return 0;
 
         /* read chunks in loop until we find the sound data chunk */
@@ -252,8 +251,8 @@ static int caf_readheader(t_soundfile *sf)
             if (sys_verbose)
             {
                 t_datachunk *data = &buf.b_datachunk;
-                if (soundfile_readbytes(sf->sf_fd, headersize + CAFCHUNKSIZE,
-                                        buf.b_c + CAFCHUNKSIZE, 4) < 4)
+                if (fd_read(sf->sf_fd, headersize + CAFCHUNKSIZE,
+                        buf.b_c + CAFCHUNKSIZE, 4) < 4)
                     return 0;
                 caf_postdata(data, swap);
             }
@@ -276,8 +275,7 @@ static int caf_readheader(t_soundfile *sf)
                 caf_postchunk(chunk, swap);
         }
         headersize = seekto;
-        if (soundfile_readbytes(sf->sf_fd, seekto, buf.b_c,
-                                CAFCHUNKSIZE) < CAFCHUNKSIZE)
+        if (fd_read(sf->sf_fd, seekto, buf.b_c, CAFCHUNKSIZE) < CAFCHUNKSIZE)
             return 0;
     }
 
@@ -338,7 +336,7 @@ static int caf_writeheader(t_soundfile *sf, size_t nframes)
         caf_postdata(&data, swap);
     }
 
-    byteswritten = soundfile_writebytes(sf->sf_fd, 0, buf, headersize);
+    byteswritten = fd_write(sf->sf_fd, 0, buf, headersize);
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
@@ -349,8 +347,8 @@ static int caf_updateheader(t_soundfile *sf, size_t nframes)
     int64_t datasize = swap8s((nframes * sf->sf_bytesperframe) + 4, swap);
 
         /* data chunk size */
-    if (soundfile_writebytes(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4,
-                             (char *)&datasize, 8) < 8) /* + edit count */
+    if (fd_write(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4,
+            (char *)&datasize, 8) < 8) /* + edit count */
         return 0;
 
     if (sys_verbose)

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -185,13 +185,13 @@ static int caf_readheader(t_soundfile *sf)
         return 0;
     if (swap2(head->h_version, swap) != 1)
     {
-        error("CAF version %d unsupported", swap2(head->h_version, swap));
+        error("caf: version %d unsupported", swap2(head->h_version, swap));
         return 0;
     }
     if (swap2(head->h_flags, swap) != 0)
     {
             /* current spec says these should be empty */
-        error("CAF version 1 format flags invalid");
+        error("caf: version 1 format flags invalid");
         return 0;
     }
     if (sys_verbose)
@@ -208,7 +208,7 @@ static int caf_readheader(t_soundfile *sf)
         caf_postdesc(desc, swap);
     if (strncmp(desc->ds_fmtid, "lpcm", 4))
     {
-        error("CAF format \"%.4s\" not supported", desc->ds_fmtid);
+        error("caf: format \"%.4s\" not supported", desc->ds_fmtid);
         return 0;
     }
     nchannels = swap4(desc->ds_nchannels, swap);
@@ -220,12 +220,12 @@ static int caf_readheader(t_soundfile *sf)
         case 24: bytespersample = 3; break;
         case 32: bytespersample = 4; break;
         default:
-            error("CAF %d bit samples not supported ", bitspersample);
+            error("caf: %d bit samples not supported ", bitspersample);
             return 0;
     }
     if (bytespersample == 4 && !(fmtflags & kCAFLinearPCMFormatFlagIsFloat))
     {
-        error("CAF 32 bit int not supported");
+        error("caf: 32 bit int not supported");
         return 0;
     }
     bigendian = !(fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian);

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -127,7 +127,7 @@ static int next_readheader(t_soundfile *sf)
     } buf = {0};
     t_nextstep *next = &buf.b_nextstep;
 
-    if (soundfile_readbytes(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
+    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
         return 0;
 
     bigendian = next_isbigendian(next);
@@ -211,8 +211,7 @@ static int next_writeheader(t_soundfile *sf, size_t nframes)
     if (sys_verbose)
         next_posthead(&next, swap);
 
-    byteswritten = soundfile_writebytes(sf->sf_fd, 0,
-                                        (char *)&next, headersize);
+    byteswritten = fd_write(sf->sf_fd, 0, (char *)&next, headersize);
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
@@ -226,7 +225,7 @@ static int next_updateheader(t_soundfile *sf, size_t nframes)
     if (datasize > NEXTMAXBYTES)
         datasize = NEXT_UNKNOWN_SIZE;
     datasize = swap4(datasize, swap);
-    if (soundfile_writebytes(sf->sf_fd, 8, (char *)&datasize, 4) < 4)
+    if (fd_write(sf->sf_fd, 8, (char *)&datasize, 4) < 4)
         return 0;
 
     if (sys_verbose)

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -77,7 +77,7 @@ static void next_posthead(const t_nextstep *next, int swap)
     uint32_t onset = swap4(next->ns_onset, swap),
              format = swap4(next->ns_format, swap),
              datasize = swap4(next->ns_length, swap);
-    post("NEXT %.4s (%s)", next->ns_id,
+    post("next %.4s (%s)", next->ns_id,
         (next_isbigendian(next) ? "big" : "little"));
     post("  data onset %d", onset);
     if (datasize == NEXT_UNKNOWN_SIZE)
@@ -155,7 +155,7 @@ static int next_readheader(t_soundfile *sf)
         case NEXT_FORMAT_LINEAR_24: bytespersample = 3; break;
         case NEXT_FORMAT_FLOAT:     bytespersample = 4; break;
         default:
-            error("NEXT unsupported format %d", format);
+            error("next: format %d not supported", format);
             return 0;
     }
 
@@ -232,7 +232,7 @@ static int next_updateheader(t_soundfile *sf, size_t nframes)
     if (sys_verbose)
     {
         datasize = swap4(datasize, swap);
-        post("NEXT %.4s (%s)", (sf->sf_bigendian ? ".snd" : "dns."),
+        post("next %.4s (%s)", (sf->sf_bigendian ? ".snd" : "dns."),
             (sf->sf_bigendian ? "big" : "little"));
         if (datasize == NEXT_UNKNOWN_SIZE)
             post("  data length -1");

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -291,10 +291,10 @@ void soundfile_next_setup()
         next_updateheader,
         next_hasextension,
         next_addextension,
-        next_endianness,
         soundfile_type_seektoframe,
         soundfile_type_readsamples,
         soundfile_type_writesamples,
+        next_endianness,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         NULL  /* strerrorfn */

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -279,12 +279,12 @@ void soundfile_next_setup()
     t_soundfile_filetype next = {
         gensym("next"),
         NEXTHEADSIZE - 4, /* without info string */
+        NULL,  /* data */
         next_isheader,
         soundfile_filetype_open,
         soundfile_filetype_close,
         next_readheader,
         next_writeheader,
-        NULL, /* writemetafn */
         next_updateheader,
         next_hasextension,
         next_addextension,
@@ -292,7 +292,8 @@ void soundfile_next_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL  /* writemetafn */
     };
     soundfile_addfiletype(&next);
 }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -8,7 +8,6 @@
          http://soundfile.sapp.org/doc/NextFormat */
 
 #include "d_soundfile.h"
-#include "s_stuff.h" /* for sys_verbose */
 
 /* NeXTStep/Sun sound
 
@@ -71,6 +70,8 @@ static int next_isbigendian(const t_nextstep *next)
     return -1;
 }
 
+#ifdef DEBUG_SOUNDFILE
+
     /** post head info for debugging */
 static void next_posthead(const t_nextstep *next, int swap)
 {
@@ -104,6 +105,8 @@ static void next_posthead(const t_nextstep *next, int swap)
     post("  info \"%.4s%s\"",
         next->ns_info, (onset > NEXTHEADSIZE ? "..." : ""));
 }
+
+#endif /* DEBUG_SOUNDFILE */
 
 /* ------------------------- NEXT ------------------------- */
 
@@ -159,8 +162,9 @@ static int next_readheader(t_soundfile *sf)
             return 0;
     }
 
-    if (sys_verbose)
-        next_posthead(next, swap);
+#ifdef DEBUG_SOUNDFILE
+    next_posthead(next, swap);
+#endif
 
         /* copy sample format back to caller */
     sf->sf_samplerate = swap4(next->ns_samplerate, swap);
@@ -208,8 +212,9 @@ static int next_writeheader(t_soundfile *sf, size_t nframes)
             return 0;
     }
 
-    if (sys_verbose)
-        next_posthead(&next, swap);
+#ifdef DEBUG_SOUNDFILE
+    next_posthead(&next, swap);
+#endif
 
     byteswritten = fd_write(sf->sf_fd, 0, &next, headersize);
     return (byteswritten < headersize ? -1 : byteswritten);
@@ -228,16 +233,15 @@ static int next_updateheader(t_soundfile *sf, size_t nframes)
     if (fd_write(sf->sf_fd, 8, &datasize, 4) < 4)
         return 0;
 
-    if (sys_verbose)
-    {
-        datasize = swap4(datasize, swap);
-        post("next %.4s (%s)", (sf->sf_bigendian ? ".snd" : "dns."),
-            (sf->sf_bigendian ? "big" : "little"));
-        if (datasize == NEXT_UNKNOWN_SIZE)
-            post("  data length -1");
-        else
-            post("  data length %d", datasize);
-    }
+#ifdef DEBUG_SOUNDFILE
+    datasize = swap4(datasize, swap);
+    post("next %.4s (%s)", (sf->sf_bigendian ? ".snd" : "dns."),
+        (sf->sf_bigendian ? "big" : "little"));
+    if (datasize == NEXT_UNKNOWN_SIZE)
+        post("  data length -1");
+    else
+        post("  data length %d", datasize);
+#endif
 
     return 1;
 }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -136,7 +136,7 @@ static int next_readheader(t_soundfile *sf)
     swap = (bigendian != sys_isbigendian());
 
     headersize = swap4(next->ns_onset, swap);
-    if (headersize < NEXTHEADSIZE - 4) /* min valid header size */
+    if (headersize < NEXTHEADSIZE - 4) /* min valid header w/o info string */
         return 0;
 
     bytelimit = swap4(next->ns_length, swap);
@@ -211,7 +211,7 @@ static int next_writeheader(t_soundfile *sf, size_t nframes)
     if (sys_verbose)
         next_posthead(&next, swap);
 
-    byteswritten = fd_write(sf->sf_fd, 0, (char *)&next, headersize);
+    byteswritten = fd_write(sf->sf_fd, 0, &next, headersize);
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
@@ -225,7 +225,7 @@ static int next_updateheader(t_soundfile *sf, size_t nframes)
     if (datasize > NEXTMAXBYTES)
         datasize = NEXT_UNKNOWN_SIZE;
     datasize = swap4(datasize, swap);
-    if (fd_write(sf->sf_fd, 8, (char *)&datasize, 4) < 4)
+    if (fd_write(sf->sf_fd, 8, &datasize, 4) < 4)
         return 0;
 
     if (sys_verbose)
@@ -277,7 +277,7 @@ void soundfile_next_setup()
 {
     t_soundfile_filetype next = {
         gensym("next"),
-        NEXTHEADSIZE - 4, /* without info string */
+        NEXTHEADSIZE - 4, /* - info string */
         NULL,  /* data */
         next_isheader,
         soundfile_filetype_open,

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -284,6 +284,7 @@ void soundfile_next_setup()
         soundfile_filetype_close,
         next_readheader,
         next_writeheader,
+        NULL, /* writemetafn */
         next_updateheader,
         next_hasextension,
         next_addextension,

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -155,7 +155,7 @@ static int next_readheader(t_soundfile *sf)
         case NEXT_FORMAT_LINEAR_24: bytespersample = 3; break;
         case NEXT_FORMAT_FLOAT:     bytespersample = 4; break;
         default:
-            error("next: format %d not supported", format);
+            errno = SOUNDFILE_ERR_SAMPLEFMT;
             return 0;
     }
 
@@ -292,7 +292,8 @@ void soundfile_next_setup()
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
         NULL, /* readmetafn */
-        NULL  /* writemetafn */
+        NULL, /* writemetafn */
+        NULL  /* strerrfn */
     };
     soundfile_addfiletype(&next);
 }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -278,7 +278,7 @@ void soundfile_next_setup()
     t_soundfile_type next = {
         gensym("next"),
         NEXTHEADSIZE - 4, /* - info string */
-        NULL,  /* data */
+        NULL, /* data */
         next_isheader,
         soundfile_type_open,
         soundfile_type_close,
@@ -293,7 +293,7 @@ void soundfile_next_setup()
         soundfile_type_writesamples,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
-        NULL  /* strerrfn */
+        NULL  /* strerrorfn */
     };
     soundfile_addtype(&next);
 }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -275,25 +275,25 @@ static int next_endianness(int endianness)
 
 void soundfile_next_setup()
 {
-    t_soundfile_filetype next = {
+    t_soundfile_type next = {
         gensym("next"),
         NEXTHEADSIZE - 4, /* - info string */
         NULL,  /* data */
         next_isheader,
-        soundfile_filetype_open,
-        soundfile_filetype_close,
+        soundfile_type_open,
+        soundfile_type_close,
         next_readheader,
         next_writeheader,
         next_updateheader,
         next_hasextension,
         next_addextension,
         next_endianness,
-        soundfile_filetype_seektoframe,
-        soundfile_filetype_readsamples,
-        soundfile_filetype_writesamples,
+        soundfile_type_seektoframe,
+        soundfile_type_readsamples,
+        soundfile_type_writesamples,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         NULL  /* strerrfn */
     };
-    soundfile_addfiletype(&next);
+    soundfile_addtype(&next);
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -37,7 +37,7 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
         NULL, /* endiannessfn */
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
-        soundfile_filetype_writesamples,
+        NULL, /* writesamplesfn */
         NULL
     };
     memcpy(ft, &raw, sizeof(t_soundfile_filetype));

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -25,26 +25,26 @@ static int raw_readheader(t_soundfile *sf)
     return 1;
 }
 
-void soundfile_raw_setup(t_soundfile_filetype *ft)
+void soundfile_raw_setup(t_soundfile_type *type)
 {
-    t_soundfile_filetype raw = {
+    t_soundfile_type raw = {
         gensym("raw"),
         0,
         NULL,  /* data */
         NULL, /* isheaderfn */
-        soundfile_filetype_open,
-        soundfile_filetype_close,
+        soundfile_type_open,
+        soundfile_type_close,
         raw_readheader,
         NULL, /* writeheaderfn */
         NULL, /* updateheaderfn */
         NULL, /* hasextensionfn */
         NULL, /* addextensionfn */
         NULL, /* endiannessfn */
-        soundfile_filetype_seektoframe,
-        soundfile_filetype_readsamples,
+        soundfile_type_seektoframe,
+        soundfile_type_readsamples,
         NULL, /* writesamplesfn */
         NULL, /* readmetafn */
         NULL  /* writemetafn */
     };
-    memcpy(ft, &raw, sizeof(t_soundfile_filetype));
+    memcpy(type, &raw, sizeof(t_soundfile_type));
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -30,7 +30,7 @@ void soundfile_raw_setup(t_soundfile_type *type)
     t_soundfile_type raw = {
         gensym("raw"),
         0,
-        NULL,  /* data */
+        NULL, /* data */
         NULL, /* isheaderfn */
         soundfile_type_open,
         soundfile_type_close,
@@ -44,7 +44,8 @@ void soundfile_raw_setup(t_soundfile_type *type)
         soundfile_type_readsamples,
         NULL, /* writesamplesfn */
         NULL, /* readmetafn */
-        NULL  /* writemetafn */
+        NULL, /* writemetafn */
+        NULL  /* strerrorfn */
     };
     memcpy(type, &raw, sizeof(t_soundfile_type));
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -39,10 +39,10 @@ void soundfile_raw_setup(t_soundfile_type *type)
         NULL, /* updateheaderfn */
         NULL, /* hasextensionfn */
         NULL, /* addextensionfn */
-        NULL, /* endiannessfn */
         soundfile_type_seektoframe,
         soundfile_type_readsamples,
         NULL, /* writesamplesfn */
+        NULL, /* endiannessfn */
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         NULL  /* strerrorfn */

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -3,7 +3,6 @@
 * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "d_soundfile.h"
-#include "s_stuff.h" /* for sys_verbose */
 
 /* read raw lpcm (16 or 24 bit int) or 32 bit float samples without header */
 
@@ -19,8 +18,9 @@ static int raw_readheader(t_soundfile *sf)
         /* copy sample format back to caller */
     sf->sf_bytelimit = bytelimit;
 
-    if (sys_verbose)
-        post("raw %ld", bytelimit);
+#ifdef DEBUG_SOUNDFILE
+    post("raw %ld", bytelimit);
+#endif
 
     return 1;
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -3,6 +3,7 @@
 * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "d_soundfile.h"
+#include "s_stuff.h" /* for sys_verbose */
 
 /* read raw lpcm (16 or 24 bit int) or 32 bit float samples without header */
 
@@ -17,6 +18,9 @@ static int raw_readheader(t_soundfile *sf)
 
         /* copy sample format back to caller */
     sf->sf_bytelimit = bytelimit;
+
+    if (sys_verbose)
+        post("raw %ld", bytelimit);
 
     return 1;
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -30,12 +30,12 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
     t_soundfile_filetype raw = {
         gensym("raw"),
         0,
+        NULL,  /* data */
         NULL, /* isheaderfn */
         soundfile_filetype_open,
         soundfile_filetype_close,
         raw_readheader,
         NULL, /* writeheaderfn */
-        NULL, /* writemetafn */
         NULL, /* updateheaderfn */
         NULL, /* hasextensionfn */
         NULL, /* addextensionfn */
@@ -43,7 +43,8 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         NULL, /* writesamplesfn */
-        NULL
+        NULL, /* readmetafn */
+        NULL  /* writemetafn */
     };
     memcpy(ft, &raw, sizeof(t_soundfile_filetype));
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -1,0 +1,44 @@
+/* Copyright (c) 1997-1999 Miller Puckette. Updated 2020 Dan Wilcox.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+#include "d_soundfile.h"
+
+/* read raw lpcm (16 or 24 bit int) or 32 bit float samples without header */
+
+/* ------------------------- RAW ------------------------- */
+
+static int raw_readheader(t_soundfile *sf)
+{
+        /* interpret data size from file size */
+    ssize_t bytelimit = lseek(sf->sf_fd, 0, SEEK_END);
+    if (bytelimit > SFMAXBYTES || bytelimit < 0)
+        bytelimit = SFMAXBYTES;
+
+        /* copy sample format back to caller */
+    sf->sf_bytelimit = bytelimit;
+
+    return 1;
+}
+
+void soundfile_raw_setup(t_soundfile_filetype *ft)
+{
+    t_soundfile_filetype raw = {
+        gensym("raw"),
+        0,
+        NULL, /* isheaderfn */
+        soundfile_filetype_open,
+        soundfile_filetype_close,
+        raw_readheader,
+        NULL, /* writeheaderfn */
+        NULL, /* updateheaderfn */
+        NULL, /* hasextensionfn */
+        NULL, /* addextensionfn */
+        NULL, /* endiannessfn */
+        soundfile_filetype_seektoframe,
+        soundfile_filetype_readsamples,
+        soundfile_filetype_writesamples,
+        NULL
+    };
+    memcpy(ft, &raw, sizeof(t_soundfile_filetype));
+}

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -35,6 +35,7 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
         soundfile_filetype_close,
         raw_readheader,
         NULL, /* writeheaderfn */
+        NULL, /* writemetafn */
         NULL, /* updateheaderfn */
         NULL, /* hasextensionfn */
         NULL, /* addextensionfn */

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -81,7 +81,7 @@ typedef struct _chunk
     uint32_t c_size;               /**< length of data chunk            */
 } t_chunk;
 
-    /** file header, 12 bytes */
+    /** file head container chunk, 12 bytes */
 typedef struct _head
 {
     char h_id[4];                   /**< chunk id "RIFF"                */
@@ -502,7 +502,7 @@ void soundfile_wave_setup()
     t_soundfile_type wave = {
         gensym("wave"),
         WAVEHEADSIZE + WAVEFORMATSIZE + WAVECHUNKSIZE,
-        NULL,  /* data */
+        NULL, /* data */
         wave_isheader,
         soundfile_type_open,
         soundfile_type_close,

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -240,7 +240,7 @@ static int wave_readheader(t_soundfile *sf)
             formattag = swap2(format->fc_fmttag, swap);
             if (formattag == WAVE_FORMAT_EXT && chunksize == WAVEFORMATSIZE)
             {
-                error("WAVE extended format not found");
+                error("wave: extended format not found");
                 return 0;
             }
             switch (formattag)
@@ -252,12 +252,12 @@ static int wave_readheader(t_soundfile *sf)
                         formattag == WAVE_FORMAT_FLOAT)
                             break;
                 default:
-                    error("WAVE unsupported format %d", formattag); return 0;
+                    error("wave: unsupported format %d", formattag); return 0;
             }
             bytespersample = swap2(format->fc_bitspersample, swap) / 8;
             if (bytespersample == 4 && formattag != WAVE_FORMAT_FLOAT)
             {
-                error("WAVE 32 bit int not supported");
+                error("wave: 32 bit int not supported");
                 return 0;
             }
             formatfound = 1;
@@ -290,7 +290,7 @@ static int wave_readheader(t_soundfile *sf)
     }
     if (!formatfound)
     {
-        error("WAVE format chunk not found");
+        error("wave: format chunk not found");
         return 0;
     }
 
@@ -474,7 +474,7 @@ static int wave_addextension(char *filename, size_t size)
 static int wave_endianness(int endianness)
 {
     if (endianness == 1)
-        error("WAVE file forced to little endian");
+        error("wave: file forced to little endian");
     return 0;
 }
 

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -532,10 +532,10 @@ void soundfile_wave_setup()
         wave_updateheader,
         wave_hasextension,
         wave_addextension,
-        wave_endianness,
         soundfile_type_seektoframe,
         soundfile_type_readsamples,
         soundfile_type_writesamples,
+        wave_endianness,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         wave_strerror

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -501,25 +501,25 @@ static const char* wave_strerror(int errnum)
 
 void soundfile_wave_setup()
 {
-    t_soundfile_filetype wave = {
+    t_soundfile_type wave = {
         gensym("wave"),
         WAVEHEADSIZE + WAVEFORMATSIZE + WAVECHUNKSIZE,
         NULL,  /* data */
         wave_isheader,
-        soundfile_filetype_open,
-        soundfile_filetype_close,
+        soundfile_type_open,
+        soundfile_type_close,
         wave_readheader,
         wave_writeheader,
         wave_updateheader,
         wave_hasextension,
         wave_addextension,
         wave_endianness,
-        soundfile_filetype_seektoframe,
-        soundfile_filetype_readsamples,
-        soundfile_filetype_writesamples,
+        soundfile_type_seektoframe,
+        soundfile_type_readsamples,
+        soundfile_type_writesamples,
         NULL, /* readmetafn */
         NULL, /* writemetafn */
         wave_strerror
     };
-    soundfile_addfiletype(&wave);
+    soundfile_addtype(&wave);
 }

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -10,6 +10,7 @@
 /* WAVE (Waveform Audio File Format)
 
   * RIFF variant with sections split into data "chunks"
+  * chunk sizes do not include the chunk id or size (- 8)
   * chunk and sound data are little endian
   * format and sound data chunks are required
   * format tags:
@@ -483,12 +484,12 @@ void soundfile_wave_setup()
     t_soundfile_filetype wave = {
         gensym("wave"),
         WAVEHEADSIZE + WAVEFORMATSIZE + WAVECHUNKSIZE,
+        NULL,  /* data */
         wave_isheader,
         soundfile_filetype_open,
         soundfile_filetype_close,
         wave_readheader,
         wave_writeheader,
-        NULL, /* writemetafn */
         wave_updateheader,
         wave_hasextension,
         wave_addextension,
@@ -496,7 +497,8 @@ void soundfile_wave_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL  /* writemetafn */
     };
     soundfile_addfiletype(&wave);
 }

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -481,8 +481,6 @@ static int wave_addextension(char *filename, size_t size)
     /* force little endian */
 static int wave_endianness(int endianness)
 {
-    if (endianness == 1)
-        error("wave: file forced to little endian");
     return 0;
 }
 

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -488,6 +488,7 @@ void soundfile_wave_setup()
         soundfile_filetype_close,
         wave_readheader,
         wave_writeheader,
+        NULL, /* writemetafn */
         wave_updateheader,
         wave_hasextension,
         wave_addextension,

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -122,7 +122,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
     d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
-    d_soundfile_next.c d_soundfile_wave.c \
+    d_soundfile_next.c d_soundfile_raw.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -93,7 +93,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
     d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
-    d_soundfile_next.c d_soundfile_wave.c \
+    d_soundfile_next.c d_soundfile_raw.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -127,7 +127,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
     d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
-    d_soundfile_next.c d_soundfile_wave.c \
+    d_soundfile_next.c d_soundfile_raw.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -92,7 +92,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
     d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \
-    d_soundfile_next.c d_soundfile_wave.c \
+    d_soundfile_next.c d_soundfile_raw.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
     x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \


### PR DESCRIPTION
This PR is a feature branch for #855 which abstracts the file type specific function via a `t_soundfile_filetype` struct and function pointers. New file types can be implemented and added via `soundfile_addfiletype()`.

My initial approach is to just take the pragmatic refactoring I already did and abstract it. For a more *proper* architecture, I think the implementations should have more direct control over sample conversion and opening/closing files. We can look at this for "round two."