### PR TITLE
addrinfo_get_list: hack for Android and BSDs

### DIFF
--- a/src/s_net.c
+++ b/src/s_net.c
@@ -71,6 +71,14 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
          * so we fall back to IPv4 networking... */
     if (result == EAI_BADFLAGS)
     {
+        static int warned = 0;
+        if (!warned)
+        {
+            fprintf(stderr, "Warning: can't create IPv6 dual-stack socket - falling "
+                "back to IPv4. (This is a known bug in the BSD libc, which doesn't "
+                "implement the AI_ALL and AI_V4MAPPED flags for getaddrinfo().)\n");
+            warned = 1;
+        }
         hints.ai_family = AF_INET;
         hints.ai_flags = AI_PASSIVE;
         result = getaddrinfo(hostname, portstr, &hints, ailist);

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -69,7 +69,6 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
          * NOTE: this also seems to affect Android!
          * In practice, this means we can't use dual stack sockets,
          * so we fall back to IPv4 networking... */
-#if defined(__ANDROID__) || defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__)
     if (result == EAI_BADFLAGS)
     {
         hints.ai_family = AF_INET;
@@ -77,7 +76,6 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
         result = getaddrinfo(hostname, portstr, &hints, ailist);
     }
     return result;
-#endif
 }
 
 int addrinfo_ipv4_first(const struct addrinfo* ai1, const struct addrinfo* ai2)

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -47,6 +47,7 @@ const char* INET_NTOP(int af, const void *src, char *dst, socklen_t size) {
 int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
                              int port, int protocol) {
     struct addrinfo hints;
+    int result;
     char portstr[10]; /* largest port is 65535 */
     memset(&hints, 0, sizeof hints);
     hints.ai_family = AF_UNSPEC; /* IPv4 or IPv6 */
@@ -62,7 +63,21 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
                      AI_PASSIVE;    /* listen to any addr if hostname is NULL */
     portstr[0] = '\0';
     sprintf(portstr, "%d", port);
-    return getaddrinfo(hostname, portstr, &hints, ailist);
+    result = getaddrinfo(hostname, portstr, &hints, ailist);
+        /* There's currently a bug in the BSD libc where getaddrinfo()
+         * will return EAI_BADFLAGS for the AI_ALL and AI_V4MAPPED flags.
+         * NOTE: this also seems to affect Android!
+         * In practice, this means we can't use dual stack sockets,
+         * so we fall back to IPv4 networking... */
+#if defined(__ANDROID__) || defined(__FreeBSD__ ) || defined(__NetBSD__) || defined(__OpenBSD__)
+    if (result == EAI_BADFLAGS)
+    {
+        hints.ai_family = AF_INET;
+        hints.ai_flags = AI_PASSIVE;
+        result = getaddrinfo(hostname, portstr, &hints, ailist);
+    }
+    return result;
+#endif
 }
 
 int addrinfo_ipv4_first(const struct addrinfo* ai1, const struct addrinfo* ai2)


### PR DESCRIPTION
The BSD libc currently has a bug where `getaddrinfo()` returns `EAI_BADFLAGS` for the `AI_ALL` and `AI_V4MAPPED` flags.
This essential means that we can't use dual stack sockets, so we simply fall back to IPv4.

NOTE: this apparantly also affects Android!

Fixes https://github.com/pure-data/pure-data/issues/1229