### PR TITLE
[WIP] i18n help

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -48,6 +48,8 @@ void x_midi_newpdinstance( void);
 void x_midi_freepdinstance( void);
 void s_inter_newpdinstance( void);
 void s_inter_free(t_instanceinter *inter);
+void s_path_newpdinstance( void);
+void s_path_freepdinstance( void);
 void g_canvas_newpdinstance( void);
 void g_canvas_freepdinstance( void);
 void d_ugen_newpdinstance( void);
@@ -60,11 +62,13 @@ void s_stuff_newpdinstance(void)
     STUFF->st_externlist = STUFF->st_searchpath =
         STUFF->st_staticpath = STUFF->st_helppath = STUFF->st_temppath = 0;
     STUFF->st_schedblocksize = STUFF->st_blocksize = DEFDACBLKSIZE;
+    s_path_newpdinstance();
 }
 
 void s_stuff_freepdinstance(void)
 {
     freebytes(STUFF, sizeof(*STUFF));
+    s_path_freepdinstance();
 }
 
 static t_pdinstance *pdinstance_init(t_pdinstance *x)

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -204,7 +204,7 @@ EXTERN void pdinstance_free(t_pdinstance *x)
     pd_setinstance(x);
     sys_lock();
     pd_globallock();
-    
+
     instanceno = x->pd_instanceno;
     inter = x->pd_inter;
     canvas_suspend_dsp();

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -32,6 +32,7 @@ void glob_midi_setapi(t_pd *dummy, t_floatarg f);
 void glob_start_path_dialog(t_pd *dummy, t_floatarg flongform);
 void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit);
+void glob_addtohelppath(t_pd *dummy, t_symbol *path, t_float saveit);
 void glob_start_startup_dialog(t_pd *dummy, t_floatarg flongform);
 void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_ping(t_pd *dummy);
