### PR TITLE
fix MSVC compilation

### DIFF
--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -12,6 +12,7 @@ learning XCode.  */
 #define MSP
 #endif
 
+#include <stdio.h>
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
@@ -19,7 +20,6 @@ learning XCode.  */
 #include <windows.h>
 typedef int socklen_t;
 #else
-#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -75,11 +75,6 @@
 #define isdigit(x)      (x >= '0' && x <= '9')
 #endif
 
-#ifdef _MSC_VER
-#define strtof(a, b) _atoldbl(a, *b)
-#endif
-
-
 char *atoif(char *s, long int *value, long int *type);
 
 static struct ex_ex *ex_lex(struct expr *expr, long int *n);


### PR DESCRIPTION
1st commit - x_vexp: remove use of _atoldbl instead of strtof for msvc
The expr objects are not working properly when compiling libpd on Windows with MSVC (I didn't try with Pd directly because I never managed to compile it with MSVC but I guess there is the same problem). The object doesn't manage to parse the ascii to float or integer because `atoif()` ([x_vexp.c#L1979](https://github.com/pure-data/pure-data/blob/master/src/x_vexp.c#L1979)) uses `strtof()` that on Windows with MSVC is defined by `#define strtof(a, b) _atoldbl(a, *b)` ([x_vexp.c#L78](https://github.com/pure-data/pure-data/blob/master/src/x_vexp.c#L78)). So it generates an error: `expr: syntax error:...`. I don't know why this method is overwritten for MSVC but using the default system implementation fixes the problem. 
2nd commit - pd~: use #include <stdio.h>
This can be included directly for all OS and compilation system