### PR TITLE
readsf~/writesf~ fixes

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -2016,15 +2016,16 @@ static void readsf_tick(t_readsf *x)
 static t_int *readsf_perform(t_int *w)
 {
     t_readsf *x = (t_readsf *)(w[1]);
-    t_soundfile sf = {0};
     int vecsize = x->x_vecsize, noutlets = x->x_noutlets, i;
     size_t j;
     t_sample *fp;
-    soundfile_copy(&sf, &x->x_sf);
     if (x->x_state == STATE_STREAM)
     {
         int wantbytes;
+        t_soundfile sf = {0};
         pthread_mutex_lock(&x->x_mutex);
+            /* copy with mutex locked! */
+        soundfile_copy(&sf, &x->x_sf);
         wantbytes = vecsize * sf.sf_bytesperframe;
         while (!x->x_eof && x->x_fifohead >= x->x_fifotail &&
                 x->x_fifohead < x->x_fifotail + wantbytes-1)
@@ -2535,14 +2536,15 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 static t_int *writesf_perform(t_int *w)
 {
     t_writesf *x = (t_writesf *)(w[1]);
-    t_soundfile sf = {0};
     int vecsize = x->x_vecsize;
-    soundfile_copy(&sf, &x->x_sf);
     if (x->x_state == STATE_STREAM)
     {
         size_t roominfifo;
         size_t wantbytes;
+        t_soundfile sf = {0};
         pthread_mutex_lock(&x->x_mutex);
+            /* copy with mutex locked! */
+        soundfile_copy(&sf, &x->x_sf);
         wantbytes = vecsize * sf.sf_bytesperframe;
         roominfifo = x->x_fifotail - x->x_fifohead;
         if (roominfifo <= 0)

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1901,13 +1901,17 @@ static void *readsf_child_main(void *zz)
                 set EOF and signal once more */
             if (sf.sf_fd >= 0)
             {
+                    /* only set EOF if there is no pending "open" request!
+                    Otherwise, we might accidentally set EOF after it has been
+                    unset in readsf_open() and the stream would fail silently. */
+                if (x->x_requestcode != REQUEST_OPEN)
+                    x->x_eof = 1;
+                x->x_sf.sf_fd = -1;
                     /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
                 pthread_mutex_lock(&x->x_mutex);
-                x->x_eof = 1;
-                x->x_sf.sf_fd = -1;
             }
             sfread_cond_signal(&x->x_answercondition);
         }


### PR DESCRIPTION
* fix regression with `[readsf~]`: sending an `[open(` message while a stream is running causes the next stream to fail silently. This didn't happen in Pd 0.51 and before.
* fix possible race condition in `readsf_perform` and `writesf_perform`
* minimize critical section in EOF branch in `readsf_perform`
* cosmetic fixes

The first issue has bitten me recently in a rehearsal. While looking at the code I found a few other possible race conditions, hence this PR.