### PR TITLE
stable development branch

### DIFF
--- a/doc/5.reference/file-help.pd
+++ b/doc/5.reference/file-help.pd
@@ -1,68 +1,60 @@
-#N canvas 467 185 622 652 12;
+#N canvas 467 221 622 652 12;
 #X text 459 59 details:;
 #X text 457 42 click for;
-#N canvas 221 76 916 951 handle 0;
+#N canvas 221 94 953 951 handle 0;
 #X text 146 24 Handle - operate on file handles;
-#X obj 67 490 file handle;
+#X obj 67 560 file handle;
 #X text 95 68 reading files;
 #X text 95 78 =============;
 #X msg 82 187 open /tmp/test.c r;
-#X msg 95 417 close;
+#X msg 95 537 close;
 #X msg 91 259 1024;
 #X text 127 261 read (up to) 1024 bytes;
-#X obj 67 535 print data;
+#X obj 67 605 print data;
 #X msg 103 299 seek 3;
 #X text 160 301 seek to the 3rd byte;
-#X msg 108 342 seek -1;
-#X text 174 340 seek to the end of file;
-#X msg 106 383 seek+ 1;
-#X text 175 383 seek to the next byte;
+#X text 225 453 seek to the next byte;
 #X msg 91 229 1;
 #X text 129 231 read the next byte;
 #X msg 67 155 open \$1;
 #X msg 67 105 bang;
 #X obj 67 130 openpanel;
-#X obj 399 517 file handle;
-#X text 427 85 =============;
-#X msg 427 444 close;
-#X msg 435 326 seek 3;
-#X text 492 328 seek to the 3rd byte;
-#X msg 440 369 seek -1;
-#X text 506 367 seek to the end of file;
-#X msg 438 410 seek+ 1;
-#X text 507 410 seek to the next byte;
-#X msg 399 112 bang;
-#X text 427 75 writing files;
-#X obj 399 137 savepanel;
-#X msg 399 162 open \$1 w;
-#X msg 414 194 open /tmp/test.c a;
-#X msg 415 224 open /tmp/test.c c;
-#X msg 423 286 104 101 108 108 111 32 119 111 114 108 100 13 10;
+#X obj 419 557 file handle;
+#X text 447 85 =============;
+#X msg 447 484 close;
+#X msg 455 326 seek 3;
+#X text 512 328 seek to the 3rd byte;
+#X msg 419 112 bang;
+#X text 447 75 writing files;
+#X obj 419 137 savepanel;
+#X msg 419 162 open \$1 w;
+#X msg 434 194 open /tmp/test.c a;
+#X msg 435 224 open /tmp/test.c c;
+#X msg 443 286 104 101 108 108 111 32 119 111 114 108 100 13 10;
 #X text 220 189 explicit Read-mode;
-#X text 491 162 open file in Write mode;
-#X text 558 193 open file for writing (Append mode);
-#X text 558 223 open file for writing (Create (or trunCate) mode);
-#X text 468 263 write some bytes;
-#X text 484 444 close the file;
-#X text 144 417 close the file;
-#X text 57 742 using out-of-range numbers of symbols leads to undefined
+#X text 511 162 open file in Write mode;
+#X text 578 193 open file for writing (Append mode);
+#X text 578 223 open file for writing (Create (or trunCate) mode);
+#X text 488 263 write some bytes;
+#X text 504 484 close the file;
+#X text 144 537 close the file;
+#X text 57 782 using out-of-range numbers of symbols leads to undefined
 behaviour., f 68;
-#X text 57 706 note: the data you read from or write to a file are
+#X text 57 746 note: the data you read from or write to a file are
 lists of bytes \, which appear in Pd as lists of numbers from 0 to
 255, f 68;
-#X obj 66 777 file;
-#X text 117 778 is the short form for;
-#X obj 286 777 file handle;
-#X obj 141 624 print INFO;
-#X obj 473 541 print ERR;
-#X text 150 534 list of bytes read;
-#X text 555 535 if opening the file or writing to it fails \, the file
+#X obj 66 817 file;
+#X text 117 818 is the short form for;
+#X obj 286 817 file handle;
+#X obj 141 664 print INFO;
+#X text 150 604 list of bytes read;
+#X text 575 575 if opening the file or writing to it fails \, the file
 is closed and a bang is sent to the 2nd outlet., f 46;
