### PR TITLE
allow [symbol] to convert float and lists

### DIFF
--- a/doc/5.reference/symbol-help.pd
+++ b/doc/5.reference/symbol-help.pd
@@ -1,26 +1,100 @@
-#N canvas 531 220 512 412 12;
-#X msg 44 107 bang;
-#X text 134 244 creation argument initializes the value;
-#X text 271 372 updated for Pd version 0.45;
-#X text 89 104 output the value;
-#X text 153 130 set and output the value;
-#X obj 43 241 symbol foo;
-#X obj 69 12 symbol;
-#X text 125 14 - STORE A SYMBOL (I.E. \, STRING);
-#X text 35 37 The symbol object stores a symbol \, Pd's data type for
+#N canvas 748 102 600 566 12;
+#X msg 58 106 bang;
+#X text 103 105 output the value;
+#X obj 70 21 symbol;
+#X text 36 57 The symbol object stores a symbol \, Pd's data type for
 handling fixed strings (often filenames or the names of other objects
-in pd).;
-#X msg 58 131 symbol bar;
-#X symbolatom 44 269 10 0 0 0 - - -;
-#X text 186 213 set the value;
-#X symbolatom 110 215 10 0 0 0 - - -;
-#X msg 64 161 zorglub;
-#X text 133 161 any other message is 'converted';
-#X text 62 303 note: unlike "float" \, etc. \, there's no "s" message
+in pd)., f 68;
+#X msg 72 138 symbol bar;
+#X symbolatom 57 417 10 0 0 0 - - -;
+#X symbolatom 131 342 10 0 0 0 - - -;
+#X msg 84 166 zorglub;
+#X text 362 505 updated for Pd version 0.51;
+#X floatatom 101 196 5 0 0 0 - - -;
+#X text 149 158 a string without the symbol selector is 'converted'
+, f 29;
+#X text 161 425 note: unlike "float" \, etc. \, there's no "send" message
 to forward to another object -- that would conflict with the function
 of converting arbitrary messages to symbols.;
-#X connect 0 0 5 0;
-#X connect 5 0 10 0;
+#X text 83 505 see also:;
+#X obj 159 505 makefilename;
+#X obj 57 445 print;
+#X msg 121 227 list a b c;
+#X msg 132 251 list 1 2 3;
+#X obj 57 378 symbol a\ b;
+#X text 153 372 creation argument initializes the value and needs to
+be a symbol atom (note \ can be used to escape spaces), f 54;
+#N canvas 859 223 463 455 convert-anything-to-symbol 0;
+#X obj 66 171 trigger bang list bang;
+#X obj 198 304 list prepend;
+#X obj 66 300 list;
+#X obj 279 272 list append 32;
+#X obj 66 338 list tosymbol;
+#X obj 141 264 list fromsymbol;
+#X obj 66 135 list;
+#N canvas 816 210 236 260 drip 0;
+#X obj 76 207 outlet;
+#X obj 97 32 inlet;
+#X obj 72 90 until;
+#X obj 76 177 list store;
+#X obj 97 61 t b b l;
+#X obj 72 119 f;
+#X obj 107 120 + 1;
+#X msg 120 94 0, f 2;
+#X msg 72 148 get \$1 1;
+#X connect 1 0 4 0;
+#X connect 2 0 5 0;
+#X connect 3 0 0 0;
+#X connect 3 1 2 1;
+#X connect 4 0 2 0;
+#X connect 4 1 7 0;
+#X connect 4 2 3 1;
+#X connect 5 0 6 0;
+#X connect 5 0 8 0;
+#X connect 6 0 5 1;
+#X connect 7 0 5 1;
+#X connect 8 0 3 0;
+#X restore 141 201 pd drip;
+#X symbolatom 66 378 10 0 0 0 - - -;
+#X obj 141 231 symbol;
+#X msg 96 98 1 2 3;
+#X text 185 99 If you need to convert full lists and anythings to a
+symbol. Here's an example on how you can do it., f 34;
+#X obj 66 413 print conversion;
+#X msg 66 37 pure data;
+#X msg 82 66 list a b c;
+#X connect 0 0 2 0;
+#X connect 0 1 7 0;
+#X connect 0 2 1 1;
+#X connect 1 0 2 1;
+#X connect 1 0 3 0;
+#X connect 2 0 4 0;
+#X connect 3 0 1 1;
+#X connect 4 0 8 0;
+#X connect 5 0 1 0;
+#X connect 6 0 0 0;
+#X connect 7 0 9 0;
+#X connect 8 0 12 0;
 #X connect 9 0 5 0;
