### PR TITLE
Update dialog_path.tcl (remove "fonts", add "audio/text" in top description)

### DIFF
--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -46,7 +46,7 @@ proc ::dialog_path::create_dialog {mytoplevel} {
     global installpath
     ::scrollboxwindow::make $mytoplevel $::sys_searchpath \
         dialog_path::add dialog_path::edit dialog_path::commit \
-        [_ "Pd search path for objects, help, fonts, and other files"] \
+        [_ "Pd search path for objects, help, audio, text and other files"] \
         450 300 1
     wm withdraw $mytoplevel
     ::pd_bindings::dialog_bindings $mytoplevel "path"


### PR DESCRIPTION
i'm removing "fonts" from the path's top description. This is misleading as it can make someone (like me) believe Pd handles fonts easily when this is only true for Gem and Gem's documentation makes it clear that you can have fonts in your path that it'll handle.

I just replaced for other file types that actually make sense for Pd (audio/text) and also made ir vague that you can have "other" files. But I didn't get into that... if I tried to tell people that externals may open different kinds of files, i'd take up too much space.