### PR TITLE
stable development branch

### DIFF
--- a/doc/1.manual/x3.htm
+++ b/doc/1.manual/x3.htm
@@ -546,7 +546,7 @@ audio configuration flags:
 -nocallback      -- use polling-mode (true by default)
 -listdev         -- list audio and MIDI devices
 
-(linux specific audio:)
+(Linux specific audio:)
 -oss            -- use ALSA audio drivers
 -alsa           -- use ALSA audio drivers
 -pa             -- use portaudio (experimental version 19)
@@ -559,6 +559,12 @@ audio configuration flags:
 -asio           -- use ASIO drivers and API
 -pa             -- synonym for -asio
 
+(Using the JACK API:)
+-jack            -- use JACK audio API
+-jackname &lt;name&gt; -- a name for your JACK client
+-nojackconnect   -- do not automatically connect pd to the JACK graph
+-jackconnect     -- automatically connect pd to the JACK graph [default]
+
 MIDI configuration flags:
 -midiindev ...   -- midi in device list; e.g., "1,3" for first and third
 -midioutdev ...  -- midi out device list, same format
@@ -570,7 +576,7 @@ MIDI configuration flags:
 -nomidiout       -- suppress MIDI output
 -nomidi          -- suppress MIDI input and output
 -ossmidi         -- use OSS midi API (Linux only)
--alsamidi        -- use ALSA midi API (Linux only
+-alsamidi        -- use ALSA midi API (Linux only)
 
 general flags:
 

--- a/doc/1.manual/x5.htm
+++ b/doc/1.manual/x5.htm
@@ -48,7 +48,7 @@ message passing.
 <P> New "file" object by Iohannes with contributions from Jean-Michael
 Celerier - general file operations.
 
-<P> Support for CAF soundfiles (by Dan Wilcox) - and the soundfile
+<P> Support for uncompressed CAF and AIFC soundfiles (by Dan Wilcox) - the soundfile
 code reorganized to make it more modular.
 
 <P> New methods for "list store" and added features to "array" (by Christof Ressi).
@@ -59,17 +59,17 @@ is better control of latency under jack.
 <P> Pd's GUI checks that Pd actually exits when asked to and if not, kills it
 to prevent rogue invisible pd instances from collecting behind the scenes.
 
-<P> bugfix in bob~ to output "correct" signal (old behavior still available
+<P> Bugfix in bob~ to output "correct" signal (old behavior still available
 by setting pd compatibility < 52).
 
 <P> libpd included as part of the Pd distribution.  A test libpd project is included
 in ../pd/libpdtest.
 
-<P> raised the limit on the size of incoming UDP packets in netreceive.
+<P> Raised the limit on the size of incoming UDP packets in netreceive.
 
-<P> some improvements to label handling in IEMguis.
+<P> Some improvements to label handling in IEMguis.
 
-<P> improved window positioning.
+<P> Improved window positioning.
 
 <p> garrays now available in color, etc. (documented in
 2.control.examples/16.more.arrays.pd), and more flags available in the "plot"
@@ -78,7 +78,7 @@ object (for arrays in data structures).
 <p> "set", "send", "delete", "insert" methods added to "list store" object, and
 new features added to "get" method.
 
-<P> as usual, numerous bug fixes and documentation updates.
+<P> As usual, numerous bug fixes and documentation updates.
 
 <P> ------------------ 0.51-4 ------------------------------
 

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -16,8 +16,10 @@ to be different but are now unified except for some fossilized names.) */
 #include "g_all_guis.h"
 #include "g_undo.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <io.h>
+#endif
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1881,15 +1881,14 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                     (int)(x->gl_screenx1), (int)(x->gl_screeny1),
                     x->gl_edit);
             }
-            snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx",
-                (unsigned long)c);
+            snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx", c);
             while (c->gl_owner && !c->gl_isclone) {
                 int cbuflen;
                 c = c->gl_owner;
                 cbuflen = (int)strlen(cbuf);
                 snprintf(cbuf + cbuflen,
                     MAXPDSTRING - cbuflen - 2,/* leave 2 for "\n\0" */
-                    " .x%lx", (unsigned long)c);
+                    " .x%lx", c);
             }
             strcat(cbuf, "\n");
             sys_gui(cbuf);

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -753,7 +753,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             i -= glist_fontheight(x);
             sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor nw "
                 "-font {{%s} -%d %s} -tags [list %s label graph]\n",
