### PR TITLE
BSD build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,11 @@ lib*.a
 *.la
 
 # externals
-*.pd_linux
-*.pd_darwin
+*.pd_*
 *.d_fat
 *.d_fat_o
 *.dll
+*.so
 
 # windows build artifacts
 src/*.com

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -141,7 +141,7 @@ double check which architectures Pd was built with, use the "file" command:
     ...
     Pd-0.47.1.app/Contents/Resources/bin/pd: Mach-O 64-bit executable x86_64
 
-### Linux & BSD
+### Linux
 
 Platform requirements:
 
@@ -413,6 +413,111 @@ If all went well, you should now be ready to build Pd, as explained in the
 instructions above in the "Windows" section:
 
     make app
+
+### BSD
+
+Building Pd for the various BSD variants is similar to the Linux way.
+The major difference is the used package manager (and the names of the packages),
+you'll want to install.
+
+### FreeBSD
+
+(Tested on FreeBSD-13)
+
+Install the core build requirements:
+
+    sudo pkg install gcc automake autoconf libtool gettext gmake
+
+You may install one (or more) libraries (depending on your needs).
+It seems that with FreeBSD-13, there are ALSA and JACK packages available:
+
+    sudo pkg install alsa-lib jackit
+
+Once your build system is set up, you can follow the general autotools build
+steps to build Pd, but make sure to use `gmake` (aka "GNU make").
+The ordinary BSD `make` will not suffice!
+
+    ./autogen.sh
+    ./configure --deken-os=FreeBSD MAKE=gmake
+    gmake
+
+    sudo gmake install
+
+### OpenBSD
+
+(Tested on OpenBSD-7)
+
+Install the core build requirements:
+
+    sudo pkg_add gcc automake autoconf libtool gettext-tools gmake
+
+(If there are multiple versions for one or more of the packages, pick your favourite or the newest one).
+
+
+You may install one (or more) libraries (depending on your needs).
+It seems that with OpenBSD-7, there are only JACK packages available:
+
+    sudo pkg_add jack
+
+By default, OpenBSD installs all its packages into `/usr/local/`,
+but the compiler does not look for headers resp. libraries in this directory.
+We can instruct autotools to automatically consider these directories
+by creating a file '/usr/local/share/config.site':
+
+    cat | sudo tee /usr/local/share/config.site>/dev/null << EOF
+    CPPFLAGS="-I/usr/local/include \$CPPFLAGS"
+    LDFLAGS="-L/usr/local/lib \$LDFLAGS"
+    EOF
+
+Also, because OpenBSD allows to coinstall multiple versions of the autotools (with no "default"),
+we must specify which version we want to use:
+
+   export AUTOCONF_VERSION=$(ls -S /usr/local/bin/autoconf-* | sed -e 's|.*-||' | sort -n | tail -1)
+   export AUTOMAKE_VERSION=$(ls -S /usr/local/bin/automake-* | sed -e 's|.*-||' | sort -n | tail -1)
+
+Now that your build system is set up, you can follow the general autotools build
+steps to build Pd, but make sure to use `gmake` (aka "GNU make").
+The ordinary BSD `make` will not suffice!
+
+    ./autogen.sh
+    ./configure --deken-os=OpenBSD --enable-jack MAKE=gmake
+    gmake
+
+    sudo gmake install
+
+### NetBSD
+
+(Tested on NetBSD-9)
+
+Install the core build requirements:
+
+    sudo pkgin install gcc automake autoconf libtool gettext-tools gmake
+
+You may install one (or more) libraries (depending on your needs).
+It seems that with NetBSD-9, there are JACK and ALSA packages available,
+but the ALSA packages seem to be broken. OSS appears to be built-in.
+
+    sudo pkgin install jack
+
+By default, NetBSD installs all its packages into `/usr/pkg/`,
+but the compiler does not look for headers resp. libraries in this directory.
+We can instruct autotools to automatically consider these directories
+by creating a file '/usr/pkg/share/config.site':
+
+    cat | sudo tee /usr/pkg/share/config.site>/dev/null << EOF
+    CPPFLAGS="-I/usr/pkg/include \$CPPFLAGS"
+    LDFLAGS="-L/usr/pkg/lib -Wl,-R/usr/pkg/lib \$LDFLAGS"
+    EOF
+
+Now that your build system is set up, you can follow the general autotools build
+steps to build Pd, but make sure to use `gmake` (aka "GNU make").
+The ordinary BSD `make` will not suffice!
+
+    ./autogen.sh
+    ./configure --deken-os=NetBSD --prefix=/usr/pkg --disable-alsa --enable-jack MAKE=gmake
+    gmake
+
+    sudo gmake install
 
 ## Makefile Build
 

--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,6 @@ AC_CHECK_HEADERS([fcntl.h \
                   sys/ioctl.h \
                   sys/param.h \
                   sys/socket.h \
-                  sys/soundcard.h \
                   sys/time.h \
                   sys/timeb.h \
                   unistd.h
@@ -313,6 +312,7 @@ AC_SUBST(EXTERNTARGET)
 AC_SUBST(EXTERNAL_EXTENSION)
 AC_SUBST(EXTERNAL_CFLAGS)
 AC_SUBST(EXTERNAL_LDFLAGS)
+AC_SUBST([OSS_LIBS])
 AC_SUBST([ALSA_LIBS])
 AC_SUBST([JACK_LIBS])
 
@@ -386,7 +386,9 @@ AC_ARG_ENABLE([oss],
     [AS_HELP_STRING([--disable-oss], [do not use OSS driver])],
     [oss=$enableval], [oss=yes])
 AS_IF([test x$oss = xyes],[
-    AC_CHECK_HEADER([sys/soundcard.h], [oss=yes], [oss=no])
+    oss=no
+    AC_CHECK_HEADERS([sys/soundcard.h soundcard.h], [oss=yes; break])
+    AC_CHECK_LIB([ossaudio], [_oss_ioctl], [OSS_LIBS="-lossaudio"])
 ])
 
 ##### ALSA #####

--- a/configure.ac
+++ b/configure.ac
@@ -251,7 +251,10 @@ AC_CHECK_FUNCS([dup2 \
                 ])
 
 # Checks for libraries.
-AC_CHECK_LIB([dl], [dlopen])
+have_dl=yes
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [have_dl=no])
+AS_IF([test "x${have_dl}" = "xyes"], AC_DEFINE([HAVE_DLOPEN], 1))
+
 AC_CHECK_LIBM
 # AC_CHECK_LIBM computes LIBM but does not add to LIBS, hence we add it in
 # src/Makefile.am under pd_LDFLAGS as well

--- a/configure.ac
+++ b/configure.ac
@@ -260,13 +260,10 @@ AC_CHECK_LIBM
 # not used directly, implicitly needed when using PortAudio on OSX
 AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [coreaudio=yes], [coreaudio=no])
 
-# Checking for `pthread_create' function in -pthread (MinGW uses unusual names)
+# Checking for `pthread_create' function in libpthread (MinGW uses unusual names)
 ## CHECK whether this can be replaced by AX_PTHREAD
-AC_CHECK_LIB([pthread], [pthread_create],LIBS="-lpthread $LIBS",
-    AC_CHECK_LIB([pthreadGC2], [pthread_create], LIBS="-lpthreadGC2 $LIBS",
-        AC_CHECK_LIB([pthreadGC1], [pthread_create], LIBS="-lpthreadGC1 $LIBS",
-            AC_CHECK_LIB([pthreadGC], [pthread_create], LIBS="-lpthreadGC $LIBS",
-         AC_MSG_WARN([pthreads required])))))
+AC_SEARCH_LIBS([pthread_create], [pthread pthreadGC2 pthreadGC1 pthreadGC], [],
+               AC_MSG_WARN([pthreads required]))
 
 # Define variables for use in Makefiles
 AC_SUBST(EXTERNTARGET)

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,7 @@ AS_CASE([$host],
         LINUX=yes
         platform=Linux
         portaudio=yes
+        watchdog=yes
         EXTERNAL_CFLAGS="-fPIC"
         EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
         EXTERNAL_EXTENSION=pd_linux
@@ -116,6 +117,7 @@ AS_CASE([$host],
 ],[*-*-gnu*],[
     HURD=yes
     platform=Hurd
+    watchdog=yes
     EXTERNAL_CFLAGS="-fPIC"
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
     EXTERNAL_EXTENSION=pd_linux
@@ -333,6 +335,14 @@ AS_IF([test "x$macos_version_min" != "x"],[
 
 #########################################
 ##### Configure Options #####
+
+
+##### realtime watchdog #####
+AC_ARG_ENABLE([watchdog],
+    [AS_HELP_STRING([--enable-watchdog], [additionally build watchdog])],,enable_watchdog="$watchdog")
+AS_IF([test "x$enable_watchdog" != "xyes"],[enable_watchdog=no])
+AM_CONDITIONAL(PD_WATCHDOG, test x$enable_watchdog = xyes)
+
 
 ##### libpd #####
 AC_ARG_ENABLE([libpd],
@@ -705,6 +715,7 @@ AC_MSG_NOTICE([
 
     fftw:                 $fftw
     wish(tcl/tk):         $wish
+    watchdog:             $enable_watchdog
     audio APIs:           $audio_backends
     midi APIs:            $midi_backends
     libpd:                $libpd

--- a/configure.ac
+++ b/configure.ac
@@ -298,10 +298,6 @@ AC_CHECK_LIBM
 # AC_CHECK_LIBM computes LIBM but does not add to LIBS, hence we add it in
 # src/Makefile.am under pd_LDFLAGS as well
 
-# Apple's CoreAudio
-# not used directly, implicitly needed when using PortAudio on OSX
-AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [coreaudio=yes], [coreaudio=no])
-
 # Checking for `pthread_create' function in libpthread (MinGW uses unusual names)
 ## CHECK whether this can be replaced by AX_PTHREAD
 AC_SEARCH_LIBS([pthread_create], [pthread pthreadGC2 pthreadGC1 pthreadGC], [],
@@ -441,6 +437,10 @@ AS_IF([test x$asio = xyes],
     AS_IF([test x$asio = xno],
         AC_MSG_WARN([ASIO SDK not found... skipping (See asio/README.txt)]))
 )
+
+##### Apple's CoreAudio #####
+# not used directly, implicitly needed when using PortAudio on OSX
+AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [coreaudio=yes], [coreaudio=no])
 
 ##### PortAudio #####
 AC_ARG_ENABLE([portaudio],

--- a/configure.ac
+++ b/configure.ac
@@ -157,15 +157,12 @@ AS_CASE([$host],
     EXTERNAL_CFLAGS=
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic"
     EXTERNAL_EXTENSION=dll
-],[*openbsd*],[
-    OPENBSD=yes
-    platform=OpenBSD
-    portaudio=yes
-    EXTERNAL_CFLAGS="-D__OPENBSD__"
-    EXTERNAL_LDFLAGS="-liberty"
-    EXTERNAL_EXTENSION=pd_openbsd
+],[*bsd*],[
+    BSD=yes
+    EXTERNAL_EXTENSION=so
 ],[
     platform=Unknown
+    EXTERNAL_EXTENSION=so
 ])
 
 AM_CONDITIONAL(ANDROID, test x$ANDROID = xyes)
@@ -176,7 +173,7 @@ AM_CONDITIONAL(MACOSX, test x$MACOSX = xyes)
 AM_CONDITIONAL(WINDOWS, test x$WINDOWS = xyes)
 AM_CONDITIONAL(CYGWIN, test x$CYGWIN = xyes)
 AM_CONDITIONAL(MINGW, test x$MINGW = xyes)
-AM_CONDITIONAL(OPENBSD, test x$OPENBSD = xyes)
+AM_CONDITIONAL(BSD, test x$BSD = xyes)
 
 #########################################
 ##### Check for programs, libs, & headers #####

--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,9 @@ AC_CHECK_HEADERS([fcntl.h \
                   unistd.h
                   ])
 
+AC_CHECK_HEADERS([endian.h machine/endian.h])
+
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T

--- a/configure.ac
+++ b/configure.ac
@@ -516,6 +516,17 @@ AS_IF([test "x${WISH}" = "xyes" -o "x${WISH}" = "xno"],
     WISH=""])
 AC_SUBST([WISH])
 
+AC_ARG_WITH([external-extension],
+    [AS_HELP_STRING([--with-external-extension=<EXT>],
+        [Extension to use for externals in extra/ (e.g. pd_linux, dll, d_fat,...)])],
+    [ext="${withval#.}"])
+AS_IF([test "x${ext}" = "xyes" -o "x${ext}" = "xno"],
+    [AC_MSG_NOTICE([--with-external-extension requires an extension, ignoring '${ext}'])
+    ext=""])
+AS_IF([test "x${ext}" != "x"], [EXTERNAL_EXTENSION="${ext}"])
+
+
+
 ##### Configure Build From Options #####
 ## configure the build based on what we have found above
 

--- a/configure.ac
+++ b/configure.ac
@@ -516,6 +516,28 @@ AS_IF([test "x${WISH}" = "xyes" -o "x${WISH}" = "xno"],
     WISH=""])
 AC_SUBST([WISH])
 
+##### Deken OS and CPU #####
+deken_id=""
+AC_ARG_WITH([deken-os],
+    [AS_HELP_STRING([--with-deken-os=<OS>],
+        [Operating System string to use for externals (e.g. Linux, Windows, Darwin,...)])],
+    [DEKEN_OS=$withval])
+AS_IF([test "x${DEKEN_OS}" = "xyes" -o "x${DEKEN_OS}" = "xno"],
+    [AC_MSG_NOTICE([--with-deken-os requires an Operating System, ignoring '${DEKEN_OS}'])
+    DEKEN_OS=""])
+AC_SUBST([DEKEN_OS])
+AS_IF([test "x${DEKEN_OS}" = "x"], [deken_id="???"], [deken_id="${DEKEN_OS}"])
+
+AC_ARG_WITH([deken-cpu],
+    [AS_HELP_STRING([--with-deken-cpu=<CPU>],
+        [CPU architecture string to use for externals (e.g. amd64, i386, arm64,...)])],
+    [DEKEN_CPU=$withval])
+AS_IF([test "x${DEKEN_CPU}" = "xyes" -o "x${DEKEN_CPU}" = "xno"],
+    [AC_MSG_NOTICE([--with-deken-cpu requires a CPU, ignoring '${DEKEN_CPU}'])
+    DEKEN_CPU=""])
+AC_SUBST([DEKEN_CPU])
+AS_IF([test "x${DEKEN_CPU}" = "x"], [deken_id="${deken_id}-???"], [deken_id="${deken_id}-${DEKEN_CPU}"])
+
 AC_ARG_WITH([external-extension],
     [AS_HELP_STRING([--with-external-extension=<EXT>],
         [Extension to use for externals in extra/ (e.g. pd_linux, dll, d_fat,...)])],
@@ -679,6 +701,7 @@ AC_MSG_NOTICE([
     External extension:   $EXTERNAL_EXTENSION
     External CFLAGS:      $EXTERNAL_CFLAGS
     External LDFLAGS:     $EXTERNAL_LDFLAGS
+    Deken identifier:     ${deken_id}
 
     fftw:                 $fftw
     wish(tcl/tk):         $wish

--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,46 @@ AC_CHECK_FUNCS([dup2 \
                 strtol
                 ])
 
+dnl qsort_r: do we have it, and if so, which variant?
+AC_CHECK_FUNCS_ONCE([qsort_r], [], [AC_DEFINE([STUPID_SORT], 1)])
+if test $ac_cv_func_qsort_r = yes; then
+  AC_CACHE_CHECK([for qsort_r signature], [ac_cv_libctf_qsort_r_signature],
+    [AC_LINK_IFELSE(
+       [AC_LANG_PROGRAM([[#undef qsort_r
+                          #include <stdlib.h>
+                          void qsort_r (void *, size_t, size_t,
+                                        int (*) (void const *, void const *,
+                                                 void *),
+                                        void *);
+                          void (*p) (void *, size_t, size_t,
+                                     int (*) (void const *, void const *,
+                                              void *),
+                                     void *) = qsort_r;
+                        ]])],
+       [ac_cv_libctf_qsort_r_signature=GNU],
+       [AC_LINK_IFELSE(
+          [AC_LANG_PROGRAM([[#undef qsort_r
+	                     #include <stdlib.h>
+                             void qsort_r (void *, size_t, size_t, void *,
+                                           int (*) (void *,
+                                                    void const *,
+                                                    void const *));
+                             void (*p) (void *, size_t, size_t, void *,
+                                        int (*) (void *, void const *,
+                                                 void const *)) = qsort_r;
+                           ]])],
+          [ac_cv_libctf_qsort_r_signature=BSD],
+          [ac_cv_libctf_qsort_r_signature=unknown])])])
+fi
+
+case x$ac_cv_libctf_qsort_r_signature in
+  xGNU)     AC_DEFINE([HAVE_QSORT_R_ARG_LAST], 1,
+	     [Whether a qsort_r exists with a void *arg as its last arg.]);;
+  xBSD)     AC_DEFINE([HAVE_QSORT_R_COMPAR_LAST], 1,
+	     [Whether a qsort_r exists with the compar function as its last arg.]);;
+  *)        AC_DEFINE([STUPID_SORT], 1);;
+esac
+
 # Checks for libraries.
 have_dl=yes
 AC_SEARCH_LIBS([dlopen], [dl dld], [], [have_dl=no])

--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -25,6 +25,10 @@ pd__la_LIBADD = $(LIBM)
 AM_LDFLAGS = -module -avoid-version -shared @EXTERNAL_LDFLAGS@ \
     -shrext .@EXTERNAL_EXTENSION@ -L$(top_builddir)/src @PD_LDFLAGS@
 
+if PD_WATCHDOG
+AM_CPPFLAGS += -DPD_WATCHDOG=1
+endif
+
 externaldir = $(pkglibdir)/extra/$(NAME)
 
 #########################################

--- a/extra/pd~/makefile
+++ b/extra/pd~/makefile
@@ -10,7 +10,7 @@ d_fat: pdsched.d_fat
 d_ppc: pdsched.d_ppc
 
 pdsched.pd_linux: pdsched.c
-	$(CC) $(LINUXCFLAGS) $(LINUXINCLUDE) -o $*.o -c $*.c
+	$(CC) -DPD_WATCHDOG=1 $(LINUXCFLAGS) $(LINUXINCLUDE) -o $*.o -c $*.c
 	$(CC) -shared -o $*.pd_linux $*.o -lc -lm
 	rm -f $*.o
 

--- a/extra/pd~/pdsched.c
+++ b/extra/pd~/pdsched.c
@@ -21,8 +21,7 @@ outputs audio and messages. */
 
 #include "binarymsg.c"
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)\
-     || defined(__GNU__)
+#if PD_WATCHDOG
 void glob_watchdog(t_pd *dummy);
 
 static void pollwatchdog( void)
