### PR TITLE
set dirty flag from font dialog only

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4798,8 +4798,6 @@ static void canvas_font(t_canvas *x, t_floatarg font, t_floatarg resize,
     if (whichresize != 3) realresx = realresize;
     if (whichresize != 2) realresy = realresize;
     canvas_dofont(x2, font, realresx, realresy);
-    if ((realresx != 1 || realresx != 1) || (oldfont != (int)font))
-        canvas_dirty(x2, 1);
     canvas_undo_add(x2, UNDO_FONT, "font",
         canvas_undo_set_font(x2, oldfont, realresize, whichresize));
 

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -47,6 +47,7 @@ proc ::dialog_font::do_apply {mytoplevel myfontsize stretchval whichstretch} {
 
     } else {
         pdsend "$mytoplevel font $myfontsize $stretchval $whichstretch"
+        pdsend "$mytoplevel dirty 1"
     }
 }
 
@@ -63,6 +64,7 @@ proc ::dialog_font::stretch_apply {gfxstub} {
             set stretchval 100
         }
         pdsend "$gfxstub font $fontsize $stretchval $whichstretch"
+        pdsend "$gfxstub dirty 1"
     }
 }
 

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -52,7 +52,11 @@ proc ::dialog_font::do_apply {mytoplevel myfontsize stretchval whichstretch} {
 }
 
 proc ::dialog_font::radio_apply {mytoplevel myfontsize} {
-    ::dialog_font::do_apply $mytoplevel $myfontsize 0 2
+    variable fontsize
+    if {$myfontsize != $fontsize} {
+        set fontsize $myfontsize
+        ::dialog_font::do_apply $mytoplevel $myfontsize 0 2
+    }
 }
 
 proc ::dialog_font::stretch_apply {gfxstub} {
@@ -62,6 +66,9 @@ proc ::dialog_font::stretch_apply {gfxstub} {
         variable whichstretch
         if {$stretchval == ""} {
             set stretchval 100
+        }
+        if {$stretchval == 100} {
+            return
         }
         pdsend "$gfxstub font $fontsize $stretchval $whichstretch"
         pdsend "$gfxstub dirty 1"
@@ -119,6 +126,7 @@ proc ::dialog_font::pdtk_canvas_dofont {gfxstub initsize} {
     } else {
         create_dialog $gfxstub
     }
+    .font.fontsize.radio$fontsize select
 }
 
 proc ::dialog_font::create_dialog {gfxstub} {
@@ -152,7 +160,6 @@ proc ::dialog_font::create_dialog {gfxstub} {
     # this is whacky Tcl at its finest, but I couldn't resist...
     foreach size $::dialog_font::sizes {
         radiobutton .font.fontsize.radio$size -value $size -text $size \
-            -variable ::dialog_font::fontsize \
             -command [format {::dialog_font::radio_apply \
                 $::dialog_font::canvaswindow %s} $size]
         pack .font.fontsize.radio$size -side top -anchor w


### PR DESCRIPTION
closes #1511

send the "dirty" message to the canvas from tcl in "apply" procs, instead of checking in canvas_font