@@ -174,6 +175,8 @@ void glob_init(void)
         gensym("path-dialog"), A_GIMME, 0);
     class_addmethod(glob_pdobject, (t_method)glob_addtopath,
         gensym("add-to-path"), A_SYMBOL, A_DEFFLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_addtohelppath,
+        gensym("add-to-helppath"), A_SYMBOL, A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_start_startup_dialog,
         gensym("start-startup-dialog"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_startup_dialog,
@@ -218,4 +221,3 @@ void sys_getversion(int *major, int *minor, int *bugfix)
     if (bugfix)
         *bugfix = PD_BUGFIX_VERSION;
 }
-

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -31,6 +31,7 @@ void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_midi_setapi(t_pd *dummy, t_floatarg f);
 void glob_start_path_dialog(t_pd *dummy, t_floatarg flongform);
 void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
+void glob_set_pathlist(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit);
 void glob_addtohelppath(t_pd *dummy, t_symbol *path, t_float saveit);
 void glob_start_startup_dialog(t_pd *dummy, t_floatarg flongform);
@@ -177,6 +178,8 @@ void glob_init(void)
         gensym("add-to-path"), A_SYMBOL, A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_addtohelppath,
         gensym("add-to-helppath"), A_SYMBOL, A_DEFFLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_set_pathlist,
+        gensym("set-pathlist"), A_GIMME, 0);
     class_addmethod(glob_pdobject, (t_method)glob_start_startup_dialog,
         gensym("start-startup-dialog"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_startup_dialog,

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -658,6 +658,17 @@ void sys_loadpreferences(const char *filename, int startingup)
         STUFF->st_searchpath =
             namelist_append_files(STUFF->st_searchpath, prefbuf);
     }
+    if (sys_getpreference("nhelppath", prefbuf, MAXPDSTRING))
+        sscanf(prefbuf, "%d", &maxi);
+    else maxi = 0x7fffffff;
+    for (i = 0; i<maxi; i++)
+    {
+        sprintf(keybuf, "helppath%d", i+1);
+        if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
+            break;
+        STUFF->st_helppath =
+            namelist_append_files(STUFF->st_helppath, prefbuf);
+    }
     if (sys_getpreference("standardpath", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_usestdpath);
     if (sys_getpreference("verbose", prefbuf, MAXPDSTRING))
@@ -784,7 +795,6 @@ void sys_savepreferences(const char *filename)
         sys_putpreference(buf1, buf2);
     }
         /* file search path */
-
     for (i = 0; 1; i++)
     {
         const char *pathelem = namelist_get(STUFF->st_searchpath, i);
@@ -795,6 +805,19 @@ void sys_savepreferences(const char *filename)
     }
     sprintf(buf1, "%d", i);
     sys_putpreference("npath", buf1);
+
+        /* help search path */
+    for (i = 0; 1; i++)
+    {
+        const char *pathelem = namelist_get(STUFF->st_helppath, i);
+        if (!pathelem)
+            break;
+        sprintf(buf1, "helppath%d", i+1);
+        sys_putpreference(buf1, pathelem);
+    }
+    sprintf(buf1, "%d", i);
+    sys_putpreference("nhelppath", buf1);
+
     sprintf(buf1, "%d", sys_usestdpath);
     sys_putpreference("standardpath", buf1);
     sprintf(buf1, "%d", sys_verbose);

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -655,8 +655,7 @@ void sys_loadpreferences(const char *filename, int startingup)
         sprintf(keybuf, "path%d", i+1);
         if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
             break;
-        STUFF->st_searchpath =
-            namelist_append_files(STUFF->st_searchpath, prefbuf);
+        namedlist_append_files("searchpath.main", prefbuf);
     }
     if (sys_getpreference("nhelppath", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &maxi);
@@ -666,8 +665,7 @@ void sys_loadpreferences(const char *filename, int startingup)
         sprintf(keybuf, "helppath%d", i+1);
         if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
             break;
-        STUFF->st_helppath =
-            namelist_append_files(STUFF->st_helppath, prefbuf);
+        namedlist_append_files("helppath.main", prefbuf);
     }
     if (sys_getpreference("standardpath", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_usestdpath);

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -135,9 +135,7 @@ struct _instanceinter
 
 extern int sys_guisetportnumber;
 extern int sys_addhist(int phase);
-void sys_set_searchpath(void);
-void sys_set_temppath(void);
-void sys_set_extrapath(void);
+void sys_set_searchpaths(void);
 void sys_set_startup(void);
 void sys_stopgui(void);
 
@@ -1352,9 +1350,7 @@ static int sys_do_startgui(const char *libdir)
 #endif
     sys_get_audio_apis(apibuf);
     sys_get_midi_apis(apibuf2);
-    sys_set_searchpath();     /* tell GUI about path and startup flags */
-    sys_set_temppath();
-    sys_set_extrapath();
+    sys_set_searchpaths();     /* tell GUI about path and startup flags */
     sys_set_startup();
                        /* ... and about font, medio APIS, etc */
     sys_vgui("pdtk_pd_startup %d %d %d {%s} %s %s {%s} %s\n",

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -1027,7 +1027,7 @@ int sys_argparse(int argc, char **argv)
         {
             if (argc < 2)
                 goto usage;
-            namedlist_append_files("helppath.main", argv[1]);
+            namedlist_append_files("helppath.temp", argv[1]);
             argc -= 2; argv += 2;
         }
         else if (!strcmp(*argv, "-open"))
@@ -1400,7 +1400,7 @@ static void sys_afterargparse(void)
     strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING-30);
     sbuf[MAXPDSTRING-30] = 0;
     strcat(sbuf, "/doc/5.reference");
-    namedlist_append_files("helppath.main", sbuf);
+    namedlist_append_files("helppath.static", sbuf);
         /* correct to make audio and MIDI device lists zero based.  On
         MMIO, however, "1" really means the second device (the first one
         is "mapper" which is was not included when the command args were

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -1010,8 +1010,7 @@ int sys_argparse(int argc, char **argv)
         {
             if (argc < 2)
                 goto usage;
-            STUFF->st_temppath =
-                namelist_append_files(STUFF->st_temppath, argv[1]);
+            namedlist_append_files("searchpath.temp", argv[1]);
             argc -= 2; argv += 2;
         }
         else if (!strcmp(*argv, "-nostdpath"))
@@ -1028,8 +1027,7 @@ int sys_argparse(int argc, char **argv)
         {
             if (argc < 2)
                 goto usage;
-            STUFF->st_helppath =
-                namelist_append_files(STUFF->st_helppath, argv[1]);
+            namedlist_append_files("helppath.main", argv[1]);
             argc -= 2; argv += 2;
         }
         else if (!strcmp(*argv, "-open"))
@@ -1402,7 +1400,7 @@ static void sys_afterargparse(void)
     strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING-30);
     sbuf[MAXPDSTRING-30] = 0;
     strcat(sbuf, "/doc/5.reference");
-    STUFF->st_helppath = namelist_append_files(STUFF->st_helppath, sbuf);
+    namedlist_append_files("helppath.main", sbuf);
         /* correct to make audio and MIDI device lists zero based.  On
         MMIO, however, "1" really means the second device (the first one
         is "mapper" which is was not included when the command args were

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -505,13 +505,13 @@ void open_via_helppath(const char *name, const char *dir)
     const char *usedir = (*dir ? dir : "./");
     int fd;
 
+
         /* 1. "objectname-help.pd" */
     strncpy(realname, name, MAXPDSTRING-10);
     realname[MAXPDSTRING-10] = 0;
     if (strlen(realname) > 3 && !strcmp(realname+strlen(realname)-3, ".pd"))
         realname[strlen(realname)-3] = 0;
-    strcat(realname, "-help.pd");
-    if ((fd = do_open_via_path(usedir, realname, "", dirbuf, &basename,
+    if ((fd = do_open_via_path(usedir, realname, "-help.pd", dirbuf, &basename,
         MAXPDSTRING, 0, STUFF->st_helppath)) >= 0)
             goto gotone;
 

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -676,6 +676,7 @@ static int do_open_via_helppath(const char *dir, const char *name,
     search attempts. */
 void open_via_helppath(const char *name, const char *dir)
 {
+    char localext[MAXPDLOCALESTRING+10]; /* lang + -help..pd */
     char realname[MAXPDSTRING], dirbuf[MAXPDSTRING], *basename;
         /* make up a silly "dir" if none is supplied */
     const char *usedir = (*dir ? dir : "./");
@@ -687,6 +688,20 @@ void open_via_helppath(const char *name, const char *dir)
     realname[MAXPDSTRING-10] = 0;
     if (strlen(realname) > 3 && !strcmp(realname+strlen(realname)-3, ".pd"))
         realname[strlen(realname)-3] = 0;
+
+    if(PATHSTUFF->ps_lang_region[0]) {
+        snprintf(localext, sizeof(localext), "-help.%s.pd", PATHSTUFF->ps_lang_region);
+        if ((fd = do_open_via_helppath(usedir, realname, localext,
+                                   dirbuf, &basename, MAXPDSTRING)) >= 0)
+            goto gotone;
+    }
+    if(PATHSTUFF->ps_lang[0]) {
+        snprintf(localext, sizeof(localext), "-help.%s.pd", PATHSTUFF->ps_lang);
+        if ((fd = do_open_via_helppath(usedir, realname, localext,
+                                   dirbuf, &basename, MAXPDSTRING)) >= 0)
+            goto gotone;
+    }
+
     if ((fd = do_open_via_helppath(usedir, realname, "-help.pd",
                                    dirbuf, &basename, MAXPDSTRING)) >= 0)
             goto gotone;

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -815,21 +815,32 @@ void glob_start_path_dialog(t_pd *dummy)
     gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
 }
 
+
+static void do_set_path(const char*listname, int argc, t_atom *argv) {
+    namedlist_free(listname);
+    while(argc--) {
+        t_symbol *s = sys_decodedialog(atom_getsymbolarg(0, 1, argv++));
+        if (*s->s_name)
+            namedlist_append_files(listname, s->s_name);
+    }
+}
+
+void glob_set_pathlist(t_pd *dummy, t_symbol *s, int argc, t_atom *argv) {
+    s = atom_getsymbolarg(0, argc, argv);
+    if(argc<1) {
+        bug("set-pathlist");
+        return;
+    }
+    do_set_path(s->s_name, argc-1, argv+1);
+}
+
     /* new values from dialog window */
 void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    namelist_free(STUFF->st_searchpath);
-    STUFF->st_searchpath = 0;
     sys_usestdpath = atom_getfloatarg(0, argc, argv);
     sys_verbose = atom_getfloatarg(1, argc, argv);
-    for (i = 0; i < argc-2; i++)
-    {
-        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
-        if (*s->s_name)
-            STUFF->st_searchpath =
-                namelist_append_files(STUFF->st_searchpath, s->s_name);
-    }
+    do_set_path("searchpath.main", argc, argv);
 }
 
     /* add one item to search path (intended for use by Deken plugin).

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -569,7 +569,7 @@ t_symbol *sys_decodedialog(t_symbol *s)
     const char *sp = s->s_name;
     int i;
     if (*sp != '+')
-        bug("sys_decodedialog: %s", sp);
+        return s;
     else sp++;
     for (i = 0; i < MAXPDSTRING-1; i++, sp++)
     {

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -803,6 +803,8 @@ void sys_set_searchpaths(void)
     do_gui_setnamelist("::sys_temppath", STUFF->st_temppath);
         /* send the hard-coded search path to pd-gui */
     do_gui_setnamelist("::sys_staticpath", STUFF->st_staticpath);
+        /* set the help paths from the prefs */
+    do_gui_setnamelist("::sys_helppath", namedlist_getlist("helppath.main"));
 }
 
     /* start a search path dialog window */
@@ -811,6 +813,7 @@ void glob_start_path_dialog(t_pd *dummy)
     char buf[MAXPDSTRING];
 
     do_gui_setnamelist("::sys_searchpath", STUFF->st_searchpath);
+    do_gui_setnamelist("::sys_helppath", namedlist_getlist("helppath.main"));
     snprintf(buf, MAXPDSTRING-1, "pdtk_path_dialog %%s %d %d\n", sys_usestdpath, sys_verbose);
     gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
 }

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -787,47 +787,30 @@ t_symbol *sys_decodedialog(t_symbol *s)
 }
 
     /* send the user-specified search path to pd-gui */
-void sys_set_searchpath(void)
+static void do_gui_setnamelist(const char*listname, t_namelist*nl)
 {
     int i;
-    t_namelist *nl;
-
     sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_searchpath, i = 0; nl; nl = nl->nl_next, i++)
+    for (i = 0; nl; nl = nl->nl_next, i++)
         sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
-    sys_gui("set ::sys_searchpath $::tmp_path\n");
+    sys_vgui("set %s %s\n", listname, "$::tmp_path");
 }
