### PR TITLE
try to make 'multiply defined' warning traceable

### DIFF
--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -201,7 +201,7 @@ t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
         {
             if (x && !warned)
             {
-                post("warning: %s: multiply defined", s->s_name);
+                pd_error(x, "warning: %s: multiply defined", s->s_name);
                 warned = 1;
             }
             x = e->e_who;


### PR DESCRIPTION
Ctrl-clicking the warning from the Pd console now correctly shows the last occurence of multiply defined `[delwrite~]`
and `[text define]`.

It's much less ideal in the case of `[array define]`, `garray` or `[table]` however:
- if the last defined object was a `garray` or a `[table]`, it opens a graph window with a
weird name like "graph2".
- if the last defined object using this name was an `[array define]`, it posts:
"... sorry, I couldn't find the source of that error."