### PR TITLE
array-editor fixes & improvements

### DIFF
--- a/src/g_array.c
+++ b/src/g_array.c
@@ -475,6 +475,20 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
 }
 
 /* jsarlo { */
+static int garray_arrayviewlist_setpage(t_symbol*arrayname, t_array*a, int page, int pagesize) {
+
+        /* make szre the requested page is within range */
+    int maxpage = (a->a_n - 1) / pagesize;
+    if(page < 0)
+        page = 0;
+    if(page > maxpage)
+        page = maxpage;
+
+    sys_vgui("::dialog_array::listview_setpage {%s} %d %d %d\n",
+        arrayname->s_name,
+        page, maxpage+1, pagesize);
+    return page;
+}
 void garray_arrayviewlist_new(t_garray *x)
 {
     int i, yonset=0, elemsize=0, page=0;
@@ -495,9 +509,7 @@ void garray_arrayviewlist_new(t_garray *x)
             0);
     gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
 
-    sys_vgui("::dialog_array::listview_setpage {%s} %d\n",
-        x->x_realname->s_name,
-        (int)page);
+    page = garray_arrayviewlist_setpage(x->x_realname, a, page, ARRAYPAGESIZE);
 
     sys_vgui("::dialog_array::listview_setdata {%s} %ld",
         x->x_realname->s_name,
@@ -529,16 +541,7 @@ void garray_arrayviewlist_fillpage(t_garray *x,
         return;
     }
 
-        /* make sure that page is within range */
-    if (page < 0) {
-        page = 0;
-    }
-    else if ((page * ARRAYPAGESIZE) >= a->a_n) {
-        page = (int)(((int)a->a_n - 1)/ (int)ARRAYPAGESIZE);
-    }
-    sys_vgui("::dialog_array::listview_setpage {%s} %d\n",
-        x->x_realname->s_name,
-        (int)page);
+    page = garray_arrayviewlist_setpage(x->x_realname, a, page, ARRAYPAGESIZE);
 
     sys_vgui("::dialog_array::listview_setdata {%s} %ld",
         x->x_realname->s_name,

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -490,7 +490,7 @@ void garray_arrayviewlist_new(t_garray *x)
     }
     x->x_listviewing = 1;
     sprintf(cmdbuf,
-            "pdtk_array_listview_new %%s %s %d\n",
+            "pdtk_array_listview_new %%s {%s} %d\n",
             x->x_realname->s_name,
             0);
     gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
@@ -557,7 +557,7 @@ void garray_arrayviewlist_fillpage(t_garray *x,
 void garray_arrayviewlist_close(t_garray *x)
 {
     x->x_listviewing = 0;
-    sys_vgui("pdtk_array_listview_closeWindow %s\n",
+    sys_vgui("pdtk_array_listview_closeWindow {%s}\n",
              x->x_realname->s_name);
 }
 /* } jsarlo */
@@ -803,7 +803,7 @@ void garray_redraw(t_garray *x)
     else
     {
       if (x->x_listviewing)
-        sys_vgui("pdtk_array_listview_fillpage %s\n",
+        sys_vgui("pdtk_array_listview_fillpage {%s}\n",
                  x->x_realname->s_name);
     }
     /* } jsarlo */

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -39,7 +39,7 @@ t_array *array_new(t_symbol *templatesym, t_gpointer *parent)
 }
 
 /* jsarlo { */
-void garray_arrayviewlist_close(t_garray *x);
+static void garray_arrayviewlist_close(t_garray *x);
 /* } jsarlo */
 
 void array_resize(t_array *x, int n)
@@ -475,7 +475,8 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
 }
 
 /* jsarlo { */
-static int garray_arrayviewlist_setpage(t_symbol*arrayname, t_array*a, int page, int pagesize) {
+static int garray_arrayviewlist_setpage(t_symbol*arrayname, t_array*a, int page, int pagesize)
+{
 
         /* make szre the requested page is within range */
     int maxpage = (a->a_n - 1) / pagesize;
@@ -489,7 +490,7 @@ static int garray_arrayviewlist_setpage(t_symbol*arrayname, t_array*a, int page,
         page, maxpage+1, pagesize);
     return page;
 }
-void garray_arrayviewlist_new(t_garray *x)
+static void garray_arrayviewlist_new(t_garray *x)
 {
     int i, yonset=0, elemsize=0, page=0;
     t_float yval;
@@ -524,8 +525,8 @@ void garray_arrayviewlist_new(t_garray *x)
     }
     sys_vgui("\n");
 }
+static void garray_arrayviewlist_fillpage(t_garray *x,
 
-void garray_arrayviewlist_fillpage(t_garray *x,
                                    t_float page,
                                    t_float fTopItem)
 {
@@ -560,7 +561,7 @@ void garray_arrayviewlist_fillpage(t_garray *x,
              topItem);
 }
 
-void garray_arrayviewlist_close(t_garray *x)
+static void garray_arrayviewlist_close(t_garray *x)
 {
     x->x_listviewing = 0;
     sys_vgui("pdtk_array_listview_closeWindow {%s}\n",

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -484,8 +484,9 @@ void garray_arrayviewlist_new(t_garray *x)
 
     if (!a)
     {
-        /* FIXME */
+            /* FIXME */
         pd_error(0, "error in garray_arrayviewlist_new()");
+        return;
     }
     x->x_listviewing = 1;
     sprintf(cmdbuf,
@@ -516,8 +517,9 @@ void garray_arrayviewlist_fillpage(t_garray *x,
     topItem = (int)fTopItem;
     if (!a)
     {
-        /* FIXME */
+            /* FIXME */
         pd_error(0, "error in garray_arrayviewlist_new()");
+        return;
     }
 
     if (page < 0) {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -12,7 +12,7 @@ namespace eval ::dialog_array:: {
 array set ::dialog_array::listview_entry {}
 array set ::dialog_array::listview_id {}
 array set ::dialog_array::listview_page {}
-set ::dialog_array::listview_pagesize 0
+set ::dialog_array::listview_pagesize 1000
 # this stores the state of the "save me" check button
 array set ::dialog_array::saveme_button {}
 # this stores the state of the "draw as" radio buttons

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -60,13 +60,13 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     wm title $windowName [concat $arrayName "(list view)"]
     # FIXME
     set font 12
-    set $windowName.lb [listbox $windowName.lb -height 20 -width 25\
-                            -selectmode extended \
-                            -relief solid -background white -borderwidth 1 \
-                            -font [format {{%s} %d %s} $::font_family $font $::font_weight]\
-                            -yscrollcommand "$windowName.lb.sb set"]
-    set $windowName.lb.sb [scrollbar $windowName.lb.sb \
-                               -command "$windowName.lb yview" -orient vertical]
+    listbox $windowName.lb -height 20 -width 25 \
+        -selectmode extended \
+        -relief solid -background white -borderwidth 1 \
+        -font [format {{%s} %d %s} $::font_family $font $::font_weight]\
+        -yscrollcommand "$windowName.lb.sb set"
+    scrollbar $windowName.lb.sb \
+        -command "$windowName.lb yview" -orient vertical
     place configure $windowName.lb.sb -relheight 1 -relx 0.9 -relwidth 0.1
     pack $windowName.lb -expand 1 -fill both
     bind $windowName.lb <Double-ButtonPress-1> \
@@ -78,10 +78,10 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         "win32" {bind $windowName.lb <ButtonPress-3> \
                      "::dialog_array::listview_popup \{$arrayName\}"}
     }
-    set $windowName.prevBtn [button $windowName.prevBtn -text "<-" \
-                                 -command "::dialog_array::listview_changepage \{$arrayName\} -1"]
-    set $windowName.nextBtn [button $windowName.nextBtn -text "->" \
-                                 -command "::dialog_array::listview_changepage \{$arrayName\} 1"]
+    button $windowName.prevBtn -text "<-" \
+        -command "::dialog_array::listview_changepage \{$arrayName\} -1"
+    button $windowName.nextBtn -text "->" \
+        -command "::dialog_array::listview_changepage \{$arrayName\} 1"
     pack $windowName.prevBtn -side left -ipadx 20 -pady 10 -anchor s
     pack $windowName.nextBtn -side right -ipadx 20 -pady 10 -anchor s
     focus $windowName
@@ -170,8 +170,8 @@ proc ::dialog_array::listview_edit {arrayName page font} {
     set ::dialog_array::listview_entry($arrayName) $itemNum
     set bbox [$lbName bbox $itemNum]
     set y [expr [lindex $bbox 1] - 4]
-    set $lbName.entry [entry $lbName.entry \
-                           -font [format {{%s} %d %s} $::font_family $font $::font_weight]]
+    entry $lbName.entry \
+        -font [format {{%s} %d %s} $::font_family $font $::font_weight]
     $lbName.entry insert 0 []
     place configure $lbName.entry -relx 0 -y $y -relwidth 1
     lower $lbName.entry

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -235,7 +235,9 @@ proc ::dialog_array::listview_edit {arrayName page font} {
     lower $entry
     focus $entry
     bind $entry <Return> \
-        "::dialog_array::listview_update_entry \{$arrayName\} $itemNum;"
+        "::dialog_array::listview_update_entry \{$arrayName\} $itemNum; break"
+    bind $entry <Escape> \
+        "destroy $entry; break"
 }
 
 proc ::dialog_array::listview_update_entry {arrayName itemNum} {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -169,7 +169,15 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         -command "::dialog_array::listview_changepage \{$arrayName\} -1"
     button $windowName.buttons.next -text "→" \
         -command "::dialog_array::listview_changepage \{$arrayName\} 1"
+
+    entry $windowName.buttons.page -textvariable ::dialog_array::listview_page($arrayName) \
+        -validate key -validatecommand "string is double %P" \
+        -justify "right" -width 5
+    bind $windowName.buttons.page <Return> \
+        "::dialog_array::listview_changepage \{$arrayName\} 0"
+
     pack $windowName.buttons.prev -side left -ipadx 20 -pady 10 -anchor s
+    pack $windowName.buttons.page -side left -padx 20 -pady 10 -anchor s
     pack $windowName.buttons.next -side right -ipadx 20 -pady 10 -anchor s
     focus $windowName
 }

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -136,7 +136,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
             -selectmode extended \
             -yscrollcommand "$sb set"
         $lb heading index -text "#" -anchor center
-        $lb heading value -text [_ "Value" ] -anchor center
+        $lb heading value -text $arrayName -anchor center
         $lb column index -width 50 -anchor e
     } stderr ] } {
         # listview

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -112,20 +112,12 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
 
 proc ::dialog_array::listview_lbselection {arrayName off size} {
     set lb [listview_windowname ${arrayName}].lb
-    set itemNums [$lb curselection]
-    set cbString ""
-    for {set i 0} {$i < [expr [llength $itemNums] - 1]} {incr i} {
-        set listItem [$lb get [lindex $itemNums $i]]
-        append cbString [string range $listItem \
-                             [expr [string first ") " $listItem] + 2] \
-                             end]
-        append cbString "\n"
+    set items {}
+    foreach idx [$lb curselection] {
+        set v [$lb get $idx]
+        lappend items [string range $v [string first ") " $v]+2 end]
     }
-    set listItem [$lb get [lindex $itemNums $i]]
-    append cbString [string range $listItem \
-                         [expr [string first ") " $listItem] + 2] \
-                         end]
-    set last $cbString
+    return [join $items "\n"]
 }
 
 # parses 'data' into numbers, and sends them to the Pd-core so it

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -155,22 +155,9 @@ proc ::dialog_array::listview_popup {arrayName} {
 }
 
 proc ::dialog_array::listview_copy {arrayName} {
-    set lb [listview_windowname ${arrayName}].lb
-    set itemNums [$lb curselection]
-    set cbString ""
-    for {set i 0} {$i < [expr [llength $itemNums] - 1]} {incr i} {
-        set listItem [$lb get [lindex $itemNums $i]]
-        append cbString [string range $listItem \
-                             [expr [string first ") " $listItem] + 2] \
-                             end]
-        append cbString "\n"
-    }
-    set listItem [$lb get [lindex $itemNums $i]]
-    append cbString [string range $listItem \
-                         [expr [string first ") " $listItem] + 2] \
-                         end]
+    set sel [listview_lbselection $arrayName {} {}]
     clipboard clear
-    clipboard append $cbString
+    clipboard append $sel
 }
 
 proc ::dialog_array::listview_paste {arrayName} {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -52,7 +52,8 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page
     set ::dialog_array::listview_id($arrayName) $id
     set windowName [format ".%sArrayWindow" $arrayName]
-    if [winfo exists $windowName] then [destroy $windowName]
+    destroy $windowName
+
     toplevel $windowName -class DialogWindow
     wm group $windowName .
     wm protocol $windowName WM_DELETE_WINDOW \

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -9,27 +9,27 @@ namespace eval ::dialog_array:: {
 }
 
 # global variables for the listview
-array set pd_array_listview_entry {}
-array set pd_array_listview_id {}
-array set pd_array_listview_page {}
-set pd_array_listview_pagesize 0
+array set ::dialog_array::listview_entry {}
+array set ::dialog_array::listview_id {}
+array set ::dialog_array::listview_page {}
+set ::dialog_array::listview_pagesize 0
 # this stores the state of the "save me" check button
-array set saveme_button {}
+array set ::dialog_array::saveme_button {}
 # this stores the state of the "draw as" radio buttons
-array set drawas_button {}
+array set ::dialog_array::drawas_button {}
 # this stores the state of the "in new graph"/"in last graph" radio buttons
 # and the "delete array" checkbutton
-array set otherflag_button {}
+array set ::dialog_array::otherflag_button {}
 
 ############ pdtk_array_dialog -- dialog window for arrays #########
 
 proc ::dialog_array::pdtk_array_listview_setpage {arrayName page} {
-    set ::pd_array_listview_page($arrayName) $page
+    set ::dialog_array::listview_page($arrayName) $page
 }
 
 proc ::dialog_array::listview_changepage {arrayName np} {
     pdtk_array_listview_setpage \
-        $arrayName [expr $::pd_array_listview_page($arrayName) + $np]
+        $arrayName [expr $::dialog_array::listview_page($arrayName) + $np]
     pdtk_array_listview_fillpage $arrayName
 }
 
@@ -39,9 +39,9 @@ proc ::dialog_array::pdtk_array_listview_fillpage {arrayName} {
                      [$windowName.lb size]]
 
     if {[winfo exists $windowName]} {
-        set cmd "$::pd_array_listview_id($arrayName) \
+        set cmd "$::dialog_array::listview_id($arrayName) \
                arrayviewlistfillpage \
-               $::pd_array_listview_page($arrayName) \
+               $::dialog_array::listview_page($arrayName) \
                $topItem"
 
         pdsend $cmd
@@ -49,8 +49,8 @@ proc ::dialog_array::pdtk_array_listview_fillpage {arrayName} {
 }
 
 proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
-    set ::pd_array_listview_page($arrayName) $page
-    set ::pd_array_listview_id($arrayName) $id
+    set ::dialog_array::listview_page($arrayName) $page
+    set ::dialog_array::listview_id($arrayName) $id
     set windowName [format ".%sArrayWindow" $arrayName]
     if [winfo exists $windowName] then [destroy $windowName]
     toplevel $windowName -class DialogWindow
@@ -150,8 +150,8 @@ proc ::dialog_array::listview_paste {arrayName} {
         if {[lindex $itemString $i] ne {}} {
             pdsend "$arrayName [expr $itemNum + \
                                        [expr $counter + \
-                                            [expr $::pd_array_listview_pagesize \
-                                                 * $::pd_array_listview_page($arrayName)]]] \
+                                            [expr $::dialog_array::listview_pagesize \
+                                                 * $::dialog_array::listview_page($arrayName)]]] \
                     [lindex $itemString $i]"
             incr counter
             set flag 0
@@ -163,11 +163,11 @@ proc ::dialog_array::listview_edit {arrayName page font} {
     set lbName [format ".%sArrayWindow.lb" $arrayName]
     if {[winfo exists $lbName.entry]} {
         ::dialog_array::listview_update_entry \
-            $arrayName $::pd_array_listview_entry($arrayName)
-        unset ::pd_array_listview_entry($arrayName)
+            $arrayName $::dialog_array::listview_entry($arrayName)
+        unset ::dialog_array::listview_entry($arrayName)
     }
     set itemNum [$lbName index active]
-    set ::pd_array_listview_entry($arrayName) $itemNum
+    set ::dialog_array::listview_entry($arrayName) $itemNum
     set bbox [$lbName bbox $itemNum]
     set y [expr [lindex $bbox 1] - 4]
     set $lbName.entry [entry $lbName.entry \
@@ -189,8 +189,8 @@ proc ::dialog_array::listview_update_entry {arrayName itemNum} {
         if {[lindex $itemString $i] ne {}} {
             pdsend "$arrayName [expr $itemNum + \
                                        [expr $counter + \
-                                            [expr $::pd_array_listview_pagesize \
-                                                 * $::pd_array_listview_page($arrayName)]]] \
+                                            [expr $::dialog_array::listview_pagesize \
+                                                 * $::dialog_array::listview_page($arrayName)]]] \
                     [lindex $itemString $i]"
             incr counter
             set flag 0
@@ -214,8 +214,8 @@ proc ::dialog_array::apply {mytoplevel} {
     pdsend "$mytoplevel arraydialog \
             [::dialog_gatom::escape [$mytoplevel.array.name.entry get]] \
             [$mytoplevel.array.size.entry get] \
-            [expr $::saveme_button($mytoplevel) + (2 * $::drawas_button($mytoplevel))] \
-            $::otherflag_button($mytoplevel)"
+            [expr $::dialog_array::saveme_button($mytoplevel) + (2 * $::dialog_array::drawas_button($mytoplevel))] \
+            $::dialog_array::otherflag_button($mytoplevel)"
 }
 
 proc ::dialog_array::openlistview {mytoplevel} {
@@ -242,9 +242,9 @@ proc ::dialog_array::pdtk_array_dialog {mytoplevel name size flags newone} {
 
     $mytoplevel.array.name.entry insert 0 [::dialog_gatom::unescape $name]
     $mytoplevel.array.size.entry insert 0 $size
-    set ::saveme_button($mytoplevel) [expr $flags & 1]
-    set ::drawas_button($mytoplevel) [expr ( $flags & 6 ) >> 1]
-    set ::otherflag_button($mytoplevel) 0
+    set ::dialog_array::saveme_button($mytoplevel) [expr $flags & 1]
+    set ::dialog_array::drawas_button($mytoplevel) [expr ( $flags & 6 ) >> 1]
+    set ::dialog_array::otherflag_button($mytoplevel) 0
 # pd -> tcl
 #  2 * (int)(template_getfloat(template_findbyname(sc->sc_template), gensym("style"), x->x_scalar->sc_vec, 1)));
 
@@ -278,18 +278,18 @@ proc ::dialog_array::create_dialog {mytoplevel newone} {
     pack $mytoplevel.array.size.entry $mytoplevel.array.size.label -side right
 
     checkbutton $mytoplevel.array.saveme -text [_ "Save contents"] \
-        -variable ::saveme_button($mytoplevel) -anchor w
+        -variable ::dialog_array::saveme_button($mytoplevel) -anchor w
     pack $mytoplevel.array.saveme -side top
 
     # draw as
     labelframe $mytoplevel.drawas -text [_ "Draw as:"] -padx 20 -borderwidth 1
     pack $mytoplevel.drawas -side top -fill x
     radiobutton $mytoplevel.drawas.points -value 0 \
-        -variable ::drawas_button($mytoplevel) -text [_ "Polygon"]
+        -variable ::dialog_array::drawas_button($mytoplevel) -text [_ "Polygon"]
     radiobutton $mytoplevel.drawas.polygon -value 1 \
-        -variable ::drawas_button($mytoplevel) -text [_ "Points"]
+        -variable ::dialog_array::drawas_button($mytoplevel) -text [_ "Points"]
     radiobutton $mytoplevel.drawas.bezier -value 2 \
-        -variable ::drawas_button($mytoplevel) -text [_ "Bezier curve"]
+        -variable ::dialog_array::drawas_button($mytoplevel) -text [_ "Bezier curve"]
     pack $mytoplevel.drawas.points -side top -anchor w
     pack $mytoplevel.drawas.polygon -side top -anchor w
     pack $mytoplevel.drawas.bezier -side top -anchor w
@@ -299,9 +299,9 @@ proc ::dialog_array::create_dialog {mytoplevel newone} {
         labelframe $mytoplevel.options -text [_ "Put array into:"] -padx 20 -borderwidth 1
         pack $mytoplevel.options -side top -fill x
         radiobutton $mytoplevel.options.radio0 -value 0 \
-            -variable ::otherflag_button($mytoplevel) -text [_ "New graph"]
+            -variable ::dialog_array::otherflag_button($mytoplevel) -text [_ "New graph"]
         radiobutton $mytoplevel.options.radio1 -value 1 \
-            -variable ::otherflag_button($mytoplevel) -text [_ "Last graph"]
+            -variable ::dialog_array::otherflag_button($mytoplevel) -text [_ "Last graph"]
         pack $mytoplevel.options.radio0 -side top -anchor w
         pack $mytoplevel.options.radio1 -side top -anchor w
     } else {
@@ -311,7 +311,7 @@ proc ::dialog_array::create_dialog {mytoplevel newone} {
             -command "::dialog_array::openlistview $mytoplevel [$mytoplevel.array.name.entry get]"
         pack $mytoplevel.options.listview -side top
         checkbutton $mytoplevel.options.deletearray -text [_ "Delete array"] \
-            -variable ::otherflag_button($mytoplevel) -anchor w
+            -variable ::dialog_array::otherflag_button($mytoplevel) -anchor w
         pack $mytoplevel.options.deletearray -side top
     }
 
@@ -364,7 +364,7 @@ proc ::dialog_array::create_dialog {mytoplevel newone} {
         $mytoplevel.buttonframe.cancel config -highlightthickness 0
     }
 
-    position_over_window "$mytoplevel" "$::focused_window"
+    position_over_window ${mytoplevel} ${::focused_window}
 }
 
 # for live widget updates on OSX

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -31,8 +31,11 @@ proc ::dialog_array::listview_lbname {arrayName} {
     return "${id}_listview.data.lb"
 }
 
-proc ::dialog_array::listview_setpage {arrayName page} {
+proc ::dialog_array::listview_setpage {arrayName page {numpages {}} {pagesize {}}} {
     set ::dialog_array::listview_page($arrayName) $page
+    if {$pagesize ne {} && [string is double $pagesize]} {
+        set ::dialog_array::listview_pagesize $pagesize
+    }
 }
 proc ::dialog_array::listview_setdata {arrayName startIndex args} {
     set lb [listview_lbname $arrayName]
@@ -137,7 +140,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
             -yscrollcommand "$sb set"
         $lb heading index -text "#" -anchor center
         $lb heading value -text $arrayName -anchor center
-        $lb column index -width 50 -anchor e
+        $lb column index -width 75 -anchor e
     } stderr ] } {
         # listview
         listbox $lb -height 20 -width 25 \

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -28,7 +28,7 @@ proc ::dialog_array::listview_windowname {arrayName} {
 }
 proc ::dialog_array::listview_lbname {arrayName} {
     set id $::dialog_array::listview_id($arrayName)
-    return "${id}_listview.lb"
+    return "${id}_listview.data.lb"
 }
 
 proc ::dialog_array::listview_setpage {arrayName page} {
@@ -84,10 +84,16 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     wm protocol $windowName WM_DELETE_WINDOW \
         "::dialog_array::listview_close $id \{$arrayName\}"
     wm title $windowName [concat $arrayName "(list view)"]
+
+    frame $windowName.data
+    pack $windowName.data -fill "both" -side top
+    frame $windowName.buttons
+    pack $windowName.buttons -fill "x" -side bottom
+
     # FIXME
     set font 12
-    set lb $windowName.lb
-    set sb ${lb}.sb
+    set lb $windowName.data.lb
+    set sb $windowName.data.sb
     listbox $lb -height 20 -width 25 \
         -selectmode extended \
         -relief solid -background white -borderwidth 1 \
@@ -95,8 +101,8 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         -yscrollcommand "$sb set"
     scrollbar $sb \
         -command "$lb yview" -orient vertical
-    place configure $sb -relheight 1 -relx 0.9 -relwidth 0.1
-    pack $lb -expand 1 -fill both
+    pack $lb -expand 1 -fill both -side left
+    pack $sb -fill y -side right
     bind $lb <Double-ButtonPress-1> \
         "::dialog_array::listview_edit \{$arrayName\} $page $font"
     # handle copy/paste
@@ -106,12 +112,12 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         "win32" {bind $lb <ButtonPress-3> \
                      "::dialog_array::listview_popup \{$arrayName\}"}
     }
-    button $windowName.prevBtn -text "<-" \
+    button $windowName.buttons.prev -text "<-" \
         -command "::dialog_array::listview_changepage \{$arrayName\} -1"
-    button $windowName.nextBtn -text "->" \
+    button $windowName.buttons.next -text "->" \
         -command "::dialog_array::listview_changepage \{$arrayName\} 1"
-    pack $windowName.prevBtn -side left -ipadx 20 -pady 10 -anchor s
-    pack $windowName.nextBtn -side right -ipadx 20 -pady 10 -anchor s
+    pack $windowName.buttons.prev -side left -ipadx 20 -pady 10 -anchor s
+    pack $windowName.buttons.next -side right -ipadx 20 -pady 10 -anchor s
     focus $windowName
 }
 

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -23,7 +23,8 @@ array set ::dialog_array::otherflag_button {}
 
 ############ pdtk_array_dialog -- dialog window for arrays #########
 proc ::dialog_array::listview_windowname {arrayName} {
-    return [format ".%sArrayWindow" $arrayName]
+    set id $::dialog_array::listview_id($arrayName)
+    return "${id}_listview"
 }
 proc ::dialog_array::listview_setpage {arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -168,9 +168,9 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     bind $lb <<Copy>> \
         "::dialog_array::listview_copy \{$arrayName\}; break"
 
-    button $windowName.buttons.prev -text "←" \
+    button $windowName.buttons.prev -text "\u2190" \
         -command "::dialog_array::listview_changepage \{$arrayName\} -1"
-    button $windowName.buttons.next -text "→" \
+    button $windowName.buttons.next -text "\u2192" \
         -command "::dialog_array::listview_changepage \{$arrayName\} 1"
 
     entry $windowName.buttons.page -textvariable ::dialog_array::listview_page($arrayName) \

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -25,8 +25,25 @@ array set ::dialog_array::otherflag_button {}
 proc ::dialog_array::listview_windowname {arrayName} {
     return [format ".%sArrayWindow" $arrayName]
 }
-proc ::dialog_array::pdtk_array_listview_setpage {arrayName page} {
+proc ::dialog_array::listview_setpage {arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page
+}
+proc ::dialog_array::listview_setdata {arrayName startIndex args} {
+    set lb [::dialog_array::listview_windowname $arrayName].lb
+    ${lb} delete 0 end
+    set idx 0
+    foreach x $args {
+        ${lb} insert $idx "[expr $startIndex + $idx]) $x"
+        incr idx
+    }
+}
+proc ::dialog_array::listview_focus {arrayName item} {
+    set lb [::dialog_array::listview_windowname $arrayName].lb
+    ${lb} yview $item
+}
+
+proc ::dialog_array::pdtk_array_listview_setpage {arrayName page} {
+    listview_setpage $arrayName $page
 }
 
 proc ::dialog_array::listview_changepage {arrayName np} {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -112,9 +112,9 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         "win32" {bind $lb <ButtonPress-3> \
                      "::dialog_array::listview_popup \{$arrayName\}"}
     }
-    button $windowName.buttons.prev -text "<-" \
+    button $windowName.buttons.prev -text "←" \
         -command "::dialog_array::listview_changepage \{$arrayName\} -1"
-    button $windowName.buttons.next -text "->" \
+    button $windowName.buttons.next -text "→" \
         -command "::dialog_array::listview_changepage \{$arrayName\} 1"
     pack $windowName.buttons.prev -side left -ipadx 20 -pady 10 -anchor s
     pack $windowName.buttons.next -side right -ipadx 20 -pady 10 -anchor s

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -22,7 +22,9 @@ array set ::dialog_array::drawas_button {}
 array set ::dialog_array::otherflag_button {}
 
 ############ pdtk_array_dialog -- dialog window for arrays #########
-
+proc ::dialog_array::listview_windowname {arrayName} {
+    return [format ".%sArrayWindow" $arrayName]
+}
 proc ::dialog_array::pdtk_array_listview_setpage {arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page
 }
@@ -34,7 +36,7 @@ proc ::dialog_array::listview_changepage {arrayName np} {
 }
 
 proc ::dialog_array::pdtk_array_listview_fillpage {arrayName} {
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     if {[winfo exists $lb]} {
         set topItem [expr [lindex [$lb yview] 0] * \
                          [$lb size]]
@@ -51,7 +53,7 @@ proc ::dialog_array::pdtk_array_listview_fillpage {arrayName} {
 proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page
     set ::dialog_array::listview_id($arrayName) $id
-    set windowName [format ".%sArrayWindow" $arrayName]
+    set windowName [listview_windowname ${arrayName}]
     destroy $windowName
 
     toplevel $windowName -class DialogWindow
@@ -91,7 +93,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
 }
 
 proc ::dialog_array::listview_lbselection {arrayName off size} {
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     set itemNums [$lb curselection]
     set cbString ""
     for {set i 0} {$i < [expr [llength $itemNums] - 1]} {incr i} {
@@ -110,7 +112,7 @@ proc ::dialog_array::listview_lbselection {arrayName off size} {
 
 # Win32 uses a popup menu for copy/paste
 proc ::dialog_array::listview_popup {arrayName} {
-    set windowName [format ".%sArrayWindow" $arrayName]
+    set windowName [listview_windowname ${arrayName}]
     set popup ${windowName}.popup
     destroy $popup
     menu $popup -tearoff false
@@ -125,7 +127,7 @@ proc ::dialog_array::listview_popup {arrayName} {
 }
 
 proc ::dialog_array::listview_copy {arrayName} {
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     set itemNums [$lb curselection]
     set cbString ""
     for {set i 0} {$i < [expr [llength $itemNums] - 1]} {incr i} {
@@ -145,7 +147,7 @@ proc ::dialog_array::listview_copy {arrayName} {
 
 proc ::dialog_array::listview_paste {arrayName} {
     set cbString [selection get -selection CLIPBOARD]
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     set itemNum [lindex [$lb curselection] 0]
     set splitChars ", \n"
     set itemString [split $cbString $splitChars]
@@ -164,7 +166,7 @@ proc ::dialog_array::listview_paste {arrayName} {
 }
 
 proc ::dialog_array::listview_edit {arrayName page font} {
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     set entry ${lb}.entry
     if {[winfo exists $entry]} {
         ::dialog_array::listview_update_entry \
@@ -186,7 +188,7 @@ proc ::dialog_array::listview_edit {arrayName page font} {
 }
 
 proc ::dialog_array::listview_update_entry {arrayName itemNum} {
-    set lb [format ".%sArrayWindow.lb" $arrayName]
+    set lb [listview_windowname ${arrayName}].lb
     set splitChars ", \n"
     set itemString [split [$lb.entry get] $splitChars]
     set flag 1
@@ -206,7 +208,7 @@ proc ::dialog_array::listview_update_entry {arrayName itemNum} {
 }
 
 proc ::dialog_array::pdtk_array_listview_closeWindow {arrayName} {
-    destroy [format ".%sArrayWindow" $arrayName]
+    destroy [listview_windowname ${arrayName}]
 }
 
 proc ::dialog_array::listview_close {mytoplevel arrayName} {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -56,7 +56,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     toplevel $windowName -class DialogWindow
     wm group $windowName .
     wm protocol $windowName WM_DELETE_WINDOW \
-        "::dialog_array::listview_close $id $arrayName"
+        "::dialog_array::listview_close $id \{$arrayName\}"
     wm title $windowName [concat $arrayName "(list view)"]
     # FIXME
     set font 12
@@ -70,18 +70,18 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     place configure $windowName.lb.sb -relheight 1 -relx 0.9 -relwidth 0.1
     pack $windowName.lb -expand 1 -fill both
     bind $windowName.lb <Double-ButtonPress-1> \
-        "::dialog_array::listview_edit $arrayName $page $font"
+        "::dialog_array::listview_edit \{$arrayName\} $page $font"
     # handle copy/paste
     switch -- $::windowingsystem {
         "x11" {selection handle $windowName.lb \
-                   "::dialog_array::listview_lbselection $arrayName"}
+                   "::dialog_array::listview_lbselection \{$arrayName\}"}
         "win32" {bind $windowName.lb <ButtonPress-3> \
-                     "::dialog_array::listview_popup $arrayName"}
+                     "::dialog_array::listview_popup \{$arrayName\}"}
     }
     set $windowName.prevBtn [button $windowName.prevBtn -text "<-" \
-                                 -command "::dialog_array::listview_changepage $arrayName -1"]
+                                 -command "::dialog_array::listview_changepage \{$arrayName\} -1"]
     set $windowName.nextBtn [button $windowName.nextBtn -text "->" \
-                                 -command "::dialog_array::listview_changepage $arrayName 1"]
+                                 -command "::dialog_array::listview_changepage \{$arrayName\} 1"]
     pack $windowName.prevBtn -side left -ipadx 20 -pady 10 -anchor s
     pack $windowName.nextBtn -side right -ipadx 20 -pady 10 -anchor s
     focus $windowName
@@ -111,10 +111,10 @@ proc ::dialog_array::listview_popup {arrayName} {
     if [winfo exists $windowName.popup] then [destroy $windowName.popup]
     menu $windowName.popup -tearoff false
     $windowName.popup add command -label [_ "Copy"] \
-        -command "::dialog_array::listview_copy $arrayName; \
+        -command "::dialog_array::listview_copy \{$arrayName\}; \
                   destroy $windowName.popup"
     $windowName.popup add command -label [_ "Paste"] \
-        -command "::dialog_array::listview_paste $arrayName; \
+        -command "::dialog_array::listview_paste \{$arrayName\}; \
                   destroy $windowName.popup"
     tk_popup $windowName.popup [winfo pointerx $windowName] \
         [winfo pointery $windowName] 0
@@ -177,7 +177,7 @@ proc ::dialog_array::listview_edit {arrayName page font} {
     lower $lbName.entry
     focus $lbName.entry
     bind $lbName.entry <Return> \
-        "::dialog_array::listview_update_entry $arrayName $itemNum;"
+        "::dialog_array::listview_update_entry \{$arrayName\} $itemNum;"
 }
 
 proc ::dialog_array::listview_update_entry {arrayName itemNum} {

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -126,8 +126,6 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     frame $windowName.buttons
     pack $windowName.buttons -fill "x" -side bottom
 
-    # FIXME
-    set font 12
     set lb $windowName.data.lb
     set sb $windowName.data.sb
     if { [ catch {
@@ -145,7 +143,6 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
         listbox $lb -height 20 -width 25 \
             -selectmode extended \
             -relief solid -background white -borderwidth 1 \
-            -font [format {{%s} %d %s} $::font_family $font $::font_weight]\
             -yscrollcommand "$sb set"
     }
     scrollbar $sb \
@@ -153,7 +150,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
     pack $lb -expand 1 -fill both -side left
     pack $sb -fill y -side right
     bind $lb <Double-ButtonPress-1> \
-        "::dialog_array::listview_edit \{$arrayName\} $page $font"
+        "::dialog_array::listview_edit \{$arrayName\} $page"
     # handle copy/paste
     catch {
         # this probably only works on X11
@@ -279,7 +276,7 @@ proc ::dialog_array::listview_paste {arrayName} {
 
 }
 
-proc ::dialog_array::listview_edit {arrayName page font} {
+proc ::dialog_array::listview_edit {arrayName page {font {}}} {
     set lb [listview_lbname ${arrayName}]
     set entry ${lb}.entry
     if {[winfo exists $entry]} {
@@ -299,8 +296,7 @@ proc ::dialog_array::listview_edit {arrayName page font} {
 
         set bbox [$lb bbox $itemNum]
         set y [expr [lindex $bbox 1] - 4]
-        entry $entry \
-            -font [format {{%s} %d %s} $::font_family $font $::font_weight]
+        entry $entry
         place configure $entry -relx 0 -y $y -relwidth 1
     }
     set ::dialog_array::listview_entry($arrayName) $itemNum

--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -26,11 +26,16 @@ proc ::dialog_array::listview_windowname {arrayName} {
     set id $::dialog_array::listview_id($arrayName)
     return "${id}_listview"
 }
+proc ::dialog_array::listview_lbname {arrayName} {
+    set id $::dialog_array::listview_id($arrayName)
+    return "${id}_listview.lb"
+}
+
 proc ::dialog_array::listview_setpage {arrayName page} {
     set ::dialog_array::listview_page($arrayName) $page
 }
 proc ::dialog_array::listview_setdata {arrayName startIndex args} {
-    set lb [::dialog_array::listview_windowname $arrayName].lb
+    set lb [listview_lbname $arrayName]
     ${lb} delete 0 end
     set idx 0
     foreach x $args {
@@ -39,7 +44,7 @@ proc ::dialog_array::listview_setdata {arrayName startIndex args} {
     }
 }
 proc ::dialog_array::listview_focus {arrayName item} {
-    set lb [::dialog_array::listview_windowname $arrayName].lb
+    set lb [listview_lbname $arrayName]
     ${lb} yview $item
 }
 
@@ -54,7 +59,7 @@ proc ::dialog_array::listview_changepage {arrayName np} {
 }
 
 proc ::dialog_array::pdtk_array_listview_fillpage {arrayName} {
-    set lb [listview_windowname ${arrayName}].lb
+    set lb [listview_lbname ${arrayName}]
     if {[winfo exists $lb]} {
         set topItem [expr [lindex [$lb yview] 0] * \
                          [$lb size]]
@@ -111,7 +116,7 @@ proc ::dialog_array::pdtk_array_listview_new {id arrayName page} {
 }
 
 proc ::dialog_array::listview_lbselection {arrayName off size} {
-    set lb [listview_windowname ${arrayName}].lb
+    set lb [listview_lbname ${arrayName}]
     set items {}
     foreach idx [$lb curselection] {
         set v [$lb get $idx]
@@ -162,13 +167,13 @@ proc ::dialog_array::listview_copy {arrayName} {
 
 proc ::dialog_array::listview_paste {arrayName} {
     set sel [selection get -selection CLIPBOARD]
-    set lb [listview_windowname ${arrayName}].lb
+    set lb [listview_lbname ${arrayName}]
     set itemNum [lindex [$lb curselection] 0]
     ::dialog_array::listview_edit+paste $arrayName $itemNum $sel
 }
 
 proc ::dialog_array::listview_edit {arrayName page font} {
-    set lb [listview_windowname ${arrayName}].lb
+    set lb [listview_lbname ${arrayName}]
     set entry ${lb}.entry
     if {[winfo exists $entry]} {
         ::dialog_array::listview_update_entry \
@@ -190,7 +195,7 @@ proc ::dialog_array::listview_edit {arrayName page font} {
 }
 
 proc ::dialog_array::listview_update_entry {arrayName itemNum} {
-    set entry [::dialog_array::listview_windowname $arrayName].lb.entry
+    set entry [listview_lbname $arrayName].entry
     ::dialog_array::listview_edit+paste $arrayName $itemNum [$entry get]
     destroy $entry
 }

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -31,6 +31,9 @@ proc ::dialog_font::do_apply {mytoplevel myfontsize stretchval whichstretch} {
         if {[winfo exists ${mytoplevel}.text]} {
             ${mytoplevel}.text.internal configure -font "-size $myfontsize"
         }
+        catch {
+            ttk::style configure Treeview -rowheight [expr {[font metrics TkDefaultFont -linespace] + 2}]
+        }
 
         # repeat a "pack" command so the font dialog can resize itself
         if {[winfo exists .font]} {

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -22,7 +22,8 @@ namespace eval ::dialog_font:: {
 
 # this could probably just be apply, but keep the old one for tcl plugins that
 # might use apply for "stretch"
-proc ::dialog_font::radio_apply {mytoplevel myfontsize} {
+
+proc ::dialog_font::do_apply {mytoplevel myfontsize stretchval whichstretch} {
     if {$mytoplevel eq ".pdwindow"} {
         foreach font [font names] {
             font configure $font -size $myfontsize
@@ -39,8 +40,12 @@ proc ::dialog_font::radio_apply {mytoplevel myfontsize} {
         ::pd_guiprefs::write menu-fontsize "$myfontsize"
 
     } else {
-        pdsend "$mytoplevel font $myfontsize 0 2"
+        pdsend "$mytoplevel font $myfontsize $stretchval $whichstretch"
     }
+}
+
+proc ::dialog_font::radio_apply {mytoplevel myfontsize} {
+    ::dialog_font::do_apply $mytoplevel $myfontsize 0 2
 }
 
 proc ::dialog_font::stretch_apply {gfxstub} {
@@ -56,26 +61,9 @@ proc ::dialog_font::stretch_apply {gfxstub} {
 }
 
 proc ::dialog_font::apply {mytoplevel myfontsize} {
-    if {$mytoplevel eq ".pdwindow"} {
-        foreach font [font names] {
-            font configure $font -size $myfontsize
-        }
-        if {[winfo exists ${mytoplevel}.text]} {
-            ${mytoplevel}.text.internal configure -font "-size $myfontsize"
-        }
-
-        # repeat a "pack" command so the font dialog can resize itself
-        if {[winfo exists .font]} {
-            pack .font.buttonframe -side bottom -fill x -pady 2m
-        }
-
-        ::pd_guiprefs::write menu-fontsize "$myfontsize"
-
-    } else {
-        variable stretchval
-        variable whichstretch
-        pdsend "$mytoplevel font $myfontsize $stretchval $whichstretch"
-    }
+    variable stretchval
+    variable whichstretch
+    ::dialog_font::do_apply $mytoplevel $myfontsize $stretchval $whichstretch
 }
 
 proc ::dialog_font::cancel {gfxstub} {


### PR DESCRIPTION
this PR fixes a couple of issues with the "array editor" and improves it otherwise (<kbd>List View</kbd> in the array preferences)

### bugfixes
- allow the user to open the <kbd>List View</kbd> for arrays with names that start with a capital letter (Closes: #1541)
- allow the user to open the <kbd>List View</kbd> for arrays with names that contain spaces
- fix editing of values that are not on the first page (Closes: #1542 )
- remove code absurdities (like `[expr $x + [expr $y + [expr $a * $b]]]`
- remove assignment absurdities (like `set $winid.x [entry $winid.x]`)
- refactored and simplified code

### improvements
- abstract interface for sending paged array-data from Pd-core to Pd-GUI
  - Pd-core no longer needs to worry how the data is stored (or represented) on the GUI side
  - we can send multiple values at once, rather than element by element
  - the GUI figures out how to display the values by itself
- (optionally) uses a nicer table-widget for showing the data
- add an entry box to directly go to a data page
- copy/paste now works on all platforms
  - either via the context-menu (that used to be windows only)
  - or via the default bindings (<kbd>Ctrl</kbd>+<kbd>C</kbd> / <kbd>Ctrl</kbd>+<kbd>V</kbd>)