### PR TITLE
[WIP] macOS Tk 8.6.10 key handling fixes

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -217,6 +217,7 @@ compiler:
 
 * macOS 10.6: i386, x86_64, ppc
 * macOS 10.7+: i386, x86_64
+* macOS 10.15: x86_64
 
 Note: a "fat" Pd may not work on all systems and/or be able to load both 32 or
 64 bit externals. Additonally, you can specify multiple architectures directly:

--- a/mac/README.txt
+++ b/mac/README.txt
@@ -61,9 +61,9 @@ argument, a "Pd.app" is built. The version argument is only used as a suffix to
 the file name and contextual version info is pulled from configure script
 output.
 
-A pre-built universal (32/64 bit) Tk 8.5.19 Wish with patches applied is
+A pre-built universal (32/64 bit) Tk 8.6.10 Wish with patches applied is
 included with the Pd source distribution and works across the majority of macOS
-versions up to 10.14. This is the default Wish.app when using osx-app.sh. If you
+versions up to 10.15. This is the default Wish.app when using osx-app.sh. If you
 want to use a different Wish.app (a newer version, a custom build, a system
 version), you can specify the donor via commandline options, for example:
 

--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -40,7 +40,7 @@ Usage: osx-app.sh [OPTIONS] [VERSION]
 
   Creates a Pd .app bundle for macOS using a Tk Wish.app wrapper
 
-  Uses the included Tk 8.4 Wish.app at mac/stuff/wish-shell.tgz by default
+  Uses the included Tk Wish.app at mac/stuff/wish-shell.tgz by default
 
 Options:
   -h,--help           display this help message

--- a/mac/patches/tk8.6.10_keyfix.patch
+++ b/mac/patches/tk8.6.10_keyfix.patch
@@ -1,0 +1,48 @@
+diff --git a/macosx/tkMacOSXKeyEvent.c b/macosx/tkMacOSXKeyEvent.c
+index 7ea085bea..b613a7789 100644
+--- a/macosx/tkMacOSXKeyEvent.c
++++ b/macosx/tkMacOSXKeyEvent.c
+@@ -85,13 +85,20 @@ static unsigned	isFunctionKey(unsigned int code);
+ 
+     switch (type) {
+     case NSKeyUp:
+-	/*Fix for bug #1ba71a86bb: key release firing on key press.*/
+-	setupXEvent(&xEvent, w, 0);
+-	xEvent.xany.type = KeyRelease;
+-	xEvent.xkey.keycode = releaseCode;
+-	xEvent.xany.serial = LastKnownRequestProcessed(Tk_Display(tkwin));
++    if (releaseCode) {
++        /*Fix for bug #1ba71a86bb: key release firing on key press.*/
++        setupXEvent(&xEvent, w, 0);
++        xEvent.xany.type = KeyRelease;
++        xEvent.xkey.keycode = releaseCode;
++        xEvent.xany.serial = LastKnownRequestProcessed(Tk_Display(tkwin));
++        releaseCode = 0;
++	}
+     case NSKeyDown:
+-	repeat = [theEvent isARepeat];
++    repeat = [theEvent isARepeat];
++    if (repeat && [NSEvent keyRepeatDelay] < 0) {
++        // ignore repeats if they are turned off in the system settings
++        return theEvent;
++    }
+ 	characters = [theEvent characters];
+ 	charactersIgnoringModifiers = [theEvent charactersIgnoringModifiers];
+         len = [charactersIgnoringModifiers length];
+@@ -176,7 +183,7 @@ static unsigned	isFunctionKey(unsigned int code);
+ 
+         int code = (len == 0) ? 0 :
+ 		[charactersIgnoringModifiers characterAtIndex: 0];
+-        if (type != NSKeyDown || isFunctionKey(code)
++        if (type != NSKeyDown || repeat || isFunctionKey(code)
+ 		|| (len > 0 && state & (ControlMask | Mod1Mask | Mod3Mask | Mod4Mask))) {
+             XEvent xEvent;
+ 
+@@ -353,6 +360,7 @@ static unsigned	isFunctionKey(unsigned int code);
+ 	    i++;
+ 	}
+     	xEvent.xany.type = KeyPress;
++    	releaseCode = (UInt16) [str characterAtIndex: 0];
+     	Tk_QueueWindowEvent(&xEvent, TCL_QUEUE_TAIL);
+     }
+     releaseCode = (UInt16) [str characterAtIndex: 0];

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -242,6 +242,29 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     bind $tkcanvas <MouseWheel>       {::pdtk_canvas::scroll %W y %D}
     bind $tkcanvas <Shift-MouseWheel> {::pdtk_canvas::scroll %W x %D}
 
+    # clear interim compose character by sending a virtual BackSpace,
+    # these events are pulled from Tk library/entry.tcl
+    # should we try to keep track of the "marked text" selection which may be
+    # more than a single character? ie. start & length of marked text
+    catch {
+        bind $tkcanvas <<TkStartIMEMarkedText>> {
+            ::pdwindow::post "%W start marked text\n"
+        }
+        bind $tkcanvas <<TkEndIMEMarkedText>> {
+            ::pdwindow::post "%W end marked text\n"
+        }
+        bind $tkcanvas <<TkClearIMEMarkedText>> {
+            ::pdwindow::post "%W clear marked text\n"
+            ::pd_bindings::sendkey %W 1 BackSpace "" 0
+            ::pd_bindings::sendkey %W 0 BackSpace "" 0
+        }
+        bind $tkcanvas <<TkAccentBackspace>> {
+            ::pdwindow::post "%W accent backspace\n"
+            ::pd_bindings::sendkey %W 1 BackSpace "" 0
+            ::pd_bindings::sendkey %W 0 BackSpace "" 0
+        }
+    } stderr
+
     # "right clicks" are defined differently on each platform
     switch -- $::windowingsystem {
         "aqua" {


### PR DESCRIPTION
This PR brings fixes for the following issues with TK 8.6.10:

1. ports the macOS key release handling patch from 8.5.9 to 8.6.10 which fixes key release and key repeat\*
2. adds event handling for the character composition events, ie. creating a ü by pressing opt+u then u

With composition, an interim character is usually shown, then replaced by the final character after the composition succeeds. For ü, ¨ is shown after the opt+u until the second u is pressed. Pressing escape during composition will leave the interim character. For the Pd GUI, the easiest solution might be to send a virtual/fake BackSpace to the Pd core to remove the interim character.

Tk 8.6 has added events for when composition starts, ends, or is cancelled which I found y looking in `library.entry.tcl` to see how the entry widget handles this. I added bindings for these to the Pd patch canvas and send BackSpaces when composition ends. This seems to work Ok, however the events refer to start and end to "marked text" which makes me wonder if we need to handle some sort of selection range and/or multiple-width characters. Maybe not? I'm not 100% sure on this yet.

One current issue is that symbol atoms are not processing the backspace and the interim characters are left and/or the last character is corrupted. Object and message boxes work fine, so I'm not sure why the symbol atom buffer is handled differently here.
 
TODOs:
* [ ] fix symbol atom issue
* [ ] test on Windows & Linux, or at least those systems which implement composition handling

\* _You will need to (re)build a Tcl/Tk 8.6.10 Wish app to include the patch and use this to build the .app bundle in order to see the key release fixes._
