### PR TITLE
Compatibility for watchOS

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -39,6 +39,7 @@ that didn't really belong anywhere. */
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <glob.h>
+#include <TargetConditionals.h>
 #else
 #include <stdlib.h>
 #endif
@@ -1034,6 +1035,8 @@ static void sys_init_deken(void)
 
 static int sys_do_startgui(const char *libdir)
 {
+#if TARGET_OS_WATCH /* fork() and execl() are marked __WATCHOS_PROHIBITED so they are unavailable in watchOS. */
+#else
     char quotebuf[MAXPDSTRING];
     char apibuf[256], apibuf2[256];
     struct addrinfo *ailist = NULL, *ai;
@@ -1360,6 +1363,7 @@ static int sys_do_startgui(const char *libdir)
     sys_vgui("set zoom_open %d\n", sys_zoom_open == 2);
 
     sys_init_deken();
+#endif /* !TARGET_OS_WATCH */
     return (0);
 }
 


### PR DESCRIPTION
I successfully compiled and ran Pd on a watchOS device recently by using a modified libpd wrapper. Had to make some minor changes to the pure-data source code itself too, see "Files changed" tab. These changes theoretically break the GUI on watchOS, but you don't ever use the GUI with libpd anyway, so this shouldn't be a problem IMO. I don't see a way to achieve this without modifying s_inter.c.