### PR TITLE
gatom-nbx consistencies

### DIFF
--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -35,15 +35,6 @@ static t_class *my_numbox_class;
 
 /* widget helper functions */
 
-static void my_numbox_tick_reset(t_my_numbox *x)
-{
-    if(x->x_gui.x_fsf.x_change && x->x_gui.x_glist)
-    {
-        x->x_gui.x_fsf.x_change = 0;
-        sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
-    }
-}
-
 static void my_numbox_tick_wait(t_my_numbox *x)
 {
     sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
@@ -335,7 +326,6 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
         if(x->x_gui.x_fsf.x_change)
         {
             x->x_gui.x_fsf.x_change = 0;
-            clock_unset(x->x_clock_reset);
             x->x_buf[0] = 0;
             sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         }
@@ -402,7 +392,6 @@ static void my_numbox_save(t_gobj *z, t_binbuf *b)
     if(x->x_gui.x_fsf.x_change)
     {
         x->x_gui.x_fsf.x_change = 0;
-        clock_unset(x->x_clock_reset);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
     binbuf_addv(b, "ssiisiiffiisssiiiisssfi", gensym("#X"), gensym("obj"),
@@ -466,7 +455,6 @@ static void my_numbox_properties(t_gobj *z, t_glist *owner)
     if(x->x_gui.x_fsf.x_change)
     {
         x->x_gui.x_fsf.x_change = 0;
-        clock_unset(x->x_clock_reset);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
     sprintf(buf, "pdtk_iemgui_dialog %%s |nbx| \
@@ -544,7 +532,6 @@ static void my_numbox_motion(t_my_numbox *x, t_floatarg dx, t_floatarg dy)
     my_numbox_clip(x);
     sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     my_numbox_bang(x);
-    clock_unset(x->x_clock_reset);
 }
 
 static void my_numbox_click(t_my_numbox *x, t_floatarg xpos, t_floatarg ypos,
@@ -571,14 +558,12 @@ static int my_numbox_newclick(t_gobj *z, struct _glist *glist,
         {
             clock_delay(x->x_clock_wait, 50);
             x->x_gui.x_fsf.x_change = 1;
-            clock_delay(x->x_clock_reset, 3000);
 
             x->x_buf[0] = 0;
         }
         else
         {
             x->x_gui.x_fsf.x_change = 0;
-            clock_unset(x->x_clock_reset);
             x->x_buf[0] = 0;
             sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         }
@@ -719,7 +704,6 @@ static void my_numbox_key(void *z, t_floatarg fkey)
     if(c == 0)
     {
         x->x_gui.x_fsf.x_change = 0;
-        clock_unset(x->x_clock_reset);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         return;
     }
@@ -747,12 +731,10 @@ static void my_numbox_key(void *z, t_floatarg fkey)
         x->x_val = atof(x->x_buf);
         x->x_buf[0] = 0;
         x->x_gui.x_fsf.x_change = 0;
-        clock_unset(x->x_clock_reset);
         my_numbox_clip(x);
         my_numbox_bang(x);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
-    clock_delay(x->x_clock_reset, 3000);
 }
 
 static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
@@ -845,7 +827,6 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     x->x_buf[0] = 0;
     my_numbox_check_minmax(x, min, max);
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    x->x_clock_reset = clock_new(x, (t_method)my_numbox_tick_reset);
     x->x_clock_wait = clock_new(x, (t_method)my_numbox_tick_wait);
     x->x_gui.x_fsf.x_change = 0;
     iemgui_newzoom(&x->x_gui);
@@ -858,7 +839,6 @@ static void my_numbox_free(t_my_numbox *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    clock_free(x->x_clock_reset);
     clock_free(x->x_clock_wait);
     gfxstub_deleteforkey(x);
 }

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -730,7 +730,6 @@ static void my_numbox_key(void *z, t_floatarg fkey)
     {
         x->x_val = atof(x->x_buf);
         x->x_buf[0] = 0;
-        x->x_gui.x_fsf.x_change = 0;
         my_numbox_clip(x);
         my_numbox_bang(x);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1078,8 +1078,8 @@ static void text_getrect(t_gobj *z, t_glist *glist,
 
     if (x->te_type == T_ATOM && x->te_width > 0)
     {
-        width = (x->te_width > 0 ? x->te_width : 6) * glist_fontwidth(glist);
-        height = glist_fontheight(glist);
+        width = x->te_width * glist_fontwidth(glist) + 2 * glist_getzoom(glist);
+        height = glist_fontheight(glist) + glist_getzoom(glist);
         if (glist_getzoom(glist) > 1)
         {
             /* zoom margins */

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -706,8 +706,7 @@ static void gatom_key(void *z, t_floatarg f)
     if (c == 0)
     {
         /* we're being notified that no more keys will come for this grab */
-        if (x->a_buf[0])
-            gatom_retext(x, 1);
+        gatom_retext(x, 1);
         return;
     }
     else if (c == '\b')

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -792,9 +792,9 @@ static void gatom_click(t_gatom *x,
             {
                 x->a_toggle = x->a_atom.a_w.w_float;
                 gatom_float(x, 0);
-                return;
             }
             else gatom_float(x, x->a_toggle);
+            return;
         }
         x->a_shift = shift;
         x->a_buf[0] = 0;

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -707,6 +707,12 @@ static void gatom_key(void *z, t_floatarg f)
     {
         /* we're being notified that no more keys will come for this grab */
         gatom_retext(x, 1);
+        if (glist_isvisible(x->a_glist))
+        {
+            t_rtext *y = glist_findrtext(x->a_glist, &x->a_text);
+            sys_vgui(".x%lx.c itemconfigure %sR -width %d\n",
+                glist_getcanvas(x->a_glist), rtext_gettag(y), x->a_glist->gl_zoom);
+        }
         return;
     }
     else if (c == '\b')
@@ -766,6 +772,12 @@ static void gatom_click(t_gatom *x,
     t_floatarg xpos, t_floatarg ypos, t_floatarg shift, t_floatarg ctrl,
     t_floatarg alt)
 {
+    if (glist_isvisible(x->a_glist))
+    {
+        t_rtext *y = glist_findrtext(x->a_glist, &x->a_text);
+        sys_vgui(".x%lx.c itemconfigure %sR -width %d\n",
+            glist_getcanvas(x->a_glist), rtext_gettag(y), 2 * x->a_glist->gl_zoom);
+    }
     if (x->a_text.te_width == 1)
     {
         if (x->a_atom.a_type == A_FLOAT)
@@ -1162,9 +1174,11 @@ static int text_click(t_gobj *z, struct _glist *glist,
     }
     else if (x->te_type == T_ATOM)
     {
-        if (doit)
+        if (doit){
             gatom_click((t_gatom *)x, (t_floatarg)xpix, (t_floatarg)ypix,
                 (t_floatarg)shift, (t_floatarg)0, (t_floatarg)alt);
+            
+        }
         return (1);
     }
     else if (x->te_type == T_MESSAGE)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -732,7 +732,7 @@ static void gatom_key(void *z, t_floatarg f)
             /* for numbers, only let reasonable characters through */
         if ((x->a_atom.a_type == A_SYMBOL) ||
             ((c >= '0' && c <= '9') || c == '.' || c == '-'
-                || c == 'e' || c == 'E'))
+                || c == '+' || c == 'e' || c == 'E'))
         {
             /* the wchar could expand to up to 4 bytes, which
              * which might overrun our a_buf;

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -530,6 +530,9 @@ typedef struct _gatom
     t_symbol *a_expanded_to; /* a_symto after $0, $1, ...  expansion */
 } t_gatom;
 
+static void atom_drawborder(t_gatom *x, t_text *t, t_glist *glist,
+    const char *tag, int width2, int height2, int firsttime);
+
     /* prepend "-" as necessary to avoid empty strings, so we can
     use them in Pd messages.  A more complete solution would be
     to introduce some quoting mechanism; but then we'd be much more
@@ -799,24 +802,7 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
     t_float wherelabel = atom_getfloatarg(4, argc, argv);
     t_symbol *symfrom = gatom_unescapit(atom_getsymbolarg(5, argc, argv));
     t_symbol *symto = gatom_unescapit(atom_getsymbolarg(6, argc, argv));
-
     gobj_vis(&x->a_text.te_g, x->a_glist, 0);
-    if (!*symfrom->s_name && *x->a_symfrom->s_name)
-        inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
-    else if (*symfrom->s_name && !*x->a_symfrom->s_name && x->a_text.te_inlet)
-    {
-        canvas_deletelinesforio(x->a_glist, &x->a_text,
-            x->a_text.te_inlet, 0);
-        inlet_free(x->a_text.te_inlet);
-    }
-    if (!*symto->s_name && *x->a_symto->s_name)
-        outlet_new(&x->a_text, 0);
-    else if (*symto->s_name && !*x->a_symto->s_name && x->a_text.te_outlet)
-    {
-        canvas_deletelinesforio(x->a_glist, &x->a_text,
-            0, x->a_text.te_outlet);
-        outlet_free(x->a_text.te_outlet);
-    }
     if (draglo >= draghi)
         draglo = draghi = 0;
     x->a_draglo = draglo;
@@ -839,8 +825,6 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
     x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
     gobj_vis(&x->a_text.te_g, x->a_glist, 1);
     canvas_dirty(x->a_glist, 1);
-
-    /* glist_retext(x->a_glist, &x->a_text); */
 }
 
     /* ---------------- gatom-specific widget functions --------------- */
@@ -877,7 +861,17 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
     int dx, int dy)
 {
     t_gatom *x = (t_gatom*)z;
-    text_displace(z, glist, dx, dy);
+    t_text *t = (t_text *)z;
+    t->te_xpix += dx;
+    t->te_ypix += dy;
+    if (glist_isvisible(glist))
+    {
+        t_rtext *y = glist_findrtext(glist, t);
+        rtext_displace(y, glist->gl_zoom * dx, glist->gl_zoom * dy);
+        atom_drawborder(x, t, glist, rtext_gettag(y),
+            rtext_width(y), rtext_height(y), 0);
+        canvas_fixlinesfor(glist, t);
+    }
     sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
         x, dx * glist->gl_zoom, dy * glist->gl_zoom);
 }
@@ -885,7 +879,27 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
 {
     t_gatom *x = (t_gatom*)z;
-    text_vis(z, glist, vis);
+    t_text *t = (t_text *)z;
+    if (vis)
+    {
+        if (gobj_shouldvis(&t->te_g, glist))
+        {
+            t_rtext *y = glist_findrtext(glist, t);
+            glist_retext(glist, t);
+            atom_drawborder(x, t, glist, rtext_gettag(y),
+                rtext_width(y), rtext_height(y), 1);
+            rtext_draw(y);
+        }
+    }
+    else
+    {
+        t_rtext *y = glist_findrtext(glist, t);
+        if (gobj_shouldvis(&t->te_g, glist))
+        {
+            text_eraseborder(t, glist, rtext_gettag(y));
+            rtext_erase(y);
+        }
+    }
     if (*x->a_label->s_name)
     {
         if (vis)
@@ -935,6 +949,9 @@ void canvas_atom(t_glist *gl, t_atomtype type,
         SETSYMBOL(&at, &s_symbol);
     }
     binbuf_add(x->a_text.te_binbuf, 1, &at);
+    outlet_new(&x->a_text,
+        x->a_atom.a_type == A_FLOAT ? &s_float: &s_symbol);
+    inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
     if (argc > 1)
         /* create from file. x, y, width, low-range, high-range, flags,
             label, receive-name, send-name */
@@ -957,20 +974,12 @@ void canvas_atom(t_glist *gl, t_atomtype type,
 
         x->a_symto = gatom_unescapit(atom_getsymbolarg(8, argc, argv));
         x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
-        if (x->a_symto == &s_)
-            outlet_new(&x->a_text,
-                x->a_atom.a_type == A_FLOAT ? &s_float: &s_symbol);
-        if (x->a_symfrom == &s_)
-            inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
         glist_add(gl, &x->a_text.te_g);
     }
     else
     {
         int connectme, xpix, ypix, indx, nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
-        outlet_new(&x->a_text,
-            x->a_atom.a_type == A_FLOAT ? &s_float: &s_symbol);
-        inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
         x->a_text.te_xpix = xpix;
         x->a_text.te_ypix = ypix;
@@ -1384,6 +1393,79 @@ void text_drawborder(t_text *x, t_glist *glist,
 
     if ((ob = pd_checkobject(&x->te_pd)))
         glist_drawiofor(glist, ob, firsttime, tag, x1, y1, x2, y2);
+    if (firsttime) /* raise cords over everything else */
+        sys_vgui(".x%lx.c raise cord\n", glist_getcanvas(glist));
+}
+
+void glist_drawiofor_atoms(t_gatom *x, t_glist *glist, t_object *ob, int firsttime,
+    const char *tag, int x1, int y1, int x2, int y2)
+{
+    int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
+    int width = x2 - x1;
+    int iow = IOWIDTH * glist->gl_zoom;
+    int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
+    /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
+    if(!*x->a_symto->s_name){
+        for (i = 0; i < n; i++)
+        {
+            int onset = x1 + (width - iow) * i / nplus;
+            if (firsttime)
+                sys_vgui(".x%lx.c create rectangle %d %d %d %d "
+                    "-tags [list %so%d outlet] -fill black\n",
+                    glist_getcanvas(glist),
+                    onset, y2 - oh + glist->gl_zoom,
+                    onset + iow, y2,
+                    tag, i);
+            else
+                sys_vgui(".x%lx.c coords %so%d %d %d %d %d\n",
+                    glist_getcanvas(glist), tag, i,
+                    onset, y2 - oh + glist->gl_zoom,
+                    onset + iow, y2);
+        }
+    }
+    n = obj_ninlets(ob);
+    nplus = (n == 1 ? 1 : n-1);
+    if(!*x->a_symfrom->s_name){
+        for (i = 0; i < n; i++)
+        {
+            int onset = x1 + (width - iow) * i / nplus;
+            if (firsttime)
+                sys_vgui(".x%lx.c create rectangle %d %d %d %d "
+                    "-tags [list %si%d inlet] -fill black\n",
+                    glist_getcanvas(glist),
+                    onset, y1,
+                    onset + iow, y1 + ih - glist->gl_zoom,
+                    tag, i);
+            else
+                sys_vgui(".x%lx.c coords %si%d %d %d %d %d\n",
+                    glist_getcanvas(glist), tag, i,
+                    onset, y1,
+                    onset + iow, y1 + ih - glist->gl_zoom);
+        }
+    }
+}
+
+void atom_drawborder(t_gatom *x, t_text *t, t_glist *glist,
+    const char *tag, int width2, int height2, int firsttime)
+{
+    t_object *ob;
+    int x1, y1, x2, y2, width, height, corner;
+    text_getrect(&t->te_g, glist, &x1, &y1, &x2, &y2);
+    width = x2 - x1;
+    height = y2 - y1;
+    corner = ((y2-y1)/4);
+    if (firsttime)
+        sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d "
+            "-width %d -capstyle projecting -tags [list %sR atom]\n",
+            glist_getcanvas(glist),
+            x1, y1,  x2-corner, y1,  x2, y1+corner, x2, y2,  x1, y2,  x1, y1,
+            glist->gl_zoom, tag);
+    else
+        sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d\n",
+            glist_getcanvas(glist), tag,
+            x1, y1,  x2-corner, y1,  x2, y1+corner,  x2, y2,  x1, y2,  x1, y1);
+    if ((ob = pd_checkobject(&t->te_pd)))
+        glist_drawiofor_atoms(x, glist, ob, firsttime, tag, x1, y1, x2, y2);
     if (firsttime) /* raise cords over everything else */
         sys_vgui(".x%lx.c raise cord\n", glist_getcanvas(glist));
 }


### PR DESCRIPTION
This PR focuses on commits that aim to improve the consistency regardng the behaviour of gatom boxes and nbx].

-----------------------------------

Commit https://github.com/pure-data/pure-data/pull/1015/commits/85f6d2b6e9720fb64f5ece3471015210d31a93b7 keeps i/olet functionality for gatom boxes when you have send/receive symbols and closes https://github.com/pure-data/pure-data/issues/1005

-----------------------------------

Commits https://github.com/pure-data/pure-data/pull/1015/commits/d80283134098def07f5894446ff468e9f151569c / https://github.com/pure-data/pure-data/pull/1015/commits/b1f48aa42013029469098fba118d38a3cecc5b4b / https://github.com/pure-data/pure-data/pull/1015/commits/8aefaa4e59edfb481d930658234632edefe18efd Close https://github.com/pure-data/pure-data/issues/851

------------------------

commit https://github.com/pure-data/pure-data/pull/1015/commits/d2ce38ee0f8f5bf37415405d7cb47c1f15d333a0 closes https://github.com/pure-data/pure-data/issues/1025

------------------------

commits https://github.com/pure-data/pure-data/pull/1015/commits/e40e64d192f33232a2d5e49393f05ce14283f0d3 & https://github.com/pure-data/pure-data/pull/1015/commits/d6c51300156ecefac12e3b8fa22154e226729c13 close https://github.com/pure-data/pure-data/issues/1013

But it also depends on commit https://github.com/pure-data/pure-data/pull/1015/commits/74878fa2a0a2e6efedde66de2ef81b24aa4e8337 that closes https://github.com/pure-data/pure-data/issues/1032


------------------------
------------------------