### PR TITLE
set canvas background color for macOS and newer Tk versions

### DIFF
--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -117,7 +117,8 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable} {
     canvas $tkcanvas -width $width -height $height \
         -highlightthickness 0 -scrollregion [list 0 0 $width $height] \
         -xscrollcommand "$mytoplevel.xscroll set" \
-        -yscrollcommand "$mytoplevel.yscroll set"
+        -yscrollcommand "$mytoplevel.yscroll set" \
+        -background white
     scrollbar $mytoplevel.xscroll -orient horizontal -command "$tkcanvas xview"
     scrollbar $mytoplevel.yscroll -orient vertical -command "$tkcanvas yview"
     pack $tkcanvas -side left -expand 1 -fill both


### PR DESCRIPTION
This small PR sets the canvas background color too white. On most systems, this is automatically white anyway, but newer versions of macOS using Tk 8.6 will use the system default gray.

*Original idea from @umlaeute on the pd-list*