-
-    /* send the temp paths from the commandline to pd-gui */
-void sys_set_temppath(void)
+void sys_set_searchpaths(void)
 {
-    int i;
-    t_namelist *nl;
-
-    sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_temppath, i = 0; nl; nl = nl->nl_next, i++)
-        sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
-    sys_gui("set ::sys_temppath $::tmp_path\n");
-}
-
-    /* send the hard-coded search path to pd-gui */
-void sys_set_extrapath(void)
-{
-    int i;
-    t_namelist *nl;
-
-    sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_staticpath, i = 0; nl; nl = nl->nl_next, i++)
-        sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
-    sys_gui("set ::sys_staticpath $::tmp_path\n");
+        /* set the search paths from the prefs */
+    do_gui_setnamelist("::sys_searchpath", STUFF->st_searchpath);
+        /* send the temp paths from the commandline to pd-gui */
+    do_gui_setnamelist("::sys_temppath", STUFF->st_temppath);
+        /* send the hard-coded search path to pd-gui */
+    do_gui_setnamelist("::sys_staticpath", STUFF->st_staticpath);
 }
 
     /* start a search path dialog window */
 void glob_start_path_dialog(t_pd *dummy)
 {
-     char buf[MAXPDSTRING];
+    char buf[MAXPDSTRING];
 
-    sys_set_searchpath();
+    do_gui_setnamelist("::sys_searchpath", STUFF->st_searchpath);
     snprintf(buf, MAXPDSTRING-1, "pdtk_path_dialog %%s %d %d\n", sys_usestdpath, sys_verbose);
     gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
 }

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -868,6 +868,20 @@ void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit)
             sys_savepreferences(0);
     }
 }
