### PR TITLE
fix t_loglevel usage

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -127,9 +127,9 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
         nbuf[79] = 0;
         (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
         if (c == pd_objectmaker)
-            verbose(PD_VERBOSE, "warning: class '%s' overwritten; old one renamed '%s'",
+            logpost(NULL, PD_VERBOSE, "warning: class '%s' overwritten; old one renamed '%s'",
                 sel->s_name, nbuf);
-        else verbose(PD_VERBOSE, "warning: old method '%s' for class '%s' renamed '%s'",
+        else logpost(NULL, PD_VERBOSE, "warning: old method '%s' for class '%s' renamed '%s'",
             sel->s_name, c->c_name->s_name, nbuf);
     }
     (*methodlist) = t_resizebytes((*methodlist),

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -533,27 +533,31 @@ EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
 
 /* ------------   printing --------------------------------- */
 
-typedef enum {
-    PD_CRITICAL = -3,
-    PD_ERROR,
-    PD_NORMAL,
-    PD_DEBUG,
-    PD_VERBOSE
-} t_loglevel;
-
 EXTERN void post(const char *fmt, ...);
 EXTERN void startpost(const char *fmt, ...);
 EXTERN void poststring(const char *s);
 EXTERN void postfloat(t_floatarg f);
 EXTERN void postatom(int argc, const t_atom *argv);
 EXTERN void endpost(void);
-EXTERN void verbose(int level, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+
 EXTERN void bug(const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 EXTERN void pd_error(const void *object, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
-EXTERN void logpost(const void *object, const int level, const char *fmt, ...)
+
+/* for logpost(); does *not* work with verbose()! */
+typedef enum {
+    PD_CRITICAL = 0,
+    PD_ERROR,
+    PD_NORMAL,
+    PD_DEBUG,
+    PD_VERBOSE
+} t_loglevel;
+
+EXTERN void logpost(const void *object, int level, const char *fmt, ...)
     ATTRIBUTE_FORMAT_PRINTF(3, 4);
-EXTERN void startlogpost(const void *object, const int level, const char *fmt, ...)
-    ATTRIBUTE_FORMAT_PRINTF(3, 4);
+
+/* deprecated, use logpost() instead. */
+EXTERN void verbose(int level, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+
 
 /* ------------  system interface routines ------------------- */
 EXTERN int sys_isabsolutepath(const char *dir);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -110,7 +110,7 @@ void sys_setchsr(int chin, int chout, int sr)
     STUFF->st_soundout = (t_sample *)getbytes(outbytes);
     memset(STUFF->st_soundout, 0, outbytes);
 
-    verbose(PD_VERBOSE, "input channels = %d, output channels = %d",
+    logpost(NULL, PD_VERBOSE, "input channels = %d, output channels = %d",
             STUFF->st_inchannels, STUFF->st_outchannels);
     canvas_resume_dsp(canvas_suspend_dsp());
 }

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -117,7 +117,7 @@ static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     snd_pcm_hw_params_alloca(&hw_params);
     snd_pcm_sw_params_alloca(&sw_params);
 
-    verbose(PD_VERBOSE, (out ? "configuring sound output..." :
+    logpost(NULL, PD_VERBOSE, (out ? "configuring sound output..." :
             "configuring sound input..."));
 
         /* set hardware parameters... */
@@ -158,7 +158,7 @@ static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     }
     else dev->a_sampwidth = 4;
 
-    verbose(PD_VERBOSE, "Sample width set to %d bytes", dev->a_sampwidth);
+    logpost(NULL, PD_VERBOSE, "Sample width set to %d bytes", dev->a_sampwidth);
 
         /* set the subformat */
     err = snd_pcm_hw_params_set_subformat(dev->a_handle,
@@ -283,7 +283,7 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
     alsa_nindev = alsa_noutdev = 0;
     alsa_jittermax = ALSA_DEFJITTERMAX;
 
-    verbose(PD_VERBOSE, "alsa: %d blocks of %d samples, total advance %d",
+    logpost(NULL, PD_VERBOSE, "alsa: %d blocks of %d samples, total advance %d",
         nfrags, frag_size, (int)(0.001 * sys_schedadvance));
 
     for (iodev = 0; iodev < naudioindev; iodev++)
@@ -296,7 +296,7 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
             continue;
         alsa_indev[alsa_nindev].a_devno = audioindev[iodev];
         snd_pcm_nonblock(alsa_indev[alsa_nindev].a_handle, 1);
-        verbose(PD_VERBOSE, "opened input device name %s", devname);
+        logpost(NULL, PD_VERBOSE, "opened input device name %s", devname);
         alsa_nindev++;
     }
     for (iodev = 0; iodev < naudiooutdev; iodev++)
@@ -798,7 +798,7 @@ static void alsa_checkiosync(void)
             }
             else if (result != SND_PCM_STATE_RUNNING)
             {
-                verbose(PD_VERBOSE, "restarting output device from state %d",
+                logpost(NULL, PD_VERBOSE, "restarting output device from state %d",
                     snd_pcm_state(alsa_outdev[iodev].a_handle));
                 if ((err = snd_pcm_start(alsa_outdev[iodev].a_handle)) < 0)
                     check_error(err, 0, "restart failed");
@@ -837,7 +837,7 @@ static void alsa_checkiosync(void)
             }
             else if (result != SND_PCM_STATE_RUNNING)
             {
-                verbose(PD_VERBOSE, "restarting input device from state %d",
+                logpost(NULL, PD_VERBOSE, "restarting input device from state %d",
                     snd_pcm_state(alsa_indev[iodev].a_handle));
                 if ((err = snd_pcm_start(alsa_indev[iodev].a_handle)) < 0)
                     check_error(err, 1, "restart failed");

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -351,7 +351,7 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
       &status, NULL);
     if (status & JackFailure) {
         pd_error(0, "JACK: couldn't connect to server, is JACK running?");
-        verbose(PD_VERBOSE, "JACK: returned status is: %d", status);
+        logpost(NULL, PD_VERBOSE, "JACK: returned status is: %d", status);
         jack_client=NULL;
         /* jack spits out enough messages already, do not warn */
         STUFF->st_inchannels = STUFF->st_outchannels = 0;
@@ -359,7 +359,7 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     }
     if (status & JackNameNotUnique)
         jack_client_name(jack_get_client_name(jack_client));
-    verbose(PD_VERBOSE, "JACK: registered as '%s'", desired_client_name);
+    logpost(NULL, PD_VERBOSE, "JACK: registered as '%s'", desired_client_name);
 
     STUFF->st_inchannels = inchans;
     STUFF->st_outchannels = outchans;

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -148,7 +148,7 @@ int mmio_do_open_audio(void)
     int i, j;
     UINT mmresult;
     int nad, nda;
-    verbose(PD_VERBOSE, "%d devices in, %d devices out",
+    logpost(NULL, PD_VERBOSE, "%d devices in, %d devices out",
             nt_nwavein, nt_nwaveout);
 
     form.wf.wFormatTag = WAVE_FORMAT_PCM;
@@ -225,7 +225,7 @@ void mmio_close_audio(void)
 {
     int errcode;
     int nda, nad;
-    verbose(PD_VERBOSE, "closing audio...");
+    logpost(NULL, PD_VERBOSE, "closing audio...");
 
     for (nda=0; nda < nt_nwaveout; nda++) /*if (nt_nwaveout) wini */
     {
@@ -249,7 +249,7 @@ void mmio_close_audio(void)
     mmio_freebufs(ntsnd_invec, nt_nwavein, nt_naudiobuffer);
     mmio_freebufs(ntsnd_outvec, nt_nwaveout, nt_naudiobuffer);
     nt_nwavein = nt_nwaveout = 0;
-    verbose(PD_VERBOSE, "done closing audio...");
+    logpost(NULL, PD_VERBOSE, "done closing audio...");
 }
 
 
@@ -700,7 +700,7 @@ int mmio_open_audio(int naudioindev, int *audioindev,
 {
     int nbuf;
 
-    verbose(PD_VERBOSE, "opening audio...");
+    logpost(NULL, PD_VERBOSE, "opening audio...");
     nt_blocksize = (blocksize ? blocksize : DEFREALDACBLKSIZE);
     nbuf = (sys_schedadvance * rate )/ (nt_blocksize * 1000000.);
     if (nbuf >= MAXBUFFER)
@@ -726,7 +726,7 @@ int mmio_open_audio(int naudioindev, int *audioindev,
     if (naudiooutdev > 1 || naudioindev > 1)
  post("separate audio device choice not supported; using sequential devices.");
     return (mmio_do_open_audio());
-    verbose(PD_VERBOSE, "done opening audio...");
+    logpost(NULL, PD_VERBOSE, "done opening audio...");
 }
 
 

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -171,7 +171,7 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
         if (fragbytes != (1 << logfragsize))
             post("warning: OSS takes only power of 2 blocksize; using %d",
                 (1 << logfragsize)/(dev->d_bytespersamp * nchannels));
-        verbose(PD_VERBOSE, "setting nfrags = %d, fragsize %d\n",
+        logpost(NULL, PD_VERBOSE, "setting nfrags = %d, fragsize %d\n",
             nfragment, fragbytes);
 
         param = orig = (nfragment<<16) + logfragsize;
@@ -184,7 +184,7 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
             post("warning: actual fragments %d, blocksize %d",
                 nfragment, (1 << logfragsize));
         }
-        verbose(PD_VERBOSE, "audiobuffer set to %d msec",
+        logpost(NULL, PD_VERBOSE, "audiobuffer set to %d msec",
             (int)(0.001 * sys_schedadvance));
     }
 
@@ -221,7 +221,7 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
 static int oss_setchannels(int fd, int wantchannels, char *devname)
 {
     int param;
-    verbose(PD_VERBOSE, "setchan %d", wantchannels);
+    logpost(NULL, PD_VERBOSE, "setchan %d", wantchannels);
     if (ioctl(fd, SNDCTL_DSP_CHANNELS, &param) == -1)
     {
         if (sys_verbose)
@@ -229,10 +229,10 @@ static int oss_setchannels(int fd, int wantchannels, char *devname)
     }
     else
     {
-        verbose(PD_VERBOSE, "channels originally %d for %s", param, devname);
+        logpost(NULL, PD_VERBOSE, "channels originally %d for %s", param, devname);
         if (param == wantchannels)
         {
-            verbose(PD_VERBOSE, "number of channels doesn't need setting\n");
+            logpost(NULL, PD_VERBOSE, "number of channels doesn't need setting\n");
             return (wantchannels);
         }
     }
@@ -309,7 +309,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                     post("couldn't get audio device flags");
                 else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                     post("couldn't set audio device flags");
-                verbose(PD_VERBOSE,
+                logpost(NULL, PD_VERBOSE,
                     "opened %s for reading and writing\n",
                         oss_devnames[thisdevice]);
                 linux_adcs[inindex].d_fd = fd;
@@ -331,7 +331,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                 post("couldn't get audio device flags");
             else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                 post("couldn't set audio device flags");
-            verbose(PD_VERBOSE, "opened %s for writing only\n",
+            logpost(NULL, PD_VERBOSE, "opened %s for writing only\n",
                 oss_devnames[thisdevice]);
         }
         if (ioctl(fd, SNDCTL_DSP_GETCAPS, &capabilities) == -1)
@@ -341,7 +341,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
             (wantchannels>OSS_MAXCHPERDEV)?OSS_MAXCHPERDEV:wantchannels,
                 oss_devnames[thisdevice]);
 
-        verbose(PD_VERBOSE, "opened audio output on %s; got %d channels",
+        logpost(NULL, PD_VERBOSE, "opened audio output on %s; got %d channels",
             oss_devnames[thisdevice], gotchans);
 
         if (gotchans < 2)
@@ -387,7 +387,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
         {
             fd = linux_adcs[n].d_fd;
             alreadyopened = 1;
-            verbose(PD_VERBOSE, "already opened it");
+            logpost(NULL, PD_VERBOSE, "already opened it");
         }
         else
         {
@@ -404,7 +404,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
                 post("couldn't get audio device flags");
             else if (fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
                 post("couldn't set audio device flags");
-            verbose(PD_VERBOSE, "opened %s for reading only\n",
+            logpost(NULL, PD_VERBOSE, "opened %s for reading only\n",
                 oss_devnames[thisdevice]);
         }
         linux_adcs[linux_nindevs].d_fd = fd;
@@ -412,7 +412,7 @@ int oss_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
         gotchans = oss_setchannels(fd,
             (wantchannels>OSS_MAXCHPERDEV)?OSS_MAXCHPERDEV:wantchannels,
                 oss_devnames[thisdevice]);
-        verbose(PD_VERBOSE, "opened audio input device %s; got %d channels",
+        logpost(NULL, PD_VERBOSE, "opened audio input device %s; got %d channels",
             oss_devnames[thisdevice], gotchans);
 
         if (gotchans < 1)

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -402,10 +402,10 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     if (outchans > 0 && pa_outdev == -1)
         outchans = 0;
 
-    verbose(PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
-    verbose(PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);
-    verbose(PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
-    verbose(PD_VERBOSE, "rate %d", rate);
+    logpost(NULL, PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
+    logpost(NULL, PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);
+    logpost(NULL, PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
+    logpost(NULL, PD_VERBOSE, "rate %d", rate);
 
     pa_inchans = STUFF->st_inchannels = inchans;
     pa_outchans = STUFF->st_outchannels = outchans;
@@ -463,7 +463,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         /* Pa_Terminate(); */
         return (1);
     }
-    else verbose(PD_VERBOSE, "... opened OK.");
+    else logpost(NULL, PD_VERBOSE, "... opened OK.");
     return (0);
 }
 

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -77,7 +77,7 @@ static void sys_initloadpreferences_file(const char *filename)
     }
     sys_prefbuf[length+1] = 0;
     close(fd);
-    verbose(PD_VERBOSE, "success reading preferences from: %s", filename);
+    logpost(NULL, PD_VERBOSE, "success reading preferences from: %s", filename);
 }
 
 static int sys_getpreference_file(const char *key, char *value, int size)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -368,8 +368,8 @@ void sys_set_priority(int mode)
     else
     {
         if (mode == MODE_RT)
-            verbose(PD_VERBOSE, "priority %d scheduling enabled.\n", p3);
-        else verbose(PD_VERBOSE, "running at normal (non-real-time) priority.\n");
+            logpost(NULL, PD_VERBOSE, "priority %d scheduling enabled.\n", p3);
+        else logpost(NULL, PD_VERBOSE, "running at normal (non-real-time) priority.\n");
     }
 #endif
 
@@ -1458,7 +1458,7 @@ void sys_setrealtime(const char *libdir)
                 this is done later when the socket is open. */
         }
     }
-    else verbose(PD_VERBOSE, "not setting real-time priority");
+    else logpost(NULL, PD_VERBOSE, "not setting real-time priority");
 #endif /* __linux__ */
 
 #ifdef _WIN32

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -233,7 +233,7 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
             height = (j+1)*sys_fontspec[i].fi_height;
             if (!did_fontwarning)
             {
-                verbose(PD_VERBOSE, "ignoring invalid font-metrics from GUI");
+                logpost(NULL, PD_VERBOSE, "ignoring invalid font-metrics from GUI");
                 did_fontwarning = 1;
             }
         }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -655,12 +655,12 @@ void sys_set_midi_api(int which)
     case(API_DEFAULTMIDI): break;
 #endif
     default:
-        verbose(PD_VERBOSE, "ignoring unknown MIDI API %d", which);
+        logpost(NULL, PD_VERBOSE, "ignoring unknown MIDI API %d", which);
         return;
     }
 
     sys_midiapi = which;
-    verbose(PD_VERBOSE, "sys_midiapi %d", sys_midiapi);
+    logpost(NULL, PD_VERBOSE, "sys_midiapi %d", sys_midiapi);
 }
 
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform);

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -86,7 +86,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_RDWR | O_MIDIFLAG);
-            verbose(PD_VERBOSE, "tried to open %s read/write; got %d\n",
+            logpost(NULL, PD_VERBOSE, "tried to open %s read/write; got %d\n",
                 oss_midinames[devno], fd);
             if (outdevindex >= 0 && fd >= 0)
                 oss_midioutfd[outdevindex] = fd;
@@ -96,7 +96,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_RDONLY | O_MIDIFLAG);
-            verbose(PD_VERBOSE, "tried to open %s read-only; got %d\n",
+            logpost(NULL, PD_VERBOSE, "tried to open %s read-only; got %d\n",
                 oss_midinames[devno], fd);
         }
         if (fd >= 0)
@@ -114,7 +114,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_WRONLY | O_MIDIFLAG);
-            verbose(PD_VERBOSE, "tried to open %s write-only; got %d\n",
+            logpost(NULL, PD_VERBOSE, "tried to open %s write-only; got %d\n",
                 oss_midinames[devno], fd);
         }
         if (fd >= 0)

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -72,7 +72,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
                     {
                         /* disable default active sense filtering */
                         Pm_SetFilter(mac_midiindevlist[mac_nmidiindev], 0);
-                        verbose(PD_VERBOSE, "MIDI input (%s) opened.",
+                        logpost(NULL, PD_VERBOSE, "MIDI input (%s) opened.",
                             info->name);
                         mac_nmidiindev++;
                     }
@@ -100,7 +100,7 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
                             j, info->name, Pm_GetErrorText(err));
                     else
                     {
-                        verbose(PD_VERBOSE, "MIDI output (%s) opened.",
+                        logpost(NULL, PD_VERBOSE, "MIDI output (%s) opened.",
                             info->name);
                         mac_nmidioutdev++;
                     }

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -298,7 +298,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
             !S_ISDIR(statbuf.st_mode));
         if (!ok)
         {
-            verbose(PD_VERBOSE, "tried %s; stat failed or directory",
+            logpost(NULL, PD_VERBOSE, "tried %s; stat failed or directory",
                 dirresult);
             close (fd);
             fd = -1;
@@ -307,7 +307,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
 #endif
         {
             char *slash;
-            verbose(PD_VERBOSE, "tried %s and succeeded", dirresult);
+            logpost(NULL, PD_VERBOSE, "tried %s and succeeded", dirresult);
             sys_unbashfilename(dirresult, dirresult);
             slash = strrchr(dirresult, '/');
             if (slash)
@@ -322,7 +322,7 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
     }
     else
     {
-        verbose(PD_VERBOSE, "tried %s and failed", dirresult);
+        logpost(NULL, PD_VERBOSE, "tried %s and failed", dirresult);
     }
     return (-1);
 }

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -146,7 +146,7 @@ static void dologpost(const void *object, const int level, const char *s)
     }
 }
 
-void logpost(const void *object, const int level, const char *fmt, ...)
+void logpost(const void *object, int level, const char *fmt, ...)
 {
     char buf[MAXPDSTRING];
     va_list ap;
@@ -256,6 +256,7 @@ void error(const char *fmt, ...)
 }
 #endif
 
+/* deprecated in favor of logpost() */
 void verbose(int level, const char *fmt, ...)
 {
     char buf[MAXPDSTRING];

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -323,7 +323,7 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
         {
             int bound = 0;
             struct addrinfo *sailist = NULL, *sai;
-            verbose(1, "connecting to %s %d, src port %d", hostbuf, portno, sportno);
+            logpost(NULL, PD_VERBOSE, "connecting to %s %d, src port %d", hostbuf, portno, sportno);
             status = addrinfo_get_list(&sailist, NULL, sportno, x->x_protocol);
             if (status != 0)
             {
@@ -356,9 +356,9 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
             }
         }
         else if (hostname && multicast)
-            verbose(1, "connecting to %s %d (multicast)", hostbuf, portno);
+            logpost(NULL, PD_VERBOSE, "connecting to %s %d (multicast)", hostbuf, portno);
         else
-            verbose(1, "connecting to %s %d", hostbuf, portno);
+            logpost(NULL, PD_VERBOSE, "connecting to %s %d", hostbuf, portno);
 
         if (x->x_protocol == SOCK_STREAM)
         {
@@ -474,7 +474,7 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
         {
             if (timeafter > lastwarntime + 2)
             {
-                verbose(0, "netsend/netreceive: blocked %d msec",
+                logpost(NULL, PD_DEBUG, "netsend/netreceive: blocked %d msec",
                      (int)(1000 * ((timeafter - timebefore) +
                      pleasewarn)));
                 pleasewarn = 0;
@@ -785,11 +785,11 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
             char hostbuf[256];
             sockaddr_get_addrstr(ai->ai_addr,
                 hostbuf, sizeof(hostbuf));
-            verbose(1, "listening on %s %d%s", hostbuf, portno,
+            logpost(NULL, PD_VERBOSE, "listening on %s %d%s", hostbuf, portno,
                 (multicast ? " (multicast)" : ""));
         }
         else
-            verbose(1, "listening on %d", portno);
+            logpost(NULL, PD_VERBOSE, "listening on %d", portno);
         break;
     }
     freeaddrinfo(ailist);


### PR DESCRIPTION
Changes:
* `t_loglevel` is meant to be used with `logpost()` instead of `verbose()`
* deprecate `verbose()` in favor of `logpost()`
* replace all `verbose(...)` calls in the code base with `logpost(NULL, ...)`

We have already discovered with horror that `verbose()` and `logpost()` use different values for the log level. Unfortunately, there is no good overall solution to make `t_loglevel` work with both functions, so I would just go ahead and only allow it for `logpost()`.

Also, I went ahead and marked `verbose()` as deprecated, since `logpost()` is the newer (and better) function. I'm wondering if we should even remove it from `m_pd.h`, just like Miller has done with `error()`...