### PR TITLE
stable development branch

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -954,7 +954,7 @@ msgstr "%1$s nach %2$s installieren?"
 msgid "Cancelling download of %s: No installation directory given."
 msgstr "Abbruch des Downloads von %s: Kein Installationsverzeichnis angegeben."
 
-msgid "Installing to non-existant directory failed"
+msgid "Installing to non-existent directory failed"
 msgstr ""
 "Die Installation in ein nicht-existierendes Verzeichnis ist fehlgeschlagen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -939,7 +939,7 @@ msgid "Cancelling download of %s: No installation directory given."
 msgstr ""
 "Cancelando la descarga de %s: No fue dado el directorio de instalación ."
 
-msgid "Installing to non-existant directory failed"
+msgid "Installing to non-existent directory failed"
 msgstr "Falla al instalar en un directorio que no existe."
 
 #, tcl-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -948,7 +948,7 @@ msgstr ""
 "Annulation du téléchargement de %s : aucun répertoire d'installation n'a "
 "été indiqué."
 
-msgid "Installing to non-existant directory failed"
+msgid "Installing to non-existent directory failed"
 msgstr "L'installation dans un répertoire inexistant a échoué"
 
 #, tcl-format

--- a/po/template.pot
+++ b/po/template.pot
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Cancelling download of %s: No installation directory given."
 msgstr ""
 
-msgid "Installing to non-existant directory failed"
+msgid "Installing to non-existent directory failed"
 msgstr ""
 
 #, tcl-format

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -70,7 +70,7 @@ void soundfile_clear(t_soundfile *sf);
     /** copy src soundfile info into dst */
 void soundfile_copy(t_soundfile *dst, const t_soundfile *src);
 
-    /** returns 1 if bytes need to be swapped due to endianess, otherwise 0 */
+    /** returns 1 if bytes need to be swapped due to endianness, otherwise 0 */
 int soundfile_needsbyteswap(const t_soundfile *sf);
 
     /** generic soundfile errors */
@@ -94,13 +94,13 @@ typedef int (*t_soundfile_isheaderfn)(const char *buf, size_t size);
 
     /** read format info from soundfile header,
         returns 1 on success or 0 on error
-        note: set sf_bytelimit = sound data size, optionaly set errno
+        note: set sf_bytelimit = sound data size, optionally set errno
         this may be called in a background thread */
 typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
 
     /** write header to beginning of an open file from an info struct
         returns header bytes written or < 0 on error
-        note: optionaly set errno
+        note: optionally set errno
         this may be called in a background thread */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -933,7 +933,7 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos,
     return (1);
 }
 
-    /* probably never used but included in case needed for compatibilty */
+    /* probably never used but included in case needed for compatibility */
 static void gatom_click(t_gatom *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 #include "m_pd.h"
 #include "s_stuff.h"
 #include "s_audio_paring.h"
@@ -412,10 +413,18 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
 
     STUFF->st_dacsr = jack_get_sample_rate (jack_client);
     jack_blocksize = jack_get_buffer_size (jack_client);
-    advance_samples = sys_schedadvance * (float)STUFF->st_dacsr / 1.e6;
+    advance_samples = sys_schedadvance * (double)STUFF->st_dacsr / 1.e6;
     advance_samples -= (advance_samples % DEFDACBLKSIZE);
-    if (advance_samples < DEFDACBLKSIZE)
-        advance_samples = DEFDACBLKSIZE;
+        /* make sure that the delay is not smaller than the Jack blocksize! */
+    if (advance_samples < jack_blocksize)
+    {
+        int delay = ((double)sys_schedadvance / 1000.) + 0.5;
+        int limit = ceil(jack_blocksize * 1000. / (double)STUFF->st_dacsr);
+        advance_samples = jack_blocksize;
+        post("warning: 'delay' setting (%d ms) too small for current blocksize "
+             "(%d samples); falling back to minimum value (%d ms)",
+             delay, jack_blocksize, limit);
+    }
 
     /* create the ports */
 

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -501,7 +501,7 @@ void jack_close_audio(void)
     jack_blocksize = 0;
 
         /* this should never be necessary since jack_close_audio() should
-        only be called form the main thread.  Still, it doens't hurt
+        only be called form the main thread.  Still, it doesn't hurt
         anything. */
     pthread_cond_broadcast(&jack_sem);
 

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -98,7 +98,7 @@ typedef struct _audiosettings
     likely to offer a working device takes precedence so that if you
     start up Pd for the first time there's a reasonable chance you'll have
     sound.  (You'd think portaudio would be best but it seems to default
-    to jack on linux, and and on Windows we only use it for ASIO).
+    to jack on linux, and on Windows we only use it for ASIO).
     If nobody shows up, define DUMMY and make it the default.*/
 #if defined(USEAPI_MMIO)
 # define API_DEFAULT API_MMIO

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -116,14 +116,12 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
     else if (argv->a_type == A_FLOAT)
     {
         int i;
+        /* print first (numeric) atom, to avoid a leading space */
         if (*x->x_sym->s_name)
-            print_startlogpost(x, "%s: ", x->x_sym->s_name);
+            print_startlogpost(x, "%s: %g", x->x_sym->s_name, atom_getfloat(argv));
         else
-        {
-            /* print first (numeric) atom, to avoid a trailing space */
             print_startlogpost(x, "%g", atom_getfloat(argv));
-            argc--; argv++;
-        }
+        argc--; argv++;
         for (i = 0; i < argc; i++)
         {
             char buf[MAXPDSTRING];

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -499,7 +499,7 @@ proc set_base_font {family weight} {
     ::pdwindow::verbose 0 "using font: $::font_family $::font_weight\n"
 }
 
-# finds sizes of the chosen font that just fit into the requried metrics
+# finds sizes of the chosen font that just fit into the required metrics
 # e.g. if the metric requires the 'M' to be 15x10 pixels,
 # and the given font at size 12 is 15x7 and at size 16 it is 19x10,
 # then we would pick size 12.

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -1767,7 +1767,7 @@ proc ::deken::clicked_link {URL filename} {
     set installdir [::deken::ensure_installdir "" ${filename}]
     if { "${installdir}" == "" } {
         ::deken::utilities::debug [format [_ "Cancelling download of %s: No installation directory given." ] $filename]
-        ::deken::status [format [_ "Installing to non-existant directory failed" ] $filename]
+        ::deken::status [format [_ "Installing to non-existent directory failed" ] $filename]
         return
     }
     set fullpkgfile [file join $installdir $filename]


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch develop that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with unresolvable file conflicts)

it supersedes #1545

---

fixes so far (this list should be manually updated whenever new fixes are pushed):

- code hygiene
  - minor spelling fixes in comments
- audio backends
  - Jack: cap "delay" to Jack blocksize + post a warning (Closes: #1587)
  - portaudio: post a warning when capping the "delay" value to the hardware blocksize
- [print]: avoid leading space when printing a list that starts with a float atom