### PR TITLE
Fix "buffer overflow detected" crash caused by incorrect JACK client name size limit

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -21,6 +21,9 @@
 #define MAX_CLIENTS 100
 #define MAX_JACK_PORTS 128  /* higher values seem to give bad xrun problems */
 #define BUF_JACK 4096
+/* taken from the PipeWire libjack implementation: the larger of the
+ * `JACK_CLIENT_NAME_SIZE` definitions I could find in the wild. */
+#define CLIENT_NAME_SIZE_FALLBACK 128
 
 static jack_nframes_t jack_out_max;
 static jack_nframes_t jack_filled = 0;
@@ -190,6 +193,8 @@ static int jack_xrun(void* arg) {
 static char** jack_get_clients(void)
 {
     const char **jack_ports;
+    int tmp_client_name_size = jack_client_name_size ? jack_client_name_size() : CLIENT_NAME_SIZE_FALLBACK;
+    char* tmp_client_name = (char*)getbytes(tmp_client_name_size);
     int i,j;
     int num_clients = 0;
     regex_t port_regex;
@@ -203,7 +208,6 @@ static char** jack_get_clients(void)
     {
         int client_seen;
         regmatch_t match_info;
-        char tmp_client_name[100];
 
         if(num_clients>=MAX_CLIENTS)break;
 
@@ -251,6 +255,7 @@ static char** jack_get_clients(void)
 
     /*    for (i=0;i<num_clients;i++) post("client: %s",jack_client_names[i]); */
 
+    freebytes( tmp_client_name, tmp_client_name_size );
     free( jack_ports );
     return jack_client_names;
 }


### PR DESCRIPTION
This removes the arbitrary `100` byte limit on JACK client names in
favour of using the limit specified by JACK itself.

From the [JACK docs][1]:

> `jack_client_name_size()`
>
> the maximum number of characters in a JACK client name including the
> final NULL character. This value is a constant.

If I `printf` the value locally, the constant turns out to be `128`.

I ran into this issue as I happen to have a default client name on my
device (Dell XPS 9310) that is `108` bytes long heh! This meant that
when selecting "jack" in the "Media" menu, pd would instantly crash.

See NixOS/nixpkgs#118835 for how I debugged and solved this.

After applying this patch, I can now use pure data with JACK
successfully.

[1]: https://jackaudio.org/api/group__ClientFunctions.html