### PR TITLE
[WIP] soundfile meta data read/write

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1414,7 +1414,7 @@ size_t soundfiler_dowrite(void *obj, t_canvas *canvas,
         }
     }
     if ((fd = create_soundfile(canvas, wa.wa_filesym->s_name,
-        sf, 0)) < 0)//wa.wa_nframes)) < 0)
+        sf, wa.wa_nframes)) < 0)
     {
         post("%s: %s\n", wa.wa_filesym->s_name, strerror(errno));
         goto fail;

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -213,9 +213,9 @@ ssize_t soundfile_readbytes(int fd, off_t offset,
 ssize_t soundfile_writebytes(int fd, off_t offset,
     const char *src, size_t size);
 
-    /** move size bytes from src location to dst location, assumes fd is O_RDWR
+    /** copy size bytes in file fd from src pos to dst pos, assumes fd is O_RDWR
         returns bytes moved on success or -1 on failure */
-ssize_t soundfile_movebytes(int fd, off_t dst, off_t src, size_t size);
+ssize_t soundfile_copybytes(int fd, off_t dst, off_t src, size_t size);
 
 /* ----- byte swappers ----- */
 
@@ -236,6 +236,9 @@ int32_t swap4s(int32_t n, int doit);
 
     /** swap 2 bytes and return if doit = 1, otherwise return n */
 uint16_t swap2(uint16_t n, int doit);
+
+    /** swap a 16 bit signed int and return if doit = 1, otherwise return n */
+int16_t swap2s(int16_t n, int doit);
 
     /** swap a 4 byte string in place if do it = 1, otherewise do nothing */
 void swapstring4(char *foo, int doit);

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -51,10 +51,6 @@ typedef struct _soundfile_filetype t_soundfile_filetype;
 typedef struct _soundfile
 {
     int sf_fd;             /**< file descriptor, >= 0 : open, -1 : closed */
-    /* implementation */
-    t_soundfile_filetype *sf_filetype; /**< implementation type           */
-    t_outlet *sf_metaout;  /**< read: meta data outlet, if meta supported */
-    void *sf_data;         /**< implementation-specific data              */
     /* format info */
     int sf_samplerate;     /**< read: file sr, write: pd sr               */
     int sf_nchannels;      /**< number of channels                        */
@@ -63,6 +59,9 @@ typedef struct _soundfile
     int sf_bigendian;      /**< sample endianness, 1 : big or 0 : little  */
     int sf_bytesperframe;  /**< number of bytes per sample frame          */
     ssize_t sf_bytelimit;  /**< number of sound data bytes to read/write  */
+    /* implementation */
+    t_soundfile_filetype *sf_filetype; /**< implementation type           */
+    void *sf_data;         /**< implementation-specific data              */
 } t_soundfile;
 
     /** clear soundfile struct to defaults, does not close or free */
@@ -112,10 +111,6 @@ typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
         this may be called in a background thread */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 
-    /** write meta data to the soundfile header and updates headersize
-        returns 1 on success or 0 on failure */
-typedef int (*t_soundfile_writemetafn)(t_soundfile *sf, int argc, t_atom *argv);
-
     /** update file header data size, returns 1 on success or 0 on error
         this may be called in a background thread */
 typedef int (*t_soundfile_updateheaderfn)(t_soundfile *sf, size_t nframes);
@@ -152,6 +147,14 @@ typedef ssize_t (*t_soundfile_readsamplesfn)(t_soundfile *sf,
 typedef ssize_t (*t_soundfile_writesamplesfn)(t_soundfile *sf,
     const unsigned char *src, size_t size);
 
+    /** read meta data from the soundfile header to the given outlet
+        returns 1 on success or 0 on failure */
+typedef int (*t_soundfile_readmetafn)(t_soundfile *sf, t_outlet *out);
+
+    /** write meta data to the soundfile header and updates headersize
+        returns 1 on success or 0 on failure */
+typedef int (*t_soundfile_writemetafn)(t_soundfile *sf, int argc, t_atom *argv);
+
     /* file type specific implementation */
 typedef struct _soundfile_filetype
 {
@@ -162,7 +165,6 @@ typedef struct _soundfile_filetype
     t_soundfile_closefn ft_closefn;               /**< must be non-NULL */
     t_soundfile_readheaderfn ft_readheaderfn;     /**< must be non-NULL */
     t_soundfile_writeheaderfn ft_writeheaderfn;   /**< must be non-NULL */
-    t_soundfile_writemetafn ft_writemetafn;       /**< NULL if not supported */
     t_soundfile_updateheaderfn ft_updateheaderfn; /**< must be non-NULL */
     t_soundfile_hasextensionfn ft_hasextensionfn; /**< must be non-NULL */
     t_soundfile_addextensionfn ft_addextensionfn; /**< must be non-NULL */
@@ -170,6 +172,8 @@ typedef struct _soundfile_filetype
     t_soundfile_seektoframefn ft_seektoframefn;   /**< must be non-NULL */
     t_soundfile_readsamplesfn ft_readsamplesfn;   /**< must be non-NULL */
     t_soundfile_writesamplesfn ft_writesamplesfn; /**< must be non-NULL */
+    t_soundfile_readmetafn ft_readmetafn;         /**< NULL if not supported */
+    t_soundfile_writemetafn ft_writemetafn;       /**< NULL if not supported */
     void *ft_data; /**< implementation specific data */
 } t_soundfile_filetype;
 
@@ -179,20 +183,20 @@ int soundfile_addfiletype(t_soundfile_filetype *ft);
 
 /* ----- default implementations ----- */
 
-    /** t_soundfile_openfn implementation */
+    /** default t_soundfile_openfn implementation */
 int soundfile_filetype_open(t_soundfile *sf, int fd);
 
-    /** t_soundfile_closefn implementation */
+    /** default t_soundfile_closefn implementation */
 int soundfile_filetype_close(t_soundfile *sf);
 
-    /** t_soundfile_seektoframefn implementation */
+    /** default t_soundfile_seektoframefn implementation */
 int soundfile_filetype_seektoframe(t_soundfile *sf, size_t frame);
 
-    /** t_soundfile_readsamplesfn implementation */
+    /** default t_soundfile_readsamplesfn implementation */
 ssize_t soundfile_filetype_readsamples(t_soundfile *sf,
     unsigned char *buf, size_t size);
 
-    /** t_soundfile_writesamplesfn implementation */
+    /** default t_soundfile_writesamplesfn implementation */
 ssize_t soundfile_filetype_writesamples(t_soundfile *sf,
     const unsigned char *buf, size_t size);
 
@@ -208,6 +212,10 @@ ssize_t soundfile_readbytes(int fd, off_t offset,
         failed */
 ssize_t soundfile_writebytes(int fd, off_t offset,
     const char *src, size_t size);
+
+    /** move size bytes from src location to dst location, assumes fd is O_RDWR
+        returns bytes moved on success or -1 on failure */
+ssize_t soundfile_movebytes(int fd, off_t dst, off_t src, size_t size);
 
 /* ----- byte swappers ----- */
 

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -12,6 +12,7 @@
 /* CAF (Core Audio Format)
 
   * RIFF variant with sections split into data "chunks"
+  * chunk sizes do not include the chunk id or size (- 12)
   * chunk data is big-endian
   * sound data can be big or little endian (set in desc fmtflags)
   * header is immediately followed by description chunk
@@ -398,7 +399,6 @@ void soundfile_caf_setup()
         soundfile_filetype_close,
         caf_readheader,
         caf_writeheader,
-        NULL, /* writemetafn */
         caf_updateheader,
         caf_hasextension,
         caf_addextension,
@@ -406,7 +406,9 @@ void soundfile_caf_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL, /* writemetafn */
+        NULL  /* data */
     };
     soundfile_addfiletype(&caf);
 }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -284,7 +284,6 @@ void soundfile_next_setup()
         soundfile_filetype_close,
         next_readheader,
         next_writeheader,
-        NULL, /* writemetafn */
         next_updateheader,
         next_hasextension,
         next_addextension,
@@ -292,7 +291,9 @@ void soundfile_next_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL, /* writemetafn */
+        NULL  /* data */
     };
     soundfile_addfiletype(&next);
 }

