### PR TITLE
macOS fixes for 0.51-4

### DIFF
--- a/mac/README.txt
+++ b/mac/README.txt
@@ -227,4 +227,12 @@ longer their inner text and text selection positioning is off.
 
 To remedy this for now, Pd 0.51-3 changed Pd's default font for macOS to Menlo
 which is included with the system since 10.6. Menlo is based on Bitstream Vera
-Mono and DejaVu Sans Mono, so there should be no issues with patch sizing or positioning.
+Mono and DejaVu Sans Mono, so there should be no issues with patch sizing or
+positioning.
+
+## Dark Mode
+
+Pd currently disables Dark Mode support by setting the
+NSRequiresAquaSystemAppearance key to true in both the app bundle's Info.plist
+and the GUI defaults preference file. This restruction may be removed in the
+future once Dark Mode is handled in the GUI.

--- a/mac/patches/README.txt
+++ b/mac/patches/README.txt
@@ -29,6 +29,12 @@ To skip applying patches, use the tcltk-wish.sh --no-patches commandline option.
 
 ## Current Patches
 
+### tk8.6.10_scrollbars.patch
+
+Backport commit which fixes scrollbars not (re)drawing, see
+
+    https://core.tcl-lang.org/tk/info/71433282feea6ae9
+
 ### tk8.5.19_keyfix.patch
 
 Fixes key release events and adds repeat handling, see

--- a/mac/patches/README.txt
+++ b/mac/patches/README.txt
@@ -29,17 +29,16 @@ To skip applying patches, use the tcltk-wish.sh --no-patches commandline option.
 
 ## Current Patches
 
+### tk8.6.10_zombiewindows.patch
+
+Backport fix for zombie windows on systems with the Touchbar which could cause
+Pd to crash when closing the Font dialog due to a nil window pointer.
+
 ### tk8.6.10_scrollbars.patch
 
 Backport commit which fixes scrollbars not (re)drawing, see
 
     https://core.tcl-lang.org/tk/info/71433282feea6ae9
-
-### tk8.5.19_keyfix.patch
-
-Fixes key release events and adds repeat handling, see
-
-    https://github.com/pure-data/pure-data/issues/213
 
 ### tk8.6.10_helpmenu.patch:
 
@@ -51,3 +50,9 @@ Fixes help menu items disabling after switching windows, see
 ### tk8.6.10_keyfix.patch
 
 The tk8.5.19_keyfix.patch updated for Tk 8.6.10.
+
+### tk8.5.19_keyfix.patch
+
+Fixes key release events and adds repeat handling, see
+
+    https://github.com/pure-data/pure-data/issues/213

