### PR TITLE
[file] object for low-level file operations

### DIFF
--- a/doc/5.reference/file-help.pd
+++ b/doc/5.reference/file-help.pd
@@ -1,0 +1,1037 @@
+#N canvas 467 185 622 652 12;
+#X text 459 59 details:;
+#X text 457 42 click for;
+#N canvas 221 76 916 951 handle 0;
+#X text 146 24 Handle - operate on file handles;
+#X obj 67 490 file handle;
+#X text 95 68 reading files;
+#X text 95 78 =============;
+#X msg 82 187 open /tmp/test.c r;
+#X msg 95 417 close;
+#X msg 91 259 1024;
+#X text 127 261 read (up to) 1024 bytes;
+#X obj 67 535 print data;
+#X msg 103 299 seek 3;
+#X text 160 301 seek to the 3rd byte;
+#X msg 108 342 seek -1;
+#X text 174 340 seek to the end of file;
+#X msg 106 383 seek+ 1;
+#X text 175 383 seek to the next byte;
+#X msg 91 229 1;
+#X text 129 231 read the next byte;
+#X msg 67 155 open \$1;
+#X msg 67 105 bang;
+#X obj 67 130 openpanel;
+#X obj 399 517 file handle;
+#X text 427 85 =============;
+#X msg 427 444 close;
+#X msg 435 326 seek 3;
+#X text 492 328 seek to the 3rd byte;
+#X msg 440 369 seek -1;
+#X text 506 367 seek to the end of file;
+#X msg 438 410 seek+ 1;
+#X text 507 410 seek to the next byte;
+#X msg 399 112 bang;
+#X text 427 75 writing files;
+#X obj 399 137 savepanel;
+#X msg 399 162 open \$1 w;
+#X msg 414 194 open /tmp/test.c a;
+#X msg 415 224 open /tmp/test.c c;
+#X msg 423 286 104 101 108 108 111 32 119 111 114 108 100 13 10;
+#X text 220 189 explicit Read-mode;
+#X text 491 162 open file in Write mode;
+#X text 558 193 open file for writing (Append mode);
+#X text 558 223 open file for writing (Create (or trunCate) mode);
+#X text 468 263 write some bytes;
+#X text 484 444 close the file;
+#X text 144 417 close the file;
+#X text 57 742 using out-of-range numbers of symbols leads to undefined
+behaviour., f 68;
+#X text 57 706 note: the data you read from or write to a file are
+lists of bytes \, which appear in Pd as lists of numbers from 0 to
+255, f 68;
+#X obj 66 777 file;
+#X text 117 778 is the short form for;
+#X obj 286 777 file handle;
+#X obj 141 624 print INFO;
+#X obj 473 541 print ERR;
+#X text 150 534 list of bytes read;
+#X text 555 535 if opening the file or writing to it fails \, the file
+is closed and a bang is sent to the 2nd outlet., f 46;
+#X text 230 592 if the file cannot be opened \, a bang is sent to the
+2nd outlet., f 63;
+#X text 231 612 when the end of the file is reached or a read error
+occurred \, the file is closed and a bang is sent too.;
+#X text 232 651 when seeking \, the position from the start of the
+file (or -1 on error) is output here., f 70;
+#N canvas 19 51 868 498 arguments 0;
+#X obj 146 145 file handle -q;
+#X text 274 145 less verbose (quiet);
+#X obj 146 175 file handle -v;
+#X text 274 175 more verbose (loud);
+#X obj 146 315 file handle -m 0o600;
+#X text 410 320 file creation mode (user/group/other permissions) in
+octal.;
+#X msg 563 149 verbose \$1;
+#X obj 563 174 file;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X text 117 249 restricted permissions of created files:;
+#X text 154 380 via a message:;
+#X obj 146 430 file;
+#X text 409 420 the creation mode only affects files that are created
+after the mode has been set.;
+#X msg 146 405 creationmode 0o600;
+#X text 408 358 the actual permissions of the created file also takes
+the umask into account. this might be ignored by the underlying filesystem.
+;
+#X text 149 281 via creation flags:;
+#X connect 6 0 7 0;
+#X connect 8 0 6 0;
+#X connect 16 0 14 0;
+#X restore 65 834 pd arguments;
+#X msg 428 490 creationmode 0o600;
+#X text 565 493 restrict permissions of to-be-created file;
+#X connect 1 0 8 0;
+#X connect 1 1 48 0;
+#X connect 4 0 1 0;
+#X connect 5 0 1 0;
+#X connect 6 0 1 0;
+#X connect 9 0 1 0;
+#X connect 11 0 1 0;
+#X connect 13 0 1 0;
+#X connect 15 0 1 0;
+#X connect 17 0 1 0;
+#X connect 18 0 19 0;
+#X connect 19 0 17 0;
+#X connect 20 1 49 0;
+#X connect 22 0 20 0;
+#X connect 23 0 20 0;
+#X connect 25 0 20 0;
+#X connect 27 0 20 0;
+#X connect 29 0 31 0;
+#X connect 31 0 32 0;
+#X connect 32 0 20 0;
+#X connect 33 0 20 0;
+#X connect 34 0 20 0;
+#X connect 35 0 20 0;
+#X connect 56 0 20 0;
+#X restore 460 86 pd handle;
+#N canvas 134 105 726 627 glob 0;
+#X obj 80 400 file glob;
+#X obj 80 465 print DATA;
+#X obj 180 425 print ERROR;
+#X msg 101 175 symbol ~/*.*;
+#X msg 131 365 symbol;
+#X msg 90 123 symbol .*;
+#X text 53 29 Glob - find pathnames matching a pattern;
+#X text 220 94 (that don't start with a dot);
+#X text 218 367 no match (files with an empty filename...);
+#X msg 122 238 symbol %WinDir%/*.exe;
+#X text 281 237 executable files in the Windows-directory;
+#X msg 80 83 symbol *;
+#X text 201 122 all files/directories starting with a dot (except for
+the special directories '.' and '..');
+#X msg 131 333 symbol .;
+#X msg 105 208 symbol /tmp/*.pd;
+#X text 232 209 all Pd-files in /tmp/;
+#X text 243 336 the '.' directory (not very useful);
+#X text 187 75 all files/directories in this directory;
+#X text 204 175 all files/directories with a dot in your homedir;
+#X msg 139 284 symbol ../*/;
+#X text 246 282 all directories in the parent directory;
+#N canvas 101 174 790 450 recursive 0;
+#X obj 112 213 file glob;
+#X msg 112 81 bang;
+#X obj 112 106 openpanel 1;
+#X obj 112 161 t s;
+#X msg 122 137 symbol .;
+#X msg 112 238 \$2 \$1;
+#X obj 112 263 route 0 1;
+#X obj 112 348 print files;
+#X msg 112 186 symbol \$1/*;
+#X obj 142 291 symbol;
+#X text 61 19 you can use [file glob] to recursively walk a directory
+tree;
+#X obj 492 213 file glob;
+#X msg 492 81 bang;
+#X obj 492 106 openpanel 1;
+#X obj 492 161 t s;
+#X msg 502 137 symbol .;
+#X msg 492 238 \$2 \$1;
+#X obj 492 263 route 0 1;
+#X obj 522 291 symbol;
+#X text 421 61 get all .pd files from the directory (+subdirs);
+#X text 65 60 get all files from the directory (+subdirs);
+#X msg 492 186 symbol \$1/*.pd \, symbol \$1/*/;
+#X obj 492 348 print pd-files;
+#X connect 0 0 5 0;
+#X connect 1 0 2 0;
+#X connect 2 0 3 0;
+#X connect 3 0 8 0;
+#X connect 4 0 3 0;
+#X connect 5 0 6 0;
+#X connect 6 0 7 0;
+#X connect 6 1 9 0;
+#X connect 8 0 0 0;
+#X connect 9 0 8 0;
+#X connect 11 0 16 0;
+#X connect 12 0 13 0;
+#X connect 13 0 14 0;
+#X connect 14 0 21 0;
+#X connect 15 0 14 0;
+#X connect 16 0 17 0;
+#X connect 17 0 22 0;
+#X connect 17 1 18 0;
+#X connect 18 0 21 0;
+#X connect 21 0 11 0;
+#X restore 202 580 pd recursive globbing;
+#X text 279 425 if no files are found or an error is encountered \,
+a bang is sent to the 2nd outlet;
+#X text 278 467 matching files and directories are sent as lists of
+<path> (including the search directory) and a <type> identifier that
+indicates if the path is a file (0) or a directory (1).;
+#N canvas 143 98 738 232 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X obj 563 174 file glob;
+#X obj 146 145 file glob -q;
+#X obj 146 175 file glob -v;
+#X connect 2 0 7 0;
+#X connect 3 0 2 0;
+#X restore 104 580 pd arguments;
+#N canvas 40 91 876 439 cross-platform 0;
+#X text 50 334 - files/dirs starting with a "." only match if the matching
+pattern explicitly contains the leading dot.;
+#X msg 496 343 symbol *;
+#X msg 596 343 symbol .*;
+#X text 569 342 vs;
+#X text 569 382 vs;
+#X msg 496 383 symbol .*;
+#X msg 596 383 symbol ..;
+#X text 50 377 - the special files/dirs "." and ".." only match if
+requested explicitly \, never with a wildcard pattern.;
+#X text 592 212 vs;
+#X msg 496 213 symbol /tmp/*;
+#X msg 616 213 symbol /*/foo;
+#X text 53 196 - the behaviour of patterns that contain wildcards in
+a path component other than the last one is *undefined* (and platform
+dependent). DO NOT USE THIS.;
+#X text 52 285 - patterns ending with anything else will match files
+AND directories;
+#X text 592 282 vs;
+#X text 612 152 vs;
+#X msg 496 153 symbol file.txt;
+#X msg 636 153 symbol *.txt;
+#X text 732 152 vs;
+#X msg 756 153 symbol fi?e.txt;
+#X text 52 265 - patterns ending with '/' will ONLY match directories
+;
+#X msg 616 283 symbol */;
+#X msg 496 283 symbol *;
+#X text 52 136 - the pattern may contain the wildcards '*' (for any
+number of characters) and '?' (for a single character) in the last
+path component. no other wildcards are supported.;
+#X text 58 52 [file glob] attempts to unify the behaviour of wildcard
+matching on different platforms. as such \, it does not support all
+features of a given pattern matching implementation (or only accidentally).
+, f 107;
+#X text 58 85 the following rules should help you to write patches
+that use platform independent globbing., f 107;
+#X text 32 29 cross-platform notes on globbing:;
+#X restore 363 580 pd cross-platform pattern matching;
+#X text 93 560 more:;
+#X connect 0 0 1 0;
+#X connect 0 1 2 0;
+#X connect 3 0 0 0;
+#X connect 4 0 0 0;
+#X connect 5 0 0 0;
+#X connect 9 0 0 0;
+#X connect 11 0 0 0;
+#X connect 13 0 0 0;
+#X connect 14 0 0 0;
+#X connect 19 0 0 0;
+#X restore 460 186 pd glob;
+#X obj 39 553 file;
+#X text 76 554 - short for "file handle";
+#X obj 28 86 file handle;
+#X obj 28 226 file stat;
+#X text 166 85 - read/write binary files;
+#X text 166 157 - find a file in Pd's search-path;
+#X text 166 187 - list files in directories;
+#X obj 28 186 file glob;
+#X obj 28 156 file which;
+#N canvas 730 134 613 498 which 0;
+#X text 65 44 Which - locate a file;
+#X obj 60 212 file which;
+#X symbolatom 60 323 0 0 0 0 - - -;
+#X obj 60 347 print found;
+#X obj 127 262 print not!found;
+#X msg 70 182 symbol nada;
+#X msg 60 146 symbol hilbert~.pd;
+#X text 42 388 notes:;
+#X text 64 415 - currently this only works for files \, not for directories!
+;
+#X text 64 436 - currently only the first match is returned;
+#X text 210 149 a file that ships with Pd;
+#X text 211 182 probably does not exist in Pd's search path;
+#N canvas 143 98 738 232 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X obj 146 145 file which -q;
+#X obj 146 175 file which -v;
+#X obj 563 174 file which;
+#X connect 2 0 9 0;
+#X connect 3 0 2 0;
+#X restore 65 464 pd arguments;
+#X symbolatom 127 238 0 0 0 0 - - -;
+#X text 61 76 tries to locate the file in using Pd's search-paths and
+returns the resolved path.;
+#X obj 60 298 unpack s f;
+#X floatatom 152 299 2 0 0 1 directory? - -;
+#X connect 1 0 15 0;
+#X connect 1 1 13 0;
+#X connect 2 0 3 0;
+#X connect 5 0 1 0;
+#X connect 6 0 1 0;
+#X connect 13 0 4 0;
+#X connect 15 0 2 0;
+#X connect 15 1 16 0;
+#X restore 460 156 pd which;
+#X obj 28 116 file mkdir;
+#X text 167 117 - create a directory;
+#N canvas 751 166 707 608 mkdir 0;
+#X text 146 24 Mkdir - create directories;
+#X obj 72 409 file mkdir;
+#X symbolatom 72 484 0 0 0 0 - - -;
+#X obj 72 508 print mkdir;
+#X obj 139 454 print ERR:mkdir;
+#X msg 72 169 bang;
+#X msg 92 229 bang;
+#X msg 92 279 symbol \$1/subdir/another/sub/directory;
+#X text 147 43 ==========================;
+#X msg 113 321 symbol .;
+#X obj 139 434 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X text 64 81 this ensures that a given directory exists by creating
+it.;
+#X text 63 99 parent directories are created as needed.;
+#X text 63 119 it is not an error \, if the requested directory already
+exists (and is a directory).;
+#X text 178 171 create a new directory;
+#X text 187 233 create a deep directory;
+#X text 194 323 (re)create an existing directory;
+#X text 271 436 on error \, a bang is sent to the 2nd outlet;
+#X text 196 509 on success \, the name of the created directory is
+sent to the 1st outlet;
+#N canvas 19 51 868 498 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X text 154 380 via a message:;
+#X text 149 281 via creation flags:;
+#X text 117 249 restricted permissions of created directories:;
+#X text 410 320 directory creation mode (user/group/other permissions)
+in octal.;
+#X msg 146 405 creationmode 0o700;
+#X text 408 358 the actual permissions of the created directory also
+takes the umask into account. this might be ignored by the underlying
+filesystem.;
+#X text 409 420 the creation mode only affects directories that are
+created after the mode has been set.;
+#X obj 146 430 file mkdir;
+#X obj 146 315 file mkdir -m 0o700;
+#X obj 146 175 file mkdir -v;
+#X obj 146 145 file mkdir -q;
+#X obj 563 174 file mkdir;
+#X connect 2 0 18 0;
+#X connect 3 0 2 0;
+#X connect 11 0 14 0;
+#X restore 65 574 pd arguments;
+#X msg 117 369 creationmode 0o700;
+#X obj 92 254 savepanel 1;
+#X obj 72 194 savepanel 1;
+#X connect 1 0 2 0;
+#X connect 1 1 10 0;
+#X connect 2 0 3 0;
+#X connect 5 0 22 0;
+#X connect 6 0 21 0;
+#X connect 7 0 1 0;
+#X connect 9 0 1 0;
+#X connect 10 0 4 0;
+#X connect 20 0 1 0;
+#X connect 21 0 7 0;
+#X connect 22 0 1 0;
+#X restore 460 116 pd mkdir;
+#X obj 28 396 file delete;
+#X text 167 397 - delete files and directories;
+#N canvas 751 166 638 696 delete 0;
+#X text 94 31 Delete - remove files and directories;
+#X obj 85 216 file delete;
+#X obj 159 243 print ERR:delete;
+#X obj 85 273 print deleted;
+#X text 51 73 NOTE: deleting destroys data. there is no confirmation
+dialog or anything of that kind.;
+#X msg 85 155 symbol nada;
+#X text 196 158 file or directory to be deleted;
+#X text 60 381 recursive deletion;
+#X obj 95 570 file delete;
+#X msg 95 489 recursive nada;
+#X obj 169 597 print ERR:recursive-delete;
+#X obj 95 647 print recursively-deleted;
+#X text 208 490 remove the nada/ directory with all its content.;
+#X text 283 239 on error \, a bang is sent to the 2nd outlet;
+#X text 197 275 on success \, the deleted path is sent to the 1st outlet
+;
+#X text 314 580 on error \, a bang is sent to the 2nd outlet;
+#X text 228 626 on success \, the deleted path is sent to the 1st outlet
+;
+#X text 212 514 if nada is a file (rather than a directory) \, it will
+be deleted just so.;
+#N canvas 143 98 738 232 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X obj 146 145 file delete -q;
+#X obj 146 175 file delete -v;
+#X obj 563 174 file delete;
+#X connect 2 0 9 0;
+#X connect 3 0 2 0;
+#X restore 505 314 pd arguments;
+#X text 60 396 ------------------;
+#X text 82 415 if you are sure that you want to remove an entire directory
+tree with all the files and subdirectories \, you can also remove it
+*recursively* using the "recursive" message.;
+#X connect 1 0 3 0;
+#X connect 1 1 2 0;
+#X connect 5 0 1 0;
+#X connect 8 0 11 0;
+#X connect 8 1 10 0;
+#X connect 9 0 8 0;
+#X restore 460 396 pd delete;
+#N canvas 751 166 876 413 copy 0;
+#X text 52 29 Copy - copy a file around;
+#X obj 91 297 file copy;
+#X msg 91 173 list source destination;
+#X text 279 172 copies the file 'source' to the new file 'destination'
+;
+#X obj 91 322 print copy;
+#X obj 171 323 print ERR:copy;
+#N canvas 5 51 542 353 arguments 0;
+#X msg 136 143 verbose \$1;
+#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X obj 136 168 outlet;
+#X text 61 82 error reporting;
+#X text 244 118 turn error-printout on/off;
+#X text 65 254 or via flags:;
+#X obj 90 292 file copy -v;
+#X text 206 294 more verbose;
+#X obj 90 322 file copy -q;
+#X text 206 324 less verbose (quiet);
+#X connect 0 0 2 0;
+#X connect 1 0 0 0;
+#X restore 120 272 pd arguments;
+#X text 50 79 [file copy] duplicates the content of a file to a destination
+;
+#X text 308 227 'destination' can be a file or a directory.;
+#X text 308 207 'source' must be a file.;
+#X text 310 260 the destination directory must exist and be writable.
+;
+#X connect 1 0 4 0;
+#X connect 1 1 5 0;
+#X connect 2 0 1 0;
+#X connect 6 0 1 0;
+#X restore 460 336 pd copy;
+#X obj 28 336 file copy;
+#X text 167 337 - copy files;
+#X obj 28 366 file move;
+#X text 167 367 - move files;
+#X obj 28 436 file split;
+#X obj 28 461 file join;
+#X obj 28 486 file splitext;
+#X obj 28 511 file splitname;
+#X text 167 467 - filename operations;
+#X obj 35 15 file;
+#X text 82 16 - low-level file operations;
+#X text 29 57 The file object's first argument sets its function:;
+#X obj 28 251 file isfile;
+#X obj 28 276 file isdirectory;
+#X obj 28 301 file size;
+#N canvas 299 113 810 612 info 0;
+#X obj 54 352 file isfile;
+#X floatatom 54 377 5 0 0 0 - - -;
+#X msg 184 182 bang;
+#X floatatom 544 377 5 0 0 0 - - -;
+#X obj 544 352 file isdirectory;
+#X text 225 181 select a file;
+#X msg 235 211 bang;
+#X text 286 210 select a directory;
+#X msg 486 209 symbol .;
+#X text 560 208 some directory;
+#X msg 486 239 symbol nada;
+#X obj 673 400 print ERR:isDir;
+#X obj 673 380 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X obj 544 401 print isDir;
+#X obj 54 401 print isFile;
+#X text 276 388 sends a bang to the 2nd outlet \, if the path could
+not be read, f 32;
+#X text 576 241 probably not there;
+#X floatatom 54 487 5 0 0 0 - - -;
+#X obj 54 462 file size;
+#X obj 54 511 print size;
+#X text 278 495 on error \, a bang is sent to the 2nd outlet;
+#X obj 145 381 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X obj 145 401 print ERR:isFile;
+#X obj 145 491 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X obj 145 511 print ERR:size;
+#X text 276 462 gets the size of a file (in bytes) \, as reported by
+the filesystem. for directories \, this will return '0'.;
+#N canvas 5 51 450 300 arguments 0;
+#X msg 68 137 verbose \$1;
+#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 52 23 error reporting;
+#X text 61 83 switch on/off error messages on the Pd-console;
+#X text 56 208 or use the "-v" resp "-q" flag;
+#X obj 62 252 file stat -v;
+#X obj 68 162 s \$0-info-path;
+#X connect 0 0 6 0;
+#X connect 1 0 0 0;
+#X restore 703 96 pd arguments;
+#X text 79 41 get metainformation about a file/directory;
+#X obj 58 75 file isfile;
+#X obj 58 105 file isdirectory;
+#X obj 58 135 file size;
+#X text 192 76 check if path is an existing regular file;
+#X text 192 106 check if path is an existing directory;
+#X text 196 137 get size of a file;
+#X obj 54 328 r \$0-info-path;
+#X obj 54 438 r \$0-info-path;
+#X obj 544 328 r \$0-info-path;
+#N canvas 143 98 738 232 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X obj 146 145 file size -q;
+#X obj 146 175 file isfile -v;
+#X obj 563 174 file isdirectory;
+#X connect 2 0 9 0;
+#X connect 3 0 2 0;
+#X restore 55 574 pd arguments;
+#N canvas 5 51 645 307 \$0-info-path 0;
+#X obj 167 58 inlet directories;
+#X obj 341 58 inlet fixes;
+#X obj 54 59 inlet files;
+#X obj 54 107 openpanel;
+#X obj 167 146 openpanel 1;
+#X obj 167 172 symbol .;
+#X msg 108 177 bang;
+#X obj 199 228 s \$0-info-path;
+#X obj 167 200 t s s;
+#X obj 167 255 outlet;
+#X connect 0 0 4 0;
+#X connect 1 0 5 0;
+#X connect 2 0 3 0;
+#X connect 3 0 5 0;
+#X connect 4 0 5 0;
+#X connect 5 0 8 0;
+#X connect 6 0 5 0;
+#X connect 8 0 9 0;
+#X connect 8 1 7 0;
+#X restore 184 265 pd \$0-info-path;
+#X symbolatom 184 290 0 0 0 0 - - -;
+#X connect 0 0 1 0;
+#X connect 0 1 21 0;
+#X connect 1 0 14 0;
+#X connect 2 0 38 0;
+#X connect 3 0 13 0;
+#X connect 4 0 3 0;
+#X connect 4 1 12 0;
+#X connect 6 0 38 1;
+#X connect 8 0 38 2;
+#X connect 10 0 38 2;
+#X connect 12 0 11 0;
+#X connect 17 0 19 0;
+#X connect 18 0 17 0;
+#X connect 18 1 23 0;
+#X connect 21 0 22 0;
+#X connect 23 0 24 0;
+#X connect 34 0 0 0;
+#X connect 35 0 18 0;
+#X connect 36 0 4 0;
+#X connect 38 0 39 0;
+#X restore 460 276 pd info;
+#N canvas 299 113 856 995 stat 0;
+#X msg 356 141 bang;
+#X text 397 140 select a file;
+#X msg 396 168 bang;
+#X text 447 167 select a directory;
+#X msg 468 206 symbol .;
+#X text 542 205 some directory;
+#X msg 468 236 symbol nada;
+#X text 558 238 probably not there;
+#X obj 185 371 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
+#000000 #000000;
+#X obj 185 391 print ERR:stat;
+#X obj 54 367 t a a;
+#X obj 86 391 print stat;
+#X obj 96 518 tgl 15 0 empty empty r 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 174 518 tgl 15 0 empty empty w 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 252 518 tgl 15 0 empty empty x 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 96 721 route uid gid;
+#X obj 96 616 route type;
+#X obj 96 641 symbol;
+#X obj 96 588 tgl 15 0 empty empty F 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 174 588 tgl 15 0 empty empty D 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 252 588 tgl 15 0 empty empty L 17 7 0 10 #fcfcfc #000000 #000000
+0 1;
+#X obj 96 561 route isfile isdirectory issymlink;
+#X symbolatom 146 641 0 0 0 0 - - -;
+#X obj 328 518 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X floatatom 96 746 5 0 0 0 - - -;
+#X floatatom 140 746 5 0 0 0 - - -;
+#X floatatom 96 695 5 0 0 0 - - -;
+#X obj 96 781 route mtime atime;
+#X msg 96 806 symbol \$1-\$2-\$3T\$4:\$5:\$6;
+#X symbolatom 96 831 0 0 0 3 modified - -;
+#X msg 280 807 symbol \$1-\$2-\$3T\$4:\$5:\$6;
+#X symbolatom 280 832 0 0 0 3 accessed - -;
+#X obj 54 491 t a a;
+#X obj 54 671 t a a;
+#X obj 54 561 t a a;
+#X obj 54 616 t a a;
+#X obj 54 721 t a a;
+#X obj 54 781 t a a;
+#X floatatom 96 456 5 0 0 0 - - -;
+#X obj 54 431 t a a;
+#X text 310 382 on error \, a bang is sent to the 2nd outlet;
+#X obj 96 431 route size;
+#X obj 96 491 route readable writable executable owned;
+#X obj 96 671 route permissions;
+#X text 406 489 whether the file is readable/writable/executable/owned
+by the user;
+#X obj 232 672 makefilename %o;
+#X symbolatom 232 697 10 0 0 0 - - -;
+#X text 406 675 numeric permissions (the more common form is the octal
+representation);
+#X text 406 554 boolean values whether the path is a file/directory/symlink
+;
+#X text 406 730 numeric user-id & group-id of the file;
+#X text 407 781 last modification resp. access time;
+#X text 409 521 (might be '-1' if undeterminable);
+#X text 405 435 file size (for regular files/symlinks \, 0 for directories
+\, -1 otherwise);
+#X text 406 621 symbolic description of the path type (after resolving
+any symlinks);
+#N canvas 5 51 450 300 arguments 0;
+#X msg 68 137 verbose \$1;
+#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 52 23 error reporting;
+#X text 61 83 switch on/off error messages on the Pd-console;
+#X text 56 208 or use the "-v" resp "-q" flag;
+#X obj 62 252 file stat -v;
+#X obj 68 162 outlet;
+#X connect 0 0 6 0;
+#X connect 1 0 0 0;
+#X restore 54 239 pd arguments;
+#N canvas 5 51 645 307 openpanel 0;
+#X obj 167 58 inlet directories;
+#X obj 341 58 inlet fixes;
+#X obj 54 59 inlet files;
+#X obj 54 107 openpanel;
+#X obj 167 146 openpanel 1;
+#X obj 167 172 symbol .;
+#X msg 108 177 bang;
+#X obj 167 197 outlet;
+#X connect 0 0 4 0;
+#X connect 1 0 5 0;
+#X connect 2 0 3 0;
+#X connect 3 0 5 0;
+#X connect 4 0 5 0;
+#X connect 5 0 7 0;
+#X connect 6 0 5 0;
+#X restore 356 262 pd openpanel;
+#X text 79 41 Stat - get metainformation about a file/directory;
+#X obj 49 317 cnv 15 80 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+0;
+#X obj 54 322 file stat;
+#N canvas 143 98 738 232 arguments 0;
+#X text 274 145 less verbose (quiet);
+#X text 274 175 more verbose (loud);
+#X msg 563 149 verbose \$1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X text 106 70 error reporting on the Pd-console;
+#X text 239 111 via flags:;
+#X text 524 100 via a message:;
+#X obj 146 145 file stat -q;
+#X obj 146 175 file stat -v;
+#X obj 563 174 file stat;
+#X connect 2 0 9 0;
+#X connect 3 0 2 0;
+#X restore 55 934 pd arguments;
+#X text 128 65 [file stat] queries the filesystem about the given path
+\, and outputs the collected data as a number of routable messages.
+;
+#X text 407 572 (the symlink flag is additional: e.g. \, if the path
+is a symlink to a directory \, both isdirectory and issymlink will
+be true);
+#X symbolatom 356 287 0 0 0 0 - - -;
+#X connect 0 0 55 0;
+#X connect 2 0 55 1;
+#X connect 4 0 55 2;
+#X connect 6 0 55 2;
+#X connect 8 0 9 0;
+#X connect 10 0 39 0;
+#X connect 10 1 11 0;
+#X connect 15 0 24 0;
+#X connect 15 1 25 0;
+#X connect 15 2 27 0;
+#X connect 16 0 17 0;
+#X connect 17 0 22 0;
+#X connect 21 0 18 0;
+#X connect 21 1 19 0;
+#X connect 21 2 20 0;
+#X connect 26 0 45 0;
+#X connect 27 0 28 0;
+#X connect 27 1 30 0;
+#X connect 28 0 29 0;
+#X connect 30 0 31 0;
+#X connect 32 0 34 0;
+#X connect 32 1 42 0;
+#X connect 33 0 36 0;
+#X connect 33 1 43 0;
+#X connect 34 0 35 0;
+#X connect 34 1 21 0;
+#X connect 35 0 33 0;
+#X connect 35 1 16 0;
+#X connect 36 0 37 0;
+#X connect 36 1 15 0;
+#X connect 37 1 27 0;
+#X connect 39 0 32 0;
+#X connect 39 1 41 0;
+#X connect 41 0 38 0;
+#X connect 42 0 12 0;
+#X connect 42 1 13 0;
+#X connect 42 2 14 0;
+#X connect 42 3 23 0;
+#X connect 43 0 26 0;
+#X connect 45 0 46 0;
+#X connect 54 0 58 0;
+#X connect 55 0 62 0;
+#X connect 58 0 10 0;
+#X connect 58 1 8 0;
+#X connect 62 0 58 0;
+#X restore 460 226 pd stat;
+#N canvas 751 166 876 413 move 0;
+#X msg 91 173 list source destination;
+#N canvas 5 51 542 353 arguments 0;
+#X msg 136 143 verbose \$1;
+#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
+#000000 0 1;
+#X obj 136 168 outlet;
+#X text 61 82 error reporting;
+#X text 244 118 turn error-printout on/off;
+#X text 65 254 or via flags:;
+#X text 206 294 more verbose;
+#X text 206 324 less verbose (quiet);
+#X obj 90 292 file move -v;
+#X obj 90 322 file move -q;
+#X connect 0 0 2 0;
+#X connect 1 0 0 0;
+#X restore 120 272 pd arguments;
+#X text 308 227 'destination' can be a file or a directory.;
+#X text 308 207 'source' must be a file.;
+#X text 310 260 the destination directory must exist and be writable.
+;
+#X text 52 29 Move - move a file to a new destination;
+#X text 50 79 [file move] moves (renames) files;
+#X text 279 172 renames the file 'source' to the new file 'destination'
+;
+#X obj 91 297 file move;
+#X obj 91 322 print move;
+#X obj 171 323 print ERR:move;
+#X text 39 372 NOTE: moving a file removes the original file.;
+#X connect 0 0 8 0;
+#X connect 1 0 8 0;
+#X connect 8 0 9 0;
+#X connect 8 1 10 0;
+#X restore 460 366 pd move;
+#X text 38 603 see also:;
+#X obj 123 602 text;
+#X obj 165 602 array;
+#X obj 214 602 list;
+#X text 167 267 - get information on existing files;
+#N canvas 371 161 807 621 split+join 0;
+#X text 44 65 filename operations;
+#N canvas 198 557 666 359 path 0;
+#X obj 103 214 symbol;
+#X symbolatom 133 168 10 0 0 0 - - -;
+#X obj 404 281 print PATH;
+#X obj 103 272 outlet;
+#X obj 56 11 inlet file;
+#X obj 56 96 openpanel;
+#X obj 139 96 openpanel 1;
+#X obj 139 69 t b;
+#X msg 139 122 symbol \$1/;
+#X obj 56 68 t b;
+#X obj 260 159 t b;
+#X obj 56 39 route file directory dir random;
+#N canvas 178 304 707 474 random 0;
+#X obj 155 39 inlet;
+#X obj 155 212 outlet;
+#X obj 155 64 t b;
+#X msg 218 40 bang;
+#X obj 155 148 random;
+#X obj 155 116 t b f;
+#X obj 155 175 text get \$0-name-split+join-strings;
+#X obj 155 89 text size \$0-name-split+join-strings;
+#X obj 391 138 text define -k \$0-name-split+join-strings;
+#A set ///foo/bar/pizza \; dir/subdir/ \; soundfile.wav \; /path/to/pd.exe
+\; ../file.txt;
+#X connect 0 0 2 0;
+#X connect 2 0 7 0;
+#X connect 3 0 2 0;
+#X connect 4 0 6 0;
+#X connect 5 0 4 0;
+#X connect 5 1 4 1;
+#X connect 6 0 1 0;
+#X connect 7 0 5 0;
+#X restore 379 88 pd random;
+#X obj 247 249 t s s b;
+#X obj 495 281 print -n;
+#X msg 495 255 -------------------;
+#X obj 247 224 r \$0-name-split+join-in;
+#X obj 247 281 s \$0-name-split+join;
+#X connect 0 0 3 0;
+#X connect 1 0 0 0;
+#X connect 4 0 11 0;
+#X connect 5 0 0 0;
+#X connect 6 0 8 0;
+#X connect 7 0 6 0;
+#X connect 8 0 0 0;
+#X connect 9 0 5 0;
+#X connect 10 0 0 0;
+#X connect 11 0 9 0;
+#X connect 11 1 7 0;
+#X connect 11 2 7 0;
+#X connect 11 3 12 0;
+#X connect 11 4 10 0;
+#X connect 12 0 0 0;
+#X connect 13 0 17 0;
+#X connect 13 1 2 0;
+#X connect 13 2 15 0;
+#X connect 15 0 14 0;
+#X connect 16 0 13 0;
+#X restore 499 105 pd path;
+#X text 367 305 if the input ends with a / \, a '/' will be sent to
+the 2nd outlet. otherwise \, the 2nd outlet will fire a bang.;
+#X obj 69 403 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+0;
+#X obj 70 236 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+0;
+#X obj 73 241 file split;
+#X obj 105 326 print split:components;
+#X obj 172 300 print split:trailingslash;
+#X obj 73 408 file join;
+#X obj 140 271 t a a;
+#X obj 73 284 t a a;
+#X obj 73 354 list append;
+#X obj 73 463 print join;
+#X symbolatom 499 130 0 0 0 0 - - #0-name-split+join-in;
+#X msg 499 27 file;
+#X msg 499 54 directory;
+#X text 373 133 or type your own:;
+#X text 431 64 select a;
+#X symbolatom 73 438 0 0 0 0 - - -;
+#X text 363 202 'split' path into components;
+#X msg 499 79 random string;
+#X text 369 395 'join' a list of path components to a full path \,
+using '/' as the path separator.;
+#X text 371 430 duplicate path separator will be removed.;
+#X text 366 228 a list of path components (symbols) is sent to the
+1st outlet. if the input started with a / \, the first path component
+will be a symbol '/'. otherwise no slashes will appear in the path
+components.;
+#X text 366 290 duplicate path separator will be removed.;
+#X text 59 164 these objects perform common string operations on filenames.
+no checks are performed verifying the validity/existence of any path-component.
+, f 88;
+#X text 57 562 conversely \, the 'file join' object accepts both symbols
+and numbers, f 105;
+#X text 58 509 NOTE: 'file split' will always output (lists of) symbols
+\, even if the component looks like a number. on one hand this makes
+it harder to [route] \, but on the other hand this will keep zero-padded
+numbers intact (think "2020/01/01/0042.wav")., f 106;
+#X obj 73 213 r \$0-name-split+join;
+#X connect 1 0 13 0;
+#X connect 5 0 10 0;
+#X connect 5 1 9 0;
+#X connect 8 0 18 0;
+#X connect 9 0 11 1;
+#X connect 9 1 7 0;
+#X connect 10 0 11 0;
+#X connect 10 1 6 0;
+#X connect 11 0 8 0;
+#X connect 14 0 1 0;
+#X connect 15 0 1 0;
+#X connect 18 0 12 0;
+#X connect 20 0 1 0;
+#X connect 28 0 5 0;
+#X restore 460 450 pd split+join;
+#N canvas 443 122 893 598 base+ext 0;
+#N canvas 198 557 780 359 path 0;
+#X obj 103 214 symbol;
+#X symbolatom 133 168 10 0 0 0 - - -;
+#X obj 384 281 print PATH;
+#X obj 103 272 outlet;
+#X obj 56 11 inlet file;
+#X obj 56 96 openpanel;
+#X obj 139 96 openpanel 1;
+#X obj 139 69 t b;
+#X msg 139 122 symbol \$1/;
+#X obj 56 68 t b;
+#X obj 260 159 t b;
+#X obj 56 39 route file directory dir random;
+#N canvas 178 304 707 474 random 0;
+#X obj 155 39 inlet;
+#X obj 155 212 outlet;
+#X obj 155 64 t b;
+#X msg 218 40 bang;
+#X obj 155 148 random;
+#X obj 155 116 t b f;
+#X obj 391 139 text define -k \$0-name-base+ext-strings;
+#A set ///foo/bar/pizza \; dir/subdir/ \; soundfile.wav \; /path/to/pd.exe
+\; ../file.txt;
+#X obj 155 175 text get \$0-name-base+ext-strings;
+#X obj 155 89 text size \$0-name-base+ext-strings;
+#X connect 0 0 2 0;
+#X connect 2 0 8 0;
+#X connect 3 0 2 0;
+#X connect 4 0 7 0;
+#X connect 5 0 4 0;
+#X connect 5 1 4 1;
+#X connect 7 0 1 0;
+#X connect 8 0 5 0;
+#X restore 379 88 pd random;
+#X obj 247 249 t s s b;
+#X obj 475 281 print -n;
+#X msg 475 255 -------------------;
+#X obj 247 224 r \$0-name-base+ext-in;
+#X obj 247 281 s \$0-name-base+ext;
+#X connect 0 0 3 0;
+#X connect 1 0 0 0;
+#X connect 4 0 11 0;
+#X connect 5 0 0 0;
+#X connect 6 0 8 0;
+#X connect 7 0 6 0;
+#X connect 8 0 0 0;
+#X connect 9 0 5 0;
+#X connect 10 0 0 0;
+#X connect 11 0 9 0;
+#X connect 11 1 7 0;
+#X connect 11 2 7 0;
+#X connect 11 3 12 0;
+#X connect 11 4 10 0;
+#X connect 12 0 0 0;
+#X connect 13 0 17 0;
+#X connect 13 1 2 0;
+#X connect 13 2 15 0;
+#X connect 15 0 14 0;
+#X connect 16 0 13 0;
+#X restore 499 105 pd path;
+#X symbolatom 499 130 0 0 0 0 - - #0-name-base+ext-in;
+#X msg 499 27 file;
+#X msg 499 54 directory;
+#X text 373 133 or type your own:;
+#X text 431 64 select a;
+#X msg 499 79 random string;
+#X obj 70 406 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+0;
+#X obj 73 411 file splitext;
+#X obj 73 466 print splitext:root+ext;
+#X obj 161 442 print splitext:no!ext;
+#X obj 70 256 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+0;
+#X obj 73 261 file splitname;
+#X obj 168 293 print splitname:file;
+#X obj 73 316 print splitname:dir+file;
+#X text 370 215 'splitname' separates the directory component from
+the file component of the path \, and outputs a list with both on the
+1st outlet.;
+#X text 372 264 if no directory component can be found \, the path
+is sent to the 2nd outlet;
+#X text 373 299 a trailing slash is removed;
+#X text 367 378 'splitname' separates the directory+file component
+from the extension of the given path \, and outputs a list with both
+on the 1st outlet.;
+#X text 369 427 if no extension is found \, the path is sent to the
+2nd outlet;
+#X text 371 452 an extension is a non-empty string after the last '.'
+in the filename-component of the path;
+#X text 372 317 the filename is the non-empty string after the last
+path-separator;
+#X text 58 529 NOTE: the 'file split*' objects will always output (lists
+of) symbols \, even if the component looks like a number. on one hand
+this makes it harder to [route] \, but on the other hand this will
+keep zero-padded numbers intact (think "2020/01/01/0042.wav")., f
+106;
+#X obj 73 380 r \$0-name-base+ext;
+#X obj 73 230 r \$0-name-base+ext;
+#X text 44 65 more filename operations;
+#X text 59 164 these objects perform common string operations on filenames.
+no checks are performed verifying the validity/existence of any path-component.
+, f 88;
+#X connect 0 0 1 0;
+#X connect 2 0 0 0;
+#X connect 3 0 0 0;
+#X connect 6 0 0 0;
+#X connect 8 0 9 0;
+#X connect 8 1 10 0;
+#X connect 12 0 14 0;
+#X connect 12 1 13 0;
+#X connect 23 0 8 0;
+#X connect 24 0 12 0;
+#X restore 460 496 pd base+ext;
+#X text 405 612 updated for Pd version 0.52;

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -333,6 +333,7 @@ nobase_dist_libpd_DATA = \
      ./5.reference/expr-help.pd \
      ./5.reference/exp~-help.pd \
      ./5.reference/fft~-help.pd \