-#X text 230 592 if the file cannot be opened \, a bang is sent to the
+#X text 230 632 if the file cannot be opened \, a bang is sent to the
 2nd outlet., f 63;
-#X text 231 612 when the end of the file is reached or a read error
+#X text 231 652 when the end of the file is reached or a read error
 occurred \, the file is closed and a bang is sent too.;
-#X text 232 651 when seeking \, the position from the start of the
+#X text 232 691 when seeking \, the position from the start of the
 file (or -1 on error) is output here., f 70;
 #N canvas 19 51 868 498 arguments 0;
 #X obj 146 145 file handle -q;
@@ -74,8 +66,8 @@ file (or -1 on error) is output here., f 70;
 octal.;
 #X msg 563 149 verbose \$1;
 #X obj 563 174 file;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -92,33 +84,53 @@ the umask into account. this might be ignored by the underlying filesystem.
 #X connect 6 0 7 0;
 #X connect 8 0 6 0;
 #X connect 16 0 14 0;
-#X restore 65 834 pd arguments;
-#X msg 428 490 creationmode 0o600;
-#X text 565 493 restrict permissions of to-be-created file;
+#X restore 65 874 pd arguments;
+#X msg 448 530 creationmode 0o600;
+#X msg 101 335 seek 3 start;
+#X text 202 331 seek to the 3rd byte from the "start", f 21;
+#X msg 100 375 seek 0 end;
+#X msg 108 412 seek -1 end;
+#X msg 105 454 seek 1 current;
+#X msg 105 484 seek -1 relative;
+#X text 225 473 seek to the previous byte ("relative" is an alias for
+"current"), f 24;
+#X text 188 374 seek to the end-of-file;
+#X text 195 411 seek to the last byte;
+#X msg 460 409 seek 10 end;
+#X text 546 407 seek beyond the end of file;
+#X msg 469 357 seek 10 start;
+#X text 572 358 seek to the 10th byte;
+#X msg 458 450 seek 10 current;
+#X text 577 450 seek to the 10th byte frm the current position;
+#X obj 493 581 print INFO;
+#X text 584 531 restrict permissions of the to-be-created file;
 #X connect 1 0 8 0;
-#X connect 1 1 48 0;
+#X connect 1 1 41 0;
 #X connect 4 0 1 0;
 #X connect 5 0 1 0;
 #X connect 6 0 1 0;
 #X connect 9 0 1 0;
-#X connect 11 0 1 0;
-#X connect 13 0 1 0;
-#X connect 15 0 1 0;
-#X connect 17 0 1 0;
-#X connect 18 0 19 0;
+#X connect 12 0 1 0;
+#X connect 14 0 1 0;
+#X connect 15 0 16 0;
+#X connect 16 0 14 0;
+#X connect 17 1 64 0;
 #X connect 19 0 17 0;
-#X connect 20 1 49 0;
-#X connect 22 0 20 0;
-#X connect 23 0 20 0;
-#X connect 25 0 20 0;
-#X connect 27 0 20 0;
-#X connect 29 0 31 0;
-#X connect 31 0 32 0;
-#X connect 32 0 20 0;
-#X connect 33 0 20 0;
-#X connect 34 0 20 0;
-#X connect 35 0 20 0;
-#X connect 56 0 20 0;
+#X connect 20 0 17 0;
+#X connect 22 0 24 0;
+#X connect 24 0 25 0;
+#X connect 25 0 17 0;
+#X connect 26 0 17 0;
+#X connect 27 0 17 0;
+#X connect 28 0 17 0;
+#X connect 48 0 17 0;
+#X connect 49 0 1 0;
+#X connect 52 0 1 0;
+#X connect 53 0 1 0;
+#X connect 54 0 1 0;
+#X connect 58 0 17 0;
+#X connect 60 0 17 0;
+#X connect 62 0 17 0;
 #X restore 460 86 pd handle;
 #N canvas 134 105 726 627 glob 0;
 #X obj 80 400 file glob;
@@ -198,8 +210,8 @@ indicates if the path is a file (0) or a directory (1).;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -288,8 +300,8 @@ that use platform independent globbing., f 107;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -326,8 +338,8 @@ returns the resolved path.;
 #X msg 92 279 symbol \$1/subdir/another/sub/directory;
 #X text 147 43 ==========================;
 #X msg 113 321 symbol .;
