### PR TITLE
keep parent canvas referenced from cloned instance

### DIFF
--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -210,7 +210,6 @@ static t_canvas *clone_makeone(t_symbol *s, int argc, t_atom *argv)
     }
     retval = (t_canvas *)pd_this->pd_newest;
     pd_this->pd_newest = 0;
-    retval->gl_owner = 0;
     retval->gl_isclone = 1;
     return (retval);
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -98,15 +98,15 @@ void gobj_delete(t_gobj *x, t_glist *glist)
 int gobj_shouldvis(t_gobj *x, struct _glist *glist)
 {
     t_object *ob;
+    int has_parent = !glist->gl_havewindow && glist->gl_isgraph
+        && glist->gl_owner && !glist->gl_isclone;
         /* if our parent is a graph, and if that graph itself isn't
            visible, then we aren't either. */
-    if (!glist->gl_havewindow && glist->gl_isgraph && glist->gl_owner
-        && !gobj_shouldvis(&glist->gl_gobj, glist->gl_owner))
+    if (has_parent && !gobj_shouldvis(&glist->gl_gobj, glist->gl_owner))
             return (0);
         /* if we're graphing-on-parent and the object falls outside the
            graph rectangle, don't draw it. */
-    if (!glist->gl_havewindow && glist->gl_isgraph && glist->gl_goprect &&
-        glist->gl_owner)
+    if (has_parent && glist->gl_goprect)
     {
         int x1, y1, x2, y2, gx1, gy1, gx2, gy2, m;
             /* for some reason the bounds check on arrays and scalars
@@ -762,7 +762,7 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
                 /* LATER disable redrawing here */
             if (x->gl_havewindow)
                 canvas_redraw(x);
-            if (x->gl_owner && glist_isvisible(x->gl_owner))
+            if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
             {
                 gobj_vis((t_gobj *)x, x->gl_owner, 0);
                 gobj_vis((t_gobj *)x, x->gl_owner, 1);
@@ -1443,7 +1443,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         {
             canvas_redraw(x);
         }
-        if (x->gl_owner && glist_isvisible(x->gl_owner))
+        if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         {
             glist_noselect(x);
             gobj_vis(&x->gl_gobj, x->gl_owner, 0);
@@ -1984,7 +1984,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 x->gl_edit);
             snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx",
                 (unsigned long)c);
-            while (c->gl_owner) {
+            while (c->gl_owner && !c->gl_isclone) {
                 int cbuflen;
                 c = c->gl_owner;
                 cbuflen = (int)strlen(cbuf);
@@ -2024,7 +2024,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             ;
             /* if we're a graph on our parent, and if the parent exists
                and is visible, show ourselves on parent. */
-        if (glist_isgraph(x) && x->gl_owner)
+        if (glist_isgraph(x) && x->gl_owner && !x->gl_isclone)
         {
             t_glist *gl2 = x->gl_owner;
             if (glist_isvisible(gl2))
@@ -2048,12 +2048,14 @@ void canvas_vis(t_canvas *x, t_floatarg f)
        any missing parameters and redraw things if necessary. */
 void canvas_setgraph(t_glist *x, int flag, int nogoprect)
 {
+    int can_graph_on_parent = x->gl_owner && !x->gl_isclone && !x->gl_loading
+        && glist_isvisible(x->gl_owner);
     if (!flag && glist_isgraph(x))
     {
-        if (x->gl_owner && !x->gl_loading && glist_isvisible(x->gl_owner))
+        if (can_graph_on_parent)
             gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         x->gl_isgraph = x->gl_hidetext = 0;
-        if (x->gl_owner && !x->gl_loading && glist_isvisible(x->gl_owner))
+        if (can_graph_on_parent)
         {
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
             canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
@@ -2067,14 +2069,14 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect)
         if (x->gl_pixheight <= 0)
             x->gl_pixheight = GLIST_DEFGRAPHHEIGHT;
 
-        if (x->gl_owner && !x->gl_loading && glist_isvisible(x->gl_owner))
+        if (can_graph_on_parent)
             gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         x->gl_isgraph = 1;
         x->gl_hidetext = !(!(flag&2));
         x->gl_goprect = !nogoprect;
         if (glist_isvisible(x) && x->gl_goprect)
             glist_redraw(x);
-        if (x->gl_owner && !x->gl_loading && glist_isvisible(x->gl_owner))
+        if (can_graph_on_parent)
         {
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
             canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
@@ -2196,7 +2198,7 @@ static void canvas_donecanvasdialog(t_glist *x,
     canvas_dirty(x, 1);
     if (x->gl_havewindow)
         canvas_redraw(x);
-    else if (glist_isvisible(x->gl_owner))
+    else if (!x->gl_isclone && glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
@@ -3317,7 +3319,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
 {
     int force = fforce;
     t_glist *g;
-    if ((x->gl_owner || x->gl_isclone) && (force == 0 || force == 1))
+    if (x->gl_owner && (force == 0 || force == 1))
         canvas_vis(x, 0);   /* if subpatch, just invis it */
     else if (force == 0)
     {
@@ -3342,7 +3344,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
     else if (force == 2)
     {
         canvas_dirty(x, 0);
-        while (x->gl_owner)
+        while (x->gl_owner && !x->gl_isclone)
             x = x->gl_owner;
         g = glist_finddirty(x);
         if (g)

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -292,7 +292,7 @@ void glist_sort(t_glist *x)
 t_inlet *canvas_addinlet(t_canvas *x, t_pd *who, t_symbol *s)
 {
     t_inlet *ip = inlet_new(&x->gl_obj, who, s, 0);
-    if (!x->gl_loading && x->gl_owner && glist_isvisible(x->gl_owner))
+    if (!x->gl_loading && x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
@@ -304,7 +304,7 @@ t_inlet *canvas_addinlet(t_canvas *x, t_pd *who, t_symbol *s)
 
 void canvas_rminlet(t_canvas *x, t_inlet *ip)
 {
-    t_canvas *owner = x->gl_owner;
+    t_canvas *owner = x->gl_isclone ? NULL : x->gl_owner;
     int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting)
         && glist_istoplevel(owner));
 
@@ -357,14 +357,14 @@ void canvas_resortinlets(t_canvas *x)
         obj_moveinletfirst(&x->gl_obj, ip);
     }
     freebytes(vec, ninlets * sizeof(*vec));
-    if (x->gl_owner && glist_isvisible(x->gl_owner))
+    if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
 }
 
 t_outlet *canvas_addoutlet(t_canvas *x, t_pd *who, t_symbol *s)
 {
     t_outlet *op = outlet_new(&x->gl_obj, s);
-    if (!x->gl_loading && x->gl_owner && glist_isvisible(x->gl_owner))
+    if (!x->gl_loading && !x->gl_isclone && x->gl_owner && glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
@@ -376,7 +376,7 @@ t_outlet *canvas_addoutlet(t_canvas *x, t_pd *who, t_symbol *s)
 
 void canvas_rmoutlet(t_canvas *x, t_outlet *op)
 {
-    t_canvas *owner = x->gl_owner;
+    t_canvas *owner = x->gl_isclone ? NULL : x->gl_owner;
     int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting)
         && glist_istoplevel(owner));
 
@@ -430,7 +430,7 @@ void canvas_resortoutlets(t_canvas *x)
         obj_moveoutletfirst(&x->gl_obj, ip);
     }
     freebytes(vec, noutlets * sizeof(*vec));
-    if (x->gl_owner && glist_isvisible(x->gl_owner))
+    if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
 }
 

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -191,7 +191,7 @@ void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
 
 t_canvas *glist_getcanvas(t_glist *x)
 {
-    while (x->gl_owner && !x->gl_havewindow && x->gl_isgraph)
+    while (x->gl_owner && !x->gl_isclone && !x->gl_havewindow && x->gl_isgraph)
             x = x->gl_owner;
     return((t_canvas *)x);
 }
@@ -662,7 +662,7 @@ void glist_redraw(t_glist *x)
                 canvas_drawredrect(x, 1);
             }
         }
-        if (x->gl_owner && glist_isvisible(x->gl_owner))
+        if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         {
             graph_vis(&x->gl_gobj, x->gl_owner, 0);
             graph_vis(&x->gl_gobj, x->gl_owner, 1);


### PR DESCRIPTION
After creating a cloned instance, the reference to its parent canvas is currently cleared:
https://github.com/pure-data/pure-data/blob/80929213b540af1ba12c2c8abd7a58d0c1eb2204/src/g_clone.c#L213

This PR proposes to keep this `gl_owner` reference intact, and use glist's field `gl_isclone` instead for discriminating clones when needed.

It allows a clone instance to behave just like any abstraction, and in particular it makes possible to:
- resolve pure-data/pure-data#929 and fix pure-data/pure-data#410 (i.e clone cannot reliably use parents search paths)
- find the parent of the clone, through menu `Window / Parent Window`
- allow `[pdcontrol]` to retrieve parents information through `[dir N(` and `[args N(`

I basically replaced:
`if (x->gl_owner)`
with: 
`if (x->gl_owner && !x->gl_isclone)`
where relevant.

(EDIT: I had previously forbidden [pdcontrol] to go back to clone's parent and retrieve its info, which wasn't necessary... I reverted that).