### PR TITLE
disable dark mode for GUI on macOS 10.14+

### DIFF
--- a/mac/README.txt
+++ b/mac/README.txt
@@ -176,6 +176,7 @@ Some important per-application settings required by the GUI include:
 * NSQuitAlwaysKeepsWindows: false, disables default 10.7+ window state saving
 * ApplePressAndHoldEnabled: false, disables character compose popup,
                                    enables key repeat for all keys
+* NSRequiresAquaSystemAppearance: true, disables dark mode for Pd GUI on 10.14+
 
 These are set in `tcl/pd_guiprefs.tcl`.
 

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -167,6 +167,9 @@ proc ::pd_guiprefs::init {} {
 
             # Disable Character Accent Selector popup so key repeat works for all keys.
             exec defaults write $::pd_guiprefs::domain ApplePressAndHoldEnabled -bool false
+
+            # Disable Dark Mode for 10.14+
+            exec defaults write $::pd_guiprefs::domain NSRequiresAquaSystemAppearance -bool true
         }
         "registry" {
             # windows uses registry


### PR DESCRIPTION
This is a quick PR which disables "dark mode" for the Pd GUI on macOS 10.14+.

Setting the NSRequiresAquaSystemAppearance default to true instructs the system to use the default "light mode" when opening the Pd GUI. This was not a problem with earlier versions of Pd using TK 8.5, but the newer Tk 8.6 is dark mode aware and result in a mismatch of light text on light backgrounds etc as the GUI is using a light-oriented color scheme.

Until we get around to full supporting dark mode, this triage fix will keep Pd legible for now.