### PR TITLE
[cputime] and Windows

### DIFF
--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -27,7 +27,8 @@
 #if defined (__linux__) || defined (__CYGWIN__) || defined (ANDROID)
 #define CLOCKHZ sysconf(_SC_CLK_TCK)
 #endif
-#if defined (__FreeBSD_kernel__) || defined(__GNU__) || defined(__OpenBSD__)
+#if defined (__FreeBSD_kernel__) || defined(__GNU__) || defined(__OpenBSD__) \
+    || defined(_WIN32)
 #include <time.h>
 #define CLOCKHZ CLOCKS_PER_SEC
 #endif


### PR DESCRIPTION
This PR makes [cputime] work again on Windows. It was showing a 'couldn't create...' when opening 'list of objects'. Not sure which commit broke it.

Note: it still have the old behavior that gives values only when DSP is on (or only the very first time a bang gets in the right inlet if this was banged prior to any left bang).