### PR TITLE
Fix typos in doc/ directory

### DIFF
--- a/doc/1.manual/x2.htm
+++ b/doc/1.manual/x2.htm
@@ -321,7 +321,7 @@ objects, or of the patch itself (by clicking outside any box.)
 
 <H3> <A id=s2.7> 2.2.8. miscellaneous </A> </H3>
 
-<P> Control-q "quits" Pd, but asks you to comfirm the quit.  To quit without
+<P> Control-q "quits" Pd, but asks you to confirm the quit.  To quit without
 having to confirm, use command-shift-Q.
 
 <H3> <A id="s3"> 2.3. messages </A> </H3>

--- a/doc/1.manual/x3.htm
+++ b/doc/1.manual/x3.htm
@@ -188,7 +188,7 @@ simply terrible.  W98, with either audio input or output suppressed, offers
 fairly good MIDI timing (~5 msec jitter).  The "first edition" used to crash
 occasionally; this might be fixed in the "second edition".
 
-/// end coment out -->
+/// end comment out -->
 
 <H4> ASIO </H4>
 
@@ -204,7 +204,7 @@ frames.
 <!--- comment out
 <P> Using MMIO I've been able to get very low latencies (6 msec) using M-audio
 PCI converters (Delta 44).
-/// end coment out -->
+/// end comment out -->
 
 <H3> <A id=s1.2> 3.3. Installing Pd in Linux </A> </H3>
 

--- a/doc/5.reference/hradio-help.pd
+++ b/doc/5.reference/hradio-help.pd
@@ -133,7 +133,7 @@ in the patch. Check below:, f 41;
 #X text 67 16 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 67 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are
@@ -543,7 +543,7 @@ Check details and how to get it back:, f 33;
 #X text 199 24 <= [hradio]: Horizontal Radio Button;
 #X text 27 59 The horizontal radio button is a GUI (Graphical User
 Interface) that sends numbers. Click on its cells to output corresponding
-values. Incomming floats set the value and are passed through (even
+values. Incoming floats set the value and are passed through (even
 if outside the range). The 'set' message only sets the value without
 output. A bang message sends the internal value., f 64;
 #N canvas 761 61 435 279 switch-example 0;

--- a/doc/5.reference/hslider-help.pd
+++ b/doc/5.reference/hslider-help.pd
@@ -136,7 +136,7 @@ in the patch. Check below:, f 41;
 #X text 67 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 68 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are
@@ -601,7 +601,7 @@ in the subpatches below:, f 39;
 #X restore 398 227 pd properties;
 #X text 22 55 The horizontal slider is a GUI (Graphical User Interface)
 that sends numbers. Click on it and drag to output values - use shift-click
-and drag for fine-tuning by a factor of a hundredth. Incomming floats
+and drag for fine-tuning by a factor of a hundredth. Incoming floats
 set the slider's value and are passed through (even if outside the
 slider's range). The 'set' message only sets the slider value without
 output. A bang message sends the slider's value., f 69;
@@ -642,7 +642,7 @@ one in the background., f 29;
 #X text 79 18 Here's an example (or a 'hack') on how to use the slider
 in a discrete way. This is for a range from 0 to 1 \, but you can rescale
 it if needed., f 34;
-#X text 79 92 This example allows you to set the number of steps dinamically.
+#X text 79 92 This example allows you to set the number of steps dynamically.
 , f 34;
 #X text 250 264 <= click and drag.;
 #X text 270 283 Right click and open for more details., f 20;

--- a/doc/5.reference/int-help.pd
+++ b/doc/5.reference/int-help.pd
@@ -21,7 +21,7 @@
 #X obj 119 438 float;
 #X msg 76 203 9.6;
 #X msg 86 225 -9.6;
-#X text 126 213 <= non-integers get truncated torward zero;
+#X text 126 213 <= non-integers get truncated toward zero;
 #X text 331 437 updated for Pd version 0.48;
 #X obj 458 324 value int-help;
 #X text 200 257 send to a named object such as a;

--- a/doc/5.reference/line-help.pd
+++ b/doc/5.reference/line-help.pd
@@ -37,8 +37,8 @@ grain;
 #X text 105 359 A float jumps to the value if no ramp time is set via
 the middle inlet, f 37;
 #X text 39 52 The line object takes values for target/time/grain and
-ramps to the specified target over the time given in miliseconds \,
-updating its output at the "grain rate" (also in miliseconds). A list
+ramps to the specified target over the time given in milliseconds \,
+updating its output at the "grain rate" (also in milliseconds). A list
 up to 3 floats distributes the values to the inlets \, as usual in
 Pd. Note that the middle inlet (that sets the time) does not set values
 for the next ramp (unlike every other inlet in Pd) - thus \, sending

--- a/doc/5.reference/line~-help.pd
+++ b/doc/5.reference/line~-help.pd
@@ -30,7 +30,7 @@ starts!), f 31;
 #X text 21 65 The line~ object generates linear ramps whose levels
 and timing are determined by messages you send it. A list of two floats
 distributes the value over the inlets \, as usual in Pd. Note that