+     ./5.reference/file-help.pd \
      ./5.reference/float-help.pd \
      ./5.reference/framp~-help.pd \
      ./5.reference/fudiformat-help.pd \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ pd_SOURCES_core = \
     x_arithmetic.c \
     x_array.c \
     x_connective.c \
+    x_file.c \
     x_gui.c \
     x_interface.c \
     x_list.c \

--- a/src/m_conf.c
+++ b/src/m_conf.c
@@ -37,6 +37,7 @@ void x_array_setup(void);
 void x_midi_setup(void);
 void x_misc_setup(void);
 void x_net_setup(void);
+void x_file_setup(void);
 void x_qlist_setup(void);
 void x_gui_setup(void);
 void x_list_setup(void);
@@ -88,6 +89,7 @@ void conf_init(void)
     x_midi_setup();
     x_misc_setup();
     x_net_setup();
+    x_file_setup();
     x_qlist_setup();
     x_gui_setup();
     x_list_setup();

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -125,7 +125,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 OBJ = $(SRC:.c=.o) 

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -98,7 +98,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 OBJ = $(SRC:.c=.o) 

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -132,7 +132,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c
+    x_file.c x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c
 
 SRSRC = u_pdsend.c u_pdreceive.c s_net.c
 

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -95,7 +95,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 PADIR = ../portaudio/portaudio

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -1,0 +1,1433 @@
+/* Copyright (c) 1997-2013 Miller Puckette and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* The "file" object. */
+#define _XOPEN_SOURCE 500
+
+#include "m_pd.h"
+#include "g_canvas.h"
+#include "s_utf8.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <time.h>
+
+#ifdef _WIN32
+# include <windows.h>
+# include <io.h>
+#else
+# include <glob.h>
+# include <ftw.h>
+#endif
+
+
+
+#ifdef _WIN32
+# include <malloc.h> /* MSVC or mingw on windows */
+#elif defined(__linux__) || defined(__APPLE__)
+# include <alloca.h> /* linux, mac, mingw, cygwin */
+#else
+# include <stdlib.h> /* BSDs for example */
+#endif
+
+
+#ifdef _WIN32
+static int do_delete_ucs2(wchar_t*pathname) {
+    struct stat sb;
+    if (!wstat(pathname, &sb) && (S_ISDIR(sb.st_mode))) {
+            /* a directory */
+        return !(RemoveDirectoryW(pathname));
+    } else {
+            /* probably a file */
+        return !(DeleteFileW(pathname));
+    }
+}
+
+static int sys_stat(const char *pathname, struct stat *statbuf) {
+    int16_t ucs2buf[MAX_PATH];
+    u8_utf8toucs2(ucs2buf, MAX_PATH, pathname, strlen(pathname));
+    return wstat(ucs2buf, statbuf);
+}
+
+static int sys_rename(const char *oldpath, const char *newpath) {
+    int16_t src[MAX_PATH], dst[MAX_PATH];
+    u8_utf8toucs2(src, MAX_PATH, oldpath, MAX_PATH);
+    u8_utf8toucs2(dst, MAX_PATH, newpath, MAX_PATH);
+    return _wrename(src, dst);
+}
+static int sys_mkdir(const char *pathname, mode_t mode) {
+    uint16_t ucs2name[MAX_PATH];
+    u8_utf8toucs2(ucs2name, MAX_PATH, pathname, MAX_PATH);
+    return !(CreateDirectoryW(ucs2name, 0));
+}
+static int sys_remove(const char *pathname) {
+    uint16_t ucs2buf[MAXPDSTRING];
+    u8_utf8toucs2(ucs2buf, MAXPDSTRING, pathname, MAXPDSTRING);
+    return do_delete_ucs2(ucs2buf);
+}
+#else
+static int sys_stat(const char *pathname, struct stat *statbuf) {
+    return stat(pathname, statbuf);
+}
+
+static int sys_rename(const char *oldpath, const char *newpath) {
+    return rename(oldpath, newpath);
+}
+static int sys_mkdir(const char *pathname, mode_t mode) {
+    return mkdir(pathname, mode);
+}
+static int sys_remove(const char *pathname) {
+    return remove(pathname);
+}
+#endif
+
+#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+# define HAVE_ALLOCA 1
+#endif
+#ifdef ALLOCA
+# undef ALLOCA
+#endif
+#ifdef FREEA
+# undef FREEA
+#endif
+
+#if HAVE_ALLOCA
+# define ALLOCA(t, x, n, max) ((x) = (t *)((n) < (max) ?            \
+            alloca((n) * sizeof(t)) : getbytes((n) * sizeof(t))))
+# define FREEA(t, x, n, max) (                                  \
+        ((n) < (max) || (freebytes((x), (n) * sizeof(t)), 0)))
+#else
+# define ALLOCA(t, x, n, max) ((x) = (t *)getbytes((n) * sizeof(t)))
+# define FREEA(t, x, n, max) (freebytes((x), (n) * sizeof(t)))
+#endif
+
+    /* expand env vars and ~ at the beginning of a path and make a copy to return */
+static char*do_expandpath(const char *from, char *to, int bufsize)
+{
+    if ((strlen(from) == 1 && from[0] == '~') || (strncmp(from,"~/", 2) == 0))
+    {
+#ifdef _WIN32
+        const char *home = getenv("USERPROFILE");
+#else
+        const char *home = getenv("HOME");
+#endif
+        if (home)
+        {
+            strncpy(to, home, bufsize);
+            to[bufsize-1] = 0;
+            strncpy(to + strlen(to), from + 1, bufsize - strlen(to));
+            to[bufsize-1] = 0;
+        }
+        else *to = 0;
+    }
+    else
+    {
+        strncpy(to, from, bufsize);
+        to[bufsize-1] = 0;
+    }
+#ifdef _WIN32
+    {
+        char *buf = alloca(bufsize);
+        ExpandEnvironmentStrings(to, buf, bufsize-1);
+        buf[bufsize-1] = 0;
+        strncpy(to, buf, bufsize);
+        to[bufsize-1] = 0;
+    }
+#endif
+    return to;
+}
+
+    /* unbash '\' to '/', and drop duplicate '/' */
+static char*do_pathnormalize(const char *from, char *to) {
+    const char *rp;
+    char *wp, c;
+    sys_unbashfilename(from, to);
+    rp=wp=to;
+    while((*wp++=c=*rp++)) {
+        if('/' == c) {
+            while('/' == *rp++);
+            rp--;
+        }
+    }
+
+    *wp++=0;
+    return to;
+}
+
+static char*do_expandunbash(const char *from, char *to, int bufsize) {
+    do_expandpath(from, to, bufsize);
+    to[bufsize-1]=0;
+    sys_unbashfilename(to, to);
+    to[bufsize-1]=0;
+    return to;
+}
+
+static int str_endswith(char* str, char* end){
+    size_t strsize = strlen(str), endsize = strlen(end);
+    if(strsize<endsize) return 0;
+    return strcmp(str + strsize - endsize, end) == 0;
+}
+
+#ifdef _WIN32
+static const char*do_errmsg(char*buffer, size_t bufsize) {
+    char errcode[10];
+    char*s;
+    wchar_t wbuf[MAXPDSTRING];
+    DWORD err = GetLastError();
+    DWORD count = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        0, err, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, MAXPDSTRING, NULL);
+    if (!count || !WideCharToMultiByte(CP_UTF8, 0, wbuf, count+1, buffer, bufsize, 0, 0))
+        *buffer = '\0';
+    s=buffer + strlen(buffer)-1;
+    while(('\r' == *s || '\n' == *s) && s>buffer)
+        *s--=0;
+    snprintf(errcode, sizeof(errcode), " [%ld]", err);
+    errcode[sizeof(errcode)-1] = 0;
+    strcat(buffer, errcode);
+    return buffer;
+}
+#else /* !_WIN32 */
+static const char*do_errmsg(char*buffer, size_t bufsize) {
+    (void)buffer; (void)bufsize;
+    return strerror(errno);
+}
+#endif /* !_WIN32 */
+
+
+typedef struct _file_handle {
+    t_object x_obj;
+    int x_fd;
+    int x_mode; /* 0..read, 1..write */
+
+    mode_t x_creationmode; /* default: 0666, 0777 */
+    int x_verbose; /* default: 0 */
+
+    t_canvas*x_canvas;
+    t_outlet*x_dataout;
+    t_outlet*x_infoout;
+
+} t_file_handle;
+
+static int do_parse_creationmode(t_atom*ap) {
+    const char*s;
+    if(A_FLOAT==ap->a_type)
+        return atom_getfloat(ap);
+    if(A_SYMBOL!=ap->a_type)
+        return -1; /* oopsie */
+    s = atom_getsymbol(ap)->s_name;
+    if(!strncmp(s, "0o", 2)) {
+            /* octal mode */
+        char*endptr;
+        long mode = strtol(s+2, &endptr, 8);
+        return (*endptr)?-1:(int)mode;
+    } else if(!strncmp(s, "0x", 2)) {
+            /* hex mode: nobody sane uses this... */
+        char*endptr;
+        long mode = strtol(s+2, &endptr, 16);
+        return (*endptr)?-1:(int)mode;
+    } else {
+            /* free form mode: a+rwx,go-w */
+            /* not supported yet */
+        return -1;
+    }
+    return -1;
+}
+
+static void do_parse_args(t_file_handle*x, int argc, t_atom*argv) {
+        /*
+         * -q: quiet mode
+         * -v: verbose mode
+         * -m <mode>: creation mode
+         */
+    t_symbol*flag_m = gensym("-m");
+    t_symbol*flag_q = gensym("-q");
+    t_symbol*flag_v = gensym("-v");
+    while(argc--) {
+        const t_symbol*flag = atom_getsymbol(argv);
+        if (0);
+        else if (flag == flag_q) {
+            x->x_verbose--;
+        } else if (flag == flag_v) {
+            x->x_verbose++;
+        } else if (flag == flag_m) {
+            int mode;
+            if(!argc) {
+                pd_error(x, "'-m' requires an argument");
+                break;
+            }
+            argc--;
+            argv++;
+            mode = do_parse_creationmode(argv);
+            if(mode<0) {
+                char buf[MAXPDSTRING];
+                atom_string(argv, buf, MAXPDSTRING);
+                pd_error(x, "invalid creation mode '%s'", buf);
+                break;
+            } else {
+                x->x_creationmode = mode;
+            }
+        } else {
+            pd_error(x, "unknown flag %s", flag->s_name);
+            break;
+        }
+        argv++;
+    }
+    x->x_verbose = x->x_verbose > 0;
+}
+
+static t_file_handle* do_file_handle_new(t_class*cls, t_symbol*s, int argc, t_atom*argv, int verbose, mode_t creationmode) {
+    t_file_handle*x = (t_file_handle*)pd_new(cls);
+    (void)s;
+    x->x_fd = -1;
+    x->x_canvas = canvas_getcurrent();
+    x->x_creationmode = creationmode;
+    x->x_verbose = verbose;
+
+    x->x_dataout = outlet_new(&x->x_obj, 0);
+    x->x_infoout = outlet_new(&x->x_obj, 0);
+    do_parse_args(x, argc, argv);
+    return x;
+}
+
+static int do_file_open(t_file_handle*x, const char* filename, int mode) {
+    char expandbuf[MAXPDSTRING+1];
+    int fd = sys_open(do_expandpath(filename, expandbuf, MAXPDSTRING), mode, x?x->x_creationmode:0666);
+    if(x) {
+        x->x_fd = fd;
+        if(fd<0) {
+            if(x->x_verbose)
+                pd_error(x, "unable to open '%s': %s", filename, strerror(errno));
+            if(x->x_infoout)
+                outlet_bang(x->x_infoout);
+        }
+    }
+    return fd;
+}
+
+
+static void file_set_verbosity(t_file_handle*x, t_float f) {
+    x->x_verbose = (f>0.5);
+}
+static void file_set_creationmode(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+    if(argc!=1) {
+        pd_error(x, "usage: '%s <mode>'", s->s_name);
+        return;
+    }
+    x->x_creationmode = do_parse_creationmode(argv);
+}
+
+    /* ================ [file handle] ====================== */
+
+static void file_handle_close(t_file_handle*x) {
+    if (x->x_fd>=0)
+        sys_close(x->x_fd);
+    x->x_fd = -1;
+}
+static int file_handle_checkopen(t_file_handle*x, const char*cmd) {
+    if(x->x_fd<0) {
+        if(!cmd)cmd=(x->x_mode)?"write":"read";
+        pd_error(x, "'%s' without prior 'open'", cmd);
+        return 0;
+    }
+    return 1;
+}
+static void file_handle_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+    (void)s;
+    if(x->x_mode) {
+            /* write_mode */
+        unsigned char*buf;
+        size_t len = (argc>0)?argc:0;
+        if(!file_handle_checkopen(x, 0))
+            return;
+        ALLOCA(unsigned char, buf, argc, 100);
+        if(buf) {
+            ssize_t n;
+            for(n=0; n<argc; n++) {
+                buf[n] = atom_getfloat(argv+n);
+            }
+            n = write(x->x_fd, buf, len);
+            if(n >= 0 && (size_t)n < len) {
+                n = write(x->x_fd, buf+n, len-n);
+            }
+            if (n<0) {
+                pd_error(x, "write failed: %s", strerror(errno));
+                file_handle_close(x);
+                outlet_bang(x->x_infoout);
+            }
+        } else {
+            pd_error(x, "could not allocate %d bytes for writing", argc);
+        }
+        FREEA(unsigned char, buf, argc, 100);
+    } else {
+            /* read mode */
+        pd_error(x, "no way to handle 'list' messages while reading file");
+    }
+}
+static void file_handle_float(t_file_handle*x, t_float f) {
+    if(!file_handle_checkopen(x, 0))
+        return;
+    if(x->x_mode) {
+            /* write_mode: write the byte */
+        t_atom ap[1];
+        SETFLOAT(ap+0, f);
+        file_handle_list(x, &s_list, 1, ap);
+    } else {
+            /* read mode */
+        t_atom*outv;
+        unsigned char*buf;
+        ssize_t n, len, outc = f;
+        if(outc<1) {
+            pd_error(x, "cannot read %d bytes", (int)outc);
+            return;
+        }
+        ALLOCA(unsigned char, buf, outc, 100);
+        ALLOCA(t_atom, outv, outc, 100);
+        if(buf && outv) {
+            len = read(x->x_fd, buf, outc);
+            for(n=0; n<len; n++) {
+                SETFLOAT(outv+n, (t_float)buf[n]);
+            }
+            if(len>0) {
+                outlet_list(x->x_dataout, gensym("list"), len, outv);
+            } else if (!len) {
+                file_handle_close(x);
+                outlet_bang(x->x_infoout);
+            } else {
+                if(x->x_verbose)
+                    pd_error(x, "read failed: %s", strerror(errno));
+                file_handle_close(x);
+                outlet_bang(x->x_infoout);
+            }
+        } else {
+            pd_error(x, "couldn't allocate buffer for %d bytes", (int)outc);
+        }
+        FREEA(unsigned char, buf, outc, 100);
+        FREEA(t_atom, outv, outc, 100);
+    }
+}
+static void file_handle_seek(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+    off_t offset=0;
+    int whence = SEEK_SET;
+    switch(argc) {
+    case 0:
+            /* just output the current position */
+        whence=SEEK_CUR;
+        break;
+    case 2: {
+        if (A_SYMBOL!=argv[1].a_type)
+            goto usage;
+        s=atom_getsymbol(argv+1);
+        switch(*s->s_name) {
+        case 'S': case 's': case 0:
+            whence = SEEK_SET;
+            break;
+        case 'E': case 'e':
+            whence = SEEK_END;
+            break;
+        case 'C': case 'c': case 'R': case 'r':
+            whence = SEEK_CUR;
+            break;
+        default:
+            pd_error(x, "seek mode must be 'set', 'end' or 'current' (resp. 'relative')");
+            return;
+        }
+    }
+            /* falls through */
+    case 1:
+        if (A_FLOAT!=argv[0].a_type)
+            goto usage;
+        offset = (int)atom_getfloat(argv);
+        break;
+    }
+
+    if(!file_handle_checkopen(x, "seek"))
+        return;
+    offset = lseek(x->x_fd, offset, whence);
+    outlet_float(x->x_infoout, offset);
+    return;
+ usage:
+    pd_error(x, "usage: seek [<int:offset> [<symbol:mode>]]");
+}
+static void file_handle_open(t_file_handle*x, t_symbol*file, t_symbol*smode) {
+    int mode = O_RDONLY;
+    if (x->x_fd>=0) {
+        pd_error(x, "'open' without prior 'close'");
+        return;
+    }
+    if(smode && smode!=&s_) {
+        switch(smode->s_name[0]) {
+        case 'r': /* read */
+            mode = O_RDONLY;
+            break;
+        case 'w': /* write */
+            mode = O_WRONLY;
+            break;
+        case 'a': /* append */
+            mode = O_WRONLY | O_APPEND;
+            break;
+        case 'c': /* create */
+            mode = O_WRONLY | O_TRUNC;
+            break;
+        }
+    }
+    if(mode & O_WRONLY) {
+        mode |= O_CREAT;
+    }
+    if(do_file_open(x, file->s_name, mode)>=0) {
+            /* check if we haven't accidentally opened a directory */
+        struct stat sb;
+        if(fstat(x->x_fd, &sb)) {
+            file_handle_close(x);
+            if(x->x_verbose)
+                pd_error(x, "unable to stat '%s': %s", file->s_name, strerror(errno));
+            outlet_bang(x->x_infoout);
+            return;
+        }
+        if(S_ISDIR(sb.st_mode)) {
+            file_handle_close(x);
+            if(x->x_verbose)
+                pd_error(x, "unable to open directory '%s' as file", file->s_name);
+            outlet_bang(x->x_infoout);
+            return;
+        }
+        x->x_mode = (mode&O_WRONLY)?1:0;
+    }
+}
+
+static void file_handle_free(t_file_handle*x) {
+    file_handle_close(x);
+}
+
+    /* ================ [file stat] ====================== */
+static int do_file_stat(t_file_handle*x, const char*filename, struct stat*sb, int*is_symlink) {
+    int result = -1;
+    int fd = -1;
+    char buf[MAXPDSTRING+1];
+    do_expandpath(filename, buf, MAXPDSTRING);
+
+    if(is_symlink) {
+        *is_symlink=0;
+#ifdef S_IFLNK
+        if(!lstat(buf, sb)) {
+            *is_symlink = !!(S_ISLNK(sb->st_mode));
+        }
+#endif
+    }
+    result = sys_stat(buf, sb);
+    if(!result)
+        return result;
+
+    fd = do_file_open(0, filename, 0);
+
+    if(fd >= 0) {
+        result = fstat(fd, sb);
+        sys_close(fd);
+    } else
+        result = -1;
+
+    if(x) {
+        x->x_fd = -1;
+        if(result && x->x_verbose) {
+            pd_error(x, "could not stat on '%s': %s", filename, strerror(errno));
+        }
+    }
+    return result;
+}
+static void do_dataout_symbol(t_file_handle*x, const char*selector, t_symbol*s) {
+    t_atom ap[1];
+    SETSYMBOL(ap, s);
+    outlet_anything(x->x_dataout, gensym(selector), 1, ap);
+}
+static void do_dataout_float(t_file_handle*x, const char*selector, t_float f) {
+    t_atom ap[1];
+    SETFLOAT(ap, f);
+    outlet_anything(x->x_dataout, gensym(selector), 1, ap);
+}
+static void do_dataout_time(t_file_handle*x, const char*selector, time_t t) {
+    t_atom ap[7];
+    struct tm *ts = localtime(&t);
+    if(!ts) {
+        pd_error(x, "unable to convert timetamp %ld", (long int)t);
+    }
+    SETFLOAT(ap+0, ts->tm_year + 1900);
+    SETFLOAT(ap+1, ts->tm_mon + 1);
+    SETFLOAT(ap+2, ts->tm_mday);
+    SETFLOAT(ap+3, ts->tm_hour);
+    SETFLOAT(ap+4, ts->tm_min);
+    SETFLOAT(ap+5, ts->tm_sec);
+    SETFLOAT(ap+6, ts->tm_isdst);
+    outlet_anything(x->x_dataout, gensym(selector), 7, ap);
+}
+static void file_stat_symbol(t_file_handle*x, t_symbol*filename) {
+        /* get all the info for the given file */
+    struct stat sb;
+    t_symbol*s;
+    int is_symlink=0;
+    int readable=0, writable=0, executable=0, owned=-1;
+    char buf[MAXPDSTRING+1];
+
+    if(do_file_stat(x, filename->s_name, &sb, &is_symlink) < 0) {
+        outlet_bang(x->x_infoout);
+        return;
+    }
+
+        /* this is wrong: readable/writable/executable are supposed to report
+         * on the *current* user, not the *owner*
+         */
+    readable = !!(sb.st_mode & 0400);
+    writable = !!(sb.st_mode & 0200);
+    executable = !!(sb.st_mode & 0100);
+#ifdef HAVE_UNISTD_H
+        /* this is the right way */
+    do_expandpath(filename->s_name, buf, MAXPDSTRING);
+
+    readable = !(access(buf, R_OK));
+    writable = !(access(buf, W_OK));
+    executable = !(access(buf, X_OK));
+#ifndef _WIN32
+    owned = (geteuid() == sb.st_uid);
+#endif
+#endif
+
+    switch (sb.st_mode & S_IFMT) {
+    case S_IFREG:
+#ifdef S_IFLNK
+    case S_IFLNK:
+#endif
+        do_dataout_float(x, "size", (int)(sb.st_size));
+        break;
+    case S_IFDIR:
+        do_dataout_float(x, "size", 0);
+        break;
+    default:
+        do_dataout_float(x, "size", -1);
+        break;
+    }
+    do_dataout_float(x, "readable", readable);
+    do_dataout_float(x, "writable", writable);
+    do_dataout_float(x, "executable", executable);
+    do_dataout_float(x, "owned", owned);
+
+    do_dataout_float(x, "isfile", !!(S_ISREG(sb.st_mode)));
+    do_dataout_float(x, "isdirectory", !!(S_ISDIR(sb.st_mode)));
+    do_dataout_float(x, "issymlink", is_symlink);
+
+    do_dataout_float(x, "uid", (int)(sb.st_uid));
+    do_dataout_float(x, "gid", (int)(sb.st_gid));
+    do_dataout_float(x, "permissions", (int)(sb.st_mode & 0777));
+    switch (sb.st_mode & S_IFMT) {
+    case S_IFBLK:  s = gensym("blockdevice");     break;
+    case S_IFCHR:  s = gensym("characterdevice"); break;
+    case S_IFDIR:  s = gensym("directory");       break;
+    case S_IFIFO:  s = gensym("pipe");            break;
+#ifdef S_IFLNK
+    case S_IFLNK:  s = gensym("symlink");         break;
+#endif
+    case S_IFREG:  s = gensym("file");            break;
+#ifdef S_IFSOCK
+    case S_IFSOCK: s = gensym("socket");          break;
+#endif
+    default:       s = 0;                         break;
+    }
+    if(s)
+        do_dataout_symbol(x, "type", s);
+    else
+        do_dataout_symbol(x, "type", gensym("unknown"));
+
+    do_dataout_time(x, "atime", sb.st_atime);
+    do_dataout_time(x, "mtime", sb.st_mtime);
+}
+
+static void file_size_symbol(t_file_handle*x, t_symbol*filename) {
+    struct stat sb;
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+        outlet_bang(x->x_infoout);
+    } else {
+        switch (sb.st_mode & S_IFMT) {
+        case S_IFREG:
+#ifdef S_IFLNK
+        case S_IFLNK:
+#endif
+            outlet_float(x->x_dataout, (int)(sb.st_size));
+            break;
+        case S_IFDIR:
+            outlet_float(x->x_dataout, 0);
+            break;
+        default:
+            outlet_float(x->x_dataout, -1);
+            break;
+        }
+    }
+}
+static void file_isfile_symbol(t_file_handle*x, t_symbol*filename) {
+    struct stat sb;
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+        outlet_bang(x->x_infoout);
+    } else {
+        outlet_float(x->x_dataout, !!(S_ISREG(sb.st_mode)));
+    }
+}
+static void file_isdirectory_symbol(t_file_handle*x, t_symbol*filename) {
+    struct stat sb;
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+        outlet_bang(x->x_infoout);
+    } else {
+        outlet_float(x->x_dataout, !!(S_ISDIR(sb.st_mode)));
+    }
+}
+
+    /* ================ [file glob] ====================== */
+#ifdef _WIN32
+/* idiosyncracies:
+ * - cases are ignored ('a*' matches 'A.txt' and 'a.txt'), even with wine on ext4
+ * - only the filename component is returned (must prefix path separately)
+ * - non-ASCII needs special handling
+ * - '*?' seems to be illegal (e.g. 'f*?.txt'); '?*' seems to be fine though
+ * - "*" matches files starting with '.' (including '.', '..', but also .gitignore)
+ * - if the pattern includes '*.', it matches a trailing '~'
+ * - wildcards do not apply to directory-components (e.g. 'foo/ * /' (without the spaces, they are just due to C-comments constraints))
+ *
+ * plan:
+ * - concat the path and the filename
+ * - convert to utf16 (and back again)
+ * - replace '*?' with '*' in the pattern
+ * - manually filter out:
+ *   - matches starting with '.' if the pattern does not start with '.'
+ *   - matches ending in '~' if the pattern does not end with '[*?~]'
+ * - only (officially) support wildcards in the filename component (not in the paths)
+ * - if the pattern ends with '/', strip it, but return only directories
+ */
+static void file_glob_symbol(t_file_handle*x, t_symbol*spattern) {
+    WIN32_FIND_DATAW FindFileData;
+    HANDLE hFind;
+    uint16_t ucs2pattern[MAXPDSTRING];
+    char pattern[MAXPDSTRING];
+    int nostartdot=0, noendtilde=0, onlydirs=0;
+    char *filepattern, *strin, *strout;
+    int pathpatternlength=0;
+    int matchdot=0;
+
+    do_expandunbash(spattern->s_name, pattern, MAXPDSTRING);
+
+        /* '.' and '..' should only match if the pattern exquisitely asked for them */
+    if(!strcmp(".", pattern) || !strcmp("./", pattern)
+        || str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
+        matchdot=1;
+    else if(!strcmp("..", pattern) || !strcmp("../", pattern)
+        || str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
+        matchdot=2;
+
+    if (matchdot) {
+            /* windows FindFile would return the actual path rather than '.'
+             * (which would confuse our full-path construction)
+             * so we just return the result directly
+             */
+        struct stat sb;
+        if (!do_file_stat(0, pattern, &sb, 0)) {
+            t_atom outv[2];
+            size_t end = strlen(pattern);
+                /* get rid of trailing slash */
+            if('/' == pattern[end-1])
+                pattern[end-1]=0;
+            SETSYMBOL(outv+0, gensym(pattern));
+            SETFLOAT(outv+1, S_ISDIR(sb.st_mode));
+            outlet_list(x->x_dataout, gensym("list"), 2, outv);
+        } else {
+                // this gets triggered if there is no match...
+            outlet_bang(x->x_infoout);
+        }
+        return;
+    }
+
+
+    filepattern=strrchr(pattern, '/');
+    if(filepattern && !filepattern[1]) {
+            /* patterns ends with slashes: filter for dirs, and bash the trailing slashes */
+        onlydirs=1;
+        while('/' == *filepattern && filepattern>pattern) {
+            *filepattern--=0;
+        }
+        filepattern=strrchr(pattern, '/');
+    }
+    if(!filepattern)
+        filepattern=pattern;
+    else {
+        filepattern++;
+        pathpatternlength=filepattern-pattern;
+    }
+    nostartdot=('.' != *filepattern);
+    strin=filepattern;
+    strout=filepattern;
+    while(*strin) {
+        char c = *strin++;
+        *strout++ = c;
+        if('*' == c) {
+            while('?' == *strin || '*' == *strin)
+                strin++;
+        }
+    }
+    *strout=0;
+    if (strout>pattern) {
+        switch(strout[-1]) {
+        case '~':
+        case '*':
+        case '?':
+            noendtilde=0;
+            break;
+        default:
+            noendtilde=1;
+        }
+    }
+    u8_utf8toucs2(ucs2pattern, MAXPDSTRING, pattern, MAXPDSTRING);
+
+    hFind = FindFirstFileW(ucs2pattern, &FindFileData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+            // this gets triggered if there is no match...
+        outlet_bang(x->x_infoout);
+        return;
+    }
+    do {
+        t_symbol*s;
+        t_atom outv[2];
+        int len = 0;
+        int isdir = !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
+        if (matchdot!=1 && !wcscmp(L"." , FindFileData.cFileName))
+            continue;
+        if (matchdot!=2 && !wcscmp(L".." , FindFileData.cFileName))
+            continue;
+        u8_ucs2toutf8(filepattern, MAXPDSTRING-pathpatternlength, FindFileData.cFileName, MAX_PATH);
+        len = strlen(filepattern);
+
+        if(onlydirs && !isdir)
+            continue;
+        if(nostartdot && '.' == filepattern[0])
+            continue;
+        if(noendtilde && '~' == filepattern[len-1])
+            continue;
+
+        s = gensym(pattern);
+        SETSYMBOL(outv+0, s);
+        SETFLOAT(outv+1, isdir);
+        outlet_list(x->x_dataout, gensym("list"), 2, outv);
+    } while (FindNextFileW(hFind, &FindFileData) != 0);
+    FindClose(hFind);
+}
+#else /* !_WIN32 */
+static void file_glob_symbol(t_file_handle*x, t_symbol*spattern) {
+    t_atom outv[2];
+    glob_t gg;
+    int flags = 0;
+    int matchdot=0;
+    char pattern[MAXPDSTRING];
+    size_t patternlen;
+    int onlydirs;
+    do_expandpath(spattern->s_name, pattern, MAXPDSTRING);
+    patternlen=strlen(pattern);
+    onlydirs = ('/' == pattern[patternlen-1]);
+    if(!strcmp(".", pattern) || !strcmp("./", pattern)
+        || str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
+        matchdot=1;
+    else if(!strcmp("..", pattern) || !strcmp("../", pattern)
+        || str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
+        matchdot=2;
+    if(glob(pattern, flags, NULL, &gg)) {
+            // this gets triggered if there is no match...
+        outlet_bang(x->x_infoout);
+    } else {
+        size_t i;
+        for(i=0; i<gg.gl_pathc; i++) {
+            t_symbol *s;
+            char*path = gg.gl_pathv[i];
+            int isdir = 0;
+            struct stat sb;
+            int end;
+            if(!do_file_stat(0, path, &sb, 0)) {
+                isdir = S_ISDIR(sb.st_mode);
+            }
+            if(onlydirs && !isdir)
+                continue;
+            end=strlen(path);
+            if('/' == path[end-1]) {
+                path[end-1]=0;
+            }
+            if (matchdot!=1 && (!strcmp(path, ".") || str_endswith(path, "/.")))
+                continue;
+            if (matchdot!=2 && (!strcmp(path, "..") || str_endswith(path, "/..")))
+                continue;
+
+            s = gensym(path);
+            SETSYMBOL(outv+0, s);
+            SETFLOAT(outv+1, isdir);
+            outlet_list(x->x_dataout, gensym("list"), 2, outv);
+        }
+    }
+    globfree(&gg);
+}
+#endif /* _WIN32 */
+
+
+    /* ================ [file which] ====================== */
+
+static void file_which_symbol(t_file_handle*x, t_symbol*s) {
+        /* LATER we might output directories as well,... */
+    int isdir=0;
+    t_atom outv[2];
+    char dirresult[MAXPDSTRING], *nameresult;
+    int fd = canvas_open(x->x_canvas,
+        s->s_name, "",
+        dirresult, &nameresult, MAXPDSTRING,
+        1);
+    if(fd>=0) {
+        sys_close(fd);
+        if(nameresult>dirresult)
+            nameresult[-1]='/';
+        SETSYMBOL(outv+0, gensym(dirresult));
+        SETFLOAT(outv+1, isdir);
+        outlet_list(x->x_dataout, gensym("list"), 2, outv);
+    } else {
+        outlet_symbol(x->x_infoout, s);
+    }
+}
+
+
+    /* ================ [file mkdir] ====================== */
+static void file_mkdir_symbol(t_file_handle*x, t_symbol*dir) {
+    char pathname[MAXPDSTRING], *path=pathname, *str;
+    struct stat sb;
+
+    do_expandpath(dir->s_name, pathname, MAXPDSTRING);
+    pathname[MAXPDSTRING-1]=0;
+    do_pathnormalize(pathname, pathname);
+
+    if(sys_isabsolutepath(pathname)) {
+        str=strchr(path, '/');
+        if(str)
+            path=str;
+    }
+    path++;
+    while(*path) {
+            /* get to the next path separator */
+        str=strchr(path, '/');
+        if(str) {
+            *str=0;
+        }
+        if(!sys_stat(pathname, &sb) && (S_ISDIR(sb.st_mode))) {
+                // directory exists, skip...
+        } else {
+            if(sys_mkdir(pathname, x?x->x_creationmode:0777)) {
+                char buf[MAXPDSTRING];
+                pd_error(x, "failed to create '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+                outlet_bang(x->x_infoout);
+                return;
+            }
+        }
+
+        if(str) {
+            *str='/';
+            path=str+1;
+        }
+        else
+            break;
+    }
+    outlet_symbol(x->x_dataout, gensym(pathname));
+}
+
+    /* ================ [file delete] ====================== */
+#ifdef _WIN32
+static int file_do_delete_recursive_ucs2(uint16_t*path) {
+    WIN32_FIND_DATAW FindFileData;
+    HANDLE hFind;
+    uint16_t pattern[MAX_PATH];
+    swprintf(pattern, MAX_PATH, L"%ls/*", path);
+    hFind = FindFirstFileW(pattern, &FindFileData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return 1;
+    }
+    do {
+        int isdir = !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
+        swprintf(pattern, MAX_PATH, L"%ls/%ls", path, FindFileData.cFileName);
+        if(!isdir) {
+            DeleteFileW(pattern);
+        } else {
+                /* skip self and parent */
+            if(!wcscmp(L".", FindFileData.cFileName))continue;
+            if(!wcscmp(L"..", FindFileData.cFileName))continue;
+            file_do_delete_recursive_ucs2(pattern);
+        }
+    } while (FindNextFileW(hFind, &FindFileData) != 0);
+    FindClose(hFind);
+    return do_delete_ucs2(path);
+}
+
+static int file_do_delete_recursive(const char*path) {
+    uint16_t ucs2path[MAXPDSTRING];
+    u8_utf8toucs2(ucs2path, MAXPDSTRING, path, MAXPDSTRING);
+    return file_do_delete_recursive_ucs2(ucs2path);
+}
+#else /* !_WIN32 */
+static int nftw_cb(const char *path, const struct stat *s, int flag, struct FTW *f) {
+    (void)s;
+    (void)f;
+    (void)flag;
+    return remove(path);
+}
+
+static int file_do_delete_recursive(const char*pathname) {
+    return nftw(pathname, nftw_cb, 128, FTW_MOUNT|FTW_PHYS|FTW_DEPTH);
+}
+#endif /* !_WIN32 */
+
+
+static void file_delete_symbol(t_file_handle*x, t_symbol*path) {
+    char pathname[MAXPDSTRING];
+
+    do_expandunbash(path->s_name, pathname, MAXPDSTRING);
+
+    if(sys_remove(pathname)) {
+        char buf[MAXPDSTRING];
+        if(x && x->x_verbose)
+            pd_error(x, "unable to delete '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+        outlet_bang(x->x_infoout);
+    } else {
+        outlet_symbol(x->x_dataout, gensym(pathname));
+    }
+}
+
+static void file_delete_recursive(t_file_handle*x, t_symbol*path) {
+    char pathname[MAXPDSTRING];
+
+    do_expandunbash(path->s_name, pathname, MAXPDSTRING);
+
+    if(file_do_delete_recursive(pathname)) {
+        if(x->x_verbose) {
+            char buf[MAXPDSTRING];
+            pd_error(x, "unable to recursively delete '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+        }
+        outlet_bang(x->x_infoout);
+    } else {
+        outlet_symbol(x->x_dataout, gensym(pathname));
+    }
+}
+
+
+    /* ================ [file copy]/[file move] ====================== */
+static int file_do_copy(const char*source, const char*destination, int mode) {
+    int result = 0;
+    ssize_t len;
+    char buf[1024];
+    int src, dst;
+    int wflags = O_WRONLY | O_CREAT | O_TRUNC;
+#ifdef _WIN32
+    wflags |= O_BINARY;
+#endif
+    src = sys_open(source, O_RDONLY);
+    if(src<0)
+        return 1;
+    dst = sys_open(destination, wflags, mode);
+    if(dst<0) {
+        struct stat sb;
+            /* check if destination is a directory: if so calculate the new filename */
+        if(!do_file_stat(0, destination, &sb, 0) && (S_ISDIR(sb.st_mode))) {
+            char destfile[MAXPDSTRING];
+            const char*filename=strrchr(source, '/');
+            if(!filename)
+                filename=source;
+            else
+                filename++;
+            snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
+            dst = sys_open(destfile, O_WRONLY | O_CREAT | O_TRUNC, mode);
+        }
+    }
+    if(dst<0)
+        return 1;
+
+    while((len=read(src, buf, sizeof(buf)))>0) {
+        ssize_t wlen=write(dst, buf, len);
+            /* TODO: cater for partial writes */
+        if (wlen<1) {
+            result = 1 ;
+        }
+    }
+    sys_close(src);
+    sys_close(dst);
+
+    return (result);
+}
+static int file_do_move(const char*source, const char*destination, int mode) {
+    int olderrno=0;
+    int result = sys_rename(source, destination);
+    (void)mode;
+    if(result) {
+        olderrno=errno;
+            /* check whether we are trying to move a file to a directory */
+        struct stat sb;
+        int isfile=0;
+        int isdir=0;
+
+        if(do_file_stat(0, source, &sb, 0) < 0)
+            goto done; /* source is not statable, that's a serious error */
+        isfile = !(S_ISDIR(sb.st_mode));
+        if(do_file_stat(0, destination, &sb, 0) < 0)
+            goto done;  /* destination is not statable (so it doesn't exist and is not a directory either */
+        isdir = (S_ISDIR(sb.st_mode));
+        if(isfile && isdir) {
+            char destfile[MAXPDSTRING];
+            const char*filename=strrchr(source, '/');
+            if(!filename)
+                filename=source;
+            else
+                filename++;
+            snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
+            result = sys_rename(source, destfile);
+            olderrno = errno;
+        }
+    }
+
+    if(result && EXDEV == errno) {
+            /* need to manually copy the file to the another filesystem */
+        result = file_do_copy(source, destination, mode);
+        if(!result) {
+            olderrno=0;
+                /* copy succeeded, now get rid of the source file */
+            if(sys_remove(source)) {
+                    /* oops, couldn't delete the source-file...
+                     * we still report this as SUCCESS, as the file has been duplicated.
+                     * LATER we might try to unlink() the file first.
+                     * set the olderrno to print some error in verbose-mode
+                     */
+                olderrno=errno;
+            }
+        }
+    }
+ done:
+    errno=olderrno;
+    return result;
+}
+static void file_do_copymove(t_file_handle*x,
+    const char*verb, int (*fun)(const char*,const char*,int),
+    t_symbol*s, int argc, t_atom*argv) {
+    struct stat sb;
+    char src[MAXPDSTRING], dst[MAXPDSTRING];
+    if(argc != 2 || A_SYMBOL != argv[0].a_type || A_SYMBOL != argv[1].a_type) {
+        pd_error(x, "bad arguments for [file %s] - should be 'source:symbol destination:symbol'", verb);
+        return;
+    }
+    do_expandunbash(atom_getsymbol(argv+0)->s_name, src, MAXPDSTRING);
+    do_expandunbash(atom_getsymbol(argv+1)->s_name, dst, MAXPDSTRING);
+
+    if(!sys_stat(src, &sb)) {
+        if(S_ISDIR(sb.st_mode)) {
+            if(x->x_verbose) {
+                pd_error(x, "failed to %s '%s': %s", verb, src, strerror(EISDIR));
+            }
+            outlet_bang(x->x_infoout);
+            return;
+        }
+    }
+
+    errno = 0;
+    if(fun(src, dst, x->x_creationmode?x->x_creationmode:sb.st_mode)) {
+        if(x->x_verbose) {
+            char buf[MAXPDSTRING];
+            pd_error(x, "failed to %s '%s' to '%s': %s", verb, src, dst, do_errmsg(buf, MAXPDSTRING));
+        }
+        outlet_bang(x->x_infoout);
+    } else {
+        if(errno && x->x_verbose) {
+            char buf[MAXPDSTRING];
+            pd_error(x, "troubles (but overall success) to %s '%s' to '%s': %s", verb, src, dst, do_errmsg(buf, MAXPDSTRING));
+        }
+        outlet_list(x->x_dataout, s, argc, argv);
+    }
+}
+
+static void file_copy_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+    file_do_copymove(x, "copy", file_do_copy, s, argc, argv);
+}
+static void file_move_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+    file_do_copymove(x, "move", file_do_move, s, argc, argv);
+}
+
+/* ================ file path operations ====================== */
+static void file_split_symbol(t_file_handle*x, t_symbol*path) {
+    t_symbol*slashsym = gensym("/");
+    t_atom*outv;
+    int outc=0, outsize=1;
+    char buffer[MAXPDSTRING], *pathname=buffer;
+    sys_unbashfilename(path->s_name, buffer);
+    buffer[MAXPDSTRING-1] = 0;
+
+        /* first count the number of path components */
+    while(*pathname)
+        outsize += ('/'==*pathname++);
+    pathname=buffer;
+    ALLOCA(t_atom, outv, outsize, 100);
+
+    if('/' == *pathname)
+        SETSYMBOL(outv+outc, slashsym), outc++;
+
+    while(*pathname) {
+        char*pathsep;
+        while('/' == *pathname)
+            pathname++;
+        pathsep=strchr(pathname, '/');
+        if(!pathsep) {
+            if(*pathname)
+                SETSYMBOL(outv+outc, gensym(pathname)), outc++;
+            break;
+        }
+        *pathsep=0;
+        SETSYMBOL(outv+outc, gensym(pathname)), outc++;
+        pathname=pathsep+1;
+    }
+    if (*pathname)
+        outlet_bang(x->x_infoout);
+    else
+        outlet_symbol(x->x_infoout, slashsym);
+
+    outlet_list(x->x_dataout, gensym("list"), outc, outv);
+
+    FREEA(t_atom, outv, outsize, 100);
+}
+
+static void file_join_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+        /* luckily for us, the path-separator in Pd is aways '/' */
+    size_t bufsize = 0;
+    char*buffer = getbytes(bufsize);
+    (void)s;
+    while(argc--) {
+        size_t newsize;
+        int needsep=(argc>0);
+        char abuf[MAXPDSTRING], *newbuffer;
+        size_t alen;
+        atom_string(argv++, abuf, MAXPDSTRING);
+        alen = strlen(abuf);
+        if(!alen || '/' == abuf[alen-1])
+            needsep = 0;
+        newsize = bufsize + alen + needsep;
+        if (!(newbuffer = resizebytes(buffer, bufsize, newsize))) break;
+        buffer = newbuffer;
+        strcpy(buffer+bufsize, abuf);
+        if(needsep)
+            buffer[newsize-1]='/';
+        bufsize = newsize;
+    }
+    outlet_symbol(x->x_dataout, gensym(do_pathnormalize(buffer, buffer)));
+    freebytes(buffer, bufsize);
+}
+
+static void file_splitext_symbol(t_file_handle*x, t_symbol*path) {
+    char pathname[MAXPDSTRING];
+    t_atom outv[2];
+    char*str;
+    sys_unbashfilename(path->s_name, pathname);
+    pathname[MAXPDSTRING-1]=0;
+    str=pathname + strlen(pathname)-1;
+    if(str < pathname || '.' != *str)
+    {
+        while(str>=pathname) {
+            char c = *str;
+            switch(c) {
+            case '.':
+                str[0]=0;
+                SETSYMBOL(outv+0, gensym(pathname));
+                SETSYMBOL(outv+1, gensym(str+1));
+                outlet_list(x->x_dataout, gensym("list"), 2, outv);
+                return;
+            case '/':
+                str = pathname;
+                break;
+            default:
+                break;
+            }
+            str--;
+        }
+    }
+    outlet_symbol(x->x_infoout, gensym(pathname));
+}
+static void file_splitname_symbol(t_file_handle*x, t_symbol*path) {
+    char pathname[MAXPDSTRING];
+    char*str;
+    sys_unbashfilename(path->s_name, pathname);
+    pathname[MAXPDSTRING-1]=0;
+    str=strrchr(pathname, '/');
+    if(str>pathname) {
+        t_symbol*s;
+        *str++=0;
+        s = gensym(pathname);
+        if(*str) {
+            t_atom outv[2];
+            SETSYMBOL(outv+0, s);
+            SETSYMBOL(outv+1, gensym(str));
+            outlet_list(x->x_dataout, gensym("list"), 2, outv);
+        } else {
+            outlet_symbol(x->x_dataout, s);
+        }
+    } else {
+        outlet_symbol(x->x_infoout, gensym(pathname));
+    }
+}
+
+
+    /* overall creator for "file" objects - dispatch to "file handle" etc */
+t_class *file_handle_class, *file_which_class, *file_glob_class;
+t_class *file_stat_class, *file_size_class, *file_isfile_class, *file_isdirectory_class;
+t_class *file_mkdir_class, *file_delete_class, *file_copy_class, *file_move_class;
+t_class *file_split_class,*file_join_class,*file_splitext_class, *file_splitname_class;
+
+#define FILE_PD_NEW(verb, verbose, creationmode) static t_file_handle* file_##verb##_new(t_symbol*s, int argc, t_atom*argv) \
+    {                                                                   \
+        return do_file_handle_new(file_##verb##_class, s, argc, argv, verbose, creationmode); \
+    }
+
+FILE_PD_NEW(handle, 1, 0666);
+
+FILE_PD_NEW(which, 0, 0);
+FILE_PD_NEW(glob, 0, 0);
+
+FILE_PD_NEW(stat, 0, 0);
+FILE_PD_NEW(size, 0, 0);
+FILE_PD_NEW(isfile, 0, 0);
+FILE_PD_NEW(isdirectory, 0, 0);
+
+FILE_PD_NEW(mkdir, 0, 0777);
+FILE_PD_NEW(delete, 0, 0);
+FILE_PD_NEW(copy, 0, 0);
+FILE_PD_NEW(move, 0, 0);
+
+FILE_PD_NEW(split, 0, 0);
+FILE_PD_NEW(join, 0, 0);
+FILE_PD_NEW(splitext, 0, 0);
+FILE_PD_NEW(splitname, 0, 0);
+
+static t_pd *fileobj_new(t_symbol *s, int argc, t_atom*argv)
+{
+    t_file_handle*x = 0;
+    const char*verb=0;
+    if(gensym("file") == s) {
+        if (argc && A_SYMBOL == argv->a_type) {
+            verb = atom_getsymbol(argv)->s_name;
+            argc--;
+            argv++;
+        } else {
+            verb = "handle";
+        }
+    } else if (strlen(s->s_name)>5) {
+        verb = s->s_name + 5;
+    }
+    if (!verb || !*verb)
+        x = do_file_handle_new(file_handle_class, gensym("file handle"), argc, argv, 1, 0666);
+    else {
+#define ELIF_FILE_PD_NEW(name, verbose, creationmode) else              \
+            if (!strcmp(verb, #name))                                   \
+                x = do_file_handle_new(file_##name##_class, gensym("file "#name), argc, argv, verbose, creationmode)
+
+        if(0);
+        ELIF_FILE_PD_NEW(handle, 1, 0666);
+        ELIF_FILE_PD_NEW(which, 0, 0);
+        ELIF_FILE_PD_NEW(glob, 0, 0);
+        ELIF_FILE_PD_NEW(stat, 0, 0);
+        ELIF_FILE_PD_NEW(size, 0, 0);
+        ELIF_FILE_PD_NEW(isfile, 0, 0);
+        ELIF_FILE_PD_NEW(isdirectory, 0, 0);
+        ELIF_FILE_PD_NEW(mkdir, 0, 0777);
+        ELIF_FILE_PD_NEW(delete, 0, 0);
+        ELIF_FILE_PD_NEW(copy, 0, 0);
+        ELIF_FILE_PD_NEW(move, 0, 0);
+        ELIF_FILE_PD_NEW(split, 0, 0);
+        ELIF_FILE_PD_NEW(join, 0, 0);
+        ELIF_FILE_PD_NEW(splitext, 0, 0);
+        ELIF_FILE_PD_NEW(splitname, 0, 0);
+        else {
+            error("file %s: unknown function", verb);
+        }
+    }
+    return (t_pd*)x;
+}
+
+typedef enum _filenew_flag {
+    DEFAULT = 0,
+    VERBOSE = 1<<0,
+    MODE = 1<<1
+} t_filenew_flag;
+
+static t_class*file_class_new(const char*name
+    , t_file_handle* (*ctor)(t_symbol*,int,t_atom*), void (*dtor)(t_file_handle*)
+    , void (*symfun)(t_file_handle*, t_symbol*)
+    , t_filenew_flag flag
+    ) {
+    t_class*cls = class_new(gensym(name),
+        (t_newmethod)ctor, (t_method)dtor,
+        sizeof(t_file_handle), 0, A_GIMME, 0);
+    if (flag & VERBOSE)
+        class_addmethod(cls, (t_method)file_set_verbosity, gensym("verbose"), A_FLOAT, 0);
+    if (flag & MODE)
+        class_addmethod(cls, (t_method)file_set_creationmode, gensym("creationmode"), A_GIMME, 0);
+    if(symfun)
+        class_addsymbol(cls, (t_method)symfun);
+
+    class_sethelpsymbol(cls, gensym("file"));
+    return cls;
+}
+
+    /* ---------------- global setup function -------------------- */
+void x_file_setup(void)
+{
+    class_addcreator((t_newmethod)fileobj_new, gensym("file"), A_GIMME, 0);
+
+        /* [file handle] */
+    file_handle_class = file_class_new("file handle", file_handle_new, file_handle_free, 0, MODE|VERBOSE);
+    class_addmethod(file_handle_class, (t_method)file_handle_open,
+        gensym("open"), A_SYMBOL, A_DEFSYM, 0);
+    class_addmethod(file_handle_class, (t_method)file_handle_close,
+        gensym("close"), 0);
+    class_addmethod(file_handle_class, (t_method)file_handle_seek,
+        gensym("seek"), A_GIMME, 0);
+    class_addfloat(file_handle_class, file_handle_float);
+    class_addlist(file_handle_class, file_handle_list);
+
+        /* [file which] */
+    file_which_class = file_class_new("file which", file_which_new, 0, file_which_symbol, VERBOSE);
+
+        /* [file glob] */
+    file_glob_class = file_class_new("file glob", file_glob_new, 0, file_glob_symbol, VERBOSE);
+
+        /* [file stat] */
+    file_stat_class = file_class_new("file stat", file_stat_new, 0, file_stat_symbol, VERBOSE);
+    file_size_class = file_class_new("file size", file_size_new, 0, file_size_symbol, VERBOSE);
+    file_isfile_class = file_class_new("file isfile", file_isfile_new, 0, file_isfile_symbol, VERBOSE);
+    file_isdirectory_class = file_class_new("file isdirectory", file_isdirectory_new, 0, file_isdirectory_symbol, VERBOSE);
+
+        /* [file mkdir] */
+    file_mkdir_class = file_class_new("file mkdir", file_mkdir_new, 0, file_mkdir_symbol, MODE|VERBOSE);
+
+        /* [file delete] */
+    file_delete_class = file_class_new("file delete", file_delete_new, 0, file_delete_symbol, VERBOSE);
+    class_addmethod(file_delete_class, (t_method)file_delete_recursive,
+        gensym("recursive"), A_SYMBOL, 0);
+
+        /* [file copy] */
+    file_copy_class = file_class_new("file copy", file_copy_new, 0, 0, MODE|VERBOSE);
+    class_addlist(file_copy_class, (t_method)file_copy_list);
+
+        /* [file move] */
+    file_move_class = file_class_new("file move", file_move_new, 0, 0, MODE|VERBOSE);
+    class_addlist(file_move_class, (t_method)file_move_list);
+
+        /* file path objects */
+    file_split_class = file_class_new("file split", file_split_new, 0, file_split_symbol, DEFAULT);
+    file_join_class = file_class_new("file join", file_join_new, 0, 0, DEFAULT);
+    class_addlist(file_join_class, (t_method)file_join_list);
+    file_splitext_class = file_class_new("file splitext", file_splitext_new, 0, file_splitext_symbol, DEFAULT);
+    file_splitname_class = file_class_new("file splitname", file_splitname_new, 0, file_splitname_symbol, DEFAULT);
+}


### PR DESCRIPTION
Pd sorely lacks a native way to interact with files (apart from the specialized soundfile and textfile objects).

this PR adds a `[file]` object that attempts to close this gap.

like the `[text]` and `[list]` object, this object takes it's function as the 1st argument.
the functionality is closely modelled after Tcl/Tk's [`file`](https://tcl.tk/man/tcl/TclCmd/file.htm) proc.

# low level file-IO for Pd

- [x] `[file handle]`
- [x] `[file mkdir]`
- [x] `[file which]`
- [x] `[file glob]`
- [x] `[file stat]`
- [x] `[file isfile]`
- [x] `[file isdirectory]`
- [x] `[file size]`
- [x] `[file copy]`
- [x] `[file move]`
- [x] `[file delete]`

# filename operations
- [x] `[file split]`
- [x] `[file join]`
- [x] `[file splitext]`
- [x] `[file splitname]`

## reading/writing files: `[file handle]`

this allows to read/write low-level data as *bytes*.

### reading files
- `[open <filename>(` opens a file for reading
- `[open <filename> r(` opens a file for reading
- `[float <n>(` reads *n* bytes and sends them as a list
- `[close(` closes the file

### writing files
- `[open <filename> w(` opens a file for writing
- `[open <filename> a(` opens a file for writing (append mode)
- `[open <filename> c(` creates a file for writing (truncate mode)
- `[list ...(` writes bytes to file
- `[close(` closes the file

### seeking
- `[seek 10(` seeks to byte 10
- `[seek 27 set(` seeks to byte 27 (`set` is the *default* seek mode)
- `[seek -10 end(` seeks to byte 10 from the end
- `[seek 0 end(` seeks to last byte
- `[seek 1 current(` seek to next byte
- `[seek -1 relative(` seek to previous byte (alias for `current`)

## info on existing files: `[file stat]`
  - does it exist?
  - size
  - isfile, isdirectory, issymlink
  - readable, writable, executable
  - permissions, uid/gid
  - access/modification time
  - ...

there are also easier to use variants for the most important properties: `[file size]`, `[file isfile]` and `[file isdirectory]`

## finding files in Pd's search path: `[file which]`

looks for a file in Pd's (or the canvas') search paths (Fixes https://github.com/pure-data/pure-data/issues/234)

## listing files in a directory: `[file glob]`

lists all files (resp. directories) matching a wildcard pattern.

## removing files `[file delete]`

removes files/directories (optionally, directories can be removed recursively)

## filename operations
`[file split]`, `[file splitext]` and `[file splitname]` disentable the various components of a file path (dirname, basename, extension, path elements,...)
`[file join]` builds a full path from a list of components.

# tests

the object has been excessively tested on WIndows/macOS/Linux using a test-suite, ensuring that the behaviour is consistent across all platforms.
the tests are not included in this PR (see https://git.iem.at/pd/file if you are interested)