@@ -38,7 +37,12 @@ static void pollwatchdog( void)
             2 * (int)(STUFF->st_dacsr /(double)STUFF->st_schedblocksize);
     }
 }
-#endif
+#else /* ! PD_WATCHDOG */
+static void pollwatchdog( void)
+{
+    /* dummy */
+}
+#endif /* PD_WATCHDOG */
 
 static t_class *pd_ambinary_class;
 #define BUFSIZE 65536
@@ -132,10 +136,7 @@ int pd_extern_sched(char *flags)
                     *fp++ = 0;
             sched_tick();
             sys_pollgui();
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)\
-     || defined(__GNU__)
             pollwatchdog();
-#endif
             if (useascii)
                 printf(";\n");
             else putchar(A_SEMI);

--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -102,8 +102,7 @@ static t_class *pd_tilde_class;
 
 
 static const char *pd_tilde_dllextent[] = {
-#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
-    defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
     ARCHDLLEXT(".l_")
     ".pd_linux",
     ".so",
@@ -112,7 +111,7 @@ static const char *pd_tilde_dllextent[] = {
     ARCHDLLEXT(".d_")
     ".pd_darwin",
     ".so",
-#elif defined(__OPENBSD__)
+#elif defined(__OpenBSD__)
     ARCHDLLEXT(".o_")
     ".pd_openbsd",
     ".so",

--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -305,7 +305,7 @@ mkdir -p $DEST/bin
 cp -R $verbose $BUILD/src/pd          $DEST/bin/
 cp -R $verbose $BUILD/src/pdsend      $DEST/bin/
 cp -R $verbose $BUILD/src/pdreceive   $DEST/bin/
-cp -R $verbose $BUILD/src/pd-watchdog $DEST/bin/
+cp -R $verbose $BUILD/src/pd-watchdog $DEST/bin/ || true
 
 # install resources
 mkdir -p $DEST/po

--- a/portaudio/Makefile.am
+++ b/portaudio/Makefile.am
@@ -28,20 +28,31 @@ libportaudio_a_SOURCES = \
     portaudio/src/common/pa_stream.c \
     portaudio/src/common/pa_trace.c
 
-if LINUX
+if WINDOWS
+AM_CPPFLAGS += -I$(top_srcdir)/portaudio/portaudio/src/os/win
+libportaudio_a_SOURCES += \
+    portaudio/src/os/win/pa_win_coinitialize.c \
+    portaudio/src/os/win/pa_win_hostapis.c \
+    portaudio/src/os/win/pa_win_util.c \
+    portaudio/src/os/win/pa_win_waveformat.c \
+    $(empty)
+else !WINDOWS
 AM_CPPFLAGS += -I$(top_srcdir)/portaudio/portaudio/src/os/unix
 libportaudio_a_SOURCES += \
     portaudio/src/os/unix/pa_unix_hostapis.c \
     portaudio/src/os/unix/pa_unix_util.c \
+    $(empty)
+endif !WINDOWS
+
+
+if LINUX
+libportaudio_a_SOURCES += \
     portaudio/src/hostapi/alsa/pa_linux_alsa.c
 endif
 
 if MACOSX
 AM_CFLAGS += -DPA_USE_COREAUDIO
-AM_CPPFLAGS += -I$(top_srcdir)/portaudio/portaudio/src/os/unix
 libportaudio_a_SOURCES += \
-    portaudio/src/os/unix/pa_unix_hostapis.c \
-    portaudio/src/os/unix/pa_unix_util.c \
     portaudio/src/hostapi/coreaudio/pa_mac_core.c \
     portaudio/src/hostapi/coreaudio/pa_mac_core_blocking.c \
     portaudio/src/hostapi/coreaudio/pa_mac_core_utilities.c
@@ -52,12 +63,7 @@ endif
 
 if WINDOWS
 AM_CFLAGS += -DPA_USE_WMME
-AM_CPPFLAGS += -I$(top_srcdir)/portaudio/portaudio/src/os/win
 libportaudio_a_SOURCES += \
-    portaudio/src/os/win/pa_win_coinitialize.c \
-    portaudio/src/os/win/pa_win_hostapis.c \
-    portaudio/src/os/win/pa_win_util.c \
-    portaudio/src/os/win/pa_win_waveformat.c \
     portaudio/src/hostapi/wmme/pa_win_wmme.c
 if ASIO
 AM_CFLAGS += -DPA_USE_ASIO

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,15 +347,10 @@ if HURD
 # install watchdog to $(libdir)/pd/bin as it's not a user facing program
 libpdbin_PROGRAMS = pd-watchdog
 
-# force linking to pthread, which should really be done with some autotools way
-pd_LDFLAGS_core += -lpthread
-libpd_la_LIBADD += -lpthread
-
 # force linking to dl, which should really be done with some autotools way
 pd_LDFLAGS_core += -ldl
 libpd_la_LIBADD += -ldl
 endif
-
 ##### GNU/Linux #####
 if LINUX
 
@@ -380,8 +375,8 @@ libpdbin_PROGRAMS = pd-watchdog
 pd_CFLAGS += -DMACOSX
 
 # for dynamic loading & threading
-LIBS += -ldl -lpthread -framework CoreFoundation
-libpd_la_LIBADD += -ldl -lpthread
+LIBS += -ldl -framework CoreFoundation
+libpd_la_LIBADD += -ldl
 libpd_la_LDFLAGS += -framework CoreFoundation
 
 # PERTHREAD requires macOS 10.9+ SDK

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,9 +347,6 @@ if HURD
 # install watchdog to $(libdir)/pd/bin as it's not a user facing program
 libpdbin_PROGRAMS = pd-watchdog
 
-# force linking to dl, which should really be done with some autotools way
-pd_LDFLAGS_core += -ldl
-libpd_la_LIBADD += -ldl
 endif
 ##### GNU/Linux #####
 if LINUX
@@ -375,8 +372,7 @@ libpdbin_PROGRAMS = pd-watchdog
 pd_CFLAGS += -DMACOSX
 
 # for dynamic loading & threading
-LIBS += -ldl -framework CoreFoundation
-libpd_la_LIBADD += -ldl
+LIBS += -framework CoreFoundation
 libpd_la_LDFLAGS += -framework CoreFoundation
 
 # PERTHREAD requires macOS 10.9+ SDK

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,10 @@ LIBS = @LIBS@
 
 SUFFIXES = .@EXTENSION@ .@SHARED_LIB@
 
+
+pd_LDADD_core += $(LIBM)
+libpd_la_LIBADD += $(LIBM)
+
 #########################################
 ##### Files, Binaries, & Libs #####
 
@@ -347,10 +351,6 @@ libpdbin_PROGRAMS = pd-watchdog
 # --export-dynamic, and libtool sends -Wl,--export-dynamic to ld...
 pd_LDFLAGS_core += -export-dynamic
 
-# on Ubuntu/Karmic 9.10, it doesn't seem to find libm, so force it
-pd_LDFLAGS_core += $(LIBM)
-libpd_la_LIBADD += $(LIBM)
-
 # force linking to pthread, which should really be done with some autotools way
 pd_LDFLAGS_core += -lpthread
 libpd_la_LIBADD += -lpthread
@@ -370,11 +370,6 @@ libpdbin_PROGRAMS = pd-watchdog
 # this flag has to have a single leading "-" for libtool, even though ld uses
 # --export-dynamic, and libtool sends -Wl,--export-dynamic to ld...
 pd_LDFLAGS_core += -export-dynamic
-
-# on Ubuntu/Karmic 9.10, it doesn't seem to find libm, so force it
-pd_LDFLAGS_core += $(LIBM)
-libpd_la_LIBADD += $(LIBM)
-
 endif
 
 ##### Apple Mac OSX #####
@@ -388,8 +383,8 @@ libpdbin_PROGRAMS = pd-watchdog
 pd_CFLAGS += -DMACOSX
 
 # for dynamic loading & threading
-LIBS += -ldl -lm -lpthread -framework CoreFoundation
-libpd_la_LIBADD += -ldl -lm -lpthread
+LIBS += -ldl -lpthread -framework CoreFoundation
+libpd_la_LIBADD += -ldl -lpthread
 libpd_la_LDFLAGS += -framework CoreFoundation
 
 # PERTHREAD requires macOS 10.9+ SDK

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,8 @@ libpd_la_LDFLAGS = @PD_LDFLAGS@
 libpdincludedir = $(includedir)/libpd
 libpdinclude_HEADERS =
 
+libpdbin_PROGRAMS =
+
 # there are pd_* and pd_*_core variables as we need different flags on Windows
 # for the DLL and the EXE, other OSes simply set pd_* = $(pd_*_core) later
 # also, the "_core" suffix is used as this keeps automake from thinking these
@@ -51,6 +53,12 @@ bin_PROGRAMS = pd pdsend pdreceive
 
 if LIBPD
 lib_LTLIBRARIES = libpd.la
+endif
+
+if PD_WATCHDOG
+# install watchdog to $(libdir)/pd/bin as it's not a user facing program
+libpdbin_PROGRAMS += pd-watchdog
+pd_CFLAGS += -DPD_WATCHDOG=1
 endif
 
 pdsend_SOURCES = u_pdsend.c s_net.c
@@ -350,20 +358,6 @@ endif
 #########################################
 ##### Configurations Per Platform #####
 
-##### GNU/Hurd #####
-if HURD
-
-# install watchdog to $(libdir)/pd/bin as it's not a user facing program
-libpdbin_PROGRAMS = pd-watchdog
-
-endif
-##### GNU/Linux #####
-if LINUX
-
-# install watchdog to $(libdir)/pd/bin as it's not a user facing program
-libpdbin_PROGRAMS = pd-watchdog
-endif
-
 if !WINDOWS
 # this flag has to have a single leading "-" for libtool, even though ld uses
 # --export-dynamic, and libtool sends -Wl,--export-dynamic to ld...
@@ -372,9 +366,6 @@ endif
 
 ##### Apple Mac OSX #####
 if MACOSX
-
-# install watchdog to $(libdir)/pd/bin as it's not a user facing program
-libpdbin_PROGRAMS = pd-watchdog
 
 # kludge, should use auto macro __APPLE__
 # but who knows what externals rely on this

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,10 +347,6 @@ if HURD
 # install watchdog to $(libdir)/pd/bin as it's not a user facing program
 libpdbin_PROGRAMS = pd-watchdog
 
-# this flag has to have a single leading "-" for libtool, even though ld uses
-# --export-dynamic, and libtool sends -Wl,--export-dynamic to ld...
-pd_LDFLAGS_core += -export-dynamic
-
 # force linking to pthread, which should really be done with some autotools way
 pd_LDFLAGS_core += -lpthread
 libpd_la_LIBADD += -lpthread
@@ -358,7 +354,6 @@ libpd_la_LIBADD += -lpthread
 # force linking to dl, which should really be done with some autotools way
 pd_LDFLAGS_core += -ldl
 libpd_la_LIBADD += -ldl
-
 endif
 
 ##### GNU/Linux #####
@@ -366,7 +361,9 @@ if LINUX
 
 # install watchdog to $(libdir)/pd/bin as it's not a user facing program
 libpdbin_PROGRAMS = pd-watchdog
+endif
 
+if !WINDOWS
 # this flag has to have a single leading "-" for libtool, even though ld uses
 # --export-dynamic, and libtool sends -Wl,--export-dynamic to ld...
 pd_LDFLAGS_core += -export-dynamic

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -203,7 +203,7 @@ pkginclude_HEADERS = m_pd.h m_imp.h g_canvas.h g_undo.h g_all_guis.h s_stuff.h \
 
 # compatibility: m_pd.h also goes into ${includedir}/
 include_HEADERS = m_pd.h
-noinst_HEADERS = s_audio_alsa.h s_audio_paring.h s_utf8.h
+noinst_HEADERS = s_audio_alsa.h s_audio_paring.h s_utf8.h m_private_utils.h
 noinst_HEADERS += z_hooks.h z_ringbuffer.h x_libpdreceive.h
 
 if LIBPD

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -252,6 +252,7 @@ endif
 if OSS
 pd_CFLAGS += -DUSEAPI_OSS
 pd_SOURCES_standalone += s_audio_oss.c s_midi_oss.c
+pd_LDADD_standalone += @OSS_LIBS@
 endif
 
 ##### Windows MultiMedia (File) I/O #####

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -215,6 +215,14 @@ WISH=@WISH@
 WISHDEFINE=$(if $(WISH),-DWISH='"$(WISH)"')
 pd_CFLAGS += $(WISHDEFINE)
 
+# deken specifiers (if set)
+DEKEN_OS=@DEKEN_OS@
+DEKEN_CPU=@DEKEN_CPU@
+DEKEN_DEFINE=
+DEKEN_DEFINE+=$(if $(DEKEN_OS),-DDEKEN_OS='"$(DEKEN_OS)"')
+DEKEN_DEFINE+=$(if $(DEKEN_CPU),-DDEKEN_CPU='"$(DEKEN_CPU)"')
+pd_CFLAGS += $(DEKEN_DEFINE)
+
 #########################################
 ##### Configurations Per Library #####
 

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -499,25 +499,7 @@ static void tabread4_tilde_setup(void)
 /* this is all copied from d_osc.c... what include file could this go in? */
 #define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
 
-#ifdef HAVE_MACHINE_ENDIAN_H
-# include <machine/endian.h>
-#elif defined HAVE_ENDIAN_H
-# include <endian.h>
-#endif
-
-#ifdef __MINGW32__
-#include <sys/param.h>
-#endif
-
-#ifdef _MSC_VER
-/* _MSVC lacks BYTE_ORDER and LITTLE_ENDIAN */
-#define LITTLE_ENDIAN 0x0001
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
-
-#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
-# error unable to detect endianness
-#endif
+#include "m_private_utils.h"
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 # define HIOFFSET 1

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -499,14 +499,10 @@ static void tabread4_tilde_setup(void)
 /* this is all copied from d_osc.c... what include file could this go in? */
 #define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
-    || defined(__OpenBSD__)
-#include <machine/endian.h>
-#endif
-
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || \
-    defined(ANDROID)
-#include <endian.h>
+#ifdef HAVE_MACHINE_ENDIAN_H
+# include <machine/endian.h>
+#elif defined HAVE_ENDIAN_H
+# include <endian.h>
 #endif
 
 #ifdef __MINGW32__
@@ -520,7 +516,7 @@ static void tabread4_tilde_setup(void)
 #endif
 
 #if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
-#include <endian.h>
+# error unable to detect endianness
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN

--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -22,10 +22,10 @@ for another, more permissive-sounding copyright notice.  -MSP
 #include "m_pd.h"
 #include "m_imp.h"
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif

--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -22,13 +22,7 @@ for another, more permissive-sounding copyright notice.  -MSP
 #include "m_pd.h"
 #include "m_imp.h"
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
+#include "m_private_utils.h"
 
 #define FFTFLT double
 void cdft(int, int, FFTFLT *, int *, FFTFLT *);

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -11,15 +11,10 @@
 #define BIGFLOAT 1.0e+19
 #define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
 
-
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
-    || defined(__OpenBSD__)
-#include <machine/endian.h>
-#endif
-
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || \
-    defined(ANDROID)
-#include <endian.h>
+#ifdef HAVE_MACHINE_ENDIAN_H
+# include <machine/endian.h>
+#elif defined HAVE_ENDIAN_H
+# include <endian.h>
 #endif
 
 #ifdef __MINGW32__
@@ -33,7 +28,7 @@
 #endif
 
 #if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
-#include <endian.h>
+# error unable to detect endianness
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -11,25 +11,7 @@
 #define BIGFLOAT 1.0e+19
 #define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
 
-#ifdef HAVE_MACHINE_ENDIAN_H
-# include <machine/endian.h>
-#elif defined HAVE_ENDIAN_H
-# include <endian.h>
-#endif
-
-#ifdef __MINGW32__
-#include <sys/param.h>
-#endif
-
-#ifdef _MSC_VER
-/* _MSVC lacks BYTE_ORDER and LITTLE_ENDIAN */
-#define LITTLE_ENDIAN 0x0001
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
-
-#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
-# error unable to detect endianness
-#endif
+#include "m_private_utils.h"
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 # define HIOFFSET 1

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -17,9 +17,7 @@
 #include "g_all_guis.h"
 #include <math.h>
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 #ifdef _WIN32
 #include <io.h>

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -21,9 +21,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef _MSC_VER
-# define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 /* --------------- bng     gui-bang ------------------------- */
 

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -19,9 +19,7 @@ to be different but are now unified except for some fossilized names.) */
 #ifdef _WIN32
 #include <io.h>
 #endif
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
     /* LATER consider adding font size to this struct (see glist_getfont()) */
 struct _canvasenvironment

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -5,20 +5,8 @@
 
 /* ---------- clone - maintain copies of a patch ----------------- */
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
-
+#include "m_private_utils.h"
 #define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
-
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < LIST_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 
 t_class *clone_class;
 static t_class *clone_in_class, *clone_out_class;
@@ -153,13 +141,13 @@ static void clone_out_anything(t_out *x, t_symbol *s, int argc, t_atom *argv)
     int first =
         1 + (s != &s_list && s != &s_float && s != &s_symbol && s != &s_bang),
             outc = argc + first;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     SETFLOAT(outv, x->o_n);
     if (first == 2)
         SETSYMBOL(outv + 1, s);
     memcpy(outv+first, argv, sizeof(t_atom) * argc);
     outlet_list(x->o_outlet, 0, outc, outv);
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static PERTHREAD int clone_voicetovis = -1;

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -5,13 +5,14 @@
 
 /* ---------- clone - maintain copies of a patch ----------------- */
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif
+
 #define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
 
 #define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < LIST_NGETBYTE ?  \

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -11,9 +11,7 @@
 #include "g_undo.h"
 #include "s_utf8.h" /*-- moo --*/
 #include <string.h>
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 struct _instanceeditor
 {

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -588,28 +588,25 @@ done:
 #define SMALLMSG 5
 #define HUGEMSG 1000
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
-#define HAVE_ALLOCA 1
-#endif
-
-#ifdef HAVE_ALLOCA
-
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif
+
+#ifndef DONT_USE_ALLOCA
 
 #define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < HUGEMSG ?  \
         alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
 #define ATOMS_FREEA(x, n) ( \
     ((n) < HUGEMSG || (freebytes((x), (n) * sizeof(t_atom)), 0)))
-#else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
-#define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
-#endif
+
+#else /* ! DONT_USE_ALLOCA */
+# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+# define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
+#endif /* ! DONT_USE_ALLOCA */
 
 void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
 {

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -19,9 +19,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 static t_symbol *class_loadsym;     /* name under which an extern is invoked */
 static void pd_defaultfloat(t_pd *x, t_float f);

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -199,10 +199,8 @@ void glob_init(void)
          gensym("fast-forward"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_settracing,
          gensym("set-tracing"), A_FLOAT, 0);
-#if defined(__linux__) || defined(__FreeBSD_kernel__)
     class_addmethod(glob_pdobject, (t_method)glob_watchdog,
         gensym("watchdog"), 0);
-#endif
     class_addanything(glob_pdobject, max_default);
     pd_bind(&glob_pdobject, gensym("pd"));
 }

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -10,21 +10,7 @@ behavior for "gobjs" appears at the end of this file.  */
 #include "m_imp.h"
 #include <string.h>
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
-
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 union inletunion
 {

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -10,11 +10,14 @@ behavior for "gobjs" appears at the end of this file.  */
 #include "m_imp.h"
 #include <string.h>
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#else
+# include <stdlib.h> /* BSDs for example */
 #endif
+
 #ifdef _MSC_VER
 #define snprintf _snprintf
 #endif

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -1,0 +1,118 @@
+/* Copyright (c) 1997-1999 Miller Puckette and others.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* This file contains some small header-only utilities to be used by Pd's code. */
+
+/* NOTE: this file is an implementation detail of Pd, not to be in externals */
+
+#ifndef M_PRIVATE_UTILS_H
+#define M_PRIVATE_UTILS_H
+
+#ifndef PD_INTERNAL
+# error m_private_utils.h is a PRIVATE header. do *not* use it in your externals
+#endif
+
+#ifdef HAVE_CONFIG_H
+/* autotools might put all the HAVE_... defines into "config.h" */
+# include "config.h"
+#endif
+
+
+/* --------------------------- stack allocation helpers --------------------- */
+/* alloca helpers
+ * - ALLOCA(type, array, nmemb, maxnmemb)
+ *     allocates <nmemb> elements of <type> and points <array> to the newly
+ *     allocated memory. if <nmemb> exceeds <maxnmemb>, allocation is done on
+ *     the heap, otherwise on the stack
+ * - FREEA(type, array, nmemb, maxnmemb)
+ *     frees the <array> allocated by ALLOCA() (unless allocation was done on
+ *     the heap)
+ * if DONT_USE_ALLOCA is defined (and true), always allocates on the heap
+ *
+ * usage example:
+ * {
+ *   t_atom*outv;
+ *   ALLOCA(t_atom, outv, argc, 100);
+ *   // do something with 'outv'
+ *   FREEA(t_atom, outv, argc, 100);
+ * }
+ */
+# ifdef ALLOCA
+#  undef ALLOCA
+# endif
+# ifdef FREEA
+#  undef FREEA
+# endif
+
+#if DONT_USE_ALLOCA
+/* heap versions */
+# define ALLOCA(type, array, nmemb, maxnmemb) ((array) = (type *)getbytes((nmemb) * sizeof(type)))
+# define FREEA(type, array, nmemb, maxnmemb) (freebytes((array), (nmemb) * sizeof(type)))
+
+#else /* !DONT_USE_ALLOCA */
+/* stack version (unless <nmemb> exceeds <maxnmemb>) */
+
+# ifdef HAVE_ALLOCA_H
+#  include <alloca.h> /* linux, mac, mingw, cygwin,... */
+# elif defined _WIN32
+#  include <malloc.h> /* MSVC or mingw on windows */
+# else
+#  include <stdlib.h> /* BSDs for example */
+# endif
+
+# define ALLOCA(type, array, nmemb, maxnmemb) ((array) = (type *)((nmemb) < (maxnmemb) ? \
+            alloca((nmemb) * sizeof(type)) : getbytes((nmemb) * sizeof(type))))
+# define FREEA(type, array, nmemb, maxnmemb) (                          \
+        ((nmemb) < (maxnmemb) || (freebytes((array), (nmemb) * sizeof(type)), 0)))
+#endif /* !DONT_USE_ALLOCA */
+
+
+/* --------------------------- endianness helpers --------------------- */
+#ifdef HAVE_MACHINE_ENDIAN_H
+# include <machine/endian.h>
+#elif defined HAVE_ENDIAN_H
+# include <endian.h>
+#endif
+
+#ifdef __MINGW32__
+# include <sys/param.h>
+#endif
+
+/* BSD has deprecated BYTE_ORDER in favour of _BYTE_ORDER
+ * others might follow...
+ */
+#if !defined(BYTE_ORDER) && defined(_BYTE_ORDER)
+# define BYTE_ORDER _BYTE_ORDER
+#endif
+#if !defined(LITTLE_ENDIAN) && defined(_LITTLE_ENDIAN)
+# define LITTLE_ENDIAN _LITTLE_ENDIAN
+#endif
+
+#ifdef _MSC_VER
+/* _MSVC lacks BYTE_ORDER and LITTLE_ENDIAN */
+# if !defined(LITTLE_ENDIAN)
+#  define LITTLE_ENDIAN 0x0001
+# endif
+# if !defined(BYTE_ORDER)
+#  define BYTE_ORDER LITTLE_ENDIAN
+# endif
+#endif
+
+#if defined(__GNUC__) && defined(_XOPEN_SOURCE) && !defined(_DEFAULT_SOURCE)
+# warning _XOPEN_SOURCE might prevent endianess macros from being defined. Did you forget to also define _DEFAULT_SOURCE?
+#endif
+
+
+#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
+# error unable to detect endianness
+#endif
+
+
+/* -------------------------MSVC compat defines --------------------- */
+#ifdef _MSC_VER
+# define snprintf _snprintf
+#endif
+
+
+#endif /* M_PRIVATE_UTILS_H */

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -99,13 +99,12 @@
 # endif
 #endif
 