-the right inlet (that sets the ramp time in miliseconds) does not remember
+the right inlet (that sets the ramp time in milliseconds) does not remember
 old values (unlike every other inlet in Pd). Thus \, if you don't priorly
 specify a time in the right inlet and sent line~ a float \, it jumps
 immediately to the target value., f 64;

--- a/doc/5.reference/makefilename-help.pd
+++ b/doc/5.reference/makefilename-help.pd
@@ -110,7 +110,7 @@ a symbol (symbols are converted to 0). Floats are truncated.;
 #X obj 269 287 makefilename [%E];
 #X text 53 53 This pattern allows you to insert a number with scientific
 notation into a symbol (symbols are converted to 0). The '%e' or '%E'
-pattern specify respectively wether the exponential character is lower
+pattern specify respectively whether the exponential character is lower
 (e) or upper (E) case., f 71;
 #X connect 0 0 3 0;
 #X connect 0 0 8 0;
@@ -159,7 +159,7 @@ pattern specify respectively wether the exponential character is lower
 numbers are converted to scientific notation., f 78;
 #X text 34 53 This pattern allows you to insert a number with or without
 scientific notation into a symbol (symbols are converted to 0). The
-'%g' or '%G' pattern specify respectively wether the exponential character
+'%g' or '%G' pattern specify respectively whether the exponential character
 is lower (e) or upper (E) case. The scientific notation is only used
 if there's not enough digit resolution. The default precision is 6
 digits and we'll see how to change that later. Also \, the decimal
@@ -268,7 +268,7 @@ negative numbers doesn't work.;
 #X obj 262 386 makefilename [%X];
 #X text 61 46 This pattern is allows you to insert a signed (only positive)
 hexadecimal integer into a symbol (symbols are converted to 0). Floats
-are trunctaed. The '%x' or '%X' pattern specify respectively wether
+are trunctaed. The '%x' or '%X' pattern specify respectively whether
 the the characters are lower or upper case. Note that since this is
 an unsigned format \, sending negative numbers doesn't work., f 61
 ;
@@ -368,13 +368,13 @@ numeric types (%d/%i/%e/%E/%f/%g/%G):, f 47;
 #X msg 128 284 9;
 #X msg 164 284 16;
 #X msg 231 284 1e+09;
-#X text 44 222 For "%x" and "%X" \, the number is preceeded by "0x"
+#X text 44 222 For "%x" and "%X" \, the number is preceded by "0x"
 (if %x) or ""0X" (if %5)., f 43;
 #X symbolatom 55 399 14 0 0 0 - - -;
 #X obj 55 361 makefilename [%#x];
 #X obj 196 361 makefilename [%#X];
 #X text 25 22 The '#' flag presents an alternate form of some numeric
-types. For "%o" \, the number is preceeded by a "0".;
+types. For "%o" \, the number is preceded by a "0".;
 #X floatatom 532 240 10 0 0 0 - - -;
 #X symbolatom 382 336 18 0 0 0 - - -;
 #X symbolatom 532 336 18 0 0 0 - - -;
@@ -430,7 +430,7 @@ subpatches for more details and examples., f 51;
 #X msg 156 352 31;
 #X msg 234 352 1e+06;
 #X obj 194 426 makefilename [%05x];
-#X text 39 286 The width field takes an optional preceeding '0' flag
+#X text 39 286 The width field takes an optional preceding '0' flag
 that fills the extra characters with zeroes instead of spaces.;
 #X floatatom 539 176 0 0 0 0 - - -;
 #X symbolatom 539 240 12 0 0 0 - - -;
@@ -454,7 +454,7 @@ that fills the extra characters with zeroes instead of spaces.;
 #X symbolatom 724 435 12 0 0 0 - - -;
 #X msg 724 314 1;
 #X msg 772 339 -1e+06;
-#X text 498 63 You can combine the width field with the preceeding
+#X text 498 63 You can combine the width field with the preceding
 +/# flags where pertinent., f 40;
 #X msg 592 315 100;
 #X msg 760 314 100;
