### PR TITLE
prevent duplicate connections

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4341,7 +4341,7 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
 
         /* check if objects are already connected */
     if (canvas_isconnected(x, objsrc, outno, objsink, inno)) {
-        logpost(src, 3, "this pair of iolets is already connected");
+        logpost(src, 3, "io pair already connected");
         goto bad;
     }
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4341,7 +4341,7 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
 
         /* check if objects are already connected */
     if (canvas_isconnected(x, objsrc, outno, objsink, inno)) {
-        logpost(src, 3, "refusing duplicate connection");
+        logpost(src, 3, "this pair of iolets is already connected");
         goto bad;
     }
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4320,14 +4320,30 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     if (EDITOR->paste_canvas == x) whoout += EDITOR->paste_onset,
         whoin += EDITOR->paste_onset;
     for (src = x->gl_list; whoout; src = src->g_next, whoout--)
-        if (!src->g_next) goto bad; /* bug fix thanks to Hannes */
+        if (!src->g_next) {
+            src = NULL;
+            logpost(sink, 3, "cannot connect non-existing object");
+            goto bad; /* bug fix thanks to Hannes */
+        }
     for (sink = x->gl_list; whoin; sink = sink->g_next, whoin--)
-        if (!sink->g_next) goto bad;
+        if (!sink->g_next) {
+            sink = NULL;
+            logpost(src, 3, "cannot connect to non-existing object");
+            goto bad;
+        }
 
         /* check they're both patchable objects */
     if (!(objsrc = pd_checkobject(&src->g_pd)) ||
-        !(objsink = pd_checkobject(&sink->g_pd)))
-            goto bad;
+        !(objsink = pd_checkobject(&sink->g_pd))) {
+        logpost(src?src:sink, 3, "cannot connect unpatchable object");
+        goto bad;
+    }
+
+        /* check if objects are already connected */
+    if (canvas_isconnected(x, objsrc, outno, objsink, inno)) {
+        logpost(src, 3, "refusing duplicate connection");
+        goto bad;
+    }
 
         /* if object creation failed, make dummy inlets or outlets
            as needed */


### PR DESCRIPTION
this PR simply checks whether a pair of iolets is already connected, and if so refuses to continue.

Closes: https://github.com/pure-data/pure-data/issues/1308

this also prints some info why connecting failed (at debug-loglevel), complete with clickable printout to easily find the problem.
