### PR TITLE
improve symbol table performance (version 2)

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1266,6 +1266,8 @@ static void canvas_start_dsp(void)
         pd_bang(gensym("pd-dsp-started")->s_thing);
 }
 
+void symtab_rehash(void);
+
 static void canvas_stop_dsp(void)
 {
     if (THISGUI->i_dspstate)
@@ -1276,6 +1278,8 @@ static void canvas_stop_dsp(void)
         if (gensym("pd-dsp-stopped")->s_thing)
             pd_bang(gensym("pd-dsp-stopped")->s_thing);
     }
+        /* use the opportunity to clean up the symbol table */
+    symtab_rehash();
 }
 
     /* DSP can be suspended before, and resumed after, operations which

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -862,9 +862,9 @@ static t_symbol *dogensym(const char *s, t_symbol *oldsym,
         sym2 = oldsym;
     else sym2 = (t_symbol *)t_getbytes(sizeof(*sym2));
     symname = t_getbytes(length+1);
+    memcpy(symname, s, length+1);
     sym2->s_next = 0;
     sym2->s_thing = 0;
-    strcpy(symname, s);
     sym2->s_name = symname;
     *symhashloc = sym2;
     return (sym2);

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -91,9 +91,6 @@ EXTERN t_float *obj_findsignalscalar(const t_object *x, int m);
 void pd_globallock(void);
 void pd_globalunlock(void);
 
-/* misc */
-#define SYMTABHASHSIZE 1024
-
 EXTERN t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir);
 EXTERN void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv);
 EXTERN void glob_quit(void *dummy); /* glob_exit(0); */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -823,7 +823,7 @@ struct _pdinstance
     t_canvas *pd_canvaslist;    /* list of all root canvases */
     struct _template *pd_templatelist;  /* list of all templates */
     int pd_instanceno;          /* ordinal number of this instance */
-    t_symbol **pd_symhash;      /* symbol table hash table */
+    struct _symtab *pd_symhash; /* symbol table */
     t_instancemidi *pd_midi;    /* private stuff for x_midi.c */
     t_instanceinter *pd_inter;  /* private stuff for s_inter.c */
     t_instanceugen *pd_ugen;    /* private stuff for d_ugen.c */


### PR DESCRIPTION
This is an alternative version of https://github.com/pure-data/pure-data/pull/1170. The performance is only a little bit worse, but not significantly.

Since @millerpuckette had concerns regarding the rehashing, this PR uses a hybrid approach for the case where the (last) table exceeds the max. load factor (`N elements / N buckets`)

* if DSP is on, we *add* a new, larger table. We *don't* rehash to avoid audio dropouts
* if DSP is off, we create a single new, larger table and insert all existing symbols (= rehashing). We also do this whenever DSP is switched off and there is more than 1 symbol table.

Here's a benchmark of the symbol table creation routine:

| table size | time (ms) |
| --------- | ---------- |
| 16384 | 0.023712 |
| 65536 | 0.094442 |
| 262144 | 0.343732 |
| 1048576 | 1.207408 |

I think those numbers are acceptable. If someone manages to create 1 million symbols, they should cope with a single audio dropout :-). (And by that time, the old symbol table would be bog slow anyway). With the current settings (initial size = 4096, grow factor = 2), I expect most Pd projects to only grow the symbol table 1-2 times, which takes 0.01 ms resp. 0.02 ms.

NOTE: `DEFSYMTABSIZE`, `SYMTABMAXLOAD` and `SYMTABGROW` can all be overriden at compile time, e.g. for memory constrained environments.