### PR TITLE
Increase socket receive buffer sizes

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -81,7 +81,7 @@ typedef struct _fdpoll
     void *fdp_ptr;
 } t_fdpoll;
 
-#define INBUFSIZE 4096
+#define INBUFSIZE 65536 // must be power of 2!
 
 struct _socketreceiver
 {
@@ -495,12 +495,12 @@ static int socketreceiver_doread(t_socketreceiver *x)
 
 static void socketreceiver_getudp(t_socketreceiver *x, int fd)
 {
-    char buf[INBUFSIZE+1];
+    char *buf = x->sr_inbuf;
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
     int ret, readbytes = 0;
     while (1)
     {
-        ret = (int)recvfrom(fd, buf, INBUFSIZE, 0,
+        ret = (int)recvfrom(fd, buf, INBUFSIZE-1, 0,
             (struct sockaddr *)x->sr_fromaddr, (x->sr_fromaddr ? &fromaddrlen : 0));
         if (ret < 0)
         {
@@ -521,11 +521,11 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
         else if (ret > 0)
         {
                 /* handle too large UDP packets */
-            if (ret > INBUFSIZE)
+            if (ret > INBUFSIZE-1)
             {
                 post("warning: incoming UDP packet truncated from %d to %d bytes.",
-                    ret, INBUFSIZE);
-                ret = INBUFSIZE;
+                    ret, INBUFSIZE-1);
+                ret = INBUFSIZE-1;
             }
             buf[ret] = 0;
     #if 0

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -110,6 +110,7 @@ struct _instanceinter
     int i_maxfd;
     int i_guisock;
     t_socketreceiver *i_socketreceiver;
+    unsigned char *i_recvbuf;
     t_guiqueue *i_guiqueuehead;
     t_binbuf *i_inbinbuf;
     char *i_guibuf;
@@ -386,6 +387,11 @@ void sys_set_priority(int mode)
 #endif /* __linux__ */
 
 /* ------------------ receiving incoming messages over sockets ------------- */
+
+unsigned char *sys_getrecvbuf(void)
+{
+    return pd_this->pd_inter->i_recvbuf;
+}
 
 void sys_sockerror(const char *s)
 {
@@ -1557,6 +1563,7 @@ void sys_stopgui(void)
 void s_inter_newpdinstance(void)
 {
     pd_this->pd_inter = getbytes(sizeof(*pd_this->pd_inter));
+    pd_this->pd_inter->i_recvbuf = getbytes(NET_MAXBUFSIZE);
 #if PDTHREADS
     pthread_mutex_init(&pd_this->pd_inter->i_mutex, NULL);
     pd_this->pd_islocked = 0;
@@ -1569,6 +1576,7 @@ void s_inter_newpdinstance(void)
 
 void s_inter_free(t_instanceinter *inter)
 {
+    freebytes(inter->i_recvbuf, NET_MAXBUFSIZE);
     if (inter->i_fdpoll)
     {
         binbuf_free(inter->i_inbinbuf);

--- a/src/s_net.h
+++ b/src/s_net.h
@@ -18,6 +18,8 @@ typedef int socklen_t;
 #include <netdb.h>
 #endif
 
+#define NET_MAXBUFSIZE 65536 /* should be power of 2 */
+
 /* socket address */
 
 /// getaddrinfo() convenience wrapper which generates a list of IPv4 and IPv6

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -22,6 +22,8 @@ standard output. */
 
 #include "s_net.h"
 
+#define BUFSIZE 65536
+
 typedef struct _fdpoll
 {
     int fdp_fd;
@@ -36,6 +38,7 @@ static t_fdpoll *fdpoll;
 static int maxfd;
 static int sockfd;
 static int protocol;
+char recvbuf[BUFSIZE];
 
 static void sockerror(char *s);
 static void dopoll(void);
@@ -43,8 +46,6 @@ static void sockerror(char *s);
 
 /* print addrinfo lists for debugging */
 /* #define PRINT_ADDRINFO */
-
-#define BUFSIZE 4096
 
 int main(int argc, char **argv)
 {
@@ -297,8 +298,7 @@ static void makeoutput(char *buf, int len)
 
 static void udpread(void)
 {
-    char buf[BUFSIZE];
-    int ret = recv(sockfd, buf, BUFSIZE, 0);
+    int ret = recv(sockfd, recvbuf, BUFSIZE, 0);
     if (ret < 0)
     {
         sockerror("recv (udp)");
@@ -306,7 +306,7 @@ static void udpread(void)
         exit(EXIT_FAILURE);
     }
     else if (ret > 0)
-        makeoutput(buf, ret);
+        makeoutput(recvbuf, ret);
 }
 
 static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -22,8 +22,6 @@ standard output. */
 
 #include "s_net.h"
 
-#define BUFSIZE 65536
-
 typedef struct _fdpoll
 {
     int fdp_fd;
@@ -38,7 +36,7 @@ static t_fdpoll *fdpoll;
 static int maxfd;
 static int sockfd;
 static int protocol;
-char recvbuf[BUFSIZE];
+char recvbuf[NET_MAXBUFSIZE];
 
 static void sockerror(char *s);
 static void dopoll(void);
@@ -239,7 +237,7 @@ static void addport(int fd)
     nfdpoll++;
     if (fd >= maxfd) maxfd = fd + 1;
     fp->fdp_outlen = fp->fdp_discard = fp->fdp_gotsemi = 0;
-    if (!(fp->fdp_outbuf = (char*) malloc(BUFSIZE)))
+    if (!(fp->fdp_outbuf = (char*) malloc(NET_MAXBUFSIZE)))
     {
         fprintf(stderr, "out of memory");
         exit(EXIT_FAILURE);
@@ -298,7 +296,7 @@ static void makeoutput(char *buf, int len)
 
 static void udpread(void)
 {
-    int ret = recv(sockfd, recvbuf, BUFSIZE, 0);
+    int ret = recv(sockfd, recvbuf, NET_MAXBUFSIZE, 0);
     if (ret < 0)
     {
         sockerror("recv (udp)");
@@ -322,7 +320,7 @@ static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)
         if((c != '\n') || (!x->fdp_gotsemi))
             outbuf[outlen++] = c;
         x->fdp_gotsemi = 0;
-        if (outlen >= (BUFSIZE-1)) /*output buffer overflow; reserve 1 for '\n' */
+        if (outlen >= (NET_MAXBUFSIZE-1)) /*output buffer overflow; reserve 1 for '\n' */
         {
             fprintf(stderr, "pdreceive: message too long; discarding\n");
             outlen = 0;
@@ -348,9 +346,9 @@ static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)
 static void tcpread(t_fdpoll *x)
 {
     int  ret;
-    char inbuf[BUFSIZE];
+    char inbuf[NET_MAXBUFSIZE];
 
-    ret = recv(x->fdp_fd, inbuf, BUFSIZE, 0);
+    ret = recv(x->fdp_fd, inbuf, NET_MAXBUFSIZE, 0);
     if (ret < 0)
     {
         sockerror("recv (tcp)");

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -18,9 +18,7 @@ static void sockerror(char *s);
 /* print addrinfo lists for debugging */
 /* #define PRINT_ADDRINFO */
 
-#define BUFSIZE 65536
-
-char sendbuf[BUFSIZE];
+char sendbuf[NET_MAXBUFSIZE];
 
 int main(int argc, char **argv)
 {
@@ -111,7 +109,7 @@ int main(int argc, char **argv)
     {
         char *bp;
         int nsent, nsend;
-        if (!fgets(sendbuf, BUFSIZE, stdin))
+        if (!fgets(sendbuf, NET_MAXBUFSIZE, stdin))
             break;
         nsend = strlen(sendbuf);
         for (bp = sendbuf, nsent = 0; nsent < nsend;)

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -18,7 +18,9 @@ static void sockerror(char *s);
 /* print addrinfo lists for debugging */
 /* #define PRINT_ADDRINFO */
 
-#define BUFSIZE 4096
+#define BUFSIZE 65536
+
+char sendbuf[BUFSIZE];
 
 int main(int argc, char **argv)
 {
@@ -107,12 +109,12 @@ int main(int argc, char **argv)
     /* now loop reading stdin and sending it to socket */
     while (1)
     {
-        char buf[BUFSIZE], *bp;
+        char *bp;
         int nsent, nsend;
-        if (!fgets(buf, BUFSIZE, stdin))
+        if (!fgets(sendbuf, BUFSIZE, stdin))
             break;
-        nsend = strlen(buf);
-        for (bp = buf, nsent = 0; nsent < nsend;)
+        nsend = strlen(sendbuf);
+        for (bp = sendbuf, nsent = 0; nsent < nsend;)
         {
             int res = 0;
             if (protocol == SOCK_DGRAM)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -41,38 +41,6 @@ static void outlet_sockaddr(t_outlet *o, const struct sockaddr *sa)
 
 /* ----------------------------- net ------------------------- */
 
-static PERTHREAD unsigned char *netreceive_buf;
-static PERTHREAD int netreceive_refcount;
-
-unsigned char * netreceive_getbuf(void)
-{
-    if (!netreceive_buf)
-    {
-        /* called from a different thread than netreceive_setup(),
-           will inevitably leak memory */
-        netreceive_buf = getbytes(NET_MAXBUFSIZE);
-    }
-    return netreceive_buf;
-}
-
-void netreceive_init(void)
-{
-    if (!netreceive_buf)
-    {
-        netreceive_buf = getbytes(NET_MAXBUFSIZE);
-    }
-    netreceive_refcount++;
-}
-
-void netreceive_term(t_class *c)
-{
-    if (--netreceive_refcount == 0)
-    {
-        freebytes(netreceive_buf, NET_MAXBUFSIZE);
-        netreceive_buf = 0;
-    }
-}
-
 static t_class *netsend_class;
 
 typedef struct _netsend
@@ -146,9 +114,11 @@ static void *netsend_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
+unsigned char *sys_getrecvbuf(void);
+
 static void netsend_readbin(t_netsend *x, int fd)
 {
-    unsigned char *inbuf;
+    unsigned char *inbuf = sys_getrecvbuf();
     int ret = 0, readbytes = 0, i;
     struct sockaddr_storage fromaddr = {0};
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
@@ -157,7 +127,6 @@ static void netsend_readbin(t_netsend *x, int fd)
         bug("netsend_readbin");
         return;
     }
-    inbuf = netreceive_getbuf();
     while (1)
     {
         if (x->x_protocol == SOCK_DGRAM)
@@ -954,14 +923,11 @@ static void netreceive_setup(void)
     netreceive_class = class_new(gensym("netreceive"),
         (t_newmethod)netreceive_new, (t_method)netreceive_free,
         sizeof(t_netreceive), 0, A_GIMME, 0);
-    class_setfreefn(netreceive_class, netreceive_term);
     class_addmethod(netreceive_class, (t_method)netreceive_listen,
         gensym("listen"), A_GIMME, 0);
     class_addmethod(netreceive_class, (t_method)netreceive_send,
         gensym("send"), A_GIMME, 0);
     class_addlist(netreceive_class, (t_method)netreceive_send);
-
-    netreceive_init();
 }
 
 void x_net_setup(void)


### PR DESCRIPTION
This PR increases the buffer sizes of all socket receivers to 65536, so we can receive large UDP packets. It is based on the current update branch to avoid merge conflicts with recent changes in the networking code.

One thing I'm not happy about is that in `socketreceiver_doread` we have a huge buffer on the stack. I think it won't do much harm, though, because messages are passed only after the function returns.

This implements https://github.com/pure-data/pure-data/issues/903

I verified that I can now send and receive UDP messages up to approx. 65355 bytes with `[netreceive -b]` and `[netreceive -b -u]`.

Note that this only makes sense via localhost. Actual networks will fragment and might even drop such large packets.
