### PR TITLE
improve alsa device detection

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,7 +124,7 @@ pkginclude_HEADERS = m_pd.h m_imp.h g_canvas.h g_undo.h g_all_guis.h s_stuff.h \
 
 # compatibility: m_pd.h also goes into ${includedir}/
 include_HEADERS = m_pd.h
-noinst_HEADERS = s_audio_alsa.h s_audio_paring.h s_utf8.h
+noinst_HEADERS = s_audio_alsa.h s_alsa_pcm_list.h s_audio_paring.h s_utf8.h
 
 # we want these in the dist tarball
 EXTRA_DIST = CHANGELOG.txt notes.txt pd.rc \
@@ -143,7 +143,7 @@ pd_CFLAGS += $(WISHDEFINE)
 if ALSA
 pd_CFLAGS += -DUSEAPI_ALSA
 pd_LDADD_core += @ALSA_LIBS@
-pd_SOURCES_core += s_audio_alsa.c s_audio_alsamm.c s_midi_alsa.c
+pd_SOURCES_core += s_audio_alsa.c s_audio_alsamm.c s_alsa_pcm_list.c s_midi_alsa.c
 endif
 
 ##### OSX CoreAudio #####

--- a/src/s_alsa_pcm_list.c
+++ b/src/s_alsa_pcm_list.c
@@ -1,0 +1,60 @@
+#include "s_alsa_pcm_list.h"
+#include <alsa/asoundlib.h>
+
+alsa_pcm_list_t *alsa_pcm_list_init(alsa_pcm_list_dir dir)
+{
+    alsa_pcm_list_t *info = malloc(sizeof(alsa_pcm_list_t));
+    if (info == NULL)
+        return NULL;
+
+    info->n         = NULL;
+    info->name_prev = NULL;
+    info->filter = dir == ALSA_PCM_OUTPUT_LIST ? "Output" : "Input";
+    if (snd_device_name_hint(-1, "pcm", &info->hints) >= 0)
+        info->n = info->hints;
+    return info;
+}
+
+const char *alsa_pcm_list_get_next(alsa_pcm_list_t *info)
+{
+    char *name = NULL, *io;
+
+    if (!info)
+        return NULL;
+
+    for (; *info->n != NULL; ++info->n) {
+        io = snd_device_name_get_hint(*info->n, "IOID");
+        if (io == NULL || strcmp(io, info->filter) == 0)
+        {
+            char *colon;
+            int uniq = 0;
+            name = snd_device_name_get_hint(*info->n, "NAME");
+            colon = strchr(name, ':');
+            if (colon) {
+                *colon = '\0';
+            }
+
+            if (info->name_prev == NULL || strcmp(name, info->name_prev) != 0) {
+                uniq = 1;
+            }
+
+            free(info->name_prev); // one behind on free (last one is freed in alsa_pcm_list_free())
+            info->name_prev = name;
+            if (uniq)
+                break;
+            else
+                name = NULL;
+        }
+        free(io);
+    }
+    return name;
+}
+
+void alsa_pcm_list_free(alsa_pcm_list_t *info)
+{
+    if (info) {
+        free(info->name_prev);
+        snd_device_name_free_hint(info->hints);
+        free(info);
+    }
+}

--- a/src/s_alsa_pcm_list.h
+++ b/src/s_alsa_pcm_list.h
@@ -1,0 +1,21 @@
+#ifndef ALSA_PCM_LIST_H
+#define ALSA_PCM_LIST_H
+
+typedef struct alsa_pcm_list {
+    const char *filter;
+    void **hints;
+    void **n;
+    char *name_prev;
+} alsa_pcm_list_t;
+
+typedef enum {
+    ALSA_PCM_INPUT_LIST,
+    ALSA_PCM_OUTPUT_LIST
+} alsa_pcm_list_dir;
+
+alsa_pcm_list_t *alsa_pcm_list_init(alsa_pcm_list_dir dir);
+const char *alsa_pcm_list_get_next(alsa_pcm_list_t *info);
+void alsa_pcm_list_free(alsa_pcm_list_t *info);
+
+
+#endif


### PR DESCRIPTION
This is an attempt to improve  #967

It now makes `pd -alsa -listdev` list
```
audio input devices:
1. default
2. null
3. jack
4. pulse
5. sysdefault
6. front
7. dmix
8. dsnoop
9. hw
10. plughw
11. usbstream
audio output devices:
1. default
2. null
3. jack
4. pulse
5. sysdefault
6. front
7. surround21
8. surround40
9. surround41
10. surround50
11. surround51
12. surround71
13. iec958
14. hdmi
15. dmix
16. dsnoop
17. hw
18. plughw
19. usbstream
API number 1

no MIDI input devices found
no MIDI output devices found
priority 94 scheduling failed.
```
i.e. the same as 

`aplay -L | grep '^[[:graph:]]' | cut -d: -f1 | uniq`
and
`arecord -L | grep '^[[:graph:]]' | cut -d: -f1 | uniq`