-                (long)glist_getcanvas(x),  x1, i,
+                glist_getcanvas(x),  x1, i,
                 arrayname->s_name, sys_font,
                 fs, sys_fontweight, tag);
         }

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -588,7 +588,7 @@ int rtext_findatomfor(t_rtext *x, int xpos, int ypos)
     return (natom-1);
 }
 
-void gatom_key(void *z, t_floatarg f);
+void gatom_key(void *z, t_symbol *keysym, t_floatarg f);
 
 void rtext_key(t_rtext *x, int keynum, t_symbol *keysym)
 {
@@ -597,7 +597,7 @@ void rtext_key(t_rtext *x, int keynum, t_symbol *keysym)
         /* CR to atom boxes sends message and resets */
     if (keynum == '\n' && x->x_text->te_type == T_ATOM)
     {
-        gatom_key(x->x_text, keynum);
+        gatom_key(x->x_text, keysym, keynum);
         return;
     }
     if (keynum)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -434,7 +434,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
             tcl/tk by escaping the close brace otherwise.  The GUI code
             drops the last character in the string. */
         sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %d %d {%s } %d %s\n",
-            (long)canvas, x->x_tag, rtext_gettype(x)->s_name,
+            canvas, x->x_tag, rtext_gettype(x)->s_name,
             text_xpix(x->x_text, x->x_glist) + lmargin,
                 text_ypix(x->x_text, x->x_glist) + tmargin,
             escbuf,

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -763,6 +763,7 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
     }
     else if (c == '\n')
     {
+        x->a_doubleclicked = 0;
         if (t == x->a_glist->gl_editor->e_textedfor)
         {
             rtext_gettext(t, &buf, &bufsize);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -51,7 +51,7 @@
 #endif
 
 /* define this to enable thread signaling instead of polling */
-#define THREADSIGNAL
+// #define THREADSIGNAL
 
     /* LATER try to figure out how to handle default devices in portaudio;
     the way s_audio.c handles them isn't going to work here. */

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -508,7 +508,16 @@ static int socketreceiver_doread(t_socketreceiver *x)
             if (sys_debuglevel & DEBUG_MESSDOWN)
             {
                 size_t bufsize = (bp>messbuf)?(bp-messbuf):0;
+        #ifdef _WIN32
+            #ifdef _MSC_VER
+                fwprintf(stderr, L"<< %.*S\n", (int)bufsize, messbuf);
+            #else
+                fwprintf(stderr, L"<< %.*s\n", (int)bufsize, messbuf);
+            #endif
+                fflush(stderr);
+        #else
                 fprintf(stderr, "<< %.*s\n", (int)bufsize, messbuf);
+        #endif
             }
             x->sr_inhead = inhead;
             x->sr_intail = intail;
@@ -811,7 +820,19 @@ void sys_vgui(const char *fmt, ...)
             msglen  = INTER->i_guisize - INTER->i_guihead;
     }
     if (sys_debuglevel & DEBUG_MESSUP)
-        fprintf(stderr, ">> %s", INTER->i_guibuf + INTER->i_guihead);
+    {
+        const char *mess = INTER->i_guibuf + INTER->i_guihead;
+#ifdef _WIN32
+    #ifdef _MSC_VER
+        fwprintf(stderr, L">> %S", mess);
+    #else
+        fwprintf(stderr, L">> %s", mess);
+    #endif
+        fflush(stderr);
+#else
+        fprintf(stderr, ">> %s", mess);
+#endif
+    }
     INTER->i_guihead += msglen;
     INTER->i_bytessincelastping += msglen;
 }

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -363,7 +363,10 @@ int sys_main(int argc, const char **argv)
     if (sys_verbose)
         fprintf(stderr, "float precision = %lu bits\n", sizeof(t_float)*8);
     if (sys_version)    /* if we were just asked our version, exit here. */
+    {
+        fflush(stderr);
         return (0);
+    }
     sys_setsignalhandlers();
     sys_afterargparse();                    /* post-argparse settings */
     if (sys_dontstartgui)
