### PR TITLE
fix PERTHREAD build error by setting macos version min 10.9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_CANONICAL_HOST
 
 
 ########################################
-#### ohoh. automake<<1.16 do not like $(top_srcdir) in _SOURCES.
+#### ohoh. automake<<1.16 does not like $(top_srcdir) in _SOURCES.
 AS_IF([test "x${am__api_version}" = "x1.15" ], [
   enable_dependency_tracking=no
   AC_MSG_WARN([legacy automake detected: disabled dependency-tracking!
@@ -69,8 +69,8 @@ AS_CASE([$host],
         # a set of search paths are used on macOS in s_inter.c
         wish="default search paths"
 
-        # required for dlopen & weak linking for older OSX version support
-        CFLAGS="-mmacosx-version-min=10.6 $CFLAGS"
+        # required for dlopen & weak linking for older macOS version support
+        macos_version_min=10.6
     ],[
         platform=iOS
         locales=no
@@ -284,6 +284,8 @@ AS_IF([test x$debug = xyes],[
 
 #########################################
 ##### Configure Options #####
+
+##### libpd #####
 AC_ARG_ENABLE([libpd],
     [AS_HELP_STRING([--enable-libpd], [additionally build libpd])])
 AC_ARG_ENABLE([libpd-utils],
@@ -539,15 +541,26 @@ AS_IF([test ! "x${WISH}" = "x"],[
 
 ##### libpd #####
 AS_IF([test "x${enable_libpd}" = "xyes"],[
-        libpd="yes"
-        libpd_=""
-        AS_IF([test "x${enable_libpd_instance}" = "xyes"],[ libpd_="${libpd_}+multi "])
-        AS_IF([test "x${enable_libpd_utils}" = "xyes"],[ libpd_="${libpd_}+utils "])
-        AS_IF([test "x${enable_libpd_extra}" = "xyes"],[ libpd_="${libpd_}+extra "])
-        AS_IF([test "x${enable_libpd_setlocale}" = "xno"],[ libpd_="${libpd_}-setlocale "])
-        AS_IF([test "x${libpd_}" != "x"],[ libpd="${libpd} ( ${libpd_})"])
+    libpd="yes"
+    libpd_=""
+    AS_IF([test "x${enable_libpd_instance}" = "xyes"],[
+        libpd_="${libpd_}+multi "
+        AS_IF([test "x$MACOSX" = "xyes"],[
+            macos_version_min=10.9
+            AC_MSG_NOTICE([Setting macOS version min 10.9 for libpd instance])
+        ])
+    ])
+    AS_IF([test "x${enable_libpd_utils}" = "xyes"],[ libpd_="${libpd_}+utils "])
+    AS_IF([test "x${enable_libpd_extra}" = "xyes"],[ libpd_="${libpd_}+extra "])
+    AS_IF([test "x${enable_libpd_setlocale}" = "xno"],[ libpd_="${libpd_}-setlocale "])
+    AS_IF([test "x${libpd_}" != "x"],[ libpd="${libpd} ( ${libpd_})"])
 ],[
-        libpd="no"
+    libpd="no"
+])
+
+##### macOS version min #####
+AS_IF([test "x$macos_version_min" != "x"],[
+    CFLAGS="-mmacosx-version-min=$macos_version_min $CFLAGS"
 ])
 
 #########################################

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,11 @@ midi_backends=""
 DEBUG_CFLAGS="-O0"
 RELEASE_CFLAGS="-ffast-math -funroll-loops -fomit-frame-pointer -O3"
 
+# common flags applied to all pd binaries
+PD_CPPFLAGS=""
+PD_CFLAGS=""
+PD_LDFLAGS=""
+
 #########################################
 ##### OS Detection #####
 
@@ -80,19 +85,19 @@ AS_CASE([$host],
     # homebrew paths
     AS_IF([test -e /usr/local],[
         AM_CPPFLAGS="-I/usr/local/include $INCLUDES"
-        LDFLAGS="-L/usr/local/lib $LDFLAGS"
+        PD_LDFLAGS="-L/usr/local/lib $PD_LDFLAGS"
     ])
 
     # fink paths
     AS_IF([test -e /sw],[
         AM_CPPFLAGS="-I/sw/include $INCLUDES"
-        LDFLAGS="-L/sw/lib $LDFLAGS"
+        PD_LDFLAGS="-L/sw/lib $PD_LDFLAGS"
     ])
 
     # macports paths
     AS_IF([test -e /opt/local],[
         AM_CPPFLAGS="-I/opt/local/include $INCLUDES"
-        LDFLAGS="-L/opt/local/lib $LDFLAGS"
+        PD_LDFLAGS="-L/opt/local/lib $PD_LDFLAGS"
     ])
 
     EXTERNAL_LDFLAGS="-bundle -undefined dynamic_lookup"
@@ -276,10 +281,15 @@ AC_ARG_ENABLE([debug],
     [AS_HELP_STRING([--enable-debug], [use debugging support])],
     [debug=$enableval], [debug=no])
 AS_IF([test x$debug = xyes],[
-    CFLAGS="$CFLAGS $DEBUG_CFLAGS"
+    PD_CFLAGS="$DEBUG_CFLAGS $PD_CFLAGS"
 ],[
-    CFLAGS="$CFLAGS $RELEASE_CFLAGS"
-    CPPFLAGS="$CPPFLAGS -DNDEBUG"
+    PD_CFLAGS="$RELEASE_CFLAGS $PD_CFLAGS"
+    PD_CPPFLAGS="-DNDEBUG $PD_CPPFLAGS"
+])
+
+##### macOS version min #####
+AS_IF([test "x$macos_version_min" != "x"],[
+    PD_CFLAGS="-mmacosx-version-min=$macos_version_min $PD_CFLAGS"
 ])
 
 #########################################
@@ -307,8 +317,8 @@ AM_CONDITIONAL(LIBPD_NO_SETLOCALE, test x$enable_libpd_setlocale = xno)
 PD_CHECK_UNIVERSAL(ARCH, [universal=yes], [universal=no])
 AM_CONDITIONAL(UNIVERSAL, test x$universal = xyes)
 AS_IF([test x$universal = xyes],[
-    CFLAGS="$ARCH_CFLAGS $CFLAGS"
-    LDFLAGS="$ARCH_LDFLAGS $LDFLAGS"
+    PD_CFLAGS="$ARCH_CFLAGS $PD_CFLAGS"
+    PD_LDFLAGS="$ARCH_LDFLAGS $PD_LDFLAGS"
 ])
 
 ##### Gettext #####
@@ -543,13 +553,7 @@ AS_IF([test ! "x${WISH}" = "x"],[
 AS_IF([test "x${enable_libpd}" = "xyes"],[
     libpd="yes"
     libpd_=""
-    AS_IF([test "x${enable_libpd_instance}" = "xyes"],[
-        libpd_="${libpd_}+multi "
-        AS_IF([test "x$MACOSX" = "xyes"],[
-            macos_version_min=10.9
-            AC_MSG_NOTICE([Setting macOS version min 10.9 for libpd instance])
-        ])
-    ])
+    AS_IF([test "x${enable_libpd_instance}" = "xyes"],[ libpd_="${libpd_}+multi "])
     AS_IF([test "x${enable_libpd_utils}" = "xyes"],[ libpd_="${libpd_}+utils "])
     AS_IF([test "x${enable_libpd_extra}" = "xyes"],[ libpd_="${libpd_}+extra "])
     AS_IF([test "x${enable_libpd_setlocale}" = "xno"],[ libpd_="${libpd_}-setlocale "])
@@ -558,10 +562,10 @@ AS_IF([test "x${enable_libpd}" = "xyes"],[
     libpd="no"
 ])
 
-##### macOS version min #####
-AS_IF([test "x$macos_version_min" != "x"],[
-    CFLAGS="-mmacosx-version-min=$macos_version_min $CFLAGS"
-])
+# pass common flags via @PD_*@ AM variables for use in Makefiles
+AC_SUBST(PD_CPPFLAGS)
+AC_SUBST(PD_CFLAGS)
+AC_SUBST(PD_LDFLAGS)
 
 #########################################
 ##### Output files #####
@@ -610,9 +614,9 @@ AC_MSG_NOTICE([
     Installation prefix:  $prefix
 
     Compiler:             $CC
-    CPPFLAGS:             $CPPFLAGS
-    CFLAGS:               $CFLAGS
-    LDFLAGS:              $LDFLAGS
+    CPPFLAGS:             $PD_CPPFLAGS $CPPFLAGS
+    CFLAGS:               $PD_CFLAGS $CFLAGS
+    LDFLAGS:              $PD_LDFLAGS $LDFLAGS
     INCLUDES:             $AM_CPPFLAGS
     LIBS:                 $LIBS
 

--- a/extra/bob~/GNUmakefile.am
+++ b/extra/bob~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 bob__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/bonk~/GNUmakefile.am
+++ b/extra/bonk~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 bonk__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/choice/GNUmakefile.am
+++ b/extra/choice/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 choice_la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/fiddle~/GNUmakefile.am
+++ b/extra/fiddle~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 fiddle__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/loop~/GNUmakefile.am
+++ b/extra/loop~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 AM_LIBS = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/lrshift~/GNUmakefile.am
+++ b/extra/lrshift~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 AM_LIBS = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -19,11 +19,11 @@ EXTRA_DIST = makefile notes.txt binarymsg.c
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 pd__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/pique/GNUmakefile.am
+++ b/extra/pique/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 pique_la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/sigmund~/GNUmakefile.am
+++ b/extra/sigmund~/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 sigmund__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/extra/stdout/GNUmakefile.am
+++ b/extra/stdout/GNUmakefile.am
@@ -17,11 +17,11 @@ EXTRA_DIST = makefile
 dist_external_DATA = $(PATCHES) $(OTHERDATA)
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = @EXTERNAL_CFLAGS@
-AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD
+AM_CFLAGS = @EXTERNAL_CFLAGS@ @PD_CFLAGS@
+AM_CPPFLAGS	+= -I$(top_srcdir)/src -DPD @PD_CPPFLAGS@
 AM_LIBS = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
-    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src
+    -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
 externaldir = $(pkglibdir)/extra/$(NAME)
 

--- a/portaudio/Makefile.am
+++ b/portaudio/Makefile.am
@@ -4,10 +4,12 @@
 ##### Defaults & Paths #####
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = -DNEWBUFFER
+AM_CFLAGS = -DNEWBUFFER @PD_CFLAGS@
 AM_CPPFLAGS += \
     -I$(top_srcdir)/portaudio/portaudio/include \
-    -I$(top_srcdir)/portaudio/portaudio/src/common
+    -I$(top_srcdir)/portaudio/portaudio/src/common \
+    @PD_CPPFLAGS@
+AM_LDFLAGS = @PD_LDFLAGS@
 
 #########################################
 ##### Files, Binaries, & Libs #####
@@ -73,7 +75,7 @@ endif
 endif
 
 # empty var for headers list footer
-empty=
+empty =
 
 # include the headers in the dist so you can build
 # find portaudio -type file -name *.h | sort | awk '{print "   ", $1, "\\"}'; echo '     $(empty)'

--- a/portmidi/Makefile.am
+++ b/portmidi/Makefile.am
@@ -4,10 +4,12 @@
 ##### Defaults & Paths #####
 
 AUTOMAKE_OPTIONS = foreign
-AM_CFLAGS = -DNEWBUFFER
+AM_CFLAGS = -DNEWBUFFER @PD_CFLAGS@
 AM_CPPFLAGS += \
     -I$(top_srcdir)/portmidi/portmidi/pm_common \
-    -I$(top_srcdir)/portmidi/portmidi/porttime
+    -I$(top_srcdir)/portmidi/portmidi/porttime \
+    @PD_CPPFLAGS@
+AM_LDFLAGS = @PD_LDFLAGS@
 
 #########################################
 ##### Files, Binaries, & Libs #####
@@ -47,7 +49,7 @@ libportmidi_a_SOURCES += \
 endif
 
 # empty var for headers list footer
-empty=
+empty =
 
 # include the headers in the dist so you can build
 # find portmidi -type file -name *.h | sort | awk '{print "   ", $1, "\\"}'; echo '     $(empty)'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,17 +2,23 @@
 ##### Defaults & Paths #####
 
 AUTOMAKE_OPTIONS = foreign
-CLEANFILES=
+CLEANFILES =
 
 bin_SCRIPTS =
 noinst_SCRIPTS =
 
-pd_CFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" -DPD_INTERNAL
-pd_LDFLAGS =
+AM_CPPFLAGS = @PD_CPPFLAGS@
+AM_CFLAGS = @PD_CFLAGS@
+AM_LDFLAGS = @PD_LDFLAGS@
+
+pd_CFLAGS = -DPD -DPD_INTERNAL -DINSTALL_PREFIX=\"$(prefix)\" @PD_CFLAGS@
+pd_LDFLAGS = @PD_LDFLAGS@
 pd_LDADD =
-libpd_la_CPPFLAGS = -DPD -DPD_INTERNAL -DUSEAPI_DUMMY
+
+libpd_la_CPPFLAGS = -DPD -DPD_INTERNAL -DUSEAPI_DUMMY @PD_CPPFLAGS@
+libpd_la_CFLAGS = @PD_CFLAGS@
 libpd_la_LIBADD =
-libpd_la_LDFLAGS =
+libpd_la_LDFLAGS = @PD_LDFLAGS@
 libpdincludedir = $(includedir)/libpd
 libpdinclude_HEADERS =
 
@@ -20,14 +26,14 @@ libpdinclude_HEADERS =
 # for the DLL and the EXE, other OSes simply set pd_* = $(pd_*_core) later
 # also, the "_core" suffix is used as this keeps automake from thinking these
 # are library or binary variables since we only need them as placeholders
-pd_LDFLAGS_core =
+pd_LDFLAGS_core = @PD_LDFLAGS@
 pd_LDADD_core =
-pd_LDFLAGS_standalone =
+pd_LDFLAGS_standalone = @PD_LDFLAGS@
 pd_LDADD_standalone =
 
-pdsend_CFLAGS =
-pdreceive_CFLAGS =
-pd_watchdog_CFLAGS =
+pdsend_CFLAGS = @PD_CFLAGS@
+pdreceive_CFLAGS = @PD_CFLAGS@
+pd_watchdog_CFLAGS = @PD_CFLAGS@
 
 LIBS = @LIBS@
 
@@ -86,8 +92,6 @@ libpd_la_SOURCES += \
     $(top_srcdir)/extra/stdout/stdout.c \
     $(empty)
 endif
-
-
 
 # on Windows, pd.exe contains only s_entry.c and links against pd.dll
 # (where all the logic resides), that's why we have to split the sources
@@ -199,7 +203,7 @@ endif
 
 # we want these in the dist tarball
 EXTRA_DIST = CHANGELOG.txt notes.txt pd.rc \
-    makefile.gnu  makefile.mac  makefile.mingw  makefile.msvc \
+    makefile.gnu makefile.mac makefile.mingw makefile.msvc \
     d_soundfile.h s_audio_audiounit.c s_audio_esd.c
 
 # add WISH define if it's set
@@ -302,7 +306,7 @@ endif
 
 endif
 
-
+##### Jack Audio Connection Kit #####
 if JACK
 pd_SOURCES_standalone += s_audio_paring.c
 else !JACK
@@ -310,7 +314,6 @@ if PORTAUDIO
 pd_SOURCES_standalone += s_audio_paring.c
 endif PORTAUDIO
 endif !JACK
-
 
 ##### NO API? #####
 # if no audio or midi api was detected/specified, fall back to dummy apis
@@ -388,6 +391,11 @@ pd_CFLAGS += -DMACOSX
 LIBS += -ldl -lm -lpthread -framework CoreFoundation
 libpd_la_LIBADD += -ldl -lm -lpthread
 libpd_la_LDFLAGS += -framework CoreFoundation
+
+# PERTHREAD requires macOS 10.9+ SDK
+if LIBPD_MULTIINSTANCE
+libpd_la_CFLAGS += -mmacosx-version-min=10.9
+endif
 
 endif
 


### PR DESCRIPTION
This PR fixes #1443 by adding logic to configure to set the macOS version min to 10.9 when building with `--enable-libpd-instance`. Building with instances on < 10.9 will most likely fail anyway, so there aren't any macOS version checks.

There is also an indentation fix to the added libpd stuff.