### PR TITLE
iemguis color method: allow setting individual colors

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -363,6 +363,14 @@ int iemgui_compatible_colorarg(int index, int argc, t_atom* argv)
     return iemgui_getcolorarg(index, argc, argv);
 }
 
+int iemgui_color_single(int ac, t_atom *av)
+{
+    if(ac < 3) return iemgui_compatible_colorarg(0, ac, av);
+    return (((int)atom_getfloatarg(0, ac, av) & 255) << 16)
+        + (((int)atom_getfloatarg(1, ac, av) & 255) << 8)
+        + ((int)atom_getfloatarg(2, ac, av) & 255);
+}
+
 void iemgui_all_dollar2raute(t_symbol **srlsym)
 {
     srlsym[0] = iemgui_dollar2raute(srlsym[0]);
@@ -521,6 +529,21 @@ void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 
 void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
+    if((ac >= 2) && (av->a_type == A_SYMBOL))
+    {
+        t_symbol *name = atom_getsymbolarg(0, ac, av);
+        if(name == gensym("background")) {
+            iemgui->x_bcol = iemgui_color_single(ac - 1, av + 1);
+            ac = 0;
+        } else if(name == gensym("front")) {
+            iemgui->x_fcol = iemgui_color_single(ac - 1, av + 1);
+            ac = 0;
+        } else if(name == gensym("label")) {
+            iemgui->x_lcol = iemgui_color_single(ac - 1, av + 1);
+            ac = 0;
+        }
+    }
+    
     if (ac >= 1)
         iemgui->x_bcol = iemgui_compatible_colorarg(0, ac, av);
     if (ac == 2 && pd_compatibilitylevel < 47)


### PR DESCRIPTION
allow to send to a gui: `[ color name {col} (` ; closes https://github.com/pure-data/pure-data/issues/941

color names are: "background" "front" and "label"

color can be expressed as:
- hex color: `#RRGGBB`
- float triplet in [0;255] range: `red green blue`
- one-float Pd color scheme index (e.g: 13 = red)
- legacy one-float 18-bit style
![Capture du 2020-04-15 00-03-49](https://user-images.githubusercontent.com/3748246/79279823-32825400-7eaf-11ea-8f6f-0e214808f53b.png)
