### PR TITLE
numerous smallish GUI-feature

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -187,17 +187,21 @@ t_symbol *iemgui_raute2dollar(t_symbol *s)
 t_symbol *iemgui_put_in_braces(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING], *s2;
+    char buf[MAXPDSTRING+1], *s2;
     int i = 0;
     if (strlen(s->s_name) >= MAXPDSTRING)
         return (s);
     for (s1 = s->s_name, s2 = buf; ; s1++, s2++, i++)
     {
         if (i == 0)
-            *(s2++) = '{';
+        {
+            *s2 = '{';
+            s2++;
+        }           
         if (!(*s2 = *s1))
         {
-            *(s2++) = '}';
+            *s2 = '}';
+            s2++;
             *s2 = '\0';
             break;
         }
@@ -409,7 +413,6 @@ void iemgui_all_put_in_braces(t_symbol **srlsym)
 
 void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 {
-    t_symbol *snd;
     int sndable=1, oldsndrcvable=0;
 
     if(iemgui->x_fsf.x_rcv_able)
@@ -418,9 +421,8 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
         oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
 
     if(!strcmp(s->s_name, "empty")) sndable = 0;
-    snd = iemgui_raute2dollar(s);
-    iemgui->x_snd_unexpanded = snd;
-    iemgui->x_snd = snd = canvas_realizedollar(iemgui->x_glist, snd);
+    iemgui->x_snd_unexpanded = s;
+    iemgui->x_snd = canvas_realizedollar(iemgui->x_glist, s);
     iemgui->x_fsf.x_snd_able = sndable;
     iemgui_verify_snd_ne_rcv(iemgui);
     if(glist_isvisible(iemgui->x_glist))
@@ -438,7 +440,7 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
         oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
 
     if(!strcmp(s->s_name, "empty")) rcvable = 0;
-    rcv = iemgui_raute2dollar(s);
+    rcv = s;
     iemgui->x_rcv_unexpanded = rcv;
     rcv = canvas_realizedollar(iemgui->x_glist, rcv);
     if(rcvable)
@@ -472,7 +474,7 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
         /* tb } */
 
     old = iemgui->x_lab;
-    iemgui->x_lab_unexpanded = iemgui_raute2dollar(s);
+    iemgui->x_lab_unexpanded = s;
     iemgui->x_lab = canvas_realizedollar(iemgui->x_glist, iemgui->x_lab_unexpanded);
 
     char lab_escaped[MAXPDSTRING];
@@ -700,7 +702,6 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     iemgui->x_isa.x_loadinit = init;
     if(!strcmp(srl[0]->s_name, "empty")) sndable = 0;
     if(!strcmp(srl[1]->s_name, "empty")) rcvable = 0;
-    iemgui_all_raute2dollar(srl);
     iemgui_all_dollararg2sym(iemgui, srl);
     if(rcvable)
     {

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -372,8 +372,8 @@ void garray_properties(t_garray *x)
         /* create dialog window.  LATER fix this to escape '$'
         properly; right now we just detect a leading '$' and escape
         it.  There should be a systematic way of doing this. */
-    sprintf(cmdbuf, "pdtk_array_dialog %%s %s %d %d 0\n",
-            iemgui_dollar2raute(x->x_name)->s_name, a->a_n, x->x_saveit +
+    sprintf(cmdbuf, "pdtk_array_dialog %%s {%s} %d %d 0\n",
+            x->x_name->s_name, a->a_n, x->x_saveit +
             2 * filestyle);
     gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
 }
@@ -391,7 +391,7 @@ void glist_arraydialog(t_glist *parent, t_symbol *name, t_floatarg size,
     if (otherflag == 0 || (!(gl = glist_findgraph(parent))))
         gl = glist_addglist(parent, &s_, 0, 1,
             size, -1, 0, 0, 0, 0);
-    a = graph_array(gl, iemgui_raute2dollar(name), &s_float, size, flags);
+    a = graph_array(gl, name, &s_float, size, flags);
     canvas_dirty(parent, 1);
 }
 
@@ -417,7 +417,6 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
     else
     {
         long size;
-        t_symbol *argname = iemgui_raute2dollar(name);
         t_array *a = garray_getarray(x);
         t_template *scalartemplate;
         if (!a)
@@ -431,7 +430,7 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
                 x->x_scalar->sc_template->s_name);
             return;
         }
-        if (argname != x->x_name)
+        if (name != x->x_name)
         {
             /* jsarlo { */
             if (x->x_listviewing)
@@ -439,9 +438,9 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
               garray_arrayviewlist_close(x);
             }
             /* } jsarlo */
-            x->x_name = argname;
+            x->x_name = name;
             pd_unbind(&x->x_gobj.g_pd, x->x_realname);
-            x->x_realname = canvas_realizedollar(x->x_glist, argname);
+            x->x_realname = canvas_realizedollar(x->x_glist, name);
             pd_bind(&x->x_gobj.g_pd, x->x_realname);
                 /* redraw the whole glist, just so the name change shows up */
             if (x->x_glist->gl_havewindow)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -38,16 +38,6 @@ typedef struct _canvas_private
 #define GLIST_DEFCANVASWIDTH 450
 #define GLIST_DEFCANVASHEIGHT 300
 
-/* since the window decorations aren't included, open new windows a few
-pixels down so you can possibly move the window later.  Apple needs less
-because its menus are at top of screen; we're more generous for other
-desktops because the borders have both window title area and menus. */
-#ifdef __APPLE__
-#define GLIST_DEFCANVASYLOC 22
-#else
-#define GLIST_DEFCANVASYLOC 50
-#endif
-
 /* ---------------------- variables --------------------------- */
 
 t_class *canvas_class;
@@ -331,7 +321,7 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     t_canvas *owner = canvas_getcurrent();
     t_symbol *s = &s_;
     int vis = 0, width = GLIST_DEFCANVASWIDTH, height = GLIST_DEFCANVASHEIGHT;
-    int xloc = 0, yloc = GLIST_DEFCANVASYLOC;
+    int xloc = GLIST_DEFCANVASXLOC, yloc = GLIST_DEFCANVASYLOC;
     int font = (owner ? owner->gl_font : sys_defaultfont);
     glist_init(x);
     x->gl_obj.te_type = T_OBJECT;
@@ -488,10 +478,10 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_font =  (canvas_getcurrent() ?
         canvas_getcurrent()->gl_font : sys_defaultfont);
     x->gl_zoom = g->gl_zoom;
-    x->gl_screenx1 = 0;
+    x->gl_screenx1 = GLIST_DEFCANVASXLOC;
     x->gl_screeny1 = GLIST_DEFCANVASYLOC;
-    x->gl_screenx2 = 450;
-    x->gl_screeny2 = 300;
+    x->gl_screenx2 = GLIST_DEFCANVASWIDTH;
+    x->gl_screeny2 = GLIST_DEFCANVASHEIGHT;
     x->gl_owner = g;
     canvas_bind(x);
     x->gl_isgraph = 1;
@@ -1061,8 +1051,9 @@ static void *subcanvas_new(t_symbol *s)
 {
     t_atom a[6];
     t_canvas *x, *z = canvas_getcurrent();
+
     if (!*s->s_name) s = gensym("/SUBPATCH/");
-    SETFLOAT(a, 0);
+    SETFLOAT(a+0, GLIST_DEFCANVASXLOC);
     SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
     SETFLOAT(a+2, GLIST_DEFCANVASWIDTH);
     SETFLOAT(a+3, GLIST_DEFCANVASHEIGHT);

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -637,6 +637,7 @@ EXTERN void guiconnect_notarget(t_guiconnect *x, double timedelay);
 /* ------------- IEMGUI routines used in other g_ files ---------------- */
 EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
 EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
+EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
 
 /*-------------  g_clone.c ------------- */
 extern t_class *clone_class;

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -51,6 +51,13 @@ extern "C" {
 #define GLIST_DEFGRAPHWIDTH 200
 #define GLIST_DEFGRAPHHEIGHT 140
 
+#define GLIST_DEFCANVASXLOC 0
+#ifdef __APPLE__
+#define GLIST_DEFCANVASYLOC 22
+#else
+#define GLIST_DEFCANVASYLOC 50
+#endif
+
 /* ----------------------- data ------------------------------- */
 
 typedef struct _updateheader

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1967,11 +1967,19 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             t_undo *undo = canvas_undo_get(x);
             t_undo_action *udo = undo ? undo->u_last : 0;
             canvas_create_editor(x);
-            sys_vgui("pdtk_canvas_new .x%lx %d %d +%d+%d %d\n", x,
-                (int)(x->gl_screenx2 - x->gl_screenx1),
-                (int)(x->gl_screeny2 - x->gl_screeny1),
-                (int)(x->gl_screenx1), (int)(x->gl_screeny1),
-                x->gl_edit);
+            if ((GLIST_DEFCANVASXLOC == x->gl_screenx1) && (GLIST_DEFCANVASYLOC == x->gl_screeny1)) /* initial values for new windows */
+            {
+                sys_vgui("pdtk_canvas_new .x%lx %d %d {} %d\n", x,
+                    (int)(x->gl_screenx2 - x->gl_screenx1),
+                    (int)(x->gl_screeny2 - x->gl_screeny1),
+                    x->gl_edit);
+            } else {
+                sys_vgui("pdtk_canvas_new .x%lx %d %d +%d+%d %d\n", x,
+                    (int)(x->gl_screenx2 - x->gl_screenx1),
+                    (int)(x->gl_screeny2 - x->gl_screeny1),
+                    (int)(x->gl_screenx1), (int)(x->gl_screeny1),
+                    x->gl_edit);
+            }
             snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx",
                 (unsigned long)c);
             while (c->gl_owner && !c->gl_isclone) {

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4824,11 +4824,10 @@ static void canvas_dofont(t_canvas *x, t_floatarg font, t_floatarg xresize,
             gobj_displace(y, x, nx1-x1, ny1-y1);
         }
     }
-    if (glist_isvisible(x))
-        glist_redraw(x);
     for (y = x->gl_list; y; y = y->g_next)
         if (pd_checkglist(&y->g_pd)  && !canvas_isabstraction((t_canvas *)y))
             canvas_dofont((t_canvas *)y, font, xresize, yresize);
+    if(x->gl_havewindow) canvas_redraw(x);
 }
 
     /* canvas_menufont calls up a TK dialog which calls this back */
@@ -4848,6 +4847,8 @@ static void canvas_font(t_canvas *x, t_floatarg font, t_floatarg resize,
     if (whichresize != 3) realresx = realresize;
     if (whichresize != 2) realresy = realresize;
     canvas_dofont(x2, font, realresx, realresy);
+    if ((realresx != 1 || realresx != 1) || (oldfont != (int)font))
+        canvas_dirty(x2, 1);
     canvas_undo_add(x2, UNDO_FONT, "font",
         canvas_undo_set_font(x2, oldfont, realresize, whichresize));
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2426,6 +2426,8 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                         x->gl_editor->e_onmotion = MA_CONNECT;
                         x->gl_editor->e_xwas = xpos;
                         x->gl_editor->e_ywas = ypos;
+
+                        sys_vgui("::pdtk_canvas::cords_to_foreground .x%lx.c 0\n", x);
                         sys_vgui(
                             ".x%lx.c create line %d %d %d %d -width %d -tags x\n",
                             x, xpos, ypos, xpos, ypos,
@@ -2665,7 +2667,10 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 #if 0
     post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, mod, doit);
 #endif
-    if (doit) sys_vgui(".x%lx.c delete x\n", x);
+    if (doit) {
+        sys_vgui("::pdtk_canvas::cords_to_foreground .x%lx.c 1\n", x);
+        sys_vgui(".x%lx.c delete x\n", x);
+    }
     else sys_vgui(".x%lx.c coords x %d %d %d %d\n",
                   x, x->gl_editor->e_xwas,
                   x->gl_editor->e_ywas, xpos, ypos);

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -231,15 +231,36 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     t_binbuf *b = binbuf_new();
     int xpix, ypix;
 
+    // enable autoconnect
+    int connectme, indx, nobj;
+    canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
+    // align vsl and hsl like others objects
+    if (guiobjname== gensym("hsl"))
+    {
+        xpix+=3;
+    }
+    else if (guiobjname== gensym("vsl"))
+    {
+        ypix+=3;
+    }
+
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
-    glist_noselect(gl);
+
     SETSYMBOL(&at, guiobjname);
     binbuf_restore(b, 1, &at);
-    glist_getnextxy(gl, &xpix, &ypix);
-    canvas_objtext(gl, xpix/gl->gl_zoom, ypix/gl->gl_zoom, 0, 1, b);
-    canvas_startmotion(glist_getcanvas(gl));
-    canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-        (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+    canvas_objtext(gl,  xpix, ypix, 0, 1, b);
+
+    if (connectme)
+    {
+        canvas_connect(gl, indx, 0, nobj, 0);
+    }
+    else 
+    {
+        canvas_startmotion(glist_getcanvas(gl));
+    }
+    if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+	canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
+           (void *)canvas_undo_set_create(glist_getcanvas(gl)));
 }
 
 void canvas_bng(t_glist *gl, t_symbol *s, int argc, t_atom *argv)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -575,7 +575,7 @@ static t_symbol *gatom_escapit(t_symbol *s)
         shmo[99] = 0;
         return (gensym(shmo));
     }
-    else return (iemgui_dollar2raute(s));
+    else return s;
 }
 
     /* undo previous operation: strip leading "-" if found. */
