### PR TITLE
increase ATOMBUFSIZE to 200, max symbol atom width to 120

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -507,7 +507,7 @@ void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 
 /* ---------------------- the "atom" text item ------------------------ */
 
-#define ATOMBUFSIZE 40
+#define ATOMBUFSIZE 200
 #define ATOM_LABELLEFT 0
 #define ATOM_LABELRIGHT 1
 #define ATOM_LABELUP 2
@@ -840,8 +840,8 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
     x->a_draghi = draghi;
     if (width < 0)
         width = 4;
-    else if (width > 80)
-        width = 80;
+    else if (width > 120)
+        width = 120;
     x->a_text.te_width = width;
     x->a_wherelabel = ((int)wherelabel & 3);
     x->a_label = label;


### PR DESCRIPTION
I know about symbol table pollution etc., still, that artificial limit is annoying. If there is no technical reason to keep it that low, I'd like to have it increased. Also, I don't understand why one is allowed to create symbol atoms with a width larger than the largest symbol one can type. I'd rather have it the other way around. 