-#X obj 139 434 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
-#000000 #000000;
+#X obj 139 434 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X text 64 81 this ensures that a given directory exists by creating
 it.;
 #X text 63 99 parent directories are created as needed.;
@@ -343,8 +355,8 @@ sent to the 1st outlet;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -412,8 +424,8 @@ be deleted just so.;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -444,8 +456,8 @@ tree with all the files and subdirectories \, you can also remove it
 #X obj 171 323 print ERR:copy;
 #N canvas 5 51 542 353 arguments 0;
 #X msg 136 143 verbose \$1;
-#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X obj 136 168 outlet;
 #X text 61 82 error reporting;
 #X text 244 118 turn error-printout on/off;
@@ -496,8 +508,8 @@ tree with all the files and subdirectories \, you can also remove it
 #X text 560 208 some directory;
 #X msg 486 239 symbol nada;
 #X obj 673 400 print ERR:isDir;
-#X obj 673 380 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
-#000000 #000000;
+#X obj 673 380 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X obj 544 401 print isDir;
 #X obj 54 401 print isFile;
 #X text 276 388 sends a bang to the 2nd outlet \, if the path could
@@ -507,18 +519,18 @@ not be read, f 32;
 #X obj 54 462 file size;
 #X obj 54 511 print size;
 #X text 278 495 on error \, a bang is sent to the 2nd outlet;
-#X obj 145 381 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
-#000000 #000000;
+#X obj 145 381 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X obj 145 401 print ERR:isFile;
-#X obj 145 491 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
-#000000 #000000;
+#X obj 145 491 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X obj 145 511 print ERR:size;
 #X text 276 462 gets the size of a file (in bytes) \, as reported by
 the filesystem. for directories \, this will return '0'.;
 #N canvas 5 51 450 300 arguments 0;
 #X msg 68 137 verbose \$1;
-#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 52 23 error reporting;
 #X text 61 83 switch on/off error messages on the Pd-console;
 #X text 56 208 or use the "-v" resp "-q" flag;
@@ -541,8 +553,8 @@ the filesystem. for directories \, this will return '0'.;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -604,30 +616,24 @@ the filesystem. for directories \, this will return '0'.;
 #X text 542 205 some directory;
 #X msg 468 236 symbol nada;
 #X text 558 238 probably not there;
-#X obj 185 371 bng 15 250 50 0 empty empty empty 17 7 0 10 #fcfcfc
-#000000 #000000;
+#X obj 185 371 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
 #X obj 185 391 print ERR:stat;
 #X obj 54 367 t a a;
 #X obj 86 391 print stat;
-#X obj 96 518 tgl 15 0 empty empty r 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
-#X obj 174 518 tgl 15 0 empty empty w 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
-#X obj 252 518 tgl 15 0 empty empty x 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
+#X obj 96 518 tgl 15 0 empty empty r 17 7 0 10 -262144 -1 -1 0 1;
+#X obj 174 518 tgl 15 0 empty empty w 17 7 0 10 -262144 -1 -1 0 1;
+#X obj 252 518 tgl 15 0 empty empty x 17 7 0 10 -262144 -1 -1 0 1;
 #X obj 96 721 route uid gid;
 #X obj 96 616 route type;
 #X obj 96 641 symbol;
-#X obj 96 588 tgl 15 0 empty empty F 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
-#X obj 174 588 tgl 15 0 empty empty D 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
-#X obj 252 588 tgl 15 0 empty empty L 17 7 0 10 #fcfcfc #000000 #000000
-0 1;
+#X obj 96 588 tgl 15 0 empty empty F 17 7 0 10 -262144 -1 -1 0 1;
+#X obj 174 588 tgl 15 0 empty empty D 17 7 0 10 -262144 -1 -1 0 1;
+#X obj 252 588 tgl 15 0 empty empty L 17 7 0 10 -262144 -1 -1 0 1;
 #X obj 96 561 route isfile isdirectory issymlink;
 #X symbolatom 146 641 0 0 0 0 - - -;
-#X obj 328 518 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 328 518 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X floatatom 96 746 5 0 0 0 - - -;
 #X floatatom 140 746 5 0 0 0 - - -;
 #X floatatom 96 695 5 0 0 0 - - -;
