### PR TITLE
restore sending extra path to help browser

### DIFF
--- a/src/s_main.c
+++ b/src/s_main.c
@@ -368,12 +368,12 @@ int sys_main(int argc, const char **argv)
     if (sys_version)    /* if we were just asked our version, exit here. */
         return (0);
     sys_setsignalhandlers();
+    sys_afterargparse();                    /* post-argparse settings */
     if (sys_dontstartgui)
         clock_set((sys_fakefromguiclk =
             clock_new(0, (t_method)sys_fakefromgui)), 0);
     else if (sys_startgui(sys_libdir->s_name)) /* start the gui */
         return (1);
-    sys_afterargparse();                    /* post-argparse settings */
     if (sys_hipriority)
         sys_setrealtime(sys_libdir->s_name); /* set desired process priority */
     if (sys_externalschedlib)


### PR DESCRIPTION
since 95b614656cd62214d6779014e5173d8af697814b, the help browser doesn't display `extra` paths content anymore.

this is because  `s_main::sys_main()` first calls `s_inter::sys_startgui()`, which calls `s_inter::sys_do_startgui()` which then calls `s_path::sys_set_extrapath()` ( which sends the extrapath to GUI), before it calls `s_main::sys_afterargparse()` which calls `s_path::sys_setextrapath()` (which initializes the extrapath for the OS).

This PR just makes `sys_main()` calling `sys_afterargparse()` before `sys_startgui()`.