### PR TITLE
add float method to [random] to allow setting the range and generating a value

### DIFF
--- a/doc/5.reference/random-help.pd
+++ b/doc/5.reference/random-help.pd
@@ -1,14 +1,13 @@
 #N canvas 490 69 497 442 12;
-#X msg 54 217 bang;
-#X obj 54 306 random 5;
-#X floatatom 107 279 0 0 0 0 - - -;
-#X floatatom 54 334 0 0 0 0 - - -;
-#X msg 73 249 seed 123;
-#X text 95 216 bang for output;
-#X text 145 250 message to set the seed;
-#X text 140 277 inlet to reset the range;
-#X text 123 306 argument to initialize the range;
-#X text 256 367 updated for Pd version 0.33;
+#X msg 44 207 bang;
+#X obj 124 316 random 5;
+#X floatatom 177 289 0 0 0 0 - - -;
+#X floatatom 124 344 0 0 0 0 - - -;
+#X msg 97 233 seed 123;
+#X text 85 206 bang for output;
+#X text 169 234 message to set the seed;
+#X text 210 287 inlet to reset the range;
+#X text 193 316 argument to initialize the range;
 #X text 19 46 Random outputs pseudo random integers from 0 to N-1 where
 N is the creation argument (5 in the example below.) You can specify
 a seed if you wish. Seeds are kept locally so that if two Randoms are
@@ -20,11 +19,15 @@ the quality of the pseudo random number generator. It isn't any standard
 one!;
 #X obj 28 11 random;
 #X text 92 11 - pseudo random integers;
-#X obj 54 362 print;
+#X obj 124 372 print;
 #X text 53 404 see also:;
 #X obj 131 404 expr;
+#X text 256 367 updated for Pd version 0.52;
+#X floatatom 140 262 5 0 0 0 - - -;
+#X text 185 262 set range & output value;
 #X connect 0 0 1 0;
 #X connect 1 0 3 0;
 #X connect 2 0 1 1;
-#X connect 3 0 14 0;
+#X connect 3 0 13 0;
 #X connect 4 0 1 0;
+#X connect 17 0 1 0;

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -82,6 +82,12 @@ static void random_bang(t_random *x)
     outlet_float(x->x_obj.ob_outlet, nval);
 }
 
+static void random_float(t_random *x, t_floatarg f)
+{
+    x->x_f = f;
+    random_bang(x);
+}
+
 static void random_seed(t_random *x, t_float f, t_float glob)
 {
     x->x_state = f;
@@ -92,6 +98,7 @@ static void random_setup(void)
     random_class = class_new(gensym("random"), (t_newmethod)random_new, 0,
         sizeof(t_random), 0, A_DEFFLOAT, 0);
     class_addbang(random_class, random_bang);
+    class_addfloat(random_class, (t_method)random_float);
     class_addmethod(random_class, (t_method)random_seed,
         gensym("seed"), A_FLOAT, 0);
 }


### PR DESCRIPTION
This adds a float method to random in order to be able to simply send a float to the left inlet to set the range and immediately generate a value.
motivated by https://forum.puredata.info/topic/13592/random-hot-inlet-doesn-t-allow-float