@@ -519,7 +519,7 @@ of '%g'/'%G' \, the width field is valid only for the integer output.
 #X obj 231 189 makefilename [%.4s];
 #X msg 231 115 symbol abcde;
 #X msg 127 115 symbol abcd;
-#X text 61 260 In this case \, the width field can be preceeded to
+#X text 61 260 In this case \, the width field can be preceded to
 set a minimum of characters filled with spaces., f 48;
 #X msg 141 316 symbol ab;
 #X msg 219 316 symbol abc;
@@ -624,7 +624,7 @@ is specified by a "." and is followed by the precision number. See
 subpatches below for the examples., f 51;
 #X restore 216 475 pd precision;
 #X text 127 236 - string;
-#X text 33 366 The types can be preceeded by optional fields \, which
+#X text 33 366 The types can be preceded by optional fields \, which
 can be combined and included in the order below:;
 #X restore 392 395 pd possible_types_&_syntax;
 #X text 43 394 updated for Pd version 0.51;

--- a/doc/5.reference/my_canvas-help.pd
+++ b/doc/5.reference/my_canvas-help.pd
@@ -261,7 +261,7 @@ only the first and the third are valid and set \, respectively \, background
 and label colors (as there's no "front" color \, the 2nd value is ignored).
 , f 76;
 #X text 58 65 Integers from 0 to 29 represent the 30 preset colors
-found in the properties window \, values above are wraped. Negative
+found in the properties window \, values above are wrapped. Negative
 integers were used to encode RGB values (and that still works for backwards
 compatibility). But since Pd 0.47-0 \, you can set colors with hexadecimal
 RGB symbol values \, which are followed by "#"., f 76;
@@ -473,7 +473,7 @@ included in Pd version 0.34., f 28;
 #X obj 68 171 !=;
 #X obj 155 371 outlet;
 #X obj 64 43 receive from_K1;
-#X text 212 274 The list is ouput only if either of the values has
+#X text 212 274 The list is output only if either of the values has
 changed, f 23;
 #X obj 175 334 print K1;
 #X connect 0 0 7 1;
@@ -515,7 +515,7 @@ it and then get into the edit mode to move them., f 52;
 #X obj 128 170 !=;
 #X obj 68 171 !=;
 #X obj 155 381 outlet;
-#X text 212 274 The list is ouput only if either of the values has
+#X text 212 274 The list is output only if either of the values has
 changed, f 23;
 #X obj 64 43 receive from_K2;
 #X obj 180 336 print K2;

--- a/doc/5.reference/netreceive-help.pd
+++ b/doc/5.reference/netreceive-help.pd
@@ -71,7 +71,7 @@ compatible clients) that have opened connections here., f 84;
 ;
 #X text 23 451 *) On some systems you can also receive IPv4 messages.
 This certainly doesn't work on Windows!, f 54;
-#X text 21 115 For backwards comptability \, hostname resolution favors
+#X text 21 115 For backwards compatibility \, hostname resolution favors
 IPv4 results., f 69;
 #X text 20 63 By default \, netreceive listens on all IPv4 and IPv6
 interfaces \, but you can restrict it to a specific interface \, e.g.

--- a/doc/5.reference/numbox2-help.pd
+++ b/doc/5.reference/numbox2-help.pd
@@ -24,7 +24,7 @@ click for properties., f 16;
 sends numbers. Click on it and drag to output values - use shift-click
 and drag for fine-tuning by a factor of a hundredth. You can also click
 on the object \, type a number value and then 'enter' to output it.
-Incomming floats set the number box's value and are passed through.
+Incoming floats set the number box's value and are passed through.
 The 'set' message only sets the value without output. A bang message
 sends the number box's value., f 70;
 #X text 28 156 Insert it from the Put menu (named as "Number2") or
@@ -99,7 +99,7 @@ in the patch. Check below:, f 41;
 #X text 67 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 68 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are
@@ -378,7 +378,7 @@ values., f 20;
 #X text 44 35 The size message sets the object's size and takes number
 of digits and height values (in number of pixels). The number of digits
 affect the box width \, but note that the box's width also depends
-on the height paramater \, as well as the font type and font size.
+on the height parameter \, as well as the font type and font size.
 , f 51;
 #X connect 0 0 7 0;
 #X connect 1 0 7 0;
@@ -585,7 +585,7 @@ to the one in the background., f 29;
 #X text 204 210 increment value;
 #X text 66 33 Here's an example (or a 'hack') on how to use the number
 box in a discrete way., f 34;
