### PR TITLE
allow large amounts of data to be sent to the GUI (and limit the Pd-console's length)

### DIFF
--- a/m4/universal.m4
+++ b/m4/universal.m4
@@ -65,7 +65,7 @@ if test "$universal_binary" != no; then
     
     dnl add to arch list if it passes the linker
     AC_MSG_CHECKING([if linker accepts arch: $arch])
-    AC_TRY_LINK([], [return 0;], [
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])], [
       _pd_universal="$_pd_universal -arch $arch"
       AC_MSG_RESULT([yes])
     ], [

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -675,8 +675,7 @@ static void sys_trytogetmoreguibuf(int newsize)
     if (newsize > 70000 && sizewas < 70000)
     {
         int i;
-        for (i = INTER->i_guitail;
-            i < INTER->i_guihead; i++)
+        for (i = INTER->i_guitail; i < INTER->i_guihead; i++)
                 fputc(INTER->i_guibuf[i], stderr);
     }
     sizewas = newsize;
@@ -691,14 +690,14 @@ static void sys_trytogetmoreguibuf(int newsize)
         this by intentionally setting newbuf to zero */
     if (!newbuf)
     {
-        int bytestowrite = INTER->i_guitail -
-            INTER->i_guihead;
+        int bytestowrite = INTER->i_guitail - INTER->i_guihead;
         int written = 0;
         while (1)
         {
-            int res = (int)send(INTER->i_guisock,
-                INTER->i_guibuf + INTER->i_guitail +
-                    written, bytestowrite, 0);
+            int res = (int)send(
+                INTER->i_guisock,
+                INTER->i_guibuf + INTER->i_guitail + written,
+                bytestowrite, 0);
             if (res < 0)
             {
                 perror("pd output pipe");
@@ -742,15 +741,14 @@ void sys_vgui(const char *fmt, ...)
         INTER->i_guisize = GUI_ALLOCCHUNK;
         INTER->i_guihead = INTER->i_guitail = 0;
     }
-    if (INTER->i_guihead > INTER->i_guisize -
-        (GUI_ALLOCCHUNK/2))
-            sys_trytogetmoreguibuf(INTER->i_guisize +
-                GUI_ALLOCCHUNK);
+    if (INTER->i_guihead > INTER->i_guisize - (GUI_ALLOCCHUNK/2)) {
+            sys_trytogetmoreguibuf(INTER->i_guisize + GUI_ALLOCCHUNK);
+    }
     va_start(ap, fmt);
-    msglen = vsnprintf(INTER->i_guibuf +
-        INTER->i_guihead,
-            INTER->i_guisize - INTER->i_guihead,
-                fmt, ap);
+    msglen = vsnprintf(
+        INTER->i_guibuf  + INTER->i_guihead,
+        INTER->i_guisize - INTER->i_guihead,
+        fmt, ap);
     va_end(ap);
     if(msglen < 0)
     {
@@ -760,25 +758,25 @@ void sys_vgui(const char *fmt, ...)
     }
     if (msglen >= INTER->i_guisize - INTER->i_guihead)
     {
-        int msglen2, newsize = INTER->i_guisize + 1 +
-            (msglen > GUI_ALLOCCHUNK ? msglen : GUI_ALLOCCHUNK);
+        int msglen2, newsize =
+            INTER->i_guisize
+            + 1
+            + (msglen > GUI_ALLOCCHUNK ? msglen : GUI_ALLOCCHUNK);
         sys_trytogetmoreguibuf(newsize);
 
         va_start(ap, fmt);
-        msglen2 = vsnprintf(INTER->i_guibuf +
-            INTER->i_guihead,
-                INTER->i_guisize - INTER->i_guihead,
-                    fmt, ap);
+        msglen2 = vsnprintf(
+            INTER->i_guibuf  + INTER->i_guihead,
+            INTER->i_guisize - INTER->i_guihead,
+            fmt, ap);
         va_end(ap);
         if (msglen2 != msglen)
             bug("sys_vgui");
-        if (msglen >= INTER->i_guisize -
-            INTER->i_guihead) msglen =
-                INTER->i_guisize - INTER->i_guihead;
+        if (msglen >= INTER->i_guisize - INTER->i_guihead)
+            msglen  = INTER->i_guisize - INTER->i_guihead;
     }
     if (sys_debuglevel & DEBUG_MESSUP)
-        fprintf(stderr, "%s",
-            INTER->i_guibuf + INTER->i_guihead);
+        fprintf(stderr, "%s", INTER->i_guibuf + INTER->i_guihead);
     INTER->i_guihead += msglen;
     INTER->i_bytessincelastping += msglen;
 }
@@ -793,9 +791,10 @@ static int sys_flushtogui(void)
     int writesize = INTER->i_guihead - INTER->i_guitail,
         nwrote = 0;
     if (writesize > 0)
-        nwrote = (int)send(INTER->i_guisock,
+        nwrote = (int)send(
+            INTER->i_guisock,
             INTER->i_guibuf + INTER->i_guitail,
-                writesize, 0);
+            writesize, 0);
 
 #if 0
     if (writesize)
@@ -809,20 +808,17 @@ static int sys_flushtogui(void)
     }
     else if (!nwrote)
         return (0);
-    else if (nwrote >= INTER->i_guihead -
-        INTER->i_guitail)
-            INTER->i_guihead = INTER->i_guitail = 0;
+    else if (nwrote >= INTER->i_guihead - INTER->i_guitail)
+        INTER->i_guihead = INTER->i_guitail = 0;
     else if (nwrote)
     {
         INTER->i_guitail += nwrote;
         if (INTER->i_guitail > (INTER->i_guisize >> 2))
         {
             memmove(INTER->i_guibuf,
-                INTER->i_guibuf + INTER->i_guitail,
-                    INTER->i_guihead -
-                        INTER->i_guitail);
-            INTER->i_guihead = INTER->i_guihead -
-                INTER->i_guitail;
+                INTER->i_guibuf  + INTER->i_guitail,
+                INTER->i_guihead - INTER->i_guitail);
+            INTER->i_guihead = INTER->i_guihead - INTER->i_guitail;
             INTER->i_guitail = 0;
         }
     }
