### PR TITLE
Don't force the pdwindow into the upper-left corner of the screen

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -38,16 +38,6 @@ typedef struct _canvas_private
 #define GLIST_DEFCANVASWIDTH 450
 #define GLIST_DEFCANVASHEIGHT 300
 
-/* since the window decorations aren't included, open new windows a few
-pixels down so you can possibly move the window later.  Apple needs less
-because its menus are at top of screen; we're more generous for other
-desktops because the borders have both window title area and menus. */
-#ifdef __APPLE__
-#define GLIST_DEFCANVASYLOC 22
-#else
-#define GLIST_DEFCANVASYLOC 50
-#endif
-
 /* ---------------------- variables --------------------------- */
 
 t_class *canvas_class;
@@ -331,7 +321,7 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     t_canvas *owner = canvas_getcurrent();
     t_symbol *s = &s_;
     int vis = 0, width = GLIST_DEFCANVASWIDTH, height = GLIST_DEFCANVASHEIGHT;
-    int xloc = 0, yloc = GLIST_DEFCANVASYLOC;
+    int xloc = GLIST_DEFCANVASXLOC, yloc = GLIST_DEFCANVASYLOC;
     int font = (owner ? owner->gl_font : sys_defaultfont);
     glist_init(x);
     x->gl_obj.te_type = T_OBJECT;
@@ -488,10 +478,10 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_font =  (canvas_getcurrent() ?
         canvas_getcurrent()->gl_font : sys_defaultfont);
     x->gl_zoom = g->gl_zoom;
-    x->gl_screenx1 = 0;
+    x->gl_screenx1 = GLIST_DEFCANVASXLOC;
     x->gl_screeny1 = GLIST_DEFCANVASYLOC;
-    x->gl_screenx2 = 450;
-    x->gl_screeny2 = 300;
+    x->gl_screenx2 = GLIST_DEFCANVASWIDTH;
+    x->gl_screeny2 = GLIST_DEFCANVASHEIGHT;
     x->gl_owner = g;
     canvas_bind(x);
     x->gl_isgraph = 1;
