### PR TITLE
g_editor: Don't enter object-edit mode after dragging an object

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2917,11 +2917,13 @@ void canvas_mouseup(t_canvas *x,
         canvas_doconnect(x, xpos, ypos, mod, 1);
     else if (x->gl_editor->e_onmotion == MA_REGION)
         canvas_doregion(x, xpos, ypos, 1);
-    else if (x->gl_editor->e_onmotion == MA_MOVE ||
-        x->gl_editor->e_onmotion == MA_RESIZE)
+    else if ((x->gl_editor->e_onmotion == MA_MOVE ||
+        x->gl_editor->e_onmotion == MA_RESIZE) && !x->gl_editor->e_lastmoved)
     {
-            /* after motion or resizing, if there's only one text item
-               selected, activate the text */
+            /* if there's only one text item selected *and* the mouse hasn't moved,
+               activate the text -- i.e., standard click/drag behavior:
+	       - Single click, no motion: enter object for editing.
+	       - Click-drag with motion: move object, keep it selected */
         if (x->gl_editor->e_selection &&
             !(x->gl_editor->e_selection->sel_next))
         {

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2383,8 +2383,8 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
         else
         {
             int noutlet;
-                /* resize?  only for "true" text boxes or canvases*/
-            if (ob && !x->gl_editor->e_selection &&
+                /* resize?  only for "true" text boxes or canvases */
+            if (ob &&
                 (ob->te_pd->c_wb == &text_widgetbehavior ||
                     pd_checkglist(&ob->te_pd)) &&
                         xpos >= x2-4 && ypos < y2-4)


### PR DESCRIPTION
There is one behavior in the Pd interface that drives me actually insane -- I mean, occasionally shouting/screaming at the computer when it's requiring extra steps just to move an object around.

And that is: When you drag a single object on the canvas, and release the mouse button, it enters object-edit mode (to edit the text in the object).

From a UI design perspective, this is... baffling. You're either editing the object (click) or moving it (drag). When you're editing it, you're not moving it; when you're moving it, there's no justification to assume that the user means to edit. I can't think of any UI design principle that would call for these use cases to be intermixed.

The fix appears to be simple: A flag to detect whether the mouse has moved or not already exists! It's just not used in this one place.