### PR TITLE
explicitly sign bundled frameworks when creating mac app

### DIFF
--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -360,7 +360,11 @@ cd - > /dev/null # quiet
 # note: "-" identity results in "ad-hoc signing" aka no signing is performed
 # for one, this allows loading un-validated external libraries on macOS 10.15+:
 # https://cutecoder.org/programming/shared-framework-hardened-runtime
-codesign -v --deep -s "-" --entitlements stuff/pd.entitlements $APP
+codesign $verbose -f -s "-" --entitlements stuff/pd.entitlements \
+    ${APP}/Contents/Frameworks/Tcl.framework/Versions/Current
+codesign $verbose -f -s "-" --entitlements stuff/pd.entitlements \
+    ${APP}/Contents/Frameworks/Tk.framework/Versions/Current
+codesign $verbose --deep -s "-" --entitlements stuff/pd.entitlements $APP
 
 # finish up
 touch $APP


### PR DESCRIPTION
This is a *possible* fix for code signing issues when building the macOS .app bundle.

Following this [Stack Overflow post](https://stackoverflow.com/questions/7697508/how-do-you-codesign-framework-bundles-for-the-mac-app-store), apparently bundled frameworks must be explicitly signed as the --deep flag will not actually handle this on it's own. Go figure.

Please test.