@@ -665,8 +671,8 @@ representation);
 any symlinks);
 #N canvas 5 51 450 300 arguments 0;
 #X msg 68 137 verbose \$1;
-#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 68 116 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 52 23 error reporting;
 #X text 61 83 switch on/off error messages on the Pd-console;
 #X text 56 208 or use the "-v" resp "-q" flag;
@@ -693,15 +699,15 @@ any symlinks);
 #X connect 6 0 5 0;
 #X restore 356 262 pd openpanel;
 #X text 79 41 Stat - get metainformation about a file/directory;
-#X obj 49 317 cnv 15 80 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+#X obj 49 317 cnv 15 80 30 empty empty empty 20 12 0 14 -233017 -66577
 0;
 #X obj 54 322 file stat;
 #N canvas 143 98 738 232 arguments 0;
 #X text 274 145 less verbose (quiet);
 #X text 274 175 more verbose (loud);
 #X msg 563 149 verbose \$1;
-#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 563 127 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X text 106 70 error reporting on the Pd-console;
 #X text 239 111 via flags:;
 #X text 524 100 via a message:;
@@ -768,8 +774,8 @@ be true);
 #X msg 91 173 list source destination;
 #N canvas 5 51 542 353 arguments 0;
 #X msg 136 143 verbose \$1;
-#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 #fcfcfc #000000
-#000000 0 1;
+#X obj 136 122 tgl 15 0 empty empty empty 17 7 0 10 -262144 -1 -1 0
+1;
 #X obj 136 168 outlet;
 #X text 61 82 error reporting;
 #X text 244 118 turn error-printout on/off;
@@ -867,9 +873,9 @@ be true);
 #X restore 499 105 pd path;
 #X text 367 305 if the input ends with a / \, a '/' will be sent to
 the 2nd outlet. otherwise \, the 2nd outlet will fire a bang.;
-#X obj 69 403 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+#X obj 69 403 cnv 15 120 30 empty empty empty 20 12 0 14 -233017 -66577
 0;
-#X obj 70 236 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+#X obj 70 236 cnv 15 120 30 empty empty empty 20 12 0 14 -233017 -66577
 0;
 #X obj 73 241 file split;
 #X obj 105 326 print split:components;
@@ -987,12 +993,12 @@ numbers intact (think "2020/01/01/0042.wav")., f 106;
 #X text 373 133 or type your own:;
 #X text 431 64 select a;
 #X msg 499 79 random string;
-#X obj 70 406 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+#X obj 70 406 cnv 15 120 30 empty empty empty 20 12 0 14 -233017 -66577
 0;
 #X obj 73 411 file splitext;
 #X obj 73 466 print splitext:root+ext;
 #X obj 161 442 print splitext:no!ext;
-#X obj 70 256 cnv 15 120 30 empty empty empty 20 12 0 14 #e0e0e0 #404040
+#X obj 70 256 cnv 15 120 30 empty empty empty 20 12 0 14 -233017 -66577
 0;
 #X obj 73 261 file splitname;
 #X obj 168 293 print splitname:file;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1614,7 +1614,7 @@ typedef struct _readsf
     t_float x_insamplerate;           /**< input signal sample rate, if known */
         /* parameters to communicate with subthread */
     t_soundfile_request x_requestcode; /**< pending request to I/O thread */
-    const char *x_filename;   /**< file to open (string permanently alloced) */
+    const char *x_filename;   /**< file to open (string permanently allocated) */
     int x_fileerror;          /**< slot for "errno" return */
     t_soundfile x_sf;         /**< soundfile fd, type, and format info */
     size_t x_onsetframes;     /**< number of sample frames to skip */

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -78,7 +78,7 @@ typedef struct _head
     char h_formtype[4];              /**< format: "AIFF" or "AIFC"     */
 } t_head;
 
