### PR TITLE
[ci] add GitHub workflow

### DIFF
--- a/.github/workflows/puredata.yml
+++ b/.github/workflows/puredata.yml
@@ -1,0 +1,16 @@
+name: pure-data
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  puredata:
+    uses: pure-data/pure-data-ci/.github/workflows/puredata.yml@main


### PR DESCRIPTION
yet another CI provider...

the reason to use this one is mainly because we get instant feedback in PRs of whether the build actually succeeds (e.g. things like #1495 should be really easy to catch with this)

this (again) uses an external workflow definition so we can adapt to changes in the infrastructure without bothering with Pd's repository.