@@ -515,7 +518,10 @@ static void sys_printusage(void)
 {
     unsigned int i;
     for (i = 0; i < sizeof(usagemessage)/sizeof(*usagemessage); i++)
+    {
         fprintf(stderr, "%s", usagemessage[i]);
+        fflush(stderr);
+    }
 }
 
     /* parse a comma-separated numeric list, returning the number found */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -319,7 +319,9 @@ int sys_main(int argc, const char **argv)
     _set_fmode( _O_BINARY );
 # else  /* MinGW */
     {
+#ifndef _fmode
         extern int _fmode;
+#endif
         _fmode = _O_BINARY;
     }
 # endif /* _MSC_VER */

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -48,14 +48,6 @@ char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
     return dst;
 }
 
-static char* strnpointerid(char *dest, const void *pointer, size_t len)
-{
-    *dest=0;
-    if (pointer)
-        snprintf(dest, len, ".x%lx", (unsigned long)pointer);
-    return dest;
-}
-
 static void dopost(const char *s)
 {
     if (sys_printhook)
@@ -105,12 +97,8 @@ static void doerror(const void *object, const char *s)
 #endif
     }
     else
-    {
-        char obuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::logpost {%s} 1 {%s}\n",
-                 strnpointerid(obuf, object, MAXPDSTRING),
-                 pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
-    }
+        sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n",
+            object, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 static void dologpost(const void *object, const int level, const char *s)
@@ -141,12 +129,8 @@ static void dologpost(const void *object, const int level, const char *s)
 #endif
     }
     else
-    {
-        char obuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::logpost {%s} %d {%s}\n",
-                 strnpointerid(obuf, object, MAXPDSTRING),
-                 level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
-    }
+        sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n",
+            object, level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 void logpost(const void *object, int level, const char *fmt, ...)

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -98,7 +98,7 @@ static void textbuf_open(t_textbuf *x)
             x, 600, 340, x->b_sym->s_name,
                  sys_hostfontsize(glist_getfont(x->b_canvas),
                     glist_getzoom(x->b_canvas)));
-        sprintf(buf, ".x%lx", (unsigned long)x);
+        sprintf(buf, ".x%lx", x);
         x->b_guiconnect = guiconnect_new(&x->b_ob.ob_pd, gensym(buf));
         textbuf_senditup(x);
     }

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -2013,6 +2013,7 @@ noinletnum:
 char *
 atoif(char *s, long int *value, long int *type)
 {
+    const char*s0 = s;
     char *p;
         long lval;
         float fval;
@@ -2034,6 +2035,9 @@ atoif(char *s, long int *value, long int *type)
                 }
                 s++;
         }
+        if(s0 == p)
+            return 0;
+
         *type = ET_INT;
         *((t_int *) value) = lval;
         return (p);

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -80,12 +80,13 @@ proc pdtk_canvas_place_window {width height geometry} {
     # read back the current geometry +posx+posy into variables
     set w $width
     set h $height
+    set xypos ""
     if { "" != ${geometry} } {
         scan $geometry {%[+]%d%[+]%d} - x - y
         foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
-        set geometry ${w}x${h}+${x}+${y}
+        set xypos +${x}+${y}
     }
-    return [list ${w} ${h} ${geometry}]
+    return [list ${w} ${h} ${w}x${h}${xypos}]
 }
 
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -83,7 +83,7 @@ proc pdtk_canvas_place_window {width height geometry} {
     if { "" != ${geometry} } {
         scan $geometry {%[+]%d%[+]%d} - x - y
         foreach {x y w h} [pdtk_canvas_wrap_window $x $y $width $height] {break}
-        set geometry +${x}+${y}
+        set geometry ${w}x${h}+${x}+${y}
     }
     return [list ${w} ${h} ${geometry}]
 }


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with an unresolvable file conflict)


it supersedes #1428

---

fixes so far (this list should be manually updated whenever new fixes are pushed):

- fix memory corruption with new gatoms (Closes: #1453)
- fix crash in `gatom_key` (Closes: #1453)
- fix lockup with `[expr .]` (Closes: #1468)
- fix scrollbar flickering (Closes: #1410)
- fix GUI-communication debug printout on Windows (needs special handling for 8-bit chars...)
- documentation: minor fixes for cmdline-flags in HTML docs (dangling parens, ...)
- flush stderr when printing Pd version or usage message
- fix some compiler warnings with mingw64
- don't define `THREADSIGNAL` in portaudio backend (Closes: #1475)
