### PR TITLE
Refactor TCL-specific string handling into pdgui_vmess()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,6 +152,7 @@ pd_SOURCES_core = \
     m_sched.c \
     s_audio.c \
     s_inter.c \
+    s_inter_gui.c \
     s_loader.c \
     s_main.c \
     s_net.c \

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -103,7 +103,7 @@ t_int *upsampling_perform_linear(t_int *w)
 
 void resample_init(t_resample *x)
 {
-  x->method=0;
+  x->method=-1;
 
   x->downsample=x->upsample=1;
 
@@ -140,7 +140,7 @@ void resample_dsp(t_resample *x,
       return;
     }
     switch (method) {
-    default:
+    default: /* always zero padding */
       dsp_add(downsampling_perform_0, 4, in, out, (t_int)(insize/outsize), (t_int)insize);
     }
 
@@ -151,10 +151,10 @@ void resample_dsp(t_resample *x,
       return;
     }
     switch (method) {
-    case 1:
+    case 1: /* sample and hold */
       dsp_add(upsampling_perform_hold, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
       break;
-    case 2:
+    case 2: /* linear interpolation */
       if (x->bufsize != 1) {
         t_freebytes(x->buffer, x->bufsize*sizeof(*x->buffer));
         x->bufsize = 1;
@@ -162,7 +162,7 @@ void resample_dsp(t_resample *x,
       }
       dsp_add(upsampling_perform_linear, 5, x, in, out, (t_int)(outsize/insize), (t_int)insize);
       break;
-    default:
+    default: /* zero padding */
       dsp_add(upsampling_perform_0, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
     }
   }

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -482,7 +482,7 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
     pdgui_strnescape( lab_escaped, MAXPDSTRING, iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name) );
 
     if(glist_isvisible(iemgui->x_glist) && iemgui->x_lab != old)
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape \"%s \"] \n",
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape \"%s\"] \n",
                  glist_getcanvas(iemgui->x_glist), x,
                  strcmp(s->s_name, "empty")?lab_escaped:"");
 }

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -525,9 +525,17 @@ void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *a
         f = 4;
     iemgui->x_fontsize = f;
     if(glist_isvisible(iemgui->x_glist))
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s}\n",
-                 glist_getcanvas(iemgui->x_glist), x, iemgui->x_font,
-                 iemgui->x_fontsize*zoom, sys_fontweight);
+    {
+        char tag[128];
+        t_atom fontatoms[3];
+        sprintf(tag, "%lxLABEL", x);
+        SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
+        SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+        SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
+        pdgui_vmess(0, "crs rA",
+            glist_getcanvas(iemgui->x_glist), "itemconfigure", tag,
+            "-font", 3, fontatoms);
+    }
 }
 
 void iemgui_size(void *x, t_iemgui *iemgui)
@@ -857,4 +865,3 @@ external GUI object uses obsolete Pd function iemgui_all_colfromload()");
         iemgui->x_lcol = iemgui_color_hex[bflcol[2]];
     }
 }
-

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -482,9 +482,13 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
     pdgui_strnescape( lab_escaped, MAXPDSTRING, iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name) );
 
     if(glist_isvisible(iemgui->x_glist) && iemgui->x_lab != old)
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape \"%s\"] \n",
-                 glist_getcanvas(iemgui->x_glist), x,
-                 strcmp(s->s_name, "empty")?lab_escaped:"");
+    {
+        char tag[128];
+        sprintf(tag, "%lxLABEL", x);
+        pdgui_vmess("pdtk_text_set", "css",
+                  glist_getcanvas(iemgui->x_glist),
+                  tag, strcmp(s->s_name, "empty")?s->s_name:"");
+    }
 }
 
 void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
@@ -493,10 +497,14 @@ void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av
     iemgui->x_ldx = (int)atom_getfloatarg(0, ac, av);
     iemgui->x_ldy = (int)atom_getfloatarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
-        sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-                 glist_getcanvas(iemgui->x_glist), x,
-                 text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom,
-                 text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom);
+    {
+        char tag[128];
+        sprintf(tag, "%lxLABEL", x);
+        pdgui_vmess(0, "crs ii",
+            glist_getcanvas(iemgui->x_glist), "coords", tag,
+            text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom,
+            text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom);
+    }
 }
 
 void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
@@ -646,19 +654,10 @@ void iemgui_newzoom(t_iemgui *iemgui)
 
 void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
 {
-    char label[MAXPDSTRING];
-
     srl[0] = iemgui->x_snd;
     srl[1] = iemgui->x_rcv;
-
-    strcpy(label, iemgui->x_lab->s_name);
-    pdgui_strnescape(label, MAXPDSTRING,
-                    iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name));
-    srl[2] = gensym(label);
-
-    iemgui_all_dollar2raute(srl);
+    srl[2] = iemgui->x_lab;
     iemgui_all_sym2dollararg(iemgui, srl);
-    iemgui_all_put_in_braces(srl);
 }
 
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -494,7 +494,7 @@ static void garray_arrayviewlist_fillpage(t_garray *x,
     if(page < 0)
         page = 0;
 
-    sys_vgui("::dialog_array::listview_setpage {%s} %d %d %d\n",
+    pdgui_vmess("::dialog_array::listview_setpage", "s iii",
         x->x_realname->s_name,
         page, maxpage+1, pagesize);
 
@@ -509,7 +509,7 @@ static void garray_arrayviewlist_fillpage(t_garray *x,
     }
     sys_vgui("\n");
 
-    sys_vgui("::dialog_array::listview_focus {%s} %d\n",
+    pdgui_vmess("::dialog_array::listview_focus", "si",
              x->x_realname->s_name,
              topItem);
 }
@@ -537,7 +537,7 @@ static void garray_arrayviewlist_new(t_garray *x)
 static void garray_arrayviewlist_close(t_garray *x)
 {
     x->x_listviewing = 0;
-    sys_vgui("pdtk_array_listview_closeWindow {%s}\n",
+    pdgui_vmess("pdtk_array_listview_closeWindow", "s",
              x->x_realname->s_name);
 }
 /* } jsarlo */
@@ -783,7 +783,7 @@ void garray_redraw(t_garray *x)
     else
     {
       if (x->x_listviewing)
-        sys_vgui("pdtk_array_listview_fillpage {%s}\n",
+          pdgui_vmess("pdtk_array_listview_fillpage", "s",
                  x->x_realname->s_name);
     }
     /* } jsarlo */

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -512,7 +512,6 @@ static void garray_arrayviewlist_fillpage(t_garray *x,
 
 static void garray_arrayviewlist_new(t_garray *x)
 {
-    char cmdbuf[200];
     int size=0;
     t_word*data=0;
 
@@ -521,11 +520,11 @@ static void garray_arrayviewlist_new(t_garray *x)
         return;
     }
     x->x_listviewing = 1;
-    sprintf(cmdbuf,
-            "pdtk_array_listview_new %%s {%s} %d\n",
-            x->x_realname->s_name,
-            0);
-    gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
+
+    pdgui_stub_vnew(&x->x_gobj.g_pd,
+        "pdtk_array_listview_new", x,
+        "si",
+        x->x_realname->s_name, 0);
 
     garray_arrayviewlist_fillpage(x, 0, 0);
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -265,7 +265,7 @@ static void garray_fittograph(t_garray *x, int n, int style)
             glist_redraw(gl);
         }
             /* close any dialogs that might have the wrong info now... */
-        gfxstub_deleteforkey(gl);
+        pdgui_stub_deleteforkey(gl);
     }
 }
 
@@ -347,21 +347,21 @@ void canvas_menuarray(t_glist *canvas)
 {
     t_glist *x = (t_glist *)canvas;
     int gcount;
-    char cmdbuf[200], arraybuf[80];
+    char arraybuf[80];
     for (gcount = 1; gcount < 1000; gcount++)
     {
         sprintf(arraybuf, "array%d", gcount);
         if (!pd_findbyclass(gensym(arraybuf), garray_class))
             break;
     }
-    sprintf(cmdbuf, "pdtk_array_dialog %%s array%d 100 3 1\n", gcount);
-    gfxstub_new(&x->gl_pd, x, cmdbuf);
+    pdgui_stub_vnew(&x->gl_pd,
+        "pdtk_array_dialog", x, "siii",
+        arraybuf, 100, 3, 1);
 }
 
     /* called from graph_dialog to set properties */
 void garray_properties(t_garray *x)
 {
-    char cmdbuf[200];
     t_array *a = garray_getarray(x);
     t_scalar *sc = x->x_scalar;
     int style = template_getfloat(template_findbyname(sc->sc_template),
@@ -371,14 +371,12 @@ void garray_properties(t_garray *x)
 
     if (!a)
         return;
-    gfxstub_deleteforkey(x);
-        /* create dialog window.  LATER fix this to escape '$'
-        properly; right now we just detect a leading '$' and escape
-        it.  There should be a systematic way of doing this. */
-    sprintf(cmdbuf, "pdtk_array_dialog %%s {%s} %d %d 0\n",
-            x->x_name->s_name, a->a_n, x->x_saveit +
-            2 * filestyle);
-    gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
+    pdgui_stub_deleteforkey(x);
+    pdgui_stub_vnew(&x->x_gobj.g_pd,
+        "pdtk_array_dialog", x,
+        "siii",
+        x->x_name->s_name,
+        a->a_n, x->x_saveit + 2 * filestyle, 0);
 }
 
     /* this is called back from the dialog window to create a garray.
@@ -550,7 +548,7 @@ static void garray_free(t_garray *x)
         garray_arrayviewlist_close(x);
     }
     /* } jsarlo */
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
     pd_unbind(&x->x_gobj.g_pd, x->x_realname);
         /* just in case we're still bound to #A from loading... */
     while ((x2 = pd_findbyclass(gensym("#A"), garray_class)))

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -480,6 +480,7 @@ static void garray_arrayviewlist_fillpage(t_garray *x,
 {
     int i, size=0, topItem=(int)fTopItem;
     int pagesize=ARRAYPAGESIZE, page=(int)fPage, maxpage;
+    int offset, length;
     t_word *data=0;
 
     if(!garray_getfloatwords(x, &size, &data)) {
@@ -498,16 +499,13 @@ static void garray_arrayviewlist_fillpage(t_garray *x,
         x->x_realname->s_name,
         page, maxpage+1, pagesize);
 
-    sys_vgui("::dialog_array::listview_setdata {%s} %ld",
-        x->x_realname->s_name,
-        (long long)(page * pagesize));
-    for (i = page * pagesize;
-         (i < (page + 1) * pagesize && i < size);
-         i++)
-    {
-        sys_vgui(" %g", data[i].w_float);
-    }
-    sys_vgui("\n");
+    offset = page*pagesize;
+    length = ((offset+pagesize) > size)?size-offset:pagesize;
+
+    pdgui_vmess("::dialog_array::listview_setdata", "siw",
+             x->x_realname->s_name,
+             offset,
+             length, data + offset);
 
     pdgui_vmess("::dialog_array::listview_focus", "si",
              x->x_realname->s_name,

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -258,26 +258,30 @@ void bng_check_minmax(t_bng *x, int ftbreak, int fthold)
 static void bng_properties(t_gobj *z, t_glist *owner)
 {
     t_bng *x = (t_bng *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
-    sprintf(buf, "pdtk_iemgui_dialog %%s |bang| \
-            ----------dimensions(pix):----------- %d %d size: 0 0 empty \
-            --------flash-time(ms)(ms):--------- %d intrrpt: %d hold: %d \
-            %d empty empty %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_flashtime_break, x->x_flashtime_hold, 2,/*min_max_schedule+clip*/
-            -1, x->x_gui.x_isa.x_loadinit, -1, -1,/*no linlog, no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r ir ir  i  irr ii ri ss sii ii rrr",
+        "|bang|",
+        "----------dimensions(pix):-----------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "size:",
+        0, 0, "empty",
+        "--------flash-time(ms)(ms):---------",
+        x->x_flashtime_break, "intrrpt:",
+        x->x_flashtime_hold, "hold:",
+        2 /* clip */,
+        -1, "empty", "empty", /* no linlog */
+        x->x_gui.x_isa.x_loadinit, -1 /* no steady */,
+        "empty", -1, /* no multi */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void bng_set(t_bng *x)
@@ -534,7 +538,7 @@ static void bng_ff(t_bng *x)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     clock_free(x->x_clock_lck);
     clock_free(x->x_clock_hld);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_bang_setup(void)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -927,7 +927,7 @@ void canvas_free(t_canvas *x)
     freebytes(x->gl_xlabel, x->gl_nxlabels * sizeof(*(x->gl_xlabel)));
     freebytes(x->gl_ylabel, x->gl_nylabels * sizeof(*(x->gl_ylabel)));
     gstub_cutoff(x->gl_stub);
-    gfxstub_deleteforkey(x);        /* probably unnecessary */
+    pdgui_stub_deleteforkey(x);        /* probably unnecessary */
     if (!x->gl_owner && !x->gl_isclone)
         canvas_takeofflist(x);
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -972,6 +972,15 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
     }
 }
 
+static void _canvas_delete_line(t_canvas*x, t_outconnect *oc)
+{
+    char tag[128];
+    if (!glist_isvisible(x))
+        return;
+    sprintf(tag, "l%lx", oc);
+    pdgui_vmess(0, "crs", glist_getcanvas(x), "delete", tag);
+}
+
     /* kill all lines for the object */
 void canvas_deletelinesfor(t_canvas *x, t_text *text)
 {
@@ -982,11 +991,7 @@ void canvas_deletelinesfor(t_canvas *x, t_text *text)
     {
         if (t.tr_ob == text || t.tr_ob2 == text)
         {
-            if (glist_isvisible(x))
-            {
-                sys_vgui(".x%lx.c delete l%lx\n",
-                    glist_getcanvas(x), oc);
-            }
+            _canvas_delete_line(x, oc);
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
         }
     }
@@ -1004,11 +1009,7 @@ void canvas_deletelinesforio(t_canvas *x, t_text *text,
         if ((t.tr_ob == text && t.tr_outlet == outp) ||
             (t.tr_ob2 == text && t.tr_inlet == inp))
         {
-            if (glist_isvisible(x))
-            {
-                sys_vgui(".x%lx.c delete l%lx\n",
-                    glist_getcanvas(x), oc);
-            }
+            _canvas_delete_line(x, oc);
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
         }
     }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -939,30 +939,35 @@ static void canvas_drawlines(t_canvas *x)
     t_linetraverser t;
     t_outconnect *oc;
     {
+        char tag[128];
+        const char*tags[2] = {tag, "cord"};
         linetraverser_start(&t, x);
         while ((oc = linetraverser_next(&t)))
-            sys_vgui(
-        ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-                glist_getcanvas(x),
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
-                (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
-                oc);
+        {
+            sprintf(tag, "l%lx", oc);
+            pdgui_vmess(0, "crr iiii ri rS",
+                glist_getcanvas(x), "create", "line",
+                t.tr_lx1,t.tr_ly1, t.tr_lx2,t.tr_ly2,
+                "-width", (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
+                "-tags", 2, tags);
+        }
     }
 }
-
 void canvas_fixlinesfor(t_canvas *x, t_text *text)
 {
     t_linetraverser t;
     t_outconnect *oc;
-    
+
     linetraverser_start(&t, x);
     while ((oc = linetraverser_next(&t)))
     {
         if (t.tr_ob == text || t.tr_ob2 == text)
         {
-            sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
-                glist_getcanvas(x), oc,
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
+            char tag[128];
+            sprintf(tag, "l%lx", oc);
+            pdgui_vmess(0, "crs iiii",
+                glist_getcanvas(x), "coords", tag,
+                t.tr_lx1,t.tr_ly1, t.tr_lx2,t.tr_ly2);
         }
     }
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -164,7 +164,7 @@ void canvas_updatewindowlist(void)
 {
             /* not if we're in a reload */
     if (!THISGUI->i_reloadingabstraction)
-        sys_gui("::pd_menus::update_window_menu\n");
+        pdgui_vmess("::pd_menus::update_window_menu", 0);
 }
 
     /* add a glist the list of "root" canvases (toplevels without parents.) */
@@ -739,8 +739,10 @@ void canvas_reflecttitle(t_canvas *x)
         strncat(namebuf, " [edit]", MAXPDSTRING-strlen(namebuf)-1);
         namebuf[MAXPDSTRING-1] = 0;
     }
-    sys_vgui("pdtk_canvas_reflecttitle .x%lx {%s} {%s} {%s} %d\n",
-        x, canvas_getdir(x)->s_name, x->gl_name->s_name, namebuf, x->gl_dirty);
+    pdgui_vmess("pdtk_canvas_reflecttitle", "^ sss i",
+        x,
+        canvas_getdir(x)->s_name, x->gl_name->s_name, namebuf,
+        x->gl_dirty);
 }
 
     /* mark a glist dirty or clean */
@@ -768,12 +770,16 @@ void canvas_drawredrect(t_canvas *x, int doit)
             x2 = x1 + x->gl_zoom * x->gl_pixwidth,
             y1 = x->gl_zoom * x->gl_ymargin,
             y2 = y1 + x->gl_zoom * x->gl_pixheight;
-        sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
-            "-fill #ff8080 -width %d -capstyle projecting -tags GOP\n",
-            glist_getcanvas(x), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1,
-                x->gl_zoom);
+        pdgui_vmess(0, "crr iiiiiiiiii rr ri rr rr",
+            glist_getcanvas(x), "create", "line",
+            x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
+            "-fill", "#ff8080",
+            "-width", x->gl_zoom,
+            "-capstyle", "projecting",
+            "-tags", "GOP"); /* better: "-tags", 1, &"GOP" */
     }
-    else sys_vgui(".x%lx.c delete GOP\n",  glist_getcanvas(x));
+    else
+        pdgui_vmess(0, "crs", glist_getcanvas(x), "delete", "GOP");
 }
 
     /* the window becomes "mapped" (visible and not miniaturized) or
@@ -801,7 +807,7 @@ void canvas_map(t_canvas *x, t_floatarg f)
             canvas_drawlines(x);
             if (x->gl_isgraph && x->gl_goprect)
                 canvas_drawredrect(x, 1);
-            sys_vgui("pdtk_canvas_getscroll .x%lx.c\n", x);
+            pdgui_vmess("pdtk_canvas_getscroll", "c", x);
         }
     }
     else
@@ -814,7 +820,7 @@ void canvas_map(t_canvas *x, t_floatarg f)
                 return;
             }
                 /* just clear out the whole canvas */
-            sys_vgui(".x%lx.c delete all\n", x);
+            pdgui_vmess(0, "crs", x, "delete", "all");
             x->gl_mapped = 0;
         }
     }
@@ -1371,7 +1377,7 @@ static void canvas_start_dsp(void)
 {
     t_canvas *x;
     if (THISGUI->i_dspstate) ugen_stop();
-    else sys_gui("pdtk_pd_dsp ON\n");
+    else pdgui_vmess("pdtk_pd_dsp", "s", "ON");
     ugen_start();
 
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
@@ -1387,7 +1393,7 @@ static void canvas_stop_dsp(void)
     if (THISGUI->i_dspstate)
     {
         ugen_stop();
-        sys_gui("pdtk_pd_dsp OFF\n");
+        pdgui_vmess("pdtk_pd_dsp", "s", "OFF");
         canvas_dspstate = THISGUI->i_dspstate = 0;
         if (gensym("pd-dsp-stopped")->s_thing)
             pd_bang(gensym("pd-dsp-stopped")->s_thing);
@@ -2212,5 +2218,5 @@ void glob_open(t_pd *ignore, t_symbol *name, t_symbol *dir, t_floatarg f)
         return;
     }
     if (!glob_evalfile(ignore, name, dir))
-        sys_vgui("::pdwindow::busyrelease\n");
+        pdgui_vmess("::pdwindow::busyrelease", 0);
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2868,18 +2868,8 @@ void canvas_mouseup(t_canvas *x,
             t_glist *gl2;
                 /* first though, check we aren't an abstraction with a
                    dirty sub-patch that would be discarded if we edit this. */
-            if (pd_class(&g->g_pd) == canvas_class &&
-                canvas_isabstraction((t_glist *)g) &&
-                (gl2 = glist_finddirty((t_glist *)g)))
-            {
-                vmess(&gl2->gl_pd, gensym("menu-open"), "");
-                x->gl_editor->e_onmotion = MA_NONE;
-                sys_vgui(
-                    "pdtk_check .x%lx [format [_ \"Discard changes to '%%s'?\"] %s] {.x%lx dirty 0;\n} no\n",
-                    canvas_getrootfor(gl2),
-                    canvas_getrootfor(gl2)->gl_name->s_name, gl2);
+            if (canvas_undo_confirmdiscard(g))
                 return;
-            }
                 /* OK, activate it */
             gobj_activate(x->gl_editor->e_selection->sel_what, x, 1);
         }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2899,7 +2899,7 @@ static void canvas_displaceselection(t_canvas *x, int dx, int dy)
 {
     t_selection *y;
     int resortin = 0, resortout = 0;
-    if (!EDITOR->canvas_undo_already_set_move)
+    if (x->gl_editor->e_selection && !EDITOR->canvas_undo_already_set_move)
     {
         canvas_undo_add(x, UNDO_MOTION, "motion", canvas_undo_set_move(x, 1));
         EDITOR->canvas_undo_already_set_move = 1;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -58,6 +58,16 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
 /* ------------------------ managing the selection ----------------- */
 void glist_deselectline(t_glist *x);
+
+static void _editor_selectlinecolor(t_glist*x, const char*color)
+{
+    char tag[128];
+    sprintf(tag, "l%lx", x->gl_editor->e_selectline_tag);
+    pdgui_vmess(0, "crs rs",
+        x, "itemconfigure", tag,
+        "-fill", color);
+
+}
 void glist_selectline(t_glist *x, t_outconnect *oc, int index1,
     int outno, int index2, int inno)
 {
@@ -71,8 +81,7 @@ void glist_selectline(t_glist *x, t_outconnect *oc, int index1,
         x->gl_editor->e_selectline_index2 = index2;
         x->gl_editor->e_selectline_inno = inno;
         x->gl_editor->e_selectline_tag = oc;
-        sys_vgui(".x%lx.c itemconfigure l%lx -fill blue\n",
-            x, x->gl_editor->e_selectline_tag);
+        _editor_selectlinecolor(x, "blue");
     }
 }
 
@@ -81,8 +90,7 @@ void glist_deselectline(t_glist *x)
     if (x->gl_editor)
     {
         x->gl_editor->e_selectedline = 0;
-        sys_vgui(".x%lx.c itemconfigure l%lx -fill black\n",
-            x, x->gl_editor->e_selectline_tag);
+        _editor_selectlinecolor(x, "black");
     }
 }
 

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -718,10 +718,8 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                 x1, y1, x1, y2, x2, y2, x2, y1, x1, y1, glist_getzoom(x), tag);
         }
         else
-        {
-            sys_vgui(".x%lx.c delete %s\n",
-                glist_getcanvas(x->gl_owner), tag);
-        }
+            pdgui_vmess(0, "crs",
+                glist_getcanvas(x->gl_owner), "delete", tag);
         return;
     }
         /* otherwise draw (or erase) us as a graph inside another glist. */
@@ -857,8 +855,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
     }
     else
     {
-        sys_vgui(".x%lx.c delete %s\n",
-            glist_getcanvas(x->gl_owner), tag);
+        pdgui_vmess(0, "crs", glist_getcanvas(x->gl_owner), "delete", tag);
         for (g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 0);
     }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -685,6 +685,37 @@ void glist_redraw(t_glist *x)
 
 int garray_getname(t_garray *x, t_symbol **namep);
 
+static void _graph_create_line4(t_glist *x, int x1, int y1, int x2, int y2, const char**tags2)
+{
+    pdgui_vmess(0, "crr iiii ri rS",
+              glist_getcanvas(x->gl_owner),
+              "create", "line",
+              x1,y1, x2,y2,
+              "-width", glist_getzoom(x),
+              "-tags", 2, tags2);
+}
+
+static void _graph_create_text(
+    t_glist *x, int posX, int posY,
+    const char*name,
+    const char*anchor,
+    int fontsize,
+    int numtags, const char**tags)
+{
+    t_atom fontatoms[3];
+    SETSYMBOL(fontatoms+0, gensym(sys_font));
+    SETFLOAT (fontatoms+1, fontsize);
+    SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
+    pdgui_vmess(0, "crr ii rs rr rA rS",
+              glist_getcanvas(x),
+              "create", "text",
+              posX, posY,
+              "-text", name,
+              "-anchor", anchor,
+              "-font", 3, fontatoms,
+              "-tags", numtags, tags);
+}
+
 
     /* Note that some code in here would also be useful for drawing
     graph decorations in toplevels... */
@@ -779,28 +810,28 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                     f += x->gl_xtick.k_inc)
             {
                 int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                _graph_create_line4(x,
                     (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix, glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                    (int)glist_xtopixels(x, f), (int)upix - tickpix,
+                    tags2);
+                _graph_create_line4(x,
                     (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix, glist_getzoom(x), tag);
+                    (int)glist_xtopixels(x, f), (int)lpix + tickpix,
+                    tags2);
             }
             for (i = 1, f = x->gl_xtick.k_point - x->gl_xtick.k_inc;
                 f > 0.99 * x->gl_x1 + 0.01*x->gl_x2;
                     i++, f -= x->gl_xtick.k_inc)
             {
                 int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                _graph_create_line4(x,
                     (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix, glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                    (int)glist_xtopixels(x, f), (int)upix - tickpix,
+                    tags2);
+                _graph_create_line4(x,
                     (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix, glist_getzoom(x), tag);
+                    (int)glist_xtopixels(x, f), (int)lpix + tickpix,
+                    tags2);
             }
         }
 
@@ -816,49 +847,46 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                     i++, f += x->gl_ytick.k_inc)
             {
                 int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                _graph_create_line4(x,
                     x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                    x1 + tickpix, (int)glist_ytopixels(x, f),
+                    tags2);
+                _graph_create_line4(x,
                     x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
+                    x2 - tickpix, (int)glist_ytopixels(x, f),
+                    tags2);
             }
             for (i = 1, f = x->gl_ytick.k_point - x->gl_ytick.k_inc;
                 f > 0.99 * lbound + 0.01 * ubound;
                     i++, f -= x->gl_ytick.k_inc)
             {
                 int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                _graph_create_line4(x,
                     x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
+                    x1 + tickpix, (int)glist_ytopixels(x, f),
+                    tags2);
+                _graph_create_line4(x,
                     x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
+                    x2 - tickpix, (int)glist_ytopixels(x, f),
+                    tags2);
             }
         }
             /* draw x labels */
         for (i = 0; i < x->gl_nxlabels; i++)