--- a/mac/patches/tk8.6.10_scrollbars.patch
+++ b/mac/patches/tk8.6.10_scrollbars.patch
@@ -1,0 +1,28 @@
+diff --git a/macosx/tkMacOSXNotify.c b/macosx/tkMacOSXNotify.c
+index afee942c5..71fcc5a10 100644
+--- a/macosx/tkMacOSXNotify.c
++++ b/macosx/tkMacOSXNotify.c
+@@ -303,6 +303,7 @@ TkMacOSXEventsSetupProc(
+ 	 * Call this with dequeue=NO -- just checking if the queue is empty.
+ 	 */
+ 
++	while (Tcl_DoOneEvent(TCL_IDLE_EVENTS|TCL_DONT_WAIT)) {}
+ 	NSEvent *currentEvent =
+ 	        [NSApp nextEventMatchingMask:NSAnyEventMask
+ 			untilDate:[NSDate distantPast]
+@@ -372,6 +373,7 @@ TkMacOSXEventsCheckProc(
+ 
+ 	[NSApp _lockAutoreleasePool];
+ 	do {
++		while (Tcl_DoOneEvent(TCL_IDLE_EVENTS|TCL_DONT_WAIT)) {}
+ 	    modalSession = TkMacOSXGetModalSession();
+ 	    testEvent = [NSApp nextEventMatchingMask:NSAnyEventMask
+ 		    untilDate:[NSDate distantPast]
+@@ -385,6 +387,7 @@ TkMacOSXEventsCheckProc(
+ 	    if (testEvent && [[testEvent window] inLiveResize]) {
+ 		break;
+ 	    }
++	    while (Tcl_DoOneEvent(TCL_IDLE_EVENTS|TCL_DONT_WAIT)) {}
+ 	    currentEvent = [NSApp nextEventMatchingMask:NSAnyEventMask
+ 		    untilDate:[NSDate distantPast]
+ 		    inMode:GetRunLoopMode(modalSession)

--- a/mac/patches/tk8.6.10_zombiewindows.patch
+++ b/mac/patches/tk8.6.10_zombiewindows.patch
@@ -1,0 +1,167 @@
+diff --git a/macosx/tkMacOSXPrivate.h b/macosx/tkMacOSXPrivate.h
+index 9417b62e6..dff6a200d 100644
+--- a/macosx/tkMacOSXPrivate.h
++++ b/macosx/tkMacOSXPrivate.h
+@@ -433,6 +433,18 @@ VISIBILITY_HIDDEN
+ - (void) setAppleMenu: (NSMenu *) menu;
+ @end
+ 
++/*
++ * These methods are exposed because they are needed to prevent zombie windows
++ * on systems with a TouchBar.  The TouchBar Key-Value observer holds a
++ * reference to the key window, which prevents deallocation of the key window
++ * when it is closed.
++ */
++
++@interface NSApplication(TkWm)
++- (id) _setKeyWindow: (NSWindow *) window;
++- (id) _setMainWindow: (NSWindow *) window;
++@end
++
+ #endif /* _TKMACPRIV */
+ 
+ int TkMacOSXGetAppPath(ClientData cd, Tcl_Interp *ip, int objc, Tcl_Obj *const objv[]);
+diff --git a/macosx/tkMacOSXWm.c b/macosx/tkMacOSXWm.c
+index ceb3f3f7e..f24f198f0 100644
+--- a/macosx/tkMacOSXWm.c
++++ b/macosx/tkMacOSXWm.c
+@@ -879,6 +879,7 @@ TkWmDeadWindow(
+     TkWindow *winPtr)		/* Top-level window that's being deleted. */
+ {
+     WmInfo *wmPtr = winPtr->wmInfoPtr, *wmPtr2;
++    NSWindow *ourNSWindow;
+ 
+     if (wmPtr == NULL) {
+ 	return;
+@@ -952,77 +953,87 @@ TkWmDeadWindow(
+     }
+ 
+     /*
+-     * Delete the Mac window and remove it from the windowTable. The window
+-     * could be nil if the window was never mapped. However, we don't do this
+-     * for embedded windows, they don't go in the window list, and they do not
+-     * own their portPtr's.
++     * Unregister the NSWindow and remove all references to it from the Tk
++     * data structures.  If the NSWindow is a child, disassociate it from
++     * the parent.  Then close and release the NSWindow.
+      */
+ 
+-    NSWindow *window = wmPtr->window;
+-
+-    if (window && !Tk_IsEmbedded(winPtr)) {
+-	NSWindow *parent = [window parentWindow];
++    ourNSWindow = wmPtr->window;
++    if (ourNSWindow && !Tk_IsEmbedded(winPtr)) {
++	NSWindow *parent = [ourNSWindow parentWindow];
++	TkMacOSXUnregisterMacWindow(ourNSWindow);
++        if (winPtr->window) {
++            ((MacDrawable *) winPtr->window)->view = nil;
++        }
++	wmPtr->window = NULL;
+ 
+ 	if (parent) {
+-	    [parent removeChildWindow:window];
++	    [parent removeChildWindow:ourNSWindow];
+ 	}
+-#if DEBUG_ZOMBIES > 0
++
++#if DEBUG_ZOMBIES > 1
+ 	{
+-	    const char *title = [[window title] UTF8String];
++	    const char *title = [[ourNSWindow title] UTF8String];
+ 	    if (title == nil) {
+ 		title = "unnamed window";
+ 	    }
+ 	    fprintf(stderr, ">>>> Closing <%s>. Count is: %lu\n", title,
+-		    [window retainCount]);
++		    [ourNSWindow retainCount]);
+ 	}
+ #endif
+-	[window close];
+-	TkMacOSXUnregisterMacWindow(window);
+-        if (winPtr->window) {
+-            ((MacDrawable *) winPtr->window)->view = nil;
+-        }
+-	wmPtr->window = NULL;
+-        [window release];
+-
+-	/* Activate the highest window left on the screen. */
+-	NSArray *windows = [NSApp orderedWindows];
+-	for (id nswindow in windows) {
+-	    TkWindow *winPtr2 = TkMacOSXGetTkWindow(nswindow);
+ 
+-	    if (winPtr2 && nswindow != window) {
+-		WmInfo *wmPtr = winPtr2->wmInfoPtr;
+-		BOOL minimized = (wmPtr->hints.initial_state == IconicState
+-			|| wmPtr->hints.initial_state == WithdrawnState);
++	/*
++	 * When a window is closed we want to move the focus to the next
++	 * highest window.  Apple's documentation says that calling the
++	 * orderOut method of the key window will accomplish this.  But
++	 * experiment shows that this is not the case.  So we have to reset the
++	 * key window ourselves.  When the window is the last one on the screen
++	 * there is no choice for a new key window.  Moreover, if the host
++	 * computer has a TouchBar then the TouchBar holds a reference to the
++	 * key window which prevents it from being deallocated until it stops
++	 * being the key window.  On these systems the only option for
++	 * preventing zombies is to set the key window to nil.
++	 */
+ 
+-		/*
+-		 * If no windows are left on the screen and the next window is
+-		 * iconified or withdrawn, we don't want to make it be the
+-		 * KeyWindow because that would cause it to be displayed on the
+-		 * screen.
+-		 */
++	for (NSWindow *w in [NSApp orderedWindows]) {
++	    TkWindow *winPtr2 = TkMacOSXGetTkWindow(w);
++	    BOOL isOnScreen;
+ 
+-		if ([nswindow canBecomeKeyWindow] && !minimized) {
+-		    [nswindow makeKeyAndOrderFront:NSApp];
+-		    break;
+-		}
++	    if (!winPtr2 || !winPtr2->wmInfoPtr) {
++		continue;
++	    }
++	    wmPtr2 = winPtr2->wmInfoPtr;
++	    isOnScreen = (wmPtr2->hints.initial_state != IconicState &&
++			  wmPtr2->hints.initial_state != WithdrawnState);
++	    if (w != ourNSWindow && isOnScreen && [w canBecomeKeyWindow]) {
++		[w makeKeyAndOrderFront:NSApp];
++		break;
+ 	    }
+ 	}
+ 
+ 	/*
+-	 * Process all window events immediately to force the closed window to
+-	 * be deallocated.  But don't do this for the root window as that is
+-	 * unnecessary and can lead to segfaults.
++	 * Prevent zombies on systems with a TouchBar.
+ 	 */
+ 
+-	if (winPtr->parentPtr) {
+-	    while (Tcl_DoOneEvent(TCL_WINDOW_EVENTS|TCL_DONT_WAIT)) {}
++	if (ourNSWindow == [NSApp keyWindow]) {
++	    [NSApp _setKeyWindow:nil];
++	    [NSApp _setMainWindow:nil];
+ 	}
++	[ourNSWindow close];
++	[ourNSWindow release];
+ 	[NSApp _resetAutoreleasePool];
+-#if DEBUG_ZOMBIES > 0
++
++#if DEBUG_ZOMBIES > 1
+ 	fprintf(stderr, "================= Pool dump ===================\n");
+ 	[NSAutoreleasePool showPools];
+ #endif
++
+     }
++
++    /*
++     * Deallocate the wmInfo and clear the wmInfoPtr.
++     */
++
+     ckfree(wmPtr);
+     winPtr->wmInfoPtr = NULL;
+ }

--- a/mac/stuff/Info.plist
+++ b/mac/stuff/Info.plist
@@ -55,6 +55,8 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Microphone access is required for audio input.</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -408,6 +408,10 @@ proc ::dialog_audio::pdtk_audio_dialog {mytoplevel \
         $mytoplevel.saveall config -highlightthickness 0
         $mytoplevel.buttonframe.ok config -highlightthickness 0
         $mytoplevel.buttonframe.cancel config -highlightthickness 0
+
+        # don't use -topmost on macOS with Tk 8.6+ as it places the window above
+        # *all* windows including those of other applications
+        catch {wm attributes $mytoplevel -topmost 0}
     }
 
     # set min size based on widget sizing & pos over pdwindow

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -118,7 +118,7 @@ proc ::dialog_font::create_dialog {gfxstub} {
     pack .font.buttonframe -side bottom -pady 2m
     button .font.buttonframe.ok -text [_ "OK"] \
         -command "::dialog_font::ok $gfxstub" -default active
-    pack .font.buttonframe.ok -side left -expand 1 -fill x -ipadx 10
+    pack .font.buttonframe.ok -side left -expand 1 -padx 15 -ipadx 10
 
     labelframe .font.fontsize -text [_ "Font Size"] -padx 5 -pady 4 -borderwidth 1 \
         -width [::msgcat::mcmax "Font Size"] -labelanchor n

--- a/tcl/dialog_message.tcl
+++ b/tcl/dialog_message.tcl
@@ -66,8 +66,6 @@ proc ::dialog_message::create_dialog {mytoplevel} {
     .message configure -menu $::dialog_menubar
     .message configure -padx 10 -pady 5
     ::pd_bindings::dialog_bindings .message "message"
-    # not all Tcl/Tk versions or platforms support -topmost, so catch the error
-    catch {wm attributes $id -topmost 1}
 
     frame .message.f
     pack .message.f -side top -fill x -expand 1

--- a/tcl/dialog_midi.tcl
+++ b/tcl/dialog_midi.tcl
@@ -406,6 +406,10 @@ proc ::dialog_midi::pdtk_midi_dialog {id \
         $id.saveall config -highlightthickness 0
         $id.buttonframe.ok config -highlightthickness 0
         $id.buttonframe.cancel config -highlightthickness 0
+
+        # don't use -topmost on macOS with Tk 8.6+ as it places the window above
+        # *all* windows including those of other applications
+        catch {wm attributes $id -topmost 0}
     }
 
     # set min size based on widget sizing & pos over pdwindow

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -23,8 +23,6 @@ proc ::dialog_startup::chooseCommand { prompt initialValue } {
     wm minsize .inputbox 450 30
     wm resizable .inputbox 0 0
     wm geom .inputbox "450x30"
-    # not all Tcl/Tk versions or platforms support -topmost, so catch the error
-    catch {wm attributes $mytoplevel -topmost 1}
 
     button .inputbox.button -text [_ "OK"] -command { destroy .inputbox } \
         -width [::msgcat::mcmax [_ "OK"]]

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -89,7 +89,10 @@ proc ::pd_menucommands::menu_toggle_editmode {} {
 
 # send a message to a pd canvas receiver
 proc ::pd_menucommands::menu_send {window message} {
-    set mytoplevel [winfo toplevel $window]
+    if { [catch {set mytoplevel [winfo toplevel $window]} ] } {
+        ::pdwindow::logpost {} 4 "menu_send: skipping unknown window '$window'\n"
+        return
+    }
     if {[winfo class $mytoplevel] eq "PatchWindow"} {
         pdsend "$mytoplevel $message"
     } elseif {$mytoplevel eq ".pdwindow"} {


### PR DESCRIPTION
## Update

I'm lumping in a few other fixes to this PR in lieu of opening a new one (lazy).

* [x] added Tk patch which fixes font dialog crash on systems with the Touchbar
* [x] audio and midi dialogs should no longer be set with `wm attribute -topmost 1` on macOS as they appear over *all* application windows
* [x] removed a couple other uses of `wm attribute -topmost 1` which were never actually applied as they use the wrong window variable name (copy/paste leftovers?), this can be reverted if I'm wrong
* [x] match font dialog ok button sizing to that of other dialogs 
* [x] fixed Pd showing Dark Mode on first launch, before disabling key is set in defaults preferences file

## Original Description

This PR fixes #1237 by adding a Tk 8.6.10 patch which backports commit for scrollbars on macOS 10.14 (and probably newer versions as well).

Apparently, they were not being updated on some events, so the TK scrollbars are not (re)drawn resulting in this for a patch with 1 object with a far xy location:

<img width="607" alt="Screen Shot 2020-12-15 at 11 19 09 PM" src="https://user-images.githubusercontent.com/480637/102279609-f9155300-3f2b-11eb-81bb-5f253dd3da65.png">

The same type of patch looks like this with this PR applied:

<img width="562" alt="Screen Shot 2020-12-15 at 11 20 08 PM" src="https://user-images.githubusercontent.com/480637/102279738-311c9600-3f2c-11eb-8d35-1ea57f1b82a1.png">



