### PR TITLE
Disable local-portaudio if portaudio is disabled in general

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,9 +42,9 @@ RELEASE_CFLAGS="-ffast-math -funroll-loops -fomit-frame-pointer -O3"
 PD_CHECK_IPHONE(IPHONEOS=yes, IPHONEOS=no, AC_MSG_ERROR([iOS SDK not available]))
 PD_CHECK_ANDROID(ANDROID=yes, ANDROID=no, AC_MSG_ERROR([Android SDK not available]))
 
-case $host in
-*darwin*)
-    if test "x${IPHONEOS}" = "xno"; then
+AS_CASE([$host],
+[*darwin*],[
+    AS_IF([test "x${IPHONEOS}" = "xno"],[
         MACOSX=yes
         platform="Mac OSX"
         coreaudio=yes
@@ -59,53 +59,50 @@ case $host in
 
         # required for dlopen & weak linking for older OSX version support
         CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
-    else
+    ],[
         platform=iOS
         locales=no
         wish="not used"
-    fi
+    ])
 
     # homebrew paths
-    if test -e /usr/local ; then
+    AS_IF([test -e /usr/local],[
         AM_CPPFLAGS="-I/usr/local/include $INCLUDES"
         LDFLAGS="-L/usr/local/lib $LDFLAGS"
-    fi
+    ])
 
     # fink paths
-    if test -e /sw ; then
+    AS_IF([test -e /sw],[
         AM_CPPFLAGS="-I/sw/include $INCLUDES"
         LDFLAGS="-L/sw/lib $LDFLAGS"
-    fi
+    ])
 
     # macports paths
-    if test -e /opt/local ; then
+    AS_IF([test -e /opt/local],[
         AM_CPPFLAGS="-I/opt/local/include $INCLUDES"
         LDFLAGS="-L/opt/local/lib $LDFLAGS"
-    fi
+    ])
 
     EXTERNAL_LDFLAGS="-bundle -undefined dynamic_lookup"
-    ;;
-*linux*|*kfreebsd*gnu*)
+],[*linux*|*kfreebsd*gnu*],[
     # GNU/kFreeBSD are for Debian, were they are treated very similar to linux
-    if test "x${ANDROID}" = "xno"; then
+    AS_IF([test "x${ANDROID}" = "xno"],[
         LINUX=yes
         platform=Linux
         portaudio=yes
         EXTERNAL_CFLAGS="-fPIC"
         EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
         EXTERNAL_EXTENSION=pd_linux
-    else
+    ],[
         platform=Android
-    fi
-    ;;
-*-*-gnu*)
+    ])
+],[*-*-gnu*],[
     HURD=yes
     platform=Hurd
     EXTERNAL_CFLAGS="-fPIC"
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
     EXTERNAL_EXTENSION=pd_linux
-    ;;
-*mingw*)
+],[*mingw*],[
     WINDOWS=yes
     MINGW=yes
     platform=MinGW
@@ -125,8 +122,7 @@ case $host in
     # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling
     ac_cv_func_malloc_0_nonnull=yes
     ac_cv_func_realloc_0_nonnull=yes
-    ;;
-*cygwin*)
+],[*cygwin*],[
     WINDOWS=yes
     CYGWIN=yes
     platform=Cygwin
@@ -142,19 +138,16 @@ case $host in
     EXTERNAL_CFLAGS=
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic"
     EXTERNAL_EXTENSION=dll
-    ;;
-*openbsd*)
+],[*openbsd*],[
     OPENBSD=yes
     platform=OpenBSD
     portaudio=yes
     EXTERNAL_CFLAGS="-D__OPENBSD__"
     EXTERNAL_LDFLAGS="-liberty"
     EXTERNAL_EXTENSION=pd_openbsd
-    ;;
-*)
+],[
     platform=Unknown
-    ;;
-esac
+])
 
 AM_CONDITIONAL(ANDROID, test x$ANDROID = xyes)
 AM_CONDITIONAL(IPHONEOS, test x$IPHONEOS = xyes)
@@ -273,19 +266,19 @@ AC_SUBST([AM_CPPFLAGS], [$AM_CPPFLAGS])
 AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [use debugging support])],
     [debug=$enableval], [debug=no])
