### PR TITLE
Fix x_file.c build under macOS

### DIFF
--- a/src/x_file.c
+++ b/src/x_file.c
@@ -3,7 +3,7 @@
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* The "file" object. */
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 
 #include "m_pd.h"
 #include "g_canvas.h"


### PR DESCRIPTION
Defining _XOPEN_SOURCE 500 seems to disable snprintf at least on Xcode 12 with the macOS 11.3 sdk, bump it to 600.

Here's a simple example that fails to build on mac (and from what I could find on the internet, on BSD too):

```C
#define _XOPEN_SOURCE 500
#include <stdio.h>

int main()
{
    char c[1000];
    snprintf(c, 10, "foo %d", 123);
}
``` 

fails with 

```
foo.c:7:5: error: implicitly declaring library function 'snprintf' with type 'int (char *, unsigned long, const char *, ...)' [-Werror,-Wimplicit-function-declaration]
    snprintf(c, 10, "foo %d", 123);
    ^
foo.c:7:5: note: include the header <stdio.h> or explicitly provide a declaration for 'snprintf'
1 error generated.
```

(and works with the macro defined to 600)