### PR TITLE
change width and height to be correct after update idletasks in ::pd_bindings::patch_configure

### DIFF
--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -347,6 +347,8 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     if {$width == 1 || $height == 1} {
         # make sure the window is fully created
         update idletasks
+        set width [winfo width $mytoplevel]
+        set height [winfo height $mytoplevel]
     }
     pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
     # send the size/location of the window and canvas to 'pd' in the form of:


### PR DESCRIPTION
due to the different way tk handles timing (on osx at least) in the current 8.6 branch, the incorrect width and height might be the last values sent to pd (as of tk commit: https://core.tcl-lang.org/tk/info/491f5a56ddf503da). Therefore they should be set to the correct values after update idletasks