-if test x$debug = xyes ; then
+AS_IF([test x$debug = xyes],[
     CFLAGS="$CFLAGS $DEBUG_CFLAGS"
-else
+],[
     CFLAGS="$CFLAGS $RELEASE_CFLAGS"
-fi
+])
 
 ##### Universal/multi architecture build on macOS #####
 PD_CHECK_UNIVERSAL(ARCH, [universal=yes], [universal=no])
 AM_CONDITIONAL(UNIVERSAL, test x$universal = xyes)
-if test x$universal = xyes ; then
+AS_IF([test x$universal = xyes],[
     CFLAGS="$ARCH_CFLAGS $CFLAGS"
     LDFLAGS="$ARCH_LDFLAGS $LDFLAGS"
-fi
+])
 
 ##### Gettext #####
 # Gettext is needed to build language localizations.
@@ -293,13 +286,13 @@ AC_ARG_ENABLE([locales],
     [AS_HELP_STRING([--disable-locales],
         [do not compile localizations (requires gettext)])],
     [locales=$enableval])
-if test x$locales = xyes ; then
+AS_IF([test x$locales = xyes],[
     AC_CHECK_PROG(HAVE_MSGFMT, [msgfmt], yes, no)
-    if test x$HAVE_MSGFMT = xno ; then
+    AS_IF([test x$HAVE_MSGFMT = xno],[
         AC_MSG_WARN([Install GNU gettext with msgfmt if you want localizations to be compiled!])
         locales=no
-    fi
-fi
+    ])
+])
 AM_CONDITIONAL(MSGFMT, test x$HAVE_MSGFMT = xyes)
 
 ##### OSS #####
@@ -308,9 +301,9 @@ AM_CONDITIONAL(MSGFMT, test x$HAVE_MSGFMT = xyes)
 AC_ARG_ENABLE([oss],
     [AS_HELP_STRING([--disable-oss], [do not use OSS driver])],
     [oss=$enableval], [oss=yes])
-if test x$oss = xyes ; then
-    AC_CHECK_HEADER(sys/soundcard.h, [oss=yes], [oss=no])
-fi
+AS_IF([test x$oss = xyes],[
+    AC_CHECK_HEADER([sys/soundcard.h], [oss=yes], [oss=no])
+])
 
 ##### ALSA #####
 # shouldn't we use AM_PATH_ALSA from /usr/share/aclocal/alsa.m4
@@ -318,9 +311,9 @@ fi
 AC_ARG_ENABLE([alsa],
     [AS_HELP_STRING([--disable-alsa], [do not use ALSA audio driver])],
     [alsa=$enableval], [alsa=yes])
-if test x$alsa = xyes ; then
+AS_IF([test x$alsa = xyes],[
     AC_CHECK_LIB([asound], [snd_pcm_info], [ALSA_LIBS="-lasound"], [alsa=no])
-fi
+])
 
 ##### JACK FRAMEWORK #####
 # on macOS, use the JackOSX.com Jackmp.framework not the jack lib by default
@@ -330,21 +323,21 @@ AC_ARG_ENABLE([jack-framework],
         [do not weak link to Jackmp.framework on macOS])],
     [jack_framework=$enableval])
 test x$MACOSX = xyes || jack_framework=no
-if test x$jack_framework = xyes ; then
+AS_IF([test x$jack_framework = xyes],[
     AC_MSG_NOTICE([Weak linking to Jackmp.framework])
-fi
+])
 
 ##### JACK #####
 AC_ARG_ENABLE([jack],
     [AS_HELP_STRING([--enable-jack], [use JACK audio server])],
     [jack=$enableval], [jack=no])