@@ -583,7 +583,7 @@ static t_symbol *gatom_unescapit(t_symbol *s)
 {
     if (*s->s_name == '-')
         return (gensym(s->s_name+1));
-    else return (iemgui_raute2dollar(s));
+    else return s;
 }
 
 static void gatom_redraw(t_gobj *client, t_glist *glist)

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -25,7 +25,7 @@ char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
     while(1)
     {
         int c = src[ptin];
-        if (c == '\\' || c == '{' || c == '}') {
+        if (c == '\\' || c == '{' || c == '}' || c == '[' || c == ']') {
             dst[ptout++] = '\\';
             if (dstlen && ptout >= dstlen){
                 dst[ptout-1] = 0;

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -56,8 +56,8 @@ static void *table_donew(t_symbol *s, int size, int flags,
     }
     if (size < 1)
         size = 100;
-    SETFLOAT(a, 0);
-    SETFLOAT(a+1, 50);
+    SETFLOAT(a, GLIST_DEFCANVASXLOC);
+    SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
     SETFLOAT(a+2, xpix + 100);
     SETFLOAT(a+3, ypix + 100);
     SETSYMBOL(a+4, s);

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -49,10 +49,10 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
     }
 
         /* make a canvas... */
-    SETFLOAT(a, 0);
-    SETFLOAT(a+1, 50);
-    SETFLOAT(a+2, 600);
-    SETFLOAT(a+3, 400);
+    SETFLOAT(a+0, GLIST_DEFCANVASXLOC); /* xpos */
+    SETFLOAT(a+1, GLIST_DEFCANVASYLOC); /* ypos */
+    SETFLOAT(a+2, 600); /* width */
+    SETFLOAT(a+3, 400); /* height */
     SETSYMBOL(a+4, s);
     SETFLOAT(a+5, 0);
     x = canvas_new(0, 0, 6, a);

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -20,6 +20,41 @@ namespace eval ::dialog_font:: {
 # there is a single properties panel that adjusts based on which PatchWindow
 # has focus
 
+# this could probably just be apply, but keep the old one for tcl plugins that
+# might use apply for "stretch"
+proc ::dialog_font::radio_apply {mytoplevel myfontsize} {
+    if {$mytoplevel eq ".pdwindow"} {
+        foreach font [font names] {
+            font configure $font -size $myfontsize
+        }
+        if {[winfo exists ${mytoplevel}.text]} {
+            ${mytoplevel}.text.internal configure -font "-size $myfontsize"
+        }
+
+        # repeat a "pack" command so the font dialog can resize itself
+        if {[winfo exists .font]} {
+            pack .font.buttonframe -side bottom -fill x -pady 2m
+        }
+
+        ::pd_guiprefs::write menu-fontsize "$myfontsize"
+
+    } else {
+        pdsend "$mytoplevel font $myfontsize 0 2"
+    }
+}
+
+proc ::dialog_font::stretch_apply {gfxstub} {
+    if {$gfxstub ne ".pdwindow"} {
+        variable fontsize
+        variable stretchval
+        variable whichstretch
+        if {$stretchval == ""} {
+            set stretchval 100
+        }
+        pdsend "$gfxstub font $fontsize $stretchval $whichstretch"
+    }
+}
+
 proc ::dialog_font::apply {mytoplevel myfontsize} {
     if {$mytoplevel eq ".pdwindow"} {
         foreach font [font names] {
@@ -50,12 +85,6 @@ proc ::dialog_font::cancel {gfxstub} {
     destroy .font
 }
 
-proc ::dialog_font::ok {gfxstub} {
-    variable fontsize
-    apply $gfxstub $fontsize
-    cancel $gfxstub
-}
-
 proc ::dialog_font::update_font_dialog {mytoplevel} {
     variable canvaswindow $mytoplevel
     if {[winfo exists .font]} {
@@ -72,7 +101,7 @@ proc ::dialog_font::arrow_fontchange {change} {
     set max [llength $sizes]
     if {$position >= $max} {set position [expr $max-1]}
     set fontsize [lindex $sizes $position]
-    ::dialog_font::apply $canvaswindow $fontsize
+    ::dialog_font::radio_apply $canvaswindow $fontsize
 }
 
 # this should be called pdtk_font_dialog like the rest of the panels, but it
@@ -107,7 +136,7 @@ proc ::dialog_font::create_dialog {gfxstub} {
     # replace standard bindings to work around the gfxstub stuff and use
     # break to prevent the close window command from going to other bindings.
     # .font won't exist anymore, so it'll cause errors down the line...
-    bind .font <KeyPress-Return> "::dialog_font::ok $gfxstub; break"
+    bind .font <KeyPress-Return> "::dialog_font::cancel $gfxstub; break"
     bind .font <KeyPress-Escape> "::dialog_font::cancel $gfxstub; break"
     bind .font <$::modifier-Key-w> "::dialog_font::cancel $gfxstub; break"
     wm protocol .font WM_DELETE_WINDOW "dialog_font::cancel $gfxstub"
@@ -116,9 +145,9 @@ proc ::dialog_font::create_dialog {gfxstub} {
 
     frame .font.buttonframe
     pack .font.buttonframe -side bottom -pady 2m
-    button .font.buttonframe.ok -text [_ "OK"] \
-        -command "::dialog_font::ok $gfxstub" -default active
-    pack .font.buttonframe.ok -side left -expand 1 -padx 15 -ipadx 10
+    button .font.buttonframe.ok -text [_ "Close"] \
+        -command "::dialog_font::cancel $gfxstub" -default active
+    pack .font.buttonframe.ok -side left -expand 1 -fill x -ipadx 10
 
     labelframe .font.fontsize -text [_ "Font Size"] -padx 5 -pady 4 -borderwidth 1 \
         -width [::msgcat::mcmax "Font Size"] -labelanchor n
@@ -128,7 +157,8 @@ proc ::dialog_font::create_dialog {gfxstub} {
     foreach size $::dialog_font::sizes {
         radiobutton .font.fontsize.radio$size -value $size -text $size \
             -variable ::dialog_font::fontsize \
-            -command [format {::dialog_font::apply $::dialog_font::canvaswindow %s} $size]
+            -command [format {::dialog_font::radio_apply \
+                $::dialog_font::canvaswindow %s} $size]
         pack .font.fontsize.radio$size -side top -anchor w
     }
 
@@ -136,7 +166,8 @@ proc ::dialog_font::create_dialog {gfxstub} {
         -width [::msgcat::mcmax "Stretch"] -labelanchor n
     pack .font.stretch -side left -padx 5 -fill y
 
-    entry .font.stretch.entry -textvariable ::dialog_font::stretchval -width 5
+    entry .font.stretch.entry -textvariable ::dialog_font::stretchval -width 5 \
+        -validate key -vcmd {string is int %P}
     pack .font.stretch.entry -side top -pady 5
 
     radiobutton .font.stretch.radio1 -text [_ "X and Y"] \
@@ -149,6 +180,11 @@ proc ::dialog_font::create_dialog {gfxstub} {
     pack .font.stretch.radio1 -side top -anchor w
     pack .font.stretch.radio2 -side top -anchor w
     pack .font.stretch.radio3 -side top -anchor w
+    
+    button .font.stretch.apply -text [_ "Apply"] \
+        -command "::dialog_font::stretch_apply $gfxstub" -default active
+    pack .font.stretch.apply -side left -expand 1 -fill x -ipadx 10 \
+        -anchor s
 
     # for focus handling on OSX
     if {$::windowingsystem eq "aqua"} {

--- a/tcl/dialog_gatom.tcl
+++ b/tcl/dialog_gatom.tcl
@@ -20,19 +20,19 @@ proc ::dialog_gatom::escape {sym} {
         if {[string equal -length 1 $sym "-"]} {
             set ret [string replace $sym 0 0 "--"]
         } else {
-            set ret [string map {"$" "#"} $sym]
+            set ret $sym
         }
     }
-    return [unspace_text $ret]
+    return [string map {"$" {\$}} [unspace_text $ret]]
 }
 
 proc ::dialog_gatom::unescape {sym} {
     if {[string equal -length 1 $sym "-"]} {
         set ret [string replace $sym 0 0 ""]
     } else {
-        set ret [string map {"#" "$"} $sym]
+        set ret $sym
     }
-    return $ret
+    return [respace_text $ret]
 }
 
 proc ::dialog_gatom::apply {mytoplevel} {

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -362,16 +362,10 @@ proc ::dialog_iemgui::apply {mytoplevel} {
     } else {
         set hhhgui_nam [eval concat $$var_iemgui_gui_nam]}
 
-    if {[string index $hhhsnd 0] == "$"} {
-        set hhhsnd [string replace $hhhsnd 0 0 #] }
-    if {[string index $hhhrcv 0] == "$"} {
-        set hhhrcv [string replace $hhhrcv 0 0 #] }
-    if {[string index $hhhgui_nam 0] == "$"} {
-        set hhhgui_nam [string replace $hhhgui_nam 0 0 #] }
 
-    set hhhsnd [unspace_text $hhhsnd]
-    set hhhrcv [unspace_text $hhhrcv]
-    set hhhgui_nam [unspace_text $hhhgui_nam]
+    set hhhsnd [string map {"$" {\$}} [unspace_text $hhhsnd]]
+    set hhhrcv [string map {"$" {\$}} [unspace_text $hhhrcv]]
+    set hhhgui_nam [string map {"$" {\$}} [unspace_text $hhhgui_nam]]
 
     # make sure the offset boxes have a value
     if {[eval concat $$var_iemgui_gn_dx] eq ""} {set $var_iemgui_gn_dx 0}
@@ -485,18 +479,12 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
     set $var_iemgui_num $num
     set $var_iemgui_steady $steady
     if {$snd == "empty"} {set $var_iemgui_snd [format ""]
-    } else {set $var_iemgui_snd [format "%s" $snd]}
+    } else {set $var_iemgui_snd [respace_text [format "%s" $snd]]}
     if {$rcv == "empty"} {set $var_iemgui_rcv [format ""]
-    } else {set $var_iemgui_rcv [format "%s" $rcv]}
+    } else {set $var_iemgui_rcv [respace_text [format "%s" $rcv]]}
     if {$gui_name == "empty"} {set $var_iemgui_gui_nam [format ""]
-    } else {set $var_iemgui_gui_nam [format "%s" $gui_name]}
+    } else {set $var_iemgui_gui_nam [respace_text [format "%s" $gui_name]]}
 
-    if {[string index [eval concat $$var_iemgui_snd] 0] == "#"} {
-        set $var_iemgui_snd [string replace [eval concat $$var_iemgui_snd] 0 0 $] }
-    if {[string index [eval concat $$var_iemgui_rcv] 0] == "#"} {
-        set $var_iemgui_rcv [string replace [eval concat $$var_iemgui_rcv] 0 0 $] }
-    if {[string index [eval concat $$var_iemgui_gui_nam] 0] == "#"} {
-        set $var_iemgui_gui_nam [string replace [eval concat $$var_iemgui_gui_nam] 0 0 $] }
     set $var_iemgui_gn_dx $gn_dx
     set $var_iemgui_gn_dy $gn_dy
     set $var_iemgui_gn_f $gn_f

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -307,11 +307,6 @@ proc init_for_platform {} {
                     ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 0
-            # Tk handles the window placement differently on each
-            # platform. With X11, the x,y placement refers to the window
-            # frame's upper left corner. http://wiki.tcl.tk/11502
-            set ::windowframex 3
-            set ::windowframey 53
             # trying loading icon in the GUI directory
             if {$::tcl_version >= 8.5} {
                 set icon [file join $::sys_guidir pd.gif]
@@ -361,11 +356,6 @@ proc init_for_platform {} {
                 ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 22
-            # Tk handles the window placement differently on each platform, on
-            # Mac OS X, the x,y placement refers to the content window's upper
-            # left corner (not of the window frame) http://wiki.tcl.tk/11502
-            set ::windowframex 0
-            set ::windowframey 0
             # mouse cursors for all the different modes
             set ::cursor_runmode_nothing "arrow"
             set ::cursor_runmode_clickme "center_ptr"
@@ -396,12 +386,6 @@ proc init_for_platform {} {
                     ]
             # some platforms have a menubar on the top, so place below them
             set ::menubarsize 0
-            # Tk handles the window placement differently on each platform, on
-            # Mac OS X, the x,y placement refers to the content window's upper
-            # left corner. http://wiki.tcl.tk/11502
-            # TODO this probably needs a script layer: http://wiki.tcl.tk/11291
-            set ::windowframex 0
-            set ::windowframey 0
             # TODO use 'winico' package for full, hicolor icon support
             wm iconbitmap . -default [file join $::sys_guidir pd.ico]
             # add local fonts to Tk's font list using pdfontloader

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -347,9 +347,11 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     if {$width == 1 || $height == 1} {
         # make sure the window is fully created
         update idletasks
-        set width [winfo width $mytoplevel]
-        set height [winfo height $mytoplevel]
     }
+    # the geometry we receive from the callback is really for the frame
+    # however, we need position including the border decoration
+    # as this is how we restore the position
+    scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
     pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
     # send the size/location of the window and canvas to 'pd' in the form of:
     #    left top right bottom

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -362,9 +362,11 @@ proc ::pd_menus::build_help_menu {mymenu} {
         -command {menu_objectlist}
     $mymenu add  separator
     $mymenu add command -label [_ "puredata.info"] \
-        -command {menu_openfile {http://puredata.info}}
+        -command {menu_openfile {https://puredata.info}}
+    $mymenu add command -label [_ "Check for updates"] -command {menu_openfile \
+        {https://pdlatest.puredata.info}}
     $mymenu add command -label [_ "Report a bug"] -command {menu_openfile \
-        {http://bugs.puredata.info}}
+        {https://bugs.puredata.info}}
 }
 
 #------------------------------------------------------------------------------#

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -425,3 +425,16 @@ proc ::pdtk_canvas::pdtk_canvas_reflecttitle {mytoplevel \
         wm title $mytoplevel "$name$dirtychar$arguments - $path"
     }
 }
+
+proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
+    set col black
+    if { $state == 0 } {
+        set col lightgrey
+    }
+    foreach id [$mytoplevel find withtag {cord && !selected}] {
+        # don't apply backgrouding on selected (blue) lines
+        if { [lindex [$mytoplevel itemconfigure $id -fill] 4 ] ne "blue" } {
+            $mytoplevel itemconfigure $id -fill $col
+        }
+    }
+}

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -50,7 +50,7 @@ if {$::tcl_version < 8.5 || \
         }
         if {$h > $height} {
             # 30 for window framing
-            set h [expr $height - $::menubarsize - $::windowframey]
+            set h [expr $height - $::menubarsize]
             set y $::menubarsize
         }
 
@@ -71,17 +71,15 @@ if {$::tcl_version < 8.5 || \
 # easy for people to customize these calculations based on their Window
 # Manager, desires, etc.
 proc pdtk_canvas_place_window {width height geometry} {
-    ::pdwindow::configure_window_offset
-
     # read back the current geometry +posx+posy into variables
-    scan $geometry {%[+]%d%[+]%d} - x - y
-    set xywh [pdtk_canvas_wrap_window \
-        [expr $x - $::windowframex] [expr $y - $::windowframey] $width $height]
-    set x [lindex $xywh 0]
-    set y [lindex $xywh 1]
-    set w [lindex $xywh 2]
-    set h [lindex $xywh 3]
-    return [list ${w} ${h} ${w}x${h}+${x}+${y}]
+    set w $width
+    set h $height
+    if { "" != ${geometry} } {
+        scan $geometry {%[+]%d%[+]%d} - x - y
+        foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
+        set geometry +${x}+${y}
+    }
+    return [list ${w} ${h} ${geometry}]
 }
 
 
@@ -89,10 +87,7 @@ proc pdtk_canvas_place_window {width height geometry} {
 # canvas new/saveas
 
 proc pdtk_canvas_new {mytoplevel width height geometry editable} {
-    set l [pdtk_canvas_place_window $width $height $geometry]
-    set width [lindex $l 0]
-    set height [lindex $l 1]
-    set geometry [lindex $l 2]
+    foreach {width height geometry} [pdtk_canvas_place_window $width $height $geometry] {break;}
     set ::undo_actions($mytoplevel) no
     set ::redo_actions($mytoplevel) no
 
@@ -110,7 +105,9 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable} {
     # started_loading_file proc.  Perhaps this doesn't make sense tho
     event generate $mytoplevel <<Loading>>
 
-    wm geometry $mytoplevel $geometry
+    if { "" != ${geometry} } {
+        wm geometry $mytoplevel $geometry
+    }
     wm minsize $mytoplevel $::canvas_minwidth $::canvas_minheight
 
     set tkcanvas [tkcanvas_name $mytoplevel]

--- a/tcl/pdtk_textwindow.tcl
+++ b/tcl/pdtk_textwindow.tcl
@@ -24,12 +24,17 @@ proc pdtk_textwindow_open {name geometry title font} {
         bind $name <<Modified>> "pdtk_textwindow_dodirty $name"
         text $name.text -relief raised -highlightthickness 0 -bd 2 \
             -font [get_font_for_size $font] \
+            -exportselection 1 -undo 1 \
             -yscrollcommand "$name.scroll set" -background white
         scrollbar $name.scroll -command "$name.text yview"
         pack $name.scroll -side right -fill y
         pack $name.text -side left -fill both -expand 1
         bind $name.text <$::modifier-Key-s> "pdtk_textwindow_send $name"
         bind $name.text <$::modifier-Key-w> "pdtk_textwindow_close $name 1"
+        bind $name.text <$::modifier-Key-a> "pdtk_textwindow_selectall $name; break"
+        bind $name.text <$::modifier-Key-z> "pdtk_textwindow_undo $name; break"
+        bind $name.text <$::modifier-Shift-Key-Z> "pdtk_textwindow_redo $name; break"
+        bind $name.text <$::modifier-Shift-Key-z> "pdtk_textwindow_redo $name; break"
         focus $name.text
     }
 }
@@ -99,5 +104,24 @@ proc pdtk_textwindow_close {name ask} {
             if {$answer == "yes"} {pdtk_textwindow_send $name}
             if {$answer != "cancel"} {pdsend [concat $name close]}
         } else {pdsend [concat $name close]}
+    }
+}
+
+proc pdtk_textwindow_selectall {name} {
+    if {[winfo exists $name]} {
+        $name.text tag add sel 1.0 end
+        $name.text mark set insert end
+    }
+}
+
+proc pdtk_textwindow_undo {name} {
+    if {[winfo exists $name]} {
+        catch {$name.text edit undo}
+    }
+}
+
+proc pdtk_textwindow_redo {name} {
+    if {[winfo exists $name]} {
+        catch {$name.text edit redo}
     }
 }

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -390,7 +390,7 @@ proc ::pdwindow::create_window {} {
     } else {
         wm minsize .pdwindow 400 51
     }
-    wm geometry .pdwindow =500x400+20+50
+    wm geometry .pdwindow =500x400
 
     frame .pdwindow.header -borderwidth 1 -relief flat -background lightgray
     pack .pdwindow.header -side top -fill x -ipady 5
@@ -496,30 +496,6 @@ proc ::pdwindow::create_window_finalize {} {
         ::dialog_font::apply .pdwindow $fontsize
     }
 }
-
-proc ::pdwindow::configure_window_offset {{winid .pdwindow}} {
-    # on X11 measure the size of the window decoration, so we can open windows at the correct position
-    if {$::windowingsystem eq "x11"} {
-        if {[winfo viewable $winid]} {
-            # wait for possible race-conditions at startup...
-            if {[winfo viewable .pdwindow] && ![winfo viewable .pdwindow.header.pad1]} {
-                tkwait visibility .pdwindow.header.pad1
-            }
-
-            regexp -- {([0-9]+)x([0-9]+)\+(-?[0-9]+)\+(-?[0-9]+)} [wm geometry $winid] -> \
-                _ _ _left _top
-            set ::windowframex [expr {[winfo rootx $winid] - $_left}]
-            set ::windowframey [expr {[winfo rooty $winid] - $_top}]
-
-            #puts "======================="
-            #puts "[wm geometry $winid]"
-            #puts "winfo [winfo rootx $winid] [winfo rooty $winid]"
-            #puts "windowframe: $winid $::windowframex $::windowframey"
-            #puts "======================="
-        }
-    }
-}
-
 
 # this needs to happen *after* the main menu is created, otherwise the default Wish
 # menu is not replaced by the custom Apple menu on OSX

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -150,7 +150,14 @@ proc enquote_path {message} {
 #enquote a string to send it to Pd.  Blow off semi and comma; alias spaces
 #we also blow off "{", "}", "\" because they'll just cause bad trouble later.
 proc unspace_text {x} {
-    set y [string map {" " "_" ";" "" "," "" "{" "" "}" "" "\\" ""} $x]
+    set y [string map {" " {\ } ";" "" "," "" "{" "" "}" "" "\\" ""} $x]
+    if {$y eq ""} {set y "empty"}
+    concat $y
+}
+
+#dequote a string received from Pd.
+proc respace_text {x} {
+    set y [string map {{\ } " "} $x]
     if {$y eq ""} {set y "empty"}
     concat $y
 }


### PR DESCRIPTION
this is PR aggregates a number of other GUI/patching-related PRs that are typically small inscope.

each PR has been squashed to a single commit (even so each commit is quite small) which should make reviewing and cherry-picking a lot easier.
(the main reason to do this PR was - apart from getting those things included - to cleanup old PRs that have accumulated multiple mergebacks in the past)

included PRs:

- select-all, undo, redo for the `[text]` window
  - Closes: #430
- Menu to "check for updates" and use https:// for URLs
  - Closes: #1123
  - Closes: #1127
- Use Window Manager intelligence for placing new windows
  - Closes: #1296
  - Closes:  #348 (except on Windows)
- Prevent duplicate connections (in broken patches)
  - Closes: #1308
  - Closes: #1309
- Grey-out existing connections while creating new connections
  - Closes: #882
  - Closes: #887
- Enable autoconnection of iemgui's (created via shortcuts)
  - Closes: #756
  - Closes: #826 
- Permissive labels (allow dollars, spaces, braces,...), while simplifying the code!
   - Closes: https://github.com/pure-data/pure-data/pull/948
   - Closes: https://github.com/pure-data/pure-data/pull/953
   - Closes: https://github.com/pure-data/pure-data/issues/417
   - Closes: https://github.com/pure-data/pure-data/issues/558
   - Closes: https://github.com/pure-data/pure-data/issues/880
   - Closes: https://github.com/pure-data/pure-data/issues/960
- Font dialog cleanups
  - Closes: https://github.com/pure-data/pure-data/pull/1247
  - Closes: https://github.com/pure-data/pure-data/pull/1248