-#X text 66 85 This example allows you to set the increment value dinamically.
+#X text 66 85 This example allows you to set the increment value dynamically.
 , f 34;
 #X connect 0 0 2 0;
 #X connect 2 0 1 0;

--- a/doc/5.reference/slop~-help.pd
+++ b/doc/5.reference/slop~-help.pd
@@ -504,7 +504,7 @@ down., f 60;
 #X text 154 122 max downward slope;
 #X text 206 210 max upward slope;
 #X text 387 34 The slew limiter is a filter whose cutoff frequency
-is infinite (so that the output folows teh input exactly) unless the
+is infinite (so that the output follows the input exactly) unless the
 input varies from the previous output by more than the highest slope
 we allow (the slew limit) times the sample period (i.e. \, the maximum
 variation allowed over the space of a sample). This limit is therefore
@@ -656,7 +656,7 @@ envelope followers are converted to dBFS for the IEM VU meter., f
 #X text 69 27 jitter remover;
 #X text 378 68 If you have a noisy sensor \, one approach to smoothing
 it is to set slop~ u pto only react to motion past a certain window.
-The linear frequeny cutoff is set to zero so that the output only changes
+The linear frequency cutoff is set to zero so that the output only changes
 when the input strays by more than the maximum upward or downward slew.
 ;
 #X text 377 159 Set the jitter range to zero to see the original signal

--- a/doc/5.reference/threshold~-help.pd
+++ b/doc/5.reference/threshold~-help.pd
@@ -25,7 +25,7 @@ before triggering again.;
 #X text 244 163 "set" to change the parameters;
 #X text 271 219 zero or nonzero in inlet to set the state to "high"
 or "low". There is no debounce period after this.;
-#X text 161 11 - triger from audio signal;
+#X text 161 11 - trigger from audio signal;
 #X connect 3 0 4 0;
 #X connect 4 0 8 0;
 #X connect 4 1 9 0;

--- a/doc/5.reference/toggle-help.pd
+++ b/doc/5.reference/toggle-help.pd
@@ -216,7 +216,7 @@ in the patch. Check below:, f 41;
 #X text 47 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 345 133 Set RGB values in the sliders;
 #X text 60 157 Open subpatches for the conversion from RGB to hexadecimal
 ============>, f 38;

--- a/doc/5.reference/vdl-help.pd
+++ b/doc/5.reference/vdl-help.pd
@@ -76,7 +76,7 @@ in the patch. Check below:, f 41;
 #X connect 17 0 21 0;
 #X connect 22 0 3 0;
 #X restore 335 421 pd position;
-#X text 85 49 WARNING: This object is still in Pd for backwarss compatibilty
+#X text 85 49 WARNING: This object is still in Pd for backwarss compatibility
 but has been deprecated in Pd 0.36. Just use the new [vradio] instead
 now., f 39;
 #X obj 390 25 vradio 15 1 0 8 empty empty empty 0 -8 0 10 -262144 -1
@@ -108,7 +108,7 @@ now., f 39;
 #X text 67 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 68 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are

--- a/doc/5.reference/vline~-help.pd
+++ b/doc/5.reference/vline~-help.pd
@@ -41,7 +41,7 @@ starts!), f 32;
 starts!), f 32;
 #X text 43 53 The vline~ object \, like line~ \, generates linear ramps
 whose levels and timing are determined by messages you send it. It
-takes a target value \, a time interval in miliseconds and an initial
+takes a target value \, a time interval in milliseconds and an initial
 delay (also in ms). Ramps may start and stop between audio samples
 \, in which case the output is interpolated accordingly., f 61;
 #X text 43 142 A list up to three floats distributes the value over
@@ -50,7 +50,7 @@ the inlets \, as usual in Pd. Note that the middle and right inlet
 other inlet in Pd). Thus \, if you send vline~ a float without priorly
 specifying a ramp time and delay and sent \, it jumps immediately to
 the target value. On the other hand \, a list of two values will not
-have a delay time if no delay time was priorily set in the right inlet.
+have a delay time if no delay time was priorly set in the right inlet.
 , f 61;
 #X connect 0 0 1 0;
 #X connect 2 0 0 0;

--- a/doc/5.reference/vradio-help.pd
+++ b/doc/5.reference/vradio-help.pd
@@ -134,7 +134,7 @@ in the patch. Check below:, f 41;
 #X text 67 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 68 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are
