### PR TITLE
Propagate changed samplerate from JACK, by restarting the DSP

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -322,7 +322,7 @@ nobase_dist_libpd_DATA = \
      ./5.reference/declare-help.pd \
      ./5.reference/delay-help.pd \
      ./5.reference/delay-tilde-objects-help.pd \
-     ./5.reference/drawpolygon-help.pd \
+     ./5.reference/draw-shapes-help.pd \
      ./5.reference/drawtext-help.pd \
      ./5.reference/element-help.pd \
      ./5.reference/env~-help.pd \

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -160,7 +160,10 @@ static int callbackprocess(jack_nframes_t nframes, void *arg)
 static int
 jack_srate (jack_nframes_t srate, void *arg)
 {
+    const t_float oldrate = STUFF->st_dacsr;
     STUFF->st_dacsr = srate;
+    if (oldrate != STUFF->st_dacsr)
+        canvas_update_dsp();
     return 0;
 }
 


### PR DESCRIPTION
if JACK dynamically changes the samplerate, we need to update the internal sample rate.
this PR does this by automatically restarting the DSP (but only if DSP is currently ON and the srate actually changed).


### current behaviour:
- Pd/JACK runs at 44kHz; DSP is on; [osc~ 440] sounds at 440Hz
- JACK dynamically switches to 48kHz
- Pd's output pitches up to 479Hz
- Pd prints "partial read" to the terminal.
- turning Pd's DSP off and on again, pitches the output back to 440Hz

that's a bit weird.

with the new behaviour the samplerate switch is *almost* seamless.
There's a short glitch when switching, because the samplerate change notification is asynchronous; therefore thus the output will be detuned for a couple of ms.