### PR TITLE
update file-help.pd wrong send in pd base+ext

### DIFF
--- a/doc/5.reference/file-help.pd
+++ b/doc/5.reference/file-help.pd
@@ -946,7 +946,7 @@ the file component of the path \, and outputs a list with both on the
 #X text 338 322 if no directory component can be found \, the path
 is sent to the 2nd outlet;
 #X text 339 357 a trailing slash is removed;
-#X text 333 436 'splitname' separates the directory+file component
+#X text 333 436 'splittext' separates the directory+file component
 from the extension of the given path \, and outputs a list with both
 on the 1st outlet.;
 #X text 335 485 if no extension is found \, the path is sent to the

--- a/doc/5.reference/file-help.pd
+++ b/doc/5.reference/file-help.pd
@@ -1024,7 +1024,7 @@ no checks are performed verifying the validity/existence of any path-component.
 #X connect 16 0 11 0;
 #X connect 17 0 0 0;
 #X restore 216 146 pd path;
-#X symbolatom 216 171 0 0 0 0 - - \$0-name-split+join-in 0;
+#X symbolatom 216 171 0 0 0 0 - - \$0-name-base+ext-in 0;
 #X msg 216 68 file;
 #X msg 226 95 directory;
 #X text 89 171 or type your own:;


### PR DESCRIPTION
The symbol atom in pd base+ext seems to be wrong, and was triggering the receive in another subpatch (pd split+join)

Edit: i also changed a comment that seems to be wrong too... it was talking about splittext, but was saying splitname