### PR TITLE
don't prefix [print] ouput with "verbose(2)" when sending to stderr or via printhook

### DIFF
--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -5,10 +5,19 @@
 /* interface objects */
 
 #include "m_pd.h"
+#include "s_stuff.h"
 #include <string.h>
 
 /* -------------------------- print ------------------------------ */
 static t_class *print_class;
+
+  /* avoid prefixing with "verbose(2): "
+  when printing to stderr or via printhook. */
+#define print_startlogpost(object, level, fmt, args...) do{ \
+    if (sys_printhook || sys_printtostderr) \
+        startpost(fmt, args); \
+    else startlogpost(object, level, fmt, args); \
+} while(0)
 
 typedef struct _print
 {
@@ -46,29 +55,32 @@ static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 
 static void print_bang(t_print *x)
 {
-    logpost(x, 2, "%s%sbang", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startlogpost(x, 2, "%s%sbang", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    endpost();
 }
 
 static void print_pointer(t_print *x, t_gpointer *gp)
 {
-    logpost(x, 2, "%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startlogpost(x, 2, "%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    endpost();
 }
 
 static void print_float(t_print *x, t_float f)
 {
-    logpost(x, 2, "%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
+    print_startlogpost(x, 2, "%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
+    endpost();
 }
 
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    startlogpost(x, 2, "%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
+    print_startlogpost(x, 2, "%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
         s->s_name);
     for (i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
         atom_string(argv+i, buf, MAXPDSTRING);
-        startlogpost(x, 2, " %s", buf);
+        print_startlogpost(x, 2, " %s", buf);
     }
     endpost();
 }
@@ -99,18 +111,18 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
     {
         int i;
         if (*x->x_sym->s_name)
-            startlogpost(x, 2, "%s: ", x->x_sym->s_name);
+            print_startlogpost(x, 2, "%s: ", x->x_sym->s_name);
         else
         {
             /* print first (numeric) atom, to avoid a trailing space */
-            startlogpost(x, 2, "%g", atom_getfloat(argv));
+            print_startlogpost(x, 2, "%g", atom_getfloat(argv));
             argc--; argv++;
         }
         for (i = 0; i < argc; i++)
         {
             char buf[MAXPDSTRING];
             atom_string(argv+i, buf, MAXPDSTRING);
-            startlogpost(x, 2, " %s", buf);
+            print_startlogpost(x, 2, " %s", buf);
         }
         endpost();
     }


### PR DESCRIPTION
In https://lists.puredata.info/pipermail/pd-dev/2021-08/022830.html , Roman Haefeli reports that the [print] object printout is garbled with the "verbose(2): " prefix when printing to stderr.

This is due to the "trackable print" addition (see #464).

Here is a possible fix, that just restores the original [print] behavior when sending to stderr or using a printhook.

