### PR TITLE
Fix macros for MSC

### DIFF
--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -537,13 +537,14 @@ ex_toint(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
                 FUNC_EVAL_UNARY(left, toint, (int), optr, 0);
         }
 
-#ifdef _MSC_VER
-/* rint is now advertised as part of the microsoft SDK but my MSVC still
-doesn't find it - so here it is again. */
+#ifdef __MSC__
+#if (_MSC_VER < 1800)
+/* rint is not available for Visual Studio Version < Visual Studio 2013 */
 static double rint(double x)
 {
         return (floor(x + 0.5));
 }
+#endif
 #endif
 
 /*

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -537,7 +537,7 @@ ex_toint(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
                 FUNC_EVAL_UNARY(left, toint, (int), optr, 0);
         }
 
-#ifdef __MSC__
+#ifdef _MSC_VER
 #if (_MSC_VER < 1800)
 /* rint is not available for Visual Studio Version < Visual Studio 2013 */
 static double rint(double x)


### PR DESCRIPTION
Fix macros for Visual Studio version >= Visual Studio 2013. This fixes #904 