### PR TITLE
fix t_methodentry bug introduced by using unsigned char instead of t_atomtype

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -138,9 +138,7 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
     m = (*methodlist) + nmethod;
     m->me_name = sel;
     m->me_fun = (t_gotfn)fn;
-    i = 0;
-    while ((m->me_arg[i] = args[i]))
-        i++;
+    memcpy(m->me_arg, args, MAXPDARG+1);
 }
 
 #ifdef PDINSTANCE

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -114,7 +114,7 @@ static t_pdinstance *pdinstance_init(t_pdinstance *x)
 }
 
 static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
-    int nmethod, t_gotfn fn, t_symbol *sel, t_atomtype *args,
+    int nmethod, t_gotfn fn, t_symbol *sel, unsigned char *args,
         t_pdinstance *pdinstance)
 {
     int i;
@@ -639,7 +639,7 @@ void class_addmethod(t_class *c, t_method fn, t_symbol *sel,
     }
     else
     {
-        t_atomtype argvec[MAXPDARG+1];
+        unsigned char argvec[MAXPDARG+1];
         nargs = 0;
         while (argtype != A_NULL && nargs < MAXPDARG)
         {


### PR DESCRIPTION
Fix `t_methodentry` bug introduced by using `unsigned char` instead of `t_atomtype` in this commit https://github.com/pure-data/pure-data/commit/0a727e594ffa4a85f2c3c8c18d51730ffcce160b. 

The methods' arguments are not well forwarded in `pd_typemess ()` because of the type of `me_arg` mismatches with the structure.

The bug is really annoying because when opening a patch the connection cannot be created, etc.  

I don't know why the bug doesn't seem to happen in Pd 0.52.0 (this might be related to my compiler - XCode 13.0 - AppleClang 13.0.0.13000029). 

I tested the fix using PDINSTANCE=1 (for Camomile) but  it should also work with PDINSTANCE=0.