### PR TITLE
Convert file operations to use "fileops" abstraction layer

### DIFF
--- a/extra/bonk~/bonk~.c
+++ b/extra/bonk~/bonk~.c
@@ -991,13 +991,12 @@ static void bonk_read(t_bonk *x, t_symbol *s)
     t_float *fp2;
 
     /* fbar: canvas_open code taken from g_array.c */
-    FILE *fd;
+    t_fileops_handle fd;
     char buf[MAXPDSTRING], *bufptr;
-    int filedesc;
+    t_fileops_handle filedesc;
 
-    if ((filedesc = canvas_open(x->x_canvas,
-            s->s_name, "", buf, &bufptr, MAXPDSTRING, 0)) < 0 
-                || !(fd = fdopen(filedesc, "r")))
+    if (!canvas_open(x->x_canvas,
+            s->s_name, "", buf, &bufptr, &filedesc, MAXPDSTRING, 0))
     {
         post("%s: open failed", s->s_name);
         return;
@@ -1007,7 +1006,7 @@ static void bonk_read(t_bonk *x, t_symbol *s)
     while (1)
     {
         for (i = x->x_nfilters, fp = vec; i--; fp++)
-            if (fscanf(fd, "%f", fp) < 1) goto nomore;
+            if (sys_fileops.scanf(fd, "%f", fp) < 1) goto nomore;
         x->x_template = (t_template *)t_resizebytes(x->x_template,
             ntemplate * sizeof(t_template),
                 (ntemplate + 1) * sizeof(t_template));
@@ -1027,7 +1026,7 @@ nomore:
     }
     post("bonk: read %d templates\n", ntemplate);
     x->x_ntemplate = ntemplate;
-    fclose(fd);
+    sys_fileops.close(fd);
 }
 #endif
 

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -813,7 +813,7 @@ broken:
 int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crflag)
 {
     long length;
-    int fd;
+    t_fileops_handle fd;
     int readret;
     char *buf;
     char namebuf[MAXPDSTRING];
@@ -824,13 +824,13 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
         snprintf(namebuf, MAXPDSTRING-1, "%s", filename);
     namebuf[MAXPDSTRING-1] = 0;
 
-    if ((fd = sys_open(namebuf, 0)) < 0)
+    if (!sys_fileops.open(namebuf, 0, &fd))
     {
         fprintf(stderr, "open: ");
         perror(namebuf);
         return (1);
     }
-    if ((length = (long)lseek(fd, 0, SEEK_END)) < 0 || lseek(fd, 0, SEEK_SET) < 0
+    if ((length = (long)sys_fileops.seek(fd, 0, FILEOPS_SEEK_END)) < 0 || sys_fileops.seek(fd, 0, FILEOPS_SEEK_SET) < 0
         || !(buf = t_getbytes(length)))
     {
         fprintf(stderr, "lseek: ");
@@ -838,9 +838,9 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
         close(fd);
         return(1);
     }
-    if ((readret = (int)read(fd, buf, length)) < length)
+    if ((readret = (int)sys_fileops.read(fd, buf, length)) < length)
     {
-        fprintf(stderr, "read (%d %ld) -> %d\n", fd, length, readret);
+        fprintf(stderr, "read (%" PRIx64 " %ld) -> %d\n", (unsigned long long)fd, length, readret);
         perror(namebuf);
         close(fd);
         t_freebytes(buf, length);
@@ -869,15 +869,15 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
 int binbuf_read_via_canvas(t_binbuf *b, const char *filename, const t_canvas *canvas,
     int crflag)
 {
-    int filedesc;
+    t_fileops_handle filedesc;
     char buf[MAXPDSTRING], *bufptr;
-    if ((filedesc = canvas_open(canvas, filename, "",
-        buf, &bufptr, MAXPDSTRING, 0)) < 0)
+    if (!canvas_open(canvas, filename, "",
+        buf, &bufptr, &filedesc, MAXPDSTRING, 0))
     {
         error("%s: can't open", filename);
         return (1);
     }
-    else close (filedesc);
+    else sys_fileops.close (filedesc);
     if (binbuf_read(b, bufptr, buf, crflag))
         return (1);
     else return (0);
@@ -887,15 +887,15 @@ int binbuf_read_via_canvas(t_binbuf *b, const char *filename, const t_canvas *ca
 int binbuf_read_via_path(t_binbuf *b, const char *filename, const char *dirname,
     int crflag)
 {
-    int filedesc;
+    t_fileops_handle filedesc;
     char buf[MAXPDSTRING], *bufptr;
-    if ((filedesc = open_via_path(
-        dirname, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
+    if (!open_via_path(
+        dirname, filename, "", buf, &bufptr, &filedesc, MAXPDSTRING, 0))
     {
         error("%s: can't open", filename);
         return (1);
     }
-    else close (filedesc);
+    else sys_fileops.close (filedesc);
     if (binbuf_read(b, bufptr, buf, crflag))
         return (1);
     else return (0);
@@ -908,7 +908,7 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd);
     semicolons. */
 int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int crflag)
 {
-    FILE *f = 0;
+    t_fileops_handle fd; bool fdopen = false;
     char sbuf[WBUFSIZE], fbuf[MAXPDSTRING], *bp = sbuf, *ep = sbuf + WBUFSIZE;
     t_atom *ap;
     t_binbuf *y = 0;
@@ -929,12 +929,13 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
         x = y;
     }
 
-    if (!(f = sys_fopen(fbuf, "w")))
+    if (!sys_fileops.open(fbuf, FILEOPS_WRITE, &fd))
     {
         fprintf(stderr, "open: ");
         sys_unixerror(fbuf);
         goto fail;
     }
+    fdopen = true;
     for (ap = z->b_vec, indx = z->b_n; indx--; ap++)
     {
         int length;
@@ -945,7 +946,7 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
         else length = 40;
         if (ep - bp < length)
         {
-            if (fwrite(sbuf, bp-sbuf, 1, f) < 1)
+            if (sys_fileops.write(fd, sbuf, bp-sbuf))
             {
                 sys_unixerror(fbuf);
                 goto fail;
@@ -972,13 +973,13 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
             ncolumn++;
         }
     }
-    if (fwrite(sbuf, bp-sbuf, 1, f) < 1)
+    if (sys_fileops.write(fd, sbuf, bp-sbuf) < 1)
     {
         sys_unixerror(fbuf);
         goto fail;
     }
 
-    if (fflush(f) != 0)
+    if (sys_fileops.flush(fd) != 0)
     {
         sys_unixerror(fbuf);
         goto fail;
@@ -986,13 +987,13 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
 
     if (y)
         binbuf_free(y);
-    fclose(f);
+    sys_fileops.close(fd);
     return (0);
 fail:
     if (y)
         binbuf_free(y);
-    if (f)
-        fclose(f);
+    if (fdopen)
+        sys_fileops.close(fd);
     return (1);
 }
 

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -71,8 +71,16 @@ typedef unsigned __int8   uint8_t;
 typedef unsigned __int16  uint16_t;
 typedef unsigned __int32  uint32_t;
 typedef unsigned __int64  uint64_t;
+typedef unsigned __int8   bool;
+#define false 0
+#define true 1
+#define PRIxPTR "p"
+#define tobool(x) ((x)?true:false)
 #else
-# include <stdint.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#define tobool(x) ((bool)(x))
 #endif
 
 /* for FILE, needed by sys_fopen() and sys_fclose() only */
@@ -304,6 +312,10 @@ typedef void (*t_gotfn5)(void *x,
 EXTERN void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv);
 EXTERN t_pd *pd_newest(void);
 
+/* --------------- fileops -------------------- */
+
+#include "s_fileops.h"
+
 /* --------------- memory management -------------------- */
 EXTERN void *getbytes(size_t nbytes);
 EXTERN void *getzbytes(size_t nbytes);
@@ -443,8 +455,8 @@ EXTERN int sys_zoomfontheight(int fontsize, int zoom, int worstcase);
 EXTERN int sys_fontwidth(int fontsize);
 EXTERN int sys_fontheight(int fontsize);
 EXTERN void canvas_dataproperties(t_glist *x, t_scalar *sc, t_binbuf *b);
-EXTERN int canvas_open(const t_canvas *x, const char *name, const char *ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
+EXTERN bool canvas_open(const t_canvas *x, const char *name, const char *ext,
+    char *dirresult, char **nameresult, t_fileops_handle *fd, unsigned int size, int bin);
 
 /* ---------------- widget behaviors ---------------------- */
 
@@ -549,20 +561,11 @@ EXTERN void sys_ouch(void);
 EXTERN int sys_isabsolutepath(const char *dir);
 EXTERN void sys_bashfilename(const char *from, char *to);
 EXTERN void sys_unbashfilename(const char *from, char *to);
-EXTERN int open_via_path(const char *dir, const char *name, const char *ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
+EXTERN bool open_via_path(const char *dir, const char *name, const char *ext,
+    char *dirresult, char **nameresult, t_fileops_handle *file, unsigned int size, int bin);
 EXTERN int sched_geteventno(void);
 EXTERN double sys_getrealtime(void);
 EXTERN int (*sys_idlehook)(void);   /* hook to add idle time computation */
-
-/* Win32's open()/fopen() do not handle UTF-8 filenames so we need
- * these internal versions that handle UTF-8 filenames the same across
- * all platforms.  They are recommended for use in external
- * objectclasses as well so they work with Unicode filenames on Windows */
-EXTERN int sys_open(const char *path, int oflag, ...);
-EXTERN int sys_close(int fd);
-EXTERN FILE *sys_fopen(const char *filename, const char *mode);
-EXTERN int sys_fclose(FILE *stream);
 
 /* ------------  threading ------------------- */
 EXTERN void sys_lock(void);

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -41,39 +41,39 @@ static PERTHREAD FILE *sys_prefsavefp;
 
 static void sys_initloadpreferences_file(const char *filename)
 {
-    int fd;
+    t_fileops_handle fd;
     long length;
-    if ((fd = open(filename, 0)) < 0)
+    if (!sys_fileops.open(filename, 0, &fd))
     {
         if (sys_verbose)
             perror(filename);
         return;
     }
-    length = lseek(fd, 0, 2);
+    length = sys_fileops.seek(fd, 0, 2);
     if (length < 0)
     {
         if (sys_verbose)
             perror(filename);
-        close(fd);
+        sys_fileops.close(fd);
         return;
     }
-    lseek(fd, 0, 0);
+    sys_fileops.seek(fd, 0, 0);
     if (!(sys_prefbuf = malloc(length + 2)))
     {
         error("couldn't allocate memory for preferences buffer");
-        close(fd);
+        sys_fileops.close(fd);
         return;
     }
     sys_prefbuf[0] = '\n';
-    if (read(fd, sys_prefbuf+1, length) < length)
+    if (sys_fileops.read(fd, sys_prefbuf+1, length) < length)
     {
         perror(filename);
         sys_prefbuf[0] = 0;
-        close(fd);
+        sys_fileops.close(fd);
         return;
     }
     sys_prefbuf[length+1] = 0;
-    close(fd);
+    sys_fileops.close(fd);
     if (sys_verbose)
         post("success reading preferences from: %s", filename);
 }

--- a/src/s_fileops.c
+++ b/src/s_fileops.c
@@ -1,0 +1,207 @@
+/* Copyright (c) 2020 Andi McClure.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+#include "s_fileops.h"
+
+static bool null_open(const char *path, t_fileops_flags flags, t_fileops_handle *handle) {
+    return false;
+}
+static bool null_close(t_fileops_handle handle) {
+    return false;
+}
+static bool null_stat(t_fileops_handle handle, t_fileops_stat *stat) {
+    return false;
+}
+static int64_t null_seek(t_fileops_handle handle, int64_t offset, t_fileops_flags flags) {
+    return 0;
+}
+static ssize_t null_read(t_fileops_handle handle, void *buf, size_t nbyte) {
+    return 0;
+}
+static ssize_t null_write(t_fileops_handle handle, const void *buf, size_t nbyte) {
+    return 0;
+}
+static ssize_t null_scanf(t_fileops_handle handle, const char * restrict format, ...) {
+    return 0;
+}
+static ssize_t null_vscanf(t_fileops_handle handle, const char * restrict format, va_list ap) {
+    return 0;
+}
+static ssize_t null_printf(t_fileops_handle handle, const char * restrict format, ...) {
+    return 0;
+}
+static ssize_t null_vprintf(t_fileops_handle handle, const char * restrict format, va_list ap) {
+    return 0;
+}
+static bool null_flush(t_fileops_handle handle) {
+    return false;
+}
+
+#define FILEOPS_NULL_VALUES {null_open, null_close, null_stat, null_seek, null_read, null_write, null_scanf, null_vscanf, null_printf, null_vprintf}
+
+const t_fileops sys_fileops_null = FILEOPS_NULL_VALUES;
+
+#ifndef _PD_METAFILE_NO_DEFAULT
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#define SYS_TOHANDLE(x) ((intptr_t)(void *)(x))
+#define SYS_FROMHANDLE(x) ((FILE *)(void *)(x))
+
+#ifdef _LARGEFILE64_SOURCE
+# define open  open64
+# define lseek lseek64
+# define fstat fstat64
+# define stat  stat64
+#error TODO
+#endif
+
+static void std_flags_to_fopen_string(char *mode, t_fileops_flags flags, bool *doreopen) {
+    int midx = 0;
+    if (!(flags & (FILEOPS_WRITE | FILEOPS_READ)))
+        flags = flags | FILEOPS_WRITE | FILEOPS_READ;
+    // CREAT does not mesh precisely with the fopen concept.
+    if ((flags & FILEOPS_WRITE) && !(flags & FILEOPS_CREAT)) {
+        mode[0] = 'r';
+        mode[1] = '+';
+        midx = 2;
+        if (doreopen)
+            *doreopen = true;
+    } else {
+        if (flags & FILEOPS_READ) {
+            mode[midx] = 'r';
+            midx++;
+        }
+        if (flags & FILEOPS_WRITE) {
+            mode[midx] = midx>0?'+':'w';
+            midx++;
+        }
+        if (doreopen)
+            *doreopen = false;
+    }
+    mode[midx++] = '\0';
+}
+
+// FIXME: This doesn't correctly recreate the O_CREAT behavior; a better way to do this would be fdopen/_fdopen
+static bool std_open(const char *path, t_fileops_flags flags, t_fileops_handle *handle) {
+    char mode[3];
+    bool doreopen;
+
+    std_flags_to_fopen_string(mode, flags, &doreopen);
+
+// IF BODY PD CODE
+#ifdef _WIN32
+    char namebuf[MAXPDSTRING];
+    wchar_t ucs2buf[MAXPDSTRING];
+    wchar_t ucs2mode[MAXPDSTRING];
+    sys_bashfilename(path, namebuf);
+    u8_utf8toucs2(ucs2buf, MAXPDSTRING, namebuf, MAXPDSTRING-1);
+    /* mode only uses ASCII, so no need for a full conversion, just copy it */
+    mbstowcs(ucs2mode, mode, MAXPDSTRING);
+    FILE * f = _wfopen(ucs2buf, ucs2mode);
+#else
+  char namebuf[MAXPDSTRING];
+  sys_bashfilename(path, namebuf);
+  FILE *f = fopen(namebuf, mode);
+#endif
+
+  if (f && doreopen) {
+    std_flags_to_fopen_string(mode, flags & ~(FILEOPS_CREAT), NULL);
+    f = freopen(path, mode, f);
+  }
+
+  *handle = (intptr_t)(void *)f;
+  return tobool(f);
+}
+static bool std_close(t_fileops_handle handle) {
+    FILE *f = (FILE *)(void *)handle;
+    int result = fclose(f);
+    return 0 == result;
+}
+
+static bool std_stat(t_fileops_handle handle, t_fileops_stat *stat) {
+#ifdef _WIN32
+    // On Windows fopen fails on directories, so we always know the answer by this point is no.
+    stat->isdir = false;
+    stat->isdir_known = true;
+#else
+    FILE *f = SYS_FROMHANDLE(handle);
+    int fd = fileno(f);
+    struct stat data;
+    if (fstat(fd, &data))
+        return false;
+    stat->isdir = tobool(data.st_mode & S_IFDIR);
+    stat->isdir_known = true;
+#endif
+    return true;
+}
+static int64_t std_seek(t_fileops_handle handle, int64_t offset, t_fileops_flags flags) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    int whence = 0;
+    if (flags & FILEOPS_SEEK_SET)
+        whence = SEEK_SET;
+    else if (flags & FILEOPS_SEEK_CUR)
+        whence = SEEK_CUR;
+    else if (flags & FILEOPS_SEEK_END)
+        whence = SEEK_END;
+    int64_t result = fseek(f, offset, whence);
+    if (result<0)
+        return -1;
+    return ftell(f);
+}
+static ssize_t std_read(t_fileops_handle handle, void *buf, size_t nbyte) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    return fread(buf, 1, nbyte, f);
+}
+static ssize_t std_write(t_fileops_handle handle, const void *buf, size_t nbyte) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    return fwrite(buf, 1, nbyte, f);
+}
+static ssize_t std_scanf(t_fileops_handle handle, const char * restrict format, ...) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    va_list ap;
+    int result;
+
+    va_start(ap, format);
+    result = vfscanf(f, format, ap);
+    va_end(ap);
+
+    return result;
+}
+static ssize_t std_vscanf(t_fileops_handle handle, const char * restrict format, va_list ap) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    return vfscanf(f, format, ap);
+}
+static ssize_t std_printf(t_fileops_handle handle, const char * restrict format, ...) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    va_list ap;
+    int result;
+
+    va_start(ap, format);
+    result = vfprintf(f, format, ap);
+    va_end(ap);
+
+    return result;
+}
+static ssize_t std_vprintf(t_fileops_handle handle, const char * restrict format, va_list ap) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    return vfprintf(f, format, ap);
+}
+static bool std_flush(t_fileops_handle handle) {
+    FILE *f = SYS_FROMHANDLE(handle);
+    return !fflush(f);
+}
+
+#define FILEOPS_STD_VALUES {std_open, std_close, std_stat, std_seek, std_read, std_write, std_scanf, std_vscanf, std_printf, std_vprintf}
+
+t_fileops sys_fileops_standard = FILEOPS_STD_VALUES;
+
+t_fileops sys_fileops = FILEOPS_STD_VALUES;
+
+#else
+
+t_fileops sys_fileops = FILEOPS_NULL_VALUES;
+
+#endif

--- a/src/s_fileops.c
+++ b/src/s_fileops.c
@@ -14,7 +14,7 @@ static bool null_stat(t_fileops_handle handle, t_fileops_stat *stat) {
     return false;
 }
 static int64_t null_seek(t_fileops_handle handle, int64_t offset, t_fileops_flags flags) {
-    return 0;
+    return -1;
 }
 static ssize_t null_read(t_fileops_handle handle, void *buf, size_t nbyte) {
     return 0;

--- a/src/s_fileops.h
+++ b/src/s_fileops.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/* Copyright (c) 2020 Andi McClure.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+
+typedef intptr_t t_fileops_handle;
+
+typedef enum {
+	FILEOPS_NONE = 0,
+	FILEOPS_READ = 1,
+	FILEOPS_WRITE = 2,
+	FILEOPS_CREAT = 4,
+	FILEOPS_TRUNC = 8,
+	FILEOPS_SEEK_SET = 0x10,
+	FILEOPS_SEEK_CUR = 0x20,
+	FILEOPS_SEEK_END = 0x40,
+} t_fileops_flags;
+
+typedef struct _fileops_stat {
+	bool isdir_known; // If false, isdir value is undefined
+	bool isdir;
+} t_fileops_stat;
+
+typedef struct _t_fileops /* All function pointers return true on success */
+{
+	bool (*open)(const char *path, t_fileops_flags flags, t_fileops_handle *handle);
+	bool (*close)(t_fileops_handle handle);
+	bool (*stat)(t_fileops_handle handle, t_fileops_stat *stat);
+	int64_t (*seek)(t_fileops_handle handle, int64_t offset, t_fileops_flags flags);
+	ssize_t (*read)(t_fileops_handle handle, void *buf, size_t nbyte);
+	ssize_t (*write)(t_fileops_handle handle, const void *buf, size_t nbyte);
+	ssize_t (*scanf)(t_fileops_handle handle, const char * restrict format, ...);
+	ssize_t (*vscanf)(t_fileops_handle handle, const char * restrict format, va_list ap);
+	ssize_t (*printf)(t_fileops_handle handle, const char * restrict format, ...);
+	ssize_t (*vprintf)(t_fileops_handle handle, const char * restrict format, va_list ap);
+	bool (*flush)(t_fileops_handle handle);
+} t_fileops;
+
+// Also search: fstat, sys_fopen
+
+extern t_fileops sys_fileops;

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -204,11 +204,11 @@ int sys_defaultfont;
 static void openit(const char *dirname, const char *filename)
 {
     char dirbuf[MAXPDSTRING], *nameptr;
-    int fd = open_via_path(dirname, filename, "", dirbuf, &nameptr,
-        MAXPDSTRING, 0);
-    if (fd >= 0)
+    t_fileops_handle fd;
+    if (open_via_path(dirname, filename, "", dirbuf, &nameptr,
+        &fd, MAXPDSTRING, 0))
     {
-        close (fd);
+        sys_fileops.close (fd);
         glob_evalfile(0, gensym(nameptr), gensym(dirbuf));
     }
     else

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -22,10 +22,10 @@ void namelist_free(t_namelist *listwas);
 const char *namelist_get(const t_namelist *namelist, int n);
 void sys_setextrapath(const char *p);
 extern int sys_usestdpath;
-int sys_open_absolute(const char *name, const char* ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin, int *fdp);
-int sys_trytoopenone(const char *dir, const char *name, const char* ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
+bool sys_open_absolute(const char *name, const char* ext,
+    char *dirresult, char **nameresult, unsigned int size, int bin, t_fileops_handle *fdp);
+bool sys_trytoopenone(const char *dir, const char *name, const char* ext,
+    char *dirresult, char **nameresult, t_fileops_handle *file, unsigned int size, int bin);
 t_symbol *sys_decodedialog(t_symbol *s);
 
 /* s_file.c */


### PR DESCRIPTION
This is a largeish feature patch. The basic idea is all OS/standard file operations (`open`, `fopen` etc) have been removed and replaced with calls to function pointers in a global structure named `sys_fileops`.

### Motivation

I am interested in embedding libpd into a video game. In video game world, it is common to use a "**virtual file system**". A popular example of a VFS is [physfs](https://icculus.org/physfs/). Physfs allows you to specify one or more assets sources such as a directory or a .zip file. Physfs then presents a fake filesystem constructed from your assets sources and exposes I/O functions for working with this fake filesystem. Reasons you might want to use a VFS library like Physfs include: Security (Physfs ensures your program doesn't read or write outside the assets directory even by accident); the convenience of storing your assets in a .zip file or appending them to your exe; the possibility of combining several assets folders into one (I've used this before to implement mod support); Android friendliness (APK files are .zip files— I see there is an Android build of libpd, but I'm confused how exactly it loads files since your Android assets are going to be in the APK, not at a file path); and support for exotic game systems that might not have any filesystem at all.

The game I personally want to embed libpd in targets Android, and uses a [small VFS library](lovr.org) which is modeled on physfs. Unless I somehow teach libpd to talk to our VFS library I won't be able to use puredata, because pdlib normally loads everything by path and the .pd files and sound assets I want to load are embedded in the Android APK.

I had a conversation on the [mailing list](https://lists.puredata.info/pipermail/pd-dev/2020-05/022388.html) about this, I was given some hints as to how to load a .pd file without touching the filesystem, but they involved calling undocumented garray functions that I don't think are currently directly exposed in the libpd interface. Dan Wilcox suggested that if I had a proposed API or PR for VFS support I should try this github.

### API

This patch does not implement a Virtual File System. Instead, it creates a set of simple wrappers that allow you to "bring your own VFS", and which default to using the normal filesystem.

The patch consists of a new `s_fileops.c` and `s_fileops.h`. s_fileops.h defines these types:

* `t_fileops`: This is a structure containing a series of function pointers named `open`, `close`, `stat`, `seek`, `read`, `write`, `scanf`, `vscanf`, `printf`, `vprintf`. The interfaces for these functions mirror `open`, `close`, `stat`, `lseek`, `read`, `write`, `fscanf`, `vfscanf`, `fprintf` and `vfprintf` respectively. These turned out to be the functions you need to offer to support all code currently in libpd.

    s_fileops.c comes with two filled-out `t_fileops` structures, `sys_fileops_standard`, in which every function wraps the `FILE *` functions from the C standard library (`fopen`, etc)  and `sys_fileops_null`, where every function immediately fails.

    There is a global extern `t_fileops` named `sys_fileops`. By default (unless you compile with `_PD_FILEOPS_NO_DEFAULT`), it is set to the contents of `sys_fileops_standard`.
* `t_fileops_handle`: This is an opaque handle which is passed into the `t_fileops` functions in lieu of a file descriptor. Its meaning is defined by a particular t_fileops struct. It is an `intptr_t` because the intent is it should be possible for it to be any of a pointer, a filehandle, or an index of some kind.
* `t_fileops_flags`, a bitmask enum that incorporates both the flags passed to `open` and the "whence" value passed to `seek`.
* `t_fileops_stat`, a structure that `stat` writes its values into (currently the only members are two bools, `isdir` and `isdir_known`; puredata doesn't use `stat` for anything except making sure it isn't accidentally opening a directory as a file).

I have converted all file operations in pure-data to use the `sys_fileops` functions instead of whatever they were doing before (for example, calls to `fopen` have been replaced with calls to `sys_fileops.open`). The idea is that when running the pure-data application, `sys_fileops` will remain set to its default values (call the stdlib) and users will not experience anything different; but when using pdlib, you have the option of calling `void sys_fileops_set(t_fileops *fileops);` at startup, and this will overwrite `sys_fileops` with your own custom filesystem implementation.

One note on API consequences: the t_fileops `open` does not return a `t_fileops_handle`; instead, it returns a bool (true for success, false for failure) and the `t_fileops_handle` value is a pointer out argument. This is because there's no universal "invalid" value for `t_fileops_handle` (if a `t_fileops` defines its handles as pointers the "invalid" pointer would be NULL; if it implements them as filehandles, an invalid value might be -1) so it has to return the handle and success/failure separately. This had repercussions throughout pure-data/libpd because there are many functions in pure-data, such as `canvas_open`, which return a filehandle or a `FILE *` and expect the caller to detect failure from an invalid value.

### TODO

This patch "works" in that I can build `samples/c/pdtest` in the libpd repo against patched pure-data and the sample works as expected. However there are a few things that need to be done before this patch can be accepted. (I wanted to get this proof-of-concept posted here and get feedback on the API before moving on these final items.)

* I haven't implemented `sys_fileops_set` yet. I want this function to be kind of "smart" in that if a function isn't included it should fill it in with functions from `sys_fileops_null`, if `read` and `write` are provided but `printf`/`scanf` aren't it would be really cool if it could provide a printf/scanf based on the given `read` and `write` (you might be able to do this with `funopen`? though I'm not sure you can get funopen on Windows…).

* **I have not added `s_fileops.c` to the build system yet.** Instead it says `#include "s_fileops.c"` at the end of s_path.c. This is awful, but I'm not sure I understand the build system(s) here well enough to fix it myself. Is there a list of every file you need to add a new .c file to to get the various pure-data and libpd build scripts to recognize it?

* If this patch is accepted, I would like to also submit sample code to the `libpd` repo containing a `t_fileops` implementation for Physfs (the VFS library people are most likely to use).

* I broke _LARGEFILE64_SOURCE but haven't fixed it.

* I haven't tested on Windows.

### …Questions?

This turned out to be a pretty big patch. I tried to make the API as simple (and therefore hopefully uncontroversial) as possible, and to my eye the patch actually simplifies the libpd code (before, libpd was actually using a mishmash of `open` and `fopen` in different places, occasionally awkwardly switching from one to the other with `fdopen`). However, there are some places I am not quite sure I did the right thing.

Feedback invited on:

* My emulation of the `open` flags using `fopen` turned out to be pretty… awkward. `fopen` with "w" behaves as if O_CREAT is always true, and emulating O_CREAT false on "w" is pretty convoluted. (One option would be to *always* open with `open` and then `fdopen`, as the old code did in some places, but it seems **nice** to be using the C stdlib exclusively here.)

* I think the O_TRUNC behavior is totally wrong. I think the current code in this patch **always** truncates files when writing them. I have not reviewed the uses of `open` in the existing code to see if this breaks anything anywhere.

* I'm not sure my decision to use `true` for success and `false` for failure was a good one. It required introducing `bool` to the `_MSC_VER` block in `m_pd.h` defining all the C99 types MSVC doesn't support, and a weird `tobool` function (because without C99 a simple cast to bool won't coerce to true/false). Some other options here would have been:

    * A number of file operations in the codebase follow the convention of 0 for success and -1 for failure. Using 0 and -1 would make the newly introduced fileops functions more consistent with the existing file functions (as well as `t_fileops::seek`, which uses -1 for failure because its interface is lseek's), and would mean we don't have to introduce `bool` to puredata.

    * Instead of `intptr_t`, `t_fileops_handle` could be `void *` and we could simply define that NULL always means an invalid fileops_handle. This would mean I could back out the signature changes to functions like `canvas_open` (although we'd still be returning a different value, and we'd still have to replace n<0 filehandle checks with !n pointer checks). If someone defining a `t_fileops` wants to use a file descriptor they can malloc the space for one and return that.

* This patch simplifies the Windows compatibility significantly (because we're no longer working with filehandles), which is great, but because I don't completely understand the existing Windows compatibility I'm worried I broke something. In particular, instead of simply calling `fopen`, on `_WIN32` you translate the path to a `wchar_t` and call `_wfopen`. Why?

* There is a directory named `extras/pd~`. The source in this directory calls `open` and other file operations independently. It would be slightly hard to convert this to `t_fileops` because in one place it makes explicit use of the fact stdin is a filehandle. I don't know what this code is or whether it's a problem it isn't using fileops. What is it?

* I implemented this patch against the git revision in the most recent version of `libpd`. I think this corresponds to the `libpd` branch. Github says the patch does not cleanly apply against `master` or `develop`. I don't know what your branching strategy is so I don't know what you need from me here.

* I am not totally sure how to give this a full test. As mentioned I tested with `samples/c/pdtest` in libpd but this doesn't test, for example, loading sound files.

* Because this patch simplified the Windows compatibility and removed some functions, a comment that legitimately appears to date from the 90s saying `/* Bill Gates is a big fat hen */` was removed. This felt like demolishing a historic preservation site

### PS

By the way, after writing `s_fileops.c` and `s_fileops.h` I realized that the API I'd designed for this patch was not puredata specific. At some point I will probably extract the contents of those two files, remove the puredata derived code (currently, `std_open` only) and post a version as a CC0 (ie, not encumbered by the puredata license) standalone library on my own github.