### PR TITLE
Changing pkgconfig to pkg-config on windows mingw building instructions

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -319,12 +319,12 @@ Open an Msys2 shell and install the compiler chain, autotools, & gettext via:
 
     # 64 bit
     pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang \
-              make pkg-config autoconf automake libtool \
+              make autoconf automake libtool \
               mingw-w64-x86_64-gettext
 
     # 32 bit
     pacman -S mingw-w64-i686-toolchain mingw-w64-i686-clang \
-              make pkg-config autoconf automake libtool \
+              make autoconf automake libtool \
               mingw-w64-i686-gettext
 
 Install git if you want to clone the Pd sources from Github, etc:

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -319,12 +319,12 @@ Open an Msys2 shell and install the compiler chain, autotools, & gettext via:
 
     # 64 bit
     pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang \
-              make pkgconfig autoconf automake libtool \
+              make pkg-config autoconf automake libtool \
               mingw-w64-x86_64-gettext
 
     # 32 bit
     pacman -S mingw-w64-i686-toolchain mingw-w64-i686-clang \
-              make pkgconfig autoconf automake libtool \
+              make pkg-config autoconf automake libtool \
               mingw-w64-i686-gettext
 
 Install git if you want to clone the Pd sources from Github, etc:

--- a/doc/1.manual/x6.htm
+++ b/doc/1.manual/x6.htm
@@ -292,12 +292,12 @@ brew link --force gettext</pre>
 
 <pre># 64 bit
 pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang \
-          make pkgconfig autoconf automake libtool \
+          make pkg-config autoconf automake libtool \
           mingw-w64-x86_64-gettext
 
 # 32 bit
 pacman -S mingw-w64-i686-toolchain mingw-w64-i686-clang \
-          make pkgconfig autoconf automake libtool \
+          make pkg-config autoconf automake libtool \
           mingw-w64-i686-gettext</pre>
 		  
 <p>Install git if you want to clone the Pd sources from Github, etc:</p>

--- a/doc/1.manual/x6.htm
+++ b/doc/1.manual/x6.htm
@@ -292,12 +292,12 @@ brew link --force gettext</pre>
 
 <pre># 64 bit
 pacman -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang \
-          make pkg-config autoconf automake libtool \
+          make autoconf automake libtool \
           mingw-w64-x86_64-gettext
 
 # 32 bit
 pacman -S mingw-w64-i686-toolchain mingw-w64-i686-clang \
-          make pkg-config autoconf automake libtool \
+          make autoconf automake libtool \
           mingw-w64-i686-gettext</pre>
 		  
 <p>Install git if you want to clone the Pd sources from Github, etc:</p>


### PR DESCRIPTION
hello, just learning how to compile pd on windows 10, and in both instructions about mingw it says to install pkgconfig, but trying that gives me:

~~~
$ pacman -S pkgconfig
error: target not found: pkgconfig
~~~

changing it to pkg-config it worked: 

~~~
$ pacman -S pkg-config
resolving dependencies...
looking for conflicting packages...

Packages (1) pkg-config-0.29.2-4
~~~

So I changed both INSTALL.txt and x6.htm, hope this is ok