+void glob_addtohelppath(t_pd *dummy, t_symbol *path, t_float saveit)
+{
+    int saveflag = (int)saveit;
+    t_symbol *s = sys_decodedialog(path);
+    if (*s->s_name)
+    {
+        if (saveflag < 0)
+            namedlist_append_files("helppath.temp", s->s_name);
+        else
+            namedlist_append_files("helppath.main", s->s_name);
+        if (saveit > 0)
+            sys_savepreferences(0);
+    }
+}
 
     /* set the global list vars for startup libraries and flags */
 void sys_set_startup(void)

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -20,6 +20,21 @@ t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup);
 EXTERN t_namelist *namelist_append_files(t_namelist *listwas, const char *s);
 void namelist_free(t_namelist *listwas);
 const char *namelist_get(const t_namelist *namelist, int n);
+
+        /* append a new name to the named list;
+         * if 'name' is non-NULL it is added to the list (modulo allowdup)
+         *+ and any non-existing list is created
+         * reserved names that map to lists in STUFF:
+         * - 'searchpath.temp'   -> STUFF->st_temppath
+         * - 'searchpath.main'   -> STUFF->st_searchpath
+         * - 'searchpath.static' -> STUFF->st_staticpath
+         * - 'helppath.main'     -> STUFF->st_helppath
+         */
+void namedlist_append(const char*listname, const char*name, int allowdup);
+EXTERN void namedlist_append_files(const char*listname, const char *s);
+void namedlist_free(const char*listname);
+EXTERN t_namelist *namedlist_getlist(const char*listname);
+
 void sys_setextrapath(const char *p);
 extern int sys_usestdpath;
 int sys_open_absolute(const char *name, const char* ext,
@@ -413,6 +428,7 @@ struct _instancestuff
     t_sample *st_soundout;
     t_sample *st_soundin;
     double st_time_per_dsp_tick;    /* obsolete - included for GEM?? */
+    void *st_private; /* anonymous pointer to more data */
 };
 
 #define STUFF (pd_this->pd_stuff)

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -8,6 +8,7 @@ namespace eval ::dialog_path:: {
     variable verbose_button 0
     variable docspath ""
     variable installpath ""
+    variable helppath_widget
     namespace export pdtk_path_dialog
 }
 
