### PR TITLE
add finddefault.c to libportmidi.a

### DIFF
--- a/portmidi/Makefile.am
+++ b/portmidi/Makefile.am
@@ -23,7 +23,8 @@ AM_CPPFLAGS += -I$(top_srcdir)/portmidi/portmidi/pm_linux
 libportmidi_a_SOURCES += \
     portmidi/porttime/ptlinux.c \
     portmidi/pm_linux/pmlinux.c \
-    portmidi/pm_linux/pmlinuxalsa.c
+    portmidi/pm_linux/pmlinuxalsa.c \
+    portmidi/pm_linux/finddefault.c
 endif
 
 # disable portmidi rate limiting on macos


### PR DESCRIPTION
On linux:

```bash
./configure --disable-oss --enable-portmidi
make -j $(nproc)
```
fails.

Reason: `libportmidi.a` is missing the compilation of `finddefault.c`
