### PR TITLE
Release cursor if binbuf_read fails

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2086,5 +2086,6 @@ void glob_open(t_pd *ignore, t_symbol *name, t_symbol *dir, t_floatarg f)
         canvas_vis(gl, 1);
         return;
     }
-    glob_evalfile(ignore, name, dir);
+    if (!glob_evalfile(ignore, name, dir))
+        sys_vgui("::pdwindow::busyrelease\n");
 }


### PR DESCRIPTION
The cursor is grabbed when Pd expects that a canvas is going to be created, but if `binbuf_read` fails, `proc pdtk_canvas_new` won't get called and the cursor won't be released.