### PR TITLE
writesf~: fix unfinite loop on I/O error

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -2413,8 +2413,7 @@ static void *writesf_child_main(void *zz)
                 pute("open failed\n");
                 pute(filename);
 #endif
-                x->x_requestcode = REQUEST_NOTHING;
-                continue;
+                goto bail;
             }
             /* check if another request has been made; if so, field it */
             if (x->x_requestcode != REQUEST_BUSY)
@@ -2484,7 +2483,7 @@ static void *writesf_child_main(void *zz)
                     pute("fileerror\n");
 #endif
                     x->x_fileerror = errno;
-                    break;
+                    goto bail;
                 }
                 else
                 {
@@ -2502,6 +2501,22 @@ static void *writesf_child_main(void *zz)
                     /* signal parent in case it's waiting for data */
                 sfread_cond_signal(&x->x_answercondition);
             }
+            continue;
+
+        bail:
+            if (x->x_requestcode == REQUEST_BUSY)
+                x->x_requestcode = REQUEST_NOTHING;
+                /* hit an error; close file if necessary,
+                set EOF and signal once more */
+            if (x->x_fd >= 0)
+            {
+                pthread_mutex_unlock(&x->x_mutex);
+                close (x->x_fd);
+                pthread_mutex_lock(&x->x_mutex);
+                x->x_eof = 1;
+                x->x_fd = -1;
+            }
+            sfread_cond_signal(&x->x_answercondition);
         }
         else if (x->x_requestcode == REQUEST_CLOSE ||
             x->x_requestcode == REQUEST_QUIT)
@@ -2604,7 +2619,7 @@ static t_int *writesf_perform(t_int *w)
         roominfifo = x->x_fifotail - x->x_fifohead;
         if (roominfifo <= 0)
             roominfifo += x->x_fifosize;
-        while (roominfifo < wantbytes + 1)
+        while (!x->x_eof && roominfifo < wantbytes + 1)
         {
             fprintf(stderr, "writesf waiting for disk write..\n");
             fprintf(stderr, "(head %d, tail %d, room %d, want %d)\n",
@@ -2615,6 +2630,20 @@ static t_int *writesf_perform(t_int *w)
             roominfifo = x->x_fifotail - x->x_fifohead;
             if (roominfifo <= 0)
                 roominfifo += x->x_fifosize;
+        }
+        if (x->x_eof)
+        {
+            if (x->x_fileerror)
+            {
+                pd_error(x, "dsp: %s: %s", x->x_filename,
+                    (x->x_fileerror == EIO ?
+                        "unknown or bad header format" :
+                            strerror(x->x_fileerror)));
+            }
+            x->x_state = STATE_IDLE;
+            sfread_cond_signal(&x->x_requestcondition);
+            pthread_mutex_unlock(&x->x_mutex);
+            return (w+2);
         }
 
         soundfile_xferout_sample(sfchannels, x->x_outvec,


### PR DESCRIPTION
Make sure that Pd doesn't get stuck in an infinite loop if `open` or `write` fails in `writesf_child_main`. Also print error message.

The code basically follows the one in `[readsf~]`, with slight adaptions where necessary.

Fixes https://github.com/pure-data/pure-data/issues/1211

NOTE: this has been incorporated into #855