-#if defined(__GNUC__) && defined(_XOPEN_SOURCE) && !defined(_DEFAULT_SOURCE)
-# warning _XOPEN_SOURCE might prevent endianess macros from being defined. Did you forget to also define _DEFAULT_SOURCE?
-#endif
-
-
 #if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
-# error unable to detect endianness
+# if defined(__GNUC__) && defined(_XOPEN_SOURCE)
+#  warning unable to detect endianness (continuing anyhow)
+# else
+#  error unable to detect endianness
+# endif
 #endif
 
 

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -301,8 +301,6 @@ static int sched_idletask( void)
         rtn = 1;
     sys_unlock();
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)\
-                || defined(__GNU__)
         /* if there's no GUI but we're running in "realtime", here is
         where we arrange to ping the watchdog every 2 seconds.  (If there's
         a GUI, it initiates the ping instead to be sure there's communication
@@ -313,7 +311,6 @@ static int sched_idletask( void)
             /* ping every 2 seconds */
         sched_nextpingtime = sched_counter + 2 * APPROXTICKSPERSEC;
     }
-#endif
 
         /* clear the "DIO error" warning 1 sec after it flashes */
     if (sched_counter > sched_nextmeterpolltime)

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -57,6 +57,7 @@ CPPFLAGS = -DPD \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DHAVE_ALLOCA_H=1 \
     -DHAVE_ENDIAN_H=1 \
     -DHAVE_QSORT_R_ARG_LAST=1 \