@@ -44,6 +45,7 @@ proc ::dialog_path::pdtk_path_dialog {mytoplevel extrapath verbose} {
 proc ::dialog_path::create_dialog {mytoplevel} {
     global docspath
     global installpath
+    global helppath_widget
     ::scrollboxwindow::make $mytoplevel $::sys_searchpath \
         dialog_path::add dialog_path::edit dialog_path::commit \
         [_ "Pd search path for objects, help, audio, text and other files"] \
@@ -138,6 +140,18 @@ proc ::dialog_path::create_dialog {mytoplevel} {
         $mytoplevel.nb.buttonframe.ok config -highlightthickness 0
         $mytoplevel.nb.buttonframe.cancel config -highlightthickness 0
     }
+
+    # help path
+    labelframe $mytoplevel.helppath -text [_ "Additional Pd Help Paths"] \
+        -borderwidth 1 -padx 5 -pady 5
+    ::scrollbox::make $mytoplevel.helppath $::sys_helppath  ::dialog_path::add_help  ::dialog_path::edit_help
+    $mytoplevel.helppath.listbox.box configure -height 3
+    $mytoplevel.helppath.listbox.box selection clear 0 end
+    pack $mytoplevel.helppath -side top -anchor s -fill x -padx {2m 4m} -pady 2m
+    set helppath_widget $mytoplevel.helppath
+
+    # remove focus from helppath-widget by giving it to the searchpath widget
+    focus $mytoplevel.listbox.box
 
     # re-adjust height based on optional sections
     update
@@ -247,6 +261,7 @@ proc ::dialog_path::commit {new_path} {
     global verbose_button
     global docspath
     global installpath
+    global helppath_widget
 
     # save buttons and search paths
     set changed false
@@ -267,4 +282,17 @@ proc ::dialog_path::commit {new_path} {
         # run this after since it checks ::deken::installpath value
         ::pd_docsdir::update_path $docspath
     }
+
+    # save helppath
+    set ::sys_helppath [::scrollboxwindow::get_listdata ${helppath_widget}]
+    pdsend "pd set-pathlist helppath.main [pdtk_encode ${::sys_helppath}]"
+}
+
+############ pdtk_helppath_dialog -- dialog window for help path #########
+proc ::dialog_path::add_help {} {
+    return [::dialog_path::choosePath "" [_ "Add a new help path"]]
+}
+
+proc ::dialog_path::edit_help {currentpath} {
+    return [::dialog_path::choosePath $currentpath "Edit existing help path \[$currentpath\]"]
 }

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -161,6 +161,8 @@ set sys_searchpath {}
 set sys_temppath {}
 # hard-coded search paths for objects, help, plugins, etc.
 set sys_staticpath {}
+# user-specified help paths
+set sys_helppath {}
 # the path to the folder where the current plugin is being loaded from
 set current_plugin_loadpath {}
 # a list of plugins that were loaded

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -458,7 +458,7 @@ proc load_locale {} {
                set lang ""
                # on modern systems (>= Vista?) the locale can be found in HKCU\Control Panel\International :: LocaleName
                catch {
-                   set lang [ registry get {HKEY_CURRENT_USER\Control Panel\International} LocaleName]
+                   set lang [ registry get {HKEY_CURRENT_USER\Control Panel\International} LocaleName ]
                }
                # on older systems (XP,...) there's a similar string on HKCU\Control Panel\International :: sLanguage
                # (upper-case 3-letters; of MS own invention; luckily the first two letters are often the same)
@@ -468,7 +468,8 @@ proc load_locale {} {
                            [registry get {HKEY_CURRENT_USER\Control Panel\International} sLanguage] 0 1] ]
                }
                if { ${lang} ne "" } {
-                   ::msgcat::mclocale ${lang}
+                   # need to normalize the locale from '<lang>-<region>' to '<lang>_<region>'
+                   ::msgcat::mclocale [ string map {- _} ${lang} ]
                }
            }
     }

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -91,6 +91,23 @@ proc add_to_searchpaths {path {save true}} {
     lappend ::sys_searchpath "$path"
 }
 
