### PR TITLE
Implement sig_tilde_perf8

### DIFF
--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -18,7 +18,7 @@ typedef struct _sig
     t_float x_f;
 } t_sig;
 
-static t_int *sig_tilde_perform(t_int *w)
+t_int *sig_tilde_perform(t_int *w)
 {
     t_float f = *(t_float *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
@@ -28,7 +28,7 @@ static t_int *sig_tilde_perform(t_int *w)
     return (w+4);
 }
 
-static t_int *sig_tilde_perf8(t_int *w)
+t_int *sig_tilde_perf8(t_int *w)
 {
     t_float f = *(t_float *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -55,7 +55,10 @@ static void sig_tilde_float(t_sig *x, t_float f)
 
 static void sig_tilde_dsp(t_sig *x, t_signal **sp)
 {
-    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    if (sp[0]->s_n & 7)
+        dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    else
+        dsp_add(sig_tilde_perf8, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void *sig_tilde_new(t_floatarg f)

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -1270,35 +1270,8 @@ void dsp_add_copy(t_sample *in, t_sample *out, int n)
         dsp_add(copy_perf8, 3, in, out, (t_int)n);
 }
 
-static t_int *sig_tilde_perform(t_int *w)
-{
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
-        *out++ = f;
-    return (w+4);
-}
-
-static t_int *sig_tilde_perf8(t_int *w)
-{
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-
-    for (; n; n -= 8, out += 8)
-    {
-        out[0] = f;
-        out[1] = f;
-        out[2] = f;
-        out[3] = f;
-        out[4] = f;
-        out[5] = f;
-        out[6] = f;
-        out[7] = f;
-    }
-    return (w+4);
-}
+extern t_int *sig_tilde_perform(t_int *w);
+extern t_int *sig_tilde_perf8(t_int *w);
 
 void dsp_add_scalarcopy(t_float *in, t_sample *out, int n)
 {


### PR DESCRIPTION
Also, remove duplicate definitions of `sig_tilde_perform` and `sig_tilde_perf8`, and instead make these functions non-static so that they can be referred to with extern declarations.