### PR TITLE
h/vslider-help: Correct description of logarithmic range

### DIFF
--- a/doc/5.reference/hslider-help.pd
+++ b/doc/5.reference/hslider-help.pd
@@ -550,8 +550,8 @@ jumps to the position you clicked on the slider and drags from there.
 #X text 288 208 1000;
 #X text 57 29 The slider's behavior can be linear (default) or logarithmic
 and you can set this with the 'lin' or 'log' messages \, respectively.
-Check below the difference. In the logarithmic mode \, the minimum
-range can never be 0 or negative., f 48;
+Check below the difference. In the logarithmic mode \, the range may
+never touch or cross 0 (both positive or both negative are OK)., f 48;
 #X connect 0 0 5 0;
 #X connect 1 0 0 0;
 #X connect 2 0 0 0;

--- a/doc/5.reference/vslider-help.pd
+++ b/doc/5.reference/vslider-help.pd
@@ -538,8 +538,8 @@ jumps to the position you clicked on the slider and drags from there.
 #X text 191 166 logarithmic;
 #X text 50 27 The slider's behavior can be linear (default) or logarithmic
 and you can set this with the 'lin' or 'log' messages \, respectively.
-Check below the difference. In the logarithmic mode \, the minimum
-range can never be 0 or negative., f 48;
+Check below the difference. In the logarithmic mode \, the range may
+never touch or cross 0 (both positive or both negative are OK)., f 48;
 #X obj 144 203 vsl 18 128 1 1000 0 0 empty empty empty 0 -9 0 10 -262144
 -1 -1 0 1;
 #X floatatom 144 354 8 0 0 0 - - -;


### PR DESCRIPTION
Updates a minor detail in h- and v-slider help. The subpatch about linear or logarithmic ranges claimed that a log range must be positive. This isn't true.

The real condition is that `hi / lo` must be positive, which is the case if both numbers are positive *or* both numbers are negative (and of course non-zero). A slider with a range e.g. -100 to -1 works perfectly well.