### PR TITLE
Augment _MSC_VER check on stdint include to check _MSC_VER number

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -61,8 +61,10 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 #include <stddef.h>     /* just for size_t -- how lame! */
 #endif
 
-/* Microsoft Visual Studio is not C99, it does not provide stdint.h */
-#ifdef _MSC_VER
+/* Microsoft Visual Studio is not C99, but since VS2015 has included most C99 headers:
+   https://docs.microsoft.com/en-us/previous-versions/hh409293(v=vs.140)#c-runtime-library
+   These definitions recreate stdint.h types, but only in pre-2015 Visual Studio: */
+#if defined(_MSC_VER) && _MSC_VER < 1900
 typedef signed __int8     int8_t;
 typedef signed __int16    int16_t;
 typedef signed __int32    int32_t;


### PR DESCRIPTION
In m_pd.h it checks for `_MSC_VER`, and if defined it inlines a tiny fake stdint.h instead of including stdint.h, noting "Visual Studio is not C99".
However, [since VS2015](https://docs.microsoft.com/en-us/previous-versions/hh409293(v=vs.140)#c-runtime-library) many C99 headers including stdint.h have shipped with MSVC.
So for `_MSC_VER` greater than or equal to 1900 ([Visual Studio 2015 / Visual Studio 14.0](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019)) it is safe to simply include stdint.

This would be a good change because it prevents conflicts when you include both m_pd and stdint.h in a file compiled with modern MSVC, which is something I experienced using libpd while testing #1096.

I have not exhaustively tested this patch with different versions of Visual Studio or anything.