### PR TITLE
[oscparse] improvements

### DIFF
--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -290,8 +290,8 @@ static t_class *oscparse_class;
 
 typedef struct _oscparse
 {
-    t_object    x_obj;
-    t_int       x_flag;
+    t_object x_obj;
+    int x_flag;
 } t_oscparse;
 
 #define ROUNDUPTO4(x) (((x) + 3) & (~3))
@@ -392,12 +392,12 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
         if(x->x_flag)
         {
             t_symbol *sym = grabstring(argc, argv, &i, 1);
-              t_float f = 0.0f;
-              char *str_end = NULL;
-              f = strtod(sym->s_name, &str_end);
-              if (f == 0 && sym->s_name == str_end)
-                  SETSYMBOL(outv+j, sym);
-              else SETFLOAT(outv+j, f);
+            t_float f = 0.0f;
+            char *str_end = NULL;
+            f = strtod(sym->s_name, &str_end);
+            if (f == 0 && sym->s_name == str_end)
+                SETSYMBOL(outv+j, sym);
+            else SETFLOAT(outv+j, f);
         }
         else SETSYMBOL(outv+j, grabstring(argc, argv, &i, 1));
     }
@@ -482,7 +482,7 @@ static t_oscparse *oscparse_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_oscparse *x = (t_oscparse *)pd_new(oscparse_class);
     x->x_flag = 0;
-    if (argc && argv[0].a_w.w_symbol == gensym("-float"))
+    if (argc && argv[0].a_w.w_symbol == gensym("-n"))
     {
         x->x_flag = 1;
     }

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -291,6 +291,7 @@ static t_class *oscparse_class;
 typedef struct _oscparse
 {
     t_object x_obj;
+    t_outlet *x_address_n;
     int x_flag;
 } t_oscparse;
 
@@ -386,6 +387,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
     dataonset = ROUNDUPTO4(i + 1);
     /* post("outc %d, typeonset %d, dataonset %d, nfield %d", outc, typeonset,
         dataonset, nfield); */
+    int address_n;
     for (i = j = 0; i < typeonset-1 && argv[i].a_w.w_float != 0 &&
          j < outc; j++)
     {
@@ -400,6 +402,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
             else SETFLOAT(outv+j, f);
         }
         else SETSYMBOL(outv+j, grabstring(argc, argv, &i, 1));
+        address_n = j + 1;
     }
     for (i = typeonset, k = dataonset; i < typeonset + nfield; i++)
     {
@@ -472,6 +475,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
                 (int)(argv[i].a_w.w_float), (int)(argv[i].a_w.w_float));
         }
     }
+    outlet_float(x->x_address_n, address_n);
     outlet_list(x->x_obj.ob_outlet, 0, j, outv);
     return;
 tooshort:
@@ -487,6 +491,7 @@ static t_oscparse *oscparse_new(t_symbol *s, int argc, t_atom *argv)
         x->x_flag = 1;
     }
     outlet_new(&x->x_obj, gensym("list"));
+    x->x_address_n = outlet_new((t_object *)x, &s_float);
     return (x);
 }
 


### PR DESCRIPTION
[oscparse] always parses addresses as symbols, even if they look like floats, which make it really hard to use [route]. I propose a flag that turns addresses that look like floats into floats.

We also add an outlet that gives the index in the output list that splits the address from the data

closes https://github.com/pure-data/pure-data/issues/1299

also closes https://github.com/pure-data/pure-data/issues/1858