### PR TITLE
Fix typo in `-guicmd` help string

### DIFF
--- a/doc/1.manual/x3.htm
+++ b/doc/1.manual/x3.htm
@@ -587,7 +587,7 @@ general flags:
 -gui             -- start GUI (true by default)
 -nogui           -- suppress starting the GUI
 -guiport &lt;n&gt;     -- connect to pre-existing GUI over port &lt;n&gt;
--guicmd "cmd..." -- start alternatve GUI program (e.g., remote via ssh)
+-guicmd "cmd..." -- start alternative GUI program (e.g., remote via ssh)
 -send "msg..."   -- send a message at startup, after patches are loaded
 -prefs           -- load preferences on startup (true by default)
 -noprefs         -- suppress loading preferences on startup

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -507,7 +507,7 @@ static char *(usagemessage[]) = {
 "-gui             -- start GUI (true by default)\n",
 "-nogui           -- suppress starting the GUI\n",
 "-guiport <n>     -- connect to pre-existing GUI over port <n>\n",
-"-guicmd \"cmd...\" -- start alternatve GUI program (e.g., remote via ssh)\n",
+"-guicmd \"cmd...\" -- start alternative GUI program (e.g., remote via ssh)\n",
 "-send \"msg...\"   -- send a message at startup, after patches are loaded\n",
 "-prefs           -- load preferences on startup (true by default)\n",
 "-noprefs         -- suppress loading preferences on startup\n",


### PR DESCRIPTION
The help string said this previously:
```
-guicmd "cmd..." -- start alternatve GUI program (e.g., remote via ssh)
```
This patch fixes the spelling to "alternative".

A second occurrence of the same typo in the manual is also fixed.