### PR TITLE
generate tcl event before window closes

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2019,6 +2019,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 canvas_destroy_editor(x);
             return;
         }
+        sys_vgui("event generate .x%lx <<WindowClosing>>\n", x);
         glist_noselect(x);
         if (glist_isvisible(x))
             canvas_map(x, 0);


### PR DESCRIPTION
This allows tcl/tk gui objects to store their state before they're deleted
closes #1323 