+# adds to the sys_helppath user help paths directly
+proc add_to_helppaths {path {save true}} {
+    # try not to add duplicates
+    foreach helppath $::sys_helppath {
+        set dir [string trimright $helppath [file separator]]
+        if {"$dir" eq "$path"} {
+            return
+        }
+    }
+    # tell pd about the new path
+    if {$save} {set save 1} else {set save 0}
+    pdsend "pd add-to-helppath [pdtk_encodedialog ${path}] $save"
+    # append to help paths as this won't be
+    # updated from the pd core until a restart
+    lappend ::sys_helppath "$path"
+}
+
 # ------------------------------------------------------------------------------
 # window info (name, path, parents, children, etc.)
 


### PR DESCRIPTION
this is a work-in progress branch to enable i18n help files (that can be provided by the user).

there has been a bit of discussion about this on https://github.com/pure-data/pddp/issues/7

- supports help-patches in multiple languages
- help paths can now be saved in the preferences
- help patches can be dynamically added via a new `add-to-helppath` global message (cf. the old `add-to-path` message)

## language selection
- language selection is based on the `LANG` environment variable (just like the GUI already does).
- for a given `LANG=so_DJ`, Pd will first check whether there is a help-patch `bang-help.so_dj.pd` (`<language>_<country>`), i that fails for `bang-help.so.pd` and finally fall back to `bang-help.pd`
  - locale specifiers are normalized to lowercase; hyphens replaced by underscore; everything after a `.` (typically: the encoding) is ignored. thus `om-KE.UTF-8` becomes `om_ke`
  - if the local specifier does not include the `_<country>` suffix, it won't be searched for


