### PR TITLE
fix the gatom's label font size when zoomed in

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1047,7 +1047,7 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
                 glist_getcanvas(glist), x,
                 (double)x1, (double)y1,
                 canvas_realizedollar(x->a_glist, x->a_label)->s_name,
-                gatom_fontsize(x), "black");
+                gatom_fontsize(x) * glist_getzoom(glist), "black");
         }
         else sys_vgui(".x%lx.c delete %lx.l\n", glist_getcanvas(glist), x);
     }


### PR DESCRIPTION
this PR fixes bad gatoms' label font size when the canvas is zoomed-in, see:
https://lists.puredata.info/pipermail/pd-list/2021-11/130208.html