--- a/src/d_soundfile_raw.c
+++ b/src/d_soundfile_raw.c
@@ -35,7 +35,6 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
         soundfile_filetype_close,
         raw_readheader,
         NULL, /* writeheaderfn */
-        NULL, /* writemetafn */
         NULL, /* updateheaderfn */
         NULL, /* hasextensionfn */
         NULL, /* addextensionfn */
@@ -43,7 +42,9 @@ void soundfile_raw_setup(t_soundfile_filetype *ft)
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         NULL, /* writesamplesfn */
-        NULL
+        NULL, /* readmetafn */
+        NULL, /* writemetafn */
+        NULL  /* data */
     };
     memcpy(ft, &raw, sizeof(t_soundfile_filetype));
 }

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -10,6 +10,7 @@
 /* WAVE (Waveform Audio File Format)
 
   * RIFF variant with sections split into data "chunks"
+  * chunk sizes do not include the chunk id or size (- 8)
   * chunk and sound data are little endian
   * format and sound data chunks are required
   * format tags:
@@ -488,7 +489,6 @@ void soundfile_wave_setup()
         soundfile_filetype_close,
         wave_readheader,
         wave_writeheader,
-        NULL, /* writemetafn */
         wave_updateheader,
         wave_hasextension,
         wave_addextension,
@@ -496,7 +496,9 @@ void soundfile_wave_setup()
         soundfile_filetype_seektoframe,
         soundfile_filetype_readsamples,
         soundfile_filetype_writesamples,
-        NULL
+        NULL, /* readmetafn */
+        NULL, /* writemetafn */
+        NULL  /* data */
     };
     soundfile_addfiletype(&wave);
 }


### PR DESCRIPTION
This PR is a piggyback to #894 which adds basic meta data read and write via:

* read: `[soundfiler]` "-meta" read flag which outputs meta data as lists from the 2nd "info" outlet 
* write: `[writesf~]` "meta" message which takes meta type name and a list and adds to the opened file's header, ie. send this after opening but before starting the write stream

<img width="728" alt="Screen Shot 2020-02-20 at 5 46 42 PM" src="https://user-images.githubusercontent.com/480637/74958788-c3860300-5409-11ea-8e5f-45a51dbd4de8.png">

So far, this is partially a proof-of-concept for the soundfile backend API, but can be expanded to cover *much requested* data access, ie. instrument & sampler meta data.

What's been implemented so far:
* aiff: text chunks (name, author, copyright, annotation)
