### PR TITLE
fix sys_audiodevnumbertoname() using dynamic memory allocation

### DIFF
--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -27,7 +27,7 @@ typedef long t_pa_sample;
 #define SYS_XFERSAMPS (SYS_DEFAULTCH*DEFDACBLKSIZE)
 #define SYS_XFERSIZE (SYS_SAMPLEWIDTH * SYS_XFERSAMPS)
 #define MAXNDEV 128
-#define DEVDESCSIZE 1024
+#define DEVDESCSIZE 100
 
 static void audio_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti, int *cancallback,


### PR DESCRIPTION
This PR is related to issue reported on libpd: https://github.com/libpd/libpd/issues/312.
For reason that I don't fully understand the size of `outdevlist[]` seems too big (`MAXNDEV*DEVDESCSIZE` with `MAXNDEV`is 64 and `DEVDESCSIZE`is 1024 and I set `MAXNDEV` to 1 and the problem was fixed but obviously was not a good solution). This seems to be related to the use of pd in a mutli-instance and multi-thread context. The best solution seemed to use dynamic allocation.