### PR TITLE
Add option for native tk bezier cables

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -13,6 +13,7 @@ to be different but are now unified except for some fossilized names.) */
 #include "s_utf8.h"
 #include "g_canvas.h"
 #include <string.h>
+#include <math.h>
 #include "g_all_guis.h"
 #include "g_undo.h"
 
@@ -820,12 +821,12 @@ static void canvas_drawlines(t_canvas *x)
     {
         linetraverser_start(&t, x);
         while ((oc = linetraverser_next(&t)))
-            sys_vgui(
-        ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-                glist_getcanvas(x),
+			sys_vgui(
+        		"::pdtk_canvas::pdtk_connect %d %d %d %d %d [list l%lx cord] "
+        		".x%lx.c\n",
                 t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
                 (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
-                oc);
+                oc, glist_getcanvas(x));
     }
 }
 
@@ -839,9 +840,9 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
     {
         if (t.tr_ob == text || t.tr_ob2 == text)
         {
-            sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
-                glist_getcanvas(x), oc,
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
+            sys_vgui("::pdtk_canvas::pdtk_coords "
+            	"%d %d %d %d l%lx .x%lx.c\n",
+                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2, oc, glist_getcanvas(x));
         }
     }
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2431,9 +2431,10 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                         x->gl_editor->e_xwas = xpos;
                         x->gl_editor->e_ywas = ypos;
                         sys_vgui(
-                            ".x%lx.c create line %d %d %d %d -width %d -tags x\n",
-                            x, xpos, ypos, xpos, ypos,
-                            (issignal ? 2 : 1) * x->gl_zoom);
+                            "::pdtk_canvas::pdtk_connect %d %d %d %d %d "
+                            "x .x%lx.c\n",
+                            xpos, ypos, xpos, ypos,
+                            (issignal ? 2 : 1) * x->gl_zoom, x);
                     }
                     else canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
                 }
@@ -2642,12 +2643,12 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
                 + iom;
             ly2 = y21;
             sys_vgui(
-                ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-                glist_getcanvas(x),
+                "::pdtk_canvas::pdtk_connect %d %d %d %d %d [list l%lx cord] "
+        		".x%lx.c\n",
                 lx1, ly1, lx2, ly2,
                 (obj_issignaloutlet(src, nout) ? 2 : 1) *
                 x->gl_zoom,
-                oc);
+                oc, glist_getcanvas(x));
             canvas_undo_add(x, UNDO_CONNECT, "connect", canvas_undo_set_connect(x,
                     canvas_getindex(x, &src->ob_g), nout,
                     canvas_getindex(x, &sink->ob_g), nin));
@@ -2670,9 +2671,10 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
     post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, mod, doit);
 #endif
     if (doit) sys_vgui(".x%lx.c delete x\n", x);
-    else sys_vgui(".x%lx.c coords x %d %d %d %d\n",
-                  x, x->gl_editor->e_xwas,
-                  x->gl_editor->e_ywas, xpos, ypos);
+    else sys_vgui("::pdtk_canvas::pdtk_coords "
+            	"%d %d %d %d x .x%lx.c\n",
+                  x->gl_editor->e_xwas, x->gl_editor->e_ywas,
+                  xpos, ypos, x);
 
     if ((y1 = canvas_findhitbox(x, xwas, ywas, &x11, &y11, &x12, &y12))
         && (y2 = canvas_findhitbox(x, xpos, ypos, &x21, &y21, &x22, &y22)))
@@ -4342,9 +4344,10 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     if (glist_isvisible(x))
     {
         sys_vgui(
-            ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-            glist_getcanvas(x), 0, 0, 0, 0,
-            (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom, oc);
+            "::pdtk_canvas::pdtk_connect 0 0 0 0 %d [list l%lx cord] "
+        	".x%lx.c\n",
+            (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom,
+            oc, glist_getcanvas(x));
         canvas_fixlinesfor(x, objsrc);
     }
     return;

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -199,6 +199,8 @@ set popup_ycanvas 0
 set modifier ""
 # current state of the Edit Mode menu item
 set editmode_button 0
+# use bezier curves
+set curve_cords false
 
 
 ## per toplevel/patch data

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -427,3 +427,70 @@ proc ::pdtk_canvas::pdtk_canvas_reflecttitle {mytoplevel \
         wm title $mytoplevel "$name$dirtychar$arguments - $path"
     }
 }
+
+proc ::pdtk_canvas::pdtk_connect {x1 y1 x2 y2 width tags canv} {
+# from pd-l2ork
+	if {$::curve_cords} {
+		set ymax 0;
+		set halfx [expr {($x2 - $x1)/2}]
+		set halfy [expr {($y2 - $y1)/2}]
+		set yoff [expr {abs($halfy)}]
+		if {$halfy >= 0} {
+			# second object is below the first
+			if {abs($halfx) <= 10} {
+				set ymax [expr {abs($halfy * pow($halfx/10.0, 2))}]
+				if {$ymax > 10} {
+					set ymax 10
+				}
+			} else {
+				set ymax 10
+			}
+		} else {
+			# second object is above the first
+			set ymax 20
+		}
+		if {$yoff > $ymax} {
+			set yoff $ymax;
+		}
+		${canv} create line $x1 $y1 $x1 [expr {$y1 + $yoff}] \
+			[expr {$x1 + $halfx}] [expr {$y1 + $halfy}] $x2 \
+			[expr {$y2 - $yoff}] $x2 $y2 -smooth 1 -splinesteps 16 \
+			-width $width -tags $tags
+	} else {
+		# have to set smooth and splinesteps in case it changes
+		${canv} create line $x1 $y1 $x2 $y2 -width $width -tags $tags \
+			-smooth 1 -splinesteps 16
+	}
+}
+
+proc ::pdtk_canvas::pdtk_coords {x1 y1 x2 y2 tag canv} {
+	# from pd-l2ork
+	if {$::curve_cords} {
+		set ymax 0;
+		set halfx [expr {($x2 - $x1)/2}]
+		set halfy [expr {($y2 - $y1)/2}]
+		set yoff [expr {abs($halfy)}]
+		if {$halfy >= 0} {
+			# second object is below the first
+			if {abs($halfx) <= 10} {
+				set ymax [expr {abs($halfy * pow($halfx/10.0, 2))}]
+				if {$ymax > 10} {
+					set ymax 10
+				}
+			} else {
+				set ymax 10
+			}
+		} else {
+			# second object is above the first
+			set ymax 20
+		}
+		if {$yoff > $ymax} {
+			set yoff $ymax;
+		}
+		${canv} coords $tag $x1 $y1 $x1 [expr {$y1 + $yoff}] \
+			[expr {$x1 + $halfx}] [expr {$y1 + $halfy}] $x2 \
+			[expr {$y2 - $yoff}] $x2 $y2
+	} else {
+		${canv} coords $tag $x1 $y1 $x2 $y2
+	}
+}


### PR DESCRIPTION
I used -smooth option for canvas create line, and am doing some math in 2 new tcl procs for creating the lines and setting the coordinates, and there's a new global variable ::curve_cords for turning it off and on (off by default)

This is adding more computation in tcl.. though not much more if straight cables are opted for I think.