### PR TITLE
[sig~] use the vectorized perf8 version

### DIFF
--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -18,36 +18,6 @@ typedef struct _sig
     t_float x_f;
 } t_sig;
 
-static t_int *sig_tilde_perform(t_int *w)
-{
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
-        *out++ = f;
-    return (w+4);
-}
-
-static t_int *sig_tilde_perf8(t_int *w)
-{
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-
-    for (; n; n -= 8, out += 8)
-    {
-        out[0] = f;
-        out[1] = f;
-        out[2] = f;
-        out[3] = f;
-        out[4] = f;
-        out[5] = f;
-        out[6] = f;
-        out[7] = f;
-    }
-    return (w+4);
-}
-
 static void sig_tilde_float(t_sig *x, t_float f)
 {
     x->x_f = f;
@@ -55,7 +25,7 @@ static void sig_tilde_float(t_sig *x, t_float f)
 
 static void sig_tilde_dsp(t_sig *x, t_signal **sp)
 {
-    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add_scalarcopy(&x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
 }
 
 static void *sig_tilde_new(t_floatarg f)

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -1270,7 +1270,7 @@ void dsp_add_copy(t_sample *in, t_sample *out, int n)
         dsp_add(copy_perf8, 3, in, out, (t_int)n);
 }
 
-static t_int *sig_tilde_perform(t_int *w)
+static t_int *scalarcopy_perform(t_int *w)
 {
     t_float f = *(t_float *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
@@ -1280,7 +1280,7 @@ static t_int *sig_tilde_perform(t_int *w)
     return (w+4);
 }
 
-static t_int *sig_tilde_perf8(t_int *w)
+static t_int *scalarcopy_perf8(t_int *w)
 {
     t_float f = *(t_float *)(w[1]);
     t_sample *out = (t_sample *)(w[2]);
@@ -1303,9 +1303,9 @@ static t_int *sig_tilde_perf8(t_int *w)
 void dsp_add_scalarcopy(t_float *in, t_sample *out, int n)
 {
     if (n&7)
-        dsp_add(sig_tilde_perform, 3, in, out, (t_int)n);
+        dsp_add(scalarcopy_perform, 3, in, out, (t_int)n);
     else
-        dsp_add(sig_tilde_perf8, 3, in, out, (t_int)n);
+        dsp_add(scalarcopy_perf8, 3, in, out, (t_int)n);
 }
 
 /* ------------------------ samplerate~~ -------------------------- */


### PR DESCRIPTION
hey,
while studying the code I realized that [sig~] never used its vectorized `sig_tilde_perf8()` function.

Moreover, both `sig_tilde_perform()` and `sig_tilde_perf8()` were (privately) defined twice, in both `d_ctl.c` and `d_ugen.c`, and a public `dsp_add_scalarcopy()` already existed, which takes care of calling the `perf8()` when the vector size is a multiple of 8.

So here is a simplification (and a fix...) for [sig~] that calls `dsp_add_scalarcopy()` and removes duplicate sig_perform functions.