### PR TITLE
fix reading NULL pref strings on some macOS versions

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -9,8 +9,8 @@ extern "C" {
 #endif
 
 #define PD_MAJOR_VERSION 0
-#define PD_MINOR_VERSION 50
-#define PD_BUGFIX_VERSION 3
+#define PD_MINOR_VERSION 51
+#define PD_BUGFIX_VERSION 0
 #define PD_TEST_VERSION "test1"
 extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -312,15 +312,11 @@ static int sys_getpreference(const char *key, char *value, int size)
         int ret = 0;
         if (CFDictionaryGetValueIfPresent(sys_prefdict, k,
                                           (const void **)&v)) {
-            const char *s = CFStringGetCStringPtr((CFStringRef)v,
-                                                  kCFStringEncodingUTF8);
-            if (s)
-            {
-                ret = (strncpy(value, s, size) != NULL);
+            ret = CFStringGetCString((CFStringRef)v, value, size,
+                                     kCFStringEncodingUTF8);
 #if 0
-                if (ret) fprintf(stderr, "plist read %s = %s\n", key, value);
+            if (ret) fprintf(stderr, "plist read %s = %s\n", key, value);
 #endif
-            }
             if (v) CFRelease(v);
         }
         CFRelease(k);
@@ -354,7 +350,7 @@ static int sys_getpreference(const char *key, char *value, int size)
         value[nread] = 0;
         if (value[nread-1] == '\n')     /* remove newline character at end */
             value[nread-1] = 0;
-        return(1);
+        return (1);
     }
 }
 


### PR DESCRIPTION
This is a small bugfix PR which fixes some preference strings being read as NULL preference on macOS by using CFStringGetCString instead of CFStringGetCStringPtr.

The [Apple docs](https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr?language=objc) mention that CFStringGetCStringPtr may return NULL even if the string value is valid. It then mentions to use CFStringGetCString as a backup. In this case, we need to have our own copy so it makes sense to simply use CFStringGetCString anyway.