### search order
- similar to the search paths,  there are now three different help paths
  - temporary help paths (added via the `-helppath` cmdline flag)
  - preference help paths
  - static help paths (`@PD@/doc/5.reference`)
 
this is the order a help-path gets searched for:
  - absolute paths
  - relative to current `dir` (as specified when calling `open_via_helppath()`)
  - temporary (cmdline) help paths
  - temporary (cmdline) search paths
  - preference help paths
  - preference search paths
  - static (built-in) help paths
  - static (built-in) search paths

just for reference, this is how it used to be:
  - absolute paths
  - relative to current `dir` (as specified when calling `open_via_helppath()`)
  - temporary (cmdline) search paths
  - temporary (cmdline) help paths
  - static (built-in) help paths
  - static (built-in) search paths

so the changes are:
- `-helppath` cmdline-flag takes precedence over `-path`
- ordinary search-paths (for finding libraries,...) that are added via the preferences are now searched too
- obviously there weren't any "preference" help paths in the original version

### user provided localisation

one of the key ideas was to allow users to add i18n support for a given language, e.g. by downloading a language pack via deken.

this allows the Pd core to not have to worry about maintaining help patches in multiple languages.

such packages should be able to override the default documentation without exposing the gory details to the end user.

for this to work, we need a way to dynamically register new help paths with Pd, hence the new `add-to-helppath` global message.

### binary compatibility
for the static/temporary helppaths the t_pdinstance struct had to be extended with a new member.
this new member `st_private` is a simple `(void*)` pointer that completely hides the implementation from any external, using the PIMPL idiom.
nevertheless, the size of the `t_pdinstance` changes.

there's a seemingly unused member `double st_time_per_dsp_tick` which i would like to reuse (as it has the same or a larger size) for the new `st_private`.
Pd's code is full of comments that it should get rid of the `st_time_per_dsp_tick` member (but assumes that GEM might use it. i've checked the Gem (including its history) and haven't found anything like that).

if we could reuse that member, binary compatibility should be OK.

## Tasks

- [x] load help patches based on their language code
       using `<objectname>-help.<locale>.pd`
- [x] dynamically addable help paths
       so that language packs can install their help patches anywhere, and only need to tell Pd where to look for
- [x] store help paths in preferences
       so that dynamically added help paths persist
       - temporary help paths (added via `-helppath`) and built-in help paths are **not** stored
- [x] help path preferences GUI
      help paths can be saved to (and restored from) the preferences. the "Path" preferences have been enhanced to also allow manipulation of the (stored) help paths.
- [ ] automatic handling of newer versions
      if you have a language pack installed for the help-files and install a new version of Pd (with updated help-patches), you would get the translated & outdated help patches, but you really should get the fresh & non-translated ones.

# Testing binaries

If you want to test this branch but cannot compile yourself, you can get binaries with the `i18n-features` from our nightly snapshots:
- [macOS/64bit](https://git.iem.at/pd/pure-data/-/jobs/artifacts/feature%2Fi18n-help/download?job=macOS)
- [Windows/64bit](https://git.iem.at/pd/pure-data/-/jobs/artifacts/feature%2Fi18n-help/download?job=w64)
- [Windows/32bit](https://git.iem.at/pd/pure-data/-/jobs/artifacts/feature%2Fi18n-help/download?job=w32)


---

PS: please use the  https://github.com/pure-data/pddp/issues/7 ticket (or create  a new ticket at https://github.com/pure-data/pddp/issues/) for brainstorming ideas about i18n help patches.

comments about the specifics of the current implementation are of course welcome here...
