### PR TITLE
Permissive iemgui labels

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -12,6 +12,7 @@
 #include <ctype.h>
 #include "m_pd.h"
 #include "g_canvas.h"
+#include "s_stuff.h"
 
 #include "g_all_guis.h"
 #include <math.h>
@@ -186,21 +187,17 @@ t_symbol *iemgui_raute2dollar(t_symbol *s)
 t_symbol *iemgui_put_in_braces(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING+1], *s2;
+    char buf[MAXPDSTRING], *s2;
     int i = 0;
     if (strlen(s->s_name) >= MAXPDSTRING)
         return (s);
     for (s1 = s->s_name, s2 = buf; ; s1++, s2++, i++)
     {
         if (i == 0)
-        {
-            *s2 = '{';
-            s2++;
-        }
+            *(s2++) = '{';
         if (!(*s2 = *s1))
         {
-            *s2 = '}';
-            s2++;
+            *(s2++) = '}';
             *s2 = '\0';
             break;
         }
@@ -477,10 +474,14 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_lab_unexpanded = iemgui_raute2dollar(s);
     iemgui->x_lab = canvas_realizedollar(iemgui->x_glist, iemgui->x_lab_unexpanded);
 
+    char lab_escaped[MAXPDSTRING];
+    lab_escaped[MAXPDSTRING-1] = 0;
+    pdgui_strnescape( lab_escaped, MAXPDSTRING, iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name) );
+
     if(glist_isvisible(iemgui->x_glist) && iemgui->x_lab != old)
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text {%s} \n",
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape \"%s \"] \n",
                  glist_getcanvas(iemgui->x_glist), x,
-                 strcmp(s->s_name, "empty")?iemgui->x_lab->s_name:"");
+                 strcmp(s->s_name, "empty")?lab_escaped:"");
 }
 
 void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
@@ -644,9 +645,15 @@ void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
 {
     srl[0] = iemgui->x_snd;
     srl[1] = iemgui->x_rcv;
-    srl[2] = iemgui->x_lab;
-    iemgui_all_sym2dollararg(iemgui, srl);
+
+    char label[MAXPDSTRING];
+    strcpy(label, iemgui->x_lab->s_name);
+    pdgui_strnescape(label, MAXPDSTRING,
+                    iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name));
+    srl[2] = gensym(label);
+
     iemgui_all_dollar2raute(srl);
+    iemgui_all_sym2dollararg(iemgui, srl);
     iemgui_all_put_in_braces(srl);
 }
 

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -196,7 +196,7 @@ t_symbol *iemgui_put_in_braces(t_symbol *s)
         {
             *s2 = '{';
             s2++;
-        }           
+        }
         if (!(*s2 = *s1))
         {
             *s2 = '}';

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -183,6 +183,31 @@ t_symbol *iemgui_raute2dollar(t_symbol *s)
     return(gensym(buf));
 }
 
+t_symbol *iemgui_put_in_braces(t_symbol *s)
+{
+    const char *s1;
+    char buf[MAXPDSTRING+1], *s2;
+    int i = 0;
+    if (strlen(s->s_name) >= MAXPDSTRING)
+        return (s);
+    for (s1 = s->s_name, s2 = buf; ; s1++, s2++, i++)
+    {
+        if (i == 0)
+        {
+            *s2 = '{';
+            s2++;
+        }           
+        if (!(*s2 = *s1))
+        {
+            *s2 = '}';
+            s2++;
+            *s2 = '\0';
+            break;
+        }
+    }
+    return(gensym(buf));
+}
+
 void iemgui_verify_snd_ne_rcv(t_iemgui *iemgui)
 {
     iemgui->x_fsf.x_put_in2out = 1;
@@ -375,6 +400,13 @@ void iemgui_all_raute2dollar(t_symbol **srlsym)
     srlsym[0] = iemgui_raute2dollar(srlsym[0]);
     srlsym[1] = iemgui_raute2dollar(srlsym[1]);
     srlsym[2] = iemgui_raute2dollar(srlsym[2]);
+}
+
+void iemgui_all_put_in_braces(t_symbol **srlsym)
+{
+    srlsym[0] = iemgui_put_in_braces(srlsym[0]);
+    srlsym[1] = iemgui_put_in_braces(srlsym[1]);
+    srlsym[2] = iemgui_put_in_braces(srlsym[2]);
 }
 
 void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -615,6 +647,7 @@ void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
     srl[2] = iemgui->x_lab;
     iemgui_all_sym2dollararg(iemgui, srl);
     iemgui_all_dollar2raute(srl);
+    iemgui_all_put_in_braces(srl);
 }
 
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -630,7 +630,6 @@ EXTERN void guiconnect_notarget(t_guiconnect *x, double timedelay);
 /* ------------- IEMGUI routines used in other g_ files ---------------- */
 EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
 EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
-EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
 
 /*-------------  g_clone.c ------------- */
 extern t_class *clone_class;

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -630,6 +630,7 @@ EXTERN void guiconnect_notarget(t_guiconnect *x, double timedelay);
 /* ------------- IEMGUI routines used in other g_ files ---------------- */
 EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
 EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
+EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
 
 /*-------------  g_clone.c ------------- */
 extern t_class *clone_class;

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -25,7 +25,7 @@ char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
     while(1)
     {
         int c = src[ptin];
-        if (c == '\\' || c == '{' || c == '}') {
+        if (c == '\\' || c == '{' || c == '}' || c == '[' || c == ']') {
             dst[ptout++] = '\\';
             if (dstlen && ptout >= dstlen){
                 dst[ptout-1] = 0;


### PR DESCRIPTION
This allows the use of `[` and `]` in iemgui's objects labels.

I've tested the labels and checked if the send/receives are working as expected.

_(Tested on Win 10)_

![image](https://user-images.githubusercontent.com/11790621/79628841-24387000-811b-11ea-87a7-242b734652ab.png)

Fixes #880