### PR TITLE
rename Intrrpt/Hold to min/max in bng properties

### DIFF
--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -504,8 +504,8 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header \
             set iemgui_type [_ "Bang"]
             set wdt_label "Size:"
             set iemgui_range_header [_ "Flash Time (msec)"]
-            set min_rng_label [_ "Intrrpt:"]
-            set max_rng_label [_ "Hold:"] }
+            set min_rng_label [_ "Min:"]
+            set max_rng_label [_ "Max:"] }
         "|tgl|" {
             set iemgui_type [_ "Toggle"]
             set wdt_label [_ "Size:"]


### PR DESCRIPTION
This closes https://github.com/pure-data/pure-data/issues/976 and over there there's a discussion why I think these names are terrible.

In fact, I have already documented how these work properly in my rewrite of the iemguis documentation, but it'd be much simpler and easier to explain/document if we just change the names.

I will get to the documentation itself once the iemguis-merge PR gets merged and will also take care of many other documentation related stuff - I'm keeping track of al the things I need to change.