@@ -1061,8 +1051,9 @@ static void *subcanvas_new(t_symbol *s)
 {
     t_atom a[6];
     t_canvas *x, *z = canvas_getcurrent();
+
     if (!*s->s_name) s = gensym("/SUBPATCH/");
-    SETFLOAT(a, 0);
+    SETFLOAT(a+0, GLIST_DEFCANVASXLOC);
     SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
     SETFLOAT(a+2, GLIST_DEFCANVASWIDTH);
     SETFLOAT(a+3, GLIST_DEFCANVASHEIGHT);

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -51,6 +51,13 @@ extern "C" {
 #define GLIST_DEFGRAPHWIDTH 200
 #define GLIST_DEFGRAPHHEIGHT 140
 
+#define GLIST_DEFCANVASXLOC 0
+#ifdef __APPLE__
+#define GLIST_DEFCANVASYLOC 22
+#else
+#define GLIST_DEFCANVASYLOC 50
+#endif
+
 /* ----------------------- data ------------------------------- */
 
 typedef struct _updateheader

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1981,11 +1981,19 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             t_undo *undo = canvas_undo_get(x);
             t_undo_action *udo = undo ? undo->u_last : 0;
             canvas_create_editor(x);
-            sys_vgui("pdtk_canvas_new .x%lx %d %d +%d+%d %d\n", x,
-                (int)(x->gl_screenx2 - x->gl_screenx1),
-                (int)(x->gl_screeny2 - x->gl_screeny1),
-                (int)(x->gl_screenx1), (int)(x->gl_screeny1),
-                x->gl_edit);
+            if ((GLIST_DEFCANVASXLOC == x->gl_screenx1) && (GLIST_DEFCANVASYLOC == x->gl_screeny1)) /* initial values for new windows */
+            {
+                sys_vgui("pdtk_canvas_new .x%lx %d %d {} %d\n", x,
+                    (int)(x->gl_screenx2 - x->gl_screenx1),
+                    (int)(x->gl_screeny2 - x->gl_screeny1),
+                    x->gl_edit);
+            } else {
+                sys_vgui("pdtk_canvas_new .x%lx %d %d +%d+%d %d\n", x,
+                    (int)(x->gl_screenx2 - x->gl_screenx1),
+                    (int)(x->gl_screeny2 - x->gl_screeny1),
+                    (int)(x->gl_screenx1), (int)(x->gl_screeny1),
+                    x->gl_edit);
+            }
             snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx",
                 (unsigned long)c);
             while (c->gl_owner) {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -56,8 +56,8 @@ static void *table_donew(t_symbol *s, int size, int flags,
     }
     if (size < 1)
         size = 100;
-    SETFLOAT(a, 0);
-    SETFLOAT(a+1, 50);
+    SETFLOAT(a, GLIST_DEFCANVASXLOC);
+    SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
     SETFLOAT(a+2, xpix + 100);
     SETFLOAT(a+3, ypix + 100);
     SETSYMBOL(a+4, s);

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -49,10 +49,10 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
     }
 
         /* make a canvas... */
-    SETFLOAT(a, 0);
-    SETFLOAT(a+1, 50);
-    SETFLOAT(a+2, 600);
-    SETFLOAT(a+3, 400);
+    SETFLOAT(a+0, GLIST_DEFCANVASXLOC); /* xpos */
+    SETFLOAT(a+1, GLIST_DEFCANVASYLOC); /* ypos */
+    SETFLOAT(a+2, 600); /* width */
+    SETFLOAT(a+3, 400); /* height */
     SETSYMBOL(a+4, s);
     SETFLOAT(a+5, 0);
     x = canvas_new(0, 0, 6, a);

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -307,11 +307,6 @@ proc init_for_platform {} {
                     ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 0
-            # Tk handles the window placement differently on each
-            # platform. With X11, the x,y placement refers to the window
-            # frame's upper left corner. http://wiki.tcl.tk/11502
-            set ::windowframex 3
-            set ::windowframey 53
             # trying loading icon in the GUI directory
             if {$::tcl_version >= 8.5} {
                 set icon [file join $::sys_guidir pd.gif]
@@ -361,11 +356,6 @@ proc init_for_platform {} {
                 ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 22
-            # Tk handles the window placement differently on each platform, on
-            # Mac OS X, the x,y placement refers to the content window's upper
-            # left corner (not of the window frame) http://wiki.tcl.tk/11502
-            set ::windowframex 0
-            set ::windowframey 0
             # mouse cursors for all the different modes
             set ::cursor_runmode_nothing "arrow"
             set ::cursor_runmode_clickme "center_ptr"
@@ -396,12 +386,6 @@ proc init_for_platform {} {
                     ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 0
-            # Tk handles the window placement differently on each platform, on
-            # Mac OS X, the x,y placement refers to the content window's upper
-            # left corner. http://wiki.tcl.tk/11502
-            # TODO this probably needs a script layer: http://wiki.tcl.tk/11291
-            set ::windowframex 0
-            set ::windowframey 0
             # TODO use 'winico' package for full, hicolor icon support
             wm iconbitmap . -default [file join $::sys_guidir pd.ico]
             # add local fonts to Tk's font list using pdfontloader

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -347,9 +347,11 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     if {$width == 1 || $height == 1} {
         # make sure the window is fully created
         update idletasks
-        set width [winfo width $mytoplevel]
-        set height [winfo height $mytoplevel]
     }
+    # the geometry we receive from the callback is really for the frame
+    # however, we need position including the border decoration
+    # as this is how we restore the position
+    scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
     pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
     # send the size/location of the window and canvas to 'pd' in the form of:
     #    left top right bottom

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -50,7 +50,7 @@ if {$::tcl_version < 8.5 || \
         }
         if {$h > $height} {
             # 30 for window framing
-            set h [expr $height - $::menubarsize - $::windowframey]
+            set h [expr $height - $::menubarsize]
             set y $::menubarsize
         }
 
@@ -71,16 +71,9 @@ if {$::tcl_version < 8.5 || \
 # easy for people to customize these calculations based on their Window
 # Manager, desires, etc.
 proc pdtk_canvas_place_window {width height geometry} {
-    ::pdwindow::configure_window_offset
-
     # read back the current geometry +posx+posy into variables
     scan $geometry {%[+]%d%[+]%d} - x - y
-    set xywh [pdtk_canvas_wrap_window \
-        [expr $x - $::windowframex] [expr $y - $::windowframey] $width $height]
-    set x [lindex $xywh 0]
-    set y [lindex $xywh 1]
-    set w [lindex $xywh 2]
-    set h [lindex $xywh 3]
+    foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
     return [list ${w} ${h} ${w}x${h}+${x}+${y}]
 }
 
@@ -89,10 +82,7 @@ proc pdtk_canvas_place_window {width height geometry} {
 # canvas new/saveas
 
 proc pdtk_canvas_new {mytoplevel width height geometry editable} {
-    set l [pdtk_canvas_place_window $width $height $geometry]
-    set width [lindex $l 0]
-    set height [lindex $l 1]
-    set geometry [lindex $l 2]
+    foreach {width height geometry} [pdtk_canvas_place_window $width $height $geometry] {break;}
     set ::undo_actions($mytoplevel) no
     set ::redo_actions($mytoplevel) no
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -72,9 +72,14 @@ if {$::tcl_version < 8.5 || \
 # Manager, desires, etc.
 proc pdtk_canvas_place_window {width height geometry} {
     # read back the current geometry +posx+posy into variables
-    scan $geometry {%[+]%d%[+]%d} - x - y
-    foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
-    return [list ${w} ${h} ${w}x${h}+${x}+${y}]
+    set w $width
+    set h $height
+    if { "" != ${geometry} } {
+        scan $geometry {%[+]%d%[+]%d} - x - y
+        foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
+        set geometry +${x}+${y}
+    }
+    return [list ${w} ${h} ${geometry}]
 }
 
 
@@ -100,7 +105,9 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable} {
     # started_loading_file proc.  Perhaps this doesn't make sense tho
     event generate $mytoplevel <<Loading>>
 
-    wm geometry $mytoplevel $geometry
+    if { "" != ${geometry} } {
+        wm geometry $mytoplevel $geometry
+    }
     wm minsize $mytoplevel $::canvas_minwidth $::canvas_minheight
 
     set tkcanvas [tkcanvas_name $mytoplevel]

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -338,7 +338,7 @@ proc ::pdwindow::create_window {} {
     } else {
         wm minsize .pdwindow 400 51
     }
-    wm geometry .pdwindow =500x400+20+50
+    wm geometry .pdwindow =500x400
 
     frame .pdwindow.header -borderwidth 1 -relief flat -background lightgray
     pack .pdwindow.header -side top -fill x -ipady 5

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -445,30 +445,6 @@ proc ::pdwindow::create_window_finalize {} {
     }
 }
 
-proc ::pdwindow::configure_window_offset {{winid .pdwindow}} {
-    # on X11 measure the size of the window decoration, so we can open windows at the correct position
-    if {$::windowingsystem eq "x11"} {
-        if {[winfo viewable $winid]} {
-            # wait for possible race-conditions at startup...
-            if {[winfo viewable .pdwindow] && ![winfo viewable .pdwindow.header.pad1]} {
-                tkwait visibility .pdwindow.header.pad1
-            }
-
-            regexp -- {([0-9]+)x([0-9]+)\+(-?[0-9]+)\+(-?[0-9]+)} [wm geometry $winid] -> \
-                _ _ _left _top
-            set ::windowframex [expr {[winfo rootx $winid] - $_left}]
-            set ::windowframey [expr {[winfo rooty $winid] - $_top}]
-
-            #puts "======================="
-            #puts "[wm geometry $winid]"
-            #puts "winfo [winfo rootx $winid] [winfo rooty $winid]"
-            #puts "windowframe: $winid $::windowframex $::windowframey"
-            #puts "======================="
-        }
-    }
-}
-
-
 # this needs to happen *after* the main menu is created, otherwise the default Wish
 # menu is not replaced by the custom Apple menu on OSX
 proc ::pdwindow::configure_menubar {} {


### PR DESCRIPTION
instead let the WM choose

this most likely will put the PdWindow in the center.
on my system (Linux, multi-monitor) it puts the PdWindow in the center of
the currently active monitor; which is nice if the leftmost monitor is
occupied by something else and you actually work on a righthand monitor)

## update

this PR lets the Window Manager (WM) choose the position of the PdWindow ("Pd console") and the *initial* position of a newly created patch window.
given that window managers have invested significant brainpower into how to best place windows for the user (and some of them even let the user configure how they want this window positioning to happen), i think we should rely on their powers rather than inventing our own ad-hoc solution for the problem (which some people - including myself - find irritating).

once a patch window gets saved, the window position is stored within the patch and respected once the patch gets re-opened.

the PR also improves accurate storing/restoring of window positions, regardless of the size of the window borders.
(the only exception is on Windows, where a slim window with a wrapped menu-bar gets wrongly positioned; this has been a known issue for some time and is not a regression; it seems there really is [no general solution for *this* problem](https://stackoverflow.com/questions/67177411))


for those who really want a fixed position of the main PdWindow, a trivial GUI-plugin can do that job.

e.g. putting the following `pdwindow-position-plugin.tcl` into the `extra/` folder (or some other path search by Pd on startup) will restore the original behaviour:

```
if {[winfo exists .pdwindow]} {
    wm geometry .pdwindow  =500x400+20+50
}
``` 