### PR TITLE
make menu-fontsize persistent

### DIFF
--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -31,10 +31,16 @@ proc ::dialog_font::apply {mytoplevel myfontsize} {
         if {[lsearch [font names] TkMenuFont] >= 0} {
             font configure TkMenuFont -size -$myfontsize
         }
-        .pdwindow.text.internal configure -font "-size -$myfontsize"
+        if {[winfo exists ${mytoplevel}.text]} {
+            ${mytoplevel}.text.internal configure -font "-size -$myfontsize"
+        }
 
-# repeat a "pack" command so the font dialog can resize itself
-        pack .font.buttonframe -side bottom -fill x -pady 2m
+        # repeat a "pack" command so the font dialog can resize itself
+        if {[winfo exists .font]} {
+            pack .font.buttonframe -side bottom -fill x -pady 2m
+        }
+
+        ::pd_guiprefs::write menu-fontsize "$myfontsize"
 
     } else {
         variable stretchval
@@ -81,6 +87,7 @@ proc ::dialog_font::pdtk_canvas_dofont {gfxstub initsize} {
     variable fontsize $initsize
     variable whichstretch 1
     variable stretchval 100
+    if {$fontsize < 0} {set fontsize [expr -$fontsize]}
     if {$fontsize < 8} {set fontsize 12}
     if {[winfo exists .font]} {
         wm deiconify .font

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -439,6 +439,10 @@ proc ::pdwindow::create_window_finalize {} {
     # this ought to be called after all elements of the window (including the
     # menubar!) have been created!
     if {![winfo viewable .pdwindow.text]} { tkwait visibility .pdwindow.text }
+    set fontsize [::pd_guiprefs::read menu-fontsize]
+    if {$fontsize != ""} {
+        ::dialog_font::apply .pdwindow $fontsize
+    }
 }
 
 proc ::pdwindow::configure_window_offset {{winid .pdwindow}} {


### PR DESCRIPTION
when changing the `Font` via the menu of a canvas, the font-size is stored within the patch. whenever the patch is re-opened, the selected font-size is used.

however, when changing the `Font` for the main Pd-window (which will in fact change the font-size for all the menus, and for the Pd-console), there's no way to make this change persistent: next time you start Pd, the original font-size is used for the menus.

this is esp. annoying for HDPI displays, where the default font is often illegible.


this PR stores the font-size for the menus in the GUI-preferences, and restores the selected font-size when starting Pd.



Closes: https://github.com/pure-data/pure-data/issues/572, https://github.com/pure-data/pure-data/issues/1084