### PR TITLE
bugfix: forget preferences

### DIFF
--- a/src/s_file.c
+++ b/src/s_file.c
@@ -841,11 +841,19 @@ void glob_savepreferences(t_pd *dummy, t_symbol *filesym)
 void glob_forgetpreferences(t_pd *dummy)
 {
 #if !defined(_WIN32) && !defined(__APPLE__)
-    if (system("cat ~/.pdsettings >& /dev/null\n"))
+    char user_prefs_file[MAXPDSTRING]; /* user prefs file */
+    const char *homedir = getenv("HOME");
+    struct stat statbuf;
+    snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
+        (homedir ? homedir : "."));
+    user_prefs_file[MAXPDSTRING-1] = 0;
+    if (stat(user_prefs_file, &statbuf) != 0) {
         post("no Pd settings to clear");
-    else if (!system("rm ~/.pdsettings\n"))
-        post("removed .pdsettings file");
-    else post("couldn't delete .pdsettings file");
+    } else if (!unlink(user_prefs_file)) {
+        post("removed %s file", user_prefs_file);
+    } else {
+        post("couldn't delete %s file: %s", user_prefs_file, strerror(errno));
+    }
 #endif  /* !defined(_WIN32) && !defined(__APPLE__) */
 #ifdef __APPLE__
     char cmdbuf[MAXPDSTRING];

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -579,18 +579,28 @@ proc pdtk_pd_startup {major minor bugfix test
     set ::done_init 1
 }
 
-##### routine to ask user if OK and, if so, send a message on to Pd ######
-proc pdtk_check {mytoplevel message reply_to_pd default} {
+##### routine to ask user if OK and, if so return '1' (or else '0')
+# (this really should be in some other file)
+proc pdtk_yesnodialog {mytoplevel message default} {
     wm deiconify $mytoplevel
     raise $mytoplevel
     if {$::windowingsystem eq "win32"} {
-        set answer [tk_messageBox -message [_ $message] -type yesno -default $default \
-                        -icon question -title [wm title $mytoplevel]]
-    } else {
-        set answer [tk_messageBox -message [_ $message] -type yesno \
-                        -default $default -parent $mytoplevel -icon question]
-    }
+           set answer [tk_messageBox -message [_ $message] -type yesno \
+                                     -default $default -icon question \
+                                     -title [wm title $mytoplevel]]
+       } {
+           set answer [tk_messageBox -message [_ $message] -type yesno \
+                                     -default $default -icon question \
+                                     -parent $mytoplevel]
+       }
     if {$answer eq "yes"} {
+           return 1
+    }
+    return 0
+}
+##### routine to ask user if OK and, if so, send a message on to Pd ######
+proc pdtk_check {mytoplevel message reply_to_pd default} {
+    if {[ pdtk_yesnodialog $mytoplevel $message $default ]} {
         pdsend $reply_to_pd
     }
 }

--- a/tcl/pd_docsdir.tcl
+++ b/tcl/pd_docsdir.tcl
@@ -67,7 +67,11 @@ proc ::pd_docsdir::init {{reset false}} {
         }
         set docspath_default [file join $docspath_default "Pd"]
         # prompt
