### PR TITLE
stable development branch

### DIFF
--- a/msw/build-wxp-32.sh
+++ b/msw/build-wxp-32.sh
@@ -44,3 +44,5 @@ zip -r /tmp/pd-$pdversion.msw.zip  pd-$pdversion
 
 echo /tmp/pd-$pdversion.msw.zip
 echo /tmp/pd-$pdversion.windows-installer.exe
+
+echo wine `pwd`/pd-$pdversion/bin/wish85.exe `pwd`/pd-$pdversion/tcl/pd-gui.tcl

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -305,7 +305,10 @@ static int iemgui_getcolorarg(int index, int argc, t_atom*argv)
     {
         t_symbol*s=atom_getsymbolarg(index, argc, argv);
         if ('#' == s->s_name[0])
-            return (int)strtol(s->s_name+1, 0, 16);
+        {
+            int col = (int)strtol(s->s_name+1, 0, 16);
+            return col & 0xFFFFFF;
+        }
     }
     return 0;
 }

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -61,8 +61,10 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 #include <stddef.h>     /* just for size_t -- how lame! */
 #endif
 
-/* Microsoft Visual Studio is not C99, it does not provide stdint.h */
-#ifdef _MSC_VER
+/* Microsoft Visual Studio is not C99, but since VS2015 has included most C99 headers:
+   https://docs.microsoft.com/en-us/previous-versions/hh409293(v=vs.140)#c-runtime-library
+   These definitions recreate stdint.h types, but only in pre-2015 Visual Studio: */
+#if defined(_MSC_VER) && _MSC_VER < 1900
 typedef signed __int8     int8_t;
 typedef signed __int16    int16_t;
 typedef signed __int32    int32_t;

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -11,7 +11,7 @@ extern "C" {
 #define PD_MAJOR_VERSION 0
 #define PD_MINOR_VERSION 51
 #define PD_BUGFIX_VERSION 1
-#define PD_TEST_VERSION "test1"
+#define PD_TEST_VERSION ""
 extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 
 /* old name for "MSW" flag -- we have to take it for the sake of many old

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -68,7 +68,7 @@ SYSSRC += s_midi_pm.c s_audio_pa.c s_audio_paring.c    \
     $(PADIR)/src/common/pa_debugprint.c  \
     $(PADIR)/src/common/pa_ringbuffer.c  \
     $(PADIR)/src/os/unix/pa_unix_util.c  \
-    $(PADIR)/src/os/mac_osx/pa_mac_hostapis.c              \
+    $(PADIR)/src/os/unix/pa_unix_hostapis.c                \
     $(PADIR)/src/hostapi/coreaudio/pa_mac_core.c           \
     $(PADIR)/src/hostapi/coreaudio/pa_mac_core_blocking.c  \
     $(PADIR)/src/hostapi/coreaudio/pa_mac_core_utilities.c \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -12,6 +12,8 @@ GUINAME= libPdTcl.dylib
 ARCH= -arch i386 -arch ppc
 EXTRAARCH= -arch i386 -arch x86_64 -arch ppc
 
+MKDIR_P = mkdir -p
+
 prefix = /usr/local
 exec_prefix = ${prefix}
 bindir = ${exec_prefix}/bin
@@ -128,6 +130,11 @@ bin: pd $(BIN_DIR)/pd-watchdog gui $(BIN_DIR)/pdsend \
 
 $(OBJ) : %.o : %.c
 	$(CC) $(CFLAGS) $(INCLUDE) -c -o $(OBJ_DIR)/$*.o $*.c 
+
+$(OBJ): $(OBJ_DIR)
+
+$(OBJ_DIR):
+	$(MKDIR_P) $@
 
 pd: $(PDEXEC)
 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -10,8 +10,7 @@ CC = gcc
 CXX = g++
 WINDRES = windres
 
-cvs_root_dir = ../..
-pd_src = $(cvs_root_dir)/pd
+pd_src = ..
 DLL_DIR = $(pd_src)/src
 
 BIN_DIR = ../bin

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -247,7 +247,7 @@ install:  all
 	install -p ../tcl/*.tcl $(DESTDIR)$(bindir)/
 	install -p $(PDEXEC) $(DESTDIR)$(bindir)/$(PDEXEC)
 	install -p $(PDCOM) $(DESTDIR)$(bindir)/$(PDCOM)
-	install -p pd.dll $(DESTDIR)$(bindir)/pd.dll
+	install -p $(PDDLL) $(DESTDIR)$(bindir)/pd.dll
 	install -p ../tcl/pd.ico $(DESTDIR)$(bindir)/pd.ico
 	install -p $(PDSEND) $(DESTDIR)$(bindir)/$(PDSEND)
 	install -p $(PDRECEIVE) $(DESTDIR)$(bindir)/$(PDRECEIVE)

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -9,6 +9,7 @@
 CC = gcc
 CXX = g++
 WINDRES = windres
+MKDIR_P = mkdir -p
 
 pd_src = ..
 DLL_DIR = $(pd_src)/src
@@ -186,23 +187,23 @@ $(PMOBJ) : %.o : %.c
 $(VOBJ) : %.o : %.c
 	$(CC) $(CFLAGS) $(GFLAGS) $(INCLUDE) -c -o $*.o $*.c 
 
-$(PDSEND): u_pdsend.o s_net.o
+$(PDSEND): $(EXECDIR) u_pdsend.o s_net.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(PDSEND) u_pdsend.o s_net.o $(LIBS)
 	$(STRIP) $(PDSEND)
 
-$(PDRECEIVE): u_pdreceive.o s_net.o
+$(PDRECEIVE): $(EXECDIR) u_pdreceive.o s_net.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(PDRECEIVE) u_pdreceive.o s_net.o $(LIBS)
 	$(STRIP) $(PDRECEIVE)
 
-$(PDEXEC): s_entry.o pd.res
+$(PDEXEC): $(EXECDIR) s_entry.o pd.res
 	$(CXX) $(LDFLAGS) -mwindows -o $(PDEXEC) s_entry.o pd.res $(LIBS) pd.a
 	$(STRIP) -s $(PDEXEC)
 
-$(PDCOM): s_entry.o
+$(PDCOM): $(EXECDIR) s_entry.o
 	$(CXX) $(LDFLAGS) -o $(PDCOM) s_entry.o $(LIBS) pd.a
 	$(STRIP) -s $(PDCOM)
 
-$(PDDLL): $(OBJC)
+$(PDDLL): $(EXECDIR) $(OBJC)
 	$(CXX) -shared $(LDFLAGS) -o $(PDDLL) $(OBJC) $(LIBS) \
 		-Wl,--export-all-symbols -Wl,--out-implib=pd.a; 
 	$(STRIP) $(PDDLL)
@@ -210,11 +211,14 @@ $(PDDLL): $(OBJC)
 pd.res: pd.rc
 	$(WINDRES) pd.rc -O coff -o pd.res
 
-../bin/pdstatic.exe: $(OBJC)
+$(EXECDIR)/pdstatic.exe: $(OBJC) $(EXECDIR)
 	$(CXX) -static \
-            $(LDFLAGS) -o ../bin/pdstatic.exe $(OBJC) \
+            $(LDFLAGS) -o $@ $(OBJC) \
             $(LIBS) -lole32 -static-libgcc -static-libstdc++
-	$(STRIP) -s ../bin/pdstatic.exe
+	$(STRIP) -s $@
+
+$(EXECDIR):
+	$(MKDIR_P) $@
 
 #vstschedlib.dll: $(VOBJ)
 #	$(DLLWRAP) --export-all-symbols --output-def vst.def \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -44,7 +44,9 @@ DLLWRAP= dllwrap
 MORECFLAGS = -O3 -funroll-loops -fomit-frame-pointer
 
 PADIR = $(pd_src)/portaudio/portaudio
-ASIODIR = $(pd_src)/lib/ASIOSDK
+
+asiodir := $(firstword $(wildcard $(pd_src)/lib/ASIOSDK $(pd_src)/asio/ASIOSDK))
+ASIODIR ?= $(asiodir)
 ASIOINC = -I$(ASIODIR)/common -I$(ASIODIR)/host -I$(ASIODIR)/host/pc
 INCPA = -I$(PADIR)/include -I$(PADIR)/src/common -I$(PADIR)/src/os/win \
       $(ASIOINC)

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -26,7 +26,7 @@ typedef long t_pa_sample;
 #define SYS_BYTESPERCHAN (DEFDACBLKSIZE * SYS_SAMPLEWIDTH)
 #define SYS_XFERSAMPS (SYS_DEFAULTCH*DEFDACBLKSIZE)
 #define SYS_XFERSIZE (SYS_SAMPLEWIDTH * SYS_XFERSAMPS)
-#define MAXNDEV 20
+#define MAXNDEV 128
 #define DEVDESCSIZE 1024
 
 static void audio_getdevs(char *indevlist, int *nindevs,

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -21,7 +21,6 @@
 #define MAX_CLIENTS 100
 #define MAX_JACK_PORTS 128  /* higher values seem to give bad xrun problems */
 #define BUF_JACK 4096
-#define JACK_OUT_MAX  64
 
 static jack_nframes_t jack_out_max;
 static jack_nframes_t jack_filled = 0;
@@ -46,8 +45,7 @@ static int pollprocess(jack_nframes_t nframes, void *arg)
     jack_default_audio_sample_t *out, *in;
 
     pthread_mutex_lock(&jack_mutex);
-    if (nframes > JACK_OUT_MAX) jack_out_max = nframes;
-    else jack_out_max = JACK_OUT_MAX;
+    jack_out_max = nframes;
     if (nframes >= DEFDACBLKSIZE && jack_filled >= nframes)
     {
         if (jack_filled != nframes)

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -48,7 +48,7 @@ static int pollprocess(jack_nframes_t nframes, void *arg)
     pthread_mutex_lock(&jack_mutex);
     if (nframes > JACK_OUT_MAX) jack_out_max = nframes;
     else jack_out_max = JACK_OUT_MAX;
-    if (jack_filled >= nframes)
+    if (nframes >= DEFDACBLKSIZE && jack_filled >= nframes)
     {
         if (jack_filled != nframes)
             fprintf(stderr,"Partial read\n");
@@ -96,6 +96,13 @@ static int pollprocess(jack_nframes_t nframes, void *arg)
     }
     else
     {           /* PD could not keep up ! */
+        if (nframes < DEFDACBLKSIZE)
+        {
+            static int firsttime = 1;
+            if(firsttime)
+                fprintf(stderr,"jack: nframes %d smaller than blocksize %d: NO SOUND!\n", nframes, DEFDACBLKSIZE);
+            firsttime = 0;
+        }
         if (jack_started) jack_dio_error = 1;
         for (j = 0; j < outport_count;  j++)
         {

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -567,8 +567,6 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
     }
 }
 
-void sys_exit(void);
-
 void socketreceiver_read(t_socketreceiver *x, int fd)
 {
     if (x->sr_udp)   /* UDP ("datagram") socket protocol */
@@ -1469,8 +1467,6 @@ void sys_setrealtime(const char *libdir)
 #endif /* __APPLE__ */
 }
 
-extern void sys_exit(void);
-
 /* This is called when something bad has happened, like a segfault.
 Call glob_quit() below to exit cleanly.
 LATER try to save dirty documents even in the bad case. */
@@ -1494,8 +1490,12 @@ void sys_bail(int n)
     else _exit(1);
 }
 
+extern void sys_exit(void);
+
 void glob_exit(void *dummy, t_float status)
 {
+        /* sys_exit() sets the sys_quit flag, so all loops end */
+    sys_exit();
     sys_close_audio();
     sys_close_midi();
     if (sys_havegui())

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -511,8 +511,8 @@ void sys_pollmidiqueue(void)
 
 /******************** dialog window and device listing ********************/
 
-#define MAXNDEV 20
-#define DEVDESCSIZE 80
+#define MAXNDEV 128
+#define DEVDESCSIZE 1024
 
 #define DEVONSET 1  /* To agree with command line flags, normally start at 1 */
 

--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -179,9 +179,11 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
     pack $mytoplevel.settings.bsc.bs_popup -side right
     pack $mytoplevel.settings.bsc.bs_label -side right -padx {0 10}
     if {$audio_callback >= 0} {
-        checkbutton $mytoplevel.settings.bsc.c_button -variable audio_callback \
-            -text [_ "Use callbacks"] -anchor w
-        pack $mytoplevel.settings.bsc.c_button -side right
+        frame $mytoplevel.settings.callback
+        pack $mytoplevel.settings.callback -side bottom -fill x
+        checkbutton $mytoplevel.settings.callback.c_button -variable audio_callback \
+            -text [_ "Use callbacks"]
+        pack $mytoplevel.settings.callback.c_button -side right
     }
 
     # input devices
@@ -354,11 +356,9 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
     button $mytoplevel.buttonframe.cancel -text [_ "Cancel"] \
         -command "::dialog_audio::cancel $mytoplevel"
     pack $mytoplevel.buttonframe.cancel -side left -expand 1 -fill x -padx 15 -ipadx 10
-    if {$::windowingsystem ne "aqua"} {
-        button $mytoplevel.buttonframe.apply -text [_ "Apply"] \
-            -command "::dialog_audio::apply $mytoplevel"
-        pack $mytoplevel.buttonframe.apply -side left -expand 1 -fill x -padx 15 -ipadx 10
-    }
+    button $mytoplevel.buttonframe.apply -text [_ "Apply"] \
+        -command "::dialog_audio::apply $mytoplevel"
+    pack $mytoplevel.buttonframe.apply -side left -expand 1 -fill x -padx 15 -ipadx 10
     button $mytoplevel.buttonframe.ok -text [_ "OK"] \
         -command "::dialog_audio::ok $mytoplevel" -default active
     pack $mytoplevel.buttonframe.ok -side left -expand 1 -fill x -padx 15 -ipadx 10

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -23,10 +23,10 @@ namespace eval ::dialog_font:: {
 proc ::dialog_font::apply {mytoplevel myfontsize} {
     if {$mytoplevel eq ".pdwindow"} {
         foreach font [font names] {
-            font configure $font -size -$myfontsize
+            font configure $font -size $myfontsize
         }
         if {[winfo exists ${mytoplevel}.text]} {
-            ${mytoplevel}.text.internal configure -font "-size -$myfontsize"
+            ${mytoplevel}.text.internal configure -font "-size $myfontsize"
         }
 
         # repeat a "pack" command so the font dialog can resize itself

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -22,14 +22,8 @@ namespace eval ::dialog_font:: {
 
 proc ::dialog_font::apply {mytoplevel myfontsize} {
     if {$mytoplevel eq ".pdwindow"} {
-        if {[lsearch [font names] TkTextFont] >= 0} {
-            font configure TkTextFont -size -$myfontsize
-        }
-        if {[lsearch [font names] TkDefaultFont] >= 0} {
-            font configure TkDefaultFont -size -$myfontsize
-        }
-        if {[lsearch [font names] TkMenuFont] >= 0} {
-            font configure TkMenuFont -size -$myfontsize
+        foreach font [font names] {
+            font configure $font -size -$myfontsize
         }
         if {[winfo exists ${mytoplevel}.text]} {
             ${mytoplevel}.text.internal configure -font "-size -$myfontsize"

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -11,6 +11,15 @@ namespace eval ::pd_bindings:: {
 }
 set ::pd_bindings::key2iso ""
 
+
+# wrapper around bind(3tk)to deal with CapsLock
+# the actual bind-sequence is is build as '<${seq_prefix}-${seq_nocase}',
+# with the $seq_nocase part bing bound both as upper-case and lower-case
+proc ::pd_bindings::bind_capslock {tag seq_prefix seq_nocase script} {
+    bind $tag <${seq_prefix}-[string tolower ${seq_nocase}]> $script
+    bind $tag <${seq_prefix}-[string toupper ${seq_nocase}]> $script
+}
+
 # TODO rename pd_bindings to window_bindings after merge is done
 
 # Some commands are bound using "" quotations so that the $mytoplevel is
@@ -40,31 +49,31 @@ proc ::pd_bindings::global_bindings {} {
     # we use 'bind all' everywhere to get as much of Tk's automatic binding
     # behaviors as possible, things like not sending an event for 'O' when
     # 'Control-O' is pressed
-    bind all <$::modifier-Key-a>      {menu_send %W selectall}
-    bind all <$::modifier-Key-b>      {menu_helpbrowser}
-    bind all <$::modifier-Key-c>      {menu_send %W copy}
-    bind all <$::modifier-Key-d>      {menu_send %W duplicate}
-    bind all <$::modifier-Key-e>      {menu_toggle_editmode}
-    bind all <$::modifier-Key-f>      {menu_find_dialog}
-    bind all <$::modifier-Key-g>      {menu_send %W findagain}
-    bind all <$::modifier-Key-k>      {menu_send %W connect_selection}
-    bind all <$::modifier-Key-n>      {menu_new}
-    bind all <$::modifier-Key-o>      {menu_open}
-    bind all <$::modifier-Key-p>      {menu_print $::focused_window}
-    bind all <$::modifier-Key-r>      {menu_raise_pdwindow}
-    bind all <$::modifier-Key-s>      {menu_send %W menusave}
-    bind all <$::modifier-Key-t>      {menu_send %W triggerize}
-    bind all <$::modifier-Key-v>      {menu_send %W paste}
-    bind all <$::modifier-Key-w>      {::pd_bindings::window_close %W}
-    bind all <$::modifier-Key-x>      {menu_send %W cut}
-    bind all <$::modifier-Key-z>      {menu_undo}
-    bind all <$::modifier-Key-1>      {menu_send_float %W obj 0}
-    bind all <$::modifier-Key-2>      {menu_send_float %W msg 0}
-    bind all <$::modifier-Key-3>      {menu_send_float %W floatatom 0}
-    bind all <$::modifier-Key-4>      {menu_send_float %W symbolatom 0}
-    bind all <$::modifier-Key-5>      {menu_send_float %W text 0}
-    bind all <$::modifier-Key-slash>  {pdsend "pd dsp 1"}
-    bind all <$::modifier-Key-period> {pdsend "pd dsp 0"}
+    bind_capslock all $::modifier-Key a {menu_send %W selectall}
+    bind_capslock all $::modifier-Key b {menu_helpbrowser}
+    bind_capslock all $::modifier-Key c {menu_send %W copy}
+    bind_capslock all $::modifier-Key d {menu_send %W duplicate}
+    bind_capslock all $::modifier-Key e {menu_toggle_editmode}
+    bind_capslock all $::modifier-Key f {menu_find_dialog}
+    bind_capslock all $::modifier-Key g {menu_send %W findagain}
+    bind_capslock all $::modifier-Key k {menu_send %W connect_selection}
+    bind_capslock all $::modifier-Key n {menu_new}
+    bind_capslock all $::modifier-Key o {menu_open}
+    bind_capslock all $::modifier-Key p {menu_print $::focused_window}
+    bind_capslock all $::modifier-Key r {menu_raise_pdwindow}
+    bind_capslock all $::modifier-Key s {menu_send %W menusave}
+    bind_capslock all $::modifier-Key t {menu_send %W triggerize}
+    bind_capslock all $::modifier-Key v {menu_send %W paste}
+    bind_capslock all $::modifier-Key w {::pd_bindings::window_close %W}
+    bind_capslock all $::modifier-Key x {menu_send %W cut}
+    bind_capslock all $::modifier-Key z {menu_undo}
+    bind all <$::modifier-Key-1>        {menu_send_float %W obj 0}
+    bind all <$::modifier-Key-2>        {menu_send_float %W msg 0}
+    bind all <$::modifier-Key-3>        {menu_send_float %W floatatom 0}
+    bind all <$::modifier-Key-4>        {menu_send_float %W symbolatom 0}
+    bind all <$::modifier-Key-5>        {menu_send_float %W text 0}
+    bind all <$::modifier-Key-slash>    {pdsend "pd dsp 1"}
+    bind all <$::modifier-Key-period>   {pdsend "pd dsp 0"}
 
     # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
     # "+" key... this only makes sense on US keyboards but some users
@@ -78,51 +87,32 @@ proc ::pd_bindings::global_bindings {} {
     # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
 
     # annoying, but Tk's bind needs uppercase letter to get the Shift
-    bind all <$::modifier-Shift-Key-A> {menu_send %W menuarray}
-    bind all <$::modifier-Shift-Key-B> {menu_send %W bng}
-    bind all <$::modifier-Shift-Key-C> {menu_send %W mycnv}
-    bind all <$::modifier-Shift-Key-D> {menu_send %W vradio}
-    bind all <$::modifier-Shift-Key-G> {menu_send %W graph}
-    bind all <$::modifier-Shift-Key-J> {menu_send %W hslider}
-    bind all <$::modifier-Shift-Key-I> {menu_send %W hradio}
-    bind all <$::modifier-Shift-Key-L> {menu_clear_console}
-    bind all <$::modifier-Shift-Key-M> {menu_message_dialog}
-    bind all <$::modifier-Shift-Key-N> {menu_send %W numbox}
-    bind all <$::modifier-Shift-Key-Q> {pdsend "pd quit"}
-    bind all <$::modifier-Shift-Key-R> {menu_send %W tidy}
-    bind all <$::modifier-Shift-Key-S> {menu_send %W menusaveas}
-    bind all <$::modifier-Shift-Key-T> {menu_send %W toggle}
-    bind all <$::modifier-Shift-Key-U> {menu_send %W vumeter}
-    bind all <$::modifier-Shift-Key-V> {menu_send %W vslider}
-    bind all <$::modifier-Shift-Key-W> {::pd_bindings::window_close %W 1}
-    bind all <$::modifier-Shift-Key-Z> {menu_redo}
-    # lowercase bindings, for the CapsLock case
-    bind all <$::modifier-Shift-Key-a> {menu_send %W menuarray}
-    bind all <$::modifier-Shift-Key-b> {menu_send %W bng}
-    bind all <$::modifier-Shift-Key-c> {menu_send %W mycnv}
-    bind all <$::modifier-Shift-Key-d> {menu_send %W vradio}
-    bind all <$::modifier-Shift-Key-g> {menu_send %W graph}
-    bind all <$::modifier-Shift-Key-j> {menu_send %W hslider}
-    bind all <$::modifier-Shift-Key-i> {menu_send %W hradio}
-    bind all <$::modifier-Shift-Key-l> {menu_clear_console}
-    bind all <$::modifier-Shift-Key-m> {menu_message_dialog}
-    bind all <$::modifier-Shift-Key-n> {menu_send %W numbox}
-    bind all <$::modifier-Shift-Key-q> {pdsend "pd quit"}
-    bind all <$::modifier-Shift-Key-r> {menu_send %W tidy}
-    bind all <$::modifier-Shift-Key-s> {menu_send %W menusaveas}
-    bind all <$::modifier-Shift-Key-t> {menu_send %W toggle}
-    bind all <$::modifier-Shift-Key-u> {menu_send %W vumeter}
-    bind all <$::modifier-Shift-Key-v> {menu_send %W vslider}
-    bind all <$::modifier-Shift-Key-w> {::pd_bindings::window_close %W 1}
-    bind all <$::modifier-Shift-Key-z> {menu_redo}
+    bind_capslock all $::modifier-Shift-Key A {menu_send %W menuarray}
+    bind_capslock all $::modifier-Shift-Key B {menu_send %W bng}
+    bind_capslock all $::modifier-Shift-Key C {menu_send %W mycnv}
+    bind_capslock all $::modifier-Shift-Key D {menu_send %W vradio}
+    bind_capslock all $::modifier-Shift-Key G {menu_send %W graph}
+    bind_capslock all $::modifier-Shift-Key J {menu_send %W hslider}
+    bind_capslock all $::modifier-Shift-Key I {menu_send %W hradio}
+    bind_capslock all $::modifier-Shift-Key L {menu_clear_console}
+    bind_capslock all $::modifier-Shift-Key M {menu_message_dialog}
+    bind_capslock all $::modifier-Shift-Key N {menu_send %W numbox}
+    bind_capslock all $::modifier-Shift-Key Q {pdsend "pd quit"}
+    bind_capslock all $::modifier-Shift-Key R {menu_send %W tidy}
+    bind_capslock all $::modifier-Shift-Key S {menu_send %W menusaveas}
+    bind_capslock all $::modifier-Shift-Key T {menu_send %W toggle}
+    bind_capslock all $::modifier-Shift-Key U {menu_send %W vumeter}
+    bind_capslock all $::modifier-Shift-Key V {menu_send %W vslider}
+    bind_capslock all $::modifier-Shift-Key W {::pd_bindings::window_close %W 1}
+    bind_capslock all $::modifier-Shift-Key Z {menu_redo}
     bind all <KeyPress-Escape>         {menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1 %k}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
          # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
         if {$::tcl_version < 8.5} {
-            bind all <$::modifier-Key-q>       {pdsend "pd verifyquit"}
-            bind all <$::modifier-Key-m>       {menu_minimize %W}
+            bind_capslock all $::modifier-Key q       {pdsend "pd verifyquit"}
+            bind_capslock all $::modifier-Key m       {menu_minimize %W}
             bind all <$::modifier-quoteleft>   {menu_raisenextwindow}
         }
         # BackSpace/Delete report the wrong isos (unicode representations) on OSX,
@@ -136,8 +126,8 @@ proc ::pd_bindings::global_bindings {} {
         bind all <KeyPress-Clear>          {::pd_bindings::sendkey %W 1 %K "" 1 %k}
         bind all <KeyRelease-Clear>        {::pd_bindings::sendkey %W 0 %K "" 1 %k}
     } else {
-        bind all <$::modifier-Key-q>       {pdsend "pd verifyquit"}
-        bind all <$::modifier-Key-m>       {menu_minimize %W}
+        bind_capslock all $::modifier-Key q       {pdsend "pd verifyquit"}
+        bind_capslock all $::modifier-Key m       {menu_minimize %W}
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown
@@ -160,21 +150,20 @@ proc ::pd_bindings::global_bindings {} {
 proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
     variable modifier
 
-    bind $mytoplevel <KeyPress-Escape>   "dialog_${dialogname}::cancel $mytoplevel"
-    bind $mytoplevel <KeyPress-Return>   "dialog_${dialogname}::ok $mytoplevel"
-    bind $mytoplevel <$::modifier-Key-w> "dialog_${dialogname}::cancel $mytoplevel"
+    bind $mytoplevel <KeyPress-Escape>          "dialog_${dialogname}::cancel $mytoplevel"
+    bind $mytoplevel <KeyPress-Return>          "dialog_${dialogname}::ok $mytoplevel"
+    bind_capslock $mytoplevel $::modifier-Key w "dialog_${dialogname}::cancel $mytoplevel"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
     if {$mytoplevel ne ".find"} {
-        bind $mytoplevel <$::modifier-Key-s>       {bell; break}
-        bind $mytoplevel <$::modifier-Shift-Key-s> {bell; break}
-        bind $mytoplevel <$::modifier-Shift-Key-S> {bell; break}
-        bind $mytoplevel <$::modifier-Key-p>       {bell; break}
+        bind_capslock $mytoplevel $::modifier-Key s       {bell; break}
+        bind_capslock $mytoplevel $::modifier-Shift-Key s {bell; break}
+        bind_capslock $mytoplevel $::modifier-Key p       {bell; break}
     } else {
         # find may may allow passthrough to it's target search patch
         ::dialog_find::update_bindings
     }
-    bind $mytoplevel <$::modifier-Key-t>           {bell; break}
+    bind_capslock $mytoplevel $::modifier-Key t           {bell; break}
 
     wm protocol $mytoplevel WM_DELETE_WINDOW "dialog_${dialogname}::cancel $mytoplevel"
 }

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -396,7 +396,7 @@ proc ::pdwindow::create_window {} {
     frame .pdwindow.tcl -borderwidth 0
     pack .pdwindow.tcl -side bottom -fill x
     # TODO this should use the pd_font_$size created in pd-gui.tcl
-    text .pdwindow.text -relief raised -bd 2 -font {$::font_family -12} \
+    text .pdwindow.text -relief raised -bd 2 -font {$::font_family 10} \
         -highlightthickness 0 -borderwidth 1 -relief flat \
         -yscrollcommand ".pdwindow.scroll set" -width 60 \
         -undo false -autoseparators false -maxundo 1 -takefocus 0


### PR DESCRIPTION
this is meant as a successor of the update/0.51 and similar PRs (where it was always a bit awkward to have the Pd target-version embedded).

the idea is to have a permanent branch develop that only gets curated, small, no-brainer changes that can be easily merged into master at any time.


PS: if anybody can explain how to create PRs that are kept open after merging (or at least: can be opened again after merging), that would be fantastic. (it's a bit boring to re-open this PR after each release ;-))

PPS: supersedes #1105

---

Fixes included (this list should get updated whenever a new fix is included. keep in mind that updating the list might be forgotten though...)
- GUI-stuff
  - #814 (tcl-error when updating a closed GOP)
  - #1152 (some keyboard shortcuts don't work with <kbd>CapsLock</kbd> on
  - #1158 (Tcl error and freezes when using an out-of-range value for setting the color of iemguis)
- audio stuff
  - #1163 (Pd hangs when quitting with a callback scheduler)
  - #1162 (Pd segfaults if jackd has a blocksize that is smaller than `DEFDACBLKSIZE`)
  - #1110 (not enough audio/midi devices displayed in the menu)
- compilation stuff
  - refined check for MSVC supporting `stdint.h`
  - allow building a fresh-clone with the non-autotools makefiles (#1161 , see also https://git.iem.at/pd/pure-data/-/pipelines for automatic builds on a number of OSs/architectures/build-systems)