+    -DPD_WATCHDOG=1 \
     -DPDGUIDIR=\"tcl/\" \
     -D_LARGEFILE64_SOURCE -DINSTALL_PREFIX=\"$(prefix)\" \
     -Wall -W -Wstrict-prototypes  -Wno-address\

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -56,6 +56,7 @@ libpdtcldir = $(libpddir)/tcl
 CPPFLAGS = -DPD \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DHAVE_ALLOCA_H=1 \
     -DHAVE_ENDIAN_H=1 \
+    -DHAVE_QSORT_R_ARG_LAST=1 \
     -DPDGUIDIR=\"tcl/\" \
     -D_LARGEFILE64_SOURCE -DINSTALL_PREFIX=\"$(prefix)\" \
     -Wall -W -Wstrict-prototypes  -Wno-address\

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -53,7 +53,7 @@ libpdtcldir = $(libpddir)/tcl
 # to allow easy overriding of CODECFLAGS and to allow adding MORECFLAGS:
 
 # C preprocessor flags, and flags controlling errors and warnings
-CPPFLAGS = -DPD \
+CPPFLAGS = -DPD -DPD_INTERNAL \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DHAVE_ALLOCA_H=1 \
     -DHAVE_ENDIAN_H=1 \
     -DHAVE_QSORT_R_ARG_LAST=1 \

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -53,7 +53,8 @@ libpdtcldir = $(libpddir)/tcl
 # to allow easy overriding of CODECFLAGS and to allow adding MORECFLAGS:
 
 # C preprocessor flags, and flags controlling errors and warnings