@@ -541,7 +541,7 @@ box. Right click for properties (to set size \, colors \, labels \,
 etc)., f 64;
 #X text 99 55 The vertical radio button is a GUI (Graphical User Interface)
 that sends numbers. Click on its cells to output corresponding values.
-Incomming floats set the value and are passed through (even if outside
+Incoming floats set the value and are passed through (even if outside
 the range). The 'set' message only sets the value without output. A
 bang message sends the internal value., f 52;
 #X text 294 369 COMPATIBILITY NOTE: The behavior changed in Pd 0.46!

--- a/doc/5.reference/vslider-help.pd
+++ b/doc/5.reference/vslider-help.pd
@@ -12,7 +12,7 @@
 #X text 64 15 <= [vslider]/[vsl]: Vertical Slider;
 #X text 79 46 The vertical slider is a GUI (Graphical User Interface)
 that sends numbers. Click on it and drag to output values - use shift-click
-and drag for fine-tuning by a factor of a hundredth. Incomming floats
+and drag for fine-tuning by a factor of a hundredth. Incoming floats
 set the slider's value and are passed through (even if outside the
 slider's range). The 'set' message only sets the slider value without
 output. A bang message sends the slider's value., f 56;
@@ -130,7 +130,7 @@ in the patch. Check below:, f 41;
 #X text 67 17 The 'color' message takes a list of three values to set
 background \, front and label colors \, respectively. Integers from
 0 to 29 represent the 30 preset colors found in the properties window
-\, values above are wraped., f 77;
+\, values above are wrapped., f 77;
 #X text 68 68 Negative integers were used to encode RGB values (and
 that still works for backwards compatibility). But since Pd 0.47-0
 \, you can set colors with hexadecimal RGB symbol values \, which are
@@ -645,7 +645,7 @@ one in the background., f 29;
 in a discrete way. This is for a range from 0 to 1 \, but you can rescale
 it if needed., f 34;
 #X text 114 113 This example allows you to set the number of steps
-dinamically., f 34;
+dynamically., f 34;
 #X text 100 306 <= click and drag.;
 #X text 120 325 Right click and open for more details., f 20;
 #X msg 150 203 8;

--- a/doc/5.reference/vu-help.pd
+++ b/doc/5.reference/vu-help.pd
@@ -169,7 +169,7 @@ only the first and the third are valid and set \, respectively \, background
 and label colors (as there's no "front" color \, the 2nd value is ignored).
 , f 76;
 #X text 28 63 Integers from 0 to 29 represent the 30 preset colors
-found in the properties window \, values above are wraped. Negative
+found in the properties window \, values above are wrapped. Negative
 integers were used to encode RGB values (and that still works for backwards
 compatibility). But since Pd 0.47-0 \, you can set colors with hexadecimal
 RGB symbol values \, which are followed by "#"., f 76;
@@ -462,7 +462,7 @@ usual with other Pd objects., f 50;
 ;
 #X obj 147 102 vu 15 160 empty empty -1 -8 0 12 -66577 -1 0 0;
 #X obj 164 102 vu 15 160 empty empty -1 -8 0 12 -66577 -1 1 0;
-#X text 156 23 The 'scale' message toggles the dB-scale lable on or
+#X text 156 23 The 'scale' message toggles the dB-scale label on or
 off (on by default)., f 40;
 #X text 230 157 It's convenient hiding the scale of a [vu] for a stereo
 pair., f 32;
@@ -499,7 +499,7 @@ labels \, etc) ===>, f 17;
 is in dB (0-100 range \, pd style) but needs to be converted to dBFS
 (and we do that by simply subtracting 100)., f 31;
 #X text 345 225 The slop~ object is used here for peak detection. We
-need to convert the output to dB with rmstodb and also subract by 100
+need to convert the output to dB with rmstodb and also subtract by 100
 to convert it to dBFS., f 31;
 #X connect 0 0 18 0;
 #X connect 1 0 12 0;

--- a/doc/6.externs/0.README.txt
+++ b/doc/6.externs/0.README.txt
@@ -11,7 +11,7 @@ to compile externs using mingw but this makefile doesn't support that).
 To compile, type "make pd_linux", "nmake pd_nt" (for windows), or
 "make pd_darwin" (for Mac OSX).
 
-If you have saved these files to a new location (other than the Pd distrubution
+If you have saved these files to a new location (other than the Pd distribution
 itself), it will probably be necessary to customize the makefile by changing the
 definition of "PDNTINCLUDE" (windows) or "LINUXINCLUDE" (linux or Mac)
 to point back to the PD source directory.


### PR DESCRIPTION
Found using `codespell v2.0.dev`