### PR TITLE
Fix two typos in samplerate~-help.pd

### DIFF
--- a/doc/5.reference/samplerate~-help.pd
+++ b/doc/5.reference/samplerate~-help.pd
@@ -29,14 +29,14 @@ samplerate must be half of the parent patch., f 44;
 current audio sample rate. If called within a subwindow that is up-
 or down-sampled \, the sample rate of signals within that subwindow
 are reported (see [pd resampling] subpatch below)., f 57;
-#X text 65 160 Here we litsen to "pd-dsp-started" to receive a bang
+#X text 65 160 Here we listen to "pd-dsp-started" to receive a bang
 (automatically sent when DSP is started in Pd) to get the sample rate
 when DSP starts. This also works whenever the sample rate may change
 when the audio is running. This is useful when designing filters whose
 coefficients usually have to be updated when the sample rate changes.
 ;
 #X text 109 286 DSP On/Off;
-#X obj 160 420 Pd-messages;
+#X obj 160 420 pd-messages;
 #X connect 2 0 3 0;
 #X connect 4 0 2 0;
 #X connect 5 0 4 0;


### PR DESCRIPTION
"litsen" --> "listen"

[Pd-messages] --> [pd-messages] (this abstraction failed to be created)