### PR TITLE
[bng] - rename "intrrpt" and "hold" parameters in properties

### DIFF
--- a/doc/5.reference/bng-help.pd
+++ b/doc/5.reference/bng-help.pd
@@ -207,8 +207,8 @@ gui-objects, f 31;
 #X floatatom 546 266 5 100 3000 0 - - -;
 #X obj 493 288 pack 0 0;
 #X msg 493 313 \; foo5_rcv flashtime \$1 \$2;
-#X text 549 237 interrupt-time;
-#X text 587 267 hold-time;
+#X text 549 237 minimum;
+#X text 587 267 maximum;
 #X text 522 432 init bang on loadbang;
 #X text 468 218 flash-time:;
 #X obj 484 241 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -516,8 +516,8 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
             set iemgui_type [_ "Bang"]
             set wdt_label "Size:"
             set iemgui_range_header [_ "Flash Time (msec)"]
-            set min_rng_label [_ "Intrrpt:"]
-            set max_rng_label [_ "Hold:"] }
+            set min_rng_label [_ "Min:"]
+            set max_rng_label [_ "Max:"] }
         "|tgl|" {
             set iemgui_type [_ "Toggle"]
             set wdt_label [_ "Size:"]


### PR DESCRIPTION
This closes https://github.com/pure-data/pure-data/issues/976 and presents an alternative that seems to be a more proper.

"intrrpt" is renamed to "min" and "hold" is renamed to "max".