### PR TITLE
finally save iemguis colors as hex symbols

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -270,9 +270,7 @@ void iemgui_all_sym2dollararg(t_iemgui *iemgui, t_symbol **srlsym)
 }
 
 static t_symbol* color2symbol(int col) {
-    const int  compat = (pd_compatibilitylevel < 48)?1:
-        /* FIXXME: for Pd>=0.48, the default compatibility mode should be OFF */
-        1;
+    const int  compat = (pd_compatibilitylevel < 48) ? 1 : 0;
 
     char colname[MAXPDSTRING];
     colname[0] = colname[MAXPDSTRING-1] = 0;


### PR DESCRIPTION
IMO it's time to give up retro-compatibility to Pd <= 0.47 by default, so that iemguis colors can be saved using full resolution hex-symbols.

e.g: instead of saving vslider like this:
`#X obj 96 97 vsl 15 128 0 127 0 0 empty empty test 0 -9 0 10 -258113 -257985 -159808 0 1;
`
let's use:
`#X obj 96 97 vsl 15 128 0 127 0 0 empty empty test 0 -9 0 10 #fc0400 #f8fc00 #9c00fc 0 1;`

That was planned for 0.48 ;-)