### PR TITLE
gatom/nbx consistency

### DIFF
--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -726,7 +726,7 @@ static void my_numbox_key(void *z, t_floatarg fkey)
         return;
     }
     if(((c >= '0') && (c <= '9')) || (c == '.') || (c == '-') ||
-        (c == 'e') || (c == 'E'))
+        (c == 'e') || (c == '+') || (c == 'E'))
     {
         if(strlen(x->x_buf) < (IEMGUI_MAX_NUM_LEN-2))
         {

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -748,7 +748,6 @@ static void my_numbox_key(void *z, t_floatarg fkey)
     {
         x->x_val = atof(x->x_buf);
         x->x_buf[0] = 0;
-        x->x_gui.x_fsf.x_change = 0;
         if (pd_compatibilitylevel < 51)
             my_numbox_clip(x);
         my_numbox_bang(x);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -726,7 +726,7 @@ static void my_numbox_key(void *z, t_floatarg fkey)
         return;
     }
     if(((c >= '0') && (c <= '9')) || (c == '.') || (c == '-') ||
-        (c == 'e') || (c == '+') || (c == 'E'))
+        (c == 'e') || (c == 'E'))
     {
         if(strlen(x->x_buf) < (IEMGUI_MAX_NUM_LEN-2))
         {

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -571,8 +571,7 @@ static void gatom_retext(t_gatom *x, int senditup)
 {
     binbuf_clear(x->a_text.te_binbuf);
     binbuf_add(x->a_text.te_binbuf, 1, &x->a_atom);
-    if (senditup && glist_isvisible(x->a_glist)
-        && gobj_shouldvis(&x->a_text.te_g, x->a_glist))
+    if (senditup && glist_isvisible(x->a_glist))
             sys_queuegui(x, x->a_glist, gatom_redraw);
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -733,7 +733,7 @@ static void gatom_key(void *z, t_floatarg f)
             /* for numbers, only let reasonable characters through */
         if ((x->a_atom.a_type == A_SYMBOL) ||
             ((c >= '0' && c <= '9') || c == '.' || c == '-'
-                || c == 'e' || c == 'E'))
+                || c == '+' || c == 'e' || c == 'E'))
         {
             /* the wchar could expand to up to 4 bytes, which
              * which might overrun our a_buf;

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -882,8 +882,6 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
 {
     t_gatom *x = (t_gatom*)z;
-    
-//    text_vis(z, glist, vis);
     t_text *t = (t_text *)z;
     if (vis)
     {
@@ -905,7 +903,6 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
             rtext_erase(y);
         }
     }
-    
     if (*x->a_label->s_name)
     {
         if (vis)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1217,8 +1217,7 @@ void text_save(t_gobj *z, t_binbuf *b)
     else if (x->te_type == T_ATOM)
     {
         t_atomtype t = ((t_gatom *)x)->a_atom.a_type;
-        t_symbol *sel = (t == A_SYMBOL ? gensym("symbolatom") :
-            (t == A_FLOAT ? gensym("floatatom") : gensym("intatom")));
+        t_symbol *sel = (t == A_SYMBOL ? gensym("symbolatom") : gensym("floatatom"));
         t_symbol *label = gatom_escapit(((t_gatom *)x)->a_label);
         t_symbol *symfrom = gatom_escapit(((t_gatom *)x)->a_symfrom);
         t_symbol *symto = gatom_escapit(((t_gatom *)x)->a_symto);


### PR DESCRIPTION
This PR is mainly aimed at improving the consistency between the behaviour of gatom (atom number/symbol boxes) and [nbx].

-------------------

- commit (https://github.com/pure-data/pure-data/pull/1004/commits/18b3df16826f065c7c2f65fc6a190beaec4a3678) closes https://github.com/pure-data/pure-data/issues/996

-------------------

- commit (https://github.com/pure-data/pure-data/pull/1004/commits/2525aa0bbbf9218eaf7d7f8729a953f54dc8f400) closes https://github.com/pure-data/pure-data/issues/1005

-------------------

- commits (https://github.com/pure-data/pure-data/pull/1004/commits/a5f46c415a9979678a2f0248686d32722f9a5849), (https://github.com/pure-data/pure-data/pull/1004/commits/02ba4ac5e64c28cb2dfb3866ee170b30bb087cb7) and (https://github.com/pure-data/pure-data/pull/1004/commits/e76996e5d9fff191d1a30a038d253cdfc19dc781) commits close https://github.com/pure-data/pure-data/issues/851 - see: https://github.com/pure-data/pure-data/issues/851#issuecomment-629194457

-------------------