-CPPFLAGS = -DPD -DHAVE_LIBDL -DHAVE_UNISTD_H -DHAVE_ALLOCA_H \
+CPPFLAGS = -DPD \
+    -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DHAVE_ALLOCA_H=1 \
     -DPDGUIDIR=\"tcl/\" \
     -D_LARGEFILE64_SOURCE -DINSTALL_PREFIX=\"$(prefix)\" \
     -Wall -W -Wstrict-prototypes  -Wno-address\

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -55,6 +55,7 @@ libpdtcldir = $(libpddir)/tcl
 # C preprocessor flags, and flags controlling errors and warnings
 CPPFLAGS = -DPD \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DHAVE_ALLOCA_H=1 \
+    -DHAVE_ENDIAN_H=1 \
     -DPDGUIDIR=\"tcl/\" \
     -D_LARGEFILE64_SOURCE -DINSTALL_PREFIX=\"$(prefix)\" \
     -Wall -W -Wstrict-prototypes  -Wno-address\

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -34,6 +34,7 @@ PMDIR = ../portmidi/portmidi
 CPPFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
     -DHAVE_ALLOCA_H=1 \
+    -DHAVE_QSORT_R_COMPAR_LAST=1 \
     -DHAVE_MACHINE_ENDIAN_H=1 \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -32,7 +32,7 @@ PADIR = ../portaudio/portaudio
 PMDIR = ../portmidi/portmidi
 
 CPPFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" \
-    -DHAVE_LIBDL -DMACOSX -DHAVE_UNISTD_H -I/usr/X11R6/include \
+    -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \
     -I$(PMDIR)/pm_mac -I$(PMDIR)/porttime \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -33,6 +33,7 @@ PMDIR = ../portmidi/portmidi
 
 CPPFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
