### PR TITLE
fix flag parsing in sys_doflags

### DIFF
--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -57,6 +57,7 @@ PDLIB = /NODEFAULTLIB:libcmt /NODEFAULTLIB:libcpmt /NODEFAULTLIB:oldnames \
     /NODEFAULTLIB:libc /NODEFAULTLIB:uuid /NODEFAULTLIB:ole32 \
     $(EXTRA_LIBPATH) \
     kernel32.lib \
+    shell32.lib \
     ws2_32.lib winmm.lib \
     advapi32.lib setupapi.lib \
     ../bin/pthreadVC.lib \

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -722,8 +722,8 @@ void glob_start_startup_dialog(t_pd *dummy)
     char buf[MAXPDSTRING];
 
     sys_set_startup();
-    sprintf(buf, "pdtk_startup_dialog %%s %d \"%s\"\n", sys_defeatrt,
-        (sys_flags? sys_flags->s_name : ""));
+    snprintf(buf, MAXPDSTRING, "pdtk_startup_dialog %%s %d {%s}\n",
+        sys_defeatrt, (sys_flags ? sys_flags->s_name : ""));
     gfxstub_new(&glob_pdobject, (void *)glob_start_startup_dialog, buf);
 }
 

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -42,6 +42,10 @@
 #include <fcntl.h>
 #include <ctype.h>
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 #ifdef _LARGEFILE64_SOURCE
 # define open  open64
 # define lseek lseek64


### PR DESCRIPTION
Currently, the parser in `sys_doflags` simply splits tokens based on whitespace and doesn't respect quotation marks. This means we can't store command line flags like the following:

`-font-face "Courier New"`

Solution:

* use `CommandLineToArgvw` on Windows
* use `wordexp` for Unix

Tested on Windows, Linux and macOS. Fixes https://github.com/pure-data/pure-data/issues/1065