### PR TITLE
fixed vertical offset issue in triggerize_line fn

### DIFF
--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -368,24 +368,31 @@ static int triggerize_line(t_glist*x, t_triggerize_return*tr)
             float posSource, posSink;
             int nio;
             int _x; /* dummy variable */
+	    int posSourceY, posSinkY;
+	    int boxHeight;  /* height of inserted box */
             int posLeft, posRight;
 
                 /* get real x-position of the outlet */
-            gobj_getrect(src, x, &posLeft, &_x, &posRight, &_x);
+            gobj_getrect(src, x, &posLeft, &_x, &posRight, &posSourceY);
             posLeft /= x->gl_zoom;
             posRight /= x->gl_zoom;
+	    posSourceY /= x->gl_zoom;
             nio = obj_noutlets(obj1);
             posSource = posLeft + (posRight - posLeft - IOWIDTH) * src_out / ((nio==1)?1.:(nio-1.));
 
                 /* get real x-position of the inlet */
-            gobj_getrect(dst, x, &posLeft, &_x, &posRight, &_x);
+            gobj_getrect(dst, x, &posLeft, &posSinkY, &posRight, &_x);
             posLeft /= x->gl_zoom;
             posRight /= x->gl_zoom;
+            posSinkY /= x->gl_zoom;
             nio = obj_ninlets(obj2);
             posSink = posLeft + (posRight - posLeft - IOWIDTH) * dst_in / ((nio==1)?1.:(nio-1.));
 
+		/* get height of the box that will be inserted */
+	    boxHeight = glist_fontheight(x) / x->gl_zoom + 4; /* ATOM_BMARGIN = 4 */
+
             posx = (posSource + posSink) * 0.5;
-            posy = (obj1->te_ypix + obj2->te_ypix) >> 1;
+            posy = (posSourceY + posSinkY - boxHeight) >> 1;
         }
     }
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1431894/102325697-baab8280-3f83-11eb-8f5e-8a0aa3c52f27.png)

when selecting a line between two objects and then pressing ctrl + t, the new trigger box (or pd nop~) is created in the wrong place if the first object (source) height is bigger than default object height (due to its gop properties enabled).
image.
The proposed modification in g_editor_extras.c fixes this issue.
This pull request substitutes https://github.com/pure-data/pure-data/pull/1241