### PR TITLE
Use "move" to displace objects instead of "coords"

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -947,8 +947,19 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
     {
         x->gl_obj.te_xpix += dx;
         x->gl_obj.te_ypix += dy;
-        if (glist_isvisible(glist)) {
-            glist_redraw(x);
+        if (glist_isvisible(glist) && x->gl_owner && !x->gl_isclone
+        && glist_isvisible(x->gl_owner))
+        {
+            sys_vgui(".x%lx.c move graph%lx %d %d\n",
+                glist_getcanvas(x->gl_owner), (t_int)x, dx*x->gl_zoom, dy*x->gl_zoom);
+            sys_vgui(".x%lx.c move graph%lxiolet %d %d\n",
+                glist_getcanvas(glist), (t_int)x, dx*x->gl_zoom, dy*x->gl_zoom);
+            t_gobj *g;
+            for (g = x->gl_list; g; g = g->g_next)
+            {
+                gobj_vis(g, x, 0); // gobj_displace doesn't work well (also moves inside graph)
+                gobj_vis(g, x, 1);
+            }
             canvas_fixlinesfor(glist, &x->gl_obj);
         }
     }

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1251,8 +1251,10 @@ static void text_displace(t_gobj *z, t_glist *glist,
     {
         t_rtext *y = glist_findrtext(glist, x);
         rtext_displace(y, glist->gl_zoom * dx, glist->gl_zoom * dy);
-        text_drawborder(x, glist, rtext_gettag(y),
-            rtext_width(y), rtext_height(y), 0);
+        sys_vgui(".x%lx.c move %sR %d %d\n", glist_getcanvas(glist), rtext_gettag(y),
+                 dx * glist->gl_zoom, dy * glist->gl_zoom);
+        sys_vgui(".x%lx.c move %siolet %d %d\n", glist_getcanvas(glist), rtext_gettag(y),
+                 dx * glist->gl_zoom, dy * glist->gl_zoom);
         canvas_fixlinesfor(glist, x);
     }
 }
@@ -1442,11 +1444,11 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
         int onset = x1 + (width - iow) * i / nplus;
         if (firsttime)
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                "-tags [list %so%d outlet] -fill black\n",
+                "-tags [list %so%d %siolet outlet] -fill black\n",
                 glist_getcanvas(glist),
                 onset, y2 - oh + glist->gl_zoom,
                 onset + iow, y2,
-                tag, i);
+                tag, i, tag);
         else
             sys_vgui(".x%lx.c coords %so%d %d %d %d %d\n",
                 glist_getcanvas(glist), tag, i,
@@ -1460,11 +1462,11 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
         int onset = x1 + (width - iow) * i / nplus;
         if (firsttime)
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                "-tags [list %si%d inlet] -fill black\n",
+                "-tags [list %si%d %siolet inlet] -fill black\n",
                 glist_getcanvas(glist),
                 onset, y1,
                 onset + iow, y1 + ih - glist->gl_zoom,
-                tag, i);
+                tag, i, tag);
         else
             sys_vgui(".x%lx.c coords %si%d %d %d %d %d\n",
                 glist_getcanvas(glist), tag, i,


### PR DESCRIPTION
closes https://github.com/pure-data/pure-data/issues/1634

The only thing is that all the graph objects ("gobj") inside it get redrawn, with 

```
                gobj_vis(g, x, 0);
                gobj_vis(g, x, 1);
```

much like in https://github.com/pure-data/pure-data/blob/master/src/g_graph.c#L656

I'm doing this cause I don't know better

there's a gobj_displace code in https://github.com/pure-data/pure-data/blob/master/src/g_canvas.c#L71

but if I use that, the objects get displaced alright when moving the graph on the parent but they also get moved inside the abstraction, which screws things up...

I still think that redrawing "gobj" objects is not ideal, but we can think of a way not to do that later...