+    -DHAVE_ALLOCA_H=1 \
     -DHAVE_MACHINE_ENDIAN_H=1 \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -33,6 +33,7 @@ PMDIR = ../portmidi/portmidi
 
 CPPFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
+    -DHAVE_MACHINE_ENDIAN_H=1 \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \
     -I$(PMDIR)/pm_mac -I$(PMDIR)/porttime \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -31,7 +31,8 @@ libpdtcldir = $(libpddir)/tcl
 PADIR = ../portaudio/portaudio
 PMDIR = ../portmidi/portmidi
 
-CPPFLAGS = -DPD -DINSTALL_PREFIX=\"$(prefix)\" \
+CPPFLAGS = -DINSTALL_PREFIX=\"$(prefix)\" \
+    -DPD -DPD_INTERNAL \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
     -DHAVE_ALLOCA_H=1 \
     -DHAVE_QSORT_R_COMPAR_LAST=1 \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -67,8 +67,11 @@ WARN_CFLAGS = -Wall -W -Wstrict-prototypes -Wno-unused \
 # Also, for SetDllDirectory() s_loader.c, we need a minimum of Windows
 # XP SP1.  WINVER isn't fine-grained enough for that, so we use the
 # next minor version of Windows, 5.2.
-ARCH_CFLAGS = -DPD -DPD_INTERNAL -DPA_USE_ASIO -DPA_USE_WMME -DWINVER=0x0502 \
-     -DUSEAPI_MMIO -DUSEAPI_PORTAUDIO -mms-bitfields -DWISH='"wish85.exe"'
+ARCH_CFLAGS = -DPD -DPD_INTERNAL -DWINVER=0x0502 \
+     -DPA_USE_ASIO -DPA_USE_WMME \
+     -DUSEAPI_MMIO -DUSEAPI_PORTAUDIO \
+     -mms-bitfields \
+     -DWISH='"wish85.exe"'
 
 CFLAGS += $(ARCH_CFLAGS) $(WARN_CFLAGS) $(OPT_CFLAGS) $(MORECFLAGS)
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -24,9 +24,7 @@
 #include <errno.h>
 #include <math.h>
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 #define SYS_DEFAULTCH 2
 #define MAXNDEV 128

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -25,7 +25,14 @@
 #include <sched.h>
 #include <sys/mman.h>
 #include "s_audio_alsa.h"
-#include <endian.h>
+
+
+
+#ifdef HAVE_MACHINE_ENDIAN_H
+# include <machine/endian.h>
+#elif defined HAVE_ENDIAN_H
+# include <endian.h>
+#endif
 
 /* Defines */
 #define DEBUG(x) x

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -26,13 +26,7 @@
 #include <sys/mman.h>
 #include "s_audio_alsa.h"
 
-
-
-#ifdef HAVE_MACHINE_ENDIAN_H
-# include <machine/endian.h>
-#elif defined HAVE_ENDIAN_H
-# include <endian.h>
-#endif
+#include "m_private_utils.h"
 
 /* Defines */
 #define DEBUG(x) x

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -5,7 +5,11 @@
 
 /* this file inputs and outputs audio using the OSS API available on linux. */
 
-#include <sys/soundcard.h>
+#ifdef HAVE_SOUNDCARD_H
+# include <soundcard.h>
+#else
+# include <sys/soundcard.h>
+#endif
 
 #ifndef SNDCTL_DSP_GETISPACE
 #define SNDCTL_DSP_GETISPACE SOUND_PCM_GETISPACE

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -38,10 +38,10 @@
 #include <unistd.h>
 #endif
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -30,20 +30,10 @@
 #include <fcntl.h>
 #include <portaudio.h>
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 #ifndef _WIN32          /* for the "dup2" workaround -- do we still need it? */
 #include <unistd.h>
