### PR TITLE
Fix TCL error when closing the message dialog

### DIFF
--- a/tcl/dialog_message.tcl
+++ b/tcl/dialog_message.tcl
@@ -41,7 +41,7 @@ proc ::dialog_message::ok {mytoplevel} {
 
 # mytoplevel isn't used here, but is kept for compatibility with other dialog cancel procs
 proc ::dialog_message::cancel {mytoplevel} {
-    destroy .message
+    wm withdraw .message
 }
 
 # the message panel is opened from the menu and key bindings
@@ -49,7 +49,7 @@ proc ::dialog_message::open_message_dialog {mytoplevel} {
     if {[winfo exists .message]} {
         wm deiconify .message
         raise .message
-        focus .message
+        focus .message.f.entry
     } else {
         create_dialog $mytoplevel
     }


### PR DESCRIPTION
Fixes #923

The problem is caused because the .message window gets destroyed *before* [this binding](https://github.com/pure-data/pure-data/blob/e2ef8158e83900734d263a3fda343a47ed0c9e3a/tcl/pd_bindings.tcl#L118) is executed.