### PR TITLE
Note that [savestate] fires before connections are made

### DIFF
--- a/doc/5.reference/savestate-help.pd
+++ b/doc/5.reference/savestate-help.pd
@@ -1,4 +1,4 @@
-#N canvas 711 48 578 672 12;
+#N canvas 48 77 1046 479 12;
 #X obj 82 73 savestate-example;
 #A saved 110 660;
 #X text 223 71 open the abstraction at left (right- or CTRL- click
@@ -8,21 +8,21 @@ used from within., f 46;
 #A saved 221 440;
 #X text 223 162 parameters for different copies of the abstraction
 are saved and restored independently., f 32;
-#X text 348 610 updated for Pd version 0.49.;
-#X text 81 445 The abstraction may itself be modified at will without
+#X text 828 430 updated for Pd version 0.49.;
+#X text 81 302 The abstraction may itself be modified at will without
 disturbing the saved states of its copies in any calling patches \,
 as long as the usage of the saved and restored lists is kept compatible.
 ;
-#X text 80 512 Multiple savestate objects are not differentated - they
-all receive all lists sent to any one of them.;
-#X text 81 550 Hint: 'text' objects can be saved/restored using 'text
+#X text 610 272 Multiple savestate objects are not differentiated -
+they all receive all lists sent to any one of them.;
+#X text 610 322 Hint: 'text' objects can be saved/restored using 'text
 tolist' and 'text fromlist'.;
-#X text 82 422 Abstractions within 'clone' objects are not handled.
+#X text 82 272 Abstractions within 'clone' objects are not handled.
 ;
 #X obj 75 27 savestate;
 #X text 148 26 - save and restore run-time state from within an abstraction
-, f 70;
-#X text 81 250 The savestate object is used inside abstractions to
+;
+#X text 608 66 The savestate object is used inside abstractions to
 save their state as they are used in a calling (parent) patch. When
 the parent patch (such as this one \, which calls the "savestate-example"
 abstraction) is saved \, the included savestate object sends a 'bang'
@@ -32,3 +32,7 @@ These lists are saved as part of the calling patch. If the calling
 patch is reopened later \, the lists are sent out the left outlet of
 the savestate object. The abstraction can then use them to restore
 its state.;
+#X text 81 373 The saved states are output very early when the patch
+is loaded. You should not make any assumptions whether any objects
+(including [send]/[receive]) or connections outside of the abstraction
+using [savestate] and its subpatches are already available.;


### PR DESCRIPTION
this adds a paragraph explaining the when using `[savestate]`, the user shouldn't assume that they can send data to objects outside of the abstraction.

Closes: https://github.com/pure-data/pure-data/issues/1201