### PR TITLE
add bang mehotd to atan2

### DIFF
--- a/src/x_arithmetic.c
+++ b/src/x_arithmetic.c
@@ -591,21 +591,29 @@ static t_class *atan2_class;    /* ----------- atan2 --------------- */
 typedef struct _atan2
 {
     t_object x_ob;
-    t_float x_f;
+    t_float  x_f1;
+    t_float  x_f2;
 } t_atan2;
 
 static void *atan2_new(void)
 {
     t_atan2 *x = (t_atan2 *)pd_new(atan2_class);
-    floatinlet_new(&x->x_ob, &x->x_f);
-    x->x_f = 0;
+    floatinlet_new(&x->x_ob, &x->x_f2);
+    x->x_f1 = x->x_f2 = 0;
     outlet_new(&x->x_ob, &s_float);
     return (x);
 }
 
+static void atan2_bang(t_atan2 *x)
+{
+    t_float r = (x->x_f1 == 0 && x->x_f2 == 0 ? 0 : ATAN2(x->x_f1, x->x_f2));
+    outlet_float(x->x_ob.ob_outlet, r);
+}
+
 static void atan2_float(t_atan2 *x, t_float f)
 {
-    t_float r = (f == 0 && x->x_f == 0 ? 0 : ATAN2(f, x->x_f));
+    x->x_f1 = f;
+    t_float r = (x->x_f1 == 0 && x->x_f2 == 0 ? 0 : ATAN2(x->x_f1, x->x_f2));
     outlet_float(x->x_ob.ob_outlet, r);
 }
 
@@ -922,6 +930,7 @@ void x_arithmetic_setup(void)
     atan2_class = class_new(gensym("atan2"), atan2_new, 0,
         sizeof(t_atan2), 0, 0);
     class_addfloat(atan2_class, (t_method)atan2_float);
+    class_addbang(atan2_class, atan2_bang);
     class_sethelpsymbol(atan2_class, math_sym);
 
     sqrt_class = class_new(gensym("sqrt"), sqrt_new, 0,


### PR DESCRIPTION
currently atan2 is the odd one out in math binary operators - the only one without a bang method. For the sake of consistency, I'm adding it.

closes https://github.com/pure-data/pure-data/issues/1435