### PR TITLE
add "-open-with-args" command line option

### DIFF
--- a/src/s_main.c
+++ b/src/s_main.c
@@ -60,7 +60,15 @@ t_symbol *sys_flags;    /* more command-line flags */
 
 const char *sys_guicmd;
 t_symbol *sys_libdir;
-static t_namelist *sys_openlist;
+
+typedef struct _patchlist
+{
+    struct _patchlist *pl_next;
+    char *pl_file;
+    char *pl_args;
+} t_patchlist;
+
+static t_patchlist *sys_openlist;
 static t_namelist *sys_messagelist;
 static int sys_version;
 int sys_oldtclversion;      /* hack to warn g_rtext.c about old text sel */
@@ -184,7 +192,50 @@ int sys_fontheight(int fontsize)
 int sys_defaultfont;
 #define DEFAULTFONT 12
 
-static void openit(const char *dirname, const char *filename)
+static t_patchlist * patchlist_append(t_patchlist *listwas,
+    const char *files, const char *args)
+{
+    t_namelist *nl, *nl2;
+    nl = namelist_append_files(0, files);
+    for (nl2 = nl; nl2; nl2 = nl2->nl_next)
+    {
+        t_patchlist *pl, *pl2;
+        pl = (t_patchlist *)(getbytes(sizeof(*pl)));
+        pl->pl_next = 0;
+        pl->pl_file = (char *)getbytes(strlen(nl2->nl_string) + 1);
+        strcpy(pl->pl_file, nl2->nl_string);
+        if (args)
+        {
+            pl->pl_args = (char *)getbytes(strlen(args) + 1);
+            strcpy(pl->pl_args, args);
+        }
+        else pl->pl_args = 0;
+        if (!listwas)
+            listwas = pl;
+        else
+        {
+            for (pl2 = listwas; pl2->pl_next; pl2 = pl2->pl_next) ;
+            pl2->pl_next = pl;
+        }
+    }
+    namelist_free(nl);
+    return (listwas);
+}
+
+static void patchlist_free(t_patchlist *list)
+{
+    t_patchlist *pl, *pl2;
+    for (pl = list; pl; pl = pl2)
+    {
+        pl2 = pl->pl_next;
+        freebytes(pl->pl_file, strlen(pl->pl_file) + 1);
+        if (pl->pl_args)
+            freebytes(pl->pl_args, strlen(pl->pl_args) + 1);
+        freebytes(pl, sizeof(*pl));
+    }
+}
+
+static void openit(const char *dirname, const char *filename, const char *args)
 {
     char dirbuf[MAXPDSTRING], *nameptr;
     int fd = open_via_path(dirname, filename, "", dirbuf, &nameptr,
@@ -192,6 +243,15 @@ static void openit(const char *dirname, const char *filename)
     if (fd >= 0)
     {
         close (fd);
+        if (args && *args)
+        {
+            t_binbuf *b1 = binbuf_new(), *b2 = binbuf_new();
+            binbuf_text(b1, args, strlen(args));
+            binbuf_addbinbuf(b2, b1); // bash semis, commas and dollars
+            canvas_setargs(binbuf_getnatom(b2), binbuf_getvec(b2));
+            binbuf_free(b1);
+            binbuf_free(b2);
+        }
         glob_evalfile(0, gensym(nameptr), gensym(dirbuf));
     }
     else
@@ -209,6 +269,7 @@ open(), read(), etc, calls to be served somehow from the GUI too. */
 void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     const char *cwd = atom_getsymbolarg(0, argc, argv)->s_name;
+    t_patchlist *pl;
     t_namelist *nl;
     unsigned int i;
     int did_fontwarning = 0;
@@ -251,9 +312,9 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
         sys_oktoloadfiles(1);
     }
         /* open patches specifies with "-open" args */
-    for  (nl = sys_openlist; nl; nl = nl->nl_next)
-        openit(cwd, nl->nl_string);
-    namelist_free(sys_openlist);
+    for (pl = sys_openlist; pl; pl = pl->pl_next)
+        openit(cwd, pl->pl_file, pl->pl_args);
+    patchlist_free(sys_openlist);
     sys_openlist = 0;
         /* send messages specified with "-send" args */
     for  (nl = sys_messagelist; nl; nl = nl->nl_next)
@@ -480,6 +541,7 @@ static char *(usagemessage[]) = {
 "-stdpath         -- search standard directory (true by default)\n",
 "-helppath <path> -- add to help file search path\n",
 "-open <file>     -- open file(s) on startup\n",
+"-open-with-args <file> <args> -- open file(s) on startup with arguments\n",
 "-lib <file>      -- load object library(s) (omit file extensions)\n",
 "-font-size <n>      -- specify default font size in points\n",
 "-font-face <name>   -- specify default font\n",
@@ -1146,9 +1208,15 @@ int sys_argparse(int argc, const char **argv)
         {
             if (argc < 2)
                 goto usage;
-
-            sys_openlist = namelist_append_files(sys_openlist, argv[1]);
+            sys_openlist = patchlist_append(sys_openlist, argv[1], 0);
             argc -= 2; argv += 2;
+        }
+        else if (!strcmp(*argv, "-open-with-args"))
+        {
+            if (argc < 3)
+                goto usage;
+            sys_openlist = patchlist_append(sys_openlist, argv[1], argv[2]);
+            argc -= 3; argv += 3;
         }
         else if (!strcmp(*argv, "-lib"))
         {
@@ -1377,9 +1445,10 @@ int sys_argparse(int argc, const char **argv)
     if (!sys_defaultfont)
         sys_defaultfont = DEFAULTFONT;
     for (; argc > 0; argc--, argv++)
-        sys_openlist = namelist_append_files(sys_openlist, *argv);
+        sys_openlist = patchlist_append(sys_openlist, *argv, 0);
 
     sys_set_audio_settings(&as);
+
     return (0);
 }
 


### PR DESCRIPTION
This allows to open patches with creation arguments.

Syntax: `-open-with-args <patch> <arguments>`

Multiple arguments have to be enclosed in quotation marks.

Example:

`pd -open-with-args foo.pd "bar baz 1 2 3"`

Simple test patch: [foo.zip](https://github.com/pure-data/pure-data/files/4758116/foo.zip)

Closes https://github.com/pure-data/pure-data/issues/1058

---

Of course, you can also open multiple patches:

`pd -open-with-args patch1.pd "1 2 3" -open-with-args patch2.pd "foo bar baz"`

---

Or you can load several patches with the same arguments:

`pd -open-with-args "patch1.pd:patch2.pd" "1 2 3"`

NOTE: the colon seperator is *not* a new feature. (On Windows you have to use a semicolon, instead.)