-    /** commmon chunk, 26 (AIFF) or 30+ (AIFC) bytes
+    /** common chunk, 26 (AIFF) or 30+ (AIFC) bytes
         note: sample frames is split to avoid struct alignment padding */
 typedef struct _commchunk
 {

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -26,7 +26,7 @@
   this implementation:
 
     * does not support headerless files
-    * supports big and little endian, system endianess used by default
+    * supports big and little endian, system endianness used by default
     * sets a default info string: "Pd "
     * tries to set sound data length, otherwise falls back to "unknown size"
     * sample format: 16 and 24 bit lpcm, 32 bit float, no 32 bit lpcm

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -277,7 +277,8 @@ static void hradio_save(t_gobj *z, t_binbuf *b)
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2], x->x_fval);
+                bflcol[0], bflcol[1], bflcol[2],
+                x->x_gui.x_isa.x_loadinit?x->x_fval:0.);
     binbuf_addv(b, ";");
 }
 

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -240,7 +240,7 @@ static void hslider_save(t_gobj *z, t_binbuf *b)
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
                 bflcol[0], bflcol[1], bflcol[2],
-                x->x_val, x->x_steady);
+                x->x_gui.x_isa.x_loadinit?x->x_val:0, x->x_steady);
     binbuf_addv(b, ";");
 }
 

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -583,7 +583,7 @@ static void *voutlet_newsig(t_symbol *s)
     else if (s == gensym("lin"))x->x_updown.method=2;    /* up: linear interpolation */
     else if (s == gensym("linear"))x->x_updown.method=2; /* up: linear interpolation */
     else if (s == gensym("pad"))x->x_updown.method=0;    /* up: zero pad */
-    else x->x_updown.method=3;                           /* up: zero-padding; down: ignore samples inbetween */
+    else x->x_updown.method=3;                           /* up: zero-padding; down: ignore samples between */
 
     return (x);
 }

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -414,7 +414,7 @@ static void my_numbox_save(t_gobj *z, t_binbuf *b)
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
                 bflcol[0], bflcol[1], bflcol[2],
-                x->x_val, x->x_log_height);
+                x->x_gui.x_isa.x_loadinit?x->x_val:0., x->x_log_height);
     binbuf_addv(b, ";");
 }
 

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -256,7 +256,9 @@ static void toggle_save(t_gobj *z, t_binbuf *b)
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2], x->x_on, x->x_nonzero);
+                bflcol[0], bflcol[1], bflcol[2],
+                x->x_gui.x_isa.x_loadinit?x->x_on:0.f,
+                x->x_nonzero);
     binbuf_addv(b, ";");
 }
 

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -272,7 +272,8 @@ static void vradio_save(t_gobj *z, t_binbuf *b)
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2], x->x_fval);
+                bflcol[0], bflcol[1], bflcol[2],
+                x->x_gui.x_isa.x_loadinit?x->x_fval:0.);
     binbuf_addv(b, ";");
 }
 

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -243,7 +243,7 @@ static void vslider_save(t_gobj *z, t_binbuf *b)
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
                 bflcol[0], bflcol[1], bflcol[2],