-        set msg [_ "Do you want Pd to create a documents directory for patches and external libraries?\n\nLocation: %s\n\nYou can change or disable this later in the Path preferences." ]
+        if {[file isdir ${docspath_default}]} {
+            set msg [_ "Do you want Pd to use the existing documents directory for patches and external libraries?\n\nLocation: %s\n\nYou can change or disable this later in the Path preferences." ]
+        } {
+            set msg [_ "Do you want Pd to create a documents directory for patches and external libraries?\n\nLocation: %s\n\nYou can change or disable this later in the Path preferences." ]
+        }
         set _args "-message \"[format $msg $docspath_default]\" -type yesnocancel -default yes -icon question -parent .pdwindow"
         switch -- [eval tk_messageBox ${_args}] {
             yes {

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -94,8 +94,8 @@ proc ::pd_guiprefs::init {} {
             # ------------------------------------------------------------------------------
             # macOS: read a plist file using the 'defaults' command
             #
-            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
-                if {![catch {exec defaults read $adomain $akey} conf]} {
+            proc ::pd_guiprefs::get_config {domain key {arr false}} {
+                if {![catch {exec defaults read $domain $key} conf]} {
                     if {$arr} {
                         set conf [plist_array_to_tcl_list $conf]
                     }
@@ -103,11 +103,11 @@ proc ::pd_guiprefs::init {} {
                     # value not found, so set empty value
                     if {$arr} {
                         # initialize w/ empty array for NSRecentDocuments, etc
-                        exec defaults write $adomain $akey -array
+                        exec defaults write $domain $key -array
                         set conf {}
                     } else {
                         # not an array
-                        exec defaults write $adomain $akey ""
+                        exec defaults write $domain $key ""
                         set conf ""
                     }
                 }
@@ -117,22 +117,22 @@ proc ::pd_guiprefs::init {} {
             # macOS: write configs to plist file using the 'defaults' command
             # if $arr is true, we write an array
             #
-            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+            proc ::pd_guiprefs::write_config {data domain key {arr false}} {
                 if {$arr} {
                     # FIXME empty and write again so we don't lose the order
-                    if {[catch {exec defaults write $adomain $akey -array} errorMsg]} {
-                        puts "write_config $akey: $errorMsg\n"
+                    if {[catch {exec defaults write $domain $key -array} errorMsg]} {
+                        puts "write_config $key: $errorMsg\n"
                     }
                     foreach item $data {
                         set escaped [escape_for_plist $item]
-                        if {[catch {eval exec defaults write $adomain $akey -array-add $escaped} errorMsg]} {
-                            puts "write_config $akey: $errorMsg\n"
+                        if {[catch {eval exec defaults write $domain $key -array-add $escaped} errorMsg]} {
+                            puts "write_config $key: $errorMsg\n"
                         }
                     }
                 } else {
                     set escaped [escape_for_plist $data]
-                    if {[catch {exec defaults write $adomain $akey $escaped} errorMsg]} {
-                        puts "write_config $akey: $errorMsg\n"
+                    if {[catch {exec defaults write $domain $key $escaped} errorMsg]} {
+                        puts "write_config $key: $errorMsg\n"
                     }
                 }
                 return
@@ -156,10 +156,10 @@ proc ::pd_guiprefs::init {} {
             # ------------------------------------------------------------------------------
             # w32: read in the registry
             #
-            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+            proc ::pd_guiprefs::get_config {domain key {arr false}} {
                 package require registry
-                set adomain [join [list ${::pd_guiprefs::registrypath} ${adomain}] \\]
-                if {![catch {registry get ${adomain} $akey} conf]} {
+                set domain [join [list ${::pd_guiprefs::registrypath} ${domain}] \\]
+                if {![catch {registry get ${domain} $key} conf]} {
                     return [expr {$conf}]
                 }
                 return {}
@@ -168,17 +168,17 @@ proc ::pd_guiprefs::init {} {
             # w32: write configs to registry
             # if $arr is true, we write an array
             #
-            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+            proc ::pd_guiprefs::write_config {data domain key {arr false}} {
                 package require registry
                 # FIXME: ugly
-                set adomain [join [list ${::pd_guiprefs::registrypath} ${adomain}] \\]
+                set domain [join [list ${::pd_guiprefs::registrypath} ${domain}] \\]
                 if {$arr} {
-                    if {[catch {registry set ${adomain} $akey $data multi_sz} errorMsg]} {
-                        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
+                    if {[catch {registry set ${domain} $key $data multi_sz} errorMsg]} {
+                        ::pdwindow::error "write_config $data $key: $errorMsg\n"
                     }
                 } else {
-                    if {[catch {registry set ${adomain} $akey $data sz} errorMsg]} {
-                        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
+                    if {[catch {registry set ${domain} $key $data sz} errorMsg]} {
+                        ::pdwindow::error "write_config $data $key: $errorMsg\n"
                     }
                 }
                 return
@@ -191,15 +191,15 @@ proc ::pd_guiprefs::init {} {
             # ------------------------------------------------------------------------------
             # linux: read a config file and return its lines splitted.
             #
-            proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
-                return [::pd_guiprefs::get_config_file $adomain $akey $arr]
+            proc ::pd_guiprefs::get_config {domain key {arr false}} {
+                return [::pd_guiprefs::get_config_file $domain $key $arr]
             }
             # ------------------------------------------------------------------------------
             # linux: write configs to USER_APP_CONFIG_DIR
             # $arr is true if the data needs to be written in an array
             #
-            proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
-                return [::pd_guiprefs::write_config_file $data $adomain $akey $arr]
+            proc ::pd_guiprefs::write_config {data domain key {arr false}} {
+                return [::pd_guiprefs::write_config_file $data $domain $key $arr]
             }
         }
         default {
@@ -220,8 +220,8 @@ proc ::pd_guiprefs::init {} {
 # ------------------------------------------------------------------------------
 # read a config file and return its lines splitted.
 #
-proc ::pd_guiprefs::get_config_file {adomain {akey} {arr false}} {
-    set filename [file join ${::pd_guiprefs::configdir} ${adomain} ${akey}.conf]
+proc ::pd_guiprefs::get_config_file {domain key {arr false}} {
+    set filename [file join ${::pd_guiprefs::configdir} ${domain} ${key}.conf]
     set conf {}
     if {
         [file exists $filename] == 1
@@ -239,13 +239,13 @@ proc ::pd_guiprefs::get_config_file {adomain {akey} {arr false}} {
 # write configs to USER_APP_CONFIG_DIR
 # $arr is true if the data needs to be written in an array
 #
-proc ::pd_guiprefs::write_config_file {data {adomain} {akey} {arr false}} {
-    ::pd_guiprefs::prepare_domain ${adomain}
+proc ::pd_guiprefs::write_config_file {data domain key {arr false}} {
+    ::pd_guiprefs::prepare_domain ${domain}
     # right now I (yvan) assume that data are just \n separated, i.e. no keys
     set data [join $data "\n"]
-    set filename [file join ${::pd_guiprefs::configdir} ${adomain} ${akey}.conf]
+    set filename [file join ${::pd_guiprefs::configdir} ${domain} ${key}.conf]
     if {[catch {set fl [open $filename w]} errorMsg]} {
-        ::pdwindow::error "write_config $data $akey: $errorMsg\n"
+        ::pdwindow::error "write_config $data $key: $errorMsg\n"
     } else {
         puts -nonewline $fl $data
         close $fl
@@ -257,10 +257,10 @@ proc ::pd_guiprefs::write_config_file {data {adomain} {akey} {arr false}} {
 #################################################################
 
 ## these are stubs that will be overwritten in ::pd_guiprefs::init()
-proc ::pd_guiprefs::write_config {data {adomain} {akey} {arr false}} {
+proc ::pd_guiprefs::write_config {data domain key {arr false}} {
     ::pdwindow::error "::pd_guiprefs::write_config not implemented for $::platform\n"
 }
-proc ::pd_guiprefs::get_config {adomain {akey} {arr false}} {
+proc ::pd_guiprefs::get_config {domain key {arr false}} {
     ::pdwindow::error "::pd_guiprefs::get_config not implemented for $::platform\n"
 }
 
@@ -336,9 +336,9 @@ proc ::pd_guiprefs::prepare_domain {{domain {}}} {
 # ------------------------------------------------------------------------------
 # convenience proc to init prefs value, returns default if not found
 #
-proc ::pd_guiprefs::init_config {adomain akey {default ""} {arr false}} {
+proc ::pd_guiprefs::init_config {domain key {default ""} {arr false}} {
     set conf ""
-    catch {set conf [::pd_guiprefs::get_config $adomain $akey $arr]}
+    catch {set conf [::pd_guiprefs::get_config $domain $key $arr]}
     if {$conf eq ""} {set conf $default}
     return $conf
 }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -151,7 +151,7 @@ proc ::pd_guiprefs::init {} {
                     } {
                         exec defaults delete ${domain} ${key}
                     }
-                }] errorMsg} {
+                } errorMsg] } {
                     ::pdwindow::error "delete_config ${domain}::${key}: $errorMsg\n"
                     return 0
                 }
@@ -219,7 +219,7 @@ proc ::pd_guiprefs::init {} {
                     } {
                         registry delete ${domain} ${key}
                     }
-                }] errorMsg} {
+                } errorMsg] } {
                     ::pdwindow::error "delete_config ${domain}::${key}: $errorMsg\n"
                     return 0
                 }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -548,9 +548,18 @@ proc ::pd_menus::loadpreferences {} {
 }
 
 proc ::pd_menus::forgetpreferences {} {
-    pdtk_check .pdwindow \
-        [_ "Delete all preferences?\n(takes effect when Pd is restarted)"] \
-        {pd forget-preferences} yes
+    if {[pdtk_yesnodialog .pdwindow \
+             [_ "Delete all preferences?\n(takes effect when Pd is restarted)"] \
+             yes]} {
+        pdsend "pd forget-preferences"
+        if {[::pd_guiprefs::delete_config]} {
+            ::pdwindow::post [_ "removed GUI settings" ]
+        } {
+            ::pdwindow::post [_ "no Pd-GUI settings to clear" ]
+        }
+        ::pdwindow::post "\n"
+
+    }
 }
 
 proc ::pd_menus::create_preferences_menu {mymenu} {


### PR DESCRIPTION
in the <kbd>File</kbd>-><kbd>Preferences</kbd> menu, there's an item that says `Forget All...` and which is supposed to reset-all preferences.

Only, it doesn't.

- GUI preferences are completely left alone
- on linux, i get an error on the Pd-console
  > "no Pd settings to clear"

  and an error in the terminal
  > "sh: 2: Syntax error: Bad fd number"

  and the `~/.pdsettings` file is left as is (#552)

- on Windows there might be a similar problem (as indicated in #552), though i have't confirmed so far.

this PR fixes at least the GUI-side and the linux side.

- GUI: implement a `::pd_guiprefs::delete_config` proc and uses it when the user requests to "Forget All...[preferences]".
- core/linux: replace the `system()` calls by proper `stat()` and `unlink()` calls.

the deleting of GUI-preferences has only been tested on Linux, but it is implemented for macOS and Windows.
given that a small typo might delete the entire registry, i would highly appreciate if one of the Windows-folks (@Spacechild1 , @Lucarda ) could review and test.