### PR TITLE
fix MSC compilation for the recent addition of [trace] (fixes CI checks)

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -16,6 +16,10 @@ behavior for "gobjs" appears at the end of this file.  */
 # include <alloca.h> /* linux, mac, mingw, cygwin */
 #endif
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 union inletunion
 {
     t_symbol *iu_symto;


### PR DESCRIPTION
Now that `m_obj.c` uses `snprintf`, it must define it as a shortcut for `_snprintf` in the case of MSC, just like e.g m_binbuf.c:
```
#ifdef _MSC_VER
#define snprintf _snprintf
#endif

```
