### PR TITLE
improve symbol table performance

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -862,9 +862,9 @@ static t_symbol *dogensym(const char *s, t_symbol *oldsym,
         sym2 = oldsym;
     else sym2 = (t_symbol *)t_getbytes(sizeof(*sym2));
     symname = t_getbytes(length+1);
+    memcpy(symname, s, length+1);
     sym2->s_next = 0;
     sym2->s_thing = 0;
-    strcpy(symname, s);
     sym2->s_name = symname;
     *symhashloc = sym2;
     return (sym2);

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -91,9 +91,6 @@ EXTERN t_float *obj_findsignalscalar(const t_object *x, int m);
 void pd_globallock(void);
 void pd_globalunlock(void);
 
-/* misc */
-#define SYMTABHASHSIZE 1024
-
 EXTERN t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir);
 EXTERN void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv);
 EXTERN void glob_quit(void *dummy); /* glob_exit(0); */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -847,6 +847,8 @@ struct _pdinstance
 #if PDTHREADS
     int pd_islocked;
 #endif
+    int pd_symhashsize;
+    int pd_symhashcount;
 };
 #define t_pdinstance struct _pdinstance
 EXTERN t_pdinstance pd_maininstance;


### PR DESCRIPTION
Pd's symbol table has a constant size (1024), which means that performance degrades and approaches O(N) if many symbols are added.

The usual solution is to grow and rehash the symbol table after it has exceeded a certain load factor (`N elements / N buckets`) to keep it O(1).

0.75 is a common value for the maximum load factor. I've found out that Pd already creates ~500 symbols on startup (without any externals), which corresponds to a load factor of ~0.5. Add 250 more symbols and you've already approached the recommended limit.

I did some benchmarks with the following test patch: [symtab-test.zip](https://github.com/pure-data/pure-data/files/5313375/symtab-test.zip)

With this PR, symbol insertion and lookup is consistently faster, but the difference becomes really apparent after repeatedly inserting 100 000 random symbols:
| N | old (ms) | new (ms) |
| - | --------- | --------- |
| 1 | ~200 | ~60     |
| ... |          |             |
| 10 | ~8000 | ~60 |

Of course, rehashing is not free. However, it only happens relatively rarely - in fact, it becomes less rare with increasing table size!
Here's some benchmark for the additional cost of rehashing:

| old size | time (ms) |
| --------| -------- |
| 1024   | 0.042286 |
| 2048   | 0.061581   |
| 4096   | 0.183102   |
| 8192   | 0.413827   |
| 16384 | 1.021430 |
| 32768 | 1.442237 |
| 65536 | 2.822481 |
| 131072 | 9.373512 |
| 262144 | 23.967074
| 524288 | 57.996962 |

You can see that rehashing is pretty much O(N). Rehashing a large symbol table naturally takes some time and might lead to audio dropouts. From the point of realtime safety, this is bad. On the other hand, rehashing occurs very rarely and the rest of the time you get significantly better performance.

Another benchmark:

Time needed to add 10 random symbols with `[makefilename %d]` for specific symbol table sizes:
| table size | old (ms) | new (ms) |
| --------- | -------- | ---------- |
| 100 000 | 0.1         |  0.012      |
| 200 000 | 0.2         |  0.012      |
| 300 000 | 0.3         |   0.012      |
| 400 000 | 0.4         |  0.012      |
| 500 000 | 0.5         |  0.012      |

It is pretty obvious how the new implementation stays O(1), while the old implementation degrades to O(N). Actually, 0.5 ms for 10 random symbols is pretty terrible, that's 1/3 of the time budget for a 64 sample block!

---

One thing I'm not sure about:

Currently, I store the symbol table size and item count in `t_pdinstance`. I don't really like this because they shouldn't be exposed in the public API. I've thought about storing it in `t_instancestuff`, but that would mean a potential cache miss. The Pd instance, on the other hand, is always in the cache (because we already access `pd_symhash`). I guess that's also the reason why the symbol table itself resides in `t_pdinstance`, although it has no business being exposed in `m_pd.h`...