@@ -919,23 +915,21 @@ void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
 void sys_unqueuegui(void *client)
 {
     t_guiqueue *gq, *gq2;
-    while (INTER->i_guiqueuehead &&
-        INTER->i_guiqueuehead->gq_client == client)
+    while (INTER->i_guiqueuehead && INTER->i_guiqueuehead->gq_client == client)
     {
         gq = INTER->i_guiqueuehead;
-        INTER->i_guiqueuehead =
-            INTER->i_guiqueuehead->gq_next;
+        INTER->i_guiqueuehead = INTER->i_guiqueuehead->gq_next;
         t_freebytes(gq, sizeof(*gq));
     }
     if (!INTER->i_guiqueuehead)
         return;
     for (gq = INTER->i_guiqueuehead; (gq2 = gq->gq_next); gq = gq2)
         if (gq2->gq_client == client)
-    {
-        gq->gq_next = gq2->gq_next;
-        t_freebytes(gq2, sizeof(*gq2));
-        break;
-    }
+        {
+            gq->gq_next = gq2->gq_next;
+            t_freebytes(gq2, sizeof(*gq2));
+            break;
+        }
 }
 
     /* poll for any incoming packets, or for GUI updates to send.  call with

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -700,7 +700,7 @@ static void sys_trytogetmoreguibuf(int newsize)
         this by intentionally setting newbuf to zero */
     if (!newbuf)
     {
-        int bytestowrite = INTER->i_guitail - INTER->i_guihead;
+        int bytestowrite = INTER->i_guihead - INTER->i_guitail;
         int written = 0;
         while (1)
         {

--- a/tcl/pd_connect.tcl
+++ b/tcl/pd_connect.tcl
@@ -3,7 +3,7 @@ package provide pd_connect 0.1
 
 namespace eval ::pd_connect:: {
     variable pd_socket
-    variable cmds_from_pd ""
+    variable cmdbuf ""
     variable plugin_dispatch_receivers
 
     namespace export to_pd
@@ -70,20 +70,20 @@ proc ::pd_connect::register_plugin_dispatch_receiver { nameatom callback } {
 
 proc ::pd_connect::pd_readsocket {} {
      variable pd_socket
-     variable cmds_from_pd
+     variable cmdbuf
      if {[eof $pd_socket]} {
          # if we lose the socket connection, that means pd quit, so we quit
          close $pd_socket
          exit
-     } 
-     append cmds_from_pd [read $pd_socket]
-     if {[string index $cmds_from_pd end] ne "\n" || \
-             ![info complete $cmds_from_pd]} {
+     }
+     append cmdbuf [read $pd_socket]
+     if {[string index $cmdbuf end] ne "\n" || \
+             ![info complete $cmdbuf]} {
          # the block is incomplete, wait for the next block of data
          return
      } else {
-         set docmds $cmds_from_pd
-         set cmds_from_pd ""
+         set docmds $cmdbuf
+         set cmdbuf ""
          if {![catch {uplevel #0 $docmds} errorname]} {
              # we ran the command block without error, reset the buffer
          } else {

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -198,6 +198,7 @@ proc ::pdwindow::verbose {level message} {
 # clear the log and the buffer
 proc ::pdwindow::clear_console {} {
     variable logbuffer {}
+    variable _curlogbuffer 0
     .pdwindow.text.internal delete 0.0 end
 }
 

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -136,7 +136,7 @@ proc ::pdwindow::logpost {object_id level message} {
         after idle .pdwindow.text.internal yview end
     }
     # -stderr only sets $::stderr if 'pd-gui' is started before 'pd'
-    if {$::stderr} {puts stderr $message}
+    if {$::stderr} {puts -nonewline stderr $message}
 }
 
 # shortcuts for posting to the Pd window

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -56,7 +56,7 @@ proc ::pdwindow::busyrelease {} {
 
 proc ::pdwindow::buffer_message {object_id level message} {
     variable logbuffer
-    lappend logbuffer $object_id $level $message
+    lappend logbuffer [list $object_id $level $message]
 }
 
 proc ::pdwindow::insert_log_line {object_id level message} {
@@ -80,9 +80,11 @@ proc ::pdwindow::filter_buffer_to_text {args} {
     variable maxloglevel
     .pdwindow.text.internal delete 0.0 end
     set i 0
-    foreach {object_id level message} $logbuffer {
-        if { $level <= $::loglevel || $maxloglevel == $::loglevel} {
-            insert_log_line $object_id $level $message
+    foreach logentry $logbuffer {
+        foreach {object_id level message} $logentry {
+            if { $level <= $::loglevel || $maxloglevel == $::loglevel} {
+                insert_log_line $object_id $level $message
+            }
         }
         # this could take a while, so update the GUI every 10000 lines
         if { [expr $i % 10000] == 0} {update idletasks}
@@ -160,8 +162,10 @@ proc ::pdwindow::save_logbuffer_to_file {} {
     set f [open $filename w]
     puts $f "Pd $::PD_MAJOR_VERSION.$::PD_MINOR_VERSION-$::PD_BUGFIX_VERSION$::PD_TEST_VERSION on $::tcl_platform(os) $::tcl_platform(machine)"
     puts $f "--------------------------------------------------------------------------------"
-    foreach {object_id level message} $logbuffer {
-        puts -nonewline $f $message
+    foreach logentry $logbuffer {
+        foreach {object_id level message} $logentry {
+            puts -nonewline $f $message
+        }
     }
     ::pdwindow::post "saved console to: $filename\n"
     close $f

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -12,7 +12,8 @@ namespace eval ::pdwindow:: {
     variable logmenuitems
     variable maxloglevel 4
 
-    variable lastlevel 0
+    # private variables
+    variable _lastlevel 0       ;# loglevel of last post (for automatic endpost level)
 
     namespace export create_window
     namespace export pdtk_post
@@ -123,7 +124,7 @@ proc ::pdwindow::select_by_id {args} {
 # information about the patches they are building
 proc ::pdwindow::logpost {object_id level message} {
     variable maxloglevel
-    variable lastlevel $level
+    variable _lastlevel $level
 
     buffer_message $object_id $level $message
     if {[llength [info commands .pdwindow.text.internal]] &&
@@ -151,8 +152,8 @@ proc ::pdwindow::pdtk_post {message} {post $message}
 
 proc ::pdwindow::endpost {} {
     variable linecolor
-    variable lastlevel
-    logpost {} $lastlevel "\n"
+    variable _lastlevel
+    logpost {} $_lastlevel "\n"
     set linecolor [expr ! $linecolor]
 }
 


### PR DESCRIPTION
currently the GUI crashes when printing *large* amounts of data, as can happen when accidentally `[print]`ing a counter that 
 (#345).

a very simple example of such a crashing patch is:
~~~pd
#N canvas 851 401 450 300 12;
#X msg 86 46 1e+07;
#X obj 86 71 until;
#X obj 86 121 print;
#X msg 86 96 1 2 3 4;
#X connect 0 0 1 0;
#X connect 1 0 3 0;
#X connect 3 0 2 0;
~~~

there were several underlying issues:
- the Pd-console keeps all messages ever printed (unless explicitely cleared). this obviously fills the memory over time.
- an integer-overflow when allocating more memory for gui messages
- untested and broken code leading to data loss (and thus un-executable tcl-code) in the core->gui communication was triggered whenever such an integer-overflow occured
- the GUI - hoping to recover from the data-loss - would allocate more and more memory until it eventually crashed.
- the GUI would also crash if the cmdbuffer received from the core would not end with `LF` (`\n`) for more than 2GB.

this PR fixes this in multiple ways:
- prevent integer-overflow when allocating more memory for the GUI-communication
- fix the code that synchronously flushes the data to the GUI when the queue gets stuck (this is an emergency handling to keep the system alive, and as such it is not realtime friendly at all)
- improve the code on the (receiving) GUI side that checks whether the cmdbuffer can actually be executed.
- limit the maximum number of lines displayed in the Pd-console (whenever the `::pdwindow::maxlogbuffer` limit is exceeded, the Pd-console is cleared except for the last `::pdwindow::keeplogbuffer` lines. these values are currently set to `21000` (max. number of lines) resp. `1000` (lines to keep when autoclearing); the idea is to LATER make this settable via GUI-preferences)