### PR TITLE
macOS default font Menlo (for now)

### DIFF
--- a/font/README.txt
+++ b/font/README.txt
@@ -18,6 +18,13 @@ The default font weight on Linux is bold.
 
 ## macOS
 
+Note: As of Pd 0.51-3, the default font for macOS has been changed to Menlo.
+There is an issue with DejaVu Sans Mono where characters are rendered thin and
+closer together in the patch canvas than on previous versions of macOS which
+causes problems with object sizing and text edit selections. Menlo is an Apple
+font provided with systems back to 10.6 and is based on Bitstream Vera Mono and
+DejaVu Sans Mono, so there should be no issues with patch sizing or positioning.
+
 DVSM is included within the Pd .app bundle. If Pd is run from the commandline
 DVSM needs to be installed to the system otherwise the fallback font is Monaco.
 

--- a/mac/README.txt
+++ b/mac/README.txt
@@ -217,3 +217,14 @@ Pd .app bundle id:
 
     # reset all of Pd's privacy settings
     tccutil reset All org.puredata.pd.pd-gui
+
+## Font Issues with macOS 10.15+
+
+macOS 10.15 furthered changes to font rendering begin with 10.14 with the weird
+result that Pd's default font, DejaVu Sans Mono, renders thin and closer
+together than system fonts. This results in objects on the patch canvas that are 
+longer their inner text and text selection positioning is off.
+
+To remedy this for now, Pd 0.51-3 changed Pd's default font for macOS to Menlo
+which is included with the system since 10.6. Menlo is based on Bitstream Vera
+Mono and DejaVu Sans Mono, so there should be no issues with patch sizing or positioning.

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -71,10 +71,11 @@ int sys_nmidiin = -1;
 int sys_midiindevlist[MAXMIDIINDEV] = {1};
 int sys_midioutdevlist[MAXMIDIOUTDEV] = {1};
 
-char sys_font[100] = "DejaVu Sans Mono";
 #if __APPLE__
+char sys_font[100] = "Menlo"; /* hack until DVSM bug is fixed on macOS 10.15+ */
 char sys_fontweight[10] = "normal";
 #else
+char sys_font[100] = "DejaVu Sans Mono";
 char sys_fontweight[10] = "bold";
 #endif
 static int sys_main_srate;

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -340,6 +340,9 @@ proc init_for_platform {} {
                 # old default font for Tk 8.4 on macOS
                 # since font detection requires 8.5+
                 set ::font_family "Monaco"
+            } else {
+                # hack until DVSM bug is fixed on macOS 10.15+
+                set ::font_family "Menlo"
             }
             option add *DialogWindow*background "#E8E8E8" startupFile
             option add *DialogWindow*Entry.highlightBackground "#E8E8E8" startupFile
@@ -477,8 +480,10 @@ proc get_font_for_size {fsize} {
 # always do a good job of choosing in respect to Pd's needs.  So this chooses
 # from a list of fonts that are known to work well with Pd.
 proc find_default_font {} {
-    set testfonts {"DejaVu Sans Mono" "Bitstream Vera Sans Mono" "Monaco" \
-        "Inconsolata" "Courier 10 Pitch" "Andale Mono" "Droid Sans Mono"}
+    set testfonts {
+        "DejaVu Sans Mono" "Bitstream Vera Sans Mono" "Menlo" "Monaco" \
+        "Inconsolata" "Courier 10 Pitch" "Andale Mono" "Droid Sans Mono"
+    }
     foreach family $testfonts {
         if {[lsearch -exact -nocase [font families] $family] > -1} {
             set ::font_family $family


### PR DESCRIPTION
This PR changes the default font for macOS to Menlo. This is a hack until the render issue (#988) with DejaVu Sans Mono can be fixed on macOS 10.15+.

This only sets a new default font family name. DejaVu Sans Mono is still included in the app bundle for now which should help with testing once we have a fix for the rendering issue. Documentation on this change is included in `font/README.txt` and system-specific `mac/README.txt`.