-            sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
-                "-anchor %s -tags [list %s label graph]\n",
-                glist_getcanvas(x),
+            _graph_create_text(x,
                 (int)glist_xtopixels(x, atof(x->gl_xlabel[i]->s_name)),
                 (int)glist_ytopixels(x, x->gl_xlabely),
-                x->gl_xlabel[i]->s_name, sys_font,
-                fs, sys_fontweight, xlabelanchor, tag);
-
+                x->gl_xlabel[i]->s_name,
+                xlabelanchor, -fs,
+                3, tags3);
             /* draw y labels */
         for (i = 0; i < x->gl_nylabels; i++)
-            sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
-                "-anchor %s -tags [list %s label graph]\n",
-                glist_getcanvas(x),
+            _graph_create_text(x,
                 (int)glist_xtopixels(x, x->gl_ylabelx),
                 (int)glist_ytopixels(x, atof(x->gl_ylabel[i]->s_name)),
-                x->gl_ylabel[i]->s_name, sys_font,
-                fs, sys_fontweight, ylabelanchor, tag);
+                x->gl_ylabel[i]->s_name,
+                ylabelanchor, -fs,
+                3, tags3);
 
             /* draw contents of graph as glist */
         for (g = x->gl_list; g; g = g->g_next)

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -280,29 +280,34 @@ static void hradio_save(t_gobj *z, t_binbuf *b)
 static void hradio_properties(t_gobj *z, t_glist *owner)
 {
     t_radio *x = (t_radio *)z;
-    char buf[800];
     t_symbol *srl[3];
     int hchange = -1;
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
     if(pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)
         hchange = x->x_change;
-    sprintf(buf, "pdtk_iemgui_dialog %%s |hradio| \
-            ----------dimensions(pix):----------- %d %d size: 0 0 empty \
-            empty 0.0 empty 0.0 empty %d \
-            %d new-only new&old %d %d number: %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            0,/*no_schedule*/
-            hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number,
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(
+        &x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r ir ir  i  irr ii ri ss sii ii rrr",
+        "|hradio|",
+        "----------dimensions(pix):-----------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "size:",
+        0, 0, "empty",
+        "empty",
+        0, "empty",
+        0, "empty",
+        0 /* no schedule */,
+        hchange, "new-only", "new&old",
+        x->x_gui.x_isa.x_loadinit, -1 /* no steady */,
+        "number:", x->x_number, /* multi */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void hradio_dialog(t_radio *x, t_symbol *s, int argc, t_atom *argv)
@@ -677,7 +682,7 @@ static void hradio_ff(t_radio *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_hradio_setup(void)

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -288,26 +288,31 @@ void hslider_check_minmax(t_slider *x, double min, double max)
 static void hslider_properties(t_gobj *z, t_glist *owner)
 {
     t_slider *x = (t_slider *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
-    sprintf(buf, "pdtk_iemgui_dialog %%s |hsl| \
-            --------dimensions(pix)(pix):-------- %d %d width: %d %d height: \
-            -----------output-range:----------- %g left: %g right: %g \
-            %d lin log %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_SL_MINSIZE, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_min, x->x_max, 0.0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady, -1,/*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r fr fr  i  irr ii ri ss sii ii rrr",
+        "|hsl|",
+        "--------dimensions(pix)(pix):--------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_SL_MINSIZE, "width:",
+        x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "height:",
+        "-----------output-range:-----------",
+        x->x_min, "bottom:",
+        x->x_max, "top:",
+        0 /*no_schedule*/,
+        x->x_lin0_log1, "lin", "log",
+        x->x_gui.x_isa.x_loadinit, x->x_steady,
+        "empty", -1, /* no multi, but iem-characteristic */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void hslider_set(t_slider *x, t_floatarg f)    /* bugfix */
@@ -638,7 +643,7 @@ static void hslider_free(t_slider *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_hslider_setup(void)

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -234,7 +234,7 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs,
                     dsp_add(vinlet_doprolog, 3, x, insig->s_vec,
                         (t_int)re_parentvecsize);
             else {
-              int method = (x->x_updown.method == 3?
+              int method = (x->x_updown.method == -1?
                   (pd_compatibilitylevel < 44 ? 0 : 1) : x->x_updown.method);
               resamplefrom_dsp(&x->x_updown, insig->s_vec, parentvecsize,
                   re_parentvecsize, method);

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -285,9 +285,8 @@ static void *vinlet_newsig(t_symbol *s, int argc, t_atom *argv)
         method = symbol2resamplemethod(s);
         if (method >= 0)
             x->x_updown.method = method;
-        if (s == gensym("fwd"))         /* turn on forwarding */
-            x->x_fwdout = outlet_new(&x->x_obj, 0);
     }
+    x->x_fwdout = outlet_new(&x->x_obj, 0);
     return (x);
 }
 

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -19,6 +19,15 @@ life elsewhere. */
 void signal_setborrowed(t_signal *sig, t_signal *sig2);
 void signal_makereusable(t_signal *sig);
 
+static int symbol2resamplemethod(t_symbol*s)
+{
+    if      (s == gensym("hold"  )) return 1; /* up: sample and hold */
+    else if (s == gensym("lin"   )) return 2; /* up: linear interpolation */
+    else if (s == gensym("linear")) return 2; /* up: linear interpolation */
+    else if (s == gensym("pad"   )) return 0; /* up: zero pad */
+    return -1;  /* default: sample/hold unless version<0.44 (where it's zero-pad) */
+}
+
 /* ------------------------- vinlet -------------------------- */
 t_class *vinlet_class;
 
@@ -249,7 +258,7 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs,
     }
 }
 
-static void *vinlet_newsig(t_symbol *s)
+static void *vinlet_newsig(t_symbol *s, int argc, t_atom *argv)
 {
     t_vinlet *x = (t_vinlet *)pd_new(vinlet_class);
     x->x_canvas = canvas_getcurrent();
@@ -268,16 +277,17 @@ static void *vinlet_newsig(t_symbol *s)
      *
      * up till now we provide several upsampling methods and 1 single downsampling method (no filtering !)
      */
-    if (s == gensym("hold"))
-        x->x_updown.method = 1;       /* up: sample and hold */
-    else if (s == gensym("lin") || s == gensym("linear"))
-        x->x_updown.method = 2;       /* up: linear interpolation */
-    else if (s == gensym("pad"))
-        x->x_updown.method = 0;       /* up: zero-padding */
-    else x->x_updown.method = 3;      /* sample/hold unless version<0.44 */
-
-    if (s == gensym("fwd"))         /* turn on forwarding */
-        x->x_fwdout = outlet_new(&x->x_obj, 0);
+    x->x_updown.method = -1;
+    while(argc-->0)
+    {
+        int method;
+        s = atom_getsymbol(argv++);
+        method = symbol2resamplemethod(s);
+        if (method >= 0)
+            x->x_updown.method = method;
+        if (s == gensym("fwd"))         /* turn on forwarding */
+            x->x_fwdout = outlet_new(&x->x_obj, 0);
+    }
     return (x);
 }
 
@@ -285,7 +295,7 @@ static void vinlet_setup(void)
 {
     vinlet_class = class_new(gensym("inlet"), (t_newmethod)vinlet_new,
         (t_method)vinlet_free, sizeof(t_vinlet), CLASS_NOINLET, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)vinlet_newsig, gensym("inlet~"), A_DEFSYM, 0);
+    class_addcreator((t_newmethod)vinlet_newsig, gensym("inlet~"), A_GIMME, 0);
     class_addbang(vinlet_class, vinlet_bang);
     class_addpointer(vinlet_class, vinlet_pointer);
     class_addfloat(vinlet_class, vinlet_float);
@@ -539,7 +549,7 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs,
                     (t_int)re_parentvecsize);
             else
             {
-                int method = (x->x_updown.method == 3?
+                int method = (x->x_updown.method < 0 ?
                     (pd_compatibilitylevel < 44 ? 0 : 1) : x->x_updown.method);
                 dsp_add(voutlet_doepilog_resampling, 2, x, (t_int)re_parentvecsize);
                 resampleto_dsp(&x->x_updown, outsig->s_vec, re_parentvecsize,
@@ -579,11 +589,7 @@ static void *voutlet_newsig(t_symbol *s)
      *
      * up till now we provide several upsampling methods and 1 single downsampling method (no filtering !)
      */
-    if (s == gensym("hold"))x->x_updown.method=1;        /* up: sample and hold */
-    else if (s == gensym("lin"))x->x_updown.method=2;    /* up: linear interpolation */
-    else if (s == gensym("linear"))x->x_updown.method=2; /* up: linear interpolation */
-    else if (s == gensym("pad"))x->x_updown.method=0;    /* up: zero pad */
-    else x->x_updown.method=3;                           /* up: zero-padding; down: ignore samples between */
+    x->x_updown.method = symbol2resamplemethod(s);
 
     return (x);
 }

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -30,28 +30,43 @@ static t_class *my_canvas_class;
 
 void my_canvas_draw_new(t_my_canvas *x, t_glist *glist)
 {
+    int zoom = IEMGUI_ZOOM(x);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int offset = (IEMGUI_ZOOM(x) > 1 ? IEMGUI_ZOOM(x) : 0); /* keep zoomed border inside visible area */
+    int offset = (zoom > 1 ? zoom : 0); /* keep zoomed border inside visible area */
     t_canvas *canvas = glist_getcanvas(glist);
+    char tag[128];
+    char *tags_label[]={tag, "label", "text"};
+    t_atom fontatoms[3];
+    SETSYMBOL(fontatoms+0, gensym(x->x_gui.x_font));
+    SETFLOAT (fontatoms+1, -(x->x_gui.x_fontsize)*zoom);
+    SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x -tags %lxRECT\n",
-             canvas, xpos, ypos,
-             xpos + x->x_vis_w * IEMGUI_ZOOM(x),
-             ypos + x->x_vis_h * IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -outline #%06x -tags %lxBASE\n",
-             canvas, xpos + offset, ypos + offset,
-             xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h,
-             IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
-             -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas,
-             xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+    sprintf(tag, "%lxRECT", x);
+    pdgui_vmess(0, "crr iiii rk rk rs",
+        canvas, "create", "rectangle",
+        xpos,ypos, xpos+x->x_vis_w*zoom,ypos+x->x_vis_h*zoom,
+        "-fill", x->x_gui.x_bcol,
+        "-outline", x->x_gui.x_bcol,
+        "-tags", tag);
+
+    sprintf(tag, "%lxBASE", x);
+    pdgui_vmess(0, "crr iiii ri rk rs",
+        canvas, "create", "rectangle",
+        xpos+offset,ypos+offset, xpos+offset+x->x_gui.x_w,ypos+offset+x->x_gui.x_h,
+        "-width", zoom,
+        "-outline", x->x_gui.x_bcol,
+        "-tags", tag);
+
+    sprintf(tag, "%lxLABEL", x);
+    pdgui_vmess(0, "crr ii rs rr rA rk rS",
+        canvas, "create", "text",
+        xpos+x->x_gui.x_ldx*zoom, ypos+x->x_gui.x_ldy*zoom,
+        "-text", (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        "-anchor", "w",
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_lcol,
+        "-tags", 3, tags_label);
 }
 
 void my_canvas_draw_move(t_my_canvas *x, t_glist *glist)
@@ -93,16 +108,31 @@ void my_canvas_draw_erase(t_my_canvas* x, t_glist* glist)
 
 void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
 {
+    int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
+    char tag[128];
+    t_atom fontatoms[3];
+    SETSYMBOL(fontatoms+0, gensym(x->x_gui.x_font));
+    SETFLOAT (fontatoms+1, -(x->x_gui.x_fontsize)*zoom);
+    SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-    sys_vgui(".x%lx.c itemconfigure %lxRECT -fill #%06x -outline #%06x\n", canvas, x,
-             x->x_gui.x_bcol, x->x_gui.x_bcol);
-    sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol,
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
+    sprintf(tag, "%lxRECT", x);
+    pdgui_vmess(0, "crs rk rk",
+        canvas, "itemconfigure", tag,
+        "-fill", x->x_gui.x_bcol,
+        "-outline", x->x_gui.x_bcol);
+
+    sprintf(tag, "%lxBASE", x);
+    pdgui_vmess(0, "crs rk",
+        canvas, "itemconfigure", tag,
+        "-outline", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
+
+    sprintf(tag, "%lxLABEL", x);
+    pdgui_vmess(0, "crs rA rk rs",
+        canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_lcol,
+        "-text", (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
 }
 
 void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
@@ -160,26 +190,26 @@ static void my_canvas_save(t_gobj *z, t_binbuf *b)
 static void my_canvas_properties(t_gobj *z, t_glist *owner)
 {
     t_my_canvas *x = (t_my_canvas *)z;
-    char buf[800];
     t_symbol *srl[3];
 
     iemgui_properties(&x->x_gui, srl);
-    sprintf(buf, "pdtk_iemgui_dialog %%s |cnv| \
-            ------selectable_dimensions(pix):------ %d %d size: 0.0 0.0 empty \
-            ------visible_rectangle(pix)(pix):------ %d width: %d height: %d \
-            %d empty empty %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x none #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), 1,
-            x->x_vis_w, x->x_vis_h, 0,/*no_schedule*/
-            -1, -1, -1, -1,/*no linlog, no init, no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r ir ir  i  irr ii ri ss sii ii krk",
+        "|cnv|",
+        "------selectable_dimensions(pix):------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), 1, "size:",
+        0, 0, "empty",
+        "------visible_rectangle(pix)(pix):------",
+        x->x_vis_w, "width:",
+        x->x_vis_h, "height:",
+        0, /* no_schedule */
+        -1, "empty", "empty", /* no linlog */
+        -1, -1, /* no loadbang, no steady */
+        "empty", -1, /* num */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,  /* label font */
+        x->x_gui.x_bcol, "none", x->x_gui.x_lcol);
 }
 
 static void my_canvas_get_pos(t_my_canvas *x)
@@ -374,7 +404,7 @@ static void my_canvas_ff(t_my_canvas *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_mycanvas_setup(void)

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -60,26 +60,35 @@ void my_canvas_draw_move(t_my_canvas *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int offset = (IEMGUI_ZOOM(x) > 1 ? IEMGUI_ZOOM(x) : 0);
     t_canvas *canvas = glist_getcanvas(glist);
+    char tag[128];
 
-    sys_vgui(".x%lx.c coords %lxRECT %d %d %d %d\n",
-             canvas, x, xpos, ypos,
-             xpos + x->x_vis_w * IEMGUI_ZOOM(x),
-             ypos + x->x_vis_h * IEMGUI_ZOOM(x));
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x, xpos + offset, ypos + offset,
-             xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+    sprintf(tag, "%lx%s", x, "RECT");
+    pdgui_vmess(0, "crs iiii",
+              canvas, "coords", tag,
+        xpos, ypos,
+        xpos + x->x_vis_w * IEMGUI_ZOOM(x), ypos + x->x_vis_h * IEMGUI_ZOOM(x));
+    sprintf(tag, "%lx%s", x, "BASE");
+    pdgui_vmess(0, "crs iiii",
+              canvas, "coords", tag,
+        xpos + offset, ypos + offset,
+        xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
+    sprintf(tag, "%lx%s", x, "LABEL");
+    pdgui_vmess(0, "crs ii",
+              canvas, "coords", tag,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
 void my_canvas_draw_erase(t_my_canvas* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-
-    sys_vgui(".x%lx.c delete %lxBASE\n", canvas, x);
-    sys_vgui(".x%lx.c delete %lxRECT\n", canvas, x);
-    sys_vgui(".x%lx.c delete %lxLABEL\n", canvas, x);
+    char tag[128];
+    sprintf(tag, "%lxBASE", x);
+    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    sprintf(tag, "%lxRECT", x);
+    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    sprintf(tag, "%lxLABEL", x);
+    pdgui_vmess(0, "crs", canvas, "delete", tag);
 }
 
 void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
@@ -99,15 +108,11 @@ void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
 void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-
-    if(x->x_gui.x_fsf.x_selected)
-    {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-    }
-    else
-    {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, x->x_gui.x_bcol);
-    }
+    char tag[128];
+    sprintf(tag, "%lxBASE", x);
+    pdgui_vmess(0, "crs rk",
+        canvas, "itemconfigure", tag,
+        "-outline", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
 }
 
 void my_canvas_draw(t_my_canvas *x, t_glist *glist, int mode)

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -459,8 +459,11 @@ int my_numbox_check_minmax(t_my_numbox *x, double min, double max)
 static void my_numbox_properties(t_gobj *z, t_glist *owner)
 {
     t_my_numbox *x = (t_my_numbox *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
     if(x->x_gui.x_fsf.x_change)
@@ -469,24 +472,25 @@ static void my_numbox_properties(t_gobj *z, t_glist *owner)
         clock_unset(x->x_clock_reset);
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
-    sprintf(buf, "pdtk_iemgui_dialog %%s |nbx| \
-            -------dimensions(digits)(pix):------- %d %d width: %d %d height: \
-            -----------output-range:----------- %g min: %g max: %d \
-            %d lin log %d %d log-height: %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_numwidth, MINDIGITS, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_min, x->x_max, 0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, -1,
-                x->x_log_height, /*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
-                0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+
+    pdgui_stub_vnew(
+        &x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r fr fr  i  irr ii ri ss sii ii rrr",
+        "|nbx|",
+        "-------dimensions(digits)(pix):-------",
+        x->x_numwidth, MINDIGITS, "width:",
+        x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "height:",
+        "-----------output-range:-----------",
+        x->x_min, "min:",
+        x->x_max, "max:",
+        0 /* no_schedule */,
+        x->x_lin0_log1, "lin", "log",
+        x->x_gui.x_isa.x_loadinit, -1,
+        "log-height:", x->x_log_height, /* no multi, but iem-characteristic */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void my_numbox_bang(t_my_numbox *x)
@@ -877,7 +881,7 @@ static void my_numbox_free(t_my_numbox *x)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     clock_free(x->x_clock_reset);
     clock_free(x->x_clock_wait);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_numbox_setup(void)

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -825,8 +825,10 @@ static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
 static void canvas_menusaveas(t_canvas *x, t_float fdestroy)
 {
     t_canvas *x2 = canvas_getrootfor(x);
-    sys_vgui("pdtk_canvas_saveas .x%lx {%s} {%s} %d\n", x2,
-        x2->gl_name->s_name, canvas_getdir(x2)->s_name, (fdestroy != 0));
+    pdgui_vmess("pdtk_canvas_saveas", "^ ss i",
+        x2,
+        x2->gl_name->s_name, canvas_getdir(x2)->s_name,
+        (fdestroy != 0));
 }
 
 static void canvas_menusave(t_canvas *x, t_float fdestroy)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -397,6 +397,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
     else rtext_formattext(x, widthp, heightp, indexp,
             tempbuf, &outchars_b, &selstart_b, &selend_b,
             fontwidth, fontheight);
+    tempbuf[outchars_b]=0;
 
     if (action && x->x_text->te_width && x->x_text->te_type != T_ATOM)
     {

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -432,7 +432,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
             character is an unescaped backslash ('\') which would have confused
             tcl/tk by escaping the close brace otherwise.  The GUI code
             drops the last character in the string. */
-        sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %d %d {%s } %d %s\n",
+        sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %d %d {%s} %d %s\n",
             canvas, x->x_tag, rtext_gettype(x)->s_name,
             text_xpix(x->x_text, x->x_glist) + lmargin,
                 text_ypix(x->x_text, x->x_glist) + tmargin,
@@ -443,7 +443,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
     }
     else if (action == SEND_UPDATE)
     {
-        sys_vgui("pdtk_text_set .x%lx.c %s {%s }\n",
+        sys_vgui("pdtk_text_set .x%lx.c %s {%s}\n",
             canvas, x->x_tag, escbuf);
         if (*widthp != x->x_drawnwidth || *heightp != x->x_drawnheight)
             text_drawborder(x->x_text, x->x_glist, x->x_tag,

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -452,19 +452,20 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
         {
             if (selend_b > selstart_b)
             {
-                sys_vgui(".x%lx.c select from %s %d\n", canvas,
+                pdgui_vmess(0, "crr si",
+                    canvas, "select", "from",
                     x->x_tag, u8_charnum(x->x_buf, selstart_b));
-                sys_vgui(".x%lx.c select to %s %d\n", canvas,
+                pdgui_vmess(0, "crr si",
+                    canvas, "select", "to",
                     x->x_tag, u8_charnum(x->x_buf, selend_b) - 1);
-                sys_vgui(".x%lx.c focus \"\"\n", canvas);
+                pdgui_vmess(0, "crs", canvas, "focus", "");
             }
             else
             {
-                sys_vgui(".x%lx.c select clear\n", canvas);
-                sys_vgui(".x%lx.c icursor %s %d\n", canvas, x->x_tag,
-                    u8_charnum(x->x_buf, selstart_b));
-                sys_vgui("focus .x%lx.c\n", canvas);
-                sys_vgui(".x%lx.c focus %s\n", canvas, x->x_tag);
+                pdgui_vmess(0, "crr", canvas, "select", "clear");
+                pdgui_vmess(0, "cr si", canvas, "icursor", x->x_tag, u8_charnum(x->x_buf, selstart_b));
+                pdgui_vmess("focus", "c", canvas);
+                pdgui_vmess(0, "crs", canvas, "focus", x->x_tag);
             }
         }
     }
@@ -523,21 +524,20 @@ void rtext_draw(t_rtext *x)
 
 void rtext_erase(t_rtext *x)
 {
-    sys_vgui(".x%lx.c delete %s\n", glist_getcanvas(x->x_glist), x->x_tag);
+    pdgui_vmess(0, "crs", glist_getcanvas(x->x_glist), "delete", x->x_tag);
 }
 
 void rtext_displace(t_rtext *x, int dx, int dy)
 {
-    sys_vgui(".x%lx.c move %s %d %d\n", glist_getcanvas(x->x_glist),
-        x->x_tag, dx, dy);
+    pdgui_vmess(0, "crs ii", glist_getcanvas(x->x_glist), "move", x->x_tag,
+        dx, dy);
 }
 
 void rtext_select(t_rtext *x, int state)
 {
-    t_glist *glist = x->x_glist;
-    t_canvas *canvas = glist_getcanvas(glist);
-    sys_vgui(".x%lx.c itemconfigure %s -fill %s\n", canvas,
-        x->x_tag, (state? "blue" : "black"));
+    pdgui_vmess(0, "crs rr",
+        glist_getcanvas(x->x_glist), "itemconfigure", x->x_tag,
+        "-fill", (state? "blue" : "black"));
 }
 
 void gatom_undarken(t_text *x);
@@ -549,7 +549,7 @@ void rtext_activate(t_rtext *x, int state)
     t_canvas *canvas = glist_getcanvas(glist);
     if (state)
     {
-        sys_vgui("pdtk_text_editing .x%lx %s 1\n", canvas, x->x_tag);
+        pdgui_vmess("pdtk_text_editing", "^si", canvas, x->x_tag, 1);
         glist->gl_editor->e_textedfor = x;
         glist->gl_editor->e_textdirty = 0;
         x->x_dragfrom = x->x_selstart = 0;
@@ -558,7 +558,7 @@ void rtext_activate(t_rtext *x, int state)
     }
     else
     {
-        sys_vgui("pdtk_text_editing .x%lx {} 0\n", canvas);
+        pdgui_vmess("pdtk_text_editing", "^si", canvas, "", 0);
         if (glist->gl_editor->e_textedfor == x)
             glist->gl_editor->e_textedfor = 0;
         x->x_active = 0;

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -587,13 +587,9 @@ static void scalar_properties(t_gobj *z, struct _glist *owner)
     b = glist_writetobinbuf(owner, 0);
     binbuf_gettext(b, &buf, &bufsize);
     binbuf_free(b);
-    buf = t_resizebytes(buf, bufsize, bufsize+1);
-    buf[bufsize] = 0;
-    sprintf(buf2, "pdtk_data_dialog %%s {");
-    gfxstub_new((t_pd *)owner, x, buf2);
-    sys_gui(buf);
-    sys_gui("}\n");
-    t_freebytes(buf, bufsize+1);
+    pdgui_stub_vnew((t_pd*)owner, "pdtk_data_dialog", x,
+        "p", bufsize, buf);
+    t_freebytes(buf, bufsize);
 }
 
 static const t_widgetbehavior scalar_widgetbehavior =
@@ -620,7 +616,7 @@ static void scalar_free(t_scalar *x)
         return;
     }
     word_free(x->sc_vec, template);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
         /* the "size" field in the class is zero, so Pd doesn't try to free
         us automatically (see pd_free()) */
     freebytes(x, sizeof(t_scalar) + (template->t_n - 1) * sizeof(*x->sc_vec));

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -383,20 +383,21 @@ static void scalar_getrect(t_gobj *z, t_glist *owner,
 
 static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
 {
+    char tag[128];
+    sprintf(tag, "select%lx", x);
     if (state)
     {
         int x1, y1, x2, y2;
-
         scalar_getrect(&x->sc_gobj, glist, &x1, &y1, &x2, &y2);
         x1--; x2++; y1--; y2++;
-        sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d \
-            -width 0 -fill blue -tags select%lx\n",
-                glist_getcanvas(glist), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1,
-                x);
-    }
-    else
-    {
-        sys_vgui(".x%lx.c delete select%lx\n", glist_getcanvas(glist), x);
+        pdgui_vmess(0, "crr iiiiiiiiii ri rr rs",
+                  glist_getcanvas(glist), "create", "line",
+                  x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
+                  "-width", 0,
+                  "-fill", "blue",
+                  "-tags", tag);
+    } else {
+        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
     }
 }
 
@@ -474,14 +475,21 @@ static void scalar_vis(t_gobj *z, t_glist *owner, int vis)
         /* if we don't know how to draw it, make a small rectangle */
     if (!templatecanvas)
     {
+        char tag[128];
+        sprintf(tag, "scalar%lx", x);
+
         if (vis)
         {
             int x1 = glist_xtopixels(owner, basex);
             int y1 = glist_ytopixels(owner, basey);
-            sys_vgui(".x%lx.c create rectangle %d %d %d %d -tags scalar%lx\n",
-                glist_getcanvas(owner), x1-1, y1-1, x1+1, y1+1, x);
+            pdgui_vmess(0, "crr iiii rs",
+                      glist_getcanvas(owner),
+                      "create", "rectangle",
+                      x1-1,y1-1, x1+1,y1+1,
+                      "-tags", tag);
         }
-        else sys_vgui(".x%lx.c delete scalar%lx\n", glist_getcanvas(owner), x);
+        else
+            pdgui_vmess(0, "crs", glist_getcanvas(owner), "delete", tag);
         return;
     }
 

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2645,12 +2645,16 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist,
     int vis)
 {
     t_drawnumber *x = (t_drawnumber *)z;
+    char tag[80];
+    const char*tags[] = {tag, "label"};
 
         /* see comment in plot_vis() */
     if (vis && !fielddesc_getfloat(&x->x_vis, template, data, 0))
         return;
+    sprintf(tag, "drawnumber%lx", data);
     if (vis)
     {
+        t_atom fontatoms[3];
         t_atom at;
         int xloc = glist_xtopixels(glist,
             basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
@@ -2660,15 +2664,21 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist,
         numbertocolor(fielddesc_getfloat(&x->x_color, template, data, 1),
             colorstring);
         drawnumber_getbuf(x, data, template, buf);
-        sys_vgui(".x%lx.c create text %d %d -anchor nw -fill %s -text {%s}",
-                glist_getcanvas(glist), xloc, yloc, colorstring, buf);
-        sys_vgui(" -font {{%s} -%d %s}", sys_font,
-            sys_hostfontsize(glist_getfont(glist), glist_getzoom(glist)),
-                sys_fontweight);
-        sys_vgui(" -tags [list drawnumber%lx label]\n", data);
+
+        SETSYMBOL(fontatoms+0, gensym(sys_font));
+        SETFLOAT (fontatoms+1,-sys_hostfontsize(glist_getfont(glist), glist_getzoom(glist)));
+        SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
+        pdgui_vmess(0, "crr ii rs rs rs rA rS",
+            glist_getcanvas(glist), "create", "text",
+            xloc, yloc,
+            "-anchor", "nw",
+            "-fill", colorstring,
+            "-text", buf,
+            "-font", 3, fontatoms,
+            "-tags", 2, tags);
     }
-    else sys_vgui(".x%lx.c delete drawnumber%lx\n",
-        glist_getcanvas(glist), data);
+    else
+        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
 }
 
 static void drawnumber_motionfn(void *z, t_floatarg dx, t_floatarg dy,

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1214,10 +1214,11 @@ static void curve_vis(t_gobj *z, t_glist *glist,
     t_curve *x = (t_curve *)z;
     int i, n = x->x_npoints;
     t_fielddesc *f = x->x_vec;
-
+    char tag[80];
         /* see comment in plot_vis() */
     if (vis && !fielddesc_getfloat(&x->x_vis, template, data, 0))
         return;
+    sprintf(tag, "curve%lx", data);
     if (vis)
     {
         if (n > 1)
@@ -1225,7 +1226,8 @@ static void curve_vis(t_gobj *z, t_glist *glist,
             int flags = x->x_flags, closed = (flags & CLOSED);
             t_float width = fielddesc_getfloat(&x->x_width, template, data, 1);
             char outline[20], fill[20];
-            int pix[200];
+            t_word pix[200];
+
             if (n > 100)
                 n = 100;
                 /* calculate the pixel values before we start printing
@@ -1234,9 +1236,9 @@ static void curve_vis(t_gobj *z, t_glist *glist,
                 have to allocate memory here. */
             for (i = 0, f = x->x_vec; i < n; i++, f += 2)
             {
-                pix[2*i] = glist_xtopixels(glist,
+                pix[2*i].w_float = glist_xtopixels(glist,
                     basex + fielddesc_getcoord(f, template, data, 1));
-                pix[2*i+1] = glist_ytopixels(glist,
+                pix[2*i+1].w_float = glist_ytopixels(glist,
                     basey + fielddesc_getcoord(f+1, template, data, 1));
             }
             if (width < 1) width = 1;
@@ -1245,30 +1247,39 @@ static void curve_vis(t_gobj *z, t_glist *glist,
             numbertocolor(
                 fielddesc_getfloat(&x->x_outlinecolor, template, data, 1),
                 outline);
+
+            pdgui_vmess(0, "crr iiii rf ri rs",
+                glist_getcanvas(glist), "create",
+                (flags & CLOSED)?"polygon":"line",
+                0, 0, 0, 0,
+                "-width", width,
+                "-smooth", !!(flags & BEZ),
+                "-tags", tag);
+
+            pdgui_vmess(0, "crs w",
+                glist_getcanvas(glist), "coords", tag,
+                2*n, pix);
+
             if (flags & CLOSED)
             {
                 numbertocolor(
                     fielddesc_getfloat(&x->x_fillcolor, template, data, 1),
                     fill);
-                sys_vgui(".x%lx.c create polygon\\\n",
-                    glist_getcanvas(glist));
-            }
-            else sys_vgui(".x%lx.c create line\\\n", glist_getcanvas(glist));
-            for (i = 0; i < n; i++)
-                sys_vgui("%d %d\\\n", pix[2*i], pix[2*i+1]);
-            sys_vgui("-width %f\\\n", width);
-            if (flags & CLOSED) sys_vgui("-fill %s -outline %s\\\n",
-                fill, outline);
-            else sys_vgui("-fill %s\\\n", outline);
-            if (flags & BEZ) sys_vgui("-smooth 1\\\n");
-            sys_vgui("-tags curve%lx\n", data);
+                pdgui_vmess(0, "crs rs rs",
+                    glist_getcanvas(glist), "itemconfigure", tag,
+                    "-fill", fill,
+                    "-outline", outline);
+            } else
+                pdgui_vmess(0, "crs rs",
+                    glist_getcanvas(glist), "itemconfigure", tag,
+                    "-fill", outline);
         }
         else post("warning: drawing shapes need at least two points to be graphed");
     }
     else
     {
-        if (n > 1) sys_vgui(".x%lx.c delete curve%lx\n",
-            glist_getcanvas(glist), data);
+        if (n > 1)
+            pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
     }
 }
 
@@ -1761,13 +1772,15 @@ static void plot_vis(t_gobj *z, t_glist *glist,
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval,
+    t_float linewidth, xloc, xinc, yloc, style, yval,
         vis, scalarvis, edit;
     double xsum;
     t_array *array;
     int nelem;
     char *elem;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
+    char tag[80], tag0[80];
+    const char*tags[] = {tag, tag0, "array"};
         /* even if the array is "invisible", if its visibility is
         set by an instance variable you have to explicitly erase it,
         because the flag could earlier have been on when we were getting
@@ -1788,11 +1801,20 @@ static void plot_vis(t_gobj *z, t_glist *glist,
     nelem = array->a_n;
     elem = (char *)array->a_vec;
 
+    sprintf(tag , "plot%lx", data);
+        /* a tag that uniquely identifies the sub-plot */
+    sprintf(tag0, "plot%lx_array%lx_onset%+d%+d%+d", data, elem, wonset, xonset, yonset);
+
     if (glist->gl_isgraph)
         linewidth *= glist_getzoom(glist);
 
     if (tovis)
     {
+         /* we use t_word because pdgui_vmess() has a convenient FLOATWORDS type
+          * FLOATARRAY is impractical (as it sends a list, and the GUI expects arguments)
+          */
+        t_word coordinates[1024*2];
+
         if (style == PLOTSTYLE_POINTS)
         {
             t_float minyval = 1e20, maxyval = -1e20;
@@ -1800,9 +1822,10 @@ static void plot_vis(t_gobj *z, t_glist *glist,
             char color[20];
             numbertocolor(fielddesc_getfloat(&x->x_outlinecolor, template,
                 data, 1), color);
+
             for (xsum = basex + xloc, i = 0; i < nelem; i++)
             {
-                t_float yval, xpix, ypix, nextxloc;
+                t_float yval, xpix, ypix, nextxloc, usexloc;
                 int ixpix, inextx;
 
                 if (xonset >= 0)
@@ -1833,14 +1856,14 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                     maxyval = yval;
                 if (i == nelem-1 || inextx != ixpix)
                 {
-                    sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                        "-fill %s -width 0 -tags [list plot%lx array]\n",
-                        glist_getcanvas(glist),
-                        ixpix, (int)glist_ytopixels(glist,
-                            basey + fielddesc_cvttocoord(yfielddesc, minyval)),
-                        inextx, (int)(glist_ytopixels(glist,
-                            basey + fielddesc_cvttocoord(yfielddesc, maxyval))
-                                + linewidth), color, data);
+
+                    pdgui_vmess(0, "crr iiii rs rf rS",
+                        glist_getcanvas(glist), "create", "rectangle",
+                        ixpix , (int) glist_ytopixels(glist, basey + fielddesc_cvttocoord(yfielddesc, minyval)),
+                        inextx, (int)(glist_ytopixels(glist, basey + fielddesc_cvttocoord(yfielddesc, maxyval)) + linewidth),
+                        "-fill", color,
+                        "-width", 0.,
+                        "-tags", 3, tags);
                     ndrawn++;
                     minyval = 1e20;
                     maxyval = -1e20;
@@ -1857,15 +1880,14 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                 /* draw the trace */
             numbertocolor(fielddesc_getfloat(&x->x_outlinecolor, template,
                 data, 1), outline);
+
             if (wonset >= 0)
             {
                     /* found "w" field which controls linewidth.  The trace is
                     a filled polygon with 2n points. */
-                sys_vgui(".x%lx.c create polygon \\\n",
-                    glist_getcanvas(glist));
-
                 for (i = 0, xsum = xloc; i < nelem; i++)
                 {
+                    t_float usexloc;
                     if (xonset >= 0)
                         usexloc = xloc + *(t_float *)((elem + elemsize * i)
                             + xonset);
@@ -1881,15 +1903,18 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                     ixpix = xpix + 0.5;
                     if (xonset >= 0 || ixpix != lastpixel)
                     {
-                        sys_vgui("%d %f \\\n", ixpix,
-                            glist_ytopixels(glist,
-                                basey + fielddesc_cvttocoord(yfielddesc,
-                                    yloc + yval) -
-                                        fielddesc_cvttocoord(wfielddesc,wval)));
+                        coordinates[ndrawn*2+0].w_float = ixpix;
+                        coordinates[ndrawn*2+1].w_float = glist_ytopixels(
+                            glist,
+                            basey
+                            + yloc
+                            + fielddesc_cvttocoord(yfielddesc, yval)
+                            - fielddesc_cvttocoord(wfielddesc, wval));
                         ndrawn++;
                     }
                     lastpixel = ixpix;
-                    if (ndrawn >= 1000) goto ouch;
+                    if (ndrawn*2 >= sizeof(coordinates)/sizeof(*coordinates))
+                        goto ouch;
                 }
                 lastpixel = -1;
                 for (i = nelem-1; i >= 0; i--)
@@ -1910,79 +1935,112 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                     ixpix = xpix + 0.5;
                     if (xonset >= 0 || ixpix != lastpixel)
                     {
-                        sys_vgui("%d %f \\\n", ixpix, glist_ytopixels(glist,
-                            basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                                yval) +
-                                    fielddesc_cvttocoord(wfielddesc, wval)));
+                        coordinates[ndrawn*2+0].w_float = ixpix;
+                        coordinates[ndrawn*2+1].w_float = glist_ytopixels(
+                            glist,
+                            basey
+                            + yloc
+                            + fielddesc_cvttocoord(yfielddesc, yval)
+                            + fielddesc_cvttocoord(wfielddesc, wval));
                         ndrawn++;
                     }
                     lastpixel = ixpix;
-                    if (ndrawn >= 1000) goto ouch;
+                    if (ndrawn*2 >= sizeof(coordinates)/sizeof(*coordinates))
+                        goto ouch;
                 }
+
                     /* TK will complain if there aren't at least 3 points.
                     There should be at least two already. */
                 if (ndrawn < 4)
                 {
-                    sys_vgui("%d %f \\\n", ixpix + 10, glist_ytopixels(glist,
-                        basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                            yval) +
-                                fielddesc_cvttocoord(wfielddesc, wval)));
-                    sys_vgui("%d %f \\\n", ixpix + 10, glist_ytopixels(glist,
-                        basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                            yval) -
-                                fielddesc_cvttocoord(wfielddesc, wval)));
+                    coordinates[ndrawn*2+0].w_float = ixpix + 10;
+                    coordinates[ndrawn*2+1].w_float = glist_ytopixels(
+                        glist,
+                        basey
+                        + yloc
+                        + fielddesc_cvttocoord(yfielddesc, yval)
+                        - fielddesc_cvttocoord(wfielddesc, wval));
+                    ndrawn++;
+
+                    coordinates[ndrawn*2+0].w_float = ixpix + 10;
+                    coordinates[ndrawn*2+1].w_float = glist_ytopixels(
+                        glist,
+                        basey
+                        + yloc
+                        + fielddesc_cvttocoord(yfielddesc, yval)
+                        + fielddesc_cvttocoord(wfielddesc, wval));
+                    ndrawn++;
                 }
             ouch:
-                sys_vgui(" -width %d -fill %s -outline %s\\\n",
-                    (glist->gl_isgraph ? glist_getzoom(glist) : 1),
-                    outline, outline);
-                if (style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
 
-                sys_vgui("-tags [list plot%lx array]\n", data);
+                pdgui_vmess(0, "crr ri rs rs ri rS",
+                    glist_getcanvas(glist), "create", "polygon",
+                    "-width", (glist->gl_isgraph ? glist_getzoom(glist) : 1),
+                    "-fill", outline,
+                    "-outline", outline,
+                    "-smooth", (style == PLOTSTYLE_BEZ),
+                    "-tags", 3, tags);
+
+                pdgui_vmess(0, "crs w",
+                    glist_getcanvas(glist), "coords", tag0,
+                    ndrawn*2, coordinates);
             }
             else if (linewidth > 0)
             {
                     /* no "w" field.  If the linewidth is positive, draw a
                     segmented line with the requested width; otherwise don't
                     draw the trace at all. */
-                sys_vgui(".x%lx.c create line \\\n", glist_getcanvas(glist));
-
-                for (xsum = xloc, i = 0; i < nelem; i++)
+                for (i = 0, xsum = xloc; i < nelem; i++)
                 {
                     t_float usexloc;
                     if (xonset >= 0)
-                        usexloc = xloc + *(t_float *)((elem + elemsize * i) +
-                            xonset);
+                        usexloc = xloc + *(t_float *)((elem + elemsize * i)
+                            + xonset);
                     else usexloc = xsum, xsum += xinc;
                     if (yonset >= 0)
                         yval = *(t_float *)((elem + elemsize * i) + yonset);
                     else yval = 0;
                     yval = CLIP(yval);
+
+
                     xpix = glist_xtopixels(glist,
                         basex + fielddesc_cvttocoord(xfielddesc, usexloc));
                     ixpix = xpix + 0.5;
                     if (xonset >= 0 || ixpix != lastpixel)
                     {
-                        sys_vgui("%d %f \\\n", ixpix,
-                            glist_ytopixels(glist,
-                                basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                                    yval)));
+                        coordinates[ndrawn*2+0].w_float = ixpix;
+                        coordinates[ndrawn*2+1].w_float = glist_ytopixels(
+                            glist,
+                            basey
+                            + yloc
+                            + fielddesc_cvttocoord(yfielddesc, yval));
                         ndrawn++;
                     }
                     lastpixel = ixpix;
-                    if (ndrawn >= 1000) break;
+                    if (ndrawn*2 >= sizeof(coordinates)/sizeof(*coordinates)) break;
                 }
+
                     /* TK will complain if there aren't at least 2 points... */
-                if (ndrawn == 0) sys_vgui("0 0 0 0 \\\n");
-                else if (ndrawn == 1) sys_vgui("%d %f \\\n", ixpix + 10,
-                    glist_ytopixels(glist, basey + yloc +
-                        fielddesc_cvttocoord(yfielddesc, yval)));
+                if (ndrawn == 1)
+                {
+                    coordinates[2].w_float = ixpix + 10;
+                    coordinates[3].w_float = glist_ytopixels(glist, basey + yloc + fielddesc_cvttocoord(yfielddesc, yval));
+                    ndrawn = 2;
+                }
 
-                sys_vgui("-width %f\\\n", linewidth);
-                sys_vgui("-fill %s\\\n", outline);
-                if (style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
-
-                sys_vgui("-tags [list plot%lx array]\n", data);
+                if(ndrawn)
+                {
+                    pdgui_vmess(0, "crr iiii rf rs ri rS",
+                        glist_getcanvas(glist), "create", "line",
+                        0, 0, 0, 0,
+                        "-width", linewidth,
+                        "-fill", outline,
+                        "-smooth", (style == PLOTSTYLE_BEZ),
+                        "-tags", 3, tags);
+                    pdgui_vmess(0, "crs w",
+                        glist_getcanvas(glist), "coords", tag0,
+                        ndrawn*2, coordinates);
+                }
             }
         }
             /* We're done with the outline; now draw all the points.
@@ -2036,8 +2094,7 @@ static void plot_vis(t_gobj *z, t_glist *glist,
             }
         }
             /* and then the trace */
-        sys_vgui(".x%lx.c delete plot%lx\n",
-            glist_getcanvas(glist), data);
+        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1600,7 +1600,7 @@ void text_drawborder(t_text *x, t_glist *glist,
     if ((ob = pd_checkobject(&x->te_pd)))
         glist_drawiofor(glist, ob, firsttime, tag, x1, y1, x2, y2);
     if (firsttime) /* raise cords over everything else */
-        sys_vgui(".x%lx.c raise cord\n", glist_getcanvas(glist));
+        pdgui_vmess(0, "crr", glist_getcanvas(glist), "raise", "cord");
 }
 
 void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1205,21 +1205,22 @@ static void gatom_free(t_gatom *x)
     if (*x->a_symfrom->s_name)
         pd_unbind(&x->a_text.te_pd,
             canvas_realizedollar(x->a_glist, x->a_symfrom));
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
     sys_unqueuegui(x);
 }
 
 static void gatom_properties(t_gobj *z, t_glist *owner)
 {
     t_gatom *x = (t_gatom *)z;
-    char buf[200];
-    sprintf(buf, "pdtk_gatom_dialog %%s %d %g %g %d {%s} {%s} {%s} %d\n",
-        x->a_text.te_width, x->a_draglo, x->a_draghi,
-            x->a_wherelabel, gatom_escapit(x->a_label)->s_name,
-                gatom_escapit(x->a_symfrom)->s_name,
-                    gatom_escapit(x->a_symto)->s_name,
-                        x->a_fontsize);
-    gfxstub_new(&x->a_text.te_pd, x, buf);
+    pdgui_stub_vnew(&x->a_text.te_pd, "pdtk_gatom_dialog", x,
+        "i ff i sss i",
+        x->a_text.te_width,
+        x->a_draglo, x->a_draghi,
+        x->a_wherelabel,
+        gatom_escapit(x->a_label)->s_name,
+        gatom_escapit(x->a_symfrom)->s_name,
+        gatom_escapit(x->a_symto)->s_name,
+        x->a_fontsize);
 }
 
 

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -265,26 +265,32 @@ static void toggle_save(t_gobj *z, t_binbuf *b)
 static void toggle_properties(t_gobj *z, t_glist *owner)
 {
     t_toggle *x = (t_toggle *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
-    sprintf(buf, "pdtk_iemgui_dialog %%s |tgl| \
-            ----------dimensions(pix):----------- %d %d size: 0 0 empty \
-            -----------non-zero-value:----------- %g value: 0.0 empty %g \
-            -1 lin log %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_nonzero, 1.0,/*non_zero-schedule*/
-            x->x_gui.x_isa.x_loadinit, -1, -1,/*no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+
+    pdgui_stub_vnew(
+        &x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r fr fr  i  irr ii ri ss sii ii rrr",
+        "|tgl|",
+        "----------dimensions(pix):-----------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "size:",
+        0, 0, "empty",
+        "-----------non-zero-value:-----------",
+        x->x_nonzero, "value:",
+        0.0, "empty",
+        1 /* non_zero-schedule */,
+        -1, "lin", "log",
+        x->x_gui.x_isa.x_loadinit, -1,
+        "empty", -1, /* no multi */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void toggle_bang(t_toggle *x)
@@ -487,7 +493,7 @@ static void toggle_ff(t_toggle *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_toggle_setup(void)

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -108,7 +108,7 @@ int canvas_undo_objectstate(t_canvas *cnv, void *z, int action) {
 static void canvas_show_undomenu(t_canvas*x, const char* undo_action, const char* redo_action)
 {
     if (glist_isvisible(x) && glist_istoplevel(x))
-        sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, undo_action, redo_action);
+        pdgui_vmess("pdtk_undomenu", "^ ss", x, undo_action, redo_action);
 }
 
 static void canvas_undo_docleardirty(t_canvas *x)

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -280,29 +280,33 @@ static void vradio_save(t_gobj *z, t_binbuf *b)
 static void vradio_properties(t_gobj *z, t_glist *owner)
 {
     t_radio *x = (t_radio *)z;
-    char buf[800];
     t_symbol *srl[3];
     int hchange = -1;
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
     if(pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)
         hchange = x->x_change;
-    sprintf(buf, "pdtk_iemgui_dialog %%s |vradio| \
-            ----------dimensions(pix):----------- %d %d size: 0 0 empty \
-            empty 0.0 empty 0.0 empty %d \
-            %d new-only new&old %d %d number: %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            0,/*no_schedule*/
-            hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number,
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r ir ir  i  irr ii ri ss sii ii rrr",
+        "|vradio|",
+        "----------dimensions(pix):-----------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "size:",
+        0, 0, "empty",
+        "empty",
+        0, "empty",
+        0, "empty",
+        0 /* no schedule */,
+        hchange, "new-only", "new&old",
+        x->x_gui.x_isa.x_loadinit, -1 /* no steady */,
+        "number:", x->x_number, /* multi */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
 static void vradio_dialog(t_radio *x, t_symbol *s, int argc, t_atom *argv)
@@ -682,7 +686,7 @@ static void vradio_ff(t_radio *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_vradio_setup(void)

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -291,27 +291,31 @@ void vslider_check_minmax(t_slider *x, double min, double max)
 static void vslider_properties(t_gobj *z, t_glist *owner)
 {
     t_slider *x = (t_slider *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], fcol[10];
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(fcol, "#%06x", 0xffffff & x->x_gui.x_fcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
 
-    sprintf(buf, "pdtk_iemgui_dialog %%s |vsl| \
-            --------dimensions(pix)(pix):-------- %d %d width: %d %d height: \
-            -----------output-range:----------- %g bottom: %g top: %d \
-            %d lin log %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_SL_MINSIZE,
-            x->x_min, x->x_max, 0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady, -1,/*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r fr fr  i  irr ii ri ss sii ii rrr",
+        "|vsl|",
+        "--------dimensions(pix)(pix):--------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "width:",
+        x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_SL_MINSIZE, "height:",
+        "-----------output-range:-----------",
+        x->x_min, "bottom:",
+        x->x_max, "top:",
+        0 /*no_schedule*/,
+        x->x_lin0_log1, "lin", "log",
+        x->x_gui.x_isa.x_loadinit, x->x_steady,
+        "empty", -1, /* no multi, but iem-characteristic */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize, /* label font */
+        bcol, fcol, lcol);
 }
 
     /* compute numeric value (fval) from pixel location (val) and range */
@@ -640,7 +644,7 @@ static void vslider_free(t_slider *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_vslider_setup(void)

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -518,27 +518,29 @@ static void vu_scale(t_vu *x, t_floatarg fscale)
 static void vu_properties(t_gobj *z, t_glist *owner)
 {
     t_vu *x = (t_vu *)z;
-    char buf[800];
     t_symbol *srl[3];
+    char bcol[10], lcol[10], *fcol="none";
+    sprintf(bcol, "#%06x", 0xffffff & x->x_gui.x_bcol);
+    sprintf(lcol, "#%06x", 0xffffff & x->x_gui.x_lcol);
 
     iemgui_properties(&x->x_gui, srl);
-    sprintf(buf, "pdtk_iemgui_dialog %%s |vu| \
-            --------dimensions(pix)(pix):-------- %d %d width: %d %d height: \
-            empty 0.0 empty 0.0 empty %d \
-            %d no_scale scale %d %d empty %d \
-            %s %s \
-            %s %d %d \
-            %d %d \
-            #%06x none #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_VU_STEPS*IEM_VU_MINSIZE,
-            0,/*no_schedule*/
-            x->x_scale, -1, -1, -1,/*no linlog, no init, no multi*/
-            srl[0]->s_name, srl[1]->s_name,/*no send*/
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
-    gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
+    pdgui_stub_vnew(&x->x_gui.x_obj.ob_pd, "pdtk_iemgui_dialog", x,
+        "r  r iir iir  r ir ir  i  irr ii ri ss sii ii rrr",
+        "|vu|",
+        "--------dimensions(pix)(pix):--------",
+        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, "width:",
+        x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_VU_STEPS*IEM_VU_MINSIZE, "height:",
+        "empty",
+        0, "empty",
+        0, "empty",
+        0 /* no schedule */,
+        x->x_scale, "no_scale", "scale",
+        -1 /* no loadbang */, -1 /* no steady */,
+        "empty", -1, /* no multi */
+        srl[0]->s_name, srl[1]->s_name, /* send/receive */
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy, /* label + pos */
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,  /* label font */
+        bcol, fcol, lcol);
 }
 
 static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
@@ -738,7 +740,7 @@ static void vu_free(t_vu *x)
 {
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_unbind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
-    gfxstub_deleteforkey(x);
+    pdgui_stub_deleteforkey(x);
 }
 
 void g_vumeter_setup(void)

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -106,18 +106,7 @@ void max_default(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 
 void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
-    char str[80];
-    sys_vgui("pdtk_plugin_dispatch ");
-    for (i = 0; i < argc; i++)
-    {
-        atom_string(argv+i, str, 80);
-        sys_vgui("%s", str);
-        if (i < argc-1) {
-            sys_vgui(" ");
-        }
-    }
-    sys_vgui("\n");
+    pdgui_vmess("pdtk_plugin_dispatch", "a", argc, argv);
 }
 
 int sys_zoom_open = 1;

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -711,14 +711,62 @@ EXTERN int value_setfloat(t_symbol *s, t_float f);
 /* ------- GUI interface - functions to send strings to TK --------- */
 typedef void (*t_guicallbackfn)(t_gobj *client, t_glist *glist);
 
-EXTERN void sys_vgui(const char *fmt, ...);
-EXTERN void sys_gui(const char *s);
+EXTERN void sys_vgui(const char *fmt, ...); /* avoid this: use pdgui_vmess() instead */
+EXTERN void sys_gui(const char *s); /* avoid this: use pdgui_vmess() instead */
+
 EXTERN void sys_pretendguibytes(int n);
 EXTERN void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f);
 EXTERN void sys_unqueuegui(void *client);
     /* dialog window creation and destruction */
-EXTERN void gfxstub_new(t_pd *owner, void *key, const char *cmd);
-EXTERN void gfxstub_deleteforkey(void *key);
+EXTERN void gfxstub_new(t_pd *owner, void *key, const char *cmd); /* avoid this: use pdgui_stub_vnew() instead */
+EXTERN void gfxstub_deleteforkey(void *key); /* avoid this: use pdgui_stub_deleteforkey() instead */
+
+/*
+ * send a message to the GUI, with a simplified formatting syntax
+ * <destination>: receiver on the GUI side (e.g. a Tcl/Tk 'proc')
+ * <fmt>: string of format specifiers
+ * <...>: values according to the format specifiers
+ *
+ * the <destination> can be a NULL pointer (in which case it is ignored)
+ * the user of NULL as a <destination> is discouraged
+
+ * depending on the format specifiers, one or more values are passed
+ *    'f' : <double:value>        : a floating point number
+ *    'i' : <int:value>           : an integer number
+ *    's' : <const char*:value>   : a string
+ *    'r' : <const char*:value>   : a raw string
+ *    'x' : <void*:value>         : a generic pointer
+ *    'o' : <t_object*:value>     : an graphical object
+ *    '^' : <t_canvas*:value>     : a toplevel window (legacy)
+ *    'c' : <t_canvas*:value>     : a canvas (on a window)
+ *    'F' : <int:size> <const t_float*:values>: array of t_float's
+ *    'S' : <int:size> <const char**:values>: array of strings
+ *    'R' : <int:size> <const char**:values>: array of raw strings
+ *    'a' : <int:size> <const t_atom*:values>: list of atoms
+ *    'A' : <int:size> <const t_atom*:values>: array of atoms
+ *    'w' : <int:size> <const t_word*:values>: list of floatwords
+ *    'W' : <int:size> <const t_word*:values>: array of floatwords
+ *    'm' : <t_symbol*s:recv> <int:argc> <t_atom*:argv>: a Pd message
+ *    'p' : <int:size> <const char*:values>  : a pascal string (explicit size; not \0-terminated)
+ *    'k' : <int:color>           : a color (or kolor, if you prefer)
+ *    ' ' : none                  : ignored
+ * the use of the specifiers 'x^' is discouraged
+ * raw-strings ('rR') should only be used for constant, well-known strings
+ */
+EXTERN void pdgui_vmess(const char* destination, const char* fmt, ...);
+
+
+/* improved dialog window creation
+ * this will insert a first argument to <destination> based on <key>
+ * which the GUI can then use to callback.
+ * gfxstub_new() ensures that the given receiver will be available,
+ * even if the <owner> has been removed in the meantime.
+ * see pdgui_vmess() for a description of <fmt> and the varargs
+ */
+
+EXTERN void pdgui_stub_vnew(t_pd *owner, const char* destination, void *key, const char* fmt, ...);
+EXTERN void pdgui_stub_deleteforkey(void *key);
+
 
 extern t_class *glob_pdobject;  /* object to send "pd" messages */
 

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -189,7 +189,7 @@ void sys_log_error(int type)
     if (type != ERR_NOTHING && !sched_diored &&
         (sched_counter >= sched_dioredtime))
     {
-        sys_vgui("pdtk_pd_dio 1\n");
+        pdgui_vmess("pdtk_pd_dio", "i", 1);
         sched_diored = 1;
     }
     sched_dioredtime = sched_counter + APPROXTICKSPERSEC;
@@ -233,7 +233,7 @@ void sched_set_using_audio(int flag)
                 post("sorry, can't turn off callbacks yet; restart Pd");
                     /* not right yet! */
 
-    sys_vgui("pdtk_pd_audio %s\n", flag ? "on" : "off");
+    pdgui_vmess("pdtk_pd_audio", "r", flag ? "on" : "off");
 }
 
     /* take the scheduler forward one DSP tick, also handling clock timeouts */
@@ -320,7 +320,7 @@ static int sched_idletask( void)
     {
         if (sched_diored && (sched_counter - sched_dioredtime > 0))
         {
-            sys_vgui("pdtk_pd_dio 0\n");
+            pdgui_vmess("pdtk_pd_dio", "i", 0);
             sched_diored = 0;
         }
         sched_nextmeterpolltime = sched_counter + APPROXTICKSPERSEC;

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -115,8 +115,8 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     g_toggle.c g_undo.c g_vdial.c g_vslider.c g_vumeter.c  g_editor_extras.c \
     m_pd.c m_class.c m_obj.c m_atom.c m_memory.c m_binbuf.c \
     m_conf.c m_glob.c m_sched.c \
-    s_main.c s_inter.c s_print.c  s_loader.c s_path.c s_entry.c s_audio.c \
-    s_midi.c s_net.c s_utf8.c s_audio_paring.c \
+    s_main.c s_inter.c s_inter_gui.c s_print.c s_loader.c s_path.c s_entry.c \
+    s_audio.c s_audio_paring.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \
     d_delay.c d_resample.c d_soundfile.c d_soundfile_aiff.c d_soundfile_caf.c \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -90,7 +90,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     g_editor_extras.c \
     m_pd.c m_class.c m_obj.c m_atom.c m_memory.c m_binbuf.c \
     m_conf.c m_glob.c m_sched.c \
-    s_main.c s_inter.c s_file.c s_print.c \
+    s_main.c s_inter.c s_inter_gui.c s_file.c s_print.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -124,7 +124,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     g_editor_extras.c \
     m_pd.c m_class.c m_obj.c m_atom.c m_memory.c m_binbuf.c \
     m_conf.c m_glob.c m_sched.c \
-    s_main.c s_inter.c s_file.c s_print.c \
+    s_main.c s_inter.c s_inter_gui.c s_file.c s_print.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -87,7 +87,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     g_editor_extras.c \
     m_pd.c m_class.c m_obj.c m_atom.c m_memory.c m_binbuf.c \
     m_conf.c m_glob.c m_sched.c \
-    s_main.c s_inter.c s_file.c s_print.c \
+    s_main.c s_inter.c s_inter_gui.c s_file.c s_print.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \
     d_math.c d_fft.c d_fft_fftsg.c d_array.c d_global.c \

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -602,20 +602,32 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
         /* these are all the devices on your system: */
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
     char device[MAXPDSTRING];
+    char *indevs[MAXNDEV], *outdevs[MAXNDEV];
     int nindevs = 0, noutdevs = 0, canmulti = 0, cancallback = 0, i;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
          &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
 
-    sys_gui("global audio_indevlist; set audio_indevlist {}\n");
     for (i = 0; i < nindevs; i++)
-        sys_vgui("lappend audio_indevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
-
-    sys_gui("global audio_outdevlist; set audio_outdevlist {}\n");
+        indevs[i] = indevlist + i * DEVDESCSIZE;
     for (i = 0; i < noutdevs; i++)
-        sys_vgui("lappend audio_outdevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+        outdevs[i] = outdevlist + i * DEVDESCSIZE;
+
+    if(!nindevs) {
+        nindevs = 1;
+        indevs[0] = "";
+    }
+    if(!noutdevs) {
+        noutdevs = 1;
+        outdevs[0] = "";
+    }
+
+    pdgui_vmess("set", "rS",
+            "::audio_indevlist",
+            nindevs, indevs);
+    pdgui_vmess("set", "rS",
+            "::audio_outdevlist",
+            noutdevs, outdevs);
 
     sys_get_audio_settings(&as);
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -597,13 +597,13 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     /* start an audio settings dialog window */
 void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
 {
-    char buf[MAXPDSTRING];
     t_audiosettings as;
         /* these are all the devices on your system: */
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
     char device[MAXPDSTRING];
     char *indevs[MAXNDEV], *outdevs[MAXNDEV];
     int nindevs = 0, noutdevs = 0, canmulti = 0, cancallback = 0, i;
+    char srate[80], callback[80], blocksize[80];
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
          &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
@@ -634,27 +634,26 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
     if (as.a_nindev > 1 || as.a_noutdev > 1)
         flongform = 1;
 
+    sprintf(srate, "%s%d", audio_isfixedsr(as.a_api)?"!":"", as.a_srate);
+    sprintf(callback, "%s%d", cancallback?"":"!", as.a_callback);
+    sprintf(blocksize, "%s%d", audio_isfixedblocksize(as.a_api)?"!":"", as.a_blocksize);
+
         /* values that are fixed and must not be changed by the GUI are
         prefixed with '!';  * the GUI will then display these values but
         disable their widgets */
-    snprintf(buf, MAXPDSTRING,
-"pdtk_audio_dialog %%s \
-%d %d %d %d %d %d %d %d \
-%d %d %d %d %d %d %d %d \
-%s%d %d %d %s%d %d %s%d\n",
-        as.a_indevvec[0], as.a_indevvec[1],
-            as.a_indevvec[2], as.a_indevvec[3],
-        as.a_chindevvec[0], as.a_chindevvec[1],
-            as.a_chindevvec[2], as.a_chindevvec[3],
-        as.a_outdevvec[0], as.a_outdevvec[1],
-            as.a_outdevvec[2], as.a_outdevvec[3],
-        as.a_choutdevvec[0], as.a_choutdevvec[1],
-            as.a_choutdevvec[2], as.a_choutdevvec[3],
-        audio_isfixedsr(as.a_api)?"!":"", as.a_srate, as.a_advance, canmulti,
-        cancallback?"":"!", as.a_callback,
-        (flongform != 0), audio_isfixedblocksize(as.a_api)?"!":"", as.a_blocksize);
-    gfxstub_deleteforkey(0);
-    gfxstub_new(&glob_pdobject, (void *)glob_audio_properties, buf);
+    pdgui_stub_deleteforkey(0);
+    pdgui_stub_vnew(&glob_pdobject,
+        "pdtk_audio_dialog", (void *)glob_audio_properties,
+        "iiii iiii iiii iiii  s ii s i s",
+        as.a_indevvec   [0], as.a_indevvec   [1], as.a_indevvec   [2], as.a_indevvec   [3],
+        as.a_chindevvec [0], as.a_chindevvec [1], as.a_chindevvec [2], as.a_chindevvec [3],
+        as.a_outdevvec  [0], as.a_outdevvec  [1], as.a_outdevvec  [2], as.a_outdevvec  [3],
+        as.a_choutdevvec[0], as.a_choutdevvec[1], as.a_choutdevvec[2], as.a_choutdevvec[3],
+        srate,
+        as.a_advance, canmulti,
+        callback,
+        (flongform != 0),
+        blocksize);
 }
 
     /* new values from dialog window */

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -259,7 +259,7 @@ void sys_set_audio_settings(t_audiosettings *a)
     initted = 1;
 
     sys_log_error(ERR_NOTHING);
-    sys_vgui("set pd_whichapi %d\n", audio_nextsettings.a_api);
+    pdgui_vmess("set", "ri", "pd_whichapi", audio_nextsettings.a_api);
 }
 
 void sys_close_audio(void)
@@ -315,7 +315,7 @@ void sys_close_audio(void)
     sched_set_using_audio(SCHED_AUDIO_NONE);
     audio_callback_is_open = 0;
 
-    sys_vgui("set pd_whichapi 0\n");
+    pdgui_vmess("set", "ri", "pd_whichapi", 0);
 }
 
 void sys_init_audio(void)
@@ -440,7 +440,7 @@ void sys_reopen_audio(void)
             (as.a_callback ? SCHED_AUDIO_CALLBACK : SCHED_AUDIO_POLL));
         audio_callback_is_open = as.a_callback;
     }
-    sys_vgui("set pd_whichapi %d\n",  sys_audioapiopened);
+    pdgui_vmess("set", "ri", "pd_whichapi", sys_audioapiopened);
 }
 
 int sys_send_dacs(void)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -46,8 +46,8 @@ that didn't really belong anywhere. */
 /* colorize output, but only on a TTY */
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#else // if isatty exists outside unistd, please add another #ifdef
-static int isatty(int fd) {return 0;}
+#else /* if isatty exists outside unistd, please add another #ifdef */
+# define isatty(fd) 0
 #endif
 static int stderr_isatty;
 

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -43,13 +43,23 @@ that didn't really belong anywhere. */
 #include <stdlib.h>
 #endif
 
+/* colorize output, but only on a TTY */
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#else // if isatty exists outside unistd, please add another #ifdef
+static int isatty(int fd) {return 0;}
+#endif
+static int stderr_isatty;
+
 #define stringify(s) str(s)
 #define str(s) #s
 
 #define INTER (pd_this->pd_inter)
 
-#define DEBUG_MESSUP 1      /* messages up from pd to pd-gui */
-#define DEBUG_MESSDOWN 2    /* messages down from pd-gui to pd */
+#define DEBUG_MESSUP   1<<0    /* messages up from pd to pd-gui */
+#define DEBUG_MESSDOWN 1<<1    /* messages down from pd-gui to pd */
+#define DEBUG_COLORIZE 1<<2    /* colorize messages (if we are on a TTY) */
+
 
 #ifndef PDBINDIR
 #define PDBINDIR "bin/"
@@ -506,15 +516,25 @@ static int socketreceiver_doread(t_socketreceiver *x)
             if (sys_debuglevel & DEBUG_MESSDOWN)
             {
                 size_t bufsize = (bp>messbuf)?(bp-messbuf):0;
+                int colorize = stderr_isatty && (sys_debuglevel & DEBUG_COLORIZE);
+                const char*msg = messbuf;
+                if (('\r' == messbuf[0]) && ('\n' == messbuf[1]))
+                {
+                    bufsize-=2;
+                    msg+=2;
+                }
         #ifdef _WIN32
             #ifdef _MSC_VER
-                fwprintf(stderr, L"<< %.*S\n", (int)bufsize, messbuf);
+                fwprintf(stderr, L"<< %.*S\n", (int)bufsize, msg);
             #else
-                fwprintf(stderr, L"<< %.*s\n", (int)bufsize, messbuf);
+                fwprintf(stderr, L"<< %.*s\n", (int)bufsize, msg);
             #endif
                 fflush(stderr);
         #else
-                fprintf(stderr, "<< %.*s\n", (int)bufsize, messbuf);
+                if(colorize)
+                    fprintf(stderr, "\e[0;1;36m<< %.*s\e[0m\n", (int)bufsize, msg);
+                else
+                    fprintf(stderr, "<< %.*s\n", (int)bufsize, msg);
         #endif
             }
             x->sr_inhead = inhead;
@@ -820,15 +840,22 @@ void sys_vgui(const char *fmt, ...)
     if (sys_debuglevel & DEBUG_MESSUP)
     {
         const char *mess = INTER->i_guibuf + INTER->i_guihead;
+        int colorize = stderr_isatty && (sys_debuglevel & DEBUG_COLORIZE);
+        static int newmess = 1;
 #ifdef _WIN32
     #ifdef _MSC_VER
-        fwprintf(stderr, L">> %S", mess);
+        fwprintf(stderr, L"%S", mess);
     #else
-        fwprintf(stderr, L">> %s", mess);
+        fwprintf(stderr, L"%s", mess);
     #endif
         fflush(stderr);
 #else
-        fprintf(stderr, ">> %s", mess);
+        if (colorize)
+            fprintf(stderr, "\e[0;1;35m%s%s\e[0m", (newmess)?">> ":"", mess);
+        else
+            fprintf(stderr, "%s%s", (newmess)?">> ":"", mess);
+
+        newmess = ('\n' == mess[msglen-1]);
 #endif
     }
     INTER->i_guihead += msglen;
@@ -1585,6 +1612,7 @@ static void glist_maybevis(t_glist *gl)
 int sys_startgui(const char *libdir)
 {
     t_canvas *x;
+    stderr_isatty = isatty(2);
     for (x = pd_getcanvaslist(); x; x = x->gl_next)
         canvas_vis(x, 0);
     INTER->i_havegui = 1;

--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -12,40 +12,56 @@
 
 /* NULL-terminated */
 #define GUI_VMESS__END     0
+/* use space to structure the format-string */
 #define GUI_VMESS__IGNORE  ' '
 
+/* floating point number (automatically promoted to double) */
 #define GUI_VMESS__FLOAT   'f'
+/* fixed point number (automatically promoted to int) */
 #define GUI_VMESS__INT     'i'
-/* 0-terminated strings and pascalstrings (with an explicit size) are untrusted and need escaping */
+
+/* 0-terminated strings are untrusted and need escaping */
 #define GUI_VMESS__STRING  's'
+/* the same goes for char arrays ("pascalstring") */
 #define GUI_VMESS__PASCALSTRING 'p'
 /* rawstrings don't need encoding */
 #define GUI_VMESS__RAWSTRING  'r'
+
+/* takes an int-representation of a 24bit RGB color */
 #define GUI_VMESS__COLOR      'k'
 
+/* generic pointer; this is not actually used, and probably should stay that way */
 #define GUI_VMESS__POINTER    'x'
+/* a Pd-object */
 #define GUI_VMESS__OBJECT     'o'
+
+/* takes a Pd-message of the form "t_symbol*, int argc, t_atom*argv" */
 #define GUI_VMESS__MESSAGE    'm'
 
 /* arrays are capitalized */
 #define GUI_VMESS__ATOMS          'a' /* flat list of atoms */
 #define GUI_VMESS__ATOMARRAY      'A'
 #define GUI_VMESS__FLOATARRAY     'F'
-#define GUI_VMESS__FLOATWORDS     'w'
+#define GUI_VMESS__FLOATWORDS     'w' /* flat list of float words */
 #define GUI_VMESS__FLOATWORDARRAY 'W'
 #define GUI_VMESS__STRINGARRAY    'S'
 #define GUI_VMESS__RAWSTRINGARRAY 'R'
 
-/* why are these capitalized? because they are pointers? */
-#define GUI_VMESS__WINDOW '^' /* legacy: this should go away (use 'c' instead) */
+/* canvases */
 #define GUI_VMESS__CANVAS 'c'
 #define GUI_VMESS__CANVASARRAY 'C'
 
+/* toplevel windows are legacy: this should go away (use 'c' instead) */
+#define GUI_VMESS__WINDOW '^'
+
 /* more ideas for types (the IDs need discussion)
  * - float32 array ('1'), float64 array ('2'): think libpd
- * - symbols ('y'), symbolarray ('Y'): this is just a shorthand for 's', so probably overkill
+ * - symbols ('y'), symbolarray ('Y'): this is just a shorthand for 's',
+ *   so probably overkill
  * - t_word array ('W')
- * - color (?): '#%06x'
+
+ * - a continuation char ('+'), to keep formating and values close together:
+ *   e.g.  pdgui_vmess(..., "i+", 12, "i+", 13);
  */
 
 
@@ -57,7 +73,8 @@ static PERTHREAD size_t s_esclength = 0;
 static char*get_escapebuffer(const char*s, int size)
 {
     size_t len = (size>0)?size:strlen(s);
-    len = 2*len + 1; /* worst case needs escaping each character; and a terminating \0... */
+        /* worst case needs escaping each character; AND a terminating \0... */
+    len = 2*len + 1;
     if (len > s_esclength) {
         freebytes(s_escbuffer, s_esclength);
         s_esclength = GUI_ALLOCCHUNK*(1+len/GUI_ALLOCCHUNK);

--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -1,0 +1,397 @@
+/* Copyright (c) 2022 IOhannes m zmölnig.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* Pd side of the Pd/Pd-gui interface. */
+
+#include "m_pd.h"
+#include "s_stuff.h"
+#include <stdarg.h>
+#include <string.h>
+
+
+/* NULL-terminated */
+#define GUI_VMESS__END     0
+#define GUI_VMESS__IGNORE  ' '
+
+#define GUI_VMESS__FLOAT   'f'
+#define GUI_VMESS__INT     'i'
+/* 0-terminated strings and pascalstrings (with an explicit size) are untrusted and need escaping */
+#define GUI_VMESS__STRING  's'
+#define GUI_VMESS__PASCALSTRING 'p'
+/* rawstrings don't need encoding */
+#define GUI_VMESS__RAWSTRING  'r'
+#define GUI_VMESS__COLOR      'k'
+
+#define GUI_VMESS__POINTER    'x'
+#define GUI_VMESS__OBJECT     'o'
+#define GUI_VMESS__MESSAGE    'm'
+
+/* arrays are capitalized */
+#define GUI_VMESS__ATOMS          'a' /* flat list of atoms */
+#define GUI_VMESS__ATOMARRAY      'A'
+#define GUI_VMESS__FLOATARRAY     'F'
+#define GUI_VMESS__FLOATWORDS     'w'
+#define GUI_VMESS__FLOATWORDARRAY 'W'
+#define GUI_VMESS__STRINGARRAY    'S'
+#define GUI_VMESS__RAWSTRINGARRAY 'R'
+
+/* why are these capitalized? because they are pointers? */
+#define GUI_VMESS__WINDOW '^' /* legacy: this should go away (use 'c' instead) */
+#define GUI_VMESS__CANVAS 'c'
+#define GUI_VMESS__CANVASARRAY 'C'
+
+/* more ideas for types (the IDs need discussion)
+ * - float32 array ('1'), float64 array ('2'): think libpd
+ * - symbols ('y'), symbolarray ('Y'): this is just a shorthand for 's', so probably overkill
+ * - t_word array ('W')
+ * - color (?): '#%06x'
+ */
+
+
+static PERTHREAD char* s_escbuffer = 0;
+static PERTHREAD size_t s_esclength = 0;
+#ifndef GUI_ALLOCCHUNK
+# define GUI_ALLOCCHUNK 8192
+#endif
+static char*get_escapebuffer(const char*s, int size)
+{
+    size_t len = (size>0)?size:strlen(s);
+    len = 2*len + 1; /* worst case needs escaping each character; and a terminating \0... */
+    if (len > s_esclength) {
+        freebytes(s_escbuffer, s_esclength);
+        s_esclength = GUI_ALLOCCHUNK*(1+len/GUI_ALLOCCHUNK);
+        s_escbuffer = getbytes(s_esclength);
+    }
+    return s_escbuffer;
+}
+static const char* str_escape(const char*s, int size)
+{
+    if (!get_escapebuffer(s, size))
+        return 0;
+    return pdgui_strnescape(s_escbuffer, s_esclength, s, size);
+}
+
+typedef struct _val {
+    int type;
+    size_t size;
+    const char* string;
+    union
+    {
+        double d;
+        int i;
+        const void*p;
+    } value;
+} t_val;
+
+//#define DEBUGME
+/* constructs a string that can be passed on to sys_gui() */
+#ifdef DEBUGME
+static void print_val(t_val v) {
+    char str[80];
+    dprintf(2, "value[%c] ", v.type);
+    switch (v.type) {
+    case GUI_VMESS__ATOMS:
+        atom_string(v.value.p, str, sizeof(str));
+        dprintf(2, "(atom)%s", str);
+        break;
+    case GUI_VMESS__FLOAT:
+        dprintf(2, "(float)%f", v.value.d);
+        break;
+    case GUI_VMESS__INT:
+        dprintf(2, "(int)%d", v.value.i);
+        break;
+    case GUI_VMESS__COLOR:
+        dprintf(2, "(color)#%06x", v.value.i & 0xFFFFFF);
+        break;
+    case GUI_VMESS__STRING:
+        dprintf(2, "(string)\"%s\"", v.value.p);
+        break;
+    case GUI_VMESS__PASCALSTRING:
+        dprintf(2, "(pascalstring)\"%.*s\"", v.size, v.value.p);
+        break;
+    case GUI_VMESS__RAWSTRING:
+        dprintf(2, "(rawstring)\"%s\"", v.value.p);
+        break;
+    case GUI_VMESS__WINDOW:
+    case GUI_VMESS__CANVAS:
+        dprintf(2, "(glist)%p", v.value.p);
+            /* estimate the size required for the array */
+        break;
+    case GUI_VMESS__ATOMARRAY:
+    case GUI_VMESS__FLOATARRAY:
+    case GUI_VMESS__FLOATWORDS:
+    case GUI_VMESS__FLOATWORDARRAY:
+    case GUI_VMESS__STRINGARRAY:
+    case GUI_VMESS__RAWSTRINGARRAY:
+    case GUI_VMESS__POINTER:
+    case GUI_VMESS__OBJECT:
+    case GUI_VMESS__CANVASARRAY:
+        dprintf(2, "%dx @%p", v.size, v.value.p);
+            /* estimate the size required for the array */
+        break;
+    case GUI_VMESS__MESSAGE:
+        dprintf(2, "(message)%s %d@%p", v.string, v.size, v.value.p);
+        break;
+    default:
+        break;
+    }
+    dprintf(2, "\n");
+}
+#else
+static void print_val(t_val v) { ; }
+int dprintf(int fd, const char* format, ...) { return -1; }
+#endif
+
+static void sendatoms(int argc, t_atom*argv, int raw) {
+    int i;
+    for(i=0; i<argc; i++)
+    {
+        t_atom *a=argv++;
+        switch (a->a_type) {
+        default:
+            break;
+        case A_FLOAT:
+                /* HACK: currently ATOMARRAY is only used for setting fonts
+                 * and Tcl/Tk is picky when it receives non-integers as fontsize
+                 */
+            sys_vgui("%g ", atom_getfloat(a));
+            break;
+        case A_DOLLAR:
+        case A_DOLLSYM:
+        case A_SYMBOL:
+            if(raw)
+                sys_vgui("%s ", atom_getsymbol(a)->s_name);
+            else
+                sys_vgui("{%s} ", str_escape(atom_getsymbol(a)->s_name, 0));
+            break;
+        case A_POINTER:
+            sys_vgui("%p ", a->a_w.w_gpointer);
+            break;
+        case A_SEMI:
+            sys_vgui("\\; ");
+            break;
+        case A_COMMA:
+            if (raw)
+                sys_vgui(", ");
+            else
+                sys_vgui("{,} ");
+            break;
+        }
+    }
+}
+
+
+static int addmess(t_val v)
+{
+    int i;
+    char escbuf[MAXPDSTRING];
+        //dprintf(2, "add-message: "); print_val(v);
+    switch (v.type) {
+    case GUI_VMESS__IGNORE:
+        break;
+    case GUI_VMESS__FLOAT:
+        sys_vgui("%g", v.value.d);
+        break;
+    case GUI_VMESS__INT:
+        sys_vgui("%d", v.value.i);
+        break;
+    case GUI_VMESS__COLOR:
+        sys_vgui("#%06x", v.value.i & 0xFFFFFF);
+        break;
+    case GUI_VMESS__RAWSTRING:
+        sys_vgui("%s", v.value.p);
+        break;
+    case GUI_VMESS__STRING:
+        sys_vgui("{%s}", str_escape(v.value.p, 0));
+        break;
+    case GUI_VMESS__PASCALSTRING:
+        sys_vgui("{%s}", str_escape(v.value.p, v.size));
+        break;
+    case GUI_VMESS__POINTER:
+    case GUI_VMESS__OBJECT:
+        sys_vgui("%p", v.value.p);
+        break;
+    case GUI_VMESS__MESSAGE:
+        sys_vgui("{");
+        if (v.string)
+            sys_vgui("%s ", v.string);
+        else
+            ;
+        sendatoms(v.size, (t_atom*)v.value.p, 1);
+        sys_vgui("}");
+        break;
+    case GUI_VMESS__WINDOW:
+        sys_vgui(".x%lx", v.value.p);
+        break;
+    case GUI_VMESS__CANVAS:
+        sys_vgui(".x%lx.c", v.value.p);
+        break;
+    case GUI_VMESS__CANVASARRAY:
+    {
+        const t_canvas**data = (const t_canvas**)v.value.p;
+        sys_vgui("{");
+        for(i=0; i<v.size; i++)
+            sys_vgui(".x%lx.c ", data[i]);
+        sys_vgui("}");
+        break;
+    }
+    case GUI_VMESS__FLOATARRAY:
+    {
+        const t_float*data = (const t_float*)v.value.p;
+        sys_vgui("{");
+        for(i=0; i<v.size; i++)
+            sys_vgui("%f ", *data++);
+        sys_vgui("}");
+        break;
+    }
+    case GUI_VMESS__FLOATWORDS:
+    case GUI_VMESS__FLOATWORDARRAY:
+    {
+        const t_word*data = (const t_word*)v.value.p;
+        if (GUI_VMESS__FLOATWORDARRAY == v.type)
+            sys_vgui("{");
+        for(i=0; i<v.size; i++)
+            sys_vgui("%g ", data[i].w_float);
+        if (GUI_VMESS__FLOATWORDARRAY == v.type)
+            sys_vgui("}");
+        break;
+    }
+    case GUI_VMESS__RAWSTRINGARRAY:
+    case GUI_VMESS__STRINGARRAY:
+    {
+        const char**data = (const char**)v.value.p;
+        sys_vgui("{");
+        for(i=0; i<v.size; i++)
+        {
+            const char*s=data[i];
+            if (GUI_VMESS__RAWSTRINGARRAY == v.type)
+                sys_vgui("%s ", s);
+            else
+                sys_vgui("{%s} ", str_escape(s, 0));
+        }
+        sys_vgui("}");
+        break;
+    }
+    case GUI_VMESS__ATOMS:
+    case GUI_VMESS__ATOMARRAY:
+    {
+        if (GUI_VMESS__ATOMARRAY == v.type)
+            sys_vgui("{");
+        sendatoms(v.size, (t_atom*)v.value.p, 0);
+        if (GUI_VMESS__ATOMARRAY == v.type)
+            sys_vgui("}");
+        break;
+    }
+    default:
+        return 1;
+    }
+    return 0;
+}
+
+static int va2value(const char fmt, va_list args, t_val*v) {
+    int result = 1;
+    v->type = fmt;
+    v->size = 1;
+    switch (fmt) {
+    case GUI_VMESS__IGNORE: /* <space> */
+    case '\n': case '\t': /* other whitespace */
+        v->type = GUI_VMESS__IGNORE;
+        break;
+    case GUI_VMESS__ATOMS:
+        v->size = va_arg(args, int);
+        v->value.p = va_arg(args, t_atom*);
+        break;
+    case GUI_VMESS__FLOAT:
+        v->value.d = va_arg(args, double);
+        break;
+    case GUI_VMESS__INT:
+    case GUI_VMESS__COLOR:
+        v->value.i = va_arg(args, int);
+        break;
+    case GUI_VMESS__RAWSTRING:
+    case GUI_VMESS__STRING:
+    case GUI_VMESS__OBJECT:
+    case GUI_VMESS__POINTER:
+    case GUI_VMESS__WINDOW:
+    case GUI_VMESS__CANVAS:
+        v->value.p = va_arg(args, void*);
+        break;
+    case GUI_VMESS__ATOMARRAY:
+    case GUI_VMESS__CANVASARRAY:
+    case GUI_VMESS__FLOATARRAY:
+    case GUI_VMESS__FLOATWORDS:
+    case GUI_VMESS__FLOATWORDARRAY:
+    case GUI_VMESS__STRINGARRAY:
+    case GUI_VMESS__RAWSTRINGARRAY:
+    case GUI_VMESS__PASCALSTRING:
+        v->size = va_arg(args, int);
+        v->value.p = va_arg(args, void*);
+        break;
+    case GUI_VMESS__MESSAGE:
+    {
+        t_symbol*s = va_arg(args, t_symbol*);
+        v->string = s?s->s_name:0;
+        v->size = va_arg(args, int);
+        v->value.p = va_arg(args, void*);
+        break;
+    }
+    default:
+        result = v->size = 0;
+        fprintf(stderr, "pdgui_vmess: unknown type-ID %d ('%c')\n", fmt, fmt);
+        break;
+    }
+    return result;
+}
+
+
+void pdgui_vamess(const char* message, const char* format, va_list args)
+{
+    const char* fmt;
+    char* buf;
+    t_val v;
+
+    v.type = GUI_VMESS__RAWSTRING;
+    v.size = 1;
+    v.value.p = message;
+
+    if(message) {
+        addmess(v);
+        sys_vgui("%s", " ");
+    }
+
+        /* iterate over the format-string and add elements */
+    for(fmt = format; *fmt; fmt++) {
+        if(va2value(*fmt, args, &v) < 1)
+            continue;
+        addmess(v);
+        sys_vgui("%s", " ");
+    }
+}
+void pdgui_endmess(void)
+{
+    t_val v;
+    v.type = GUI_VMESS__RAWSTRING;
+    v.size = 1;
+    v.value.p = ";\n";
+    addmess(v);
+}
+
+
+/* constructs a string that can be passed on to sys_gui() */
+/* TODO: shouldn't this have a pointer to t_pdinstance? */
+void pdgui_vmess(const char* message, const char* format, ...)
+{
+    va_list args;
+    if (!sys_havegui())return;
+    if(!format)
+    {
+        if (message)
+            sys_vgui("%s;\n", message);
+        return;
+    }
+    va_start(args, format);
+    pdgui_vamess(message, format, args);
+    va_end(args);
+    pdgui_endmess();
+}

--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -382,7 +382,8 @@ void pdgui_vamess(const char* message, const char* format, va_list args)
         if(va2value(*fmt, args, &v) < 1)
             continue;
         addmess(v);
-        sys_vgui("%s", " ");
+        if(GUI_VMESS__IGNORE != v.type)
+            sys_vgui("%s", " ");
     }
 }
 void pdgui_endmess(void)

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -1543,11 +1543,11 @@ void sys_set_extrapath(void)
     /* start a search path dialog window */
 void glob_start_path_dialog(t_pd *dummy)
 {
-     char buf[MAXPDSTRING];
-
     sys_set_searchpath();
-    snprintf(buf, MAXPDSTRING-1, "pdtk_path_dialog %%s %d %d\n", sys_usestdpath, sys_verbose);
-    gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
+    pdgui_stub_vnew(
+        &glob_pdobject,
+        "pdtk_path_dialog", (void *)glob_start_path_dialog,
+        "ii", sys_usestdpath, sys_verbose);
 }
 
     /* new values from dialog window */
@@ -1602,12 +1602,11 @@ void sys_set_startup(void)
     /* start a startup dialog window */
 void glob_start_startup_dialog(t_pd *dummy)
 {
-    char buf[MAXPDSTRING];
-    char obuf[MAXPDSTRING];
     sys_set_startup();
-    snprintf(buf, MAXPDSTRING-1, "pdtk_startup_dialog %%s %d {%s}\n", sys_defeatrt,
-        (sys_flags? pdgui_strnescape(obuf, MAXPDSTRING, sys_flags->s_name, 0) : ""));
-    gfxstub_new(&glob_pdobject, (void *)glob_start_startup_dialog, buf);
+    pdgui_stub_vnew(
+        &glob_pdobject,
+        "pdtk_startup_dialog", (void *)glob_start_path_dialog,
+        "is", sys_defeatrt, sys_flags?sys_flags->s_name:0);
 }
 
     /* new values from dialog window */

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -605,7 +605,7 @@ void sys_open_midi(int nmidiindev, int *midiindev,
     sys_save_midi_params(nmidiindev, midiindev,
         nmidioutdev, midioutdev);
 
-    sys_vgui("set pd_whichmidiapi %d\n", sys_midiapi);
+    pdgui_vmess("set", "ri", "pd_whichmidiapi", sys_midiapi);
 
 }
 

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -690,7 +690,6 @@ extern t_class *glob_pdobject;
     /* start an midi settings dialog window */
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 {
-    char buf[1024 + 2 * MAXNDEV*(DEVDESCSIZE+4)];
         /* these are the devices you're using: */
     int nindev, midiindev[MAXMIDIINDEV];
     int noutdev, midioutdev[MAXMIDIOUTDEV];
@@ -744,30 +743,24 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
     midioutdev8 = (noutdev > 7 && midioutdev[7]>= 0 ? midioutdev[7]+1 : 0);
     midioutdev9 = (noutdev > 8 && midioutdev[8]>= 0 ? midioutdev[8]+1 : 0);
 
+    pdgui_stub_deleteforkey(0);
 #ifdef USEAPI_ALSA
-      if (sys_midiapi == API_ALSA)
-    sprintf(buf,
-"pdtk_alsa_midi_dialog %%s \
-%d %d %d %d %d %d %d %d \
-%d 1\n",
-        midiindev1, midiindev2, midiindev3, midiindev4,
-        midioutdev1, midioutdev2, midioutdev3, midioutdev4,
-        (flongform != 0));
-      else
+    if (sys_midiapi == API_ALSA)
+        pdgui_stub_vnew(&glob_pdobject,
+            "pdtk_alsa_midi_dialog", (void *)glob_midi_properties,
+            "iiii iiii ii",
+            midiindev1 , midiindev2 , midiindev3 , midiindev4 ,
+            midioutdev1, midioutdev2, midioutdev3, midioutdev4,
+            (flongform != 0), 1);
+    else
 #endif
-    sprintf(buf,
-"pdtk_midi_dialog %%s \
-%d %d %d %d %d %d %d %d %d \
-%d %d %d %d %d %d %d %d %d \
-%d\n",
-        midiindev1, midiindev2, midiindev3, midiindev4, midiindev5,
-        midiindev6, midiindev7, midiindev8, midiindev9,
-        midioutdev1, midioutdev2, midioutdev3, midioutdev4, midioutdev5,
-        midioutdev6, midioutdev7, midioutdev8, midioutdev9,
+    pdgui_stub_vnew(
+        &glob_pdobject,
+        "pdtk_midi_dialog", (void *)glob_midi_properties,
+        "iiiiiiiii iiiiiiiii i",
+        midiindev1 , midiindev2 , midiindev3 , midiindev4 , midiindev5 , midiindev6 , midiindev7 , midiindev8 , midiindev9 ,
+        midioutdev1, midioutdev2, midioutdev3, midioutdev4, midioutdev5, midioutdev6, midioutdev7, midioutdev8, midioutdev9,
         (flongform != 0));
-
-    gfxstub_deleteforkey(0);
-    gfxstub_new(&glob_pdobject, (void *)glob_midi_properties, buf);
 }
 
     /* new values from dialog window */

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -701,21 +701,24 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 
         /* these are all the devices on your system: */
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char *indevs[1+MAXNDEV], *outdevs[1+MAXNDEV];
     int nindevs = 0, noutdevs = 0, i;
     char device[MAXPDSTRING];
 
+    indevs[0] = outdevs[0] = "none";
+
     sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
         MAXNDEV, DEVDESCSIZE);
-
-    sys_gui("global midi_indevlist; set midi_indevlist {none}\n");
     for (i = 0; i < nindevs; i++)
-        sys_vgui("lappend midi_indevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
-
-    sys_gui("global midi_outdevlist; set midi_outdevlist {none}\n");
+        indevs[i+1] = indevlist + i * DEVDESCSIZE;
     for (i = 0; i < noutdevs; i++)
-        sys_vgui("lappend midi_outdevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+        outdevs[i+1] = outdevlist + i * DEVDESCSIZE;
+
+    pdgui_vmess("set", "rS", "::midi_indevlist",
+        nindevs+1, indevs); /* +1 for the leading 'none' */
+
+    pdgui_vmess("set", "rS", "::midi_outdevlist",
+        noutdevs+1, outdevs); /* +1 for the leading 'none' */
 
     sys_get_midi_params(&nindev, midiindev, &noutdev, midioutdev);
 

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -67,8 +67,7 @@ static void dopost(const char *s)
     }
     else
     {
-        char upbuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::post {%s}\n", pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        pdgui_vmess("::pdwindow::post", "s", s);
     }
 }
 
@@ -97,8 +96,8 @@ static void doerror(const void *object, const char *s)
 #endif
     }
     else
-        sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n",
-            object, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        pdgui_vmess("::pdwindow::logpost", "ois",
+                  object, 1, s);
 }
 
 static void dologpost(const void *object, const int level, const char *s)
@@ -129,8 +128,8 @@ static void dologpost(const void *object, const int level, const char *s)
 #endif
     }
     else
-        sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n",
-            object, level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        pdgui_vmess("::pdwindow::logpost", "ois",
+                  object, level, s);
 }
 
 void logpost(const void *object, int level, const char *fmt, ...)

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -46,10 +46,16 @@ static t_gfxstub *gfxstub_list;
     it so we can provide a name by which the GUI can send us back
     messages; e.g., "pdtk_canvas_dofont %s 10". */
 
+static t_symbol*gfxstub_symbol(t_gfxstub *x)
+{
+    char namebuf[80];
+    sprintf(namebuf, ".gfxstub%lx", (t_int)x);
+    return gensym(namebuf);
+}
+
 void gfxstub_new(t_pd *owner, void *key, const char *cmd)
 {
     char buf[4*MAXPDSTRING];
-    char namebuf[80];
     char sprintfbuf[MAXPDSTRING];
     char *afterpercent;
     t_int afterpercentlen;
@@ -66,9 +72,8 @@ void gfxstub_new(t_pd *owner, void *key, const char *cmd)
         return;
     }
     x = (t_gfxstub *)pd_new(gfxstub_class);
-    sprintf(namebuf, ".gfxstub%lx", (t_int)x);
 
-    s = gensym(namebuf);
+    s = gfxstub_symbol(x);
     pd_bind(&x->x_pd, s);
     x->x_owner = owner;
     x->x_sym = s;
@@ -112,7 +117,8 @@ void gfxstub_deleteforkey(void *key)
         {
             if (y->x_key == key)
             {
-                sys_vgui("destroy .gfxstub%lx\n", y);
+                t_symbol *s = gfxstub_symbol(y);
+                pdgui_vmess("destroy", "s", s->s_name);
                 y->x_owner = 0;
                 gfxstub_offlist(y);
                 didit = 1;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -185,6 +185,50 @@ static void gfxstub_setup(void)
         gensym("cancel"), 0);
 }
 
+#include <stdarg.h>
+/* pdgui_*mess() are from s_inter_gui.c */
+void pdgui_vamess(const char* message, const char* format, va_list args);
+void pdgui_endmess(void);
+
+static void _pdguistub_vamess(const char*dest, const char*fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    pdgui_vamess(dest, fmt, args);
+    va_end(args);
+}
+void pdgui_stub_vnew(t_pd *owner, const char* destination, void *key, const char* fmt, ...)
+{
+    t_symbol*s;
+    t_gfxstub *x;
+    va_list args;
+
+        /* if any exists with matching key, burn it. */
+    for (x = gfxstub_list; x; x = x->x_next)
+        if (x->x_key == key)
+            gfxstub_deleteforkey(key);
+    x = (t_gfxstub *)pd_new(gfxstub_class);
+    s = gfxstub_symbol(x);
+    pd_bind(&x->x_pd, s);
+    x->x_owner = owner;
+    x->x_sym = s;
+    x->x_key = key;
+    x->x_next = gfxstub_list;
+    gfxstub_list = x;
+
+    _pdguistub_vamess(destination, "s", s->s_name);
+    va_start(args, fmt);
+    pdgui_vamess(0, fmt, args);
+    va_end(args);
+    pdgui_endmess();
+
+
+}
+void pdgui_stub_deleteforkey(void *key)
+{
+    gfxstub_deleteforkey(key);
+}
+
 /* -------------------------- openpanel ------------------------------ */
 
 static t_class *openpanel_class;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -256,7 +256,7 @@ static void *openpanel_new(t_floatarg mode)
 static void openpanel_symbol(t_openpanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    sys_vgui("pdtk_openpanel {%s} {%s} %d\n",
+    pdgui_vmess("pdtk_openpanel", "ssi",
         x->x_s->s_name, path, x->x_mode);
 }
 
@@ -320,7 +320,8 @@ static void *savepanel_new(void)
 static void savepanel_symbol(t_savepanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    sys_vgui("pdtk_savepanel {%s} {%s}\n", x->x_s->s_name, path);
+    pdgui_vmess("pdtk_savepanel", "ss",
+        x->x_s->s_name, path);
 }
 
 static void savepanel_bang(t_savepanel *x)
@@ -513,11 +514,7 @@ static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
 
 static void pdcontrol_browse(t_pdcontrol *x, t_symbol *s)
 {
-    char buf[MAXPDSTRING];
-    snprintf(buf, MAXPDSTRING, "::pd_menucommands::menu_openfile {%s}\n",
-        s->s_name);
-    buf[MAXPDSTRING-1] = 0;
-    sys_gui(buf);
+    pdgui_vmess("::pd_menucommands::menu_openfile", "s", s->s_name);
 }
 
 static void pdcontrol_isvisible(t_pdcontrol *x)

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -69,8 +69,9 @@ static void textbuf_senditup(t_textbuf *x)
     char *txt;
     if (!x->b_guiconnect)
         return;
+
     binbuf_gettext(x->b_binbuf, &txt, &ntxt);
-    sys_vgui("pdtk_textwindow_clear .x%lx\n", x);
+    pdgui_vmess("pdtk_textwindow_clear", "^", x);
     for (i = 0; i < ntxt; )
     {
         char *j = strchr(txt+i, '\n');
@@ -79,7 +80,7 @@ static void textbuf_senditup(t_textbuf *x)
             x, j-txt-i, txt+i);
         i = (int)((j-txt)+1);
     }
-    sys_vgui("pdtk_textwindow_setdirty .x%lx 0\n", x);
+    pdgui_vmess("pdtk_textwindow_setdirty", "^i", x, 0);
     t_freebytes(txt, ntxt);
 }
 
@@ -87,8 +88,8 @@ static void textbuf_open(t_textbuf *x)
 {
     if (x->b_guiconnect)
     {
-        sys_vgui("wm deiconify .x%lx\n", x);
-        sys_vgui("raise .x%lx\n", x);
+        pdgui_vmess("wm", "r^", "deiconify", x);
+        pdgui_vmess("raise", "^", x);
         sys_vgui("focus .x%lx.text\n", x);
     }
     else
@@ -108,7 +109,7 @@ static void textbuf_close(t_textbuf *x)
 {
     if (x->b_guiconnect)
     {
-        sys_vgui("pdtk_textwindow_doclose .x%lx\n", x);
+        pdgui_vmess("pdtk_textwindow_doclose", "^", x);
         guiconnect_notarget(x->b_guiconnect, 1000);
         x->b_guiconnect = 0;
     }
@@ -203,7 +204,7 @@ static void textbuf_free(t_textbuf *x)
         binbuf_free(x->b_binbuf);
     if (x->b_guiconnect)
     {
-        sys_vgui("destroy .x%lx\n", x);
+        pdgui_vmess("destroy", "^", x);
         guiconnect_notarget(x->b_guiconnect, 1000);
     }
         /* just in case we're still bound to #A from loading... */

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -88,17 +88,20 @@ static void textbuf_open(t_textbuf *x)
 {
     if (x->b_guiconnect)
     {
+        char textid[128];
+        sprintf(textid, ".x%lx.text", x);
         pdgui_vmess("wm", "r^", "deiconify", x);
         pdgui_vmess("raise", "^", x);
-        sys_vgui("focus .x%lx.text\n", x);
+        pdgui_vmess("focus", "s", textid);
     }
     else
     {
         char buf[40];
-        sys_vgui("pdtk_textwindow_open .x%lx %dx%d {%s} %d\n",
-            x, 600, 340, x->b_sym->s_name,
-                 sys_hostfontsize(glist_getfont(x->b_canvas),
-                    glist_getzoom(x->b_canvas)));
+        sprintf(buf, "%dx%d", 600, 340);
+        pdgui_vmess("pdtk_textwindow_open", "^r si",
+                  x, buf,
+                  x->b_sym->s_name,
+                  sys_hostfontsize(glist_getfont(x->b_canvas), glist_getzoom(x->b_canvas)));
         sprintf(buf, ".x%lx", x);
         x->b_guiconnect = guiconnect_new(&x->b_ob.ob_pd, gensym(buf));
         textbuf_senditup(x);

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -593,9 +593,25 @@ proc pdtk_yesnodialog {mytoplevel message default} {
     }
     return 0
 }
-##### routine to ask user if OK and, if so, send a message on to Pd ######
+
+# routine to ask user if OK and, if so, send a message on to Pd ######
+# with built-informatting+ translation
+# modern usage:
+## pdtk_check .pdwindow {"Hello world!"} "pd dsp 1" no
+# legacy:
+## pdtk_check .pdwindow "Hello world!" "pd dsp 1" no
 proc pdtk_check {mytoplevel message reply_to_pd default} {
-    if {[ pdtk_yesnodialog $mytoplevel $message $default ]} {
+    # example: 'pdtk_check . [list "Switch compatibility to %s?" $compat] [list pd compatibility $compat ] no'
+    if {[lindex $message 0] == [lindex [lindex $message 0] 0]} {
+        set message [ list $message ]
+    }
+
+    if {[ catch {
+              set msg [format [_ [ lindex $message 0 ] ] {*}[lrange $message 1 end] ]
+          } ]} {
+           set msg [_ $message]
+       }
+    if {[ pdtk_yesnodialog $mytoplevel $msg $default ]} {
         pdsend $reply_to_pd
     }
 }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -439,7 +439,7 @@ proc ::pdtk_canvas::pdtk_canvas_setparents {mytoplevel args} {
     set parents {}
     foreach parent $args {
         if { [catch {set parent [winfo toplevel $parent]}] } {
-            if { [file extension $parent] eq .c } {set parent [file rootname $parent]}
+            if { [file extension $parent] eq ".c" } {set parent [file rootname $parent]}
         }
         lappend parents $parent
         addchild $parent $mytoplevel

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -443,6 +443,9 @@ proc ::pdtk_canvas::pdtk_canvas_setparents {mytoplevel args} {
 # receive information for setting the info in the title bar of the window
 proc ::pdtk_canvas::pdtk_canvas_reflecttitle {mytoplevel \
                                               path name arguments dirty} {
+    set path [::pdtk_text::unescape $path]
+    set name [::pdtk_text::unescape $name]
+    set arguments [::pdtk_text::unescape $arguments]
     set name [::pdtk_canvas::cleanname "$name"]
     set ::windowname($mytoplevel) $name
     set ::pdtk_canvas::::window_fullname($mytoplevel) "$path/$name"

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -434,10 +434,17 @@ proc ::pdtk_canvas::addchild {mytoplevel child} {
 
 # receive a list of all my parent windows from 'pd'
 proc ::pdtk_canvas::pdtk_canvas_setparents {mytoplevel args} {
-    set ::parentwindows($mytoplevel) $args
+    # check if the user passed a list (instead of multiple arguments)
+    if { [llength $args] == 1 } {set args [lindex $args 0]}
+    set parents {}
     foreach parent $args {
+        if { [catch {set parent [winfo toplevel $parent]}] } {
+            if { [file extension $parent] eq .c } {set parent [file rootname $parent]}
+        }
+        lappend parents $parent
         addchild $parent $mytoplevel
     }
+    set ::parentwindows($mytoplevel) $parents
 }
 
 # receive information for setting the info in the title bar of the window

--- a/tcl/pdtk_text.tcl
+++ b/tcl/pdtk_text.tcl
@@ -7,7 +7,7 @@ package provide pdtk_text 0.1
 namespace eval ::pdtk_text:: {
 # proc to sanitize the 'text'
     proc unescape {text} {
-        return [string range [subst -nocommands -novariables $text] 0 end-1]
+        return [subst -nocommands -novariables $text]
     }
 }
 


### PR DESCRIPTION
this is a first draft.

it introduces new functions in the `pdgui_*` namespace for communicating with the Pd-GUI.

## `pdgui_vmess`

`pdgui_vmess` is a replacement for `sys_vgui` used to to generate (and send) messages  from core to GUI, taking care of string escaping suitable for Tcl/Tk.

e.g:

```C
void pdgui_vmess(const char*dest, const char*format, ...);
/* ... */
pdgui_vmess("guiproc", "is", 3, "foo bar");
```

will create the string `guiproc 3 {foo bar}` which is a valid Tcl/Tk command.

the function is deliberately called `pdgui_vmess`, in order to not clash with PurrData's `gui_vmess` (which has the same signature, but the type-ids are not compatible)



### destination

the 1st argument is a "receiver" on the GUI side. for Tcl/Tk this is typically a `proc`.
The assumption is that this receiver is constant, which doesn't map nicely to Tk's object-orientation (`.foo configure -width 3`).
For now, this is solved by passing `NULL` as the first argument (which will skip it in the generated string), like so:

```C
pdgui_vmess(0, "crr iiii ri",
                glist_getcanvas(glist), "create", "rectangle",
                10, 10,  50, 50,
                "-width", 1);
```

on the long run, i think using `NULL` as the destination should be avoided, and instead fixed-named `proc`s should be used:

```C
pdgui_vmess("::pd_canvas::create", "cr iiii ri",
                glist_getcanvas(glist), 
                "rectangle",
                10, 10,  50, 50,
                "-width", 1);
```


### type-IDs
the 2nd argument is a format-specifier (similar to the one used by `binbuf_addv()`, but *NOT* the same).
the type-ID determines how the following varargs are interpreted.

valid type-IDs so far are:

| id | args | description |
|---|---|---|
|`\0`| (none) | terminates the parsing of the varargs |
| ` `| (none) | space can be used to group the format string; it has no effect on the output formatting
|`i` | `int` | **i**nteger number (due to the nature of C varargs, all ints (e.g. `char`) are automatically promoted to `int`)
|`f` | `double` | **f**loating point number (due to the nature of C varargs, all floats are automatically promoted to `double`)
|`F` | `int` `t_float*` | *a*rray of **f**loat point values (unlike `f` this has a type of `t_float`!) |
|`s`| `const char*`| a **s**tring (that might need escaping)  |
|`S`| `int` `char**`| a **s**tring *a*rray (where each string needs escaping)  |
|`r`| `const char*`| a **r**aw string (that will never be escaped)  |
|`R`| `int` `char**`| an *a*rray of **r**aw strings (that will not be escaped)  |
|`p`| `int` `const char*` | a string that is not `\0`-terminated (and instead has an extra size-field); aka **p**ascal-string |
|`a`|`int` `t_atom*` | a list of atoms (so the GUI recevies them as multiple arguments)
|`A`|`int` `t_atom*` | an *a*rray of **a**toms
|`w`|`int` `t_word*` | a list of float**w**ords  (so the GUI receives them as multiple arguments) |
|`W`|`int` `t_word*` | an *array* of float**w**ords |
|`k`| `int` | a 24bit color |
|`m` | `t_symbol*s`, `int`, `t_atom*` | a Pd-message (for the GUI to send back) |
|`c`| `t_canvas*`| the ID of a TclTk canvas associated with the given canvas |
|`C`| `int` `t_canvas*`| an *array* for canvases |
|`^`| `t_canvas*`| the ID of the (**t**oplevel) window associated with the given canvas|
|`o`|`t_object`| the ID of the **o**bject |

- arrays are capitalized.
- there are both "arrays" and "lists": *arrays* are sent to the GUI as a single argument containing all the values, whereas *lists* are a shorthand for a variable number of arguments of the same type. e.g.
  | invocation in C | translates to Tcl/Tk | note |
  |---------------|----------|-------|
  | `pdgui_vmess(foo, "w", 3, 1, 2, 3)` | `foo 1 2 3` | list |
  | `pdgui_vmess(foo, "W", 3, 1, 2, 3)` | `foo {1 2 3}` | array | 

- the `^` (toplevel window) ID is currently required by how Pd talks to Tcl/Tk.
in the future (#1695), this should not be needed any more and instead be replaced with a reference to the `c`anvas that is contained by the window (thus the use of the `^` type-id is a good indicator about where there's work to be down)

- the `o` (Pd-object) ID is currently only used by `logpost` and friends (and I would like to keep it like that); it probably should go away.

- Purr-Data has a generic `x` type-id for pointers. we cannot use that right now, as we need to format the pointer differently based on the context (mostly: window vs canvas).

##### ideas for more type-ids (none of them implemented)

|description | id | notes |
|---|---|---|
| float32 array | `1` | might be interesting for libpd (so the app can stay oblivious of `t_float`) |
| float64 array | `2` | see above |
| ~symbol, symbolarray~ |~`y`, `Y`~ | ~so the caller doesn't have to do all the `->s_name`; always escaped~ | 
| ~binbuf~ | ~`b`, `B`~ | ~alternative to the *atom array*~ |
| format continuation | `+` | only  valid at the *end* of the format string; indicates that there's another format string with associated types coming (so you can write `pdgui_vmess(0, "ii+", 1, 2, "ii" 3, 4);` as an equivalent to `pdgui_vmess(0, 'iiii', 1, 2, 3, 4);`

## `pdgui_stub_vnew`/`pdgui_stub_deleteforkey`

These are replacements for the `gfxstub_new` resp `gfxstub_deleteforkey` functions.
`pdgui_stub_vnew` adopts the type-ID syntax of `pdgui_vmess` (and shuffles the arguments to indicate the argument order on the GUI side). the `pdgui_stub_deleteforkey` is practically identical to the original `gfxstub_...` function (it's only there for  a consistent naming scheme):

```C
void pdgui_stub_vnew(t_pd *owner, const char* destination, void *key, const char* fmt, ...);
/* ... */
pdgui_stub_vnew(&x->gl_pd, "pdtk_array_dialog", x, "siii", arraybuf, 100, 3, 1);
/* ... */
pdgui_stub_deleteforkey(x);
```

- destination: "receiver" on the GUI-side (as with `pdgui_vmess`)
- fmt: list of type-IDs (as with `pdgui_vmess`)

## Discussion

### issues so far
- needs more testing
- ~not optimized at all :-)~
- ~array handling tries to guess the required size to simplify reallocation~
  - ~the guess tries to be conservative, so we are probably over-allocating~
  - ~if the guess underestimates the final size, this will fail badly~
- ~no escaping of whacko strings has been implemented yet~

~regarding the escaping, i wonder whether we should provide different type-IDs for strings that need escaping (beyond encapsulating them in curlies) and those that don't.
it just seems overkill to escape constant strings...~

### regressions
(regressions that are fixed will get a  :ballot_box_with_check: )

- [x] the editmode-indicator in the window-title has become `\[edit\]` (with backslashes)
- [x] first MIDI-device get's munged in the dialog
       (this is actually caused by some refactoring i did before switching to `pdgui_vmess()`: i just couldn't stand the https://github.com/pure-data/pure-data/blob/18c9695ba4de543c51c2c013b45b99b8f1c35a19/src/s_midi.c#L711-L713 so i turned this into a single list-assignment, forgetting the leading `none` device :facepalm: 
      on the long run, we should just get rid of the `none` device  and use a list of available devices.
- [x] dialogs that take floats will now show the full number with commas (e.g. `1.0000000` instead of `1`)
      this is not very nice, but i'd rather have the GUI take care of formatting the numbers correctly.
      (solved for now by switching to `%g` for formatting single floats)
- [x] Pd-messages (such as sent to `pdtk_check`) are escaped overzealously, and not un-escaped before sending the message back to Pd, resulting in errors like `canvas: no method for '{dirty}'` (canvas has only a method of `dirty` not `{dirty}`)
     (solved for now by not escaping the atoms before sending them (as it used to be); on the long run, the GUI should properly unescape these messages)
- [x] Pd-patches that have visible (opened) subpatches (on disk), throw a Tcl/Tk error when opened.