-if [ test x$jack_framework != xyes ] && [ test x$jack = xyes ] ; then
+AS_IF([test x$jack_framework != xyes -a x$jack = xyes],[
     AC_CHECK_LIB([rt], [shm_open], [LIBS="$LIBS -lrt"])
     AC_CHECK_LIB([jack], [jack_set_xrun_callback], [JACK_LIBS="-ljack" ; jack=xrun])
     AC_CHECK_LIB([jack], [jack_set_error_function], [JACK_LIBS="-ljack" ; jack=yes],
         [AC_MSG_WARN([JACK development files not found... skipping (See INSTALL.txt)])
         jack=no])
-fi
+])
 
 ##### MMIO #####
 AC_ARG_ENABLE([mmio],
@@ -371,21 +364,21 @@ AC_ARG_WITH([local-portaudio],
     [AS_HELP_STRING([--without-local-portaudio],
         [do not use the portaudio included with Pd])],
     [local_portaudio=$withval])
-if test x$portaudio = xyes ; then
-    if test x$local_portaudio = xno ; then
+AS_IF([test x$portaudio = xyes],[
+    AS_IF([test x$local_portaudio = xno],[
         # fall back to local portaudio if not foud
         AC_CHECK_LIB([portaudio], [Pa_Initialize],
             [AC_MSG_NOTICE([Using system PortAudio])], [local_portaudio=yes])
-    fi
-    if test x$local_portaudio = xyes ; then
-        if test -d "$srcdir/portaudio" ; then
+    ])
+    AS_IF([test x$local_portaudio = xyes],[
+        AS_IF([test -d "$srcdir/portaudio"],[
             AC_MSG_NOTICE([Using included PortAudio])
-        else
+        ],[
             AC_MSG_WARN([PortAudio not found in Pd source directory])
             portaudio=no
-        fi
-    fi
-fi
+        ])
+    ])
+])
 
 ##### PortMidi #####
 AC_ARG_ENABLE([portmidi],
@@ -399,32 +392,32 @@ AC_ARG_WITH([local-portmidi],
 AS_IF([test x$oss = xyes -a x$portmidi != xno],
   [AC_MSG_WARN([Cannot enable both OSS-midi and PortMidi... preferring OSS])
   portmidi=no])
-if test x$portmidi = xyes ; then
-    if test x$local_portmidi = xno ; then
+AS_IF([test x$portmidi = xyes],[
+    AS_IF([test x$local_portmidi = xno],[
         # fall back to local portmidi if not foud
         AC_CHECK_LIB([portmidi], [Pm_Initialize],
             [AC_MSG_NOTICE([Using system PortMidi])], [local_portmidi=yes])
-    fi
-    if test x$local_portmidi = xyes ; then
-        if test -d "$srcdir/portmidi" ; then
+    ])
+    AS_IF([test x$local_portmidi = xyes],[
+        AS_IF([test -d "$srcdir/portmidi"],[
             AC_MSG_NOTICE([Using included PortMidi])
-        else
+        ],[
             AC_MSG_WARN([PortMidi not found in Pd source directory])
             portmidi=no
-        fi
-    fi
-fi
+        ])
+    ])
+])
 
 ##### fftw v3 #####
 AC_ARG_ENABLE([fftw],
     [AS_HELP_STRING([--enable-fftw], [use FFTW package])],
     [fftw=$enableval], [fftw=no])
-if test x$fftw = xyes; then
+AS_IF([test x$fftw = xyes],[
     AC_CHECK_LIB([fftw3f], [fftwf_execute],
         [LIBS="$LIBS -lfftw3f"],
         [AC_MSG_WARN([FFTW development files not found... using built-in FFT])
         fftw=no])
-fi
+])
 AM_CONDITIONAL(FFTW, test x$fftw = xyes)
 
 ##### Wish #####

--- a/configure.ac
+++ b/configure.ac
@@ -378,7 +378,7 @@ AS_IF([test x$portaudio = xyes],[
             portaudio=no
         ])
     ])
-])
+],[local_portaudio=no])
 
 ##### PortMidi #####
 AC_ARG_ENABLE([portmidi],
@@ -406,7 +406,7 @@ AS_IF([test x$portmidi = xyes],[
             portmidi=no
         ])
     ])
-])
+],[local_portmidi=no])
 
 ##### fftw v3 #####
 AC_ARG_ENABLE([fftw],


### PR DESCRIPTION
right now, the `--disable-portaudio` flag disables PortAudio support, but still compiles the embedded copy of the PortAudio library (it just skips the linking step).

this is suboptimal, as it
- requires more ressources to compile
- is error prone (cf #1072 )

this PR completely disables PortAudio if the user passes `--disable-portaudio`.
the same goes for PortMidi.

Closes: #1072 


this PR also replaces the few remaining uses of bash's `if/else` and `switch/case` constructs to the autotools' `AS_IF` resp. `AS_CASE` macros.