-#endif
-
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
 #endif
 
 #if 1

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -29,9 +29,7 @@
 #include <tchar.h>
 #include <io.h>
 #endif
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 #ifdef __APPLE__ /* needed for plist handling */
 #include <CoreFoundation/CoreFoundation.h>
 #endif

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1030,16 +1030,12 @@ void glob_watchdog(t_pd *dummy)
 static void sys_init_deken(void)
 {
     const char*os =
-#if defined __linux__
+#if defined DEKEN_OS
+        stringify(DEKEN_OS)
+#elif defined __linux__
         "Linux"
 #elif defined __APPLE__
         "Darwin"
-#elif defined __FreeBSD__
-        "FreeBSD"
-#elif defined __NetBSD__
-        "NetBSD"
-#elif defined __OpenBSD__
-        "OpenBSD"
 #elif defined _WIN32
         "Windows"
 #else
@@ -1050,7 +1046,9 @@ static void sys_init_deken(void)
 #endif
         ;
     const char*machine =
-#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
+#if defined DEKEN_CPU
+        stringify(DEKEN_CPU)
+#elif defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
         "amd64"
 #elif defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86)
         "i386"

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -1,9 +1,12 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
 * For information on usage and redistribution, and for a DISCLAIMER OF ALL
 * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+#if !defined (HAVE_LIBDL) && HAVE_DLOPEN
+# define HAVE_LIBDL 1
+#endif
 
-#if defined(HAVE_LIBDL) || defined(__FreeBSD__)
-#include <dlfcn.h>
+#if HAVE_LIBDL
+# include <dlfcn.h>
 #endif
 #ifdef HAVE_UNISTD_H
 #include <stdlib.h>
@@ -247,7 +250,7 @@ gotone:
              makeout = (t_xxx)GetProcAddress(ntdll, "setup");
         SetDllDirectory(NULL); /* reset DLL dir to nothing */
     }