-#X connect 12 0 5 1;
-#X connect 13 0 5 0;
+#X connect 10 0 6 0;
+#X connect 13 0 6 0;
+#X connect 14 0 6 0;
+#X restore 311 295 pd convert-anything-to-symbol;
+#X text 145 196 a float is also 'converted';
+#X text 159 137 left inlet sets and outputs the value;
+#X text 212 334 right inlet only sets the value (needs to be a symbol
+message), f 31;
+#X text 126 23 - store A symbol (i.e. \, string);
+#X text 220 232 you can also convert the first item of a list, f 25
+;
+#X text 160 283 to convert all items to a symbol \, check =>, f 21
+;
+#X connect 0 0 17 0;
+#X connect 4 0 17 0;
+#X connect 5 0 14 0;
+#X connect 6 0 17 1;
+#X connect 7 0 17 0;
+#X connect 9 0 17 0;
+#X connect 15 0 17 0;
+#X connect 16 0 17 0;
+#X connect 17 0 5 0;

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -148,6 +148,13 @@ static void pdsymbol_bang(t_pdsymbol *x)
     outlet_symbol(x->x_obj.ob_outlet, x->x_s);
 }
 
+static void pdsymbol_float(t_pdsymbol *x, t_floatarg f)
+{
+    char buf[MAXPDSTRING];
+    sprintf(buf, "%g", f);
+    outlet_symbol(x->x_obj.ob_outlet, x->x_s = gensym(buf));
+}
+
 static void pdsymbol_symbol(t_pdsymbol *x, t_symbol *s)
 {
     outlet_symbol(x->x_obj.ob_outlet, x->x_s = s);
@@ -171,6 +178,8 @@ static void pdsymbol_list(t_pdsymbol *x, t_symbol *s, int ac, t_atom *av)
         pdsymbol_bang(x);
     else if (av->a_type == A_SYMBOL)
         pdsymbol_symbol(x, av->a_w.w_symbol);
+    else if (av->a_type == A_FLOAT)
+        pdsymbol_float(x, av->a_w.w_float);
     else pdsymbol_anything(x, s, ac, av);
 }
 
@@ -179,6 +188,8 @@ void pdsymbol_setup(void)
     pdsymbol_class = class_new(gensym("symbol"), (t_newmethod)pdsymbol_new, 0,
         sizeof(t_pdsymbol), 0, A_SYMBOL, 0);
     class_addbang(pdsymbol_class, pdsymbol_bang);
+    class_addfloat(pdsymbol_class, pdsymbol_float);
+    class_addlist(pdsymbol_class, pdsymbol_list);
     class_addsymbol(pdsymbol_class, pdsymbol_symbol);
     class_addanything(pdsymbol_class, pdsymbol_anything);
 }


### PR DESCRIPTION
this is a reboot of https://github.com/pure-data/pure-data/pull/984

This closes https://github.com/pure-data/pure-data/issues/983 and https://github.com/pure-data/pure-data/issues/986

The idea is to allow [symbol] to convert floats to symbol because it'd be useful and because [float] can do the opposite conversion (hence, consistency purposes).

This PR also allows lists to be converted, which seems it was intentional but left out of the code accidentally (see https://github.com/pure-data/pure-data/pull/984 )

I also included in the help an example on how to convert full lists and anythings (all items) to a symbol.