### PR TITLE
Fix typos in tcl/ directory

### DIFF
--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -53,7 +53,7 @@ proc ::dialog_find::ok {mytoplevel} {
         if {$::windowingsystem eq "aqua"} {bell}
         return
     }
-    # start seaching
+    # start searching
     set $is_searching 1
     if {$find_in_window eq ".pdwindow"} {
         if {$::tcl_version < 8.5} {

--- a/tcl/helpbrowser.tcl
+++ b/tcl/helpbrowser.tcl
@@ -379,7 +379,7 @@ proc ::helpbrowser::findfiles {basedir pattern} {
     set filelist {}
 
     # Look in the current directory for matching files, -type {f r}
-    # means ony readable normal files are looked at, -nocomplain stops
+    # means only readable normal files are looked at, -nocomplain stops
     # an error being thrown if the returned list is empty
     foreach filename [glob -nocomplain -type {f r} -path $basedir $pattern] {
         lappend filelist $filename

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -187,7 +187,7 @@ If NOT fso.FolderExists(ExtractTo) Then
    fso.CreateFolder(ExtractTo)
 End If
 
-'Extract the contants of the zip file.
+'Extract the contents of the zip file.
 set objShell = CreateObject("Shell.Application")
 set FilesInZip=objShell.NameSpace(ZipFile).items
 objShell.NameSpace(ExtractTo).CopyHere(FilesInZip)
@@ -1386,7 +1386,7 @@ proc urldecode {str} {
 ## API draft
 
 # each backend is implemented via a single proc
-## that takes a single argument "term", the term to search fo
+## that takes a single argument "term", the term to search for
 ## an empty term indicates "search for all"
 # the backend then returns a list of results
 ## each result is a list of the following elements:

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -24,7 +24,7 @@ set ::pd_guiprefs::configdir ""
 set ::pd_guiprefs::recentfiles_is_array false
 
 #################################################################
-# perferences storage locations
+# preferences storage locations
 #
 # legacy
 #   registry
@@ -234,7 +234,7 @@ proc ::pd_guiprefs::init {} {
             prepare_configdir ${::pd_guiprefs::domain}
 
             # ------------------------------------------------------------------------------
-            # linux: read a config file and return its lines splitted.
+            # linux: read a config file and return its lines split.
             #
             proc ::pd_guiprefs::get_config {domain key {arr false}} {
                 return [::pd_guiprefs::get_config_file $domain $key $arr]
@@ -289,7 +289,7 @@ proc ::pd_guiprefs::init {} {
 }
 
 # ------------------------------------------------------------------------------
-# read a config file and return its lines splitted.
+# read a config file and return its lines split.
 #
 proc ::pd_guiprefs::get_config_file {domain key {arr false}} {
     set filename [file join ${::pd_guiprefs::configdir} ${domain} ${key}.conf]

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -225,7 +225,7 @@ proc ::pd_menus::build_edit_menu {mymenu} {
 proc ::pd_menus::build_put_menu {mymenu} {
     variable accelerator
     # The trailing 0 in menu_send_float basically means leave the object box
-    # sticking to the mouse cursor. The iemguis alway do that when created
+    # sticking to the mouse cursor. The iemguis always do that when created
     # from the menu, as defined in canvas_iemguis()
     $mymenu add command -label [_ "Object"]   -accelerator "$accelerator+1" \
         -command {menu_send_float $::focused_window obj 0}

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -165,7 +165,7 @@ proc pdtk_canvas_saveas {name initialfile initialdir destroyflag} {
     set oldfilename $filename
     set filename [regsub -- "$extension$" $filename [string tolower $extension]]
     if { ! [regexp -- "\.(pd|pat|mxt)$" $filename]} {
-        # we need the file extention even on Mac OS X
+        # we need the file extension even on Mac OS X
         set filename $filename.pd
     }
     # test again after downcasing and maybe adding a ".pd" on the end


### PR DESCRIPTION
Found via `codespell v2.0.dev`