### PR TITLE
clip objects in GOP subpatch correctly in font dialog "stretch"

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4768,24 +4768,22 @@ static void canvas_dofont(t_canvas *x, t_floatarg font, t_floatarg xresize,
 {
     t_gobj *y;
     x->gl_font = font;
-    if (xresize != 1 || yresize != 1)
-    {
-        canvas_setundo(x, canvas_undo_move, canvas_undo_set_move(x, 0),
-            "motion");
-        for (y = x->gl_list; y; y = y->g_next)
-        {
-            int x1, x2, y1, y2, nx1, ny1;
-            gobj_getrect(y, x, &x1, &y1, &x2, &y2);
-            nx1 = x1 * xresize + 0.5;
-            ny1 = y1 * yresize + 0.5;
-            gobj_displace(y, x, nx1-x1, ny1-y1);
-        }
-    }
-    if (glist_isvisible(x))
-        glist_redraw(x);
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_checkglist(&y->g_pd)  && !canvas_isabstraction((t_canvas *)y))
-            canvas_dofont((t_canvas *)y, font, xresize, yresize);
+    if (xresize != 1 || yresize != 1) {
+		canvas_setundo(x, canvas_undo_move, canvas_undo_set_move(x, 0),
+			"motion");
+		for (y = x->gl_list; y; y = y->g_next)
+		{
+			int x1, x2, y1, y2, nx1, ny1, vised;
+			gobj_getrect(y, x, &x1, &y1, &x2, &y2);
+			nx1 = x1 * xresize + 0.5;
+			ny1 = y1 * yresize + 0.5;
+			gobj_displace(y, x, nx1-x1, ny1-y1);
+		}
+	}
+	for (y = x->gl_list; y; y = y->g_next)
+		if (pd_checkglist(&y->g_pd)  && !canvas_isabstraction((t_canvas *)y))
+			canvas_dofont((t_canvas *)y, font, xresize, yresize);
+	if(x->gl_havewindow) canvas_redraw(x);
 }
 
     /* canvas_menufont calls up a TK dialog which calls this back */
@@ -4805,6 +4803,8 @@ static void canvas_font(t_canvas *x, t_floatarg font, t_floatarg resize,
     if (whichresize != 3) realresx = realresize;
     if (whichresize != 2) realresy = realresize;
     canvas_dofont(x2, font, realresx, realresy);
+    if ((realresx != 1 || realresx != 1) || (oldfont != (int)font))
+    	canvas_dirty(x2, 1);
     canvas_undo_add(x2, UNDO_FONT, "font",
         canvas_undo_set_font(x2, oldfont, realresize, whichresize));
 


### PR DESCRIPTION
I noticed some more gop clipping issues when working on the font stretch tcl error bug #1245 
glist_redraw was not cutting it, canvas_redraw seems to be necessary. also set the canvas "dirty" flag after font change.

the problem was that, when using the font "stretch" entry: if a GOP non-abstraction subpatch was on the canvas, the graphcal items in the gop object would be "gobj_displace"d and redrawn on the parent canvas instead of clipped out of the child GOP, since the graphical objects contained had no way of knowing to clip themselves. (by the time glist_redraw was called the objects had already been drawn to the wrong canvas)
the window dimensions were also not getting updated correctly