### PR TITLE
stable development branch

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -322,7 +322,7 @@ nobase_dist_libpd_DATA = \
      ./5.reference/declare-help.pd \
      ./5.reference/delay-help.pd \
      ./5.reference/delay-tilde-objects-help.pd \
-     ./5.reference/drawpolygon-help.pd \
+     ./5.reference/draw-shapes-help.pd \
      ./5.reference/drawtext-help.pd \
      ./5.reference/element-help.pd \
      ./5.reference/env~-help.pd \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -294,6 +294,7 @@ nobase_dist_libpd_DATA = \
      ./4.data.structures/osc-voice.pd \
      ./4.data.structures/voice.pd \
      ./4.data.structures/z.txt \
+     ./5.reference/Pd-messages.pd \
      ./5.reference/abs~-help.pd \
      ./5.reference/acoustics-help.pd \
      ./5.reference/acoustics~-help.pd \
@@ -324,6 +325,7 @@ nobase_dist_libpd_DATA = \
      ./5.reference/delay-tilde-objects-help.pd \
      ./5.reference/draw-shapes-help.pd \
      ./5.reference/drawtext-help.pd \
+     ./5.reference/ds-text.txt \
      ./5.reference/element-help.pd \
      ./5.reference/env~-help.pd \
      ./5.reference/expr-help.pd \

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -483,7 +483,7 @@ proc ::pd_menus::insert_into_menu {mymenu entry parent} {
     for {set i 0} {$i <= [$mymenu index end]} {incr i} {
         if {[$mymenu type $i] ne "command"} {continue}
         set currentcommand [$mymenu entrycget $i -command]
-        if {$currentcommand eq "raise $entry"} {return} ;# it exists already
+        if {$currentcommand eq "::pd_menucommands::scheduleAction raise $entry"} {return} ;# it exists already
         if {$currentcommand eq "raise $parent"} {
             set insertat $i
         }


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with an unresolvable file conflict)


it supersedes #1473

---

fixes so far (this list should be manually updated whenever new fixes are pushed):

- build failure with `autotools` due to file rename
- <kbd>window</kbd> menu showing windows multiple times (#1504)