### PR TITLE
Fix disabled Help menu items on macOS

### DIFF
--- a/mac/patches/README.txt
+++ b/mac/patches/README.txt
@@ -40,6 +40,7 @@ Fixes key release events and adds repeat handling, see
 Fixes help menu items disabling after switching windows, see
 
 	https://core.tcl-lang.org/tk/info/ad7edbfafdda63e6
+	https://core.tcl-lang.org/tk/vinfo/8c9db659a45831ee
 
 ### tk8.6.10_keyfix.patch
 

--- a/mac/patches/README.txt
+++ b/mac/patches/README.txt
@@ -2,14 +2,18 @@
 
 This directory contains custom patches for the Tcl/Tk source trees.
 
-As Pd uses an older version of Tcl/Tk for backwards compatibility on macOS, small bugfixes from newer versions may need to be backported for the Pd GUI. This is handled in the mac/tcltk-wish.sh script by applying custom patches in this directory to either the Tcl and/or Tk source trees.
+As Pd uses an older version of Tcl/Tk for backwards compatibility on macOS,
+small bugfixes from newer versions may need to be backported for the Pd GUI.
+This is handled in the mac/tcltk-wish.sh script by applying custom patches in
+this directory to either the Tcl and/or Tk source trees.
 
 A simple filename match is used:
 
 * tcl${VERSION}*.patch -> applied to tcl${VERSION} source tree
 * tk${VERSION}*.patch  -> applied to tk${VERSION} source tree
 
-For example, "tcl8.5.19_somefix.patch" is applied to the "tcl8.5.19" source directory when building Tcl/Tk 8.5.19.
+For example, "tcl8.5.19_somefix.patch" is applied to the "tcl8.5.19" source
+directory when building Tcl/Tk 8.5.19.
 
 To create a patch using git within a cloned tcl or tk source tree:
 
@@ -22,3 +26,21 @@ Patches are then applied within the relevant source tree directory using:
     patch -p1 < somefix.patch
 
 To skip applying patches, use the tcltk-wish.sh --no-patches commandline option.
+
+## Current Patches
+
+### tk8.5.19_keyfix.patch
+
+Fixes key release events and adds repeat handling, see
+
+    https://github.com/pure-data/pure-data/issues/213
+
+### tk8.6.10_helpmenu.patch:
+
+Fixes help menu items disabling after switching windows, see
+
+	https://core.tcl-lang.org/tk/info/ad7edbfafdda63e6
+
+### tk8.6.10_keyfix.patch
+
+The tk8.5.19_keyfix.patch updated for Tk 8.6.10.

--- a/mac/patches/tk8.6.10_helpmenu.patch
+++ b/mac/patches/tk8.6.10_helpmenu.patch
@@ -23,7 +23,7 @@ index 735f7d292..08e7501a7 100644
 -			}
 -			[item setEnabled: !(submePtr->state == ENTRY_DISABLED)];
 -			i++;
-+			NSMenuItem *item = (NSMenuItem *) mePtr->platformEntryData;
++			NSMenuItem *item = (NSMenuItem *) submePtr->platformEntryData;
 +			[item setEnabled: submePtr->state != ENTRY_DISABLED];
  		    }
  		}

--- a/mac/patches/tk8.6.10_helpmenu.patch
+++ b/mac/patches/tk8.6.10_helpmenu.patch
@@ -1,0 +1,30 @@
+diff --git a/macosx/tkMacOSXMenu.c b/macosx/tkMacOSXMenu.c
+index 735f7d292..08e7501a7 100644
+--- a/macosx/tkMacOSXMenu.c
++++ b/macosx/tkMacOSXMenu.c
+@@ -701,22 +701,10 @@ TkpConfigureMenuEntry(
+ 		     * re-enable the entries here.
+ 		     */
+ 
+-		    int i = 0;
+-		    NSArray *itemArray = [submenu itemArray];
+-
+-		    for (NSMenuItem *item in itemArray) {
++		    for (int i = 0; i < menuRefPtr->menuPtr->numEntries; i++) {
+ 			TkMenuEntry *submePtr = menuRefPtr->menuPtr->entries[i];
+-
+-			/*
+-			 * Work around an apparent bug where itemArray can have
+-			 * more items than the menu's entries[] array.
+-			 */
+-
+-			if (i >= (int) menuRefPtr->menuPtr->numEntries) {
+-			    break;
+-			}
+-			[item setEnabled: !(submePtr->state == ENTRY_DISABLED)];
+-			i++;
++			NSMenuItem *item = (NSMenuItem *) mePtr->platformEntryData;
++			[item setEnabled: submePtr->state != ENTRY_DISABLED];
+ 		    }
+ 		}
+ 	    }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -82,8 +82,9 @@ proc ::pd_menus::configure_for_pdwindow {} {
         catch {$menubar.put entryconfigure $i -state disabled }
     }
     # Help menu
-    # make sure "List of objects..." is enabled, it sometimes greys out on Mac
-    $menubar.help entryconfigure [_ "List of objects..."] -state normal
+    if {$::windowingsystem eq "aqua"} {
+        ::pd_menus::reenable_help_items_aqua $menubar
+    }
 }
 
 proc ::pd_menus::configure_for_canvas {mytoplevel} {
@@ -113,8 +114,9 @@ proc ::pd_menus::configure_for_canvas {mytoplevel} {
     }
     update_undo_on_menu $mytoplevel $::undo_actions($mytoplevel) $::redo_actions($mytoplevel)
     # Help menu
-    # make sure "List of objects..." is enabled, it sometimes greys out on Mac
-    $menubar.help entryconfigure [_ "List of objects..."] -state normal
+    if {$::windowingsystem eq "aqua"} {
+        ::pd_menus::reenable_help_items_aqua $menubar
+    }
 }
 
 proc ::pd_menus::configure_for_dialog {mytoplevel} {
@@ -157,8 +159,9 @@ proc ::pd_menus::configure_for_dialog {mytoplevel} {
         catch {$menubar.put entryconfigure $i -state disabled }
     }
     # Help menu
-    # make sure "List of objects..." is enabled, it sometimes greys out on Mac
-    $menubar.help entryconfigure [_ "List of objects..."] -state normal
+    if {$::windowingsystem eq "aqua"} {
+        ::pd_menus::reenable_help_items_aqua $menubar
+    }
 }
 
 
@@ -629,7 +632,17 @@ proc ::pd_menus::build_media_menu_aqua {mymenu} {
 proc ::pd_menus::build_window_menu_aqua {mymenu} {
 }
 
-# the "Help" does not have cross-platform differences
+# FIXME: remove this when it is no longer necessary
+# there is a Tk Cocoa bug where Help menu items after separators may be
+# disabled after windows are cycled, as of Nov 2020 this is fixed via a fresh
+# upstream patch in our Tk 8.6.10 build distributed with Pd but we keep this in
+# case other versions of Tk are used such as those installed to the system
+proc ::pd_menus::reenable_help_items_aqua {mymenu} {
+    #if {$::tcl_version < 8.6} {
+        $mymenu.help entryconfigure [_ "List of objects..."] -state normal
+        $mymenu.help entryconfigure [_ "Report a bug"] -state normal
+    #}
+}
 
 # ------------------------------------------------------------------------------
 # menu building functions for UNIX/X11


### PR DESCRIPTION
This PR adds a patch for Tk 8.6.10 on macOS which fixes items in the Help menu being disabled after windows are cycled and not re-enabled. This is basically a fresh bugfix back port from upstream Tk development and is an alternate to #991.

Also, the `mac/patches/README.txt` has been updated with info on what each patch does.