### PR TITLE
Fix memory corruption in t_rtext

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -747,7 +747,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             i -= glist_fontheight(x);
             sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor nw "
                 "-font {{%s} -%d %s} -tags [list %s label graph]\n",
-                (long)glist_getcanvas(x),  x1, i,
+                glist_getcanvas(x),  x1, i,
                 arrayname->s_name, sys_font,
                 fs, sys_fontweight, tag);
         }

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -434,7 +434,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
             tcl/tk by escaping the close brace otherwise.  The GUI code
             drops the last character in the string. */
         sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %d %d {%s } %d %s\n",
-            (long)canvas, x->x_tag, rtext_gettype(x)->s_name,
+            canvas, x->x_tag, rtext_gettype(x)->s_name,
             text_xpix(x->x_text, x->x_glist) + lmargin,
                 text_ypix(x->x_text, x->x_glist) + tmargin,
             escbuf,

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -508,7 +508,16 @@ static int socketreceiver_doread(t_socketreceiver *x)
             if (sys_debuglevel & DEBUG_MESSDOWN)
             {
                 size_t bufsize = (bp>messbuf)?(bp-messbuf):0;
+        #ifdef _WIN32
+            #ifdef _MSC_VER
+                fwprintf(stderr, L"<< %.*S\n", (int)bufsize, messbuf);
+            #else
+                fwprintf(stderr, L"<< %.*s\n", (int)bufsize, messbuf);
+            #endif
+                fflush(stderr);
+        #else
                 fprintf(stderr, "<< %.*s\n", (int)bufsize, messbuf);
+        #endif
             }
             x->sr_inhead = inhead;
             x->sr_intail = intail;
@@ -811,7 +820,19 @@ void sys_vgui(const char *fmt, ...)
             msglen  = INTER->i_guisize - INTER->i_guihead;
     }
     if (sys_debuglevel & DEBUG_MESSUP)
-        fprintf(stderr, ">> %s", INTER->i_guibuf + INTER->i_guihead);
+    {
+        const char *mess = INTER->i_guibuf + INTER->i_guihead;
+#ifdef _WIN32
+    #ifdef _MSC_VER
+        fwprintf(stderr, L">> %S", mess);
+    #else
+        fwprintf(stderr, L">> %s", mess);
+    #endif
+        fflush(stderr);
+#else
+        fprintf(stderr, ">> %s", mess);
+#endif
+    }
     INTER->i_guihead += msglen;
     INTER->i_bytessincelastping += msglen;
 }

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -48,14 +48,6 @@ char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
     return dst;
 }
 
-static char* strnpointerid(char *dest, const void *pointer, size_t len)
-{
-    *dest=0;
-    if (pointer)
-        snprintf(dest, len, ".x%lx", (unsigned long)pointer);
-    return dest;
-}
-
 static void dopost(const char *s)
 {
     if (sys_printhook)
@@ -105,12 +97,8 @@ static void doerror(const void *object, const char *s)
 #endif
     }
     else
-    {
-        char obuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::logpost {%s} 1 {%s}\n",
-                 strnpointerid(obuf, object, MAXPDSTRING),
-                 pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
-    }
+        sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n",
+            object, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 static void dologpost(const void *object, const int level, const char *s)
@@ -141,12 +129,8 @@ static void dologpost(const void *object, const int level, const char *s)
 #endif
     }
     else
-    {
-        char obuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::logpost {%s} %d {%s}\n",
-                 strnpointerid(obuf, object, MAXPDSTRING),
-                 level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
-    }
+        sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n",
+            object, level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 void logpost(const void *object, int level, const char *fmt, ...)


### PR DESCRIPTION
`t_rtext` works on unterminated strings, but it calls utf8 functions which expects null-terminated strings. This can lead to all kinds of weirdness and memory corruption.

Solution: whenever we allocate/resize the content of `x_buf`, we make space for an extra 0 byte. `x_bufsize`, however, still behaves like strlen(), i.e. doesn't include the 0 byte. The advantage is that we only need to do this in a few places (when the buffer is allocated/resized) and don't have to touch the actual (complicated) logic in the rest of the code.

Fixes https://github.com/pure-data/pure-data/issues/1453 and https://github.com/pure-data/pure-data/issues/1422

This PR also includes 2 small drive-by commits:

* remove a few unnecessary casts when passing a pointer to ".x%lx".
* fix GUI debug printing on Windows