### PR TITLE
make sure object is visible for drawing cords and gatom labels when displacing

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -941,8 +941,10 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
     {
         x->gl_obj.te_xpix += dx;
         x->gl_obj.te_ypix += dy;
-        glist_redraw(x);
-        canvas_fixlinesfor(glist, &x->gl_obj);
+        if (glist_isvisible(glist)) {
+            glist_redraw(x);
+            canvas_fixlinesfor(glist, &x->gl_obj);
+        }
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -895,8 +895,9 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
 {
     t_gatom *x = (t_gatom*)z;
     text_displace(z, glist, dx, dy);
-    sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
-        x, dx * glist->gl_zoom, dy * glist->gl_zoom);
+    if (glist_isvisible(glist))
+        sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
+            x, dx * glist->gl_zoom, dy * glist->gl_zoom);
 }
 
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)


### PR DESCRIPTION
Fixes #1133 