-#elif defined(HAVE_LIBDL) || defined(__FreeBSD__)
+#elif HAVE_LIBDL
     dlobj = dlopen(filename, RTLD_NOW | RTLD_GLOBAL);
     if (!dlobj)
     {
@@ -404,7 +407,7 @@ int sys_run_scheduler(const char *externalschedlibname,
             externalmainfunc =
                 (t_externalschedlibmain)GetProcAddress(ntdll, "main");
     }
-#elif defined HAVE_LIBDL
+#elif HAVE_LIBDL
     {
         void *dlobj;
         dlobj = dlopen(filename, RTLD_NOW | RTLD_GLOBAL);

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -60,7 +60,7 @@ a fat binary or an indication of the instruction set. */
 
 
 static const char*sys_dllextent[] = {
-#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
     ARCHDLLEXT(".l_")
 #if defined(__x86_64__) || defined(_M_X64)
     ".l_ia64",      /* incorrect but probably in wide use */
@@ -72,7 +72,7 @@ static const char*sys_dllextent[] = {
     ARCHDLLEXT(".d_")
     ".pd_darwin",
     ".so",
-#elif defined(__OPENBSD__)
+#elif defined(__OpenBSD__)
     ARCHDLLEXT(".o_")
     ".pd_openbsd",
     ".so",

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -25,8 +25,8 @@
 #include "s_stuff.h"
 #include <stdio.h>
 #include <sys/stat.h>
+#include "m_private_utils.h"
 #ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
-#define snprintf _snprintf
 #define stat _stat
 #endif
 

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -21,9 +21,7 @@
 #include <windows.h>
 #include <winbase.h>
 #endif
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 #define stringify(s) str(s)
 #define str(s) #s

--- a/src/s_net.h
+++ b/src/s_net.h
@@ -13,6 +13,7 @@ typedef int socklen_t;
 #else
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <netdb.h>

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -23,14 +23,6 @@
 #include <windows.h>
 #endif
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
-
 #include <string.h>
 #include "m_pd.h"
 #include "m_imp.h"
@@ -47,9 +39,7 @@
 # define stat  stat64
 #endif
 
-#ifdef _MSC_VER
-# define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
     /* change '/' characters to the system's native file separator */
 void sys_bashfilename(const char *from, char *to)

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -23,10 +23,10 @@
 #include <windows.h>
 #endif
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -9,10 +9,7 @@
 #include <string.h>
 #include <errno.h>
 #include "s_stuff.h"
-
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
+#include "m_private_utils.h"
 
 t_printhook sys_printhook = NULL;
 int sys_printtostderr;

--- a/src/s_utf8.c
+++ b/src/s_utf8.c
@@ -21,13 +21,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-#ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
 
 #include "s_utf8.h"
 

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -15,27 +15,25 @@
 #include <io.h>
 #endif
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
-#define HAVE_ALLOCA 1
-#endif
 #define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
-#if HAVE_ALLOCA
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
+
+#ifndef DONT_USE_ALLOCA
+# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
         alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
+# define ATOMS_FREEA(x, n) ( \
     ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
-#else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
-#define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
-#endif
+#else /* DONT_USE_ALLOCA */
+# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+# define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
+#endif /* DONT_USE_ALLOCA */
 
 /* -- "table" - classic "array define" object by Guenter Geiger --*/
 

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -15,25 +15,9 @@
 #include <io.h>
 #endif
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
+#include "m_private_utils.h"
 
 #define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
-
-#ifndef DONT_USE_ALLOCA
-# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-# define ATOMS_FREEA(x, n) ( \
-    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
-#else /* DONT_USE_ALLOCA */
-# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
-# define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
-#endif /* DONT_USE_ALLOCA */
 
 /* -- "table" - classic "array define" object by Guenter Geiger --*/
 
@@ -631,11 +615,11 @@ static void array_get_bang(t_array_rangeop *x)
     t_atom *outv;
     if (!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
-    ATOMS_ALLOCA(outv, nitem);
+    ALLOCA(t_atom, outv, nitem, TEXT_NGETBYTE);
     for (i = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
         SETFLOAT(&outv[i],  *(t_float *)itemp);
     outlet_list(x->x_outlet, 0, nitem, outv);
-    ATOMS_FREEA(outv, nitem);
+    FREEA(t_atom, outv, nitem, TEXT_NGETBYTE);
 }
 
 static void array_get_float(t_array_rangeop *x, t_floatarg f)

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -1,13 +1,15 @@
 /* Copyright (c) 2021 IOhannes m zmölnig.
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
-
 /* The "file" object. */
 #define _XOPEN_SOURCE 600
+#define _DEFAULT_SOURCE
 
 #include "m_pd.h"
 #include "g_canvas.h"
 #include "s_utf8.h"
+
+#include "m_private_utils.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -35,34 +37,7 @@
 typedef unsigned int mode_t;
 typedef SSIZE_T ssize_t;
 # define wstat _wstat
-# define snprintf _snprintf
 #endif
-
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
-
-#ifdef ALLOCA
-# undef ALLOCA
-#endif
-#ifdef FREEA
-# undef FREEA
-#endif
-
-#ifndef DONT_USE_ALLOCA
-# define ALLOCA(t, x, n, max) ((x) = (t *)((n) < (max) ?            \
-            alloca((n) * sizeof(t)) : getbytes((n) * sizeof(t))))
-# define FREEA(t, x, n, max) (                                  \
-        ((n) < (max) || (freebytes((x), (n) * sizeof(t)), 0)))
-#else /* DONT_USE_ALLOCA */
-# define ALLOCA(t, x, n, max) ((x) = (t *)getbytes((n) * sizeof(t)))
-# define FREEA(t, x, n, max) (freebytes((x), (n) * sizeof(t)))
-#endif /* DONT_USE_ALLOCA */
-
 
 #ifndef S_ISREG
   #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -12,9 +12,7 @@ away before the panel does... */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#ifdef _MSC_VER
-#define snprintf _snprintf  /* for pdcontrol object */
-#endif
+#include "m_private_utils.h"
 
 /* --------------------- graphics responder  ---------------- */
 

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -5,25 +5,9 @@
 #include "m_pd.h"
 #include <string.h>
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
+#include "m_private_utils.h"
 
 #define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
-#ifndef DONT_USE_ALLOCA
-# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < LIST_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-# define ATOMS_FREEA(x, n) ( \
-    ((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
-#else /* DONT_USE_ALLOCA */
-# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
-# define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
-#endif /* DONT_USE_ALLOCA */
-
 
 /* the "list" object family.
 
@@ -228,7 +212,7 @@ static void list_append_list(t_list_append *x, t_symbol *s,
 {
     t_atom *outv;
     int outc = x->x_alist.l_n + argc;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     atoms_copy(argc, argv, outv);
     if (x->x_alist.l_npointer)
     {
@@ -243,7 +227,7 @@ static void list_append_list(t_list_append *x, t_symbol *s,
         alist_toatoms(&x->x_alist, outv+argc, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_append_anything(t_list_append *x, t_symbol *s,
@@ -251,7 +235,7 @@ static void list_append_anything(t_list_append *x, t_symbol *s,
 {
     t_atom *outv;
     int outc = x->x_alist.l_n + argc + 1;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     SETSYMBOL(outv, s);
     atoms_copy(argc, argv, outv + 1);
     if (x->x_alist.l_npointer)
@@ -267,7 +251,7 @@ static void list_append_anything(t_list_append *x, t_symbol *s,
         alist_toatoms(&x->x_alist, outv + 1 + argc, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_append_free(t_list_append *x)
@@ -306,7 +290,7 @@ static void list_prepend_list(t_list_prepend *x, t_symbol *s,
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     atoms_copy(argc, argv, outv + x->x_alist.l_n);
     if (x->x_alist.l_npointer)
     {
@@ -321,7 +305,7 @@ static void list_prepend_list(t_list_prepend *x, t_symbol *s,
         alist_toatoms(&x->x_alist, outv, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_prepend_anything(t_list_prepend *x, t_symbol *s,
@@ -329,7 +313,7 @@ static void list_prepend_anything(t_list_prepend *x, t_symbol *s,
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc + 1;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     SETSYMBOL(outv + x->x_alist.l_n, s);
     atoms_copy(argc, argv, outv + x->x_alist.l_n + 1);
     if (x->x_alist.l_npointer)
@@ -345,7 +329,7 @@ static void list_prepend_anything(t_list_prepend *x, t_symbol *s,
         alist_toatoms(&x->x_alist, outv, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_prepend_free(t_list_prepend *x)
@@ -395,7 +379,7 @@ static void list_store_send(t_list_store *x, t_symbol *s)
         pd_error(x, "%s: no such object", s->s_name);
         return;
     }
-    ATOMS_ALLOCA(vec, n);
+    ALLOCA(t_atom, vec, n, LIST_NGETBYTE);
     if (x->x_alist.l_npointer)
     {
         t_alist y;
@@ -409,7 +393,7 @@ static void list_store_send(t_list_store *x, t_symbol *s)
         alist_toatoms(&x->x_alist, vec, 0, n);
         pd_list(s->s_thing, gensym("list"), n, vec);
     }
-    ATOMS_FREEA(vec, n);
+    FREEA(t_atom, vec, n, LIST_NGETBYTE);
 }
 
 static void list_store_list(t_list_store *x, t_symbol *s,
@@ -417,7 +401,7 @@ static void list_store_list(t_list_store *x, t_symbol *s,
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc;
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     atoms_copy(argc, argv, outv);
     if (x->x_alist.l_npointer)
     {
@@ -432,7 +416,7 @@ static void list_store_list(t_list_store *x, t_symbol *s,
         alist_toatoms(&x->x_alist, outv+argc, 0, x->x_alist.l_n);
         outlet_list(x->x_out1, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_store_doinsert(t_list_store *x, t_symbol *s,
@@ -564,7 +548,7 @@ static void list_store_get(t_list_store *x, float f1, float f2)
         outlet_bang(x->x_out2);
         return;
     }
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     if (x->x_alist.l_npointer)
     {
         t_alist y;
@@ -578,7 +562,7 @@ static void list_store_get(t_list_store *x, float f1, float f2)
         alist_toatoms(&x->x_alist, outv, onset, outc);
         outlet_list(x->x_out1, &s_list, outc, outv);
     }
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_store_set(t_list_store *x, t_symbol *s, int argc, t_atom *argv)
@@ -668,11 +652,11 @@ static void list_split_anything(t_list_split *x, t_symbol *s,
     int argc, t_atom *argv)
 {
     t_atom *outv;
-    ATOMS_ALLOCA(outv, argc+1);
+    ALLOCA(t_atom, outv, argc+1, LIST_NGETBYTE);
     SETSYMBOL(outv, s);
     atoms_copy(argc, argv, outv + 1);
     list_split_list(x, &s_list, argc+1, outv);
-    ATOMS_FREEA(outv, argc+1);
+    FREEA(t_atom, outv, argc+1, LIST_NGETBYTE);
 }
 
 static void list_split_setup(void)
@@ -784,11 +768,11 @@ static void list_fromsymbol_symbol(t_list_fromsymbol *x, t_symbol *s)
 {
     t_atom *outv;
     int n, outc = (int)strlen(s->s_name);
-    ATOMS_ALLOCA(outv, outc);
+    ALLOCA(t_atom, outv, outc, LIST_NGETBYTE);
     for (n = 0; n < outc; n++)
         SETFLOAT(outv + n, (unsigned char)s->s_name[n]);
     outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
-    ATOMS_FREEA(outv, outc);
+    FREEA(t_atom, outv, outc, LIST_NGETBYTE);
 }
 
 static void list_fromsymbol_setup(void)
@@ -819,19 +803,13 @@ static void list_tosymbol_list(t_list_tosymbol *x, t_symbol *s,
     int argc, t_atom *argv)
 {
     int i;
-#if HAVE_ALLOCA
-    char *str = alloca(argc + 1);
-#else
-    char *str = getbytes(argc + 1);
-#endif
+    char *str;
+    ALLOCA(char, str, argc + 1, MAXPDSTRING);
     for (i = 0; i < argc; i++)
         str[i] = (char)atom_getfloatarg(i, argc, argv);
     str[argc] = 0;
     outlet_symbol(x->x_obj.ob_outlet, gensym(str));
-#if HAVE_ALLOCA
-#else
-    freebytes(str, argc+1);
-#endif
+    FREEA(char, str, argc + 1, MAXPDSTRING);
 }
 
 static void list_tosymbol_setup(void)

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -33,13 +33,7 @@
 #define CLOCKHZ CLOCKS_PER_SEC
 #endif
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
+#include "m_private_utils.h"
 
 /* -------------------------- random ------------------------------ */
 /* this is strictly homebrew and untested. */

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -33,10 +33,10 @@
 #define CLOCKHZ CLOCKS_PER_SEC
 #endif
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -13,10 +13,12 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#else
+# include <stdlib.h> /* BSDs for example */
 #endif
 
 /* print addrinfo lists for debugging */

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -13,13 +13,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#ifdef HAVE_ALLOCA_H
-# include <alloca.h> /* linux, mac, mingw, cygwin,... */
-#elif defined _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
-#else
-# include <stdlib.h> /* BSDs for example */
-#endif
+#include "m_private_utils.h"
 
 /* print addrinfo lists for debugging */
 /* #define PRINT_ADDRINFO */

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -19,30 +19,28 @@ moment it also defines "text" but it may later be better to split this off. */
 #endif
 static t_class *text_define_class;
 
-#ifdef _WIN32
+#ifdef HAVE_ALLOCA_H
+# include <alloca.h> /* linux, mac, mingw, cygwin,... */
+#elif defined _WIN32
 # include <malloc.h> /* MSVC or mingw on windows */
-#elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
 # include <stdlib.h> /* BSDs for example */
 #endif
 
+#define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
+#ifndef DONT_USE_ALLOCA
+# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
+        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
+# define ATOMS_FREEA(x, n) ( \
+    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#else /* DONT_USE_ALLOCA */
+# define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+# define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
+#endif /* DONT_USE_ALLOCA */
+
+
 #ifdef _WIN32
 #define qsort_r qsort_s   /* of course Microsoft decides to be different */
-#endif
-
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
-#define HAVE_ALLOCA 1
-#endif
-#define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
-#if HAVE_ALLOCA
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
-#else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
-#define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
 #endif
 
 /* --- common code for text define, textfile, and qlist for storing text -- */

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -78,9 +78,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define __STRICT_BSD__
 #include <math.h>
-#undef __STRICT_BSD__
 
 #include "x_vexp.h"
 


### PR DESCRIPTION
this PR collects fixes to allow building Pd on FreeBSD, OpenBSD and NetBSD.

I don't really believe that there are many Pd users on these platforms, but the exercise lead to a bit of code-cleanup and generalization.

e.g. the new code tests whether `qsort_r` is available and if not falls back to our own `STUPID_SORT` implementation,
and we no longer need to discuss that for each platform.

fixes integrate with the autotools system (but i took care to keep it working with the makefile-based system)

Closes: #1596 
Closes: #1598 
Closes: #1597 

Also fixes build and runtime problems on NetBSD (but i hadn't opened a ticket for that)