### PR TITLE
Add entries to Info.plist and pd.entitlements for Xcode SDK > 9

### DIFF
--- a/mac/stuff/Info.plist
+++ b/mac/stuff/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Pd wants to hear the sounds</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Pd wants to see the sights</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>font</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/mac/stuff/pd.entitlements
+++ b/mac/stuff/pd.entitlements
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
It seems that if using Xcode SDK 10 and later, OSX won't prompt for user permission to use the camera and will just terminate the process unless there are certain lines that indicate those resources will be used in the bundle's Info.plist file. I also added a microphone entry. (Using the camera from the Pd bundle is necessary for ofelia, for example)

https://eclecticlight.co/2018/08/27/mojaves-privacy-protection-is-complex-and-will-crash-innocent-apps/
I wasn't sure what to put for the panel's message