### PR TITLE
fix soundfiler read reading samples without tablename

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -126,13 +126,13 @@ static size_t sf_minheadersize = 0;
 static char sf_typeargs[MAXPDSTRING] = {0};
 
     /* built-in type implementations */
-void soundfile_wave_setup( void);
-void soundfile_aiff_setup( void);
-void soundfile_caf_setup( void);
-void soundfile_next_setup( void);
+void soundfile_wave_setup(void);
+void soundfile_aiff_setup(void);
+void soundfile_caf_setup(void);
+void soundfile_next_setup(void);
 
     /** set up built-in types */
-void soundfile_type_setup( void)
+void soundfile_type_setup(void)
 {
     soundfile_wave_setup(); /* default first */
     soundfile_aiff_setup();
@@ -158,7 +158,7 @@ int soundfile_addtype(const t_soundfile_type *type)
 }
 
     /** return type list head pointer */
-static t_soundfile_type **soundfile_firsttype( void)
+static t_soundfile_type **soundfile_firsttype(void)
 {
     return &sf_types[0];
 }

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1301,7 +1301,7 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     }
 
     if (!finalsize) finalsize = SFMAXFRAMES;
-    if (framesinfile > 0 && finalsize > (size_t)framesinfile)
+    if (framesinfile >= 0 && finalsize > (size_t)framesinfile)
         finalsize = framesinfile;
 
         /* no tablenames, try to use header info instead of reading */

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1518,7 +1518,7 @@ size_t soundfiler_dowrite(void *obj, t_canvas *canvas,
         soundfile_xferout_words(sf, vectors, (unsigned char *)sampbuf,
             thiswrite, wa.wa_onsetframes, normfactor);
         byteswritten = write(sf->sf_fd, sampbuf, datasize);
-        if (byteswritten < (ssize_t)datasize)
+        if (byteswritten < 0 || (size_t)byteswritten < datasize)
         {
             object_sferror(obj, "soundfiler write",
                 wa.wa_filesym->s_name, errno, sf);
@@ -1804,7 +1804,7 @@ static void *readsf_child_main(void *zz)
                         wantbytes = fifosize - x->x_fifohead;
                         if (wantbytes > READSIZE)
                             wantbytes = READSIZE;
-                        if ((ssize_t)wantbytes > sf.sf_bytelimit)
+                        if (sf.sf_bytelimit >= 0 && wantbytes > (size_t)sf.sf_bytelimit)
                             wantbytes = sf.sf_bytelimit;
 #ifdef DEBUG_SOUNDFILE_THREADS
                         fprintf(stderr, "readsf~: head %d, tail %d, size %ld\n",
@@ -1845,7 +1845,7 @@ static void *readsf_child_main(void *zz)
                         continue;
                     }
                     else wantbytes = READSIZE;
-                    if ((ssize_t)wantbytes > sf.sf_bytelimit)
+                    if (sf.sf_bytelimit >= 0 && wantbytes > (size_t)sf.sf_bytelimit)
                         wantbytes = sf.sf_bytelimit;
                 }
 #ifdef DEBUG_SOUNDFILE_THREADS
@@ -2402,7 +2402,7 @@ static void *writesf_child_main(void *zz)
                 if (x->x_requestcode != REQUEST_BUSY &&
                     x->x_requestcode != REQUEST_CLOSE)
                         break;
-                if (byteswritten < (ssize_t)writebytes)
+                if (byteswritten < 0 || (size_t)byteswritten < writebytes)
                 {
 #ifdef DEBUG_SOUNDFILE_THREADS
                     fprintf(stderr, "writesf~: fileerror %d\n", errno);


### PR DESCRIPTION
This fixes an incorrect cast introduced by 56da2e187d7ad9f72017941c7163a24e9066860a and an bad check for raw status which forced [soundfiler] to *always* read samples even when only header info should be read, ie. without a given tablename.