-                x->x_val, x->x_steady);
+                x->x_gui.x_isa.x_loadinit?x->x_val:0, x->x_steady);
     binbuf_addv(b, ";");
 }
 

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -386,7 +386,7 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                             slashed = 1;
                         else
                         {
-                            if (*sp2 == '$' && sp2[1] >= 0 && sp2[1] <= '9')
+                            if (*sp2 == '$' && sp2[1] >= '0' && sp2[1] <= '9')
                                 dollar = 1;
                             *sp1++ = *sp2;
                             slashed = 0;

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -15,6 +15,10 @@ behavior for "gobjs" appears at the end of this file.  */
 # include <alloca.h> /* linux, mac, mingw, cygwin */
 #endif
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 union inletunion
 {
     t_symbol *iu_symto;

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -61,11 +61,18 @@ static void dopost(const char *s)
     if (sys_printhook)
         (*sys_printhook)(s);
     else if (sys_printtostderr || !sys_havegui())
+    {
 #ifdef _WIN32
+    #ifdef _MSC_VER
         fwprintf(stderr, L"%S", s);
+    #else
+        fwprintf(stderr, L"%s", s);
+    #endif
+        fflush(stderr);
 #else
         fprintf(stderr, "%s", s);
 #endif
+    }
     else
     {
         char upbuf[MAXPDSTRING];
@@ -85,7 +92,18 @@ static void doerror(const void *object, const char *s)
         (*sys_printhook)(upbuf);
     }
     else if (sys_printtostderr)
+    {
+#ifdef _WIN32
+    #ifdef _MSC_VER
+        fwprintf(stderr, L"error: %S", s);
+    #else
+        fwprintf(stderr, L"error: %s", s);
+    #endif
+        fflush(stderr);
+#else
         fprintf(stderr, "error: %s", s);
+#endif
+    }
     else
     {
         char obuf[MAXPDSTRING];
@@ -108,7 +126,16 @@ static void dologpost(const void *object, const int level, const char *s)
     }
     else if (sys_printtostderr)
     {
+#ifdef _WIN32
+    #ifdef _MSC_VER
+        fwprintf(stderr, L"verbose(%d): %S", level, s);
+    #else
+        fwprintf(stderr, L"verbose(%d): %s", level, s);
+    #endif
+        fflush(stderr);
+#else
         fprintf(stderr, "verbose(%d): %s", level, s);
+#endif
     }
     else
     {

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1054,7 +1054,7 @@ static void trigger_anything(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
             outlet_bang(u->u_outlet);
         else if (u->u_type == TR_ANYTHING)
             outlet_anything(u->u_outlet, s, argc, argv);
-        else pd_error(x, "trigger: can only convert 's' to 'b' or 'a'");
+        else pd_error(x, "trigger: generic messages can only be converted to 'b' or 'a'");
     }
 }
 

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1038,7 +1038,9 @@ static void trigger_list(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
                 pd_error(x, "trigger: bad pointer");
             else outlet_pointer(u->u_outlet, argv->a_w.w_gpointer);
         }
-        else outlet_list(u->u_outlet, &s_list, argc, argv);
+        else if (u->u_type == TR_LIST)
+            outlet_list(u->u_outlet, &s_list, argc, argv);
+        else outlet_anything(u->u_outlet, s, argc, argv);
     }
 }
 
@@ -1058,28 +1060,28 @@ static void trigger_anything(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
 
 static void trigger_bang(t_trigger *x)
 {
-    trigger_list(x, 0, 0, 0);
+    trigger_list(x, &s_bang, 0, 0);
 }
 
 static void trigger_pointer(t_trigger *x, t_gpointer *gp)
 {
     t_atom at;
     SETPOINTER(&at, gp);
-    trigger_list(x, 0, 1, &at);
+    trigger_list(x, &s_pointer, 1, &at);
 }
 
 static void trigger_float(t_trigger *x, t_float f)
 {
     t_atom at;
     SETFLOAT(&at, f);
-    trigger_list(x, 0, 1, &at);
+    trigger_list(x, &s_float, 1, &at);
 }
 
 static void trigger_symbol(t_trigger *x, t_symbol *s)
 {
     t_atom at;
     SETSYMBOL(&at, s);
-    trigger_list(x, 0, 1, &at);
+    trigger_list(x, &s_symbol, 1, &at);
 }
 
 static void trigger_free(t_trigger *x)

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -3,7 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* The "file" object. */
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 
 #include "m_pd.h"
 #include "g_canvas.h"

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 1997-2013 Miller Puckette and others.
+/* Copyright (c) 2021 IOhannes m zmölnig.
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -833,6 +833,8 @@ static void text_get_float(t_text_get *x, t_floatarg f)
         else if (startfield + nfield > outc)
             pd_error(x, "text get: field request (%d %d) out of range",
                 startfield, nfield);
+        else if (nfield < 0)
+            pd_error(x, "text get: bad field count (%d)", nfield);
         else
         {
             ATOMS_ALLOCA(outv, nfield);


### PR DESCRIPTION
permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.

supersedes #1246

---
Fixes included (this list should get updated whenever a new fix is included. keep in mind that updating the list might be forgotten though...)
- allow `[file handle]` to use single-floatatom `list`-messages to read data (rather than only `float` messages) (Closes: #1358)
- Fix bogus check, whether `$` is followed by a number
- Make iemgui's only save the current value in `init`-mode (Closes: #1347)
- fix `-stderr` on Windows (utf-8 support, flushing)
- make `[trigger anything]` pass values unaltered (Closes: #683)
- fix segfault with negative field-count in `[text get]` (Closes: #1377)
- fix MSVC compilation in `[trace]` (Closes: #1381)
- fix XCode compilation of `[file]` (Closes: #1362)
