### PR TITLE
Codebase reformat

### DIFF
--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -38,14 +38,12 @@ static void *plus_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_plus *x = (t_plus *) pd_new(plus_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_plus *x = (t_plus *) pd_new(plus_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *scalarplus_perform(t_int *w)
@@ -146,14 +144,12 @@ static void *minus_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_minus *x = (t_minus *) pd_new(minus_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_minus *x = (t_minus *) pd_new(minus_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *minus_perform(t_int *w)
@@ -310,14 +306,12 @@ static void *times_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_times *x = (t_times *) pd_new(times_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_times *x = (t_times *) pd_new(times_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *times_perform(t_int *w)
@@ -473,14 +467,12 @@ static void *over_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_over *x = (t_over *) pd_new(over_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_over *x = (t_over *) pd_new(over_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *over_perform(t_int *w)
@@ -641,14 +633,12 @@ static void *max_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_max *x = (t_max *) pd_new(max_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_max *x = (t_max *) pd_new(max_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *max_perform(t_int *w)
@@ -810,14 +800,12 @@ static void *min_new(t_symbol *s, int argc, t_atom *argv)
         x->x_f = 0;
         return (x);
     }
-    else
-    {
-        t_min *x = (t_min *) pd_new(min_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+
+    t_min *x = (t_min *) pd_new(min_class);
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    x->x_f = 0;
+    return (x);
 }
 
 t_int *min_perform(t_int *w)

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -51,9 +51,9 @@ t_int *scalarplus_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in++ + f;
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in[i] + f;
     return (w + 5);
 }
 
@@ -62,8 +62,8 @@ t_int *scalarplus_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];
@@ -161,9 +161,12 @@ t_int *minus_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in1++ - *in2++;
+    int num_samples = (int) (w[4]);
+
+    for(int i = 0; i < num_samples; i++)
+    {
+        out[i] = in1[i] - in2[i];
+    }
     return (w + 5);
 }
 
@@ -172,8 +175,8 @@ t_int *minus_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -210,9 +213,9 @@ t_int *scalarminus_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in++ - f;
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in[i] - f;
     return (w + 5);
 }
 
@@ -221,8 +224,9 @@ t_int *scalarminus_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[4]);
+
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];
@@ -331,9 +335,9 @@ t_int *times_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in1++ * *in2++;
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in1[i] + in2[i];
     return (w + 5);
 }
 
@@ -342,8 +346,8 @@ t_int *times_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -380,9 +384,9 @@ t_int *scalartimes_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in++ * f;
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in[i] * f;
     return (w + 5);
 }
 
@@ -391,8 +395,8 @@ t_int *scalartimes_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];
@@ -500,12 +504,12 @@ t_int *over_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1++;
-        t_sample g = *in2++;
-        *out++ = (g ? f / g : 0);
+        t_sample f = in1[i];
+        t_sample g = in2[i];
+        out[i] = (g ? f / g : 0);
     }
     return (w + 5);
 }
@@ -515,8 +519,8 @@ t_int *over_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -553,10 +557,11 @@ t_int *scalarover_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    if(f) f = 1. / f;
-    while(n--)
-        *out++ = *in++ * f;
+    int num_samples = (int) (w[4]);
+    if(f) 
+        f = 1. / f;
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in[i] * f;
     return (w + 5);
 }
 
@@ -565,9 +570,9 @@ t_int *scalarover_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
+    int num_samples = (int) (w[4]);
     if(g) g = 1.f / g;
-    for(; n; n -= 8, in += 8, out += 8)
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];
@@ -674,12 +679,12 @@ t_int *max_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1++;
-        t_sample g = *in2++;
-        *out++ = (f > g ? f : g);
+        t_sample f = in1[i];
+        t_sample g = in2[i];
+        out[i] = (f > g ? f : g);
     }
     return (w + 5);
 }
@@ -689,8 +694,8 @@ t_int *max_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -727,11 +732,11 @@ t_int *scalarmax_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample g = *in++;
-        *out++ = (f > g ? f : g);
+        t_sample g = in[i];
+        out[i] = (f > g ? f : g);
     }
     return (w + 5);
 }
@@ -741,8 +746,8 @@ t_int *scalarmax_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];
@@ -849,12 +854,12 @@ t_int *min_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1++;
-        t_sample g = *in2++;
-        *out++ = (f < g ? f : g);
+        t_sample f = in1[i];
+        t_sample g = in2[i];
+        out[i] = (f < g ? f : g);
     }
     return (w + 5);
 }
@@ -864,8 +869,8 @@ t_int *min_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -902,11 +907,11 @@ t_int *scalarmin_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float f = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample g = *in++;
-        *out++ = (f < g ? f : g);
+        t_sample g = in[i];
+        out[i] = (f < g ? f : g);
     }
     return (w + 5);
 }
@@ -916,8 +921,8 @@ t_int *scalarmin_perf8(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_float g = *(t_float *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         t_sample f0 = in[0];
         t_sample f1 = in[1];

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -94,11 +94,15 @@ static void plus_dsp(t_plus *x, t_signal **sp)
 static void scalarplus_dsp(t_scalarplus *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalarplus_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalarplus_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void plus_setup(void)
@@ -244,21 +248,29 @@ t_int *scalarminus_perf8(t_int *w)
 static void minus_dsp(t_minus *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(minus_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(minus_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void scalarminus_dsp(t_scalarminus *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalarminus_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalarminus_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void minus_setup(void)
@@ -406,21 +418,29 @@ t_int *scalartimes_perf8(t_int *w)
 static void times_dsp(t_times *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(times_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(times_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void scalartimes_dsp(t_scalartimes *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalartimes_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalartimes_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void times_setup(void)
@@ -573,21 +593,29 @@ t_int *scalarover_perf8(t_int *w)
 static void over_dsp(t_over *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(over_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(over_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void scalarover_dsp(t_scalarover *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalarover_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalarover_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void over_setup(void)
@@ -740,21 +768,29 @@ t_int *scalarmax_perf8(t_int *w)
 static void max_dsp(t_max *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(max_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(max_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void scalarmax_dsp(t_scalarmax *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalarmax_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalarmax_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void max_setup(void)
@@ -907,21 +943,29 @@ t_int *scalarmin_perf8(t_int *w)
 static void min_dsp(t_min *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(min_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(min_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void scalarmin_dsp(t_scalarmin *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(scalarmin_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(scalarmin_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
             (t_int) sp[0]->s_n);
+    }
 }
 
 static void min_setup(void)

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -67,8 +67,14 @@ t_int *scalarplus_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = f0 + g;
         out[1] = f1 + g;
@@ -169,11 +175,23 @@ t_int *minus_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = f0 - g0;
         out[1] = f1 - g1;
@@ -206,8 +224,14 @@ t_int *scalarminus_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = f0 - g;
         out[1] = f1 - g;
@@ -315,11 +339,23 @@ t_int *times_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = f0 * g0;
         out[1] = f1 * g1;
@@ -352,8 +388,14 @@ t_int *scalartimes_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = f0 * g;
         out[1] = f1 * g;
@@ -449,7 +491,8 @@ t_int *over_perform(t_int *w)
     int n = (int) (w[4]);
     while(n--)
     {
-        t_sample f = *in1++, g = *in2++;
+        t_sample f = *in1++;
+        t_sample g = *in2++;
         *out++ = (g ? f / g : 0);
     }
     return (w + 5);
@@ -463,11 +506,23 @@ t_int *over_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = (g0 ? f0 / g0 : 0);
         out[1] = (g1 ? f1 / g1 : 0);
@@ -502,8 +557,14 @@ t_int *scalarover_perf8(t_int *w)
     if(g) g = 1.f / g;
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = f0 * g;
         out[1] = f1 * g;
@@ -598,7 +659,8 @@ t_int *max_perform(t_int *w)
     int n = (int) (w[4]);
     while(n--)
     {
-        t_sample f = *in1++, g = *in2++;
+        t_sample f = *in1++;
+        t_sample g = *in2++;
         *out++ = (f > g ? f : g);
     }
     return (w + 5);
@@ -612,11 +674,23 @@ t_int *max_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = (f0 > g0 ? f0 : g0);
         out[1] = (f1 > g1 ? f1 : g1);
@@ -652,8 +726,14 @@ t_int *scalarmax_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = (f0 > g ? f0 : g);
         out[1] = (f1 > g ? f1 : g);
@@ -748,7 +828,8 @@ t_int *min_perform(t_int *w)
     int n = (int) (w[4]);
     while(n--)
     {
-        t_sample f = *in1++, g = *in2++;
+        t_sample f = *in1++;
+        t_sample g = *in2++;
         *out++ = (f < g ? f : g);
     }
     return (w + 5);
@@ -762,11 +843,23 @@ t_int *min_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = (f0 < g0 ? f0 : g0);
         out[1] = (f1 < g1 ? f1 : g1);
@@ -802,8 +895,14 @@ t_int *scalarmin_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in += 8, out += 8)
     {
-        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
-        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = (f0 < g ? f0 : g);
         out[1] = (f1 < g ? f1 : g);

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  arithmetic binops (+, -, *, /).
 If no creation argument is given, there are two signal inlets for vector/vector
@@ -23,15 +23,15 @@ typedef struct _scalarplus
 {
     t_object x_obj;
     t_float x_f;
-    t_float x_g;            /* inlet value */
+    t_float x_g; /* inlet value */
 } t_scalarplus;
 
 static void *plus_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("+~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("+~: extra arguments ignored");
+    if(argc)
     {
-        t_scalarplus *x = (t_scalarplus *)pd_new(scalarplus_class);
+        t_scalarplus *x = (t_scalarplus *) pd_new(scalarplus_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -40,7 +40,7 @@ static void *plus_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_plus *x = (t_plus *)pd_new(plus_class);
+        t_plus *x = (t_plus *) pd_new(plus_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -50,29 +50,36 @@ static void *plus_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *scalarplus_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in++ + f;
-    return (w+5);
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in++ + f;
+    return (w + 5);
 }
 
 t_int *scalarplus_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = f0 + g; out[1] = f1 + g; out[2] = f2 + g; out[3] = f3 + g;
-        out[4] = f4 + g; out[5] = f5 + g; out[6] = f6 + g; out[7] = f7 + g;
+        out[0] = f0 + g;
+        out[1] = f1 + g;
+        out[2] = f2 + g;
+        out[3] = f3 + g;
+        out[4] = f4 + g;
+        out[5] = f5 + g;
+        out[6] = f6 + g;
+        out[7] = f7 + g;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void plus_dsp(t_plus *x, t_signal **sp)
@@ -82,26 +89,26 @@ static void plus_dsp(t_plus *x, t_signal **sp)
 
 static void scalarplus_dsp(t_scalarplus *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalarplus_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalarplus_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalarplus_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalarplus_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void plus_setup(void)
 {
-    plus_class = class_new(gensym("+~"), (t_newmethod)plus_new, 0,
-        sizeof(t_plus), 0, A_GIMME, 0);
-    class_addmethod(plus_class, (t_method)plus_dsp, gensym("dsp"), A_CANT, 0);
+    plus_class = class_new(
+        gensym("+~"), (t_newmethod) plus_new, 0, sizeof(t_plus), 0, A_GIMME, 0);
+    class_addmethod(plus_class, (t_method) plus_dsp, gensym("dsp"), A_CANT, 0);
     CLASS_MAINSIGNALIN(plus_class, t_plus, x_f);
     class_sethelpsymbol(plus_class, gensym("binops-tilde"));
-    scalarplus_class = class_new(gensym("+~"), 0, 0,
-        sizeof(t_scalarplus), 0, 0);
+    scalarplus_class =
+        class_new(gensym("+~"), 0, 0, sizeof(t_scalarplus), 0, 0);
     CLASS_MAINSIGNALIN(scalarplus_class, t_scalarplus, x_f);
-    class_addmethod(scalarplus_class, (t_method)scalarplus_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        scalarplus_class, (t_method) scalarplus_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalarplus_class, gensym("sigbinops"));
 }
 
@@ -123,10 +130,10 @@ typedef struct _scalarminus
 
 static void *minus_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("-~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("-~: extra arguments ignored");
+    if(argc)
     {
-        t_scalarminus *x = (t_scalarminus *)pd_new(scalarminus_class);
+        t_scalarminus *x = (t_scalarminus *) pd_new(scalarminus_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -135,7 +142,7 @@ static void *minus_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_minus *x = (t_minus *)pd_new(minus_class);
+        t_minus *x = (t_minus *) pd_new(minus_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -145,21 +152,22 @@ static void *minus_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *minus_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in1++ - *in2++;
-    return (w+5);
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in1++ - *in2++;
+    return (w + 5);
 }
 
 t_int *minus_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -167,70 +175,84 @@ t_int *minus_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = f0 - g0; out[1] = f1 - g1; out[2] = f2 - g2; out[3] = f3 - g3;
-        out[4] = f4 - g4; out[5] = f5 - g5; out[6] = f6 - g6; out[7] = f7 - g7;
+        out[0] = f0 - g0;
+        out[1] = f1 - g1;
+        out[2] = f2 - g2;
+        out[3] = f3 - g3;
+        out[4] = f4 - g4;
+        out[5] = f5 - g5;
+        out[6] = f6 - g6;
+        out[7] = f7 - g7;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarminus_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in++ - f;
-    return (w+5);
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in++ - f;
+    return (w + 5);
 }
 
 t_int *scalarminus_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = f0 - g; out[1] = f1 - g; out[2] = f2 - g; out[3] = f3 - g;
-        out[4] = f4 - g; out[5] = f5 - g; out[6] = f6 - g; out[7] = f7 - g;
+        out[0] = f0 - g;
+        out[1] = f1 - g;
+        out[2] = f2 - g;
+        out[3] = f3 - g;
+        out[4] = f4 - g;
+        out[5] = f5 - g;
+        out[6] = f6 - g;
+        out[7] = f7 - g;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void minus_dsp(t_minus *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(minus_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(minus_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(minus_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(minus_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void scalarminus_dsp(t_scalarminus *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalarminus_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalarminus_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalarminus_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalarminus_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void minus_setup(void)
 {
-    minus_class = class_new(gensym("-~"), (t_newmethod)minus_new, 0,
+    minus_class = class_new(gensym("-~"), (t_newmethod) minus_new, 0,
         sizeof(t_minus), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(minus_class, t_minus, x_f);
-    class_addmethod(minus_class, (t_method)minus_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        minus_class, (t_method) minus_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(minus_class, gensym("sigbinops"));
-    scalarminus_class = class_new(gensym("-~"), 0, 0,
-        sizeof(t_scalarminus), 0, 0);
+    scalarminus_class =
+        class_new(gensym("-~"), 0, 0, sizeof(t_scalarminus), 0, 0);
     CLASS_MAINSIGNALIN(scalarminus_class, t_scalarminus, x_f);
-    class_addmethod(scalarminus_class, (t_method)scalarminus_dsp,
+    class_addmethod(scalarminus_class, (t_method) scalarminus_dsp,
         gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalarminus_class, gensym("sigbinops"));
 }
@@ -254,10 +276,10 @@ typedef struct _scalartimes
 
 static void *times_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("*~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("*~: extra arguments ignored");
+    if(argc)
     {
-        t_scalartimes *x = (t_scalartimes *)pd_new(scalartimes_class);
+        t_scalartimes *x = (t_scalartimes *) pd_new(scalartimes_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -266,7 +288,7 @@ static void *times_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_times *x = (t_times *)pd_new(times_class);
+        t_times *x = (t_times *) pd_new(times_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -276,21 +298,22 @@ static void *times_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *times_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in1++ * *in2++;
-    return (w+5);
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in1++ * *in2++;
+    return (w + 5);
 }
 
 t_int *times_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -298,70 +321,84 @@ t_int *times_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = f0 * g0; out[1] = f1 * g1; out[2] = f2 * g2; out[3] = f3 * g3;
-        out[4] = f4 * g4; out[5] = f5 * g5; out[6] = f6 * g6; out[7] = f7 * g7;
+        out[0] = f0 * g0;
+        out[1] = f1 * g1;
+        out[2] = f2 * g2;
+        out[3] = f3 * g3;
+        out[4] = f4 * g4;
+        out[5] = f5 * g5;
+        out[6] = f6 * g6;
+        out[7] = f7 * g7;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalartimes_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in++ * f;
-    return (w+5);
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in++ * f;
+    return (w + 5);
 }
 
 t_int *scalartimes_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = f0 * g; out[1] = f1 * g; out[2] = f2 * g; out[3] = f3 * g;
-        out[4] = f4 * g; out[5] = f5 * g; out[6] = f6 * g; out[7] = f7 * g;
+        out[0] = f0 * g;
+        out[1] = f1 * g;
+        out[2] = f2 * g;
+        out[3] = f3 * g;
+        out[4] = f4 * g;
+        out[5] = f5 * g;
+        out[6] = f6 * g;
+        out[7] = f7 * g;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void times_dsp(t_times *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(times_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(times_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(times_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(times_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void scalartimes_dsp(t_scalartimes *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalartimes_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalartimes_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalartimes_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalartimes_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void times_setup(void)
 {
-    times_class = class_new(gensym("*~"), (t_newmethod)times_new, 0,
+    times_class = class_new(gensym("*~"), (t_newmethod) times_new, 0,
         sizeof(t_times), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(times_class, t_times, x_f);
-    class_addmethod(times_class, (t_method)times_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        times_class, (t_method) times_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(times_class, gensym("sigbinops"));
-    scalartimes_class = class_new(gensym("*~"), 0, 0,
-        sizeof(t_scalartimes), 0, 0);
+    scalartimes_class =
+        class_new(gensym("*~"), 0, 0, sizeof(t_scalartimes), 0, 0);
     CLASS_MAINSIGNALIN(scalartimes_class, t_scalartimes, x_f);
-    class_addmethod(scalartimes_class, (t_method)scalartimes_dsp,
+    class_addmethod(scalartimes_class, (t_method) scalartimes_dsp,
         gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalartimes_class, gensym("sigbinops"));
 }
@@ -384,10 +421,10 @@ typedef struct _scalarover
 
 static void *over_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("/~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("/~: extra arguments ignored");
+    if(argc)
     {
-        t_scalarover *x = (t_scalarover *)pd_new(scalarover_class);
+        t_scalarover *x = (t_scalarover *) pd_new(scalarover_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -396,7 +433,7 @@ static void *over_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_over *x = (t_over *)pd_new(over_class);
+        t_over *x = (t_over *) pd_new(over_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -406,25 +443,25 @@ static void *over_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *over_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f = *in1++, g = *in2++;
         *out++ = (g ? f / g : 0);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *over_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -432,79 +469,86 @@ t_int *over_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = (g0? f0 / g0 : 0);
-        out[1] = (g1? f1 / g1 : 0);
-        out[2] = (g2? f2 / g2 : 0);
-        out[3] = (g3? f3 / g3 : 0);
-        out[4] = (g4? f4 / g4 : 0);
-        out[5] = (g5? f5 / g5 : 0);
-        out[6] = (g6? f6 / g6 : 0);
-        out[7] = (g7? f7 / g7 : 0);
+        out[0] = (g0 ? f0 / g0 : 0);
+        out[1] = (g1 ? f1 / g1 : 0);
+        out[2] = (g2 ? f2 / g2 : 0);
+        out[3] = (g3 ? f3 / g3 : 0);
+        out[4] = (g4 ? f4 / g4 : 0);
+        out[5] = (g5 ? f5 / g5 : 0);
+        out[6] = (g6 ? f6 / g6 : 0);
+        out[7] = (g7 ? f7 / g7 : 0);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarover_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    if(f) f = 1./f;
-    while (n--) *out++ = *in++ * f;
-    return (w+5);
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    if(f) f = 1. / f;
+    while(n--)
+        *out++ = *in++ * f;
+    return (w + 5);
 }
 
 t_int *scalarover_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    if (g) g = 1.f / g;
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    if(g) g = 1.f / g;
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = f0 * g; out[1] = f1 * g; out[2] = f2 * g; out[3] = f3 * g;
-        out[4] = f4 * g; out[5] = f5 * g; out[6] = f6 * g; out[7] = f7 * g;
+        out[0] = f0 * g;
+        out[1] = f1 * g;
+        out[2] = f2 * g;
+        out[3] = f3 * g;
+        out[4] = f4 * g;
+        out[5] = f5 * g;
+        out[6] = f6 * g;
+        out[7] = f7 * g;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void over_dsp(t_over *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(over_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(over_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(over_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(over_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void scalarover_dsp(t_scalarover *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalarover_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalarover_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalarover_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalarover_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void over_setup(void)
 {
-    over_class = class_new(gensym("/~"), (t_newmethod)over_new, 0,
-        sizeof(t_over), 0, A_GIMME, 0);
+    over_class = class_new(
+        gensym("/~"), (t_newmethod) over_new, 0, sizeof(t_over), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(over_class, t_over, x_f);
-    class_addmethod(over_class, (t_method)over_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(over_class, (t_method) over_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(over_class, gensym("sigbinops"));
-    scalarover_class = class_new(gensym("/~"), 0, 0,
-        sizeof(t_scalarover), 0, 0);
+    scalarover_class =
+        class_new(gensym("/~"), 0, 0, sizeof(t_scalarover), 0, 0);
     CLASS_MAINSIGNALIN(scalarover_class, t_scalarover, x_f);
-    class_addmethod(scalarover_class, (t_method)scalarover_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        scalarover_class, (t_method) scalarover_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalarover_class, gensym("sigbinops"));
 }
 
@@ -526,10 +570,10 @@ typedef struct _scalarmax
 
 static void *max_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("max~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("max~: extra arguments ignored");
+    if(argc)
     {
-        t_scalarmax *x = (t_scalarmax *)pd_new(scalarmax_class);
+        t_scalarmax *x = (t_scalarmax *) pd_new(scalarmax_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -538,7 +582,7 @@ static void *max_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_max *x = (t_max *)pd_new(max_class);
+        t_max *x = (t_max *) pd_new(max_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -548,25 +592,25 @@ static void *max_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *max_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f = *in1++, g = *in2++;
         *out++ = (f > g ? f : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *max_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -574,79 +618,87 @@ t_int *max_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = (f0 > g0 ? f0 : g0); out[1] = (f1 > g1 ? f1 : g1);
-        out[2] = (f2 > g2 ? f2 : g2); out[3] = (f3 > g3 ? f3 : g3);
-        out[4] = (f4 > g4 ? f4 : g4); out[5] = (f5 > g5 ? f5 : g5);
-        out[6] = (f6 > g6 ? f6 : g6); out[7] = (f7 > g7 ? f7 : g7);
+        out[0] = (f0 > g0 ? f0 : g0);
+        out[1] = (f1 > g1 ? f1 : g1);
+        out[2] = (f2 > g2 ? f2 : g2);
+        out[3] = (f3 > g3 ? f3 : g3);
+        out[4] = (f4 > g4 ? f4 : g4);
+        out[5] = (f5 > g5 ? f5 : g5);
+        out[6] = (f6 > g6 ? f6 : g6);
+        out[7] = (f7 > g7 ? f7 : g7);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarmax_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample g = *in++;
         *out++ = (f > g ? f : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarmax_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = (f0 > g ? f0 : g); out[1] = (f1 > g ? f1 : g);
-        out[2] = (f2 > g ? f2 : g); out[3] = (f3 > g ? f3 : g);
-        out[4] = (f4 > g ? f4 : g); out[5] = (f5 > g ? f5 : g);
-        out[6] = (f6 > g ? f6 : g); out[7] = (f7 > g ? f7 : g);
+        out[0] = (f0 > g ? f0 : g);
+        out[1] = (f1 > g ? f1 : g);
+        out[2] = (f2 > g ? f2 : g);
+        out[3] = (f3 > g ? f3 : g);
+        out[4] = (f4 > g ? f4 : g);
+        out[5] = (f5 > g ? f5 : g);
+        out[6] = (f6 > g ? f6 : g);
+        out[7] = (f7 > g ? f7 : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void max_dsp(t_max *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(max_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(max_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(max_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(max_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void scalarmax_dsp(t_scalarmax *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalarmax_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalarmax_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalarmax_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalarmax_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void max_setup(void)
 {
-    max_class = class_new(gensym("max~"), (t_newmethod)max_new, 0,
-        sizeof(t_max), 0, A_GIMME, 0);
+    max_class = class_new(
+        gensym("max~"), (t_newmethod) max_new, 0, sizeof(t_max), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(max_class, t_max, x_f);
-    class_addmethod(max_class, (t_method)max_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(max_class, (t_method) max_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(max_class, gensym("sigbinops"));
-    scalarmax_class = class_new(gensym("max~"), 0, 0,
-        sizeof(t_scalarmax), 0, 0);
+    scalarmax_class =
+        class_new(gensym("max~"), 0, 0, sizeof(t_scalarmax), 0, 0);
     CLASS_MAINSIGNALIN(scalarmax_class, t_scalarmax, x_f);
-    class_addmethod(scalarmax_class, (t_method)scalarmax_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        scalarmax_class, (t_method) scalarmax_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalarmax_class, gensym("sigbinops"));
 }
 
@@ -668,10 +720,10 @@ typedef struct _scalarmin
 
 static void *min_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("min~: extra arguments ignored");
-    if (argc)
+    if(argc > 1) post("min~: extra arguments ignored");
+    if(argc)
     {
-        t_scalarmin *x = (t_scalarmin *)pd_new(scalarmin_class);
+        t_scalarmin *x = (t_scalarmin *) pd_new(scalarmin_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -680,7 +732,7 @@ static void *min_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_min *x = (t_min *)pd_new(min_class);
+        t_min *x = (t_min *) pd_new(min_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
@@ -690,25 +742,25 @@ static void *min_new(t_symbol *s, int argc, t_atom *argv)
 
 t_int *min_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f = *in1++, g = *in2++;
         *out++ = (f < g ? f : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *min_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -716,79 +768,87 @@ t_int *min_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = (f0 < g0 ? f0 : g0); out[1] = (f1 < g1 ? f1 : g1);
-        out[2] = (f2 < g2 ? f2 : g2); out[3] = (f3 < g3 ? f3 : g3);
-        out[4] = (f4 < g4 ? f4 : g4); out[5] = (f5 < g5 ? f5 : g5);
-        out[6] = (f6 < g6 ? f6 : g6); out[7] = (f7 < g7 ? f7 : g7);
+        out[0] = (f0 < g0 ? f0 : g0);
+        out[1] = (f1 < g1 ? f1 : g1);
+        out[2] = (f2 < g2 ? f2 : g2);
+        out[3] = (f3 < g3 ? f3 : g3);
+        out[4] = (f4 < g4 ? f4 : g4);
+        out[5] = (f5 < g5 ? f5 : g5);
+        out[6] = (f6 < g6 ? f6 : g6);
+        out[7] = (f7 < g7 ? f7 : g7);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarmin_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float f = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float f = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample g = *in++;
         *out++ = (f < g ? f : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 t_int *scalarmin_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_float g = *(t_float *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_float g = *(t_float *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
         t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
         t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
 
-        out[0] = (f0 < g ? f0 : g); out[1] = (f1 < g ? f1 : g);
-        out[2] = (f2 < g ? f2 : g); out[3] = (f3 < g ? f3 : g);
-        out[4] = (f4 < g ? f4 : g); out[5] = (f5 < g ? f5 : g);
-        out[6] = (f6 < g ? f6 : g); out[7] = (f7 < g ? f7 : g);
+        out[0] = (f0 < g ? f0 : g);
+        out[1] = (f1 < g ? f1 : g);
+        out[2] = (f2 < g ? f2 : g);
+        out[3] = (f3 < g ? f3 : g);
+        out[4] = (f4 < g ? f4 : g);
+        out[5] = (f5 < g ? f5 : g);
+        out[6] = (f6 < g ? f6 : g);
+        out[7] = (f7 < g ? f7 : g);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void min_dsp(t_min *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(min_perform, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(min_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(min_perf8, 4,
-            sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(min_perf8, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void scalarmin_dsp(t_scalarmin *x, t_signal **sp)
 {
-    if (sp[0]->s_n&7)
-        dsp_add(scalarmin_perform, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(scalarmin_perform, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
     else
-        dsp_add(scalarmin_perf8, 4, sp[0]->s_vec, &x->x_g,
-            sp[1]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(scalarmin_perf8, 4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec,
+            (t_int) sp[0]->s_n);
 }
 
 static void min_setup(void)
 {
-    min_class = class_new(gensym("min~"), (t_newmethod)min_new, 0,
-        sizeof(t_min), 0, A_GIMME, 0);
+    min_class = class_new(
+        gensym("min~"), (t_newmethod) min_new, 0, sizeof(t_min), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(min_class, t_min, x_f);
-    class_addmethod(min_class, (t_method)min_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(min_class, (t_method) min_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(min_class, gensym("sigbinops"));
-    scalarmin_class = class_new(gensym("min~"), 0, 0,
-        sizeof(t_scalarmin), 0, 0);
+    scalarmin_class =
+        class_new(gensym("min~"), 0, 0, sizeof(t_scalarmin), 0, 0);
     CLASS_MAINSIGNALIN(scalarmin_class, t_scalarmin, x_f);
-    class_addmethod(scalarmin_class, (t_method)scalarmin_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        scalarmin_class, (t_method) scalarmin_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(scalarmin_class, gensym("sigbinops"));
 }
 
@@ -802,4 +862,3 @@ void d_arithmetic_setup(void)
     max_setup();
     min_setup();
 }
-

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -1,13 +1,12 @@
 /* Copyright (c) 1997-1999 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* sampling */
 
 /* LATER make tabread4 and tabread~ */
 
 #include "m_pd.h"
-
 
 /* ------------------------- tabwrite~ -------------------------- */
 
@@ -27,7 +26,7 @@ static void tabwrite_tilde_tick(t_tabwrite_tilde *x);
 
 static void *tabwrite_tilde_new(t_symbol *s)
 {
-    t_tabwrite_tilde *x = (t_tabwrite_tilde *)pd_new(tabwrite_tilde_class);
+    t_tabwrite_tilde *x = (t_tabwrite_tilde *) pd_new(tabwrite_tilde_class);
     x->x_phase = 0x7fffffff;
     x->x_arrayname = s;
     x->x_f = 0;
@@ -36,42 +35,43 @@ static void *tabwrite_tilde_new(t_symbol *s)
 
 static void tabwrite_tilde_redraw(t_tabwrite_tilde *x)
 {
-    t_garray *a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class);
-    if (!a)
+    t_garray *a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class);
+    if(!a)
         bug("tabwrite_tilde_redraw");
-    else garray_redraw(a);
+    else
+        garray_redraw(a);
 }
 
 static t_int *tabwrite_tilde_perform(t_int *w)
 {
-    t_tabwrite_tilde *x = (t_tabwrite_tilde *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    int n = (int)(w[3]), phase = x->x_phase, endphase = x->x_nsampsintab;
-    if (!x->x_vec) goto bad;
+    t_tabwrite_tilde *x = (t_tabwrite_tilde *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    int n = (int) (w[3]), phase = x->x_phase, endphase = x->x_nsampsintab;
+    if(!x->x_vec) goto bad;
 
-    if (endphase > phase)
+    if(endphase > phase)
     {
         int nxfer = endphase - phase;
         t_word *wp = x->x_vec + phase;
-        if (nxfer > n) nxfer = n;
+        if(nxfer > n) nxfer = n;
         phase += nxfer;
-        while (nxfer--)
+        while(nxfer--)
         {
             t_sample f = *in++;
-            if (PD_BIGORSMALL(f))
-                f = 0;
+            if(PD_BIGORSMALL(f)) f = 0;
             (wp++)->w_float = f;
         }
-        if (phase >= endphase)
+        if(phase >= endphase)
         {
             tabwrite_tilde_redraw(x);
             phase = 0x7fffffff;
         }
         x->x_phase = phase;
     }
-    else x->x_phase = 0x7fffffff;
+    else
+        x->x_phase = 0x7fffffff;
 bad:
-    return (w+4);
+    return (w + 4);
 }
 
 static void tabwrite_tilde_set(t_tabwrite_tilde *x, t_symbol *s)
@@ -79,30 +79,28 @@ static void tabwrite_tilde_set(t_tabwrite_tilde *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name) pd_error(x, "tabwrite~: %s: no such array",
-            x->x_arrayname->s_name);
+        if(*s->s_name)
+            pd_error(x, "tabwrite~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_nsampsintab, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_nsampsintab, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabwrite~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabwrite_tilde_dsp(t_tabwrite_tilde *x, t_signal **sp)
 {
     tabwrite_tilde_set(x, x->x_arrayname);
-    dsp_add(tabwrite_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(tabwrite_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
-static void tabwrite_tilde_bang(t_tabwrite_tilde *x)
-{
-    x->x_phase = 0;
-}
+static void tabwrite_tilde_bang(t_tabwrite_tilde *x) { x->x_phase = 0; }
 
 static void tabwrite_tilde_start(t_tabwrite_tilde *x, t_floatarg f)
 {
@@ -111,7 +109,7 @@ static void tabwrite_tilde_start(t_tabwrite_tilde *x, t_floatarg f)
 
 static void tabwrite_tilde_stop(t_tabwrite_tilde *x)
 {
-    if (x->x_phase != 0x7fffffff)
+    if(x->x_phase != 0x7fffffff)
     {
         tabwrite_tilde_redraw(x);
         x->x_phase = 0x7fffffff;
@@ -120,17 +118,17 @@ static void tabwrite_tilde_stop(t_tabwrite_tilde *x)
 
 static void tabwrite_tilde_setup(void)
 {
-    tabwrite_tilde_class = class_new(gensym("tabwrite~"),
-        (t_newmethod)tabwrite_tilde_new, 0,
-        sizeof(t_tabwrite_tilde), 0, A_DEFSYM, 0);
+    tabwrite_tilde_class =
+        class_new(gensym("tabwrite~"), (t_newmethod) tabwrite_tilde_new, 0,
+            sizeof(t_tabwrite_tilde), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(tabwrite_tilde_class, t_tabwrite_tilde, x_f);
-    class_addmethod(tabwrite_tilde_class, (t_method)tabwrite_tilde_dsp,
+    class_addmethod(tabwrite_tilde_class, (t_method) tabwrite_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabwrite_tilde_class, (t_method)tabwrite_tilde_set,
+    class_addmethod(tabwrite_tilde_class, (t_method) tabwrite_tilde_set,
         gensym("set"), A_SYMBOL, 0);
-    class_addmethod(tabwrite_tilde_class, (t_method)tabwrite_tilde_stop,
+    class_addmethod(tabwrite_tilde_class, (t_method) tabwrite_tilde_stop,
         gensym("stop"), 0);
-    class_addmethod(tabwrite_tilde_class, (t_method)tabwrite_tilde_start,
+    class_addmethod(tabwrite_tilde_class, (t_method) tabwrite_tilde_start,
         gensym("start"), A_DEFFLOAT, 0);
     class_addbang(tabwrite_tilde_class, tabwrite_tilde_bang);
 }
@@ -155,8 +153,8 @@ static void tabplay_tilde_tick(t_tabplay_tilde *x);
 
 static void *tabplay_tilde_new(t_symbol *s)
 {
-    t_tabplay_tilde *x = (t_tabplay_tilde *)pd_new(tabplay_tilde_class);
-    x->x_clock = clock_new(x, (t_method)tabplay_tilde_tick);
+    t_tabplay_tilde *x = (t_tabplay_tilde *) pd_new(tabplay_tilde_class);
+    x->x_clock = clock_new(x, (t_method) tabplay_tilde_tick);
     x->x_phase = 0x7fffffff;
     x->x_limit = 0;
     x->x_arrayname = s;
@@ -167,36 +165,37 @@ static void *tabplay_tilde_new(t_symbol *s)
 
 static t_int *tabplay_tilde_perform(t_int *w)
 {
-    t_tabplay_tilde *x = (t_tabplay_tilde *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
+    t_tabplay_tilde *x = (t_tabplay_tilde *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
     t_word *wp;
-    int n = (int)(w[3]), phase = x->x_phase,
-        endphase = (x->x_nsampsintab < x->x_limit ?
-            x->x_nsampsintab : x->x_limit), nxfer, n3;
-    if (!x->x_vec || phase >= endphase)
-        goto zero;
+    int n = (int) (w[3]), phase = x->x_phase,
+        endphase =
+            (x->x_nsampsintab < x->x_limit ? x->x_nsampsintab : x->x_limit),
+        nxfer, n3;
+    if(!x->x_vec || phase >= endphase) goto zero;
 
     nxfer = endphase - phase;
     wp = x->x_vec + phase;
-    if (nxfer > n)
-        nxfer = n;
+    if(nxfer > n) nxfer = n;
     n3 = n - nxfer;
     phase += nxfer;
-    while (nxfer--)
+    while(nxfer--)
         *out++ = (wp++)->w_float;
-    if (phase >= endphase)
+    if(phase >= endphase)
     {
         clock_delay(x->x_clock, 0);
         x->x_phase = 0x7fffffff;
-        while (n3--)
+        while(n3--)
             *out++ = 0;
     }
-    else x->x_phase = phase;
+    else
+        x->x_phase = phase;
 
-    return (w+4);
+    return (w + 4);
 zero:
-    while (n--) *out++ = 0;
-    return (w+4);
+    while(n--)
+        *out++ = 0;
+    return (w + 4);
 }
 
 static void tabplay_tilde_set(t_tabplay_tilde *x, t_symbol *s)
@@ -204,64 +203,59 @@ static void tabplay_tilde_set(t_tabplay_tilde *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name) pd_error(x, "tabplay~: %s: no such array",
-            x->x_arrayname->s_name);
+        if(*s->s_name)
+            pd_error(x, "tabplay~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_nsampsintab, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_nsampsintab, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabplay~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabplay_tilde_dsp(t_tabplay_tilde *x, t_signal **sp)
 {
     tabplay_tilde_set(x, x->x_arrayname);
-    dsp_add(tabplay_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(tabplay_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
-static void tabplay_tilde_list(t_tabplay_tilde *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void tabplay_tilde_list(
+    t_tabplay_tilde *x, t_symbol *s, int argc, t_atom *argv)
 {
     long start = atom_getfloatarg(0, argc, argv);
     long length = atom_getfloatarg(1, argc, argv);
-    if (start < 0) start = 0;
-    if (length <= 0)
+    if(start < 0) start = 0;
+    if(length <= 0)
         x->x_limit = 0x7fffffff;
     else
-        x->x_limit = (int)(start + length);
-    x->x_phase = (int)start;
+        x->x_limit = (int) (start + length);
+    x->x_phase = (int) start;
 }
 
-static void tabplay_tilde_stop(t_tabplay_tilde *x)
-{
-    x->x_phase = 0x7fffffff;
-}
+static void tabplay_tilde_stop(t_tabplay_tilde *x) { x->x_phase = 0x7fffffff; }
 
 static void tabplay_tilde_tick(t_tabplay_tilde *x)
 {
     outlet_bang(x->x_bangout);
 }
 
-static void tabplay_tilde_free(t_tabplay_tilde *x)
-{
-    clock_free(x->x_clock);
-}
+static void tabplay_tilde_free(t_tabplay_tilde *x) { clock_free(x->x_clock); }
 
 static void tabplay_tilde_setup(void)
 {
     tabplay_tilde_class = class_new(gensym("tabplay~"),
-        (t_newmethod)tabplay_tilde_new, (t_method)tabplay_tilde_free,
+        (t_newmethod) tabplay_tilde_new, (t_method) tabplay_tilde_free,
         sizeof(t_tabplay_tilde), 0, A_DEFSYM, 0);
-    class_addmethod(tabplay_tilde_class, (t_method)tabplay_tilde_dsp,
+    class_addmethod(tabplay_tilde_class, (t_method) tabplay_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabplay_tilde_class, (t_method)tabplay_tilde_stop,
-        gensym("stop"), 0);
-    class_addmethod(tabplay_tilde_class, (t_method)tabplay_tilde_set,
+    class_addmethod(
+        tabplay_tilde_class, (t_method) tabplay_tilde_stop, gensym("stop"), 0);
+    class_addmethod(tabplay_tilde_class, (t_method) tabplay_tilde_set,
         gensym("set"), A_DEFSYM, 0);
     class_addlist(tabplay_tilde_class, tabplay_tilde_list);
 }
@@ -281,7 +275,7 @@ typedef struct _tabread_tilde
 
 static void *tabread_tilde_new(t_symbol *s)
 {
-    t_tabread_tilde *x = (t_tabread_tilde *)pd_new(tabread_tilde_class);
+    t_tabread_tilde *x = (t_tabread_tilde *) pd_new(tabread_tilde_class);
     x->x_arrayname = s;
     x->x_vec = 0;
     outlet_new(&x->x_obj, gensym("signal"));
@@ -291,32 +285,33 @@ static void *tabread_tilde_new(t_symbol *s)
 
 static t_int *tabread_tilde_perform(t_int *w)
 {
-    t_tabread_tilde *x = (t_tabread_tilde *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
+    t_tabread_tilde *x = (t_tabread_tilde *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
     int maxindex;
     t_word *buf = x->x_vec;
     int i;
 
     maxindex = x->x_npoints - 1;
-    if(maxindex<0) goto zero;
-    if (!buf) goto zero;
+    if(maxindex < 0) goto zero;
+    if(!buf) goto zero;
 
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         int index = *in++;
-        if (index < 0)
+        if(index < 0)
             index = 0;
-        else if (index > maxindex)
+        else if(index > maxindex)
             index = maxindex;
         *out++ = buf[index].w_float;
     }
-    return (w+5);
- zero:
-    while (n--) *out++ = 0;
+    return (w + 5);
+zero:
+    while(n--)
+        *out++ = 0;
 
-    return (w+5);
+    return (w + 5);
 }
 
 static void tabread_tilde_set(t_tabread_tilde *x, t_symbol *s)
@@ -324,42 +319,40 @@ static void tabread_tilde_set(t_tabread_tilde *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name)
+        if(*s->s_name)
             pd_error(x, "tabread~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabread~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabread_tilde_dsp(t_tabread_tilde *x, t_signal **sp)
 {
     tabread_tilde_set(x, x->x_arrayname);
 
-    dsp_add(tabread_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
-
+    dsp_add(tabread_tilde_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
-static void tabread_tilde_free(t_tabread_tilde *x)
-{
-}
+static void tabread_tilde_free(t_tabread_tilde *x) {}
 
 static void tabread_tilde_setup(void)
 {
     tabread_tilde_class = class_new(gensym("tabread~"),
-        (t_newmethod)tabread_tilde_new, (t_method)tabread_tilde_free,
+        (t_newmethod) tabread_tilde_new, (t_method) tabread_tilde_free,
         sizeof(t_tabread_tilde), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(tabread_tilde_class, t_tabread_tilde, x_f);
-    class_addmethod(tabread_tilde_class, (t_method)tabread_tilde_dsp,
+    class_addmethod(tabread_tilde_class, (t_method) tabread_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabread_tilde_class, (t_method)tabread_tilde_set,
+    class_addmethod(tabread_tilde_class, (t_method) tabread_tilde_set,
         gensym("set"), A_SYMBOL, 0);
 }
 
@@ -379,7 +372,7 @@ typedef struct _tabread4_tilde
 
 static void *tabread4_tilde_new(t_symbol *s)
 {
-    t_tabread4_tilde *x = (t_tabread4_tilde *)pd_new(tabread4_tilde_class);
+    t_tabread4_tilde *x = (t_tabread4_tilde *) pd_new(tabread4_tilde_class);
     x->x_arrayname = s;
     x->x_vec = 0;
     outlet_new(&x->x_obj, gensym("signal"));
@@ -391,21 +384,21 @@ static void *tabread4_tilde_new(t_symbol *s)
 
 static t_int *tabread4_tilde_perform(t_int *w)
 {
-    t_tabread4_tilde *x = (t_tabread4_tilde *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
+    t_tabread4_tilde *x = (t_tabread4_tilde *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
     int maxindex;
     t_word *buf = x->x_vec, *wp;
     double onset = x->x_onset;
     int i;
 
     maxindex = x->x_npoints - 3;
-    if(maxindex<0) goto zero;
+    if(maxindex < 0) goto zero;
 
-    if (!buf) goto zero;
+    if(!buf) goto zero;
 
-#if 0       /* test for spam -- I'm not ready to deal with this */
+#if 0 /* test for spam -- I'm not ready to deal with this */
     for (i = 0,  xmax = 0, xmin = maxindex,  fp = in1; i < n; i++,  fp++)
     {
         t_sample f = *in1;
@@ -421,33 +414,33 @@ static t_int *tabread4_tilde_perform(t_int *w)
     }
 #endif
 
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         double findex = *in++ + onset;
         int index = findex;
-        t_sample frac,  a,  b,  c,  d, cminusb;
-        if (index < 1)
+        t_sample frac, a, b, c, d, cminusb;
+        if(index < 1)
             index = 1, frac = 0;
-        else if (index > maxindex)
+        else if(index > maxindex)
             index = maxindex, frac = 1;
-        else frac = findex - index;
+        else
+            frac = findex - index;
         wp = buf + index;
         a = wp[-1].w_float;
         b = wp[0].w_float;
         c = wp[1].w_float;
         d = wp[2].w_float;
-        cminusb = c-b;
-        *out++ = b + frac * (
-            cminusb - 0.1666667f * (1.-frac) * (
-                (d - a - 3.0f * cminusb) * frac + (d + 2.0f*a - 3.0f*b)
-            )
-        );
+        cminusb = c - b;
+        *out++ = b + frac * (cminusb - 0.1666667f * (1. - frac) *
+                                           ((d - a - 3.0f * cminusb) * frac +
+                                               (d + 2.0f * a - 3.0f * b)));
     }
-    return (w+5);
- zero:
-    while (n--) *out++ = 0;
+    return (w + 5);
+zero:
+    while(n--)
+        *out++ = 0;
 
-    return (w+5);
+    return (w + 5);
 }
 
 static void tabread4_tilde_set(t_tabread4_tilde *x, t_symbol *s)
@@ -455,52 +448,50 @@ static void tabread4_tilde_set(t_tabread4_tilde *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name)
+        if(*s->s_name)
             pd_error(x, "tabread4~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabread4~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabread4_tilde_dsp(t_tabread4_tilde *x, t_signal **sp)
 {
     tabread4_tilde_set(x, x->x_arrayname);
 
-    dsp_add(tabread4_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
-
+    dsp_add(tabread4_tilde_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
-static void tabread4_tilde_free(t_tabread4_tilde *x)
-{
-}
+static void tabread4_tilde_free(t_tabread4_tilde *x) {}
 
 static void tabread4_tilde_setup(void)
 {
     tabread4_tilde_class = class_new(gensym("tabread4~"),
-        (t_newmethod)tabread4_tilde_new, (t_method)tabread4_tilde_free,
+        (t_newmethod) tabread4_tilde_new, (t_method) tabread4_tilde_free,
         sizeof(t_tabread4_tilde), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(tabread4_tilde_class, t_tabread4_tilde, x_f);
-    class_addmethod(tabread4_tilde_class, (t_method)tabread4_tilde_dsp,
+    class_addmethod(tabread4_tilde_class, (t_method) tabread4_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabread4_tilde_class, (t_method)tabread4_tilde_set,
+    class_addmethod(tabread4_tilde_class, (t_method) tabread4_tilde_set,
         gensym("set"), A_SYMBOL, 0);
 }
 
 /******************** tabosc4~ ***********************/
 
 /* this is all copied from d_osc.c... what include file could this go in? */
-#define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
+#define UNITBIT32 1572864. /* 3*2^19; bit 32 has place value 1 */
 
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
-    || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || \
+    defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
 #include <machine/endian.h>
 #endif
 
@@ -524,11 +515,11 @@ static void tabread4_tilde_setup(void)
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-# define HIOFFSET 1
-# define LOWOFFSET 0
+#define HIOFFSET 1
+#define LOWOFFSET 0
 #else
-# define HIOFFSET 0    /* word offset to find MSB */
-# define LOWOFFSET 1    /* word offset to find LSB */
+#define HIOFFSET 0  /* word offset to find MSB */
+#define LOWOFFSET 1 /* word offset to find LSB */
 #endif
 
 union tabfudge
@@ -553,11 +544,11 @@ typedef struct _tabosc4_tilde
 
 static void *tabosc4_tilde_new(t_symbol *s)
 {
-    t_tabosc4_tilde *x = (t_tabosc4_tilde *)pd_new(tabosc4_tilde_class);
+    t_tabosc4_tilde *x = (t_tabosc4_tilde *) pd_new(tabosc4_tilde_class);
     x->x_arrayname = s;
     x->x_vec = 0;
     x->x_fnpoints = 512.;
-    x->x_finvnpoints = (1./512.);
+    x->x_finvnpoints = (1. / 512.);
     outlet_new(&x->x_obj, gensym("signal"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_float, gensym("ft1"));
     x->x_f = 0;
@@ -566,10 +557,10 @@ static void *tabosc4_tilde_new(t_symbol *s)
 
 static t_int *tabosc4_tilde_perform(t_int *w)
 {
-    t_tabosc4_tilde *x = (t_tabosc4_tilde *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
+    t_tabosc4_tilde *x = (t_tabosc4_tilde *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
     int normhipart;
     union tabfudge tf;
     t_float fnpoints = x->x_fnpoints;
@@ -578,14 +569,14 @@ static t_int *tabosc4_tilde_perform(t_int *w)
     t_word *tab = x->x_vec, *addr;
     double dphase = fnpoints * x->x_phase + UNITBIT32;
 
-    if (!tab) goto zero;
+    if(!tab) goto zero;
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
 
 #if 1
-    while (n--)
+    while(n--)
     {
-        t_sample frac,  a,  b,  c,  d, cminusb;
+        t_sample frac, a, b, c, d, cminusb;
         tf.tf_d = dphase;
         dphase += *in++ * conv;
         addr = tab + (tf.tf_i[HIOFFSET] & mask);
@@ -595,12 +586,10 @@ static t_int *tabosc4_tilde_perform(t_int *w)
         b = addr[1].w_float;
         c = addr[2].w_float;
         d = addr[3].w_float;
-        cminusb = c-b;
-        *out++ = b + frac * (
-            cminusb - 0.1666667f * (1.-frac) * (
-                (d - a - 3.0f * cminusb) * frac + (d + 2.0f*a - 3.0f*b)
-            )
-        );
+        cminusb = c - b;
+        *out++ = b + frac * (cminusb - 0.1666667f * (1. - frac) *
+                                           ((d - a - 3.0f * cminusb) * frac +
+                                               (d + 2.0f * a - 3.0f * b)));
     }
 #endif
 
@@ -608,12 +597,13 @@ static t_int *tabosc4_tilde_perform(t_int *w)
     normhipart = tf.tf_i[HIOFFSET];
     tf.tf_d = dphase + (UNITBIT32 * fnpoints - UNITBIT32);
     tf.tf_i[HIOFFSET] = normhipart;
-    x->x_phase = (tf.tf_d - UNITBIT32 * fnpoints)  * x->x_finvnpoints;
-    return (w+5);
- zero:
-    while (n--) *out++ = 0;
+    x->x_phase = (tf.tf_d - UNITBIT32 * fnpoints) * x->x_finvnpoints;
+    return (w + 5);
+zero:
+    while(n--)
+        *out++ = 0;
 
-    return (w+5);
+    return (w + 5);
 }
 
 static void tabosc4_tilde_set(t_tabosc4_tilde *x, t_symbol *s)
@@ -622,18 +612,18 @@ static void tabosc4_tilde_set(t_tabosc4_tilde *x, t_symbol *s)
     int npoints, pointsinarray;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name)
+        if(*s->s_name)
             pd_error(x, "tabosc4~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &pointsinarray, &x->x_vec))
+    else if(!garray_getfloatwords(a, &pointsinarray, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabosc4~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if ((npoints = pointsinarray - 3) != (1 << ilog2(pointsinarray - 3)))
+    else if((npoints = pointsinarray - 3) != (1 << ilog2(pointsinarray - 3)))
     {
         pd_error(x, "%s: number of points (%d) not a power of 2 plus three",
             x->x_arrayname->s_name, pointsinarray);
@@ -643,36 +633,33 @@ static void tabosc4_tilde_set(t_tabosc4_tilde *x, t_symbol *s)
     else
     {
         x->x_fnpoints = npoints;
-        x->x_finvnpoints = 1./npoints;
+        x->x_finvnpoints = 1. / npoints;
         garray_usedindsp(a);
     }
 }
 
-static void tabosc4_tilde_ft1(t_tabosc4_tilde *x, t_float f)
-{
-    x->x_phase = f;
-}
+static void tabosc4_tilde_ft1(t_tabosc4_tilde *x, t_float f) { x->x_phase = f; }
 
 static void tabosc4_tilde_dsp(t_tabosc4_tilde *x, t_signal **sp)
 {
     x->x_conv = 1. / sp[0]->s_sr;
     tabosc4_tilde_set(x, x->x_arrayname);
 
-    dsp_add(tabosc4_tilde_perform, 4, x,
-        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(tabosc4_tilde_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 static void tabosc4_tilde_setup(void)
 {
-    tabosc4_tilde_class = class_new(gensym("tabosc4~"),
-        (t_newmethod)tabosc4_tilde_new, 0,
-        sizeof(t_tabosc4_tilde), 0, A_DEFSYM, 0);
+    tabosc4_tilde_class =
+        class_new(gensym("tabosc4~"), (t_newmethod) tabosc4_tilde_new, 0,
+            sizeof(t_tabosc4_tilde), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(tabosc4_tilde_class, t_tabosc4_tilde, x_f);
-    class_addmethod(tabosc4_tilde_class, (t_method)tabosc4_tilde_dsp,
+    class_addmethod(tabosc4_tilde_class, (t_method) tabosc4_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabosc4_tilde_class, (t_method)tabosc4_tilde_set,
+    class_addmethod(tabosc4_tilde_class, (t_method) tabosc4_tilde_set,
         gensym("set"), A_SYMBOL, 0);
-    class_addmethod(tabosc4_tilde_class, (t_method)tabosc4_tilde_ft1,
+    class_addmethod(tabosc4_tilde_class, (t_method) tabosc4_tilde_ft1,
         gensym("ft1"), A_FLOAT, 0);
 }
 
@@ -695,7 +682,7 @@ static void tabsend_tick(t_tabsend *x);
 
 static void *tabsend_new(t_symbol *s)
 {
-    t_tabsend *x = (t_tabsend *)pd_new(tabsend_class);
+    t_tabsend *x = (t_tabsend *) pd_new(tabsend_class);
     x->x_graphcount = 0;
     x->x_arrayname = s;
     x->x_f = 0;
@@ -704,32 +691,31 @@ static void *tabsend_new(t_symbol *s)
 
 static t_int *tabsend_perform(t_int *w)
 {
-    t_tabsend *x = (t_tabsend *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    int n = (int)w[3];
+    t_tabsend *x = (t_tabsend *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    int n = (int) w[3];
     t_word *dest = x->x_vec;
     int i = x->x_graphcount;
-    if (!x->x_vec) goto bad;
-    if (n > x->x_npoints)
-        n = x->x_npoints;
-    while (n--)
+    if(!x->x_vec) goto bad;
+    if(n > x->x_npoints) n = x->x_npoints;
+    while(n--)
     {
         t_sample f = *in++;
-        if (PD_BIGORSMALL(f))
-            f = 0;
-         (dest++)->w_float = f;
+        if(PD_BIGORSMALL(f)) f = 0;
+        (dest++)->w_float = f;
     }
-    if (!i--)
+    if(!i--)
     {
-        t_garray *a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class);
-        if (!a)
+        t_garray *a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class);
+        if(!a)
             bug("tabsend_dsp");
-        else garray_redraw(a);
+        else
+            garray_redraw(a);
         i = x->x_graphperiod;
     }
     x->x_graphcount = i;
 bad:
-    return (w+4);
+    return (w + 4);
 }
 
 static void tabsend_set(t_tabsend *x, t_symbol *s)
@@ -737,40 +723,41 @@ static void tabsend_set(t_tabsend *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name)
+        if(*s->s_name)
             pd_error(x, "tabsend~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
     {
         pd_error(x, "%s: bad template for tabsend~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabsend_dsp(t_tabsend *x, t_signal **sp)
 {
     int n = sp[0]->s_n;
-    int ticksper = sp[0]->s_sr/n;
+    int ticksper = sp[0]->s_sr / n;
     tabsend_set(x, x->x_arrayname);
-    if (ticksper < 1) ticksper = 1;
+    if(ticksper < 1) ticksper = 1;
     x->x_graphperiod = ticksper;
-    if (x->x_graphcount > ticksper) x->x_graphcount = ticksper;
-    dsp_add(tabsend_perform, 3, x, sp[0]->s_vec, (t_int)n);
+    if(x->x_graphcount > ticksper) x->x_graphcount = ticksper;
+    dsp_add(tabsend_perform, 3, x, sp[0]->s_vec, (t_int) n);
 }
 
 static void tabsend_setup(void)
 {
-    tabsend_class = class_new(gensym("tabsend~"), (t_newmethod)tabsend_new,
-        0, sizeof(t_tabsend), 0, A_DEFSYM, 0);
+    tabsend_class = class_new(gensym("tabsend~"), (t_newmethod) tabsend_new, 0,
+        sizeof(t_tabsend), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(tabsend_class, t_tabsend, x_f);
-    class_addmethod(tabsend_class, (t_method)tabsend_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabsend_class, (t_method)tabsend_set,
-        gensym("set"), A_SYMBOL, 0);
+    class_addmethod(
+        tabsend_class, (t_method) tabsend_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        tabsend_class, (t_method) tabsend_set, gensym("set"), A_SYMBOL, 0);
     class_sethelpsymbol(tabsend_class, gensym("tabsend-receive~"));
 }
 
@@ -788,24 +775,25 @@ typedef struct _tabreceive
 
 static t_int *tabreceive_perform(t_int *w)
 {
-    t_tabreceive *x = (t_tabreceive *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)w[3];
+    t_tabreceive *x = (t_tabreceive *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) w[3];
     t_word *from = x->x_vec;
-    if (from)
+    if(from)
     {
         t_int vecsize = x->x_npoints;
-        if (vecsize > n)
-            vecsize = n;
-        while (vecsize--)
+        if(vecsize > n) vecsize = n;
+        while(vecsize--)
             *out++ = (from++)->w_float;
         vecsize = n - x->x_npoints;
-        if (vecsize > 0)
-            while (vecsize--)
+        if(vecsize > 0)
+            while(vecsize--)
                 *out++ = 0;
     }
-    else while (n--) *out++ = 0;
-    return (w+4);
+    else
+        while(n--)
+            *out++ = 0;
+    return (w + 4);
 }
 
 static void tabreceive_set(t_tabreceive *x, t_symbol *s)
@@ -813,31 +801,31 @@ static void tabreceive_set(t_tabreceive *x, t_symbol *s)
     t_garray *a;
 
     x->x_arrayname = s;
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
-        if (*s->s_name)
-            pd_error(x, "tabreceive~: %s: no such array",
-                x->x_arrayname->s_name);
+        if(*s->s_name)
+            pd_error(
+                x, "tabreceive~: %s: no such array", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else if (!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
+    else if(!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
     {
-        pd_error(x, "%s: bad template for tabreceive~",
-            x->x_arrayname->s_name);
+        pd_error(x, "%s: bad template for tabreceive~", x->x_arrayname->s_name);
         x->x_vec = 0;
     }
-    else garray_usedindsp(a);
+    else
+        garray_usedindsp(a);
 }
 
 static void tabreceive_dsp(t_tabreceive *x, t_signal **sp)
 {
     tabreceive_set(x, x->x_arrayname);
-    dsp_add(tabreceive_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(tabreceive_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void *tabreceive_new(t_symbol *s)
 {
-    t_tabreceive *x = (t_tabreceive *)pd_new(tabreceive_class);
+    t_tabreceive *x = (t_tabreceive *) pd_new(tabreceive_class);
     x->x_arrayname = s;
     outlet_new(&x->x_obj, &s_signal);
     return (x);
@@ -846,12 +834,11 @@ static void *tabreceive_new(t_symbol *s)
 static void tabreceive_setup(void)
 {
     tabreceive_class = class_new(gensym("tabreceive~"),
-        (t_newmethod)tabreceive_new, 0,
-        sizeof(t_tabreceive), 0, A_DEFSYM, 0);
-    class_addmethod(tabreceive_class, (t_method)tabreceive_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(tabreceive_class, (t_method)tabreceive_set,
-        gensym("set"), A_SYMBOL, 0);
+        (t_newmethod) tabreceive_new, 0, sizeof(t_tabreceive), 0, A_DEFSYM, 0);
+    class_addmethod(
+        tabreceive_class, (t_method) tabreceive_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(tabreceive_class, (t_method) tabreceive_set, gensym("set"),
+        A_SYMBOL, 0);
     class_sethelpsymbol(tabreceive_class, gensym("tabsend-receive~"));
 }
 
@@ -871,27 +858,26 @@ static void tabread_float(t_tabread *x, t_float f)
     int npoints;
     t_word *vec;
 
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
-    else if (!garray_getfloatwords(a, &npoints, &vec))
+    else if(!garray_getfloatwords(a, &npoints, &vec))
         pd_error(x, "%s: bad template for tabread", x->x_arrayname->s_name);
     else
     {
         int n = f;
-        if (n < 0) n = 0;
-        else if (n >= npoints) n = npoints - 1;
+        if(n < 0)
+            n = 0;
+        else if(n >= npoints)
+            n = npoints - 1;
         outlet_float(x->x_obj.ob_outlet, (npoints ? vec[n].w_float : 0));
     }
 }
 
-static void tabread_set(t_tabread *x, t_symbol *s)
-{
-    x->x_arrayname = s;
-}
+static void tabread_set(t_tabread *x, t_symbol *s) { x->x_arrayname = s; }
 
 static void *tabread_new(t_symbol *s)
 {
-    t_tabread *x = (t_tabread *)pd_new(tabread_class);
+    t_tabread *x = (t_tabread *) pd_new(tabread_class);
     x->x_arrayname = s;
     outlet_new(&x->x_obj, &s_float);
     return (x);
@@ -899,11 +885,11 @@ static void *tabread_new(t_symbol *s)
 
 static void tabread_setup(void)
 {
-    tabread_class = class_new(gensym("tabread"), (t_newmethod)tabread_new,
-        0, sizeof(t_tabread), 0, A_DEFSYM, 0);
-    class_addfloat(tabread_class, (t_method)tabread_float);
-    class_addmethod(tabread_class, (t_method)tabread_set, gensym("set"),
-        A_SYMBOL, 0);
+    tabread_class = class_new(gensym("tabread"), (t_newmethod) tabread_new, 0,
+        sizeof(t_tabread), 0, A_DEFSYM, 0);
+    class_addfloat(tabread_class, (t_method) tabread_float);
+    class_addmethod(
+        tabread_class, (t_method) tabread_set, gensym("set"), A_SYMBOL, 0);
 }
 
 /* ---------- tabread4: control, 4-point interpolation --------------- */
@@ -922,44 +908,41 @@ static void tabread4_float(t_tabread4 *x, t_float f)
     int npoints;
     t_word *vec;
 
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
-    else if (!garray_getfloatwords(a, &npoints, &vec))
+    else if(!garray_getfloatwords(a, &npoints, &vec))
         pd_error(x, "%s: bad template for tabread4", x->x_arrayname->s_name);
-    else if (npoints < 4)
+    else if(npoints < 4)
         outlet_float(x->x_obj.ob_outlet, 0);
-    else if (f <= 1)
+    else if(f <= 1)
         outlet_float(x->x_obj.ob_outlet, vec[1].w_float);
-    else if (f >= npoints - 2)
+    else if(f >= npoints - 2)
         outlet_float(x->x_obj.ob_outlet, vec[npoints - 2].w_float);
     else
     {
         int n = f;
         float a, b, c, d, cminusb, frac;
         t_word *wp;
-        if (n >= npoints - 2)
-            n = npoints - 3;
+        if(n >= npoints - 2) n = npoints - 3;
         wp = vec + n;
         frac = f - n;
         a = wp[-1].w_float;
         b = wp[0].w_float;
         c = wp[1].w_float;
         d = wp[2].w_float;
-        cminusb = c-b;
-        outlet_float(x->x_obj.ob_outlet, b + frac * (
-            cminusb - 0.1666667f * (1.-frac) * (
-                (d - a - 3.0f * cminusb) * frac + (d + 2.0f*a - 3.0f*b))));
+        cminusb = c - b;
+        outlet_float(x->x_obj.ob_outlet,
+            b + frac * (cminusb - 0.1666667f * (1. - frac) *
+                                      ((d - a - 3.0f * cminusb) * frac +
+                                          (d + 2.0f * a - 3.0f * b))));
     }
 }
 
-static void tabread4_set(t_tabread4 *x, t_symbol *s)
-{
-    x->x_arrayname = s;
-}
+static void tabread4_set(t_tabread4 *x, t_symbol *s) { x->x_arrayname = s; }
 
 static void *tabread4_new(t_symbol *s)
 {
-    t_tabread4 *x = (t_tabread4 *)pd_new(tabread4_class);
+    t_tabread4 *x = (t_tabread4 *) pd_new(tabread4_class);
     x->x_arrayname = s;
     outlet_new(&x->x_obj, &s_float);
     return (x);
@@ -967,11 +950,11 @@ static void *tabread4_new(t_symbol *s)
 
 static void tabread4_setup(void)
 {
-    tabread4_class = class_new(gensym("tabread4"), (t_newmethod)tabread4_new,
+    tabread4_class = class_new(gensym("tabread4"), (t_newmethod) tabread4_new,
         0, sizeof(t_tabread4), 0, A_DEFSYM, 0);
-    class_addfloat(tabread4_class, (t_method)tabread4_float);
-    class_addmethod(tabread4_class, (t_method)tabread4_set, gensym("set"),
-        A_SYMBOL, 0);
+    class_addfloat(tabread4_class, (t_method) tabread4_float);
+    class_addmethod(
+        tabread4_class, (t_method) tabread4_set, gensym("set"), A_SYMBOL, 0);
 }
 
 /* ------------------ tabwrite: control ------------------------ */
@@ -991,30 +974,27 @@ static void tabwrite_float(t_tabwrite *x, t_float f)
     t_garray *a;
     t_word *vec;
 
-    if (!(a = (t_garray *)pd_findbyclass(x->x_arrayname, garray_class)))
+    if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
-    else if (!garray_getfloatwords(a, &vecsize, &vec))
+    else if(!garray_getfloatwords(a, &vecsize, &vec))
         pd_error(x, "%s: bad template for tabwrite", x->x_arrayname->s_name);
     else
     {
         int n = x->x_ft1;
-        if (n < 0)
+        if(n < 0)
             n = 0;
-        else if (n >= vecsize)
-            n = vecsize-1;
+        else if(n >= vecsize)
+            n = vecsize - 1;
         vec[n].w_float = f;
         garray_redraw(a);
     }
 }
 
-static void tabwrite_set(t_tabwrite *x, t_symbol *s)
-{
-    x->x_arrayname = s;
-}
+static void tabwrite_set(t_tabwrite *x, t_symbol *s) { x->x_arrayname = s; }
 
 static void *tabwrite_new(t_symbol *s)
 {
-    t_tabwrite *x = (t_tabwrite *)pd_new(tabwrite_class);
+    t_tabwrite *x = (t_tabwrite *) pd_new(tabwrite_class);
     x->x_ft1 = 0;
     x->x_arrayname = s;
     floatinlet_new(&x->x_obj, &x->x_ft1);
@@ -1023,11 +1003,11 @@ static void *tabwrite_new(t_symbol *s)
 
 void tabwrite_setup(void)
 {
-    tabwrite_class = class_new(gensym("tabwrite"), (t_newmethod)tabwrite_new,
+    tabwrite_class = class_new(gensym("tabwrite"), (t_newmethod) tabwrite_new,
         0, sizeof(t_tabwrite), 0, A_DEFSYM, 0);
-    class_addfloat(tabwrite_class, (t_method)tabwrite_float);
-    class_addmethod(tabwrite_class, (t_method)tabwrite_set, gensym("set"),
-        A_SYMBOL, 0);
+    class_addfloat(tabwrite_class, (t_method) tabwrite_float);
+    class_addmethod(
+        tabwrite_class, (t_method) tabwrite_set, gensym("set"), A_SYMBOL, 0);
 }
 
 /* ------------------------ global setup routine ------------------------- */
@@ -1045,4 +1025,3 @@ void d_array_setup(void)
     tabread4_setup();
     tabwrite_setup();
 }
-

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -303,13 +303,12 @@ static t_int *tabread_tilde_perform(t_int *w)
     int n = (int) (w[4]);
     int maxindex;
     t_word *buf = x->x_vec;
-    int i;
 
     maxindex = x->x_npoints - 1;
     if(maxindex < 0) goto zero;
     if(!buf) goto zero;
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         int index = *in++;
         if(index < 0)
@@ -408,7 +407,6 @@ static t_int *tabread4_tilde_perform(t_int *w)
     t_word *buf = x->x_vec;
     t_word *wp;
     double onset = x->x_onset;
-    int i;
 
     maxindex = x->x_npoints - 3;
     if(maxindex < 0) goto zero;
@@ -431,7 +429,7 @@ static t_int *tabread4_tilde_perform(t_int *w)
     }
 #endif
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         double findex = *in++ + onset;
         int index = findex;

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -46,7 +46,9 @@ static t_int *tabwrite_tilde_perform(t_int *w)
 {
     t_tabwrite_tilde *x = (t_tabwrite_tilde *) (w[1]);
     t_sample *in = (t_sample *) (w[2]);
-    int n = (int) (w[3]), phase = x->x_phase, endphase = x->x_nsampsintab;
+    int n = (int) (w[3]);
+    int phase = x->x_phase;
+    int endphase = x->x_nsampsintab;
     if(!x->x_vec) goto bad;
 
     if(endphase > phase)
@@ -168,10 +170,12 @@ static t_int *tabplay_tilde_perform(t_int *w)
     t_tabplay_tilde *x = (t_tabplay_tilde *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
     t_word *wp;
-    int n = (int) (w[3]), phase = x->x_phase,
-        endphase =
-            (x->x_nsampsintab < x->x_limit ? x->x_nsampsintab : x->x_limit),
-        nxfer, n3;
+    int n = (int) (w[3]);
+    int phase = x->x_phase;
+    int endphase =
+        (x->x_nsampsintab < x->x_limit ? x->x_nsampsintab : x->x_limit);
+    int nxfer;
+    int n3;
     if(!x->x_vec || phase >= endphase) goto zero;
 
     nxfer = endphase - phase;
@@ -389,7 +393,8 @@ static t_int *tabread4_tilde_perform(t_int *w)
     t_sample *out = (t_sample *) (w[3]);
     int n = (int) (w[4]);
     int maxindex;
-    t_word *buf = x->x_vec, *wp;
+    t_word *buf = x->x_vec;
+    t_word *wp;
     double onset = x->x_onset;
     int i;
 
@@ -418,7 +423,12 @@ static t_int *tabread4_tilde_perform(t_int *w)
     {
         double findex = *in++ + onset;
         int index = findex;
-        t_sample frac, a, b, c, d, cminusb;
+        t_sample frac;
+        t_sample a;
+        t_sample b;
+        t_sample c;
+        t_sample d;
+        t_sample cminusb;
         if(index < 1)
             index = 1, frac = 0;
         else if(index > maxindex)
@@ -566,7 +576,8 @@ static t_int *tabosc4_tilde_perform(t_int *w)
     t_float fnpoints = x->x_fnpoints;
     int mask = fnpoints - 1;
     t_float conv = fnpoints * x->x_conv;
-    t_word *tab = x->x_vec, *addr;
+    t_word *tab = x->x_vec;
+    t_word *addr;
     double dphase = fnpoints * x->x_phase + UNITBIT32;
 
     if(!tab) goto zero;
@@ -576,7 +587,12 @@ static t_int *tabosc4_tilde_perform(t_int *w)
 #if 1
     while(n--)
     {
-        t_sample frac, a, b, c, d, cminusb;
+        t_sample frac;
+        t_sample a;
+        t_sample b;
+        t_sample c;
+        t_sample d;
+        t_sample cminusb;
         tf.tf_d = dphase;
         dphase += *in++ * conv;
         addr = tab + (tf.tf_i[HIOFFSET] & mask);
@@ -609,7 +625,8 @@ zero:
 static void tabosc4_tilde_set(t_tabosc4_tilde *x, t_symbol *s)
 {
     t_garray *a;
-    int npoints, pointsinarray;
+    int npoints;
+    int pointsinarray;
 
     x->x_arrayname = s;
     if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
@@ -921,7 +938,12 @@ static void tabread4_float(t_tabread4 *x, t_float f)
     else
     {
         int n = f;
-        float a, b, c, d, cminusb, frac;
+        float a;
+        float b;
+        float c;
+        float d;
+        float cminusb;
+        float frac;
         t_word *wp;
         if(n >= npoints - 2) n = npoints - 3;
         wp = vec + n;

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -37,9 +37,13 @@ static void tabwrite_tilde_redraw(t_tabwrite_tilde *x)
 {
     t_garray *a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class);
     if(!a)
+    {
         bug("tabwrite_tilde_redraw");
+    }
     else
+    {
         garray_redraw(a);
+    }
 }
 
 static t_int *tabwrite_tilde_perform(t_int *w)
@@ -235,9 +239,13 @@ static void tabplay_tilde_list(
     long length = atom_getfloatarg(1, argc, argv);
     if(start < 0) start = 0;
     if(length <= 0)
+    {
         x->x_limit = 0x7fffffff;
+    }
     else
+    {
         x->x_limit = (int) (start + length);
+    }
     x->x_phase = (int) start;
 }
 
@@ -305,9 +313,13 @@ static t_int *tabread_tilde_perform(t_int *w)
     {
         int index = *in++;
         if(index < 0)
+        {
             index = 0;
+        }
         else if(index > maxindex)
+        {
             index = maxindex;
+        }
         *out++ = buf[index].w_float;
     }
     return (w + 5);
@@ -430,11 +442,17 @@ static t_int *tabread4_tilde_perform(t_int *w)
         t_sample d;
         t_sample cminusb;
         if(index < 1)
+        {
             index = 1, frac = 0;
+        }
         else if(index > maxindex)
+        {
             index = maxindex, frac = 1;
+        }
         else
+        {
             frac = findex - index;
+        }
         wp = buf + index;
         a = wp[-1].w_float;
         b = wp[0].w_float;
@@ -725,9 +743,13 @@ static t_int *tabsend_perform(t_int *w)
     {
         t_garray *a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class);
         if(!a)
+        {
             bug("tabsend_dsp");
+        }
         else
+        {
             garray_redraw(a);
+        }
         i = x->x_graphperiod;
     }
     x->x_graphcount = i;
@@ -804,12 +826,16 @@ static t_int *tabreceive_perform(t_int *w)
             *out++ = (from++)->w_float;
         vecsize = n - x->x_npoints;
         if(vecsize > 0)
+        {
             while(vecsize--)
                 *out++ = 0;
+        }
     }
     else
+    {
         while(n--)
             *out++ = 0;
+    }
     return (w + 4);
 }
 
@@ -821,8 +847,10 @@ static void tabreceive_set(t_tabreceive *x, t_symbol *s)
     if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
     {
         if(*s->s_name)
+        {
             pd_error(
                 x, "tabreceive~: %s: no such array", x->x_arrayname->s_name);
+        }
         x->x_vec = 0;
     }
     else if(!garray_getfloatwords(a, &x->x_npoints, &x->x_vec))
@@ -876,16 +904,24 @@ static void tabread_float(t_tabread *x, t_float f)
     t_word *vec;
 
     if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
+    {
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
+    }
     else if(!garray_getfloatwords(a, &npoints, &vec))
+    {
         pd_error(x, "%s: bad template for tabread", x->x_arrayname->s_name);
+    }
     else
     {
         int n = f;
         if(n < 0)
+        {
             n = 0;
+        }
         else if(n >= npoints)
+        {
             n = npoints - 1;
+        }
         outlet_float(x->x_obj.ob_outlet, (npoints ? vec[n].w_float : 0));
     }
 }
@@ -926,15 +962,25 @@ static void tabread4_float(t_tabread4 *x, t_float f)
     t_word *vec;
 
     if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
+    {
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
+    }
     else if(!garray_getfloatwords(a, &npoints, &vec))
+    {
         pd_error(x, "%s: bad template for tabread4", x->x_arrayname->s_name);
+    }
     else if(npoints < 4)
+    {
         outlet_float(x->x_obj.ob_outlet, 0);
+    }
     else if(f <= 1)
+    {
         outlet_float(x->x_obj.ob_outlet, vec[1].w_float);
+    }
     else if(f >= npoints - 2)
+    {
         outlet_float(x->x_obj.ob_outlet, vec[npoints - 2].w_float);
+    }
     else
     {
         int n = f;
@@ -997,16 +1043,24 @@ static void tabwrite_float(t_tabwrite *x, t_float f)
     t_word *vec;
 
     if(!(a = (t_garray *) pd_findbyclass(x->x_arrayname, garray_class)))
+    {
         pd_error(x, "%s: no such array", x->x_arrayname->s_name);
+    }
     else if(!garray_getfloatwords(a, &vecsize, &vec))
+    {
         pd_error(x, "%s: bad template for tabwrite", x->x_arrayname->s_name);
+    }
     else
     {
         int n = x->x_ft1;
         if(n < 0)
+        {
             n = 0;
+        }
         else if(n >= vecsize)
+        {
             n = vecsize - 1;
+        }
         vec[n].w_float = f;
         garray_redraw(a);
     }

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -193,9 +193,13 @@ static void line_tilde_stop(t_line *x)
 static void line_tilde_dsp(t_line *x, t_signal **sp)
 {
     if(sp[0]->s_n & 7)
+    {
         dsp_add(line_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+    }
     else
+    {
         dsp_add(line_tilde_perf8, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+    }
     x->x_1overn = 1. / sp[0]->s_n;
     x->x_dspticktomsec = sp[0]->s_sr / (1000 * sp[0]->s_n);
 }
@@ -532,9 +536,13 @@ static void vsnapshot_tilde_bang(t_vsnapshot *x)
     {
         int indx = clock_gettimesince(x->x_time) * x->x_sampspermsec;
         if(indx < 0)
+        {
             indx = 0;
+        }
         else if(indx >= x->x_n)
+        {
             indx = x->x_n - 1;
+        }
         val = x->x_vec[indx];
     }
     else
@@ -656,9 +664,13 @@ static t_int *env_tilde_perform(t_int *w)
 static void env_tilde_dsp(t_sigenv *x, t_signal **sp)
 {
     if(x->x_period % sp[0]->s_n)
+    {
         x->x_realperiod = x->x_period + sp[0]->s_n - (x->x_period % sp[0]->s_n);
+    }
     else
+    {
         x->x_realperiod = x->x_period;
+    }
     if(sp[0]->s_n > x->x_allocforvs)
     {
         void *xx = resizebytes(x->x_buf,
@@ -758,9 +770,13 @@ static void threshold_tilde_ft1(t_threshold_tilde *x, t_floatarg f)
 static void threshold_tilde_tick(t_threshold_tilde *x)
 {
     if(x->x_state)
+    {
         outlet_bang(x->x_outlet1);
+    }
     else
+    {
         outlet_bang(x->x_outlet2);
+    }
 }
 
 static t_int *threshold_tilde_perform(t_int *w)
@@ -769,7 +785,9 @@ static t_int *threshold_tilde_perform(t_int *w)
     t_threshold_tilde *x = (t_threshold_tilde *) (w[2]);
     int n = (int) w[3];
     if(x->x_deadwait > 0)
+    {
         x->x_deadwait -= x->x_msecpertick;
+    }
     else if(x->x_state)
     {
         /* we're high; look for low sample */

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  sig~ and line~ control-to-signal converters;
     snapshot~ signal-to-control converter.
@@ -20,21 +20,21 @@ typedef struct _sig
 
 static t_int *sig_tilde_perform(t_int *w)
 {
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
+    t_float f = *(t_float *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
         *out++ = f;
-    return (w+4);
+    return (w + 4);
 }
 
 static t_int *sig_tilde_perf8(t_int *w)
 {
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_float f = *(t_float *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
 
-    for (; n; n -= 8, out += 8)
+    for(; n; n -= 8, out += 8)
     {
         out[0] = f;
         out[1] = f;
@@ -45,22 +45,19 @@ static t_int *sig_tilde_perf8(t_int *w)
         out[6] = f;
         out[7] = f;
     }
-    return (w+4);
+    return (w + 4);
 }
 
-static void sig_tilde_float(t_sig *x, t_float f)
-{
-    x->x_f = f;
-}
+static void sig_tilde_float(t_sig *x, t_float f) { x->x_f = f; }
 
 static void sig_tilde_dsp(t_sig *x, t_signal **sp)
 {
-    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(sig_tilde_perform, 3, &x->x_f, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void *sig_tilde_new(t_floatarg f)
 {
-    t_sig *x = (t_sig *)pd_new(sig_tilde_class);
+    t_sig *x = (t_sig *) pd_new(sig_tilde_class);
     x->x_f = f;
     outlet_new(&x->x_obj, gensym("signal"));
     return (x);
@@ -68,11 +65,11 @@ static void *sig_tilde_new(t_floatarg f)
 
 static void sig_tilde_setup(void)
 {
-    sig_tilde_class = class_new(gensym("sig~"), (t_newmethod)sig_tilde_new, 0,
+    sig_tilde_class = class_new(gensym("sig~"), (t_newmethod) sig_tilde_new, 0,
         sizeof(t_sig), 0, A_DEFFLOAT, 0);
-    class_addfloat(sig_tilde_class, (t_method)sig_tilde_float);
-    class_addmethod(sig_tilde_class, (t_method)sig_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addfloat(sig_tilde_class, (t_method) sig_tilde_float);
+    class_addmethod(
+        sig_tilde_class, (t_method) sig_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* -------------------------- line~ ------------------------------ */
@@ -82,7 +79,7 @@ typedef struct _line
 {
     t_object x_obj;
     t_sample x_target; /* target value of ramp */
-    t_sample x_value; /* current value of ramp at block-borders */
+    t_sample x_value;  /* current value of ramp at block-borders */
     t_sample x_biginc;
     t_sample x_inc;
     t_float x_1overn;
@@ -95,79 +92,85 @@ typedef struct _line
 
 static t_int *line_tilde_perform(t_int *w)
 {
-    t_line *x = (t_line *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_line *x = (t_line *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     t_sample f = x->x_value;
 
-    if (PD_BIGORSMALL(f))
-            x->x_value = f = 0;
-    if (x->x_retarget)
+    if(PD_BIGORSMALL(f)) x->x_value = f = 0;
+    if(x->x_retarget)
     {
         int nticks = x->x_inletwas * x->x_dspticktomsec;
-        if (!nticks) nticks = 1;
+        if(!nticks) nticks = 1;
         x->x_ticksleft = nticks;
-        x->x_biginc = (x->x_target - x->x_value)/(t_float)nticks;
+        x->x_biginc = (x->x_target - x->x_value) / (t_float) nticks;
         x->x_inc = x->x_1overn * x->x_biginc;
         x->x_retarget = 0;
     }
-    if (x->x_ticksleft)
+    if(x->x_ticksleft)
     {
         t_sample f = x->x_value;
-        while (n--) *out++ = f, f += x->x_inc;
+        while(n--)
+            *out++ = f, f += x->x_inc;
         x->x_value += x->x_biginc;
         x->x_ticksleft--;
     }
     else
     {
         t_sample g = x->x_value = x->x_target;
-        while (n--)
+        while(n--)
             *out++ = g;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 /* TB: vectorized version */
 static t_int *line_tilde_perf8(t_int *w)
 {
-    t_line *x = (t_line *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_line *x = (t_line *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     t_sample f = x->x_value;
 
-    if (PD_BIGORSMALL(f))
-        x->x_value = f = 0;
-    if (x->x_retarget)
+    if(PD_BIGORSMALL(f)) x->x_value = f = 0;
+    if(x->x_retarget)
     {
         int nticks = x->x_inletwas * x->x_dspticktomsec;
-        if (!nticks) nticks = 1;
+        if(!nticks) nticks = 1;
         x->x_ticksleft = nticks;
-        x->x_biginc = (x->x_target - x->x_value)/(t_sample)nticks;
+        x->x_biginc = (x->x_target - x->x_value) / (t_sample) nticks;
         x->x_inc = x->x_1overn * x->x_biginc;
         x->x_retarget = 0;
     }
-    if (x->x_ticksleft)
+    if(x->x_ticksleft)
     {
         t_sample f = x->x_value;
-        while (n--) *out++ = f, f += x->x_inc;
+        while(n--)
+            *out++ = f, f += x->x_inc;
         x->x_value += x->x_biginc;
         x->x_ticksleft--;
     }
     else
     {
         t_sample f = x->x_value = x->x_target;
-        for (; n; n -= 8, out += 8)
+        for(; n; n -= 8, out += 8)
         {
-            out[0] = f; out[1] = f; out[2] = f; out[3] = f;
-            out[4] = f; out[5] = f; out[6] = f; out[7] = f;
+            out[0] = f;
+            out[1] = f;
+            out[2] = f;
+            out[3] = f;
+            out[4] = f;
+            out[5] = f;
+            out[6] = f;
+            out[7] = f;
         }
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void line_tilde_float(t_line *x, t_float f)
 {
-    if (x->x_inletvalue <= 0)
+    if(x->x_inletvalue <= 0)
     {
         x->x_target = x->x_value = f;
         x->x_ticksleft = x->x_retarget = 0;
@@ -189,17 +192,17 @@ static void line_tilde_stop(t_line *x)
 
 static void line_tilde_dsp(t_line *x, t_signal **sp)
 {
-    if(sp[0]->s_n&7)
-        dsp_add(line_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    if(sp[0]->s_n & 7)
+        dsp_add(line_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
     else
-        dsp_add(line_tilde_perf8, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
-    x->x_1overn = 1./sp[0]->s_n;
+        dsp_add(line_tilde_perf8, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+    x->x_1overn = 1. / sp[0]->s_n;
     x->x_dspticktomsec = sp[0]->s_sr / (1000 * sp[0]->s_n);
 }
 
 static void *line_tilde_new(void)
 {
-    t_line *x = (t_line *)pd_new(line_tilde_class);
+    t_line *x = (t_line *) pd_new(line_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     floatinlet_new(&x->x_obj, &x->x_inletvalue);
     x->x_ticksleft = x->x_retarget = 0;
@@ -209,18 +212,19 @@ static void *line_tilde_new(void)
 
 static void line_tilde_setup(void)
 {
-    line_tilde_class = class_new(gensym("line~"), line_tilde_new, 0,
-        sizeof(t_line), 0, 0);
-    class_addfloat(line_tilde_class, (t_method)line_tilde_float);
-    class_addmethod(line_tilde_class, (t_method)line_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(line_tilde_class, (t_method)line_tilde_stop,
-        gensym("stop"), 0);
+    line_tilde_class =
+        class_new(gensym("line~"), line_tilde_new, 0, sizeof(t_line), 0, 0);
+    class_addfloat(line_tilde_class, (t_method) line_tilde_float);
+    class_addmethod(
+        line_tilde_class, (t_method) line_tilde_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        line_tilde_class, (t_method) line_tilde_stop, gensym("stop"), 0);
 }
 
 /* -------------------------- vline~ ------------------------------ */
 static t_class *vline_tilde_class;
-#include "s_stuff.h"    /* for DEFDACBLKSIZE; this should be in m_pd.h */
+#include "s_stuff.h" /* for DEFDACBLKSIZE; this should be in m_pd.h */
+
 typedef struct _vseg
 {
     double s_targettime;
@@ -248,15 +252,15 @@ typedef struct _vline
 
 static t_int *vline_tilde_perform(t_int *w)
 {
-    t_vline *x = (t_vline *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]), i;
+    t_vline *x = (t_vline *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]), i;
     double f = x->x_value;
     double inc = x->x_inc;
     double msecpersamp = x->x_msecpersamp;
     double timenow, logicaltimenow = clock_gettimesince(x->x_referencetime);
     t_vseg *s = x->x_list;
-    if (logicaltimenow != x->x_lastlogicaltime)
+    if(logicaltimenow != x->x_lastlogicaltime)
     {
         int sampstotime = (n > DEFDACBLKSIZE ? n : DEFDACBLKSIZE);
         x->x_lastlogicaltime = logicaltimenow;
@@ -264,27 +268,26 @@ static t_int *vline_tilde_perform(t_int *w)
     }
     timenow = x->x_nextblocktime;
     x->x_nextblocktime = timenow + n * msecpersamp;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         double timenext = timenow + msecpersamp;
     checknext:
-        if (s)
+        if(s)
         {
             /* has starttime elapsed?  If so update value and increment */
-            if (s->s_starttime < timenext)
+            if(s->s_starttime < timenext)
             {
-                if (x->x_targettime <= timenext)
-                    f = x->x_target, inc = 0;
-                    /* if zero-length segment bash output value */
-                if (s->s_targettime <= s->s_starttime)
+                if(x->x_targettime <= timenext) f = x->x_target, inc = 0;
+                /* if zero-length segment bash output value */
+                if(s->s_targettime <= s->s_starttime)
                 {
                     f = s->s_target;
                     inc = 0;
                 }
                 else
                 {
-                    double incpermsec = (s->s_target - f)/
-                        (s->s_targettime - s->s_starttime);
+                    double incpermsec =
+                        (s->s_target - f) / (s->s_targettime - s->s_starttime);
                     f = f + incpermsec * (timenext - s->s_starttime);
                     inc = incpermsec * msecpersamp;
                 }
@@ -297,20 +300,20 @@ static t_int *vline_tilde_perform(t_int *w)
                 goto checknext;
             }
         }
-        if (x->x_targettime <= timenext)
+        if(x->x_targettime <= timenext)
             f = x->x_target, inc = x->x_inc = 0, x->x_targettime = 1e20;
         *out++ = f;
         f = f + inc;
         timenow = timenext;
     }
     x->x_value = f;
-    return (w+4);
+    return (w + 4);
 }
 
 static void vline_tilde_stop(t_vline *x)
 {
     t_vseg *s1, *s2;
-    for (s1 = x->x_list; s1; s1 = s2)
+    for(s1 = x->x_list; s1; s1 = s2)
         s2 = s1->s_next, t_freebytes(s1, sizeof(*s1));
     x->x_list = 0;
     x->x_inc = 0;
@@ -326,22 +329,21 @@ static void vline_tilde_float(t_vline *x, t_float f)
     t_float inlet2 = x->x_inlet2;
     double starttime = timenow + inlet2;
     t_vseg *s1, *s2, *deletefrom = 0, *snew;
-    if (PD_BIGORSMALL(f))
-        f = 0;
+    if(PD_BIGORSMALL(f)) f = 0;
 
-        /* negative delay input means stop and jump immediately to new value */
-    if (inlet2 < 0)
+    /* negative delay input means stop and jump immediately to new value */
+    if(inlet2 < 0)
     {
         x->x_value = f;
         vline_tilde_stop(x);
         return;
     }
-    snew = (t_vseg *)t_getbytes(sizeof(*snew));
-        /* check if we supplant the first item in the list.  We supplant
-        an item by having an earlier starttime, or an equal starttime unless
-        the equal one was instantaneous and the new one isn't (in which case
-        we'll do a jump-and-slide starting at that time.) */
-    if (!x->x_list || x->x_list->s_starttime > starttime ||
+    snew = (t_vseg *) t_getbytes(sizeof(*snew));
+    /* check if we supplant the first item in the list.  We supplant
+    an item by having an earlier starttime, or an equal starttime unless
+    the equal one was instantaneous and the new one isn't (in which case
+    we'll do a jump-and-slide starting at that time.) */
+    if(!x->x_list || x->x_list->s_starttime > starttime ||
         (x->x_list->s_starttime == starttime &&
             (x->x_list->s_targettime > x->x_list->s_starttime || inlet1 <= 0)))
     {
@@ -350,9 +352,9 @@ static void vline_tilde_float(t_vline *x, t_float f)
     }
     else
     {
-        for (s1 = x->x_list; (s2 = s1->s_next); s1 = s2)
+        for(s1 = x->x_list; (s2 = s1->s_next); s1 = s2)
         {
-            if (s2->s_starttime > starttime ||
+            if(s2->s_starttime > starttime ||
                 (s2->s_starttime == starttime &&
                     (s2->s_targettime > s2->s_starttime || inlet1 <= 0)))
             {
@@ -363,9 +365,9 @@ static void vline_tilde_float(t_vline *x, t_float f)
         }
         s1->s_next = snew;
         deletefrom = 0;
-    didit: ;
+    didit:;
     }
-    while (deletefrom)
+    while(deletefrom)
     {
         s1 = deletefrom->s_next;
         t_freebytes(deletefrom, sizeof(*deletefrom));
@@ -380,14 +382,14 @@ static void vline_tilde_float(t_vline *x, t_float f)
 
 static void vline_tilde_dsp(t_vline *x, t_signal **sp)
 {
-    dsp_add(vline_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
-    x->x_samppermsec = ((double)(sp[0]->s_sr)) / 1000;
-    x->x_msecpersamp = ((double)1000) / sp[0]->s_sr;
+    dsp_add(vline_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+    x->x_samppermsec = ((double) (sp[0]->s_sr)) / 1000;
+    x->x_msecpersamp = ((double) 1000) / sp[0]->s_sr;
 }
 
 static void *vline_tilde_new(void)
 {
-    t_vline *x = (t_vline *)pd_new(vline_tilde_class);
+    t_vline *x = (t_vline *) pd_new(vline_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     floatinlet_new(&x->x_obj, &x->x_inlet1);
     floatinlet_new(&x->x_obj, &x->x_inlet2);
@@ -404,12 +406,12 @@ static void *vline_tilde_new(void)
 static void vline_tilde_setup(void)
 {
     vline_tilde_class = class_new(gensym("vline~"), vline_tilde_new,
-        (t_method)vline_tilde_stop, sizeof(t_vline), 0, 0);
-    class_addfloat(vline_tilde_class, (t_method)vline_tilde_float);
-    class_addmethod(vline_tilde_class, (t_method)vline_tilde_dsp,
+        (t_method) vline_tilde_stop, sizeof(t_vline), 0, 0);
+    class_addfloat(vline_tilde_class, (t_method) vline_tilde_float);
+    class_addmethod(vline_tilde_class, (t_method) vline_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(vline_tilde_class, (t_method)vline_tilde_stop,
-        gensym("stop"), 0);
+    class_addmethod(
+        vline_tilde_class, (t_method) vline_tilde_stop, gensym("stop"), 0);
 }
 
 /* -------------------------- snapshot~ ------------------------------ */
@@ -424,7 +426,7 @@ typedef struct _snapshot
 
 static void *snapshot_tilde_new(void)
 {
-    t_snapshot *x = (t_snapshot *)pd_new(snapshot_tilde_class);
+    t_snapshot *x = (t_snapshot *) pd_new(snapshot_tilde_class);
     x->x_value = 0;
     outlet_new(&x->x_obj, &s_float);
     x->x_f = 0;
@@ -433,15 +435,15 @@ static void *snapshot_tilde_new(void)
 
 static t_int *snapshot_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
     *out = *in;
-    return (w+3);
+    return (w + 3);
 }
 
 static void snapshot_tilde_dsp(t_snapshot *x, t_signal **sp)
 {
-    dsp_add(snapshot_tilde_perform, 2, sp[0]->s_vec + (sp[0]->s_n-1),
+    dsp_add(snapshot_tilde_perform, 2, sp[0]->s_vec + (sp[0]->s_n - 1),
         &x->x_value);
 }
 
@@ -450,19 +452,16 @@ static void snapshot_tilde_bang(t_snapshot *x)
     outlet_float(x->x_obj.ob_outlet, x->x_value);
 }
 
-static void snapshot_tilde_set(t_snapshot *x, t_floatarg f)
-{
-    x->x_value = f;
-}
+static void snapshot_tilde_set(t_snapshot *x, t_floatarg f) { x->x_value = f; }
 
 static void snapshot_tilde_setup(void)
 {
-    snapshot_tilde_class = class_new(gensym("snapshot~"), snapshot_tilde_new, 0,
-        sizeof(t_snapshot), 0, 0);
+    snapshot_tilde_class = class_new(
+        gensym("snapshot~"), snapshot_tilde_new, 0, sizeof(t_snapshot), 0, 0);
     CLASS_MAINSIGNALIN(snapshot_tilde_class, t_snapshot, x_f);
-    class_addmethod(snapshot_tilde_class, (t_method)snapshot_tilde_dsp,
+    class_addmethod(snapshot_tilde_class, (t_method) snapshot_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(snapshot_tilde_class, (t_method)snapshot_tilde_set,
+    class_addmethod(snapshot_tilde_class, (t_method) snapshot_tilde_set,
         gensym("set"), A_DEFFLOAT, 0);
     class_addbang(snapshot_tilde_class, snapshot_tilde_bang);
 }
@@ -483,7 +482,7 @@ typedef struct _vsnapshot
 
 static void *vsnapshot_tilde_new(void)
 {
-    t_vsnapshot *x = (t_vsnapshot *)pd_new(vsnapshot_tilde_class);
+    t_vsnapshot *x = (t_vsnapshot *) pd_new(vsnapshot_tilde_class);
     outlet_new(&x->x_obj, &s_float);
     x->x_f = 0;
     x->x_n = 0;
@@ -494,25 +493,24 @@ static void *vsnapshot_tilde_new(void)
 
 static t_int *vsnapshot_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_vsnapshot *x = (t_vsnapshot *)(w[2]);
+    t_sample *in = (t_sample *) (w[1]);
+    t_vsnapshot *x = (t_vsnapshot *) (w[2]);
     t_sample *out = x->x_vec;
     int n = x->x_n, i;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
         out[i] = in[i];
     x->x_time = clock_getlogicaltime();
     x->x_gotone = 1;
-    return (w+3);
+    return (w + 3);
 }
 
 static void vsnapshot_tilde_dsp(t_vsnapshot *x, t_signal **sp)
 {
     int n = sp[0]->s_n;
-    if (n != x->x_n)
+    if(n != x->x_n)
     {
-        if (x->x_vec)
-            t_freebytes(x->x_vec, x->x_n * sizeof(t_sample));
-        x->x_vec = (t_sample *)getbytes(n * sizeof(t_sample));
+        if(x->x_vec) t_freebytes(x->x_vec, x->x_n * sizeof(t_sample));
+        x->x_vec = (t_sample *) getbytes(n * sizeof(t_sample));
         x->x_gotone = 0;
         x->x_n = n;
     }
@@ -523,36 +521,34 @@ static void vsnapshot_tilde_dsp(t_vsnapshot *x, t_signal **sp)
 static void vsnapshot_tilde_bang(t_vsnapshot *x)
 {
     t_sample val;
-    if (x->x_gotone)
+    if(x->x_gotone)
     {
         int indx = clock_gettimesince(x->x_time) * x->x_sampspermsec;
-        if (indx < 0)
+        if(indx < 0)
             indx = 0;
-        else if (indx >= x->x_n)
+        else if(indx >= x->x_n)
             indx = x->x_n - 1;
         val = x->x_vec[indx];
     }
-    else val = 0;
+    else
+        val = 0;
     outlet_float(x->x_obj.ob_outlet, val);
 }
 
 static void vsnapshot_tilde_ff(t_vsnapshot *x)
 {
-    if (x->x_vec)
-        t_freebytes(x->x_vec, x->x_n * sizeof(t_sample));
+    if(x->x_vec) t_freebytes(x->x_vec, x->x_n * sizeof(t_sample));
 }
 
 static void vsnapshot_tilde_setup(void)
 {
-    vsnapshot_tilde_class = class_new(gensym("vsnapshot~"),
-        vsnapshot_tilde_new, (t_method)vsnapshot_tilde_ff,
-        sizeof(t_vsnapshot), 0, 0);
+    vsnapshot_tilde_class = class_new(gensym("vsnapshot~"), vsnapshot_tilde_new,
+        (t_method) vsnapshot_tilde_ff, sizeof(t_vsnapshot), 0, 0);
     CLASS_MAINSIGNALIN(vsnapshot_tilde_class, t_vsnapshot, x_f);
-    class_addmethod(vsnapshot_tilde_class, (t_method)vsnapshot_tilde_dsp,
+    class_addmethod(vsnapshot_tilde_class, (t_method) vsnapshot_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
     class_addbang(vsnapshot_tilde_class, vsnapshot_tilde_bang);
 }
-
 
 /* ---------------- env~ - simple envelope follower. ----------------- */
 
@@ -561,18 +557,18 @@ static void vsnapshot_tilde_setup(void)
 
 typedef struct sigenv
 {
-    t_object x_obj;                 /* header */
-    void *x_outlet;                 /* a "float" outlet */
-    void *x_clock;                  /* a "clock" object */
-    t_sample *x_buf;                   /* a Hanning window */
-    int x_phase;                    /* number of points since last output */
-    int x_period;                   /* requested period of output */
-    int x_realperiod;               /* period rounded up to vecsize multiple */
-    int x_npoints;                  /* analysis window size in samples */
-    t_float x_result;                 /* result to output */
-    t_sample x_sumbuf[MAXOVERLAP];     /* summing buffer */
+    t_object x_obj;                /* header */
+    void *x_outlet;                /* a "float" outlet */
+    void *x_clock;                 /* a "clock" object */
+    t_sample *x_buf;               /* a Hanning window */
+    int x_phase;                   /* number of points since last output */
+    int x_period;                  /* requested period of output */
+    int x_realperiod;              /* period rounded up to vecsize multiple */
+    int x_npoints;                 /* analysis window size in samples */
+    t_float x_result;              /* result to output */
+    t_sample x_sumbuf[MAXOVERLAP]; /* summing buffer */
     t_float x_f;
-    int x_allocforvs;               /* extra buffer for DSP vector size */
+    int x_allocforvs; /* extra buffer for DSP vector size */
 } t_sigenv;
 
 t_class *env_tilde_class;
@@ -586,25 +582,26 @@ static void *env_tilde_new(t_floatarg fnpoints, t_floatarg fperiod)
     t_sample *buf;
     int i;
 
-    if (npoints < 1) npoints = 1024;
-    if (period < 1) period = npoints/2;
-    if (period < npoints / MAXOVERLAP + 1)
-        period = npoints / MAXOVERLAP + 1;
-    if (!(buf = getbytes(sizeof(t_sample) * (npoints + INITVSTAKEN))))
+    if(npoints < 1) npoints = 1024;
+    if(period < 1) period = npoints / 2;
+    if(period < npoints / MAXOVERLAP + 1) period = npoints / MAXOVERLAP + 1;
+    if(!(buf = getbytes(sizeof(t_sample) * (npoints + INITVSTAKEN))))
     {
         pd_error(0, "env: couldn't allocate buffer");
         return (0);
     }
-    x = (t_sigenv *)pd_new(env_tilde_class);
+    x = (t_sigenv *) pd_new(env_tilde_class);
     x->x_buf = buf;
     x->x_npoints = npoints;
     x->x_phase = 0;
     x->x_period = period;
-    for (i = 0; i < MAXOVERLAP; i++) x->x_sumbuf[i] = 0;
-    for (i = 0; i < npoints; i++)
-        buf[i] = (1. - cos((2 * 3.14159 * i) / npoints))/npoints;
-    for (; i < npoints+INITVSTAKEN; i++) buf[i] = 0;
-    x->x_clock = clock_new(x, (t_method)env_tilde_tick);
+    for(i = 0; i < MAXOVERLAP; i++)
+        x->x_sumbuf[i] = 0;
+    for(i = 0; i < npoints; i++)
+        buf[i] = (1. - cos((2 * 3.14159 * i) / npoints)) / npoints;
+    for(; i < npoints + INITVSTAKEN; i++)
+        buf[i] = 0;
+    x->x_clock = clock_new(x, (t_method) env_tilde_tick);
     x->x_outlet = outlet_new(&x->x_obj, gensym("float"));
     x->x_f = 0;
     x->x_allocforvs = INITVSTAKEN;
@@ -613,21 +610,21 @@ static void *env_tilde_new(t_floatarg fnpoints, t_floatarg fperiod)
 
 static t_int *env_tilde_perform(t_int *w)
 {
-    t_sigenv *x = (t_sigenv *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sigenv *x = (t_sigenv *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     int count;
     t_sample *sump;
     in += n;
-    for (count = x->x_phase, sump = x->x_sumbuf;
-        count < x->x_npoints; count += x->x_realperiod, sump++)
+    for(count = x->x_phase, sump = x->x_sumbuf; count < x->x_npoints;
+        count += x->x_realperiod, sump++)
     {
         t_sample *hp = x->x_buf + count;
         t_sample *fp = in;
         t_sample sum = *sump;
         int i;
 
-        for (i = 0; i < n; i++)
+        for(i = 0; i < n; i++)
         {
             fp--;
             sum += *hp++ * (*fp * *fp);
@@ -636,38 +633,39 @@ static t_int *env_tilde_perform(t_int *w)
     }
     sump[0] = 0;
     x->x_phase -= n;
-    if (x->x_phase < 0)
+    if(x->x_phase < 0)
     {
         x->x_result = x->x_sumbuf[0];
-        for (count = x->x_realperiod, sump = x->x_sumbuf;
-            count < x->x_npoints; count += x->x_realperiod, sump++)
-                sump[0] = sump[1];
+        for(count = x->x_realperiod, sump = x->x_sumbuf; count < x->x_npoints;
+            count += x->x_realperiod, sump++)
+            sump[0] = sump[1];
         sump[0] = 0;
         x->x_phase = x->x_realperiod - n;
         clock_delay(x->x_clock, 0L);
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void env_tilde_dsp(t_sigenv *x, t_signal **sp)
 {
-    if (x->x_period % sp[0]->s_n) x->x_realperiod =
-        x->x_period + sp[0]->s_n - (x->x_period % sp[0]->s_n);
-    else x->x_realperiod = x->x_period;
-    if (sp[0]->s_n > x->x_allocforvs)
+    if(x->x_period % sp[0]->s_n)
+        x->x_realperiod = x->x_period + sp[0]->s_n - (x->x_period % sp[0]->s_n);
+    else
+        x->x_realperiod = x->x_period;
+    if(sp[0]->s_n > x->x_allocforvs)
     {
         void *xx = resizebytes(x->x_buf,
             (x->x_npoints + x->x_allocforvs) * sizeof(t_sample),
             (x->x_npoints + sp[0]->s_n) * sizeof(t_sample));
-        if (!xx)
+        if(!xx)
         {
             pd_error(0, "env~: out of memory");
             return;
         }
-        x->x_buf = (t_sample *)xx;
+        x->x_buf = (t_sample *) xx;
         x->x_allocforvs = sp[0]->s_n;
     }
-    dsp_add(env_tilde_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(env_tilde_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void env_tilde_tick(t_sigenv *x) /* callback function for the clock */
@@ -675,20 +673,20 @@ static void env_tilde_tick(t_sigenv *x) /* callback function for the clock */
     outlet_float(x->x_outlet, powtodb(x->x_result));
 }
 
-static void env_tilde_ff(t_sigenv *x)           /* cleanup on free */
+static void env_tilde_ff(t_sigenv *x) /* cleanup on free */
 {
     clock_free(x->x_clock);
     freebytes(x->x_buf, (x->x_npoints + x->x_allocforvs) * sizeof(*x->x_buf));
 }
 
-
 void env_tilde_setup(void)
 {
-    env_tilde_class = class_new(gensym("env~"), (t_newmethod)env_tilde_new,
-        (t_method)env_tilde_ff, sizeof(t_sigenv), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
+    env_tilde_class = class_new(gensym("env~"), (t_newmethod) env_tilde_new,
+        (t_method) env_tilde_ff, sizeof(t_sigenv), 0, A_DEFFLOAT, A_DEFFLOAT,
+        0);
     CLASS_MAINSIGNALIN(env_tilde_class, t_sigenv, x_f);
-    class_addmethod(env_tilde_class, (t_method)env_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        env_tilde_class, (t_method) env_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* --------------------- threshold~ ----------------------------- */
@@ -698,32 +696,30 @@ static t_class *threshold_tilde_class;
 typedef struct _threshold_tilde
 {
     t_object x_obj;
-    t_outlet *x_outlet1;        /* bang out for high thresh */
-    t_outlet *x_outlet2;        /* bang out for low thresh */
-    t_clock *x_clock;           /* wakeup for message output */
-    t_float x_f;                  /* scalar inlet */
-    int x_state;                /* 1 = high, 0 = low */
-    t_float x_hithresh;           /* value of high threshold */
-    t_float x_lothresh;           /* value of low threshold */
-    t_float x_deadwait;           /* msec remaining in dead period */
-    t_float x_msecpertick;        /* msec per DSP tick */
-    t_float x_hideadtime;         /* hi dead time in msec */
-    t_float x_lodeadtime;         /* lo dead time in msec */
+    t_outlet *x_outlet1;   /* bang out for high thresh */
+    t_outlet *x_outlet2;   /* bang out for low thresh */
+    t_clock *x_clock;      /* wakeup for message output */
+    t_float x_f;           /* scalar inlet */
+    int x_state;           /* 1 = high, 0 = low */
+    t_float x_hithresh;    /* value of high threshold */
+    t_float x_lothresh;    /* value of low threshold */
+    t_float x_deadwait;    /* msec remaining in dead period */
+    t_float x_msecpertick; /* msec per DSP tick */
+    t_float x_hideadtime;  /* hi dead time in msec */
+    t_float x_lodeadtime;  /* lo dead time in msec */
 } t_threshold_tilde;
 
 static void threshold_tilde_tick(t_threshold_tilde *x);
-static void threshold_tilde_set(t_threshold_tilde *x,
-    t_floatarg hithresh, t_floatarg hideadtime,
-    t_floatarg lothresh, t_floatarg lodeadtime);
+static void threshold_tilde_set(t_threshold_tilde *x, t_floatarg hithresh,
+    t_floatarg hideadtime, t_floatarg lothresh, t_floatarg lodeadtime);
 
 static t_threshold_tilde *threshold_tilde_new(t_floatarg hithresh,
     t_floatarg hideadtime, t_floatarg lothresh, t_floatarg lodeadtime)
 {
-    t_threshold_tilde *x = (t_threshold_tilde *)
-        pd_new(threshold_tilde_class);
-    x->x_state = 0;             /* low state */
-    x->x_deadwait = 0;          /* no dead time */
-    x->x_clock = clock_new(x, (t_method)threshold_tilde_tick);
+    t_threshold_tilde *x = (t_threshold_tilde *) pd_new(threshold_tilde_class);
+    x->x_state = 0;    /* low state */
+    x->x_deadwait = 0; /* no dead time */
+    x->x_clock = clock_new(x, (t_method) threshold_tilde_tick);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_bang);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_bang);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_float, gensym("ft1"));
@@ -733,21 +729,19 @@ static t_threshold_tilde *threshold_tilde_new(t_floatarg hithresh,
     return (x);
 }
 
-    /* "set" message to specify thresholds and dead times */
-static void threshold_tilde_set(t_threshold_tilde *x,
-    t_floatarg hithresh, t_floatarg hideadtime,
-    t_floatarg lothresh, t_floatarg lodeadtime)
+/* "set" message to specify thresholds and dead times */
+static void threshold_tilde_set(t_threshold_tilde *x, t_floatarg hithresh,
+    t_floatarg hideadtime, t_floatarg lothresh, t_floatarg lodeadtime)
 {
-    if (lothresh > hithresh)
-        lothresh = hithresh;
+    if(lothresh > hithresh) lothresh = hithresh;
     x->x_hithresh = hithresh;
     x->x_hideadtime = hideadtime;
     x->x_lothresh = lothresh;
     x->x_lodeadtime = lodeadtime;
 }
 
-    /* number in inlet sets state -- note incompatible with JMAX which used
-    "int" message for this, impossible here because of auto signal conversion */
+/* number in inlet sets state -- note incompatible with JMAX which used
+"int" message for this, impossible here because of auto signal conversion */
 static void threshold_tilde_ft1(t_threshold_tilde *x, t_floatarg f)
 {
     x->x_state = (f != 0);
@@ -756,24 +750,25 @@ static void threshold_tilde_ft1(t_threshold_tilde *x, t_floatarg f)
 
 static void threshold_tilde_tick(t_threshold_tilde *x)
 {
-    if (x->x_state)
+    if(x->x_state)
         outlet_bang(x->x_outlet1);
-    else outlet_bang(x->x_outlet2);
+    else
+        outlet_bang(x->x_outlet2);
 }
 
 static t_int *threshold_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_threshold_tilde *x = (t_threshold_tilde *)(w[2]);
-    int n = (int)w[3];
-    if (x->x_deadwait > 0)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_threshold_tilde *x = (t_threshold_tilde *) (w[2]);
+    int n = (int) w[3];
+    if(x->x_deadwait > 0)
         x->x_deadwait -= x->x_msecpertick;
-    else if (x->x_state)
+    else if(x->x_state)
     {
-            /* we're high; look for low sample */
-        for (; n--; in1++)
+        /* we're high; look for low sample */
+        for(; n--; in1++)
         {
-            if (*in1 < x->x_lothresh)
+            if(*in1 < x->x_lothresh)
             {
                 clock_delay(x->x_clock, 0L);
                 x->x_state = 0;
@@ -784,10 +779,10 @@ static t_int *threshold_tilde_perform(t_int *w)
     }
     else
     {
-            /* we're low; look for high sample */
-        for (; n--; in1++)
+        /* we're low; look for high sample */
+        for(; n--; in1++)
         {
-            if (*in1 >= x->x_hithresh)
+            if(*in1 >= x->x_hithresh)
             {
                 clock_delay(x->x_clock, 0L);
                 x->x_state = 1;
@@ -797,32 +792,29 @@ static t_int *threshold_tilde_perform(t_int *w)
         }
     }
 done:
-    return (w+4);
+    return (w + 4);
 }
 
 void threshold_tilde_dsp(t_threshold_tilde *x, t_signal **sp)
 {
     x->x_msecpertick = 1000. * sp[0]->s_n / sp[0]->s_sr;
-    dsp_add(threshold_tilde_perform, 3, sp[0]->s_vec, x, (t_int)sp[0]->s_n);
+    dsp_add(threshold_tilde_perform, 3, sp[0]->s_vec, x, (t_int) sp[0]->s_n);
 }
 
-static void threshold_tilde_ff(t_threshold_tilde *x)
-{
-    clock_free(x->x_clock);
-}
+static void threshold_tilde_ff(t_threshold_tilde *x) { clock_free(x->x_clock); }
 
 static void threshold_tilde_setup(void)
 {
-    threshold_tilde_class = class_new(gensym("threshold~"),
-        (t_newmethod)threshold_tilde_new, (t_method)threshold_tilde_ff,
-        sizeof(t_threshold_tilde), 0,
+    threshold_tilde_class =
+        class_new(gensym("threshold~"), (t_newmethod) threshold_tilde_new,
+            (t_method) threshold_tilde_ff, sizeof(t_threshold_tilde), 0,
             A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(threshold_tilde_class, t_threshold_tilde, x_f);
-    class_addmethod(threshold_tilde_class, (t_method)threshold_tilde_set,
+    class_addmethod(threshold_tilde_class, (t_method) threshold_tilde_set,
         gensym("set"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(threshold_tilde_class, (t_method)threshold_tilde_ft1,
+    class_addmethod(threshold_tilde_class, (t_method) threshold_tilde_ft1,
         gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(threshold_tilde_class, (t_method)threshold_tilde_dsp,
+    class_addmethod(threshold_tilde_class, (t_method) threshold_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -838,4 +830,3 @@ void d_ctl_setup(void)
     env_tilde_setup();
     threshold_tilde_setup();
 }
-

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -254,11 +254,13 @@ static t_int *vline_tilde_perform(t_int *w)
 {
     t_vline *x = (t_vline *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]), i;
+    int n = (int) (w[3]);
+    int i;
     double f = x->x_value;
     double inc = x->x_inc;
     double msecpersamp = x->x_msecpersamp;
-    double timenow, logicaltimenow = clock_gettimesince(x->x_referencetime);
+    double timenow;
+    double logicaltimenow = clock_gettimesince(x->x_referencetime);
     t_vseg *s = x->x_list;
     if(logicaltimenow != x->x_lastlogicaltime)
     {
@@ -312,7 +314,8 @@ static t_int *vline_tilde_perform(t_int *w)
 
 static void vline_tilde_stop(t_vline *x)
 {
-    t_vseg *s1, *s2;
+    t_vseg *s1;
+    t_vseg *s2;
     for(s1 = x->x_list; s1; s1 = s2)
         s2 = s1->s_next, t_freebytes(s1, sizeof(*s1));
     x->x_list = 0;
@@ -328,7 +331,10 @@ static void vline_tilde_float(t_vline *x, t_float f)
     t_float inlet1 = (x->x_inlet1 < 0 ? 0 : x->x_inlet1);
     t_float inlet2 = x->x_inlet2;
     double starttime = timenow + inlet2;
-    t_vseg *s1, *s2, *deletefrom = 0, *snew;
+    t_vseg *s1;
+    t_vseg *s2;
+    t_vseg *deletefrom = 0;
+    t_vseg *snew;
     if(PD_BIGORSMALL(f)) f = 0;
 
     /* negative delay input means stop and jump immediately to new value */
@@ -496,7 +502,8 @@ static t_int *vsnapshot_tilde_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_vsnapshot *x = (t_vsnapshot *) (w[2]);
     t_sample *out = x->x_vec;
-    int n = x->x_n, i;
+    int n = x->x_n;
+    int i;
     for(i = 0; i < n; i++)
         out[i] = in[i];
     x->x_time = clock_getlogicaltime();

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -259,7 +259,6 @@ static t_int *vline_tilde_perform(t_int *w)
     t_vline *x = (t_vline *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
     int n = (int) (w[3]);
-    int i;
     double f = x->x_value;
     double inc = x->x_inc;
     double msecpersamp = x->x_msecpersamp;
@@ -274,7 +273,7 @@ static t_int *vline_tilde_perform(t_int *w)
     }
     timenow = x->x_nextblocktime;
     x->x_nextblocktime = timenow + n * msecpersamp;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         double timenext = timenow + msecpersamp;
     checknext:
@@ -507,8 +506,7 @@ static t_int *vsnapshot_tilde_perform(t_int *w)
     t_vsnapshot *x = (t_vsnapshot *) (w[2]);
     t_sample *out = x->x_vec;
     int n = x->x_n;
-    int i;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         out[i] = in[i];
     x->x_time = clock_getlogicaltime();
     x->x_gotone = 1;
@@ -595,7 +593,6 @@ static void *env_tilde_new(t_floatarg fnpoints, t_floatarg fperiod)
     int period = fperiod;
     t_sigenv *x;
     t_sample *buf;
-    int i;
 
     if(npoints < 1) npoints = 1024;
     if(period < 1) period = npoints / 2;
@@ -610,11 +607,11 @@ static void *env_tilde_new(t_floatarg fnpoints, t_floatarg fperiod)
     x->x_npoints = npoints;
     x->x_phase = 0;
     x->x_period = period;
-    for(i = 0; i < MAXOVERLAP; i++)
+    for(int i = 0; i < MAXOVERLAP; i++)
         x->x_sumbuf[i] = 0;
-    for(i = 0; i < npoints; i++)
+    for(int i = 0; i < npoints; i++)
         buf[i] = (1. - cos((2 * 3.14159 * i) / npoints)) / npoints;
-    for(; i < npoints + INITVSTAKEN; i++)
+    for(int i = npoints; i < npoints + INITVSTAKEN; i++)
         buf[i] = 0;
     x->x_clock = clock_new(x, (t_method) env_tilde_tick);
     x->x_outlet = outlet_new(&x->x_obj, gensym("float"));
@@ -637,9 +634,8 @@ static t_int *env_tilde_perform(t_int *w)
         t_sample *hp = x->x_buf + count;
         t_sample *fp = in;
         t_sample sum = *sump;
-        int i;
 
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             fp--;
             sum += *hp++ * (*fp * *fp);

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -50,11 +50,15 @@ static void dac_dsp(t_dac *x, t_signal **sp)
     {
         int ch = (int) (*ip - 1);
         if((*sp2)->s_n != DEFDACBLKSIZE)
+        {
             pd_error(0, "dac~: bad vector size");
+        }
         else if(ch >= 0 && ch < sys_get_outchannels())
+        {
             dsp_add(plus_perform, 4, STUFF->st_soundout + DEFDACBLKSIZE * ch,
                 (*sp2)->s_vec, STUFF->st_soundout + DEFDACBLKSIZE * ch,
                 (t_int) DEFDACBLKSIZE);
+        }
     }
 }
 
@@ -121,12 +125,18 @@ static void adc_dsp(t_adc *x, t_signal **sp)
     {
         int ch = (int) (*ip - 1);
         if((*sp2)->s_n != DEFDACBLKSIZE)
+        {
             pd_error(0, "adc~: bad vector size");
+        }
         else if(ch >= 0 && ch < sys_get_inchannels())
+        {
             dsp_add_copy(STUFF->st_soundin + DEFDACBLKSIZE * ch, (*sp2)->s_vec,
                 DEFDACBLKSIZE);
+        }
         else
+        {
             dsp_add_zero((*sp2)->s_vec, DEFDACBLKSIZE);
+        }
     }
 }
 

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  The dac~ and adc~ routines.
-*/
+ */
 
 #include "m_pd.h"
 #include "s_stuff.h"
@@ -21,10 +21,10 @@ typedef struct _dac
 
 static void *dac_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_dac *x = (t_dac *)pd_new(dac_class);
+    t_dac *x = (t_dac *) pd_new(dac_class);
     t_atom defarg[2];
     int i;
-    if (!argc)
+    if(!argc)
     {
         argv = defarg;
         argc = 2;
@@ -32,10 +32,10 @@ static void *dac_new(t_symbol *s, int argc, t_atom *argv)
         SETFLOAT(&defarg[1], 2);
     }
     x->x_n = argc;
-    x->x_vec = (t_int *)getbytes(argc * sizeof(*x->x_vec));
-    for (i = 0; i < argc; i++)
+    x->x_vec = (t_int *) getbytes(argc * sizeof(*x->x_vec));
+    for(i = 0; i < argc; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
-    for (i = 1; i < argc; i++)
+    for(i = 1; i < argc; i++)
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     x->x_f = 0;
     return (x);
@@ -45,21 +45,22 @@ static void dac_dsp(t_dac *x, t_signal **sp)
 {
     t_int i, *ip;
     t_signal **sp2;
-    for (i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
+    for(i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
-        int ch = (int)(*ip - 1);
-        if ((*sp2)->s_n != DEFDACBLKSIZE)
+        int ch = (int) (*ip - 1);
+        if((*sp2)->s_n != DEFDACBLKSIZE)
             pd_error(0, "dac~: bad vector size");
-        else if (ch >= 0 && ch < sys_get_outchannels())
-            dsp_add(plus_perform, 4, STUFF->st_soundout + DEFDACBLKSIZE*ch,
-                (*sp2)->s_vec, STUFF->st_soundout + DEFDACBLKSIZE*ch, (t_int)DEFDACBLKSIZE);
+        else if(ch >= 0 && ch < sys_get_outchannels())
+            dsp_add(plus_perform, 4, STUFF->st_soundout + DEFDACBLKSIZE * ch,
+                (*sp2)->s_vec, STUFF->st_soundout + DEFDACBLKSIZE * ch,
+                (t_int) DEFDACBLKSIZE);
     }
 }
 
 static void dac_set(t_dac *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    for (i = 0; i < argc && i < x->x_n; i++)
+    for(i = 0; i < argc && i < x->x_n; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
     canvas_update_dsp();
 }
@@ -71,11 +72,11 @@ static void dac_free(t_dac *x)
 
 static void dac_setup(void)
 {
-    dac_class = class_new(gensym("dac~"), (t_newmethod)dac_new,
-        (t_method)dac_free, sizeof(t_dac), 0, A_GIMME, 0);
+    dac_class = class_new(gensym("dac~"), (t_newmethod) dac_new,
+        (t_method) dac_free, sizeof(t_dac), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(dac_class, t_dac, x_f);
-    class_addmethod(dac_class, (t_method)dac_dsp, gensym("dsp"), A_CANT, 0);
-    class_addmethod(dac_class, (t_method)dac_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(dac_class, (t_method) dac_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(dac_class, (t_method) dac_set, gensym("set"), A_GIMME, 0);
     class_sethelpsymbol(dac_class, gensym("adc~_dac~"));
 }
 
@@ -91,10 +92,10 @@ typedef struct _adc
 
 static void *adc_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_adc *x = (t_adc *)pd_new(adc_class);
+    t_adc *x = (t_adc *) pd_new(adc_class);
     t_atom defarg[2];
     int i;
-    if (!argc)
+    if(!argc)
     {
         argv = defarg;
         argc = 2;
@@ -102,10 +103,10 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
         SETFLOAT(&defarg[1], 2);
     }
     x->x_n = argc;
-    x->x_vec = (t_int *)getbytes(argc * sizeof(*x->x_vec));
-    for (i = 0; i < argc; i++)
+    x->x_vec = (t_int *) getbytes(argc * sizeof(*x->x_vec));
+    for(i = 0; i < argc; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
         outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
@@ -114,22 +115,23 @@ static void adc_dsp(t_adc *x, t_signal **sp)
 {
     t_int i, *ip;
     t_signal **sp2;
-    for (i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
+    for(i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
-        int ch = (int)(*ip - 1);
-        if ((*sp2)->s_n != DEFDACBLKSIZE)
+        int ch = (int) (*ip - 1);
+        if((*sp2)->s_n != DEFDACBLKSIZE)
             pd_error(0, "adc~: bad vector size");
-        else if (ch >= 0 && ch < sys_get_inchannels())
-            dsp_add_copy(STUFF->st_soundin + DEFDACBLKSIZE*ch,
-                (*sp2)->s_vec, DEFDACBLKSIZE);
-        else dsp_add_zero((*sp2)->s_vec, DEFDACBLKSIZE);
+        else if(ch >= 0 && ch < sys_get_inchannels())
+            dsp_add_copy(STUFF->st_soundin + DEFDACBLKSIZE * ch, (*sp2)->s_vec,
+                DEFDACBLKSIZE);
+        else
+            dsp_add_zero((*sp2)->s_vec, DEFDACBLKSIZE);
     }
 }
 
 static void adc_set(t_adc *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    for (i = 0; i < argc && i < x->x_n; i++)
+    for(i = 0; i < argc && i < x->x_n; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
     canvas_update_dsp();
 }
@@ -141,10 +143,10 @@ static void adc_free(t_adc *x)
 
 static void adc_setup(void)
 {
-    adc_class = class_new(gensym("adc~"), (t_newmethod)adc_new,
-        (t_method)adc_free, sizeof(t_adc), 0, A_GIMME, 0);
-    class_addmethod(adc_class, (t_method)adc_dsp, gensym("dsp"), A_CANT, 0);
-    class_addmethod(adc_class, (t_method)adc_set, gensym("set"), A_GIMME, 0);
+    adc_class = class_new(gensym("adc~"), (t_newmethod) adc_new,
+        (t_method) adc_free, sizeof(t_adc), 0, A_GIMME, 0);
+    class_addmethod(adc_class, (t_method) adc_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(adc_class, (t_method) adc_set, gensym("set"), A_GIMME, 0);
     class_sethelpsymbol(adc_class, gensym("adc~_dac~"));
 }
 
@@ -153,4 +155,3 @@ void d_dac_setup(void)
     dac_setup();
     adc_setup();
 }
-

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -43,7 +43,8 @@ static void *dac_new(t_symbol *s, int argc, t_atom *argv)
 
 static void dac_dsp(t_dac *x, t_signal **sp)
 {
-    t_int i, *ip;
+    t_int i;
+    t_int *ip;
     t_signal **sp2;
     for(i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {
@@ -113,7 +114,8 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
 
 static void adc_dsp(t_adc *x, t_signal **sp)
 {
-    t_int i, *ip;
+    t_int i;
+    t_int *ip;
     t_signal **sp2;
     for(i = x->x_n, ip = x->x_vec, sp2 = sp; i--; ip++, sp2++)
     {

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -23,7 +23,6 @@ static void *dac_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_dac *x = (t_dac *) pd_new(dac_class);
     t_atom defarg[2];
-    int i;
     if(!argc)
     {
         argv = defarg;
@@ -33,9 +32,9 @@ static void *dac_new(t_symbol *s, int argc, t_atom *argv)
     }
     x->x_n = argc;
     x->x_vec = (t_int *) getbytes(argc * sizeof(*x->x_vec));
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
-    for(i = 1; i < argc; i++)
+    for(int i = 1; i < argc; i++)
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     x->x_f = 0;
     return (x);
@@ -64,8 +63,7 @@ static void dac_dsp(t_dac *x, t_signal **sp)
 
 static void dac_set(t_dac *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
-    for(i = 0; i < argc && i < x->x_n; i++)
+    for(int i = 0; i < argc && i < x->x_n; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
     canvas_update_dsp();
 }
@@ -99,7 +97,6 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_adc *x = (t_adc *) pd_new(adc_class);
     t_atom defarg[2];
-    int i;
     if(!argc)
     {
         argv = defarg;
@@ -109,9 +106,9 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
     }
     x->x_n = argc;
     x->x_vec = (t_int *) getbytes(argc * sizeof(*x->x_vec));
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
@@ -142,8 +139,7 @@ static void adc_dsp(t_adc *x, t_signal **sp)
 
 static void adc_set(t_adc *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
-    for(i = 0; i < argc && i < x->x_n; i++)
+    for(int i = 0; i < argc && i < x->x_n; i++)
         x->x_vec[i] = atom_getfloatarg(i, argc, argv);
     canvas_update_dsp();
 }

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -57,8 +57,10 @@ static void sigdelwrite_updatesr(
 static void sigdelwrite_clear(t_sigdelwrite *x) /* added by Orm Finnendahl */
 {
     if(x->x_cspace.c_n > 0)
+    {
         memset(x->x_cspace.c_vec, 0,
             sizeof(t_sample) * (x->x_cspace.c_n + XTRASAMPS));
+    }
 }
 
 /* routine to check that all delwrites/delreads/vds have same vecsize */
@@ -192,9 +194,13 @@ static void sigdelread_float(t_sigdelread *x, t_float f)
         x->x_delsamps =
             (int) (0.5 + x->x_sr * x->x_deltime) + x->x_n - x->x_zerodel;
         if(x->x_delsamps < x->x_n)
+        {
             x->x_delsamps = x->x_n;
+        }
         else if(x->x_delsamps > delwriter->x_cspace.c_n)
+        {
             x->x_delsamps = delwriter->x_cspace.c_n;
+        }
     }
 }
 
@@ -238,8 +244,10 @@ static void sigdelread_dsp(t_sigdelread *x, t_signal **sp)
             &x->x_delsamps, (t_int) sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
         if(delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+        {
             pd_error(x, "delread~ %s: blocksize larger than delwrite~ buffer",
                 x->x_sym->s_name);
+        }
     }
     else if(*x->x_sym->s_name)
         pd_error(x, "delread~: %s: no such delwrite~", x->x_sym->s_name);
@@ -348,8 +356,10 @@ static void sigvd_dsp(t_sigvd *x, t_signal **sp)
             &delwriter->x_cspace, x, (t_int) sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
         if(delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+        {
             pd_error(x, "delread4~ %s: blocksize larger than delwrite~ buffer",
                 x->x_sym->s_name);
+        }
     }
     else if(*x->x_sym->s_name)
         pd_error(x, "delread4~: %s: no such delwrite~", x->x_sym->s_name);

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -99,8 +99,11 @@ static t_int *sigdelwrite_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_delwritectl *c = (t_delwritectl *) (w[2]);
     int n = (int) (w[3]);
-    int phase = c->c_phase, nsamps = c->c_n;
-    t_sample *vp = c->c_vec, *bp = vp + phase, *ep = vp + (c->c_n + XTRASAMPS);
+    int phase = c->c_phase;
+    int nsamps = c->c_n;
+    t_sample *vp = c->c_vec;
+    t_sample *bp = vp + phase;
+    t_sample *ep = vp + (c->c_n + XTRASAMPS);
     phase += n;
 
     while(n--)
@@ -201,8 +204,11 @@ static t_int *sigdelread_perform(t_int *w)
     t_delwritectl *c = (t_delwritectl *) (w[2]);
     int delsamps = *(int *) (w[3]);
     int n = (int) (w[4]);
-    int phase = c->c_phase - delsamps, nsamps = c->c_n;
-    t_sample *vp = c->c_vec, *bp, *ep = vp + (c->c_n + XTRASAMPS);
+    int phase = c->c_phase - delsamps;
+    int nsamps = c->c_n;
+    t_sample *vp = c->c_vec;
+    t_sample *bp;
+    t_sample *ep = vp + (c->c_n + XTRASAMPS);
     if(phase < 0) phase += nsamps;
     bp = vp + phase;
 
@@ -285,7 +291,9 @@ static t_int *sigvd_perform(t_int *w)
     int nsamps = ctl->c_n;
     t_sample limit = nsamps - n;
     t_sample fn = n - 1;
-    t_sample *vp = ctl->c_vec, *bp, *wp = vp + ctl->c_phase;
+    t_sample *vp = ctl->c_vec;
+    t_sample *bp;
+    t_sample *wp = vp + ctl->c_phase;
     t_sample zerodel = x->x_zerodel;
     if(limit < 0) /* blocksize is larger than delread~ buffer size */
     {
@@ -295,9 +303,14 @@ static t_int *sigvd_perform(t_int *w)
     }
     while(n--)
     {
-        t_sample delsamps = x->x_sr * *in++ - zerodel, frac;
+        t_sample delsamps = x->x_sr * *in++ - zerodel;
+        t_sample frac;
         int idelsamps;
-        t_sample a, b, c, d, cminusb;
+        t_sample a;
+        t_sample b;
+        t_sample c;
+        t_sample d;
+        t_sample cminusb;
         if(!(delsamps >= 1.00001f)) /* too small or NAN */
             delsamps = 1.00001f;
         if(delsamps > limit) /* too big */

--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  send~, delread~, throw~, catch~ */
 
@@ -8,8 +8,9 @@
 #include <string.h>
 extern int ugen_getsortno(void);
 
-#define DEFDELVS 64             /* LATER get this from canvas at DSP time */
-static const int delread_zero = 0;    /* four bytes of zero for delread~, vd~/delread4~*/
+#define DEFDELVS 64 /* LATER get this from canvas at DSP time */
+static const int delread_zero =
+    0; /* four bytes of zero for delread~, vd~/delread4~*/
 
 /* ----------------------------- delwrite~ ----------------------------- */
 static t_class *sigdelwrite_class;
@@ -25,26 +26,27 @@ typedef struct _sigdelwrite
 {
     t_object x_obj;
     t_symbol *x_sym;
-    t_float x_deltime;  /* delay in msec (added by Mathieu Bouchard) */
+    t_float x_deltime; /* delay in msec (added by Mathieu Bouchard) */
     t_delwritectl x_cspace;
-    int x_sortno;   /* DSP sort number at which this was last put on chain */
-    int x_rsortno;  /* DSP sort # for first delread or write in chain */
-    int x_vecsize;  /* vector size for delread~ to use */
+    int x_sortno;  /* DSP sort number at which this was last put on chain */
+    int x_rsortno; /* DSP sort # for first delread or write in chain */
+    int x_vecsize; /* vector size for delread~ to use */
     t_float x_f;
 } t_sigdelwrite;
 
 #define XTRASAMPS 4
 #define SAMPBLK 4
 
-static void sigdelwrite_updatesr(t_sigdelwrite *x, t_float sr) /* added by Mathieu Bouchard */
+static void sigdelwrite_updatesr(
+    t_sigdelwrite *x, t_float sr) /* added by Mathieu Bouchard */
 {
-    int nsamps = x->x_deltime * sr * (t_float)(0.001f);
-    if (nsamps < 1) nsamps = 1;
-    nsamps += ((- nsamps) & (SAMPBLK - 1));
+    int nsamps = x->x_deltime * sr * (t_float) (0.001f);
+    if(nsamps < 1) nsamps = 1;
+    nsamps += ((-nsamps) & (SAMPBLK - 1));
     nsamps += DEFDELVS;
-    if (x->x_cspace.c_n != nsamps)
+    if(x->x_cspace.c_n != nsamps)
     {
-        x->x_cspace.c_vec = (t_sample *)resizebytes(x->x_cspace.c_vec,
+        x->x_cspace.c_vec = (t_sample *) resizebytes(x->x_cspace.c_vec,
             (x->x_cspace.c_n + XTRASAMPS) * sizeof(t_sample),
             (nsamps + XTRASAMPS) * sizeof(t_sample));
         x->x_cspace.c_n = nsamps;
@@ -52,17 +54,17 @@ static void sigdelwrite_updatesr(t_sigdelwrite *x, t_float sr) /* added by Mathi
     }
 }
 
-static void sigdelwrite_clear (t_sigdelwrite *x) /* added by Orm Finnendahl */
+static void sigdelwrite_clear(t_sigdelwrite *x) /* added by Orm Finnendahl */
 {
-  if (x->x_cspace.c_n > 0)
-    memset(x->x_cspace.c_vec, 0, sizeof(t_sample)*(x->x_cspace.c_n + XTRASAMPS));
+    if(x->x_cspace.c_n > 0)
+        memset(x->x_cspace.c_vec, 0,
+            sizeof(t_sample) * (x->x_cspace.c_n + XTRASAMPS));
 }
 
-
-    /* routine to check that all delwrites/delreads/vds have same vecsize */
+/* routine to check that all delwrites/delreads/vds have same vecsize */
 static void sigdelwrite_checkvecsize(t_sigdelwrite *x, int vecsize)
 {
-    if (x->x_rsortno != ugen_getsortno())
+    if(x->x_rsortno != ugen_getsortno())
     {
         x->x_vecsize = vecsize;
         x->x_rsortno = ugen_getsortno();
@@ -79,8 +81,8 @@ static void sigdelwrite_checkvecsize(t_sigdelwrite *x, int vecsize)
 
 static void *sigdelwrite_new(t_symbol *s, t_floatarg msec)
 {
-    t_sigdelwrite *x = (t_sigdelwrite *)pd_new(sigdelwrite_class);
-    if (!*s->s_name) s = gensym("delwrite~");
+    t_sigdelwrite *x = (t_sigdelwrite *) pd_new(sigdelwrite_class);
+    if(!*s->s_name) s = gensym("delwrite~");
     pd_bind(&x->x_obj.ob_pd, s);
     x->x_sym = s;
     x->x_deltime = msec;
@@ -94,20 +96,19 @@ static void *sigdelwrite_new(t_symbol *s, t_floatarg msec)
 
 static t_int *sigdelwrite_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_delwritectl *c = (t_delwritectl *)(w[2]);
-    int n = (int)(w[3]);
+    t_sample *in = (t_sample *) (w[1]);
+    t_delwritectl *c = (t_delwritectl *) (w[2]);
+    int n = (int) (w[3]);
     int phase = c->c_phase, nsamps = c->c_n;
     t_sample *vp = c->c_vec, *bp = vp + phase, *ep = vp + (c->c_n + XTRASAMPS);
     phase += n;
 
-    while (n--)
+    while(n--)
     {
         t_sample f = *in++;
-        if (PD_BIGORSMALL(f))
-            f = 0;
+        if(PD_BIGORSMALL(f)) f = 0;
         *bp++ = f;
-        if (bp == ep)
+        if(bp == ep)
         {
             vp[0] = ep[-4];
             vp[1] = ep[-3];
@@ -118,12 +119,13 @@ static t_int *sigdelwrite_perform(t_int *w)
         }
     }
     c->c_phase = phase;
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigdelwrite_dsp(t_sigdelwrite *x, t_signal **sp)
 {
-    dsp_add(sigdelwrite_perform, 3, sp[0]->s_vec, &x->x_cspace, (t_int)sp[0]->s_n);
+    dsp_add(
+        sigdelwrite_perform, 3, sp[0]->s_vec, &x->x_cspace, (t_int) sp[0]->s_n);
     x->x_sortno = ugen_getsortno();
     sigdelwrite_checkvecsize(x, sp[0]->s_n);
     sigdelwrite_updatesr(x, sp[0]->s_sr);
@@ -132,20 +134,20 @@ static void sigdelwrite_dsp(t_sigdelwrite *x, t_signal **sp)
 static void sigdelwrite_free(t_sigdelwrite *x)
 {
     pd_unbind(&x->x_obj.ob_pd, x->x_sym);
-    freebytes(x->x_cspace.c_vec,
-        (x->x_cspace.c_n + XTRASAMPS) * sizeof(t_sample));
+    freebytes(
+        x->x_cspace.c_vec, (x->x_cspace.c_n + XTRASAMPS) * sizeof(t_sample));
 }
 
 static void sigdelwrite_setup(void)
 {
     sigdelwrite_class = class_new(gensym("delwrite~"),
-        (t_newmethod)sigdelwrite_new, (t_method)sigdelwrite_free,
+        (t_newmethod) sigdelwrite_new, (t_method) sigdelwrite_free,
         sizeof(t_sigdelwrite), 0, A_DEFSYM, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigdelwrite_class, t_sigdelwrite, x_f);
-    class_addmethod(sigdelwrite_class, (t_method)sigdelwrite_dsp,
+    class_addmethod(sigdelwrite_class, (t_method) sigdelwrite_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(sigdelwrite_class, (t_method)sigdelwrite_clear,
-                    gensym("clear"), 0);
+    class_addmethod(
+        sigdelwrite_class, (t_method) sigdelwrite_clear, gensym("clear"), 0);
     class_sethelpsymbol(sigdelwrite_class, gensym("delay-tilde-objects"));
 }
 
@@ -156,18 +158,18 @@ typedef struct _sigdelread
 {
     t_object x_obj;
     t_symbol *x_sym;
-    t_float x_deltime;  /* delay in msec */
-    int x_delsamps;     /* delay in samples */
-    t_float x_sr;       /* samples per msec */
-    t_float x_n;        /* vector size */
-    int x_zerodel;      /* 0 or vecsize depending on read/write order */
+    t_float x_deltime; /* delay in msec */
+    int x_delsamps;    /* delay in samples */
+    t_float x_sr;      /* samples per msec */
+    t_float x_n;       /* vector size */
+    int x_zerodel;     /* 0 or vecsize depending on read/write order */
 } t_sigdelread;
 
 static void sigdelread_float(t_sigdelread *x, t_float f);
 
 static void *sigdelread_new(t_symbol *s, t_floatarg f)
 {
-    t_sigdelread *x = (t_sigdelread *)pd_new(sigdelread_class);
+    t_sigdelread *x = (t_sigdelread *) pd_new(sigdelread_class);
     x->x_sym = s;
     x->x_sr = 1;
     x->x_n = 1;
@@ -180,87 +182,90 @@ static void *sigdelread_new(t_symbol *s, t_floatarg f)
 static void sigdelread_float(t_sigdelread *x, t_float f)
 {
     t_sigdelwrite *delwriter =
-        (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
+        (t_sigdelwrite *) pd_findbyclass(x->x_sym, sigdelwrite_class);
     x->x_deltime = f;
-    if (delwriter)
+    if(delwriter)
     {
-        x->x_delsamps = (int)(0.5 + x->x_sr * x->x_deltime)
-            + x->x_n - x->x_zerodel;
-        if (x->x_delsamps < x->x_n) x->x_delsamps = x->x_n;
-        else if (x->x_delsamps > delwriter->x_cspace.c_n)
+        x->x_delsamps =
+            (int) (0.5 + x->x_sr * x->x_deltime) + x->x_n - x->x_zerodel;
+        if(x->x_delsamps < x->x_n)
+            x->x_delsamps = x->x_n;
+        else if(x->x_delsamps > delwriter->x_cspace.c_n)
             x->x_delsamps = delwriter->x_cspace.c_n;
     }
 }
 
 static t_int *sigdelread_perform(t_int *w)
 {
-    t_sample *out = (t_sample *)(w[1]);
-    t_delwritectl *c = (t_delwritectl *)(w[2]);
-    int delsamps = *(int *)(w[3]);
-    int n = (int)(w[4]);
+    t_sample *out = (t_sample *) (w[1]);
+    t_delwritectl *c = (t_delwritectl *) (w[2]);
+    int delsamps = *(int *) (w[3]);
+    int n = (int) (w[4]);
     int phase = c->c_phase - delsamps, nsamps = c->c_n;
     t_sample *vp = c->c_vec, *bp, *ep = vp + (c->c_n + XTRASAMPS);
-    if (phase < 0) phase += nsamps;
+    if(phase < 0) phase += nsamps;
     bp = vp + phase;
 
-    while (n--)
+    while(n--)
     {
         *out++ = *bp++;
-        if (bp == ep) bp -= nsamps;
+        if(bp == ep) bp -= nsamps;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void sigdelread_dsp(t_sigdelread *x, t_signal **sp)
 {
     t_sigdelwrite *delwriter =
-        (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
+        (t_sigdelwrite *) pd_findbyclass(x->x_sym, sigdelwrite_class);
     x->x_sr = sp[0]->s_sr * 0.001;
     x->x_n = sp[0]->s_n;
-    if (delwriter)
+    if(delwriter)
     {
         sigdelwrite_updatesr(delwriter, sp[0]->s_sr);
         sigdelwrite_checkvecsize(delwriter, sp[0]->s_n);
-        x->x_zerodel = (delwriter->x_sortno == ugen_getsortno() ?
-            0 : delwriter->x_vecsize);
+        x->x_zerodel =
+            (delwriter->x_sortno == ugen_getsortno() ? 0
+                                                     : delwriter->x_vecsize);
         sigdelread_float(x, x->x_deltime);
-        dsp_add(sigdelread_perform, 4,
-            sp[0]->s_vec, &delwriter->x_cspace, &x->x_delsamps, (t_int)sp[0]->s_n);
+        dsp_add(sigdelread_perform, 4, sp[0]->s_vec, &delwriter->x_cspace,
+            &x->x_delsamps, (t_int) sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
-        if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
-            pd_error(x, "delread~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);
+        if(delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+            pd_error(x, "delread~ %s: blocksize larger than delwrite~ buffer",
+                x->x_sym->s_name);
     }
-    else if (*x->x_sym->s_name)
-        pd_error(x, "delread~: %s: no such delwrite~",x->x_sym->s_name);
+    else if(*x->x_sym->s_name)
+        pd_error(x, "delread~: %s: no such delwrite~", x->x_sym->s_name);
 }
 
 static void sigdelread_setup(void)
 {
-    sigdelread_class = class_new(gensym("delread~"),
-        (t_newmethod)sigdelread_new, 0,
-        sizeof(t_sigdelread), 0, A_DEFSYM, A_DEFFLOAT, 0);
-    class_addmethod(sigdelread_class, (t_method)sigdelread_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addfloat(sigdelread_class, (t_method)sigdelread_float);
+    sigdelread_class =
+        class_new(gensym("delread~"), (t_newmethod) sigdelread_new, 0,
+            sizeof(t_sigdelread), 0, A_DEFSYM, A_DEFFLOAT, 0);
+    class_addmethod(
+        sigdelread_class, (t_method) sigdelread_dsp, gensym("dsp"), A_CANT, 0);
+    class_addfloat(sigdelread_class, (t_method) sigdelread_float);
     class_sethelpsymbol(sigdelread_class, gensym("delay-tilde-objects"));
 }
 
-
-/* ----------------------------- vd~ / delread4~ ----------------------------- */
+/* ----------------------------- vd~ / delread4~ -----------------------------
+ */
 static t_class *sigvd_class;
 
 typedef struct _sigvd
 {
     t_object x_obj;
     t_symbol *x_sym;
-    t_float x_sr;       /* samples per msec */
-    int x_zerodel;      /* 0 or vecsize depending on read/write order */
+    t_float x_sr;  /* samples per msec */
+    int x_zerodel; /* 0 or vecsize depending on read/write order */
     t_float x_f;
 } t_sigvd;
 
 static void *sigvd_new(t_symbol *s)
 {
-    t_sigvd *x = (t_sigvd *)pd_new(sigvd_class);
+    t_sigvd *x = (t_sigvd *) pd_new(sigvd_class);
     x->x_sym = s;
     x->x_sr = 1;
     x->x_zerodel = 0;
@@ -271,79 +276,79 @@ static void *sigvd_new(t_symbol *s)
 
 static t_int *sigvd_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_delwritectl *ctl = (t_delwritectl *)(w[3]);
-    t_sigvd *x = (t_sigvd *)(w[4]);
-    int n = (int)(w[5]);
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_delwritectl *ctl = (t_delwritectl *) (w[3]);
+    t_sigvd *x = (t_sigvd *) (w[4]);
+    int n = (int) (w[5]);
 
     int nsamps = ctl->c_n;
     t_sample limit = nsamps - n;
-    t_sample fn = n-1;
+    t_sample fn = n - 1;
     t_sample *vp = ctl->c_vec, *bp, *wp = vp + ctl->c_phase;
     t_sample zerodel = x->x_zerodel;
-    if (limit < 0) /* blocksize is larger than delread~ buffer size */
+    if(limit < 0) /* blocksize is larger than delread~ buffer size */
     {
-        while (n--)
+        while(n--)
             *out++ = 0;
-        return (w+6);
+        return (w + 6);
     }
-    while (n--)
+    while(n--)
     {
         t_sample delsamps = x->x_sr * *in++ - zerodel, frac;
         int idelsamps;
         t_sample a, b, c, d, cminusb;
-        if (!(delsamps >= 1.00001f))    /* too small or NAN */
+        if(!(delsamps >= 1.00001f)) /* too small or NAN */
             delsamps = 1.00001f;
-        if (delsamps > limit)           /* too big */
+        if(delsamps > limit) /* too big */
             delsamps = limit;
         delsamps += fn;
         fn = fn - 1.0f;
         idelsamps = delsamps;
-        frac = delsamps - (t_sample)idelsamps;
+        frac = delsamps - (t_sample) idelsamps;
         bp = wp - idelsamps;
-        if (bp < vp + XTRASAMPS) bp += nsamps;
+        if(bp < vp + XTRASAMPS) bp += nsamps;
         d = bp[-3];
         c = bp[-2];
         b = bp[-1];
         a = bp[0];
-        cminusb = c-b;
-        *out++ = b + frac * (
-            cminusb - 0.1666667f * (1.-frac) * (
-                (d - a - 3.0f * cminusb) * frac + (d + 2.0f*a - 3.0f*b)
-            )
-        );
+        cminusb = c - b;
+        *out++ = b + frac * (cminusb - 0.1666667f * (1. - frac) *
+                                           ((d - a - 3.0f * cminusb) * frac +
+                                               (d + 2.0f * a - 3.0f * b)));
     }
-    return (w+6);
+    return (w + 6);
 }
 
 static void sigvd_dsp(t_sigvd *x, t_signal **sp)
 {
     t_sigdelwrite *delwriter =
-        (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
+        (t_sigdelwrite *) pd_findbyclass(x->x_sym, sigdelwrite_class);
     x->x_sr = sp[0]->s_sr * 0.001;
-    if (delwriter)
+    if(delwriter)
     {
         sigdelwrite_checkvecsize(delwriter, sp[0]->s_n);
-        x->x_zerodel = (delwriter->x_sortno == ugen_getsortno() ?
-            0 : delwriter->x_vecsize);
-        dsp_add(sigvd_perform, 5,
-            sp[0]->s_vec, sp[1]->s_vec,
-                &delwriter->x_cspace, x, (t_int)sp[0]->s_n);
+        x->x_zerodel =
+            (delwriter->x_sortno == ugen_getsortno() ? 0
+                                                     : delwriter->x_vecsize);
+        dsp_add(sigvd_perform, 5, sp[0]->s_vec, sp[1]->s_vec,
+            &delwriter->x_cspace, x, (t_int) sp[0]->s_n);
         /* check block size - but only if delwriter has been initialized */
-        if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
-            pd_error(x, "delread4~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);
+        if(delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+            pd_error(x, "delread4~ %s: blocksize larger than delwrite~ buffer",
+                x->x_sym->s_name);
     }
-    else if (*x->x_sym->s_name)
-        pd_error(x, "delread4~: %s: no such delwrite~",x->x_sym->s_name);
+    else if(*x->x_sym->s_name)
+        pd_error(x, "delread4~: %s: no such delwrite~", x->x_sym->s_name);
 }
 
 static void sigvd_setup(void)
 {
-    sigvd_class = class_new(gensym("delread4~"), (t_newmethod)sigvd_new, 0,
+    sigvd_class = class_new(gensym("delread4~"), (t_newmethod) sigvd_new, 0,
         sizeof(t_sigvd), 0, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)sigvd_new, gensym("vd~"), A_DEFSYM, 0);
-    class_addmethod(sigvd_class, (t_method)sigvd_dsp, gensym("dsp"), A_CANT, 0);
+    class_addcreator((t_newmethod) sigvd_new, gensym("vd~"), A_DEFSYM, 0);
+    class_addmethod(
+        sigvd_class, (t_method) sigvd_dsp, gensym("dsp"), A_CANT, 0);
     CLASS_MAINSIGNALIN(sigvd_class, t_sigvd, x_f);
     class_sethelpsymbol(sigvd_class, gensym("delay-tilde-objects"));
 }
@@ -356,4 +361,3 @@ void d_delay_setup(void)
     sigdelread_setup();
     sigvd_setup();
 }
-

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -177,7 +177,8 @@ static t_int *sigrfft_perform(t_int *w)
 
 static void sigrfft_dsp(t_sigrfft *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n >> 1);
+    int n = sp[0]->s_n;
+    int n2 = (n >> 1);
     t_sample *in1 = sp[0]->s_vec;
     t_sample *out1 = sp[1]->s_vec;
     t_sample *out2 = sp[2]->s_vec;
@@ -236,7 +237,8 @@ static t_int *sigrifft_perform(t_int *w)
 
 static void sigrifft_dsp(t_sigrifft *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n >> 1);
+    int n = sp[0]->s_n;
+    int n2 = (n >> 1);
     t_sample *in1 = sp[0]->s_vec;
     t_sample *in2 = sp[1]->s_vec;
     t_sample *out1 = sp[2]->s_vec;
@@ -298,11 +300,16 @@ static t_int *sigframp_perform(t_int *w)
     t_sample *inimag = (t_sample *) (w[2]);
     t_sample *outfreq = (t_sample *) (w[3]);
     t_sample *outamp = (t_sample *) (w[4]);
-    t_sample lastreal = 0, currentreal = inreal[0], nextreal = inreal[1];
-    t_sample lastimag = 0, currentimag = inimag[0], nextimag = inimag[1];
+    t_sample lastreal = 0;
+    t_sample currentreal = inreal[0];
+    t_sample nextreal = inreal[1];
+    t_sample lastimag = 0;
+    t_sample currentimag = inimag[0];
+    t_sample nextimag = inimag[1];
     int n = (int) w[5];
     int m = n + 1;
-    t_sample fbin = 1, oneovern2 = 1.f / ((t_sample) n * (t_sample) n);
+    t_sample fbin = 1;
+    t_sample oneovern2 = 1.f / ((t_sample) n * (t_sample) n);
 
     inreal += 2;
     inimag += 2;
@@ -310,7 +317,10 @@ static t_int *sigframp_perform(t_int *w)
     n -= 2;
     while(n--)
     {
-        t_sample re, im, pow, freq;
+        t_sample re;
+        t_sample im;
+        t_sample pow;
+        t_sample freq;
         lastreal = currentreal;
         currentreal = nextreal;
         nextreal = *inreal++;
@@ -345,7 +355,8 @@ t_int *sigsqrt_perform(t_int *w);
 
 static void sigframp_dsp(t_sigframp *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n >> 1);
+    int n = sp[0]->s_n;
+    int n2 = (n >> 1);
     if(n < 4)
     {
         pd_error(0, "framp: minimum 4 points");

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -25,12 +25,12 @@ static t_int *sigfft_swap(t_int *w)
 {
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
-    int n = (int) w[3];
-    for(; n--; in1++, in2++)
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1;
-        *in1 = *in2;
-        *in2 = f;
+        t_sample f = in1[i];
+        in1[i] = in2[i];
+        in2[i] = f;
     }
     return (w + 4);
 }
@@ -43,8 +43,8 @@ static t_int *sigrfft_flip(t_int *w)
 {
     t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) w[3];
-    while(n--)
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
         *(--out) = -*in++;
     return (w + 4);
 }
@@ -82,8 +82,8 @@ static t_int *sigfft_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
-    int n = (int) w[3];
-    mayer_fft(n, in1, in2);
+    int num_samples = (int) (w[3]);
+    mayer_fft(num_samples, in1, in2);
     return (w + 4);
 }
 
@@ -91,8 +91,8 @@ static t_int *sigifft_perform(t_int *w)
 {
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
-    int n = (int) w[3];
-    mayer_ifft(n, in1, in2);
+    int num_samples = (int) w[3];
+    mayer_ifft(num_samples, in1, in2);
     return (w + 4);
 }
 

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -104,7 +104,9 @@ static void sigfft_dspx(t_sigfft *x, t_signal **sp, t_int *(*f)(t_int *w))
     t_sample *out1 = sp[2]->s_vec;
     t_sample *out2 = sp[3]->s_vec;
     if(out1 == in2 && out2 == in1)
+    {
         dsp_add(sigfft_swap, 3, out1, out2, (t_int) n);
+    }
     else if(out1 == in2)
     {
         dsp_add(copy_perform, 3, in2, out2, (t_int) n);
@@ -336,9 +338,13 @@ static t_int *sigframp_perform(t_int *w)
                 ((lastreal - nextreal) * re + (lastimag - nextimag) * im) /
                 (2.0f * pow);
             if(detune > 2 || detune < -2)
+            {
                 freq = pow = 0;
+            }
             else
+            {
                 freq = fbin + detune;
+            }
         }
         else
             freq = pow = 0;

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997- Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 
@@ -13,43 +13,40 @@ linked in.  The configure script can be used to select which one.
 
 /* ------------------ initialization and cleanup -------------------------- */
 
-void mayer_init( void);
-void mayer_term( void);
+void mayer_init(void);
+void mayer_term(void);
 
-static void fftclass_cleanup(t_class *c)
-{
-    mayer_term();
-}
+static void fftclass_cleanup(t_class *c) { mayer_term(); }
 
 /* ---------------- utility functions for DSP chains ---------------------- */
 
-    /* swap two arrays */
+/* swap two arrays */
 static t_int *sigfft_swap(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    int n = (int)w[3];
-    for (;n--; in1++, in2++)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    int n = (int) w[3];
+    for(; n--; in1++, in2++)
     {
         t_sample f = *in1;
         *in1 = *in2;
         *in2 = f;
     }
-    return (w+4);
+    return (w + 4);
 }
 
-    /* take array1 (supply a pointer to beginning) and copy it,
-    into decreasing addresses, into array 2 (supply a pointer one past the
-    end), and negate the sign. */
+/* take array1 (supply a pointer to beginning) and copy it,
+into decreasing addresses, into array 2 (supply a pointer one past the
+end), and negate the sign. */
 
 static t_int *sigrfft_flip(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)w[3];
-    while (n--)
-        *(--out) = - *in++;
-    return (w+4);
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) w[3];
+    while(n--)
+        *(--out) = -*in++;
+    return (w + 4);
 }
 
 /* ------------------------ fft~ and ifft~ -------------------------------- */
@@ -63,7 +60,7 @@ typedef struct fft
 
 static void *sigfft_new(void)
 {
-    t_sigfft *x = (t_sigfft *)pd_new(sigfft_class);
+    t_sigfft *x = (t_sigfft *) pd_new(sigfft_class);
     outlet_new(&x->x_obj, gensym("signal"));
     outlet_new(&x->x_obj, gensym("signal"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
@@ -73,7 +70,7 @@ static void *sigfft_new(void)
 
 static void *sigifft_new(void)
 {
-    t_sigfft *x = (t_sigfft *)pd_new(sigifft_class);
+    t_sigfft *x = (t_sigfft *) pd_new(sigifft_class);
     outlet_new(&x->x_obj, gensym("signal"));
     outlet_new(&x->x_obj, gensym("signal"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
@@ -83,20 +80,20 @@ static void *sigifft_new(void)
 
 static t_int *sigfft_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    int n = (int)w[3];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    int n = (int) w[3];
     mayer_fft(n, in1, in2);
-    return (w+4);
+    return (w + 4);
 }
 
 static t_int *sigifft_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    int n = (int)w[3];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    int n = (int) w[3];
     mayer_ifft(n, in1, in2);
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigfft_dspx(t_sigfft *x, t_signal **sp, t_int *(*f)(t_int *w))
@@ -106,19 +103,19 @@ static void sigfft_dspx(t_sigfft *x, t_signal **sp, t_int *(*f)(t_int *w))
     t_sample *in2 = sp[1]->s_vec;
     t_sample *out1 = sp[2]->s_vec;
     t_sample *out2 = sp[3]->s_vec;
-    if (out1 == in2 && out2 == in1)
-        dsp_add(sigfft_swap, 3, out1, out2, (t_int)n);
-    else if (out1 == in2)
+    if(out1 == in2 && out2 == in1)
+        dsp_add(sigfft_swap, 3, out1, out2, (t_int) n);
+    else if(out1 == in2)
     {
-        dsp_add(copy_perform, 3, in2, out2, (t_int)n);
-        dsp_add(copy_perform, 3, in1, out1, (t_int)n);
+        dsp_add(copy_perform, 3, in2, out2, (t_int) n);
+        dsp_add(copy_perform, 3, in1, out1, (t_int) n);
     }
     else
     {
-        if (out1 != in1) dsp_add(copy_perform, 3, in1, out1, (t_int)n);
-        if (out2 != in2) dsp_add(copy_perform, 3, in2, out2, (t_int)n);
+        if(out1 != in1) dsp_add(copy_perform, 3, in1, out1, (t_int) n);
+        if(out2 != in2) dsp_add(copy_perform, 3, in2, out2, (t_int) n);
     }
-    dsp_add(f, 3, sp[2]->s_vec, sp[3]->s_vec, (t_int)n);
+    dsp_add(f, 3, sp[2]->s_vec, sp[3]->s_vec, (t_int) n);
 }
 
 static void sigfft_dsp(t_sigfft *x, t_signal **sp)
@@ -133,20 +130,20 @@ static void sigifft_dsp(t_sigfft *x, t_signal **sp)
 
 static void sigfft_setup(void)
 {
-    sigfft_class = class_new(gensym("fft~"), sigfft_new, 0,
-        sizeof(t_sigfft), 0, 0);
+    sigfft_class =
+        class_new(gensym("fft~"), sigfft_new, 0, sizeof(t_sigfft), 0, 0);
     class_setfreefn(sigfft_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigfft_class, t_sigfft, x_f);
-    class_addmethod(sigfft_class, (t_method)sigfft_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigfft_class, (t_method) sigfft_dsp, gensym("dsp"), A_CANT, 0);
     mayer_init();
 
-    sigifft_class = class_new(gensym("ifft~"), sigifft_new, 0,
-        sizeof(t_sigfft), 0, 0);
+    sigifft_class =
+        class_new(gensym("ifft~"), sigifft_new, 0, sizeof(t_sigfft), 0, 0);
     class_setfreefn(sigifft_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigifft_class, t_sigfft, x_f);
-    class_addmethod(sigifft_class, (t_method)sigifft_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigifft_class, (t_method) sigifft_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigifft_class, gensym("fft~"));
     mayer_init();
 }
@@ -163,7 +160,7 @@ typedef struct rfft
 
 static void *sigrfft_new(void)
 {
-    t_sigrfft *x = (t_sigrfft *)pd_new(sigrfft_class);
+    t_sigrfft *x = (t_sigrfft *) pd_new(sigrfft_class);
     outlet_new(&x->x_obj, gensym("signal"));
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
@@ -172,41 +169,40 @@ static void *sigrfft_new(void)
 
 static t_int *sigrfft_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    int n = (int)w[2];
+    t_sample *in = (t_sample *) (w[1]);
+    int n = (int) w[2];
     mayer_realfft(n, in);
-    return (w+3);
+    return (w + 3);
 }
 
 static void sigrfft_dsp(t_sigrfft *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n>>1);
+    int n = sp[0]->s_n, n2 = (n >> 1);
     t_sample *in1 = sp[0]->s_vec;
     t_sample *out1 = sp[1]->s_vec;
     t_sample *out2 = sp[2]->s_vec;
-    if (n < 4)
+    if(n < 4)
     {
         pd_error(0, "fft: minimum 4 points");
         return;
     }
-    if (in1 != out1)
-        dsp_add(copy_perform, 3, in1, out1, (t_int)n);
-    dsp_add(sigrfft_perform, 2, out1, (t_int)n);
-    dsp_add(sigrfft_flip, 3, out1 + (n2+1), out2 + n2, (t_int)(n2-1));
-    dsp_add_zero(out1 + (n2+1), ((n2-1)&(~7)));
-    dsp_add_zero(out1 + (n2+1) + ((n2-1)&(~7)), ((n2-1)&7));
+    if(in1 != out1) dsp_add(copy_perform, 3, in1, out1, (t_int) n);
+    dsp_add(sigrfft_perform, 2, out1, (t_int) n);
+    dsp_add(sigrfft_flip, 3, out1 + (n2 + 1), out2 + n2, (t_int) (n2 - 1));
+    dsp_add_zero(out1 + (n2 + 1), ((n2 - 1) & (~7)));
+    dsp_add_zero(out1 + (n2 + 1) + ((n2 - 1) & (~7)), ((n2 - 1) & 7));
     dsp_add_zero(out2 + n2, n2);
     dsp_add_zero(out2, 1);
 }
 
 static void sigrfft_setup(void)
 {
-    sigrfft_class = class_new(gensym("rfft~"), sigrfft_new, 0,
-        sizeof(t_sigrfft), 0, 0);
+    sigrfft_class =
+        class_new(gensym("rfft~"), sigrfft_new, 0, sizeof(t_sigrfft), 0, 0);
     class_setfreefn(sigrfft_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigrfft_class, t_sigrfft, x_f);
-    class_addmethod(sigrfft_class, (t_method)sigrfft_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigrfft_class, (t_method) sigrfft_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigrfft_class, gensym("fft~"));
     mayer_init();
 }
@@ -223,7 +219,7 @@ typedef struct rifft
 
 static void *sigrifft_new(void)
 {
-    t_sigrifft *x = (t_sigrifft *)pd_new(sigrifft_class);
+    t_sigrifft *x = (t_sigrifft *) pd_new(sigrifft_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
@@ -232,44 +228,44 @@ static void *sigrifft_new(void)
 
 static t_int *sigrifft_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    int n = (int)w[2];
+    t_sample *in = (t_sample *) (w[1]);
+    int n = (int) w[2];
     mayer_realifft(n, in);
-    return (w+3);
+    return (w + 3);
 }
 
 static void sigrifft_dsp(t_sigrifft *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n>>1);
+    int n = sp[0]->s_n, n2 = (n >> 1);
     t_sample *in1 = sp[0]->s_vec;
     t_sample *in2 = sp[1]->s_vec;
     t_sample *out1 = sp[2]->s_vec;
-    if (n < 4)
+    if(n < 4)
     {
         pd_error(0, "fft: minimum 4 points");
         return;
     }
-    if (in2 == out1)
+    if(in2 == out1)
     {
-        dsp_add(sigrfft_flip, 3, out1+1, out1 + n, (t_int)(n2-1));
-        dsp_add(copy_perform, 3, in1, out1, (t_int)(n2+1));
+        dsp_add(sigrfft_flip, 3, out1 + 1, out1 + n, (t_int) (n2 - 1));
+        dsp_add(copy_perform, 3, in1, out1, (t_int) (n2 + 1));
     }
     else
     {
-        if (in1 != out1) dsp_add(copy_perform, 3, in1, out1, (t_int)(n2+1));
-        dsp_add(sigrfft_flip, 3, in2+1, out1 + n, (t_int)(n2-1));
+        if(in1 != out1) dsp_add(copy_perform, 3, in1, out1, (t_int) (n2 + 1));
+        dsp_add(sigrfft_flip, 3, in2 + 1, out1 + n, (t_int) (n2 - 1));
     }
-    dsp_add(sigrifft_perform, 2, out1, (t_int)n);
+    dsp_add(sigrifft_perform, 2, out1, (t_int) n);
 }
 
 static void sigrifft_setup(void)
 {
-    sigrifft_class = class_new(gensym("rifft~"), sigrifft_new, 0,
-        sizeof(t_sigrifft), 0, 0);
+    sigrifft_class =
+        class_new(gensym("rifft~"), sigrifft_new, 0, sizeof(t_sigrifft), 0, 0);
     class_setfreefn(sigrifft_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigrifft_class, t_sigrifft, x_f);
-    class_addmethod(sigrifft_class, (t_method)sigrifft_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigrifft_class, (t_method) sigrifft_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigrifft_class, gensym("fft~"));
     mayer_init();
 }
@@ -286,11 +282,11 @@ typedef struct framp
 
 static void *sigframp_new(void)
 {
-    t_sigframp *x = (t_sigframp *)pd_new(sigframp_class);
+    t_sigframp *x = (t_sigframp *) pd_new(sigframp_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     outlet_new(&x->x_obj, gensym("signal"));
     outlet_new(&x->x_obj, gensym("signal"));
-        /* q8_rsqrt() triggers init_rsqrt() as a side-effect */
+    /* q8_rsqrt() triggers init_rsqrt() as a side-effect */
     q8_rsqrt(-1.);
     x->x_f = 0;
     return (x);
@@ -298,21 +294,21 @@ static void *sigframp_new(void)
 
 static t_int *sigframp_perform(t_int *w)
 {
-    t_sample *inreal = (t_sample *)(w[1]);
-    t_sample *inimag = (t_sample *)(w[2]);
-    t_sample *outfreq = (t_sample *)(w[3]);
-    t_sample *outamp = (t_sample *)(w[4]);
+    t_sample *inreal = (t_sample *) (w[1]);
+    t_sample *inimag = (t_sample *) (w[2]);
+    t_sample *outfreq = (t_sample *) (w[3]);
+    t_sample *outamp = (t_sample *) (w[4]);
     t_sample lastreal = 0, currentreal = inreal[0], nextreal = inreal[1];
     t_sample lastimag = 0, currentimag = inimag[0], nextimag = inimag[1];
-    int n = (int)w[5];
+    int n = (int) w[5];
     int m = n + 1;
-    t_sample fbin = 1, oneovern2 = 1.f/((t_sample)n * (t_sample)n);
+    t_sample fbin = 1, oneovern2 = 1.f / ((t_sample) n * (t_sample) n);
 
     inreal += 2;
     inimag += 2;
     *outamp++ = *outfreq++ = 0;
     n -= 2;
-    while (n--)
+    while(n--)
     {
         t_sample re, im, pow, freq;
         lastreal = currentreal;
@@ -324,45 +320,50 @@ static t_int *sigframp_perform(t_int *w)
         re = currentreal - 0.5f * (lastreal + nextreal);
         im = currentimag - 0.5f * (lastimag + nextimag);
         pow = re * re + im * im;
-        if (pow > 1e-19)
+        if(pow > 1e-19)
         {
-            t_sample detune = ((lastreal - nextreal) * re +
-                    (lastimag - nextimag) * im) / (2.0f * pow);
-            if (detune > 2 || detune < -2) freq = pow = 0;
-            else freq = fbin + detune;
+            t_sample detune =
+                ((lastreal - nextreal) * re + (lastimag - nextimag) * im) /
+                (2.0f * pow);
+            if(detune > 2 || detune < -2)
+                freq = pow = 0;
+            else
+                freq = fbin + detune;
         }
-        else freq = pow = 0;
+        else
+            freq = pow = 0;
         *outfreq++ = freq;
         *outamp++ = oneovern2 * pow;
         fbin += 1.0f;
     }
-    while (m--) *outamp++ = *outfreq++ = 0;
-    return (w+6);
+    while(m--)
+        *outamp++ = *outfreq++ = 0;
+    return (w + 6);
 }
 
 t_int *sigsqrt_perform(t_int *w);
 
 static void sigframp_dsp(t_sigframp *x, t_signal **sp)
 {
-    int n = sp[0]->s_n, n2 = (n>>1);
-    if (n < 4)
+    int n = sp[0]->s_n, n2 = (n >> 1);
+    if(n < 4)
     {
         pd_error(0, "framp: minimum 4 points");
         return;
     }
-    dsp_add(sigframp_perform, 5, sp[0]->s_vec, sp[1]->s_vec,
-        sp[2]->s_vec, sp[3]->s_vec, (t_int)n2);
-    dsp_add(sigsqrt_perform, 3, sp[3]->s_vec, sp[3]->s_vec, (t_int)n2);
+    dsp_add(sigframp_perform, 5, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, (t_int) n2);
+    dsp_add(sigsqrt_perform, 3, sp[3]->s_vec, sp[3]->s_vec, (t_int) n2);
 }
 
 static void sigframp_setup(void)
 {
-    sigframp_class = class_new(gensym("framp~"), sigframp_new, 0,
-        sizeof(t_sigframp), 0, 0);
+    sigframp_class =
+        class_new(gensym("framp~"), sigframp_new, 0, sizeof(t_sigframp), 0, 0);
     class_setfreefn(sigframp_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigframp_class, t_sigframp, x_f);
-    class_addmethod(sigframp_class, (t_method)sigframp_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigframp_class, (t_method) sigframp_dsp, gensym("dsp"), A_CANT, 0);
     mayer_init();
 }
 

--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -116,7 +116,8 @@ EXTERN void mayer_dofft(t_sample *fz1, t_sample *fz2, int n, int sgn)
 {
     FFTFLT *buf, *fp3;
     int i;
-    t_sample *fp1, *fp2;
+    t_sample *fp1;
+    t_sample *fp2;
     if(!ooura_init(2 * n)) return;
     buf = ooura_buffer;
     for(i = 0, fp1 = fz1, fp2 = fz2, fp3 = buf; i < n; i++)
@@ -147,8 +148,10 @@ EXTERN void mayer_ifft(int n, t_sample *fz1, t_sample *fz2)
 EXTERN void mayer_realfft(int n, t_sample *fz)
 {
     FFTFLT *buf, *fp3;
-    int i, nover2 = n / 2;
-    t_sample *fp1, *fp2;
+    int i;
+    int nover2 = n / 2;
+    t_sample *fp1;
+    t_sample *fp2;
     if(!ooura_init(n)) return;
     buf = ooura_buffer;
     for(i = 0, fp1 = fz, fp3 = buf; i < n; i++, fp1++, fp3++)
@@ -164,8 +167,10 @@ EXTERN void mayer_realfft(int n, t_sample *fz)
 EXTERN void mayer_realifft(int n, t_sample *fz)
 {
     FFTFLT *buf, *fp3;
-    int i, nover2 = n / 2;
-    t_sample *fp1, *fp2;
+    int i;
+    int nover2 = n / 2;
+    t_sample *fp1;
+    t_sample *fp2;
     if(!ooura_init(n)) return;
     buf = ooura_buffer;
     buf[0] = fz[0];
@@ -508,7 +513,8 @@ void rdft(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     void cftbsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w);
     void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c);
-    int nw, nc;
+    int nw;
+    int nc;
     FFTFLT xi;
 
     nw = ip[0];
@@ -563,7 +569,9 @@ void ddct(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c);
-    int j, nw, nc;
+    int j;
+    int nw;
+    int nc;
     FFTFLT xr;
 
     nw = ip[0];
@@ -630,7 +638,9 @@ void ddst(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c);
-    int j, nw, nc;
+    int j;
+    int nw;
+    int nc;
     FFTFLT xr;
 
     nw = ip[0];
@@ -695,7 +705,13 @@ void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     void cftfsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w);
     void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c);
-    int j, k, l, m, mh, nw, nc;
+    int j;
+    int k;
+    int l;
+    int m;
+    int mh;
+    int nw;
+    int nc;
     FFTFLT xr, xi, yr, yi;
 
     nw = ip[0];
@@ -803,7 +819,13 @@ void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     void cftfsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w);
     void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c);
     void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c);
-    int j, k, l, m, mh, nw, nc;
+    int j;
+    int k;
+    int l;
+    int m;
+    int mh;
+    int nw;
+    int nc;
     FFTFLT xr, xi, yr, yi;
 
     nw = ip[0];
@@ -900,7 +922,10 @@ void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
 void makewt(int nw, int *ip, FFTFLT *w)
 {
     void makeipt(int nw, int *ip);
-    int j, nwh, nw0, nw1;
+    int j;
+    int nwh;
+    int nw0;
+    int nw1;
     FFTFLT delta, wn4r, wk1r, wk1i, wk3r, wk3i;
 
     ip[0] = nw;
@@ -969,7 +994,12 @@ void makewt(int nw, int *ip, FFTFLT *w)
 
 void makeipt(int nw, int *ip)
 {
-    int j, l, m, m2, p, q;
+    int j;
+    int l;
+    int m;
+    int m2;
+    int p;
+    int q;
 
     ip[2] = 0;
     ip[3] = 16;
@@ -990,7 +1020,8 @@ void makeipt(int nw, int *ip)
 
 void makect(int nc, int *ip, FFTFLT *c)
 {
-    int j, nch;
+    int j;
+    int nch;
     FFTFLT delta;
 
     ip[1] = nc;
@@ -1200,7 +1231,14 @@ void cftbsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w)
 
 void bitrv2(int n, int *ip, FFTFLT *a)
 {
-    int j, j1, k, k1, l, m, nh, nm;
+    int j;
+    int j1;
+    int k;
+    int k1;
+    int l;
+    int m;
+    int nh;
+    int nm;
     FFTFLT xr, xi, yr, yi;
 
     m = 1;
@@ -1554,7 +1592,14 @@ void bitrv2(int n, int *ip, FFTFLT *a)
 
 void bitrv2conj(int n, int *ip, FFTFLT *a)
 {
-    int j, j1, k, k1, l, m, nh, nm;
+    int j;
+    int j1;
+    int k;
+    int k1;
+    int l;
+    int m;
+    int nh;
+    int nm;
     FFTFLT xr, xi, yr, yi;
 
     m = 1;
@@ -2095,7 +2140,14 @@ void bitrv208neg(FFTFLT *a)
 
 void cftf1st(int n, FFTFLT *a, FFTFLT *w)
 {
-    int j, j0, j1, j2, j3, k, m, mh;
+    int j;
+    int j0;
+    int j1;
+    int j2;
+    int j3;
+    int k;
+    int m;
+    int mh;
     FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
     FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i,
         y3r, y3i;
@@ -2300,7 +2352,14 @@ void cftf1st(int n, FFTFLT *a, FFTFLT *w)
 
 void cftb1st(int n, FFTFLT *a, FFTFLT *w)
 {
-    int j, j0, j1, j2, j3, k, m, mh;
+    int j;
+    int j0;
+    int j1;
+    int j2;
+    int j3;
+    int k;
+    int m;
+    int mh;
     FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
     FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i,
         y3r, y3i;
@@ -2621,7 +2680,10 @@ void cftrec4(int n, FFTFLT *a, int nw, FFTFLT *w)
     int cfttree(int n, int j, int k, FFTFLT *a, int nw, FFTFLT *w);
     void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w);
     void cftmdl1(int n, FFTFLT *a, FFTFLT *w);
-    int isplt, j, k, m;
+    int isplt;
+    int j;
+    int k;
+    int m;
 
     m = n;
     while(m > 512)
@@ -2643,7 +2705,9 @@ int cfttree(int n, int j, int k, FFTFLT *a, int nw, FFTFLT *w)
 {
     void cftmdl1(int n, FFTFLT *a, FFTFLT *w);
     void cftmdl2(int n, FFTFLT *a, FFTFLT *w);
-    int i, isplt, m;
+    int i;
+    int isplt;
+    int m;
 
     if((k & 3) != 0)
     {
@@ -2760,7 +2824,14 @@ void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w)
 
 void cftmdl1(int n, FFTFLT *a, FFTFLT *w)
 {
-    int j, j0, j1, j2, j3, k, m, mh;
+    int j;
+    int j0;
+    int j1;
+    int j2;
+    int j3;
+    int k;
+    int m;
+    int mh;
     FFTFLT wn4r, wk1r, wk1i, wk3r, wk3i;
     FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i;
 
@@ -2870,7 +2941,15 @@ void cftmdl1(int n, FFTFLT *a, FFTFLT *w)
 
 void cftmdl2(int n, FFTFLT *a, FFTFLT *w)
 {
-    int j, j0, j1, j2, j3, k, kr, m, mh;
+    int j;
+    int j0;
+    int j1;
+    int j2;
+    int j3;
+    int k;
+    int kr;
+    int m;
+    int mh;
     FFTFLT wn4r, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
     FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y2r, y2i;
 
@@ -3549,7 +3628,11 @@ void cftx020(FFTFLT *a)
 
 void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
-    int j, k, kk, ks, m;
+    int j;
+    int k;
+    int kk;
+    int ks;
+    int m;
     FFTFLT wkr, wki, xr, xi, yr, yi;
 
     m = n >> 1;
@@ -3574,7 +3657,11 @@ void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 
 void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
-    int j, k, kk, ks, m;
+    int j;
+    int k;
+    int kk;
+    int ks;
+    int m;
     FFTFLT wkr, wki, xr, xi, yr, yi;
 
     m = n >> 1;
@@ -3599,7 +3686,11 @@ void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 
 void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
-    int j, k, kk, ks, m;
+    int j;
+    int k;
+    int kk;
+    int ks;
+    int m;
     FFTFLT wkr, wki, xr;
 
     m = n >> 1;
@@ -3620,7 +3711,11 @@ void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 
 void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
-    int j, k, kk, ks, m;
+    int j;
+    int k;
+    int kk;
+    int ks;
+    int m;
     FFTFLT wkr, wki, xr;
 
     m = n >> 1;

--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -23,11 +23,11 @@ for another, more permissive-sounding copyright notice.  -MSP
 #include "m_imp.h"
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #define FFTFLT double
@@ -42,38 +42,37 @@ static PERTHREAD int ooura_bitrevsize;
 static PERTHREAD FFTFLT *ooura_costab;
 static PERTHREAD FFTFLT *ooura_buffer;
 
-static int ooura_init( int n)
+static int ooura_init(int n)
 {
     n = (1 << ilog2(n));
-    if (n < 4)
-        return (0);
-    if (n > ooura_maxn)
+    if(n < 4) return (0);
+    if(n > ooura_maxn)
     {
-        if (ooura_maxn)
+        if(ooura_maxn)
         {
             t_freebytes(ooura_bitrev, ooura_bitrevsize);
             t_freebytes(ooura_costab, ooura_maxn * sizeof(FFTFLT) / 2);
             t_freebytes(ooura_buffer, ooura_maxn * sizeof(FFTFLT));
         }
-        ooura_bitrevsize = sizeof(int) * (2 + (1 << (ilog2(n)/2)));
-        ooura_bitrev = (int *)t_getbytes(ooura_bitrevsize);
+        ooura_bitrevsize = sizeof(int) * (2 + (1 << (ilog2(n) / 2)));
+        ooura_bitrev = (int *) t_getbytes(ooura_bitrevsize);
         ooura_bitrev[0] = 0;
-        if (!ooura_bitrev)
+        if(!ooura_bitrev)
         {
             pd_error(0, "out of memory allocating FFT buffer");
             ooura_maxn = 0;
             return (0);
         }
-        ooura_costab = (FFTFLT *)t_getbytes(n * sizeof(FFTFLT)/2);
-        if (!ooura_costab)
+        ooura_costab = (FFTFLT *) t_getbytes(n * sizeof(FFTFLT) / 2);
+        if(!ooura_costab)
         {
             pd_error(0, "out of memory allocating FFT buffer");
             t_freebytes(ooura_bitrev, ooura_bitrevsize);
             ooura_maxn = 0;
             return (0);
         }
-        ooura_buffer = (FFTFLT *)t_getbytes(n * sizeof(FFTFLT));
-        if (!ooura_buffer)
+        ooura_buffer = (FFTFLT *) t_getbytes(n * sizeof(FFTFLT));
+        if(!ooura_buffer)
         {
             pd_error(0, "out of memory allocating FFT buffer");
             t_freebytes(ooura_bitrev, ooura_bitrevsize);
@@ -87,12 +86,11 @@ static int ooura_init( int n)
     return (1);
 }
 
-static void ooura_term( void)
+static void ooura_term(void)
 {
-    if (!ooura_maxn)
-        return;
+    if(!ooura_maxn) return;
     t_freebytes(ooura_bitrev, ooura_bitrevsize);
-    t_freebytes(ooura_costab, ooura_maxn * sizeof(FFTFLT)/2);
+    t_freebytes(ooura_costab, ooura_maxn * sizeof(FFTFLT) / 2);
     t_freebytes(ooura_buffer, ooura_maxn * sizeof(FFTFLT));
     ooura_maxn = 0;
     ooura_bitrev = 0;
@@ -103,39 +101,32 @@ static void ooura_term( void)
 /* -------- initialization and cleanup -------- */
 static PERTHREAD int mayer_refcount = 0;
 
-void mayer_init( void)
-{
-    mayer_refcount++;
-}
+void mayer_init(void) { mayer_refcount++; }
 
-void mayer_term( void)
+void mayer_term(void)
 {
-    if (--mayer_refcount == 0)  /* clean up */
+    if(--mayer_refcount == 0) /* clean up */
         ooura_term();
 }
 
 /* -------- public routines -------- */
-EXTERN void mayer_fht(t_sample *fz, int n)
-{
-    post("FHT: not yet implemented");
-}
+EXTERN void mayer_fht(t_sample *fz, int n) { post("FHT: not yet implemented"); }
 
 EXTERN void mayer_dofft(t_sample *fz1, t_sample *fz2, int n, int sgn)
 {
     FFTFLT *buf, *fp3;
     int i;
     t_sample *fp1, *fp2;
-    if (!ooura_init(2*n))
-        return;
+    if(!ooura_init(2 * n)) return;
     buf = ooura_buffer;
-    for (i = 0, fp1 = fz1, fp2 = fz2, fp3 = buf; i < n; i++)
+    for(i = 0, fp1 = fz1, fp2 = fz2, fp3 = buf; i < n; i++)
     {
         fp3[0] = *fp1++;
         fp3[1] = *fp2++;
         fp3 += 2;
     }
-    cdft(2*n, sgn, buf, ooura_bitrev, ooura_costab);
-    for (i = 0, fp1 = fz1, fp2 = fz2, fp3 = buf; i < n; i++)
+    cdft(2 * n, sgn, buf, ooura_bitrev, ooura_costab);
+    for(i = 0, fp1 = fz1, fp2 = fz2, fp3 = buf; i < n; i++)
     {
         *fp1++ = fp3[0];
         *fp2++ = fp3[1];
@@ -156,52 +147,49 @@ EXTERN void mayer_ifft(int n, t_sample *fz1, t_sample *fz2)
 EXTERN void mayer_realfft(int n, t_sample *fz)
 {
     FFTFLT *buf, *fp3;
-    int i, nover2 = n/2;
+    int i, nover2 = n / 2;
     t_sample *fp1, *fp2;
-    if (!ooura_init(n))
-        return;
+    if(!ooura_init(n)) return;
     buf = ooura_buffer;
-    for (i = 0, fp1 = fz, fp3 = buf; i < n; i++, fp1++, fp3++)
+    for(i = 0, fp1 = fz, fp3 = buf; i < n; i++, fp1++, fp3++)
         buf[i] = fz[i];
     rdft(n, 1, buf, ooura_bitrev, ooura_costab);
     fz[0] = buf[0];
     fz[nover2] = buf[1];
-    for (i = 1, fp1 = fz+1, fp2 = fz+(n-1), fp3 = buf+2; i < nover2;
+    for(i = 1, fp1 = fz + 1, fp2 = fz + (n - 1), fp3 = buf + 2; i < nover2;
         i++, fp1++, fp2--, fp3 += 2)
-            *fp1 = fp3[0], *fp2 = fp3[1];
+        *fp1 = fp3[0], *fp2 = fp3[1];
 }
 
 EXTERN void mayer_realifft(int n, t_sample *fz)
 {
     FFTFLT *buf, *fp3;
-    int i, nover2 = n/2;
+    int i, nover2 = n / 2;
     t_sample *fp1, *fp2;
-    if (!ooura_init(n))
-        return;
+    if(!ooura_init(n)) return;
     buf = ooura_buffer;
     buf[0] = fz[0];
     buf[1] = fz[nover2];
-    for (i = 1, fp1 = fz+1, fp2 = fz+(n-1), fp3 = buf+2; i < nover2;
+    for(i = 1, fp1 = fz + 1, fp2 = fz + (n - 1), fp3 = buf + 2; i < nover2;
         i++, fp1++, fp2--, fp3 += 2)
-            fp3[0] = *fp1, fp3[1] = *fp2;
+        fp3[0] = *fp1, fp3[1] = *fp2;
     rdft(n, -1, buf, ooura_bitrev, ooura_costab);
-    for (i = 0, fp1 = fz, fp3 = buf; i < n; i++, fp1++, fp3++)
-        fz[i] = 2*buf[i];
+    for(i = 0, fp1 = fz, fp3 = buf; i < n; i++, fp1++, fp3++)
+        fz[i] = 2 * buf[i];
 }
 
-    /* ancient ISPW-like version, used in fiddle~ and perhaps other externs
-    here and there. */
+/* ancient ISPW-like version, used in fiddle~ and perhaps other externs
+here and there. */
 void pd_fft(t_float *buf, int npoints, int inverse)
 {
-    FFTFLT *buf2 = (FFTFLT *)alloca(2 * npoints * sizeof(FFTFLT)), *bp2;
+    FFTFLT *buf2 = (FFTFLT *) alloca(2 * npoints * sizeof(FFTFLT)), *bp2;
     t_float *fp;
     int i;
-    if (!ooura_init(2*npoints))
-        return;
-    for (i = 0, bp2 = buf2, fp = buf; i < 2 * npoints; i++, bp2++, fp++)
+    if(!ooura_init(2 * npoints)) return;
+    for(i = 0, bp2 = buf2, fp = buf; i < 2 * npoints; i++, bp2++, fp++)
         *bp2 = *fp;
-    cdft(2*npoints, (inverse ? 1 : -1), buf2, ooura_bitrev, ooura_costab);
-    for (i = 0, bp2 = buf2, fp = buf; i < 2 * npoints; i++, bp2++, fp++)
+    cdft(2 * npoints, (inverse ? 1 : -1), buf2, ooura_bitrev, ooura_costab);
+    for(i = 0, bp2 = buf2, fp = buf; i < 2 * npoints; i++, bp2++, fp++)
         *fp = *bp2;
 }
 
@@ -489,7 +477,6 @@ Appendix :
     w[] and ip[] are compatible with all routines.
 */
 
-
 void cdft(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
 {
     void makewt(int nw, int *ip, FFTFLT *w);
@@ -498,17 +485,20 @@ void cdft(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     int nw;
 
     nw = ip[0];
-    if (n > (nw << 2)) {
+    if(n > (nw << 2))
+    {
         nw = n >> 2;
         makewt(nw, ip, w);
     }
-    if (isgn >= 0) {
+    if(isgn >= 0)
+    {
         cftfsub(n, a, ip, nw, w);
-    } else {
+    }
+    else
+    {
         cftbsub(n, a, ip, nw, w);
     }
 }
-
 
 void rdft(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
 {
@@ -522,37 +512,47 @@ void rdft(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     FFTFLT xi;
 
     nw = ip[0];
-    if (n > (nw << 2)) {
+    if(n > (nw << 2))
+    {
         nw = n >> 2;
         makewt(nw, ip, w);
     }
     nc = ip[1];
-    if (n > (nc << 2)) {
+    if(n > (nc << 2))
+    {
         nc = n >> 2;
         makect(nc, ip, w + nw);
     }
-    if (isgn >= 0) {
-        if (n > 4) {
+    if(isgn >= 0)
+    {
+        if(n > 4)
+        {
             cftfsub(n, a, ip, nw, w);
             rftfsub(n, a, nc, w + nw);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftfsub(n, a, ip, nw, w);
         }
         xi = a[0] - a[1];
         a[0] += a[1];
         a[1] = xi;
-    } else {
+    }
+    else
+    {
         a[1] = 0.5 * (a[0] - a[1]);
         a[0] -= a[1];
-        if (n > 4) {
+        if(n > 4)
+        {
             rftbsub(n, a, nc, w + nw);
             cftbsub(n, a, ip, nw, w);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftbsub(n, a, ip, nw, w);
         }
     }
 }
-
 
 void ddct(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
 {
@@ -567,48 +567,59 @@ void ddct(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     FFTFLT xr;
 
     nw = ip[0];
-    if (n > (nw << 2)) {
+    if(n > (nw << 2))
+    {
         nw = n >> 2;
         makewt(nw, ip, w);
     }
     nc = ip[1];
-    if (n > nc) {
+    if(n > nc)
+    {
         nc = n;
         makect(nc, ip, w + nw);
     }
-    if (isgn < 0) {
+    if(isgn < 0)
+    {
         xr = a[n - 1];
-        for (j = n - 2; j >= 2; j -= 2) {
+        for(j = n - 2; j >= 2; j -= 2)
+        {
             a[j + 1] = a[j] - a[j - 1];
             a[j] += a[j - 1];
         }
         a[1] = a[0] - xr;
         a[0] += xr;
-        if (n > 4) {
+        if(n > 4)
+        {
             rftbsub(n, a, nc, w + nw);
             cftbsub(n, a, ip, nw, w);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftbsub(n, a, ip, nw, w);
         }
     }
     dctsub(n, a, nc, w + nw);
-    if (isgn >= 0) {
-        if (n > 4) {
+    if(isgn >= 0)
+    {
+        if(n > 4)
+        {
             cftfsub(n, a, ip, nw, w);
             rftfsub(n, a, nc, w + nw);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftfsub(n, a, ip, nw, w);
         }
         xr = a[0] - a[1];
         a[0] += a[1];
-        for (j = 2; j < n; j += 2) {
+        for(j = 2; j < n; j += 2)
+        {
             a[j - 1] = a[j] - a[j + 1];
             a[j] += a[j + 1];
         }
         a[n - 1] = xr;
     }
 }
-
 
 void ddst(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
 {
@@ -623,48 +634,59 @@ void ddst(int n, int isgn, FFTFLT *a, int *ip, FFTFLT *w)
     FFTFLT xr;
 
     nw = ip[0];
-    if (n > (nw << 2)) {
+    if(n > (nw << 2))
+    {
         nw = n >> 2;
         makewt(nw, ip, w);
     }
     nc = ip[1];
-    if (n > nc) {
+    if(n > nc)
+    {
         nc = n;
         makect(nc, ip, w + nw);
     }
-    if (isgn < 0) {
+    if(isgn < 0)
+    {
         xr = a[n - 1];
-        for (j = n - 2; j >= 2; j -= 2) {
+        for(j = n - 2; j >= 2; j -= 2)
+        {
             a[j + 1] = -a[j] - a[j - 1];
             a[j] -= a[j - 1];
         }
         a[1] = a[0] + xr;
         a[0] -= xr;
-        if (n > 4) {
+        if(n > 4)
+        {
             rftbsub(n, a, nc, w + nw);
             cftbsub(n, a, ip, nw, w);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftbsub(n, a, ip, nw, w);
         }
     }
     dstsub(n, a, nc, w + nw);
-    if (isgn >= 0) {
-        if (n > 4) {
+    if(isgn >= 0)
+    {
+        if(n > 4)
+        {
             cftfsub(n, a, ip, nw, w);
             rftfsub(n, a, nc, w + nw);
-        } else if (n == 4) {
+        }
+        else if(n == 4)
+        {
             cftfsub(n, a, ip, nw, w);
         }
         xr = a[0] - a[1];
         a[0] += a[1];
-        for (j = 2; j < n; j += 2) {
+        for(j = 2; j < n; j += 2)
+        {
             a[j - 1] = -a[j] - a[j + 1];
             a[j] -= a[j + 1];
         }
         a[n - 1] = -xr;
     }
 }
-
 
 void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
 {
@@ -677,12 +699,14 @@ void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     FFTFLT xr, xi, yr, yi;
 
     nw = ip[0];
-    if (n > (nw << 3)) {
+    if(n > (nw << 3))
+    {
         nw = n >> 3;
         makewt(nw, ip, w);
     }
     nc = ip[1];
-    if (n > (nc << 1)) {
+    if(n > (nc << 1))
+    {
         nc = n >> 1;
         makect(nc, ip, w + nw);
     }
@@ -692,9 +716,11 @@ void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     a[0] -= a[n];
     t[0] = xi - yi;
     t[m] = xi + yi;
-    if (n > 2) {
+    if(n > 2)
+    {
         mh = m >> 1;
-        for (j = 1; j < mh; j++) {
+        for(j = 1; j < mh; j++)
+        {
             k = m - j;
             xr = a[j] - a[n - j];
             xi = a[j] + a[n - j];
@@ -708,39 +734,49 @@ void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
         t[mh] = a[mh] + a[n - mh];
         a[mh] -= a[n - mh];
         dctsub(m, a, nc, w + nw);
-        if (m > 4) {
+        if(m > 4)
+        {
             cftfsub(m, a, ip, nw, w);
             rftfsub(m, a, nc, w + nw);
-        } else if (m == 4) {
+        }
+        else if(m == 4)
+        {
             cftfsub(m, a, ip, nw, w);
         }
         a[n - 1] = a[0] - a[1];
         a[1] = a[0] + a[1];
-        for (j = m - 2; j >= 2; j -= 2) {
+        for(j = m - 2; j >= 2; j -= 2)
+        {
             a[2 * j + 1] = a[j] + a[j + 1];
             a[2 * j - 1] = a[j] - a[j + 1];
         }
         l = 2;
         m = mh;
-        while (m >= 2) {
+        while(m >= 2)
+        {
             dctsub(m, t, nc, w + nw);
-            if (m > 4) {
+            if(m > 4)
+            {
                 cftfsub(m, t, ip, nw, w);
                 rftfsub(m, t, nc, w + nw);
-            } else if (m == 4) {
+            }
+            else if(m == 4)
+            {
                 cftfsub(m, t, ip, nw, w);
             }
             a[n - l] = t[0] - t[1];
             a[l] = t[0] + t[1];
             k = 0;
-            for (j = 2; j < m; j += 2) {
+            for(j = 2; j < m; j += 2)
+            {
                 k += l << 2;
                 a[k - l] = t[j] - t[j + 1];
                 a[k + l] = t[j] + t[j + 1];
             }
             l <<= 1;
             mh = m >> 1;
-            for (j = 0; j < mh; j++) {
+            for(j = 0; j < mh; j++)
+            {
                 k = m - j;
                 t[j] = t[m + k] - t[m + j];
                 t[k] = t[m + k] + t[m + j];
@@ -751,13 +787,14 @@ void dfct(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
         a[l] = t[0];
         a[n] = t[2] - t[1];
         a[0] = t[2] + t[1];
-    } else {
+    }
+    else
+    {
         a[1] = a[0];
         a[2] = t[0];
         a[0] = t[1];
     }
 }
-
 
 void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
 {
@@ -770,19 +807,23 @@ void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     FFTFLT xr, xi, yr, yi;
 
     nw = ip[0];
-    if (n > (nw << 3)) {
+    if(n > (nw << 3))
+    {
         nw = n >> 3;
         makewt(nw, ip, w);
     }
     nc = ip[1];
-    if (n > (nc << 1)) {
+    if(n > (nc << 1))
+    {
         nc = n >> 1;
         makect(nc, ip, w + nw);
     }
-    if (n > 2) {
+    if(n > 2)
+    {
         m = n >> 1;
         mh = m >> 1;
-        for (j = 1; j < mh; j++) {
+        for(j = 1; j < mh; j++)
+        {
             k = m - j;
             xr = a[j] + a[n - j];
             xi = a[j] - a[n - j];
@@ -797,39 +838,49 @@ void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
         a[mh] += a[n - mh];
         a[0] = a[m];
         dstsub(m, a, nc, w + nw);
-        if (m > 4) {
+        if(m > 4)
+        {
             cftfsub(m, a, ip, nw, w);
             rftfsub(m, a, nc, w + nw);
-        } else if (m == 4) {
+        }
+        else if(m == 4)
+        {
             cftfsub(m, a, ip, nw, w);
         }
         a[n - 1] = a[1] - a[0];
         a[1] = a[0] + a[1];
-        for (j = m - 2; j >= 2; j -= 2) {
+        for(j = m - 2; j >= 2; j -= 2)
+        {
             a[2 * j + 1] = a[j] - a[j + 1];
             a[2 * j - 1] = -a[j] - a[j + 1];
         }
         l = 2;
         m = mh;
-        while (m >= 2) {
+        while(m >= 2)
+        {
             dstsub(m, t, nc, w + nw);
-            if (m > 4) {
+            if(m > 4)
+            {
                 cftfsub(m, t, ip, nw, w);
                 rftfsub(m, t, nc, w + nw);
-            } else if (m == 4) {
+            }
+            else if(m == 4)
+            {
                 cftfsub(m, t, ip, nw, w);
             }
             a[n - l] = t[1] - t[0];
             a[l] = t[0] + t[1];
             k = 0;
-            for (j = 2; j < m; j += 2) {
+            for(j = 2; j < m; j += 2)
+            {
                 k += l << 2;
                 a[k - l] = -t[j] - t[j + 1];
                 a[k + l] = t[j] - t[j + 1];
             }
             l <<= 1;
             mh = m >> 1;
-            for (j = 1; j < mh; j++) {
+            for(j = 1; j < mh; j++)
+            {
                 k = m - j;
                 t[j] = t[m + k] + t[m + j];
                 t[k] = t[m + k] - t[m + j];
@@ -842,9 +893,7 @@ void dfst(int n, FFTFLT *a, FFTFLT *t, int *ip, FFTFLT *w)
     a[0] = 0;
 }
 
-
 /* -------- initializing routines -------- */
-
 
 #include <math.h>
 
@@ -856,20 +905,25 @@ void makewt(int nw, int *ip, FFTFLT *w)
 
     ip[0] = nw;
     ip[1] = 1;
-    if (nw > 2) {
+    if(nw > 2)
+    {
         nwh = nw >> 1;
         delta = atan(1.0) / nwh;
         wn4r = cos(delta * nwh);
         w[0] = 1;
         w[1] = wn4r;
-        if (nwh == 4) {
+        if(nwh == 4)
+        {
             w[2] = cos(delta * 2);
             w[3] = sin(delta * 2);
-        } else if (nwh > 4) {
+        }
+        else if(nwh > 4)
+        {
             makeipt(nw, ip);
             w[2] = 0.5 / cos(delta * 2);
             w[3] = 0.5 / cos(delta * 6);
-            for (j = 4; j < nwh; j += 4) {
+            for(j = 4; j < nwh; j += 4)
+            {
                 w[j] = cos(delta * j);
                 w[j + 1] = sin(delta * j);
                 w[j + 2] = cos(3 * delta * j);
@@ -877,22 +931,27 @@ void makewt(int nw, int *ip, FFTFLT *w)
             }
         }
         nw0 = 0;
-        while (nwh > 2) {
+        while(nwh > 2)
+        {
             nw1 = nw0 + nwh;
             nwh >>= 1;
             w[nw1] = 1;
             w[nw1 + 1] = wn4r;
-            if (nwh == 4) {
+            if(nwh == 4)
+            {
                 wk1r = w[nw0 + 4];
                 wk1i = w[nw0 + 5];
                 w[nw1 + 2] = wk1r;
                 w[nw1 + 3] = wk1i;
-            } else if (nwh > 4) {
+            }
+            else if(nwh > 4)
+            {
                 wk1r = w[nw0 + 4];
                 wk3r = w[nw0 + 6];
                 w[nw1 + 2] = 0.5 / wk1r;
                 w[nw1 + 3] = 0.5 / wk3r;
-                for (j = 4; j < nwh; j += 4) {
+                for(j = 4; j < nwh; j += 4)
+                {
                     wk1r = w[nw0 + 2 * j];
                     wk1i = w[nw0 + 2 * j + 1];
                     wk3r = w[nw0 + 2 * j + 2];
@@ -908,7 +967,6 @@ void makewt(int nw, int *ip, FFTFLT *w)
     }
 }
 
-
 void makeipt(int nw, int *ip)
 {
     int j, l, m, m2, p, q;
@@ -916,10 +974,12 @@ void makeipt(int nw, int *ip)
     ip[2] = 0;
     ip[3] = 16;
     m = 2;
-    for (l = nw; l > 32; l >>= 2) {
+    for(l = nw; l > 32; l >>= 2)
+    {
         m2 = m << 1;
         q = m2 << 3;
-        for (j = m; j < m2; j++) {
+        for(j = m; j < m2; j++)
+        {
             p = ip[j] << 2;
             ip[m + j] = p;
             ip[m2 + j] = p + q;
@@ -928,28 +988,27 @@ void makeipt(int nw, int *ip)
     }
 }
 
-
 void makect(int nc, int *ip, FFTFLT *c)
 {
     int j, nch;
     FFTFLT delta;
 
     ip[1] = nc;
-    if (nc > 1) {
+    if(nc > 1)
+    {
         nch = nc >> 1;
         delta = atan(1.0) / nch;
         c[0] = cos(delta * nch);
         c[nch] = 0.5 * c[0];
-        for (j = 1; j < nch; j++) {
+        for(j = 1; j < nch; j++)
+        {
             c[j] = 0.5 * cos(delta * j);
             c[nc - j] = 0.5 * sin(delta * j);
         }
     }
 }
 
-
 /* -------- child routines -------- */
-
 
 #ifdef USE_CDFT_PTHREADS
 #define USE_CDFT_THREADS
@@ -963,20 +1022,23 @@ void makect(int nc, int *ip, FFTFLT *c)
 #include <stdio.h>
 #include <stdlib.h>
 #define cdft_thread_t pthread_t
-#define cdft_thread_create(thp,func,argp) { \
-    if (pthread_create(thp, NULL, func, (void *) argp) != 0) { \
-        fprintf(stderr, "cdft thread error\n"); \
-        exit(1); \
-    } \
-}
-#define cdft_thread_wait(th) { \
-    if (pthread_join(th, NULL) != 0) { \
-        fprintf(stderr, "cdft thread error\n"); \
-        exit(1); \
-    } \
-}
+#define cdft_thread_create(thp, func, argp)                     \
+    {                                                           \
+        if(pthread_create(thp, NULL, func, (void *) argp) != 0) \
+        {                                                       \
+            fprintf(stderr, "cdft thread error\n");             \
+            exit(1);                                            \
+        }                                                       \
+    }
+#define cdft_thread_wait(th)                        \
+    {                                               \
+        if(pthread_join(th, NULL) != 0)             \
+        {                                           \
+            fprintf(stderr, "cdft thread error\n"); \
+            exit(1);                                \
+        }                                           \
+    }
 #endif /* USE_CDFT_PTHREADS */
-
 
 #ifdef USE_CDFT_WINTHREADS
 #define USE_CDFT_THREADS
@@ -990,116 +1052,151 @@ void makect(int nc, int *ip, FFTFLT *c)
 #include <stdio.h>
 #include <stdlib.h>
 #define cdft_thread_t HANDLE
-#define cdft_thread_create(thp,func,argp) { \
-    DWORD thid; \
-    *(thp) = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) func, (LPVOID) argp, 0, &thid); \
-    if (*(thp) == 0) { \
-        fprintf(stderr, "cdft thread error\n"); \
-        exit(1); \
-    } \
-}
-#define cdft_thread_wait(th) { \
-    WaitForSingleObject(th, INFINITE); \
-    CloseHandle(th); \
-}
+#define cdft_thread_create(thp, func, argp)                                   \
+    {                                                                         \
+        DWORD thid;                                                           \
+        *(thp) = CreateThread(                                                \
+            NULL, 0, (LPTHREAD_START_ROUTINE) func, (LPVOID) argp, 0, &thid); \
+        if(*(thp) == 0)                                                       \
+        {                                                                     \
+            fprintf(stderr, "cdft thread error\n");                           \
+            exit(1);                                                          \
+        }                                                                     \
+    }
+#define cdft_thread_wait(th)               \
+    {                                      \
+        WaitForSingleObject(th, INFINITE); \
+        CloseHandle(th);                   \
+    }
 #endif /* USE_CDFT_WINTHREADS */
-
 
 void cftfsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w)
 {
     void bitrv2(int n, int *ip, FFTFLT *a);
-    void bitrv216(FFTFLT *a);
-    void bitrv208(FFTFLT *a);
+    void bitrv216(FFTFLT * a);
+    void bitrv208(FFTFLT * a);
     void cftf1st(int n, FFTFLT *a, FFTFLT *w);
     void cftrec4(int n, FFTFLT *a, int nw, FFTFLT *w);
     void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w);
     void cftfx41(int n, FFTFLT *a, int nw, FFTFLT *w);
-    void cftf161(FFTFLT *a, FFTFLT *w);
-    void cftf081(FFTFLT *a, FFTFLT *w);
-    void cftf040(FFTFLT *a);
-    void cftx020(FFTFLT *a);
+    void cftf161(FFTFLT * a, FFTFLT * w);
+    void cftf081(FFTFLT * a, FFTFLT * w);
+    void cftf040(FFTFLT * a);
+    void cftx020(FFTFLT * a);
 #ifdef USE_CDFT_THREADS
     void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w);
 #endif /* USE_CDFT_THREADS */
 
-    if (n > 8) {
-        if (n > 32) {
+    if(n > 8)
+    {
+        if(n > 32)
+        {
             cftf1st(n, a, &w[nw - (n >> 2)]);
 #ifdef USE_CDFT_THREADS
-            if (n > CDFT_THREADS_BEGIN_N) {
+            if(n > CDFT_THREADS_BEGIN_N)
+            {
                 cftrec4_th(n, a, nw, w);
-            } else
-#endif /* USE_CDFT_THREADS */
-            if (n > 512) {
-                cftrec4(n, a, nw, w);
-            } else if (n > 128) {
-                cftleaf(n, 1, a, nw, w);
-            } else {
-                cftfx41(n, a, nw, w);
             }
+            else
+#endif /* USE_CDFT_THREADS */
+                if(n > 512)
+                {
+                    cftrec4(n, a, nw, w);
+                }
+                else if(n > 128)
+                {
+                    cftleaf(n, 1, a, nw, w);
+                }
+                else
+                {
+                    cftfx41(n, a, nw, w);
+                }
             bitrv2(n, ip, a);
-        } else if (n == 32) {
+        }
+        else if(n == 32)
+        {
             cftf161(a, &w[nw - 8]);
             bitrv216(a);
-        } else {
+        }
+        else
+        {
             cftf081(a, w);
             bitrv208(a);
         }
-    } else if (n == 8) {
+    }
+    else if(n == 8)
+    {
         cftf040(a);
-    } else if (n == 4) {
+    }
+    else if(n == 4)
+    {
         cftx020(a);
     }
 }
-
 
 void cftbsub(int n, FFTFLT *a, int *ip, int nw, FFTFLT *w)
 {
     void bitrv2conj(int n, int *ip, FFTFLT *a);
-    void bitrv216neg(FFTFLT *a);
-    void bitrv208neg(FFTFLT *a);
+    void bitrv216neg(FFTFLT * a);
+    void bitrv208neg(FFTFLT * a);
     void cftb1st(int n, FFTFLT *a, FFTFLT *w);
     void cftrec4(int n, FFTFLT *a, int nw, FFTFLT *w);
     void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w);
     void cftfx41(int n, FFTFLT *a, int nw, FFTFLT *w);
-    void cftf161(FFTFLT *a, FFTFLT *w);
-    void cftf081(FFTFLT *a, FFTFLT *w);
-    void cftb040(FFTFLT *a);
-    void cftx020(FFTFLT *a);
+    void cftf161(FFTFLT * a, FFTFLT * w);
+    void cftf081(FFTFLT * a, FFTFLT * w);
+    void cftb040(FFTFLT * a);
+    void cftx020(FFTFLT * a);
 #ifdef USE_CDFT_THREADS
     void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w);
 #endif /* USE_CDFT_THREADS */
 
-    if (n > 8) {
-        if (n > 32) {
+    if(n > 8)
+    {
+        if(n > 32)
+        {
             cftb1st(n, a, &w[nw - (n >> 2)]);
 #ifdef USE_CDFT_THREADS
-            if (n > CDFT_THREADS_BEGIN_N) {
+            if(n > CDFT_THREADS_BEGIN_N)
+            {
                 cftrec4_th(n, a, nw, w);
-            } else
-#endif /* USE_CDFT_THREADS */
-            if (n > 512) {
-                cftrec4(n, a, nw, w);
-            } else if (n > 128) {
-                cftleaf(n, 1, a, nw, w);
-            } else {
-                cftfx41(n, a, nw, w);
             }
+            else
+#endif /* USE_CDFT_THREADS */
+                if(n > 512)
+                {
+                    cftrec4(n, a, nw, w);
+                }
+                else if(n > 128)
+                {
+                    cftleaf(n, 1, a, nw, w);
+                }
+                else
+                {
+                    cftfx41(n, a, nw, w);
+                }
             bitrv2conj(n, ip, a);
-        } else if (n == 32) {
+        }
+        else if(n == 32)
+        {
             cftf161(a, &w[nw - 8]);
             bitrv216neg(a);
-        } else {
+        }
+        else
+        {
             cftf081(a, w);
             bitrv208neg(a);
         }
-    } else if (n == 8) {
+    }
+    else if(n == 8)
+    {
         cftb040(a);
-    } else if (n == 4) {
+    }
+    else if(n == 4)
+    {
         cftx020(a);
     }
 }
-
 
 void bitrv2(int n, int *ip, FFTFLT *a)
 {
@@ -1107,14 +1204,18 @@ void bitrv2(int n, int *ip, FFTFLT *a)
     FFTFLT xr, xi, yr, yi;
 
     m = 1;
-    for (l = n >> 2; l > 8; l >>= 2) {
+    for(l = n >> 2; l > 8; l >>= 2)
+    {
         m <<= 1;
     }
     nh = n >> 1;
     nm = 4 * m;
-    if (l == 8) {
-        for (k = 0; k < m; k++) {
-            for (j = 0; j < k; j++) {
+    if(l == 8)
+    {
+        for(k = 0; k < m; k++)
+        {
+            for(j = 0; j < k; j++)
+            {
                 j1 = 4 * j + 2 * ip[m + k];
                 k1 = 4 * k + 2 * ip[m + j];
                 xr = a[j1];
@@ -1338,9 +1439,13 @@ void bitrv2(int n, int *ip, FFTFLT *a)
             a[k1] = xr;
             a[k1 + 1] = xi;
         }
-    } else {
-        for (k = 0; k < m; k++) {
-            for (j = 0; j < k; j++) {
+    }
+    else
+    {
+        for(k = 0; k < m; k++)
+        {
+            for(j = 0; j < k; j++)
+            {
                 j1 = 4 * j + ip[m + k];
                 k1 = 4 * k + ip[m + j];
                 xr = a[j1];
@@ -1446,7 +1551,6 @@ void bitrv2(int n, int *ip, FFTFLT *a)
         }
     }
 }
-
 
 void bitrv2conj(int n, int *ip, FFTFLT *a)
 {
@@ -1454,14 +1558,18 @@ void bitrv2conj(int n, int *ip, FFTFLT *a)
     FFTFLT xr, xi, yr, yi;
 
     m = 1;
-    for (l = n >> 2; l > 8; l >>= 2) {
+    for(l = n >> 2; l > 8; l >>= 2)
+    {
         m <<= 1;
     }
     nh = n >> 1;
     nm = 4 * m;
-    if (l == 8) {
-        for (k = 0; k < m; k++) {
-            for (j = 0; j < k; j++) {
+    if(l == 8)
+    {
+        for(k = 0; k < m; k++)
+        {
+            for(j = 0; j < k; j++)
+            {
                 j1 = 4 * j + 2 * ip[m + k];
                 k1 = 4 * k + 2 * ip[m + j];
                 xr = a[j1];
@@ -1689,9 +1797,13 @@ void bitrv2conj(int n, int *ip, FFTFLT *a)
             a[k1 + 1] = xi;
             a[k1 + 3] = -a[k1 + 3];
         }
-    } else {
-        for (k = 0; k < m; k++) {
-            for (j = 0; j < k; j++) {
+    }
+    else
+    {
+        for(k = 0; k < m; k++)
+        {
+            for(j = 0; j < k; j++)
+            {
                 j1 = 4 * j + ip[m + k];
                 k1 = 4 * k + ip[m + j];
                 xr = a[j1];
@@ -1802,12 +1914,10 @@ void bitrv2conj(int n, int *ip, FFTFLT *a)
     }
 }
 
-
 void bitrv216(FFTFLT *a)
 {
-    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i,
-        x5r, x5i, x7r, x7i, x8r, x8i, x10r, x10i,
-        x11r, x11i, x12r, x12i, x13r, x13i, x14r, x14i;
+    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x7r, x7i, x8r, x8i,
+        x10r, x10i, x11r, x11i, x12r, x12i, x13r, x13i, x14r, x14i;
 
     x1r = a[2];
     x1i = a[3];
@@ -1859,13 +1969,11 @@ void bitrv216(FFTFLT *a)
     a[29] = x7i;
 }
 
-
 void bitrv216neg(FFTFLT *a)
 {
-    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i,
-        x5r, x5i, x6r, x6i, x7r, x7i, x8r, x8i,
-        x9r, x9i, x10r, x10i, x11r, x11i, x12r, x12i,
-        x13r, x13i, x14r, x14i, x15r, x15i;
+    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x6r, x6i, x7r, x7i,
+        x8r, x8i, x9r, x9i, x10r, x10i, x11r, x11i, x12r, x12i, x13r, x13i,
+        x14r, x14i, x15r, x15i;
 
     x1r = a[2];
     x1i = a[3];
@@ -1929,7 +2037,6 @@ void bitrv216neg(FFTFLT *a)
     a[31] = x8i;
 }
 
-
 void bitrv208(FFTFLT *a)
 {
     FFTFLT x1r, x1i, x3r, x3i, x4r, x4i, x6r, x6i;
@@ -1952,11 +2059,9 @@ void bitrv208(FFTFLT *a)
     a[13] = x3i;
 }
 
-
 void bitrv208neg(FFTFLT *a)
 {
-    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i,
-        x5r, x5i, x6r, x6i, x7r, x7i;
+    FFTFLT x1r, x1i, x2r, x2i, x3r, x3i, x4r, x4i, x5r, x5i, x6r, x6i, x7r, x7i;
 
     x1r = a[2];
     x1i = a[3];
@@ -1988,14 +2093,12 @@ void bitrv208neg(FFTFLT *a)
     a[15] = x4i;
 }
 
-
 void cftf1st(int n, FFTFLT *a, FFTFLT *w)
 {
     int j, j0, j1, j2, j3, k, m, mh;
-    FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i,
-        wd1r, wd1i, wd3r, wd3i;
-    FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i;
+    FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
+    FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i,
+        y3r, y3i;
 
     mh = n >> 3;
     m = 2 * mh;
@@ -2026,7 +2129,8 @@ void cftf1st(int n, FFTFLT *a, FFTFLT *w)
     wd3r = 1;
     wd3i = 0;
     k = 0;
-    for (j = 2; j < mh - 2; j += 4) {
+    for(j = 2; j < mh - 2; j += 4)
+    {
         k += 4;
         wk1r = csc1 * (wd1r + w[k]);
         wk1i = csc1 * (wd1i + w[k + 1]);
@@ -2194,14 +2298,12 @@ void cftf1st(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 3] = wk3i * x0i - wk3r * x0r;
 }
 
-
 void cftb1st(int n, FFTFLT *a, FFTFLT *w)
 {
     int j, j0, j1, j2, j3, k, m, mh;
-    FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i,
-        wd1r, wd1i, wd3r, wd3i;
-    FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i;
+    FFTFLT wn4r, csc1, csc3, wk1r, wk1i, wk3r, wk3i, wd1r, wd1i, wd3r, wd3i;
+    FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i, y2r, y2i,
+        y3r, y3i;
 
     mh = n >> 3;
     m = 2 * mh;
@@ -2232,7 +2334,8 @@ void cftb1st(int n, FFTFLT *a, FFTFLT *w)
     wd3r = 1;
     wd3i = 0;
     k = 0;
-    for (j = 2; j < mh - 2; j += 4) {
+    for(j = 2; j < mh - 2; j += 4)
+    {
         k += 4;
         wk1r = csc1 * (wd1r + w[k]);
         wk1i = csc1 * (wd1i + w[k + 1]);
@@ -2400,9 +2503,9 @@ void cftb1st(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 3] = wk3i * x0i - wk3r * x0r;
 }
 
-
 #ifdef USE_CDFT_THREADS
-struct cdft_arg_st {
+struct cdft_arg_st
+{
     int n0;
     int n;
     FFTFLT *a;
@@ -2410,7 +2513,6 @@ struct cdft_arg_st {
     FFTFLT *w;
 };
 typedef struct cdft_arg_st cdft_arg_t;
-
 
 void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w)
 {
@@ -2423,28 +2525,33 @@ void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w)
     nthread = 2;
     idiv4 = 0;
     m = n >> 1;
-    if (n > CDFT_4THREADS_BEGIN_N) {
+    if(n > CDFT_4THREADS_BEGIN_N)
+    {
         nthread = 4;
         idiv4 = 1;
         m >>= 1;
     }
-    for (i = 0; i < nthread; i++) {
+    for(i = 0; i < nthread; i++)
+    {
         ag[i].n0 = n;
         ag[i].n = m;
         ag[i].a = &a[i * m];
         ag[i].nw = nw;
         ag[i].w = w;
-        if (i != idiv4) {
+        if(i != idiv4)
+        {
             cdft_thread_create(&th[i], cftrec1_th, &ag[i]);
-        } else {
+        }
+        else
+        {
             cdft_thread_create(&th[i], cftrec2_th, &ag[i]);
         }
     }
-    for (i = 0; i < nthread; i++) {
+    for(i = 0; i < nthread; i++)
+    {
         cdft_thread_wait(th[i]);
     }
 }
-
 
 void *cftrec1_th(void *p)
 {
@@ -2460,20 +2567,21 @@ void *cftrec1_th(void *p)
     nw = ((cdft_arg_t *) p)->nw;
     w = ((cdft_arg_t *) p)->w;
     m = n0;
-    while (m > 512) {
+    while(m > 512)
+    {
         m >>= 2;
         cftmdl1(m, &a[n - m], &w[nw - (m >> 1)]);
     }
     cftleaf(m, 1, &a[n - m], nw, w);
     k = 0;
-    for (j = n - m; j > 0; j -= m) {
+    for(j = n - m; j > 0; j -= m)
+    {
         k++;
         isplt = cfttree(m, j, k, a, nw, w);
         cftleaf(m, isplt, &a[j - m], nw, w);
     }
     return (void *) 0;
 }
-
 
 void *cftrec2_th(void *p)
 {
@@ -2490,14 +2598,16 @@ void *cftrec2_th(void *p)
     w = ((cdft_arg_t *) p)->w;
     k = 1;
     m = n0;
-    while (m > 512) {
+    while(m > 512)
+    {
         m >>= 2;
         k <<= 2;
         cftmdl2(m, &a[n - m], &w[nw - m]);
     }
     cftleaf(m, 0, &a[n - m], nw, w);
     k >>= 1;
-    for (j = n - m; j > 0; j -= m) {
+    for(j = n - m; j > 0; j -= m)
+    {
         k++;
         isplt = cfttree(m, j, k, a, nw, w);
         cftleaf(m, isplt, &a[j - m], nw, w);
@@ -2505,7 +2615,6 @@ void *cftrec2_th(void *p)
     return (void *) 0;
 }
 #endif /* USE_CDFT_THREADS */
-
 
 void cftrec4(int n, FFTFLT *a, int nw, FFTFLT *w)
 {
@@ -2515,19 +2624,20 @@ void cftrec4(int n, FFTFLT *a, int nw, FFTFLT *w)
     int isplt, j, k, m;
 
     m = n;
-    while (m > 512) {
+    while(m > 512)
+    {
         m >>= 2;
         cftmdl1(m, &a[n - m], &w[nw - (m >> 1)]);
     }
     cftleaf(m, 1, &a[n - m], nw, w);
     k = 0;
-    for (j = n - m; j > 0; j -= m) {
+    for(j = n - m; j > 0; j -= m)
+    {
         k++;
         isplt = cfttree(m, j, k, a, nw, w);
         cftleaf(m, isplt, &a[j - m], nw, w);
     }
 }
-
 
 int cfttree(int n, int j, int k, FFTFLT *a, int nw, FFTFLT *w)
 {
@@ -2535,26 +2645,38 @@ int cfttree(int n, int j, int k, FFTFLT *a, int nw, FFTFLT *w)
     void cftmdl2(int n, FFTFLT *a, FFTFLT *w);
     int i, isplt, m;
 
-    if ((k & 3) != 0) {
+    if((k & 3) != 0)
+    {
         isplt = k & 1;
-        if (isplt != 0) {
+        if(isplt != 0)
+        {
             cftmdl1(n, &a[j - n], &w[nw - (n >> 1)]);
-        } else {
+        }
+        else
+        {
             cftmdl2(n, &a[j - n], &w[nw - n]);
         }
-    } else {
+    }
+    else
+    {
         m = n;
-        for (i = k; (i & 3) == 0; i >>= 2) {
+        for(i = k; (i & 3) == 0; i >>= 2)
+        {
             m <<= 2;
         }
         isplt = i & 1;
-        if (isplt != 0) {
-            while (m > 128) {
+        if(isplt != 0)
+        {
+            while(m > 128)
+            {
                 cftmdl1(m, &a[j - m], &w[nw - (m >> 1)]);
                 m >>= 2;
             }
-        } else {
-            while (m > 128) {
+        }
+        else
+        {
+            while(m > 128)
+            {
                 cftmdl2(m, &a[j - m], &w[nw - m]);
                 m >>= 2;
             }
@@ -2563,17 +2685,17 @@ int cfttree(int n, int j, int k, FFTFLT *a, int nw, FFTFLT *w)
     return isplt;
 }
 
-
 void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w)
 {
     void cftmdl1(int n, FFTFLT *a, FFTFLT *w);
     void cftmdl2(int n, FFTFLT *a, FFTFLT *w);
-    void cftf161(FFTFLT *a, FFTFLT *w);
-    void cftf162(FFTFLT *a, FFTFLT *w);
-    void cftf081(FFTFLT *a, FFTFLT *w);
-    void cftf082(FFTFLT *a, FFTFLT *w);
+    void cftf161(FFTFLT * a, FFTFLT * w);
+    void cftf162(FFTFLT * a, FFTFLT * w);
+    void cftf081(FFTFLT * a, FFTFLT * w);
+    void cftf082(FFTFLT * a, FFTFLT * w);
 
-    if (n == 512) {
+    if(n == 512)
+    {
         cftmdl1(128, a, &w[nw - 64]);
         cftf161(a, &w[nw - 8]);
         cftf162(&a[32], &w[nw - 32]);
@@ -2589,17 +2711,22 @@ void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w)
         cftf162(&a[288], &w[nw - 32]);
         cftf161(&a[320], &w[nw - 8]);
         cftf161(&a[352], &w[nw - 8]);
-        if (isplt != 0) {
+        if(isplt != 0)
+        {
             cftmdl1(128, &a[384], &w[nw - 64]);
             cftf161(&a[480], &w[nw - 8]);
-        } else {
+        }
+        else
+        {
             cftmdl2(128, &a[384], &w[nw - 128]);
             cftf162(&a[480], &w[nw - 32]);
         }
         cftf161(&a[384], &w[nw - 8]);
         cftf162(&a[416], &w[nw - 32]);
         cftf161(&a[448], &w[nw - 8]);
-    } else {
+    }
+    else
+    {
         cftmdl1(64, a, &w[nw - 32]);
         cftf081(a, &w[nw - 8]);
         cftf082(&a[16], &w[nw - 8]);
@@ -2615,10 +2742,13 @@ void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w)
         cftf082(&a[144], &w[nw - 8]);
         cftf081(&a[160], &w[nw - 8]);
         cftf081(&a[176], &w[nw - 8]);
-        if (isplt != 0) {
+        if(isplt != 0)
+        {
             cftmdl1(64, &a[192], &w[nw - 32]);
             cftf081(&a[240], &w[nw - 8]);
-        } else {
+        }
+        else
+        {
             cftmdl2(64, &a[192], &w[nw - 64]);
             cftf082(&a[240], &w[nw - 8]);
         }
@@ -2627,7 +2757,6 @@ void cftleaf(int n, int isplt, FFTFLT *a, int nw, FFTFLT *w)
         cftf081(&a[224], &w[nw - 8]);
     }
 }
-
 
 void cftmdl1(int n, FFTFLT *a, FFTFLT *w)
 {
@@ -2658,7 +2787,8 @@ void cftmdl1(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 1] = x1i - x3r;
     wn4r = w[1];
     k = 0;
-    for (j = 2; j < mh; j += 2) {
+    for(j = 2; j < mh; j += 2)
+    {
         k += 4;
         wk1r = w[k];
         wk1i = w[k + 1];
@@ -2738,7 +2868,6 @@ void cftmdl1(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 1] = -wn4r * (x0i - x0r);
 }
 
-
 void cftmdl2(int n, FFTFLT *a, FFTFLT *w)
 {
     int j, j0, j1, j2, j3, k, kr, m, mh;
@@ -2773,7 +2902,8 @@ void cftmdl2(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 1] = x1i - y0r;
     k = 0;
     kr = 2 * m;
-    for (j = 2; j < mh; j += 2) {
+    for(j = 2; j < mh; j += 2)
+    {
         k += 4;
         wk1r = w[k];
         wk1i = w[k + 1];
@@ -2872,20 +3002,22 @@ void cftmdl2(int n, FFTFLT *a, FFTFLT *w)
     a[j3 + 1] = y0i + y2i;
 }
 
-
 void cftfx41(int n, FFTFLT *a, int nw, FFTFLT *w)
 {
-    void cftf161(FFTFLT *a, FFTFLT *w);
-    void cftf162(FFTFLT *a, FFTFLT *w);
-    void cftf081(FFTFLT *a, FFTFLT *w);
-    void cftf082(FFTFLT *a, FFTFLT *w);
+    void cftf161(FFTFLT * a, FFTFLT * w);
+    void cftf162(FFTFLT * a, FFTFLT * w);
+    void cftf081(FFTFLT * a, FFTFLT * w);
+    void cftf082(FFTFLT * a, FFTFLT * w);
 
-    if (n == 128) {
+    if(n == 128)
+    {
         cftf161(a, &w[nw - 8]);
         cftf162(&a[32], &w[nw - 32]);
         cftf161(&a[64], &w[nw - 8]);
         cftf161(&a[96], &w[nw - 8]);
-    } else {
+    }
+    else
+    {
         cftf081(a, &w[nw - 8]);
         cftf082(&a[16], &w[nw - 8]);
         cftf081(&a[32], &w[nw - 8]);
@@ -2893,15 +3025,12 @@ void cftfx41(int n, FFTFLT *a, int nw, FFTFLT *w)
     }
 }
 
-
 void cftf161(FFTFLT *a, FFTFLT *w)
 {
-    FFTFLT wn4r, wk1r, wk1i,
-        x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i,
-        y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i,
-        y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i,
-        y12r, y12i, y13r, y13i, y14r, y14i, y15r, y15i;
+    FFTFLT wn4r, wk1r, wk1i, x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i,
+        y1r, y1i, y2r, y2i, y3r, y3i, y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i,
+        y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i, y12r, y12i, y13r, y13i,
+        y14r, y14i, y15r, y15i;
 
     wn4r = w[1];
     wk1r = w[2];
@@ -3052,15 +3181,12 @@ void cftf161(FFTFLT *a, FFTFLT *w)
     a[7] = x1i - x3r;
 }
 
-
 void cftf162(FFTFLT *a, FFTFLT *w)
 {
-    FFTFLT wn4r, wk1r, wk1i, wk2r, wk2i, wk3r, wk3i,
-        x0r, x0i, x1r, x1i, x2r, x2i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i,
-        y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i,
-        y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i,
-        y12r, y12i, y13r, y13i, y14r, y14i, y15r, y15i;
+    FFTFLT wn4r, wk1r, wk1i, wk2r, wk2i, wk3r, wk3i, x0r, x0i, x1r, x1i, x2r,
+        x2i, y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i, y4r, y4i, y5r, y5i, y6r,
+        y6i, y7r, y7i, y8r, y8i, y9r, y9i, y10r, y10i, y11r, y11i, y12r, y12i,
+        y13r, y13i, y14r, y14i, y15r, y15i;
 
     wn4r = w[1];
     wk1r = w[4];
@@ -3235,12 +3361,10 @@ void cftf162(FFTFLT *a, FFTFLT *w)
     a[31] = x1i - x2r;
 }
 
-
 void cftf081(FFTFLT *a, FFTFLT *w)
 {
-    FFTFLT wn4r, x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i,
-        y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i;
+    FFTFLT wn4r, x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i, y0r, y0i, y1r, y1i,
+        y2r, y2i, y3r, y3i, y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i;
 
     wn4r = w[1];
     x0r = a[0] + a[8];
@@ -3297,12 +3421,10 @@ void cftf081(FFTFLT *a, FFTFLT *w)
     a[7] = y2i - y6r;
 }
 
-
 void cftf082(FFTFLT *a, FFTFLT *w)
 {
-    FFTFLT wn4r, wk1r, wk1i, x0r, x0i, x1r, x1i,
-        y0r, y0i, y1r, y1i, y2r, y2i, y3r, y3i,
-        y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i;
+    FFTFLT wn4r, wk1r, wk1i, x0r, x0i, x1r, x1i, y0r, y0i, y1r, y1i, y2r, y2i,
+        y3r, y3i, y4r, y4i, y5r, y5i, y6r, y6i, y7r, y7i;
 
     wn4r = w[1];
     wk1r = w[2];
@@ -3369,7 +3491,6 @@ void cftf082(FFTFLT *a, FFTFLT *w)
     a[15] = x0i - x1r;
 }
 
-
 void cftf040(FFTFLT *a)
 {
     FFTFLT x0r, x0i, x1r, x1i, x2r, x2i, x3r, x3i;
@@ -3391,7 +3512,6 @@ void cftf040(FFTFLT *a)
     a[6] = x1r + x3i;
     a[7] = x1i - x3r;
 }
-
 
 void cftb040(FFTFLT *a)
 {
@@ -3415,7 +3535,6 @@ void cftb040(FFTFLT *a)
     a[7] = x1i + x3r;
 }
 
-
 void cftx020(FFTFLT *a)
 {
     FFTFLT x0r, x0i;
@@ -3428,7 +3547,6 @@ void cftx020(FFTFLT *a)
     a[3] = x0i;
 }
 
-
 void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
     int j, k, kk, ks, m;
@@ -3437,7 +3555,8 @@ void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     m = n >> 1;
     ks = 2 * nc / m;
     kk = 0;
-    for (j = 2; j < m; j += 2) {
+    for(j = 2; j < m; j += 2)
+    {
         k = n - j;
         kk += ks;
         wkr = 0.5 - c[nc - kk];
@@ -3453,7 +3572,6 @@ void rftfsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     }
 }
 
-
 void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
     int j, k, kk, ks, m;
@@ -3462,7 +3580,8 @@ void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     m = n >> 1;
     ks = 2 * nc / m;
     kk = 0;
-    for (j = 2; j < m; j += 2) {
+    for(j = 2; j < m; j += 2)
+    {
         k = n - j;
         kk += ks;
         wkr = 0.5 - c[nc - kk];
@@ -3478,7 +3597,6 @@ void rftbsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     }
 }
 
-
 void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
     int j, k, kk, ks, m;
@@ -3487,7 +3605,8 @@ void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     m = n >> 1;
     ks = nc / n;
     kk = 0;
-    for (j = 1; j < m; j++) {
+    for(j = 1; j < m; j++)
+    {
         k = n - j;
         kk += ks;
         wkr = c[kk] - c[nc - kk];
@@ -3499,7 +3618,6 @@ void dctsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     a[m] *= c[0];
 }
 
-
 void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c)
 {
     int j, k, kk, ks, m;
@@ -3508,7 +3626,8 @@ void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     m = n >> 1;
     ks = nc / n;
     kk = 0;
-    for (j = 1; j < m; j++) {
+    for(j = 1; j < m; j++)
+    {
         k = n - j;
         kk += ks;
         wkr = c[kk] - c[nc - kk];
@@ -3519,4 +3638,3 @@ void dstsub(int n, FFTFLT *a, int nc, FFTFLT *c)
     }
     a[m] *= c[0];
 }
-

--- a/src/d_fft_fftsg.c
+++ b/src/d_fft_fftsg.c
@@ -2577,7 +2577,7 @@ void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w)
 {
     void *cftrec1_th(void *p);
     void *cftrec2_th(void *p);
-    int i, idiv4, m, nthread;
+    int idiv4, m, nthread;
     cdft_thread_t th[4];
     cdft_arg_t ag[4];
 
@@ -2590,7 +2590,7 @@ void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w)
         idiv4 = 1;
         m >>= 1;
     }
-    for(i = 0; i < nthread; i++)
+    for(int i = 0; i < nthread; i++)
     {
         ag[i].n0 = n;
         ag[i].n = m;
@@ -2606,7 +2606,7 @@ void cftrec4_th(int n, FFTFLT *a, int nw, FFTFLT *w)
             cdft_thread_create(&th[i], cftrec2_th, &ag[i]);
         }
     }
-    for(i = 0; i < nthread; i++)
+    for(int i = 0; i < nthread; i++)
     {
         cdft_thread_wait(th[i]);
     }

--- a/src/d_fft_fftw.c
+++ b/src/d_fft_fftw.c
@@ -74,16 +74,14 @@ static cfftw_info *cfftw_getplan(int n, int fwd)
 
 static void cfftw_term(void)
 {
-    int i;
-    int j;
     cfftw_info *cinfo[2];
 
-    for(i = 0; i < MAXFFT + 1 - MINFFT; i++)
+    for(int i = 0; i < MAXFFT + 1 - MINFFT; i++)
     {
         cinfo[0] = &cfftw_fwd[i];
         cinfo[1] = &cfftw_bwd[i];
 
-        for(j = 0; j < 2; j++)
+        for(int j = 0; j < 2; j++)
         {
             if(cinfo[j]->plan)
             {
@@ -127,16 +125,14 @@ static rfftw_info *rfftw_getplan(int n, int fwd)
 
 static void rfftw_term(void)
 {
-    int i;
-    int j;
     rfftw_info *rinfo[2];
 
-    for(i = 0; i < MAXFFT + 1 - MINFFT; i++)
+    for(int i = 0; i < MAXFFT + 1 - MINFFT; i++)
     {
         rinfo[0] = &rfftw_fwd[i];
         rinfo[1] = &rfftw_bwd[i];
 
-        for(j = 0; j < 2; j++)
+        for(int j = 0; j < 2; j++)
         {
             if(rinfo[j]->plan)
             {
@@ -206,31 +202,29 @@ EXTERN void mayer_ifft(int n, t_sample *fz1, t_sample *fz2)
 
 EXTERN void mayer_realfft(int n, t_sample *fz)
 {
-    int i;
     rfftw_info *p = rfftw_getplan(n, 1);
     if(!p) return;
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         p->in[i] = fz[i];
     fftwf_execute(p->plan);
-    for(i = 0; i < n / 2 + 1; i++)
+    for(int i = 0; i < n / 2 + 1; i++)
         fz[i] = p->out[i];
-    for(; i < n; i++)
+    for(int i = n / 2 + 1; i < n; i++)
         fz[i] = -p->out[i];
 }
 
 EXTERN void mayer_realifft(int n, t_sample *fz)
 {
-    int i;
     rfftw_info *p = rfftw_getplan(n, 0);
     if(!p) return;
 
-    for(i = 0; i < n / 2 + 1; i++)
+    for(int i = 0; i < n / 2 + 1; i++)
         p->in[i] = fz[i];
-    for(; i < n; i++)
+    for(int i = n / 2 + 1; i < n; i++)
         p->in[i] = -fz[i];
     fftwf_execute(p->plan);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         fz[i] = p->out[i];
 }
 

--- a/src/d_fft_fftw.c
+++ b/src/d_fft_fftw.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997- Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* --------- Pd interface to FFTW library; imitate Mayer API ---------- */
 
@@ -40,31 +40,32 @@ respectively. The flags argument is either FFTW_MEASURE
 
 /* complex stuff */
 
-typedef struct {
+typedef struct
+{
     fftwf_plan plan;
-    fftwf_complex *in,*out;
+    fftwf_complex *in, *out;
 } cfftw_info;
 
-static cfftw_info cfftw_fwd[MAXFFT+1 - MINFFT],cfftw_bwd[MAXFFT+1 - MINFFT];
+static cfftw_info cfftw_fwd[MAXFFT + 1 - MINFFT],
+    cfftw_bwd[MAXFFT + 1 - MINFFT];
 
-static cfftw_info *cfftw_getplan(int n,int fwd)
+static cfftw_info *cfftw_getplan(int n, int fwd)
 {
     cfftw_info *info;
     int logn = ilog2(n);
-    if (logn < MINFFT || logn > MAXFFT)
-        return (0);
-    info = (fwd?cfftw_fwd:cfftw_bwd)+(logn-MINFFT);
-    if (!info->plan)
+    if(logn < MINFFT || logn > MAXFFT) return (0);
+    info = (fwd ? cfftw_fwd : cfftw_bwd) + (logn - MINFFT);
+    if(!info->plan)
     {
         pd_globallock();
-        if (!info->plan)    /* recheck in case it got set while we waited */
+        if(!info->plan) /* recheck in case it got set while we waited */
         {
             info->in =
-                (fftwf_complex*) fftwf_malloc(sizeof(fftwf_complex) * n);
+                (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex) * n);
             info->out =
-                (fftwf_complex*) fftwf_malloc(sizeof(fftwf_complex) * n);
+                (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex) * n);
             info->plan = fftwf_plan_dft_1d(n, info->in, info->out,
-                fwd?FFTW_FORWARD:FFTW_BACKWARD, FFTW_MEASURE);
+                fwd ? FFTW_FORWARD : FFTW_BACKWARD, FFTW_MEASURE);
         }
         pd_globalunlock();
     }
@@ -76,48 +77,49 @@ static void cfftw_term(void)
     int i, j;
     cfftw_info *cinfo[2];
 
-    for (i = 0; i < MAXFFT+1 - MINFFT; i++)
+    for(i = 0; i < MAXFFT + 1 - MINFFT; i++)
     {
-      cinfo[0] = &cfftw_fwd[i];
-      cinfo[1] = &cfftw_bwd[i];
+        cinfo[0] = &cfftw_fwd[i];
+        cinfo[1] = &cfftw_bwd[i];
 
-      for (j = 0; j < 2; j++)
-      {
-        if (cinfo[j]->plan)
+        for(j = 0; j < 2; j++)
         {
-          fftwf_destroy_plan(cinfo[j]->plan);
-          fftwf_free(cinfo[j]->in);
-          fftwf_free(cinfo[j]->out);
-          cinfo[j]->plan = 0;
-          cinfo[j]->in = 0;
-          cinfo[j]->out = 0;
+            if(cinfo[j]->plan)
+            {
+                fftwf_destroy_plan(cinfo[j]->plan);
+                fftwf_free(cinfo[j]->in);
+                fftwf_free(cinfo[j]->out);
+                cinfo[j]->plan = 0;
+                cinfo[j]->in = 0;
+                cinfo[j]->out = 0;
+            }
         }
-      }
     }
 }
 
-
 /* real stuff */
 
-typedef struct {
+typedef struct
+{
     fftwf_plan plan;
-    float *in,*out;
+    float *in, *out;
 } rfftw_info;
 
-static rfftw_info rfftw_fwd[MAXFFT+1 - MINFFT],rfftw_bwd[MAXFFT+1 - MINFFT];
+static rfftw_info rfftw_fwd[MAXFFT + 1 - MINFFT],
+    rfftw_bwd[MAXFFT + 1 - MINFFT];
 
-static rfftw_info *rfftw_getplan(int n,int fwd)
+static rfftw_info *rfftw_getplan(int n, int fwd)
 {
     rfftw_info *info;
     int logn = ilog2(n);
-    if (logn < MINFFT || logn > MAXFFT)
-        return (0);
-    info = (fwd?rfftw_fwd:rfftw_bwd)+(logn-MINFFT);
-    if (!info->plan)
+    if(logn < MINFFT || logn > MAXFFT) return (0);
+    info = (fwd ? rfftw_fwd : rfftw_bwd) + (logn - MINFFT);
+    if(!info->plan)
     {
-        info->in = (float*) fftwf_malloc(sizeof(float) * n);
-        info->out = (float*) fftwf_malloc(sizeof(float) * n);
-        info->plan = fftwf_plan_r2r_1d(n, info->in, info->out, fwd?FFTW_R2HC:FFTW_HC2R, FFTW_MEASURE);
+        info->in = (float *) fftwf_malloc(sizeof(float) * n);
+        info->out = (float *) fftwf_malloc(sizeof(float) * n);
+        info->plan = fftwf_plan_r2r_1d(
+            n, info->in, info->out, fwd ? FFTW_R2HC : FFTW_HC2R, FFTW_MEASURE);
     }
     return info;
 }
@@ -127,23 +129,23 @@ static void rfftw_term(void)
     int i, j;
     rfftw_info *rinfo[2];
 
-    for (i = 0; i < MAXFFT+1 - MINFFT; i++)
+    for(i = 0; i < MAXFFT + 1 - MINFFT; i++)
     {
-      rinfo[0] = &rfftw_fwd[i];
-      rinfo[1] = &rfftw_bwd[i];
+        rinfo[0] = &rfftw_fwd[i];
+        rinfo[1] = &rfftw_bwd[i];
 
-      for (j = 0; j < 2; j++)
-      {
-        if (rinfo[j]->plan)
+        for(j = 0; j < 2; j++)
         {
-          fftwf_destroy_plan(rinfo[j]->plan);
-          fftwf_free(rinfo[j]->in);
-          fftwf_free(rinfo[j]->out);
-          rinfo[j]->plan = 0;
-          rinfo[j]->in = 0;
-          rinfo[j]->out = 0;
+            if(rinfo[j]->plan)
+            {
+                fftwf_destroy_plan(rinfo[j]->plan);
+                fftwf_free(rinfo[j]->in);
+                fftwf_free(rinfo[j]->out);
+                rinfo[j]->plan = 0;
+                rinfo[j]->in = 0;
+                rinfo[j]->out = 0;
+            }
         }
-      }
     }
 }
 
@@ -151,7 +153,7 @@ static int mayer_refcount = 0;
 
 void mayer_init(void)
 {
-    if (mayer_refcount++ == 0)
+    if(mayer_refcount++ == 0)
     {
         /* nothing to do */
     }
@@ -159,34 +161,29 @@ void mayer_init(void)
 
 void mayer_term(void)
 {
-    if (--mayer_refcount == 0)
+    if(--mayer_refcount == 0)
     {
         cfftw_term();
         rfftw_term();
     }
 }
 
-
-EXTERN void mayer_fht(t_sample *fz, int n)
-{
-    post("FHT: not yet implemented");
-}
+EXTERN void mayer_fht(t_sample *fz, int n) { post("FHT: not yet implemented"); }
 
 static void mayer_do_cfft(int n, t_sample *fz1, t_sample *fz2, int fwd)
 {
     int i;
     float *fz;
     cfftw_info *p = cfftw_getplan(n, fwd);
-    if (!p)
-        return;
+    if(!p) return;
 
-    for (i = 0, fz = (float *)p->in; i < n; i++)
-        fz[i*2] = fz1[i], fz[i*2+1] = fz2[i];
+    for(i = 0, fz = (float *) p->in; i < n; i++)
+        fz[i * 2] = fz1[i], fz[i * 2 + 1] = fz2[i];
 
     fftwf_execute(p->plan);
 
-    for (i = 0, fz = (float *)p->out; i < n; i++)
-        fz1[i] = fz[i*2], fz2[i] = fz[i*2+1];
+    for(i = 0, fz = (float *) p->out; i < n; i++)
+        fz1[i] = fz[i * 2], fz2[i] = fz[i * 2 + 1];
 }
 
 EXTERN void mayer_fft(int n, t_sample *fz1, t_sample *fz2)
@@ -209,15 +206,14 @@ EXTERN void mayer_realfft(int n, t_sample *fz)
 {
     int i;
     rfftw_info *p = rfftw_getplan(n, 1);
-    if (!p)
-        return;
+    if(!p) return;
 
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
         p->in[i] = fz[i];
     fftwf_execute(p->plan);
-    for (i = 0; i < n/2+1; i++)
+    for(i = 0; i < n / 2 + 1; i++)
         fz[i] = p->out[i];
-    for (; i < n; i++)
+    for(; i < n; i++)
         fz[i] = -p->out[i];
 }
 
@@ -225,29 +221,27 @@ EXTERN void mayer_realifft(int n, t_sample *fz)
 {
     int i;
     rfftw_info *p = rfftw_getplan(n, 0);
-    if (!p)
-        return;
+    if(!p) return;
 
-    for (i = 0; i < n/2+1; i++)
+    for(i = 0; i < n / 2 + 1; i++)
         p->in[i] = fz[i];
-    for (; i < n; i++)
+    for(; i < n; i++)
         p->in[i] = -fz[i];
     fftwf_execute(p->plan);
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
         fz[i] = p->out[i];
 }
 
-    /* ancient ISPW-like version, used in fiddle~ and perhaps other externs
-    here and there. */
+/* ancient ISPW-like version, used in fiddle~ and perhaps other externs
+here and there. */
 void pd_fft(t_float *buf, int npoints, int inverse)
 {
     cfftw_info *p = cfftw_getplan(npoints, !inverse);
     int i;
     float *fz;
-    for (i = 0, fz = (float *)(p->in); i < 2 * npoints; i++)
+    for(i = 0, fz = (float *) (p->in); i < 2 * npoints; i++)
         *fz++ = buf[i];
     fftwf_execute(p->plan);
-    for (i = 0, fz = (float *)(p->out); i < 2 * npoints; i++)
+    for(i = 0, fz = (float *) (p->out); i < 2 * npoints; i++)
         buf[i] = *fz++;
 }
-

--- a/src/d_fft_fftw.c
+++ b/src/d_fft_fftw.c
@@ -74,7 +74,8 @@ static cfftw_info *cfftw_getplan(int n, int fwd)
 
 static void cfftw_term(void)
 {
-    int i, j;
+    int i;
+    int j;
     cfftw_info *cinfo[2];
 
     for(i = 0; i < MAXFFT + 1 - MINFFT; i++)
@@ -126,7 +127,8 @@ static rfftw_info *rfftw_getplan(int n, int fwd)
 
 static void rfftw_term(void)
 {
-    int i, j;
+    int i;
+    int j;
     rfftw_info *rinfo[2];
 
     for(i = 0; i < MAXFFT + 1 - MINFFT; i++)

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -60,13 +60,12 @@ static t_int *sighip_perform(t_int *w)
     t_sample *out = (t_sample *) (w[2]);
     t_hipctl *c = (t_hipctl *) (w[3]);
     int n = (int) w[4];
-    int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
     if(coef < 1)
     {
         t_sample normal = 0.5 * (1 + coef);
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             t_sample new = *in++ + coef *last;
             *out++ = normal * (new - last);
@@ -77,7 +76,7 @@ static t_int *sighip_perform(t_int *w)
     }
     else
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
             *out++ = *in++;
         c->c_x = 0;
     }
@@ -90,12 +89,11 @@ static t_int *sighip_perform_old(t_int *w)
     t_sample *out = (t_sample *) (w[2]);
     t_hipctl *c = (t_hipctl *) (w[3]);
     int n = (int) w[4];
-    int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
     if(coef < 1)
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             t_sample new = *in++ + coef *last;
             *out++ = new - last;
@@ -106,7 +104,7 @@ static t_int *sighip_perform_old(t_int *w)
     }
     else
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
             *out++ = *in++;
         c->c_x = 0;
     }
@@ -191,11 +189,10 @@ static t_int *siglop_perform(t_int *w)
     t_sample *out = (t_sample *) (w[2]);
     t_lopctl *c = (t_lopctl *) (w[3]);
     int n = (int) w[4];
-    int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
     t_sample feedback = 1 - coef;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         last = *out++ = coef * *in++ + feedback * last;
     if(PD_BIGORSMALL(last)) last = 0;
     c->c_x = last;
@@ -318,13 +315,12 @@ static t_int *sigbp_perform(t_int *w)
     t_sample *out = (t_sample *) (w[2]);
     t_bpctl *c = (t_bpctl *) (w[3]);
     int n = (int) w[4];
-    int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
     t_sample coef1 = c->c_coef1;
     t_sample coef2 = c->c_coef2;
     t_sample gain = c->c_gain;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample output = *in++ + coef1 * last + coef2 * prev;
         *out++ = gain * output;
@@ -400,7 +396,6 @@ static t_int *sigbiquad_perform(t_int *w)
     t_sample *out = (t_sample *) (w[2]);
     t_biquadctl *c = (t_biquadctl *) (w[3]);
     int n = (int) w[4];
-    int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
     t_sample fb1 = c->c_fb1;
@@ -408,7 +403,7 @@ static t_int *sigbiquad_perform(t_int *w)
     t_sample ff1 = c->c_ff1;
     t_sample ff2 = c->c_ff2;
     t_sample ff3 = c->c_ff3;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample output = *in++ + fb1 * last + fb2 * prev;
         if(PD_BIGORSMALL(output)) output = 0;
@@ -512,10 +507,9 @@ static t_int *sigsamphold_perform(t_int *w)
     t_sample *out = (t_sample *) (w[3]);
     t_sigsamphold *x = (t_sigsamphold *) (w[4]);
     int n = (int) w[5];
-    int i;
     t_sample lastin = x->x_lastin;
     t_sample lastout = x->x_lastout;
-    for(i = 0; i < n; i++, in1++)
+    for(int i = 0; i < n; i++, in1++)
     {
         t_sample next = *in2++;
         if(next < lastin) lastout = *in1;
@@ -585,9 +579,8 @@ static t_int *sigrpole_perform(t_int *w)
     t_sample *out = (t_sample *) (w[3]);
     t_sigrpole *x = (t_sigrpole *) (w[4]);
     int n = (int) w[5];
-    int i;
     t_sample last = x->x_last;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
@@ -650,9 +643,8 @@ static t_int *sigrzero_perform(t_int *w)
     t_sample *out = (t_sample *) (w[3]);
     t_sigrzero *x = (t_sigrzero *) (w[4]);
     int n = (int) w[5];
-    int i;
     t_sample last = x->x_last;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
@@ -715,9 +707,8 @@ static t_int *sigrzero_rev_perform(t_int *w)
     t_sample *out = (t_sample *) (w[3]);
     t_sigrzero_rev *x = (t_sigrzero_rev *) (w[4]);
     int n = (int) w[5];
-    int i;
     t_sample last = x->x_last;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
@@ -791,10 +782,9 @@ static t_int *sigcpole_perform(t_int *w)
     t_sample *outim = (t_sample *) (w[6]);
     t_sigcpole *x = (t_sigcpole *) (w[7]);
     int n = (int) w[8];
-    int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
@@ -877,10 +867,9 @@ static t_int *sigczero_perform(t_int *w)
     t_sample *outim = (t_sample *) (w[6]);
     t_sigczero *x = (t_sigczero *) (w[7]);
     int n = (int) w[8];
-    int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
@@ -962,10 +951,9 @@ static t_int *sigczero_rev_perform(t_int *w)
     t_sample *outim = (t_sample *) (w[6]);
     t_sigczero_rev *x = (t_sigczero_rev *) (w[7]);
     int n = (int) w[8];
-    int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
@@ -1059,9 +1047,8 @@ static t_int *slop_tilde_perform(t_int *w)
     t_sample coef = x->x_coef;
     t_sample *out = (t_sample *) (w[8]);
     int n = (int) w[9];
-    int i;
     t_sample last = x->x_last;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         t_sample diff = *sigin++ - last;
         t_sample inc = *freqin++ * coef;

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -45,9 +45,13 @@ static void sighip_ft1(t_sighip *x, t_floatarg f)
     x->x_hz = f;
     x->x_cspace.c_coef = 1 - f * (2 * 3.14159) / x->x_sr;
     if(x->x_cspace.c_coef < 0)
+    {
         x->x_cspace.c_coef = 0;
+    }
     else if(x->x_cspace.c_coef > 1)
+    {
         x->x_cspace.c_coef = 1;
+    }
 }
 
 static t_int *sighip_perform(t_int *w)
@@ -170,9 +174,13 @@ static void siglop_ft1(t_siglop *x, t_floatarg f)
     x->x_hz = f;
     x->x_cspace.c_coef = f * (2 * 3.14159) / x->x_sr;
     if(x->x_cspace.c_coef > 1)
+    {
         x->x_cspace.c_coef = 1;
+    }
     else if(x->x_cspace.c_coef < 0)
+    {
         x->x_cspace.c_coef = 0;
+    }
 }
 
 static void siglop_clear(t_siglop *x, t_floatarg q) { x->x_cspace.c_x = 0; }
@@ -276,9 +284,13 @@ static void sigbp_docoef(t_sigbp *x, t_floatarg f, t_floatarg q)
     x->x_q = q;
     omega = f * (2.0f * 3.14159f) / x->x_sr;
     if(q < 0.001)
+    {
         oneminusr = 1.0f;
+    }
     else
+    {
         oneminusr = omega / q;
+    }
     if(oneminusr > 1.0f) oneminusr = 1.0f;
     r = 1.0f - oneminusr;
     x->x_cspace.c_coef1 = 2.0f * sigbp_qcos(omega) * r;
@@ -1059,25 +1071,43 @@ static t_int *slop_tilde_perform(t_int *w)
         t_sample maxdiff = *poslimit++;
         t_sample mindiff = *neglimit++;
         if(inc < 0.f)
+        {
             inc = 0.f;
+        }
         else if(inc > 1.f)
+        {
             inc = 1.f;
+        }
         if(posinc < 0.f)
+        {
             posinc = 0.f;
+        }
         else if(posinc > 1.f)
+        {
             posinc = 1.f;
+        }
         if(neginc < 0.f)
+        {
             neginc = 0.f;
+        }
         else if(neginc > 1.f)
+        {
             neginc = 1.f;
+        }
         if(maxdiff < 0) maxdiff = 0;
         if(mindiff < 0) mindiff = 0;
         if(diff > maxdiff)
+        {
             diffinc = posinc * (diff - maxdiff) + inc * maxdiff;
+        }
         else if(diff < -mindiff)
+        {
             diffinc = neginc * (diff + mindiff) - inc * mindiff;
+        }
         else
+        {
             diffinc = inc * diff;
+        }
         last = *out++ = last + diffinc;
     }
     if(PD_BIGORSMALL(last)) last = 0;

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -262,8 +262,7 @@ static t_float sigbp_qcos(t_float f)
                     g * 0.5) +
                 1);
     }
-    else
-        return (0);
+    return (0);
 }
 
 static void sigbp_docoef(t_sigbp *x, t_floatarg f, t_floatarg q)

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  "filters", both linear and nonlinear.
-*/
+ */
 #include "m_pd.h"
 #include <math.h>
 
@@ -29,7 +29,7 @@ static void sighip_ft1(t_sighip *x, t_floatarg f);
 
 static void *sighip_new(t_floatarg f)
 {
-    t_sighip *x = (t_sighip *)pd_new(sighip_class);
+    t_sighip *x = (t_sighip *) pd_new(sighip_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
     outlet_new(&x->x_obj, &s_signal);
     x->x_sr = 44100;
@@ -41,100 +41,94 @@ static void *sighip_new(t_floatarg f)
 
 static void sighip_ft1(t_sighip *x, t_floatarg f)
 {
-    if (f < 0) f = 0;
+    if(f < 0) f = 0;
     x->x_hz = f;
     x->x_cspace.c_coef = 1 - f * (2 * 3.14159) / x->x_sr;
-    if (x->x_cspace.c_coef < 0)
+    if(x->x_cspace.c_coef < 0)
         x->x_cspace.c_coef = 0;
-    else if (x->x_cspace.c_coef > 1)
+    else if(x->x_cspace.c_coef > 1)
         x->x_cspace.c_coef = 1;
 }
 
 static t_int *sighip_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_hipctl *c = (t_hipctl *)(w[3]);
-    int n = (int)w[4];
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_hipctl *c = (t_hipctl *) (w[3]);
+    int n = (int) w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
-    if (coef < 1)
+    if(coef < 1)
     {
-        t_sample normal = 0.5*(1+coef);
-        for (i = 0; i < n; i++)
+        t_sample normal = 0.5 * (1 + coef);
+        for(i = 0; i < n; i++)
         {
-            t_sample new = *in++ + coef * last;
+            t_sample new = *in++ + coef *last;
             *out++ = normal * (new - last);
             last = new;
         }
-        if (PD_BIGORSMALL(last))
-            last = 0;
+        if(PD_BIGORSMALL(last)) last = 0;
         c->c_x = last;
     }
     else
     {
-        for (i = 0; i < n; i++)
+        for(i = 0; i < n; i++)
             *out++ = *in++;
         c->c_x = 0;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static t_int *sighip_perform_old(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_hipctl *c = (t_hipctl *)(w[3]);
-    int n = (int)w[4];
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_hipctl *c = (t_hipctl *) (w[3]);
+    int n = (int) w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
-    if (coef < 1)
+    if(coef < 1)
     {
-        for (i = 0; i < n; i++)
+        for(i = 0; i < n; i++)
         {
-            t_sample new = *in++ + coef * last;
+            t_sample new = *in++ + coef *last;
             *out++ = new - last;
             last = new;
         }
-        if (PD_BIGORSMALL(last))
-            last = 0;
+        if(PD_BIGORSMALL(last)) last = 0;
         c->c_x = last;
     }
     else
     {
-        for (i = 0; i < n; i++)
+        for(i = 0; i < n; i++)
             *out++ = *in++;
         c->c_x = 0;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void sighip_dsp(t_sighip *x, t_signal **sp)
 {
     x->x_sr = sp[0]->s_sr;
-    sighip_ft1(x,  x->x_hz);
-    dsp_add((pd_compatibilitylevel > 43 ?
-        sighip_perform : sighip_perform_old),
-            4, sp[0]->s_vec, sp[1]->s_vec, &x->x_cspace, (t_int)sp[0]->s_n);
+    sighip_ft1(x, x->x_hz);
+    dsp_add((pd_compatibilitylevel > 43 ? sighip_perform : sighip_perform_old),
+        4, sp[0]->s_vec, sp[1]->s_vec, &x->x_cspace, (t_int) sp[0]->s_n);
 }
 
-static void sighip_clear(t_sighip *x, t_floatarg q)
-{
-    x->x_cspace.c_x = 0;
-}
+static void sighip_clear(t_sighip *x, t_floatarg q) { x->x_cspace.c_x = 0; }
 
 void sighip_setup(void)
 {
-    sighip_class = class_new(gensym("hip~"), (t_newmethod)sighip_new, 0,
+    sighip_class = class_new(gensym("hip~"), (t_newmethod) sighip_new, 0,
         sizeof(t_sighip), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sighip_class, t_sighip, x_f);
-    class_addmethod(sighip_class, (t_method)sighip_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(sighip_class, (t_method)sighip_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(sighip_class, (t_method)sighip_clear, gensym("clear"), 0);
+    class_addmethod(
+        sighip_class, (t_method) sighip_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sighip_class, (t_method) sighip_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(sighip_class, (t_method) sighip_clear, gensym("clear"), 0);
 }
 
 /* ---------------- lop~ - 1-pole lopass filter. ----------------- */
@@ -160,7 +154,7 @@ static void siglop_ft1(t_siglop *x, t_floatarg f);
 
 static void *siglop_new(t_floatarg f)
 {
-    t_siglop *x = (t_siglop *)pd_new(siglop_class);
+    t_siglop *x = (t_siglop *) pd_new(siglop_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
     outlet_new(&x->x_obj, &s_signal);
     x->x_sr = 44100;
@@ -172,57 +166,52 @@ static void *siglop_new(t_floatarg f)
 
 static void siglop_ft1(t_siglop *x, t_floatarg f)
 {
-    if (f < 0) f = 0;
+    if(f < 0) f = 0;
     x->x_hz = f;
     x->x_cspace.c_coef = f * (2 * 3.14159) / x->x_sr;
-    if (x->x_cspace.c_coef > 1)
+    if(x->x_cspace.c_coef > 1)
         x->x_cspace.c_coef = 1;
-    else if (x->x_cspace.c_coef < 0)
+    else if(x->x_cspace.c_coef < 0)
         x->x_cspace.c_coef = 0;
 }
 
-static void siglop_clear(t_siglop *x, t_floatarg q)
-{
-    x->x_cspace.c_x = 0;
-}
+static void siglop_clear(t_siglop *x, t_floatarg q) { x->x_cspace.c_x = 0; }
 
 static t_int *siglop_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_lopctl *c = (t_lopctl *)(w[3]);
-    int n = (int)w[4];
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_lopctl *c = (t_lopctl *) (w[3]);
+    int n = (int) w[4];
     int i;
     t_sample last = c->c_x;
     t_sample coef = c->c_coef;
     t_sample feedback = 1 - coef;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
         last = *out++ = coef * *in++ + feedback * last;
-    if (PD_BIGORSMALL(last))
-        last = 0;
+    if(PD_BIGORSMALL(last)) last = 0;
     c->c_x = last;
-    return (w+5);
+    return (w + 5);
 }
 
 static void siglop_dsp(t_siglop *x, t_signal **sp)
 {
     x->x_sr = sp[0]->s_sr;
-    siglop_ft1(x,  x->x_hz);
-    dsp_add(siglop_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec,
-            &x->x_cspace, (t_int)sp[0]->s_n);
+    siglop_ft1(x, x->x_hz);
+    dsp_add(siglop_perform, 4, sp[0]->s_vec, sp[1]->s_vec, &x->x_cspace,
+        (t_int) sp[0]->s_n);
 }
 
 void siglop_setup(void)
 {
-    siglop_class = class_new(gensym("lop~"), (t_newmethod)siglop_new, 0,
+    siglop_class = class_new(gensym("lop~"), (t_newmethod) siglop_new, 0,
         sizeof(t_siglop), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(siglop_class, t_siglop, x_f);
-    class_addmethod(siglop_class, (t_method)siglop_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(siglop_class, (t_method)siglop_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(siglop_class, (t_method)siglop_clear, gensym("clear"), 0);
+    class_addmethod(
+        siglop_class, (t_method) siglop_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        siglop_class, (t_method) siglop_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(siglop_class, (t_method) siglop_clear, gensym("clear"), 0);
 }
 
 /* ---------------- bp~ - 2-pole bandpass filter. ----------------- */
@@ -252,7 +241,7 @@ static void sigbp_docoef(t_sigbp *x, t_floatarg f, t_floatarg q);
 
 static void *sigbp_new(t_floatarg f, t_floatarg q)
 {
-    t_sigbp *x = (t_sigbp *)pd_new(sigbp_class);
+    t_sigbp *x = (t_sigbp *) pd_new(sigbp_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft2"));
     outlet_new(&x->x_obj, &s_signal);
@@ -266,37 +255,39 @@ static void *sigbp_new(t_floatarg f, t_floatarg q)
 
 static t_float sigbp_qcos(t_float f)
 {
-    if (f >= -(0.5f*3.14159f) && f <= 0.5f*3.14159f)
+    if(f >= -(0.5f * 3.14159f) && f <= 0.5f * 3.14159f)
     {
-        t_float g = f*f;
-        return (((g*g*g * (-1.0f/720.0f) + g*g*(1.0f/24.0f)) - g*0.5) + 1);
+        t_float g = f * f;
+        return (((g * g * g * (-1.0f / 720.0f) + g * g * (1.0f / 24.0f)) -
+                    g * 0.5) +
+                1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
 static void sigbp_docoef(t_sigbp *x, t_floatarg f, t_floatarg q)
 {
     t_float r, oneminusr, omega;
-    if (f < 0.001) f = 10;
-    if (q < 0) q = 0;
+    if(f < 0.001) f = 10;
+    if(q < 0) q = 0;
     x->x_freq = f;
     x->x_q = q;
     omega = f * (2.0f * 3.14159f) / x->x_sr;
-    if (q < 0.001) oneminusr = 1.0f;
-    else oneminusr = omega/q;
-    if (oneminusr > 1.0f) oneminusr = 1.0f;
+    if(q < 0.001)
+        oneminusr = 1.0f;
+    else
+        oneminusr = omega / q;
+    if(oneminusr > 1.0f) oneminusr = 1.0f;
     r = 1.0f - oneminusr;
     x->x_cspace.c_coef1 = 2.0f * sigbp_qcos(omega) * r;
-    x->x_cspace.c_coef2 = - r * r;
+    x->x_cspace.c_coef2 = -r * r;
     x->x_cspace.c_gain = 2 * oneminusr * (oneminusr + r * omega);
     /* post("r %f, omega %f, coef1 %f, coef2 %f",
         r, omega, x->x_cspace.c_coef1, x->x_cspace.c_coef2); */
 }
 
-static void sigbp_ft1(t_sigbp *x, t_floatarg f)
-{
-    sigbp_docoef(x, f, x->x_q);
-}
+static void sigbp_ft1(t_sigbp *x, t_floatarg f) { sigbp_docoef(x, f, x->x_q); }
 
 static void sigbp_ft2(t_sigbp *x, t_floatarg q)
 {
@@ -310,53 +301,50 @@ static void sigbp_clear(t_sigbp *x, t_floatarg q)
 
 static t_int *sigbp_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_bpctl *c = (t_bpctl *)(w[3]);
-    int n = (int)w[4];
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_bpctl *c = (t_bpctl *) (w[3]);
+    int n = (int) w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
     t_sample coef1 = c->c_coef1;
     t_sample coef2 = c->c_coef2;
     t_sample gain = c->c_gain;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        t_sample output =  *in++ + coef1 * last + coef2 * prev;
+        t_sample output = *in++ + coef1 * last + coef2 * prev;
         *out++ = gain * output;
         prev = last;
         last = output;
     }
-    if (PD_BIGORSMALL(last))
-        last = 0;
-    if (PD_BIGORSMALL(prev))
-        prev = 0;
+    if(PD_BIGORSMALL(last)) last = 0;
+    if(PD_BIGORSMALL(prev)) prev = 0;
     c->c_x1 = last;
     c->c_x2 = prev;
-    return (w+5);
+    return (w + 5);
 }
 
 static void sigbp_dsp(t_sigbp *x, t_signal **sp)
 {
     x->x_sr = sp[0]->s_sr;
     sigbp_docoef(x, x->x_freq, x->x_q);
-    dsp_add(sigbp_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec,
-            &x->x_cspace, (t_int)sp[0]->s_n);
+    dsp_add(sigbp_perform, 4, sp[0]->s_vec, sp[1]->s_vec, &x->x_cspace,
+        (t_int) sp[0]->s_n);
 }
 
 void sigbp_setup(void)
 {
-    sigbp_class = class_new(gensym("bp~"), (t_newmethod)sigbp_new, 0,
+    sigbp_class = class_new(gensym("bp~"), (t_newmethod) sigbp_new, 0,
         sizeof(t_sigbp), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigbp_class, t_sigbp, x_f);
-    class_addmethod(sigbp_class, (t_method)sigbp_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(sigbp_class, (t_method)sigbp_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(sigbp_class, (t_method)sigbp_ft2,
-        gensym("ft2"), A_FLOAT, 0);
-    class_addmethod(sigbp_class, (t_method)sigbp_clear, gensym("clear"), 0);
+    class_addmethod(
+        sigbp_class, (t_method) sigbp_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigbp_class, (t_method) sigbp_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(
+        sigbp_class, (t_method) sigbp_ft2, gensym("ft2"), A_FLOAT, 0);
+    class_addmethod(sigbp_class, (t_method) sigbp_clear, gensym("clear"), 0);
 }
 
 /* ---------------- biquad~ - raw biquad filter ----------------- */
@@ -385,7 +373,7 @@ static void sigbiquad_list(t_sigbiquad *x, t_symbol *s, int argc, t_atom *argv);
 
 static void *sigbiquad_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_sigbiquad *x = (t_sigbiquad *)pd_new(sigbiquad_class);
+    t_sigbiquad *x = (t_sigbiquad *) pd_new(sigbiquad_class);
     outlet_new(&x->x_obj, &s_signal);
     x->x_cspace.c_x1 = x->x_cspace.c_x2 = 0;
     sigbiquad_list(x, s, argc, argv);
@@ -395,10 +383,10 @@ static void *sigbiquad_new(t_symbol *s, int argc, t_atom *argv)
 
 static t_int *sigbiquad_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    t_biquadctl *c = (t_biquadctl *)(w[3]);
-    int n = (int)w[4];
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    t_biquadctl *c = (t_biquadctl *) (w[3]);
+    int n = (int) w[4];
     int i;
     t_sample last = c->c_x1;
     t_sample prev = c->c_x2;
@@ -407,18 +395,17 @@ static t_int *sigbiquad_perform(t_int *w)
     t_sample ff1 = c->c_ff1;
     t_sample ff2 = c->c_ff2;
     t_sample ff3 = c->c_ff3;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        t_sample output =  *in++ + fb1 * last + fb2 * prev;
-        if (PD_BIGORSMALL(output))
-            output = 0;
+        t_sample output = *in++ + fb1 * last + fb2 * prev;
+        if(PD_BIGORSMALL(output)) output = 0;
         *out++ = ff1 * output + ff2 * last + ff3 * prev;
         prev = last;
         last = output;
     }
     c->c_x1 = last;
     c->c_x2 = prev;
-    return (w+5);
+    return (w + 5);
 }
 
 static void sigbiquad_list(t_sigbiquad *x, t_symbol *s, int argc, t_atom *argv)
@@ -430,22 +417,22 @@ static void sigbiquad_list(t_sigbiquad *x, t_symbol *s, int argc, t_atom *argv)
     t_float ff3 = atom_getfloatarg(4, argc, argv);
     t_float discriminant = fb1 * fb1 + 4 * fb2;
     t_biquadctl *c = &x->x_cspace;
-    if (discriminant < 0) /* imaginary roots -- resonant filter */
+    if(discriminant < 0) /* imaginary roots -- resonant filter */
     {
-            /* they're conjugates so we just check that the product
-            is less than one */
-        if (fb2 >= -1.0f) goto stable;
+        /* they're conjugates so we just check that the product
+        is less than one */
+        if(fb2 >= -1.0f) goto stable;
     }
-    else    /* real roots */
+    else /* real roots */
     {
-            /* check that the parabola 1 - fb1 x - fb2 x^2 has a
-                vertex between -1 and 1, and that it's nonnegative
-                at both ends, which implies both roots are in [1-,1]. */
-        if (fb1 <= 2.0f && fb1 >= -2.0f &&
-            1.0f - fb1 -fb2 >= 0 && 1.0f + fb1 - fb2 >= 0)
-                goto stable;
+        /* check that the parabola 1 - fb1 x - fb2 x^2 has a
+            vertex between -1 and 1, and that it's nonnegative
+            at both ends, which implies both roots are in [1-,1]. */
+        if(fb1 <= 2.0f && fb1 >= -2.0f && 1.0f - fb1 - fb2 >= 0 &&
+            1.0f + fb1 - fb2 >= 0)
+            goto stable;
     }
-        /* if unstable, just bash to zero */
+    /* if unstable, just bash to zero */
     fb1 = fb2 = ff1 = ff2 = ff3 = 0;
 stable:
     c->c_fb1 = fb1;
@@ -464,23 +451,22 @@ static void sigbiquad_set(t_sigbiquad *x, t_symbol *s, int argc, t_atom *argv)
 
 static void sigbiquad_dsp(t_sigbiquad *x, t_signal **sp)
 {
-    dsp_add(sigbiquad_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec,
-            &x->x_cspace, (t_int)sp[0]->s_n);
+    dsp_add(sigbiquad_perform, 4, sp[0]->s_vec, sp[1]->s_vec, &x->x_cspace,
+        (t_int) sp[0]->s_n);
 }
 
 void sigbiquad_setup(void)
 {
-    sigbiquad_class = class_new(gensym("biquad~"), (t_newmethod)sigbiquad_new,
+    sigbiquad_class = class_new(gensym("biquad~"), (t_newmethod) sigbiquad_new,
         0, sizeof(t_sigbiquad), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(sigbiquad_class, t_sigbiquad, x_f);
-    class_addmethod(sigbiquad_class, (t_method)sigbiquad_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigbiquad_class, (t_method) sigbiquad_dsp, gensym("dsp"), A_CANT, 0);
     class_addlist(sigbiquad_class, sigbiquad_list);
-    class_addmethod(sigbiquad_class, (t_method)sigbiquad_set, gensym("set"),
-        A_GIMME, 0);
-    class_addmethod(sigbiquad_class, (t_method)sigbiquad_set, gensym("clear"),
-        A_GIMME, 0);
+    class_addmethod(
+        sigbiquad_class, (t_method) sigbiquad_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(
+        sigbiquad_class, (t_method) sigbiquad_set, gensym("clear"), A_GIMME, 0);
 }
 
 /* ---------------- samphold~ - sample and hold  ----------------- */
@@ -497,7 +483,7 @@ t_class *sigsamphold_class;
 
 static void *sigsamphold_new(void)
 {
-    t_sigsamphold *x = (t_sigsamphold *)pd_new(sigsamphold_class);
+    t_sigsamphold *x = (t_sigsamphold *) pd_new(sigsamphold_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     outlet_new(&x->x_obj, &s_signal);
     x->x_lastin = 0;
@@ -508,55 +494,52 @@ static void *sigsamphold_new(void)
 
 static t_int *sigsamphold_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    t_sigsamphold *x = (t_sigsamphold *)(w[4]);
-    int n = (int)w[5];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    t_sigsamphold *x = (t_sigsamphold *) (w[4]);
+    int n = (int) w[5];
     int i;
     t_sample lastin = x->x_lastin;
     t_sample lastout = x->x_lastout;
-    for (i = 0; i < n; i++, in1++)
+    for(i = 0; i < n; i++, in1++)
     {
         t_sample next = *in2++;
-        if (next < lastin) lastout = *in1;
+        if(next < lastin) lastout = *in1;
         *out++ = lastout;
         lastin = next;
     }
     x->x_lastin = lastin;
     x->x_lastout = lastout;
-    return (w+6);
+    return (w + 6);
 }
 
 static void sigsamphold_dsp(t_sigsamphold *x, t_signal **sp)
 {
-    dsp_add(sigsamphold_perform, 5,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, (t_int)sp[0]->s_n);
+    dsp_add(sigsamphold_perform, 5, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, x,
+        (t_int) sp[0]->s_n);
 }
 
-static void sigsamphold_reset(t_sigsamphold *x, t_symbol *s, int argc,
-    t_atom *argv)
+static void sigsamphold_reset(
+    t_sigsamphold *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_lastin = ((argc > 0 && (argv[0].a_type == A_FLOAT)) ?
-        argv[0].a_w.w_float : 1e20);
+    x->x_lastin =
+        ((argc > 0 && (argv[0].a_type == A_FLOAT)) ? argv[0].a_w.w_float
+                                                   : 1e20);
 }
 
-static void sigsamphold_set(t_sigsamphold *x, t_float f)
-{
-    x->x_lastout = f;
-}
+static void sigsamphold_set(t_sigsamphold *x, t_float f) { x->x_lastout = f; }
 
 void sigsamphold_setup(void)
 {
     sigsamphold_class = class_new(gensym("samphold~"),
-        (t_newmethod)sigsamphold_new, 0, sizeof(t_sigsamphold), 0, 0);
+        (t_newmethod) sigsamphold_new, 0, sizeof(t_sigsamphold), 0, 0);
     CLASS_MAINSIGNALIN(sigsamphold_class, t_sigsamphold, x_f);
-    class_addmethod(sigsamphold_class, (t_method)sigsamphold_set,
+    class_addmethod(sigsamphold_class, (t_method) sigsamphold_set,
         gensym("set"), A_DEFFLOAT, 0);
-    class_addmethod(sigsamphold_class, (t_method)sigsamphold_reset,
+    class_addmethod(sigsamphold_class, (t_method) sigsamphold_reset,
         gensym("reset"), A_GIMME, 0);
-    class_addmethod(sigsamphold_class, (t_method)sigsamphold_dsp,
+    class_addmethod(sigsamphold_class, (t_method) sigsamphold_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -573,10 +556,10 @@ t_class *sigrpole_class;
 
 static void *sigrpole_new(t_float f)
 {
-    t_sigrpole *x = (t_sigrpole *)pd_new(sigrpole_class);
+    t_sigrpole *x = (t_sigrpole *) pd_new(sigrpole_class);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            f);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        f);
     outlet_new(&x->x_obj, &s_signal);
     x->x_last = 0;
     return (x);
@@ -584,53 +567,45 @@ static void *sigrpole_new(t_float f)
 
 static t_int *sigrpole_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    t_sigrpole *x = (t_sigrpole *)(w[4]);
-    int n = (int)w[5];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    t_sigrpole *x = (t_sigrpole *) (w[4]);
+    int n = (int) w[5];
     int i;
     t_sample last = x->x_last;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
         *out++ = last = coef * last + next;
     }
-    if (PD_BIGORSMALL(last))
-        last = 0;
+    if(PD_BIGORSMALL(last)) last = 0;
     x->x_last = last;
-    return (w+6);
+    return (w + 6);
 }
 
 static void sigrpole_dsp(t_sigrpole *x, t_signal **sp)
 {
-    dsp_add(sigrpole_perform, 5,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, (t_int)sp[0]->s_n);
+    dsp_add(sigrpole_perform, 5, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, x,
+        (t_int) sp[0]->s_n);
 }
 
-static void sigrpole_clear(t_sigrpole *x)
-{
-    x->x_last = 0;
-}
+static void sigrpole_clear(t_sigrpole *x) { x->x_last = 0; }
 
-static void sigrpole_set(t_sigrpole *x, t_float f)
-{
-    x->x_last = f;
-}
+static void sigrpole_set(t_sigrpole *x, t_float f) { x->x_last = f; }
 
 void sigrpole_setup(void)
 {
-    sigrpole_class = class_new(gensym("rpole~"),
-        (t_newmethod)sigrpole_new, 0, sizeof(t_sigrpole), 0, A_DEFFLOAT, 0);
+    sigrpole_class = class_new(gensym("rpole~"), (t_newmethod) sigrpole_new, 0,
+        sizeof(t_sigrpole), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigrpole_class, t_sigrpole, x_f);
-    class_addmethod(sigrpole_class, (t_method)sigrpole_set,
-        gensym("set"), A_DEFFLOAT, 0);
-    class_addmethod(sigrpole_class, (t_method)sigrpole_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigrpole_class, (t_method)sigrpole_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigrpole_class, (t_method) sigrpole_set, gensym("set"), A_DEFFLOAT, 0);
+    class_addmethod(
+        sigrpole_class, (t_method) sigrpole_clear, gensym("clear"), 0);
+    class_addmethod(
+        sigrpole_class, (t_method) sigrpole_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ---------------- rzero~ - real one-zero filter (raw) ----------------- */
@@ -646,10 +621,10 @@ t_class *sigrzero_class;
 
 static void *sigrzero_new(t_float f)
 {
-    t_sigrzero *x = (t_sigrzero *)pd_new(sigrzero_class);
+    t_sigrzero *x = (t_sigrzero *) pd_new(sigrzero_class);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            f);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        f);
     outlet_new(&x->x_obj, &s_signal);
     x->x_last = 0;
     return (x);
@@ -657,14 +632,14 @@ static void *sigrzero_new(t_float f)
 
 static t_int *sigrzero_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    t_sigrzero *x = (t_sigrzero *)(w[4]);
-    int n = (int)w[5];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    t_sigrzero *x = (t_sigrzero *) (w[4]);
+    int n = (int) w[5];
     int i;
     t_sample last = x->x_last;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
@@ -672,37 +647,30 @@ static t_int *sigrzero_perform(t_int *w)
         last = next;
     }
     x->x_last = last;
-    return (w+6);
+    return (w + 6);
 }
 
 static void sigrzero_dsp(t_sigrzero *x, t_signal **sp)
 {
-    dsp_add(sigrzero_perform, 5,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, (t_int)sp[0]->s_n);
+    dsp_add(sigrzero_perform, 5, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, x,
+        (t_int) sp[0]->s_n);
 }
 
-static void sigrzero_clear(t_sigrzero *x)
-{
-    x->x_last = 0;
-}
+static void sigrzero_clear(t_sigrzero *x) { x->x_last = 0; }
 
-static void sigrzero_set(t_sigrzero *x, t_float f)
-{
-    x->x_last = f;
-}
+static void sigrzero_set(t_sigrzero *x, t_float f) { x->x_last = f; }
 
 void sigrzero_setup(void)
 {
-    sigrzero_class = class_new(gensym("rzero~"),
-        (t_newmethod)sigrzero_new, 0, sizeof(t_sigrzero), 0, A_DEFFLOAT, 0);
+    sigrzero_class = class_new(gensym("rzero~"), (t_newmethod) sigrzero_new, 0,
+        sizeof(t_sigrzero), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigrzero_class, t_sigrzero, x_f);
-    class_addmethod(sigrzero_class, (t_method)sigrzero_set,
-        gensym("set"), A_DEFFLOAT, 0);
-    class_addmethod(sigrzero_class, (t_method)sigrzero_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigrzero_class, (t_method)sigrzero_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigrzero_class, (t_method) sigrzero_set, gensym("set"), A_DEFFLOAT, 0);
+    class_addmethod(
+        sigrzero_class, (t_method) sigrzero_clear, gensym("clear"), 0);
+    class_addmethod(
+        sigrzero_class, (t_method) sigrzero_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ---------- rzero_rev~ - real, reverse one-zero filter (raw) ------------ */
@@ -718,10 +686,10 @@ t_class *sigrzero_rev_class;
 
 static void *sigrzero_rev_new(t_float f)
 {
-    t_sigrzero_rev *x = (t_sigrzero_rev *)pd_new(sigrzero_rev_class);
+    t_sigrzero_rev *x = (t_sigrzero_rev *) pd_new(sigrzero_rev_class);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            f);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        f);
     outlet_new(&x->x_obj, &s_signal);
     x->x_last = 0;
     return (x);
@@ -729,14 +697,14 @@ static void *sigrzero_rev_new(t_float f)
 
 static t_int *sigrzero_rev_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    t_sigrzero_rev *x = (t_sigrzero_rev *)(w[4]);
-    int n = (int)w[5];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    t_sigrzero_rev *x = (t_sigrzero_rev *) (w[4]);
+    int n = (int) w[5];
     int i;
     t_sample last = x->x_last;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample next = *in1++;
         t_sample coef = *in2++;
@@ -744,37 +712,30 @@ static t_int *sigrzero_rev_perform(t_int *w)
         last = next;
     }
     x->x_last = last;
-    return (w+6);
+    return (w + 6);
 }
 
 static void sigrzero_rev_dsp(t_sigrzero_rev *x, t_signal **sp)
 {
-    dsp_add(sigrzero_rev_perform, 5,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
-            x, (t_int)sp[0]->s_n);
+    dsp_add(sigrzero_rev_perform, 5, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        x, (t_int) sp[0]->s_n);
 }
 
-static void sigrzero_rev_clear(t_sigrzero_rev *x)
-{
-    x->x_last = 0;
-}
+static void sigrzero_rev_clear(t_sigrzero_rev *x) { x->x_last = 0; }
 
-static void sigrzero_rev_set(t_sigrzero_rev *x, t_float f)
-{
-    x->x_last = f;
-}
+static void sigrzero_rev_set(t_sigrzero_rev *x, t_float f) { x->x_last = f; }
 
 void sigrzero_rev_setup(void)
 {
-    sigrzero_rev_class = class_new(gensym("rzero_rev~"),
-        (t_newmethod)sigrzero_rev_new, 0, sizeof(t_sigrzero_rev),
-        0, A_DEFFLOAT, 0);
+    sigrzero_rev_class =
+        class_new(gensym("rzero_rev~"), (t_newmethod) sigrzero_rev_new, 0,
+            sizeof(t_sigrzero_rev), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigrzero_rev_class, t_sigrzero_rev, x_f);
-    class_addmethod(sigrzero_rev_class, (t_method)sigrzero_rev_set,
+    class_addmethod(sigrzero_rev_class, (t_method) sigrzero_rev_set,
         gensym("set"), A_DEFFLOAT, 0);
-    class_addmethod(sigrzero_rev_class, (t_method)sigrzero_rev_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigrzero_rev_class, (t_method)sigrzero_rev_dsp,
+    class_addmethod(
+        sigrzero_rev_class, (t_method) sigrzero_rev_clear, gensym("clear"), 0);
+    class_addmethod(sigrzero_rev_class, (t_method) sigrzero_rev_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -792,14 +753,14 @@ t_class *sigcpole_class;
 
 static void *sigcpole_new(t_float re, t_float im)
 {
-    t_sigcpole *x = (t_sigcpole *)pd_new(sigcpole_class);
+    t_sigcpole *x = (t_sigcpole *) pd_new(sigcpole_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            re);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        re);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            im);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        im);
     outlet_new(&x->x_obj, &s_signal);
     outlet_new(&x->x_obj, &s_signal);
     x->x_lastre = x->x_lastim = 0;
@@ -809,18 +770,18 @@ static void *sigcpole_new(t_float re, t_float im)
 
 static t_int *sigcpole_perform(t_int *w)
 {
-    t_sample *inre1 = (t_sample *)(w[1]);
-    t_sample *inim1 = (t_sample *)(w[2]);
-    t_sample *inre2 = (t_sample *)(w[3]);
-    t_sample *inim2 = (t_sample *)(w[4]);
-    t_sample *outre = (t_sample *)(w[5]);
-    t_sample *outim = (t_sample *)(w[6]);
-    t_sigcpole *x = (t_sigcpole *)(w[7]);
-    int n = (int)w[8];
+    t_sample *inre1 = (t_sample *) (w[1]);
+    t_sample *inim1 = (t_sample *) (w[2]);
+    t_sample *inre2 = (t_sample *) (w[3]);
+    t_sample *inim2 = (t_sample *) (w[4]);
+    t_sample *outre = (t_sample *) (w[5]);
+    t_sample *outim = (t_sample *) (w[6]);
+    t_sigcpole *x = (t_sigcpole *) (w[7]);
+    int n = (int) w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
@@ -830,26 +791,20 @@ static t_int *sigcpole_perform(t_int *w)
         lastim = *outim++ = nextim + lastre * coefim + lastim * coefre;
         lastre = tempre;
     }
-    if (PD_BIGORSMALL(lastre))
-        lastre = 0;
-    if (PD_BIGORSMALL(lastim))
-        lastim = 0;
+    if(PD_BIGORSMALL(lastre)) lastre = 0;
+    if(PD_BIGORSMALL(lastim)) lastim = 0;
     x->x_lastre = lastre;
     x->x_lastim = lastim;
-    return (w+9);
+    return (w + 9);
 }
 
 static void sigcpole_dsp(t_sigcpole *x, t_signal **sp)
 {
-    dsp_add(sigcpole_perform, 8,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
+    dsp_add(sigcpole_perform, 8, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, sp[4]->s_vec, sp[5]->s_vec, x, (t_int) sp[0]->s_n);
 }
 
-static void sigcpole_clear(t_sigcpole *x)
-{
-    x->x_lastre = x->x_lastim = 0;
-}
+static void sigcpole_clear(t_sigcpole *x) { x->x_lastre = x->x_lastim = 0; }
 
 static void sigcpole_set(t_sigcpole *x, t_float re, t_float im)
 {
@@ -859,16 +814,15 @@ static void sigcpole_set(t_sigcpole *x, t_float re, t_float im)
 
 void sigcpole_setup(void)
 {
-    sigcpole_class = class_new(gensym("cpole~"),
-        (t_newmethod)sigcpole_new, 0, sizeof(t_sigcpole), 0,
-            A_DEFFLOAT, A_DEFFLOAT, 0);
+    sigcpole_class = class_new(gensym("cpole~"), (t_newmethod) sigcpole_new, 0,
+        sizeof(t_sigcpole), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigcpole_class, t_sigcpole, x_f);
-    class_addmethod(sigcpole_class, (t_method)sigcpole_set,
-        gensym("set"), A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(sigcpole_class, (t_method)sigcpole_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigcpole_class, (t_method)sigcpole_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(sigcpole_class, (t_method) sigcpole_set, gensym("set"),
+        A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addmethod(
+        sigcpole_class, (t_method) sigcpole_clear, gensym("clear"), 0);
+    class_addmethod(
+        sigcpole_class, (t_method) sigcpole_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* -------------- czero~ - complex one-zero filter (raw) --------------- */
@@ -885,14 +839,14 @@ t_class *sigczero_class;
 
 static void *sigczero_new(t_float re, t_float im)
 {
-    t_sigczero *x = (t_sigczero *)pd_new(sigczero_class);
+    t_sigczero *x = (t_sigczero *) pd_new(sigczero_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            re);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        re);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            im);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        im);
     outlet_new(&x->x_obj, &s_signal);
     outlet_new(&x->x_obj, &s_signal);
     x->x_lastre = x->x_lastim = 0;
@@ -902,18 +856,18 @@ static void *sigczero_new(t_float re, t_float im)
 
 static t_int *sigczero_perform(t_int *w)
 {
-    t_sample *inre1 = (t_sample *)(w[1]);
-    t_sample *inim1 = (t_sample *)(w[2]);
-    t_sample *inre2 = (t_sample *)(w[3]);
-    t_sample *inim2 = (t_sample *)(w[4]);
-    t_sample *outre = (t_sample *)(w[5]);
-    t_sample *outim = (t_sample *)(w[6]);
-    t_sigczero *x = (t_sigczero *)(w[7]);
-    int n = (int)w[8];
+    t_sample *inre1 = (t_sample *) (w[1]);
+    t_sample *inim1 = (t_sample *) (w[2]);
+    t_sample *inre2 = (t_sample *) (w[3]);
+    t_sample *inim2 = (t_sample *) (w[4]);
+    t_sample *outre = (t_sample *) (w[5]);
+    t_sample *outim = (t_sample *) (w[6]);
+    t_sigczero *x = (t_sigczero *) (w[7]);
+    int n = (int) w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
@@ -926,20 +880,16 @@ static t_int *sigczero_perform(t_int *w)
     }
     x->x_lastre = lastre;
     x->x_lastim = lastim;
-    return (w+9);
+    return (w + 9);
 }
 
 static void sigczero_dsp(t_sigczero *x, t_signal **sp)
 {
-    dsp_add(sigczero_perform, 8,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
+    dsp_add(sigczero_perform, 8, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, sp[4]->s_vec, sp[5]->s_vec, x, (t_int) sp[0]->s_n);
 }
 
-static void sigczero_clear(t_sigczero *x)
-{
-    x->x_lastre = x->x_lastim = 0;
-}
+static void sigczero_clear(t_sigczero *x) { x->x_lastre = x->x_lastim = 0; }
 
 static void sigczero_set(t_sigczero *x, t_float re, t_float im)
 {
@@ -949,16 +899,15 @@ static void sigczero_set(t_sigczero *x, t_float re, t_float im)
 
 void sigczero_setup(void)
 {
-    sigczero_class = class_new(gensym("czero~"),
-        (t_newmethod)sigczero_new, 0, sizeof(t_sigczero), 0,
-            A_DEFFLOAT, A_DEFFLOAT, 0);
+    sigczero_class = class_new(gensym("czero~"), (t_newmethod) sigczero_new, 0,
+        sizeof(t_sigczero), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigczero_class, t_sigczero, x_f);
-    class_addmethod(sigczero_class, (t_method)sigczero_set,
-        gensym("set"), A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(sigczero_class, (t_method)sigczero_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigczero_class, (t_method)sigczero_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(sigczero_class, (t_method) sigczero_set, gensym("set"),
+        A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addmethod(
+        sigczero_class, (t_method) sigczero_clear, gensym("clear"), 0);
+    class_addmethod(
+        sigczero_class, (t_method) sigczero_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------ czero_rev~ - complex one-zero filter (raw, reverse form) ----- */
@@ -975,14 +924,14 @@ t_class *sigczero_rev_class;
 
 static void *sigczero_rev_new(t_float re, t_float im)
 {
-    t_sigczero_rev *x = (t_sigczero_rev *)pd_new(sigczero_rev_class);
+    t_sigczero_rev *x = (t_sigczero_rev *) pd_new(sigczero_rev_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            re);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        re);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
-            im);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        im);
     outlet_new(&x->x_obj, &s_signal);
     outlet_new(&x->x_obj, &s_signal);
     x->x_lastre = x->x_lastim = 0;
@@ -992,25 +941,25 @@ static void *sigczero_rev_new(t_float re, t_float im)
 
 static t_int *sigczero_rev_perform(t_int *w)
 {
-    t_sample *inre1 = (t_sample *)(w[1]);
-    t_sample *inim1 = (t_sample *)(w[2]);
-    t_sample *inre2 = (t_sample *)(w[3]);
-    t_sample *inim2 = (t_sample *)(w[4]);
-    t_sample *outre = (t_sample *)(w[5]);
-    t_sample *outim = (t_sample *)(w[6]);
-    t_sigczero_rev *x = (t_sigczero_rev *)(w[7]);
-    int n = (int)w[8];
+    t_sample *inre1 = (t_sample *) (w[1]);
+    t_sample *inim1 = (t_sample *) (w[2]);
+    t_sample *inre2 = (t_sample *) (w[3]);
+    t_sample *inim2 = (t_sample *) (w[4]);
+    t_sample *outre = (t_sample *) (w[5]);
+    t_sample *outim = (t_sample *) (w[6]);
+    t_sigczero_rev *x = (t_sigczero_rev *) (w[7]);
+    int n = (int) w[8];
     int i;
     t_sample lastre = x->x_lastre;
     t_sample lastim = x->x_lastim;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample nextre = *inre1++;
         t_sample nextim = *inim1++;
         t_sample coefre = *inre2++;
         t_sample coefim = *inim2++;
-            /* transfer function is (A bar) - Z^-1, for the same
-            frequency response as 1 - AZ^-1 from czero_tilde. */
+        /* transfer function is (A bar) - Z^-1, for the same
+        frequency response as 1 - AZ^-1 from czero_tilde. */
         *outre++ = lastre - nextre * coefre - nextim * coefim;
         *outim++ = lastim - nextre * coefim + nextim * coefre;
         lastre = nextre;
@@ -1018,14 +967,13 @@ static t_int *sigczero_rev_perform(t_int *w)
     }
     x->x_lastre = lastre;
     x->x_lastim = lastim;
-    return (w+9);
+    return (w + 9);
 }
 
 static void sigczero_rev_dsp(t_sigczero_rev *x, t_signal **sp)
 {
-    dsp_add(sigczero_rev_perform, 8,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-        sp[4]->s_vec, sp[5]->s_vec, x, (t_int)sp[0]->s_n);
+    dsp_add(sigczero_rev_perform, 8, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, sp[4]->s_vec, sp[5]->s_vec, x, (t_int) sp[0]->s_n);
 }
 
 static void sigczero_rev_clear(t_sigczero_rev *x)
@@ -1041,15 +989,15 @@ static void sigczero_rev_set(t_sigczero_rev *x, t_float re, t_float im)
 
 void sigczero_rev_setup(void)
 {
-    sigczero_rev_class = class_new(gensym("czero_rev~"),
-        (t_newmethod)sigczero_rev_new, 0, sizeof(t_sigczero_rev), 0,
-            A_DEFFLOAT, A_DEFFLOAT, 0);
+    sigczero_rev_class =
+        class_new(gensym("czero_rev~"), (t_newmethod) sigczero_rev_new, 0,
+            sizeof(t_sigczero_rev), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigczero_rev_class, t_sigczero_rev, x_f);
-    class_addmethod(sigczero_rev_class, (t_method)sigczero_rev_set,
+    class_addmethod(sigczero_rev_class, (t_method) sigczero_rev_set,
         gensym("set"), A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(sigczero_rev_class, (t_method)sigczero_rev_clear,
-        gensym("clear"), 0);
-    class_addmethod(sigczero_rev_class, (t_method)sigczero_rev_dsp,
+    class_addmethod(
+        sigczero_rev_class, (t_method) sigczero_rev_clear, gensym("clear"), 0);
+    class_addmethod(sigczero_rev_class, (t_method) sigczero_rev_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -1073,7 +1021,7 @@ t_class *slop_tilde_class;
 
 static void *slop_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_slop_tilde *x = (t_slop_tilde *)pd_new(slop_tilde_class);
+    t_slop_tilde *x = (t_slop_tilde *) pd_new(slop_tilde_class);
     signalinlet_new(&x->x_obj, atom_getfloatarg(0, argc, argv));
     signalinlet_new(&x->x_obj, atom_getfloatarg(1, argc, argv));
     signalinlet_new(&x->x_obj, atom_getfloatarg(2, argc, argv));
@@ -1084,26 +1032,23 @@ static void *slop_tilde_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
-static void slop_tilde_set(t_slop_tilde *x, t_floatarg q)
-{
-    x->x_last = q;
-}
+static void slop_tilde_set(t_slop_tilde *x, t_floatarg q) { x->x_last = q; }
 
 static t_int *slop_tilde_perform(t_int *w)
 {
-    t_slop_tilde *x = (t_slop_tilde *)(w[1]);
-    t_sample *sigin = (t_sample *)(w[2]);
-    t_sample *freqin = (t_sample *)(w[3]);
-    t_sample *neglimit = (t_sample *)(w[4]);
-    t_sample *negfreqin = (t_sample *)(w[5]);
-    t_sample *poslimit = (t_sample *)(w[6]);
-    t_sample *posfreqin = (t_sample *)(w[7]);
+    t_slop_tilde *x = (t_slop_tilde *) (w[1]);
+    t_sample *sigin = (t_sample *) (w[2]);
+    t_sample *freqin = (t_sample *) (w[3]);
+    t_sample *neglimit = (t_sample *) (w[4]);
+    t_sample *negfreqin = (t_sample *) (w[5]);
+    t_sample *poslimit = (t_sample *) (w[6]);
+    t_sample *posfreqin = (t_sample *) (w[7]);
     t_sample coef = x->x_coef;
-    t_sample *out = (t_sample *)(w[8]);
-    int n = (int)w[9];
+    t_sample *out = (t_sample *) (w[8]);
+    int n = (int) w[9];
     int i;
     t_sample last = x->x_last;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         t_sample diff = *sigin++ - last;
         t_sample inc = *freqin++ * coef, diffinc;
@@ -1111,55 +1056,51 @@ static t_int *slop_tilde_perform(t_int *w)
         t_sample neginc = *negfreqin++ * coef;
         t_sample maxdiff = *poslimit++;
         t_sample mindiff = *neglimit++;
-        if (inc < 0.f)
+        if(inc < 0.f)
             inc = 0.f;
-        else if (inc > 1.f)
+        else if(inc > 1.f)
             inc = 1.f;
-        if (posinc < 0.f)
+        if(posinc < 0.f)
             posinc = 0.f;
-        else if (posinc > 1.f)
+        else if(posinc > 1.f)
             posinc = 1.f;
-        if (neginc < 0.f)
+        if(neginc < 0.f)
             neginc = 0.f;
-        else if (neginc > 1.f)
+        else if(neginc > 1.f)
             neginc = 1.f;
-        if (maxdiff < 0)
-            maxdiff = 0;
-        if (mindiff < 0)
-            mindiff = 0;
-        if (diff > maxdiff)
-            diffinc = posinc * (diff- maxdiff) + inc * maxdiff;
-        else if (diff < -mindiff)
+        if(maxdiff < 0) maxdiff = 0;
+        if(mindiff < 0) mindiff = 0;
+        if(diff > maxdiff)
+            diffinc = posinc * (diff - maxdiff) + inc * maxdiff;
+        else if(diff < -mindiff)
             diffinc = neginc * (diff + mindiff) - inc * mindiff;
-        else diffinc = inc * diff;
+        else
+            diffinc = inc * diff;
         last = *out++ = last + diffinc;
     }
-    if (PD_BIGORSMALL(last))
-        last = 0;
+    if(PD_BIGORSMALL(last)) last = 0;
     x->x_last = last;
-    return (w+10);
+    return (w + 10);
 }
 
 static void slop_tilde_dsp(t_slop_tilde *x, t_signal **sp)
 {
     x->x_coef = (2 * 3.14159) / sp[0]->s_sr;
-    dsp_add(slop_tilde_perform, 9,
-        x, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec, sp[4]->s_vec,
-            sp[5]->s_vec, sp[6]->s_vec, (t_int)sp[0]->s_n);
-
+    dsp_add(slop_tilde_perform, 9, x, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, sp[4]->s_vec, sp[5]->s_vec, sp[6]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 void slop_tilde_setup(void)
 {
-    slop_tilde_class = class_new(gensym("slop~"), (t_newmethod)slop_tilde_new, 0,
-        sizeof(t_slop_tilde), 0, A_GIMME, 0);
+    slop_tilde_class = class_new(gensym("slop~"), (t_newmethod) slop_tilde_new,
+        0, sizeof(t_slop_tilde), 0, A_GIMME, 0);
     CLASS_MAINSIGNALIN(slop_tilde_class, t_slop_tilde, x_f);
-    class_addmethod(slop_tilde_class, (t_method)slop_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(slop_tilde_class, (t_method)slop_tilde_set, gensym("set"),
-        A_FLOAT, 0);
+    class_addmethod(
+        slop_tilde_class, (t_method) slop_tilde_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        slop_tilde_class, (t_method) slop_tilde_set, gensym("set"), A_FLOAT, 0);
 }
-
 
 /* ------------------------ setup routine ------------------------- */
 

--- a/src/d_filter.c
+++ b/src/d_filter.c
@@ -268,7 +268,9 @@ static t_float sigbp_qcos(t_float f)
 
 static void sigbp_docoef(t_sigbp *x, t_floatarg f, t_floatarg q)
 {
-    t_float r, oneminusr, omega;
+    t_float r;
+    t_float oneminusr;
+    t_float omega;
     if(f < 0.001) f = 10;
     if(q < 0) q = 0;
     x->x_freq = f;
@@ -1051,7 +1053,8 @@ static t_int *slop_tilde_perform(t_int *w)
     for(i = 0; i < n; i++)
     {
         t_sample diff = *sigin++ - last;
-        t_sample inc = *freqin++ * coef, diffinc;
+        t_sample inc = *freqin++ * coef;
+        t_sample diffinc;
         t_sample posinc = *posfreqin++ * coef;
         t_sample neginc = *negfreqin++ * coef;
         t_sample maxdiff = *poslimit++;

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -37,12 +37,10 @@ static t_int *sigsend_perform(t_int *w)
 {
     t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
     {
-        *out = (PD_BIGORSMALL(*in) ? 0 : *in);
-        out++;
-        in++;
+        out[i] = (PD_BIGORSMALL(in[i]) ? 0 : in[i]);
     }
     return (w + 4);
 }
@@ -101,17 +99,17 @@ static t_int *sigreceive_perform(t_int *w)
 {
     t_sigreceive *x = (t_sigreceive *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
     t_sample *in = x->x_wherefrom;
     if(in)
     {
-        while(n--)
-            *out++ = *in++;
+        for(int i = 0; i < num_samples; i++)
+            out[i] = in[i];
     }
     else
     {
-        while(n--)
-            *out++ = 0;
+        for(int i = 0; i < num_samples; i++)
+            out[i] = 0;
     }
     return (w + 4);
 }
@@ -121,11 +119,11 @@ static t_int *sigreceive_perf8(t_int *w)
 {
     t_sigreceive *x = (t_sigreceive *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
     t_sample *in = x->x_wherefrom;
     if(in)
     {
-        for(; n; n -= 8, in += 8, out += 8)
+        for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
         {
             out[0] = in[0];
             out[1] = in[1];
@@ -139,7 +137,7 @@ static t_int *sigreceive_perf8(t_int *w)
     }
     else
     {
-        for(; n; n -= 8, in += 8, out += 8)
+        for(int i = 0; i < num_samples; i += 8, out += 8)
         {
             out[0] = 0;
             out[1] = 0;
@@ -236,9 +234,12 @@ static t_int *sigcatch_perform(t_int *w)
 {
     t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
-        *out++ = *in, *in++ = 0;
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
+    {
+        out[i] = in[i];
+        in[i] = 0;
+    }
     return (w + 4);
 }
 
@@ -247,8 +248,8 @@ static t_int *sigcatch_perf8(t_int *w)
 {
     t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    for(; n; n -= 8, in += 8, out += 8)
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
         out[0] = in[0];
         out[1] = in[1];
@@ -332,15 +333,13 @@ static t_int *sigthrow_perform(t_int *w)
 {
     t_sigthrow *x = (t_sigthrow *) (w[1]);
     t_sample *in = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
     t_sample *out = x->x_whereto;
     if(out)
     {
-        while(n--)
+        for(int i = 0; i < num_samples; i++)
         {
-            *out += (PD_BIGORSMALL(*in) ? 0 : *in);
-            out++;
-            in++;
+            out[i] += (PD_BIGORSMALL(in[i]) ? 0 : in[i]);
         }
     }
     return (w + 4);

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -1,13 +1,13 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  send~, receive~, throw~, catch~ */
 
 #include "m_pd.h"
 #include <string.h>
 
-#define DEFSENDVS 64    /* LATER get send to get this from canvas */
+#define DEFSENDVS 64 /* LATER get send to get this from canvas */
 
 /* ----------------------------- send~ ----------------------------- */
 static t_class *sigsend_class;
@@ -23,35 +23,36 @@ typedef struct _sigsend
 
 static void *sigsend_new(t_symbol *s)
 {
-    t_sigsend *x = (t_sigsend *)pd_new(sigsend_class);
+    t_sigsend *x = (t_sigsend *) pd_new(sigsend_class);
     pd_bind(&x->x_obj.ob_pd, s);
     x->x_sym = s;
     x->x_n = DEFSENDVS;
-    x->x_vec = (t_sample *)getbytes(DEFSENDVS * sizeof(t_sample));
-    memset((char *)(x->x_vec), 0, DEFSENDVS * sizeof(t_sample));
+    x->x_vec = (t_sample *) getbytes(DEFSENDVS * sizeof(t_sample));
+    memset((char *) (x->x_vec), 0, DEFSENDVS * sizeof(t_sample));
     x->x_f = 0;
     return (x);
 }
 
 static t_int *sigsend_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
     {
         *out = (PD_BIGORSMALL(*in) ? 0 : *in);
         out++;
         in++;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigsend_dsp(t_sigsend *x, t_signal **sp)
 {
-    if (x->x_n == sp[0]->s_n)
-        dsp_add(sigsend_perform, 3, sp[0]->s_vec, x->x_vec, (t_int)sp[0]->s_n);
-    else pd_error(0, "sigsend %s: unexpected vector size", x->x_sym->s_name);
+    if(x->x_n == sp[0]->s_n)
+        dsp_add(sigsend_perform, 3, sp[0]->s_vec, x->x_vec, (t_int) sp[0]->s_n);
+    else
+        pd_error(0, "sigsend %s: unexpected vector size", x->x_sym->s_name);
 }
 
 static void sigsend_free(t_sigsend *x)
@@ -62,12 +63,12 @@ static void sigsend_free(t_sigsend *x)
 
 static void sigsend_setup(void)
 {
-    sigsend_class = class_new(gensym("send~"), (t_newmethod)sigsend_new,
-        (t_method)sigsend_free, sizeof(t_sigsend), 0, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)sigsend_new, gensym("s~"), A_DEFSYM, 0);
+    sigsend_class = class_new(gensym("send~"), (t_newmethod) sigsend_new,
+        (t_method) sigsend_free, sizeof(t_sigsend), 0, A_DEFSYM, 0);
+    class_addcreator((t_newmethod) sigsend_new, gensym("s~"), A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(sigsend_class, t_sigsend, x_f);
-    class_addmethod(sigsend_class, (t_method)sigsend_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigsend_class, (t_method) sigsend_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigsend_class, gensym("send-receive-tilde"));
 }
 
@@ -84,8 +85,8 @@ typedef struct _sigreceive
 
 static void *sigreceive_new(t_symbol *s)
 {
-    t_sigreceive *x = (t_sigreceive *)pd_new(sigreceive_class);
-    x->x_n = DEFSENDVS;             /* LATER find our vector size correctly */
+    t_sigreceive *x = (t_sigreceive *) pd_new(sigreceive_class);
+    x->x_n = DEFSENDVS; /* LATER find our vector size correctly */
     x->x_sym = s;
     x->x_wherefrom = 0;
     outlet_new(&x->x_obj, &s_signal);
@@ -94,56 +95,68 @@ static void *sigreceive_new(t_symbol *s)
 
 static t_int *sigreceive_perform(t_int *w)
 {
-    t_sigreceive *x = (t_sigreceive *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sigreceive *x = (t_sigreceive *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     t_sample *in = x->x_wherefrom;
-    if (in)
+    if(in)
     {
-        while (n--)
+        while(n--)
             *out++ = *in++;
     }
     else
     {
-        while (n--)
+        while(n--)
             *out++ = 0;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 /* tb: vectorized receive function */
 static t_int *sigreceive_perf8(t_int *w)
 {
-    t_sigreceive *x = (t_sigreceive *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sigreceive *x = (t_sigreceive *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     t_sample *in = x->x_wherefrom;
-    if (in)
+    if(in)
     {
-        for (; n; n -= 8, in += 8, out += 8)
+        for(; n; n -= 8, in += 8, out += 8)
         {
-            out[0] = in[0]; out[1] = in[1]; out[2] = in[2]; out[3] = in[3];
-            out[4] = in[4]; out[5] = in[5]; out[6] = in[6]; out[7] = in[7];
+            out[0] = in[0];
+            out[1] = in[1];
+            out[2] = in[2];
+            out[3] = in[3];
+            out[4] = in[4];
+            out[5] = in[5];
+            out[6] = in[6];
+            out[7] = in[7];
         }
     }
     else
     {
-        for (; n; n -= 8, in += 8, out += 8)
+        for(; n; n -= 8, in += 8, out += 8)
         {
-            out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 0;
-            out[4] = 0; out[5] = 0; out[6] = 0; out[7] = 0;
+            out[0] = 0;
+            out[1] = 0;
+            out[2] = 0;
+            out[3] = 0;
+            out[4] = 0;
+            out[5] = 0;
+            out[6] = 0;
+            out[7] = 0;
         }
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigreceive_set(t_sigreceive *x, t_symbol *s)
 {
-    t_sigsend *sender = (t_sigsend *)pd_findbyclass((x->x_sym = s),
-        sigsend_class);
-    if (sender)
+    t_sigsend *sender =
+        (t_sigsend *) pd_findbyclass((x->x_sym = s), sigsend_class);
+    if(sender)
     {
-        if (sender->x_n == x->x_n)
+        if(sender->x_n == x->x_n)
             x->x_wherefrom = sender->x_vec;
         else
         {
@@ -160,31 +173,29 @@ static void sigreceive_set(t_sigreceive *x, t_symbol *s)
 
 static void sigreceive_dsp(t_sigreceive *x, t_signal **sp)
 {
-    if (sp[0]->s_n != x->x_n)
+    if(sp[0]->s_n != x->x_n)
     {
         pd_error(x, "receive~ %s: vector size mismatch", x->x_sym->s_name);
     }
     else
     {
         sigreceive_set(x, x->x_sym);
-        if (sp[0]->s_n&7)
-            dsp_add(sigreceive_perform, 3,
-                x, sp[0]->s_vec, (t_int)sp[0]->s_n);
-        else dsp_add(sigreceive_perf8, 3,
-            x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+        if(sp[0]->s_n & 7)
+            dsp_add(sigreceive_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+        else
+            dsp_add(sigreceive_perf8, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
     }
 }
 
 static void sigreceive_setup(void)
 {
     sigreceive_class = class_new(gensym("receive~"),
-        (t_newmethod)sigreceive_new, 0,
-        sizeof(t_sigreceive), 0, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)sigreceive_new, gensym("r~"), A_DEFSYM, 0);
-    class_addmethod(sigreceive_class, (t_method)sigreceive_set, gensym("set"),
+        (t_newmethod) sigreceive_new, 0, sizeof(t_sigreceive), 0, A_DEFSYM, 0);
+    class_addcreator((t_newmethod) sigreceive_new, gensym("r~"), A_DEFSYM, 0);
+    class_addmethod(sigreceive_class, (t_method) sigreceive_set, gensym("set"),
         A_SYMBOL, 0);
-    class_addmethod(sigreceive_class, (t_method)sigreceive_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigreceive_class, (t_method) sigreceive_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigreceive_class, gensym("send-receive-tilde"));
 }
 
@@ -201,52 +212,68 @@ typedef struct _sigcatch
 
 static void *sigcatch_new(t_symbol *s)
 {
-    t_sigcatch *x = (t_sigcatch *)pd_new(sigcatch_class);
+    t_sigcatch *x = (t_sigcatch *) pd_new(sigcatch_class);
     pd_bind(&x->x_obj.ob_pd, s);
     x->x_sym = s;
     x->x_n = DEFSENDVS;
-    x->x_vec = (t_sample *)getbytes(DEFSENDVS * sizeof(t_sample));
-    memset((char *)(x->x_vec), 0, DEFSENDVS * sizeof(t_sample));
+    x->x_vec = (t_sample *) getbytes(DEFSENDVS * sizeof(t_sample));
+    memset((char *) (x->x_vec), 0, DEFSENDVS * sizeof(t_sample));
     outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
 
 static t_int *sigcatch_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--) *out++ = *in, *in++ = 0;
-    return (w+4);
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
+        *out++ = *in, *in++ = 0;
+    return (w + 4);
 }
 
 /* tb: vectorized catch function */
 static t_int *sigcatch_perf8(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    for (; n; n -= 8, in += 8, out += 8)
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    for(; n; n -= 8, in += 8, out += 8)
     {
-       out[0] = in[0]; out[1] = in[1]; out[2] = in[2]; out[3] = in[3];
-       out[4] = in[4]; out[5] = in[5]; out[6] = in[6]; out[7] = in[7];
+        out[0] = in[0];
+        out[1] = in[1];
+        out[2] = in[2];
+        out[3] = in[3];
+        out[4] = in[4];
+        out[5] = in[5];
+        out[6] = in[6];
+        out[7] = in[7];
 
-       in[0] = 0; in[1] = 0; in[2] = 0; in[3] = 0;
-       in[4] = 0; in[5] = 0; in[6] = 0; in[7] = 0;
+        in[0] = 0;
+        in[1] = 0;
+        in[2] = 0;
+        in[3] = 0;
+        in[4] = 0;
+        in[5] = 0;
+        in[6] = 0;
+        in[7] = 0;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigcatch_dsp(t_sigcatch *x, t_signal **sp)
 {
-    if (x->x_n == sp[0]->s_n)
+    if(x->x_n == sp[0]->s_n)
     {
-        if(sp[0]->s_n&7)
-            dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec, (t_int)sp[0]->s_n);
+        if(sp[0]->s_n & 7)
+            dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec,
+                (t_int) sp[0]->s_n);
         else
-            dsp_add(sigcatch_perf8, 3, x->x_vec, sp[0]->s_vec, (t_int)sp[0]->s_n);
+            dsp_add(
+                sigcatch_perf8, 3, x->x_vec, sp[0]->s_vec, (t_int) sp[0]->s_n);
     }
-    else pd_error(0, "sigcatch %s: unexpected vector size", x->x_sym->s_name);
+    else
+        pd_error(0, "sigcatch %s: unexpected vector size", x->x_sym->s_name);
 }
 
 static void sigcatch_free(t_sigcatch *x)
@@ -257,10 +284,11 @@ static void sigcatch_free(t_sigcatch *x)
 
 static void sigcatch_setup(void)
 {
-    sigcatch_class = class_new(gensym("catch~"), (t_newmethod)sigcatch_new,
-        (t_method)sigcatch_free, sizeof(t_sigcatch), CLASS_NOINLET, A_DEFSYM, 0);
-    class_addmethod(sigcatch_class, (t_method)sigcatch_dsp,
-        gensym("dsp"), A_CANT, 0);
+    sigcatch_class = class_new(gensym("catch~"), (t_newmethod) sigcatch_new,
+        (t_method) sigcatch_free, sizeof(t_sigcatch), CLASS_NOINLET, A_DEFSYM,
+        0);
+    class_addmethod(
+        sigcatch_class, (t_method) sigcatch_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigcatch_class, gensym("throw~-catch~"));
 }
 
@@ -278,9 +306,9 @@ typedef struct _sigthrow
 
 static void *sigthrow_new(t_symbol *s)
 {
-    t_sigthrow *x = (t_sigthrow *)pd_new(sigthrow_class);
+    t_sigthrow *x = (t_sigthrow *) pd_new(sigthrow_class);
     x->x_sym = s;
-    x->x_whereto  = 0;
+    x->x_whereto = 0;
     x->x_n = DEFSENDVS;
     x->x_f = 0;
     return (x);
@@ -288,29 +316,29 @@ static void *sigthrow_new(t_symbol *s)
 
 static t_int *sigthrow_perform(t_int *w)
 {
-    t_sigthrow *x = (t_sigthrow *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sigthrow *x = (t_sigthrow *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     t_sample *out = x->x_whereto;
-    if (out)
+    if(out)
     {
-        while (n--)
+        while(n--)
         {
             *out += (PD_BIGORSMALL(*in) ? 0 : *in);
             out++;
             in++;
         }
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void sigthrow_set(t_sigthrow *x, t_symbol *s)
 {
-    t_sigcatch *catcher = (t_sigcatch *)pd_findbyclass((x->x_sym = s),
-        sigcatch_class);
-    if (catcher)
+    t_sigcatch *catcher =
+        (t_sigcatch *) pd_findbyclass((x->x_sym = s), sigcatch_class);
+    if(catcher)
     {
-        if (catcher->x_n == x->x_n)
+        if(catcher->x_n == x->x_n)
             x->x_whereto = catcher->x_vec;
         else
         {
@@ -318,32 +346,32 @@ static void sigthrow_set(t_sigthrow *x, t_symbol *s)
             x->x_whereto = 0;
         }
     }
-    else x->x_whereto = 0;  /* no match: now no longer considered an error */
+    else
+        x->x_whereto = 0; /* no match: now no longer considered an error */
 }
 
 static void sigthrow_dsp(t_sigthrow *x, t_signal **sp)
 {
-    if (sp[0]->s_n != x->x_n)
+    if(sp[0]->s_n != x->x_n)
     {
         pd_error(x, "throw~ %s: vector size mismatch", x->x_sym->s_name);
     }
     else
     {
         sigthrow_set(x, x->x_sym);
-        dsp_add(sigthrow_perform, 3,
-            x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+        dsp_add(sigthrow_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
     }
 }
 
 static void sigthrow_setup(void)
 {
-    sigthrow_class = class_new(gensym("throw~"), (t_newmethod)sigthrow_new, 0,
+    sigthrow_class = class_new(gensym("throw~"), (t_newmethod) sigthrow_new, 0,
         sizeof(t_sigthrow), 0, A_DEFSYM, 0);
-    class_addmethod(sigthrow_class, (t_method)sigthrow_set, gensym("set"),
-        A_SYMBOL, 0);
+    class_addmethod(
+        sigthrow_class, (t_method) sigthrow_set, gensym("set"), A_SYMBOL, 0);
     CLASS_MAINSIGNALIN(sigthrow_class, t_sigthrow, x_f);
-    class_addmethod(sigthrow_class, (t_method)sigthrow_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigthrow_class, (t_method) sigthrow_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigthrow_class, gensym("throw~-catch~"));
 }
 
@@ -356,4 +384,3 @@ void d_global_setup(void)
     sigcatch_setup();
     sigthrow_setup();
 }
-

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -50,9 +50,13 @@ static t_int *sigsend_perform(t_int *w)
 static void sigsend_dsp(t_sigsend *x, t_signal **sp)
 {
     if(x->x_n == sp[0]->s_n)
+    {
         dsp_add(sigsend_perform, 3, sp[0]->s_vec, x->x_vec, (t_int) sp[0]->s_n);
+    }
     else
+    {
         pd_error(0, "sigsend %s: unexpected vector size", x->x_sym->s_name);
+    }
 }
 
 static void sigsend_free(t_sigsend *x)
@@ -157,7 +161,9 @@ static void sigreceive_set(t_sigreceive *x, t_symbol *s)
     if(sender)
     {
         if(sender->x_n == x->x_n)
+        {
             x->x_wherefrom = sender->x_vec;
+        }
         else
         {
             pd_error(x, "receive~ %s: vector size mismatch", x->x_sym->s_name);
@@ -181,9 +187,13 @@ static void sigreceive_dsp(t_sigreceive *x, t_signal **sp)
     {
         sigreceive_set(x, x->x_sym);
         if(sp[0]->s_n & 7)
+        {
             dsp_add(sigreceive_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+        }
         else
+        {
             dsp_add(sigreceive_perf8, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
+        }
     }
 }
 
@@ -266,11 +276,15 @@ static void sigcatch_dsp(t_sigcatch *x, t_signal **sp)
     if(x->x_n == sp[0]->s_n)
     {
         if(sp[0]->s_n & 7)
+        {
             dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec,
                 (t_int) sp[0]->s_n);
+        }
         else
+        {
             dsp_add(
                 sigcatch_perf8, 3, x->x_vec, sp[0]->s_vec, (t_int) sp[0]->s_n);
+        }
     }
     else
         pd_error(0, "sigcatch %s: unexpected vector size", x->x_sym->s_name);
@@ -339,7 +353,9 @@ static void sigthrow_set(t_sigthrow *x, t_symbol *s)
     if(catcher)
     {
         if(catcher->x_n == x->x_n)
+        {
             x->x_whereto = catcher->x_vec;
+        }
         else
         {
             pd_error(x, "throw~ %s: vector size mismatch", x->x_sym->s_name);

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -159,7 +159,8 @@ static void *sigrsqrt_new(void)
 
 static t_int *sigrsqrt_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     while(n--)
     {
@@ -222,7 +223,8 @@ static void *sigsqrt_new(void)
 
 t_int *sigsqrt_perform(t_int *w) /* not static; also used in d_fft.c */
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     while(n--)
     {
@@ -282,7 +284,8 @@ static void *sigwrap_new(void)
 
 static t_int *sigwrap_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     while(n--)
     {
@@ -301,7 +304,8 @@ static t_int *sigwrap_perform(t_int *w)
 /* old buggy version that sometimes output 1 instead of 0 */
 static t_int *sigwrap_old_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     while(n--)
     {
@@ -351,7 +355,8 @@ static void *mtof_tilde_new(void)
 
 static t_int *mtof_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -402,7 +407,8 @@ static void *ftom_tilde_new(void)
 
 static t_int *ftom_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -447,7 +453,8 @@ static void *dbtorms_tilde_new(void)
 
 static t_int *dbtorms_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -498,7 +505,8 @@ static void *rmstodb_tilde_new(void)
 
 static t_int *rmstodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -549,7 +557,8 @@ static void *dbtopow_tilde_new(void)
 
 static t_int *dbtopow_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -600,7 +609,8 @@ static void *powtodb_tilde_new(void)
 
 static t_int *powtodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    t_sample *in = (t_sample *) w[1];
+    t_sample *out = (t_sample *) w[2];
     int n = (int) w[3];
     for(; n--; in++, out++)
     {
@@ -658,7 +668,8 @@ t_int *pow_tilde_perform(t_int *w)
     int n = (int) (w[4]);
     while(n--)
     {
-        t_sample f1 = *in1++, f2 = *in2++;
+        t_sample f1 = *in1++;
+        t_sample f2 = *in2++;
         *out++ = (f1 == 0 && f2 < 0) || (f1 < 0 && (f2 - (int) f2) != 0)
                      ? 0
                      : pow(f1, f2);
@@ -750,7 +761,8 @@ t_int *log_tilde_perform(t_int *w)
     int n = (int) (w[4]);
     while(n--)
     {
-        t_sample f = *in1++, g = *in2++;
+        t_sample f = *in1++;
+        t_sample g = *in2++;
         if(f <= 0)
             *out = -1000; /* rather than blow up, output a number << 0 */
         else if(g <= 0)

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2001 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  mathematical functions and other transfer functions, including tilde
     versions of stuff from x_acoustics.c.
@@ -24,7 +24,7 @@ typedef struct _clip
 
 static void *clip_new(t_floatarg lo, t_floatarg hi)
 {
-    t_clip *x = (t_clip *)pd_new(clip_class);
+    t_clip *x = (t_clip *) pd_new(clip_class);
     x->x_lo = lo;
     x->x_hi = hi;
     outlet_new(&x->x_obj, gensym("signal"));
@@ -36,31 +36,31 @@ static void *clip_new(t_floatarg lo, t_floatarg hi)
 
 static t_int *clip_perform(t_int *w)
 {
-    t_clip *x = (t_clip *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_clip *x = (t_clip *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f = *in++;
-        if (f < x->x_lo) f = x->x_lo;
-        if (f > x->x_hi) f = x->x_hi;
+        if(f < x->x_lo) f = x->x_lo;
+        if(f > x->x_hi) f = x->x_hi;
         *out++ = f;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void clip_dsp(t_clip *x, t_signal **sp)
 {
-    dsp_add(clip_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(clip_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void clip_setup(void)
 {
-    clip_class = class_new(gensym("clip~"), (t_newmethod)clip_new, 0,
+    clip_class = class_new(gensym("clip~"), (t_newmethod) clip_new, 0,
         sizeof(t_clip), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(clip_class, t_clip, x_f);
-    class_addmethod(clip_class, (t_method)clip_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(clip_class, (t_method) clip_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* sigrsqrt - reciprocal square root good to 8 mantissa bits  */
@@ -75,59 +75,70 @@ static float *rsqrt_exptab, *rsqrt_mantissatab;
 static void init_rsqrt(void)
 {
     int i;
-    if (!rsqrt_exptab)
+    if(!rsqrt_exptab)
     {
-        rsqrt_exptab = (float *)getbytes(DUMTAB1SIZE*sizeof(float));
-        rsqrt_mantissatab = (float *)getbytes(DUMTAB2SIZE*sizeof(float));
-        for (i = 0; i < DUMTAB1SIZE; i++)
+        rsqrt_exptab = (float *) getbytes(DUMTAB1SIZE * sizeof(float));
+        rsqrt_mantissatab = (float *) getbytes(DUMTAB2SIZE * sizeof(float));
+        for(i = 0; i < DUMTAB1SIZE; i++)
         {
-            union {
-              float f;
-              long l;
+            union
+            {
+                float f;
+                long l;
             } u;
-            int32_t l =
-                (i ? (i == DUMTAB1SIZE-1 ? DUMTAB1SIZE-2 : i) : 1)<< 23;
+
+            int32_t l = (i ? (i == DUMTAB1SIZE - 1 ? DUMTAB1SIZE - 2 : i) : 1)
+                        << 23;
             u.l = l;
-            rsqrt_exptab[i] = 1./sqrt(u.f);
+            rsqrt_exptab[i] = 1. / sqrt(u.f);
         }
-        for (i = 0; i < DUMTAB2SIZE; i++)
+        for(i = 0; i < DUMTAB2SIZE; i++)
         {
-            float f = 1 + (1./DUMTAB2SIZE) * i;
-            rsqrt_mantissatab[i] = 1./sqrt(f);
+            float f = 1 + (1. / DUMTAB2SIZE) * i;
+            rsqrt_mantissatab[i] = 1. / sqrt(f);
         }
     }
 }
 
-    /* these are used in externs like "bonk" */
+/* these are used in externs like "bonk" */
 
 t_float q8_rsqrt(t_float f0)
 {
-    union {
-      float f;
-      long l;
+    union
+    {
+        float f;
+        long l;
     } u;
+
     init_rsqrt();
     u.f = f0;
-    if (u.f < 0) return (0);
-    else return (t_float)(rsqrt_exptab[(u.l >> 23) & 0xff] *
-            rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
+    if(u.f < 0)
+        return (0);
+    else
+        return (t_float) (rsqrt_exptab[(u.l >> 23) & 0xff] *
+                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
 }
 
 t_float q8_sqrt(t_float f0)
 {
-    union {
-      float f;
-      long l;
+    union
+    {
+        float f;
+        long l;
     } u;
+
     init_rsqrt();
     u.f = f0;
-    if (u.f < 0) return (0);
-    else return (t_float)(u.f * rsqrt_exptab[(u.l >> 23) & 0xff] *
-            rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
+    if(u.f < 0)
+        return (0);
+    else
+        return (t_float) (u.f * rsqrt_exptab[(u.l >> 23) & 0xff] *
+                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
 }
 
-t_float qsqrt(t_float f) {return (q8_sqrt(f)); }
-t_float qrsqrt(t_float f) {return (q8_rsqrt(f)); }
+t_float qsqrt(t_float f) { return (q8_sqrt(f)); }
+
+t_float qrsqrt(t_float f) { return (q8_rsqrt(f)); }
 
 typedef struct sigrsqrt
 {
@@ -139,7 +150,7 @@ static t_class *sigrsqrt_class;
 
 static void *sigrsqrt_new(void)
 {
-    t_sigrsqrt *x = (t_sigrsqrt *)pd_new(sigrsqrt_class);
+    t_sigrsqrt *x = (t_sigrsqrt *) pd_new(sigrsqrt_class);
     init_rsqrt();
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
@@ -148,21 +159,25 @@ static void *sigrsqrt_new(void)
 
 static t_int *sigrsqrt_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    while (n--)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    while(n--)
     {
         t_sample f = *in++;
-        union {
-          float f;
-          long l;
+
+        union
+        {
+            float f;
+            long l;
         } u;
+
         u.f = f;
-        if (f < 0) *out++ = 0;
+        if(f < 0)
+            *out++ = 0;
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
-                rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
+                         rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
             *out++ = 1.5 * g - 0.5 * g * g * g * f;
         }
     }
@@ -171,20 +186,20 @@ static t_int *sigrsqrt_perform(t_int *w)
 
 static void sigrsqrt_dsp(t_sigrsqrt *x, t_signal **sp)
 {
-    dsp_add(sigrsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        sigrsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 void sigrsqrt_setup(void)
 {
-    sigrsqrt_class = class_new(gensym("rsqrt~"), (t_newmethod)sigrsqrt_new, 0,
+    sigrsqrt_class = class_new(gensym("rsqrt~"), (t_newmethod) sigrsqrt_new, 0,
         sizeof(t_sigrsqrt), 0, 0);
-            /* an old name for it: */
+    /* an old name for it: */
     class_addcreator(sigrsqrt_new, gensym("q8_rsqrt~"), 0);
     CLASS_MAINSIGNALIN(sigrsqrt_class, t_sigrsqrt, x_f);
-    class_addmethod(sigrsqrt_class, (t_method)sigrsqrt_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigrsqrt_class, (t_method) sigrsqrt_dsp, gensym("dsp"), A_CANT, 0);
 }
-
 
 /* sigsqrt -  square root good to 8 mantissa bits  */
 
@@ -198,30 +213,34 @@ static t_class *sigsqrt_class;
 
 static void *sigsqrt_new(void)
 {
-    t_sigsqrt *x = (t_sigsqrt *)pd_new(sigsqrt_class);
+    t_sigsqrt *x = (t_sigsqrt *) pd_new(sigsqrt_class);
     init_rsqrt();
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
 }
 
-t_int *sigsqrt_perform(t_int *w)    /* not static; also used in d_fft.c */
+t_int *sigsqrt_perform(t_int *w) /* not static; also used in d_fft.c */
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    while (n--)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    while(n--)
     {
         t_sample f = *in++;
-        union {
-          float f;
-          long l;
+
+        union
+        {
+            float f;
+            long l;
         } u;
+
         u.f = f;
-        if (f < 0) *out++ = 0;
+        if(f < 0)
+            *out++ = 0;
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
-                rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
+                         rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
             *out++ = f * (1.5 * g - 0.5 * g * g * g * f);
         }
     }
@@ -230,17 +249,17 @@ t_int *sigsqrt_perform(t_int *w)    /* not static; also used in d_fft.c */
 
 static void sigsqrt_dsp(t_sigsqrt *x, t_signal **sp)
 {
-    dsp_add(sigsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(sigsqrt_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 void sigsqrt_setup(void)
 {
-    sigsqrt_class = class_new(gensym("sqrt~"), (t_newmethod)sigsqrt_new, 0,
-        sizeof(t_sigsqrt), 0, 0);
-    class_addcreator(sigsqrt_new, gensym("q8_sqrt~"), 0);   /* old name */
+    sigsqrt_class = class_new(
+        gensym("sqrt~"), (t_newmethod) sigsqrt_new, 0, sizeof(t_sigsqrt), 0, 0);
+    class_addcreator(sigsqrt_new, gensym("q8_sqrt~"), 0); /* old name */
     CLASS_MAINSIGNALIN(sigsqrt_class, t_sigsqrt, x_f);
-    class_addmethod(sigsqrt_class, (t_method)sigsqrt_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigsqrt_class, (t_method) sigsqrt_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------------------------------ wrap~ -------------------------- */
@@ -255,7 +274,7 @@ t_class *sigwrap_class;
 
 static void *sigwrap_new(void)
 {
-    t_sigwrap *x = (t_sigwrap *)pd_new(sigwrap_class);
+    t_sigwrap *x = (t_sigwrap *) pd_new(sigwrap_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -263,49 +282,53 @@ static void *sigwrap_new(void)
 
 static t_int *sigwrap_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    while (n--)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    while(n--)
     {
         int k;
         t_sample f = *in++;
-        f = (f>INT_MAX || f<INT_MIN)?0.:f;
-        k = (int)f;
-        if (k <= f) *out++ = f-k;
-        else *out++ = f - (k-1);
+        f = (f > INT_MAX || f < INT_MIN) ? 0. : f;
+        k = (int) f;
+        if(k <= f)
+            *out++ = f - k;
+        else
+            *out++ = f - (k - 1);
     }
     return (w + 4);
 }
 
-     /* old buggy version that sometimes output 1 instead of 0 */
+/* old buggy version that sometimes output 1 instead of 0 */
 static t_int *sigwrap_old_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    while (n--)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    while(n--)
     {
         t_sample f = *in++;
         int k = f;
-        if (f > 0) *out++ = f-k;
-        else *out++ = f - (k-1);
+        if(f > 0)
+            *out++ = f - k;
+        else
+            *out++ = f - (k - 1);
     }
     return (w + 4);
 }
 
 static void sigwrap_dsp(t_sigwrap *x, t_signal **sp)
 {
-    dsp_add((pd_compatibilitylevel < 48 ?
-        sigwrap_old_perform : sigwrap_perform),
-            3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        (pd_compatibilitylevel < 48 ? sigwrap_old_perform : sigwrap_perform), 3,
+        sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 void sigwrap_setup(void)
 {
-    sigwrap_class = class_new(gensym("wrap~"), (t_newmethod)sigwrap_new, 0,
-        sizeof(t_sigwrap), 0, 0);
+    sigwrap_class = class_new(
+        gensym("wrap~"), (t_newmethod) sigwrap_new, 0, sizeof(t_sigwrap), 0, 0);
     CLASS_MAINSIGNALIN(sigwrap_class, t_sigwrap, x_f);
-    class_addmethod(sigwrap_class, (t_method)sigwrap_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigwrap_class, (t_method) sigwrap_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------------------------------ mtof_tilde~ -------------------------- */
@@ -320,7 +343,7 @@ t_class *mtof_tilde_class;
 
 static void *mtof_tilde_new(void)
 {
-    t_mtof_tilde *x = (t_mtof_tilde *)pd_new(mtof_tilde_class);
+    t_mtof_tilde *x = (t_mtof_tilde *) pd_new(mtof_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -328,15 +351,16 @@ static void *mtof_tilde_new(void)
 
 static t_int *mtof_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
-        if (f <= -1500) *out = 0;
+        if(f <= -1500)
+            *out = 0;
         else
         {
-            if (f > 1499) f = 1499;
+            if(f > 1499) f = 1499;
             *out = 8.17579891564 * exp(.0577622650 * f);
         }
     }
@@ -345,16 +369,17 @@ static t_int *mtof_tilde_perform(t_int *w)
 
 static void mtof_tilde_dsp(t_mtof_tilde *x, t_signal **sp)
 {
-    dsp_add(mtof_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        mtof_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 void mtof_tilde_setup(void)
 {
-    mtof_tilde_class = class_new(gensym("mtof~"), (t_newmethod)mtof_tilde_new, 0,
-        sizeof(t_mtof_tilde), 0, 0);
+    mtof_tilde_class = class_new(gensym("mtof~"), (t_newmethod) mtof_tilde_new,
+        0, sizeof(t_mtof_tilde), 0, 0);
     CLASS_MAINSIGNALIN(mtof_tilde_class, t_mtof_tilde, x_f);
-    class_addmethod(mtof_tilde_class, (t_method)mtof_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        mtof_tilde_class, (t_method) mtof_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------------------------------ ftom_tilde~ -------------------------- */
@@ -369,7 +394,7 @@ t_class *ftom_tilde_class;
 
 static void *ftom_tilde_new(void)
 {
-    t_ftom_tilde *x = (t_ftom_tilde *)pd_new(ftom_tilde_class);
+    t_ftom_tilde *x = (t_ftom_tilde *) pd_new(ftom_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -377,9 +402,9 @@ static void *ftom_tilde_new(void)
 
 static t_int *ftom_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
         *out = (f > 0 ? 17.3123405046 * log(.12231220585 * f) : -1500);
@@ -389,16 +414,17 @@ static t_int *ftom_tilde_perform(t_int *w)
 
 static void ftom_tilde_dsp(t_ftom_tilde *x, t_signal **sp)
 {
-    dsp_add(ftom_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        ftom_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 void ftom_tilde_setup(void)
 {
-    ftom_tilde_class = class_new(gensym("ftom~"), (t_newmethod)ftom_tilde_new, 0,
-        sizeof(t_ftom_tilde), 0, 0);
+    ftom_tilde_class = class_new(gensym("ftom~"), (t_newmethod) ftom_tilde_new,
+        0, sizeof(t_ftom_tilde), 0, 0);
     CLASS_MAINSIGNALIN(ftom_tilde_class, t_ftom_tilde, x_f);
-    class_addmethod(ftom_tilde_class, (t_method)ftom_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        ftom_tilde_class, (t_method) ftom_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------------------------------ dbtorms~ -------------------------- */
@@ -413,7 +439,7 @@ t_class *dbtorms_tilde_class;
 
 static void *dbtorms_tilde_new(void)
 {
-    t_dbtorms_tilde *x = (t_dbtorms_tilde *)pd_new(dbtorms_tilde_class);
+    t_dbtorms_tilde *x = (t_dbtorms_tilde *) pd_new(dbtorms_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -421,17 +447,17 @@ static void *dbtorms_tilde_new(void)
 
 static t_int *dbtorms_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
-        if (f <= 0) *out = 0;
+        if(f <= 0)
+            *out = 0;
         else
         {
-            if (f > 485)
-                f = 485;
-            *out = exp((LOGTEN * 0.05) * (f-100.));
+            if(f > 485) f = 485;
+            *out = exp((LOGTEN * 0.05) * (f - 100.));
         }
     }
     return (w + 4);
@@ -439,15 +465,16 @@ static t_int *dbtorms_tilde_perform(t_int *w)
 
 static void dbtorms_tilde_dsp(t_dbtorms_tilde *x, t_signal **sp)
 {
-    dsp_add(dbtorms_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(dbtorms_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 void dbtorms_tilde_setup(void)
 {
-    dbtorms_tilde_class = class_new(gensym("dbtorms~"), (t_newmethod)dbtorms_tilde_new, 0,
-        sizeof(t_dbtorms_tilde), 0, 0);
+    dbtorms_tilde_class = class_new(gensym("dbtorms~"),
+        (t_newmethod) dbtorms_tilde_new, 0, sizeof(t_dbtorms_tilde), 0, 0);
     CLASS_MAINSIGNALIN(dbtorms_tilde_class, t_dbtorms_tilde, x_f);
-    class_addmethod(dbtorms_tilde_class, (t_method)dbtorms_tilde_dsp,
+    class_addmethod(dbtorms_tilde_class, (t_method) dbtorms_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -463,7 +490,7 @@ t_class *rmstodb_tilde_class;
 
 static void *rmstodb_tilde_new(void)
 {
-    t_rmstodb_tilde *x = (t_rmstodb_tilde *)pd_new(rmstodb_tilde_class);
+    t_rmstodb_tilde *x = (t_rmstodb_tilde *) pd_new(rmstodb_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -471,15 +498,16 @@ static void *rmstodb_tilde_new(void)
 
 static t_int *rmstodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
-        if (f <= 0) *out = 0;
+        if(f <= 0)
+            *out = 0;
         else
         {
-            t_sample g = 100 + 20./LOGTEN * log(f);
+            t_sample g = 100 + 20. / LOGTEN * log(f);
             *out = (g < 0 ? 0 : g);
         }
     }
@@ -488,15 +516,16 @@ static t_int *rmstodb_tilde_perform(t_int *w)
 
 static void rmstodb_tilde_dsp(t_rmstodb_tilde *x, t_signal **sp)
 {
-    dsp_add(rmstodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(rmstodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 void rmstodb_tilde_setup(void)
 {
     rmstodb_tilde_class = class_new(gensym("rmstodb~"),
-        (t_newmethod)rmstodb_tilde_new, 0, sizeof(t_rmstodb_tilde), 0, 0);
+        (t_newmethod) rmstodb_tilde_new, 0, sizeof(t_rmstodb_tilde), 0, 0);
     CLASS_MAINSIGNALIN(rmstodb_tilde_class, t_rmstodb_tilde, x_f);
-    class_addmethod(rmstodb_tilde_class, (t_method)rmstodb_tilde_dsp,
+    class_addmethod(rmstodb_tilde_class, (t_method) rmstodb_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -512,7 +541,7 @@ t_class *dbtopow_tilde_class;
 
 static void *dbtopow_tilde_new(void)
 {
-    t_dbtopow_tilde *x = (t_dbtopow_tilde *)pd_new(dbtopow_tilde_class);
+    t_dbtopow_tilde *x = (t_dbtopow_tilde *) pd_new(dbtopow_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -520,17 +549,17 @@ static void *dbtopow_tilde_new(void)
 
 static t_int *dbtopow_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
-        if (f <= 0) *out = 0;
+        if(f <= 0)
+            *out = 0;
         else
         {
-            if (f > 870)
-                f = 870;
-            *out = exp((LOGTEN * 0.1) * (f-100.));
+            if(f > 870) f = 870;
+            *out = exp((LOGTEN * 0.1) * (f - 100.));
         }
     }
     return (w + 4);
@@ -538,15 +567,16 @@ static t_int *dbtopow_tilde_perform(t_int *w)
 
 static void dbtopow_tilde_dsp(t_dbtopow_tilde *x, t_signal **sp)
 {
-    dsp_add(dbtopow_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(dbtopow_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 void dbtopow_tilde_setup(void)
 {
-    dbtopow_tilde_class = class_new(gensym("dbtopow~"), (t_newmethod)dbtopow_tilde_new, 0,
-        sizeof(t_dbtopow_tilde), 0, 0);
+    dbtopow_tilde_class = class_new(gensym("dbtopow~"),
+        (t_newmethod) dbtopow_tilde_new, 0, sizeof(t_dbtopow_tilde), 0, 0);
     CLASS_MAINSIGNALIN(dbtopow_tilde_class, t_dbtopow_tilde, x_f);
-    class_addmethod(dbtopow_tilde_class, (t_method)dbtopow_tilde_dsp,
+    class_addmethod(dbtopow_tilde_class, (t_method) dbtopow_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -562,7 +592,7 @@ t_class *powtodb_tilde_class;
 
 static void *powtodb_tilde_new(void)
 {
-    t_powtodb_tilde *x = (t_powtodb_tilde *)pd_new(powtodb_tilde_class);
+    t_powtodb_tilde *x = (t_powtodb_tilde *) pd_new(powtodb_tilde_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = 0;
     return (x);
@@ -570,15 +600,16 @@ static void *powtodb_tilde_new(void)
 
 static t_int *powtodb_tilde_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)w[1], *out = (t_sample *)w[2];
-    int n = (int)w[3];
-    for (; n--; in++, out++)
+    t_sample *in = (t_sample *) w[1], *out = (t_sample *) w[2];
+    int n = (int) w[3];
+    for(; n--; in++, out++)
     {
         t_sample f = *in;
-        if (f <= 0) *out = 0;
+        if(f <= 0)
+            *out = 0;
         else
         {
-            t_sample g = 100 + 10./LOGTEN * log(f);
+            t_sample g = 100 + 10. / LOGTEN * log(f);
             *out = (g < 0 ? 0 : g);
         }
     }
@@ -587,15 +618,16 @@ static t_int *powtodb_tilde_perform(t_int *w)
 
 static void powtodb_tilde_dsp(t_powtodb_tilde *x, t_signal **sp)
 {
-    dsp_add(powtodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(powtodb_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 void powtodb_tilde_setup(void)
 {
-    powtodb_tilde_class = class_new(gensym("powtodb~"), (t_newmethod)powtodb_tilde_new, 0,
-        sizeof(t_powtodb_tilde), 0, 0);
+    powtodb_tilde_class = class_new(gensym("powtodb~"),
+        (t_newmethod) powtodb_tilde_new, 0, sizeof(t_powtodb_tilde), 0, 0);
     CLASS_MAINSIGNALIN(powtodb_tilde_class, t_powtodb_tilde, x_f);
-    class_addmethod(powtodb_tilde_class, (t_method)powtodb_tilde_dsp,
+    class_addmethod(powtodb_tilde_class, (t_method) powtodb_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
 }
 
@@ -610,7 +642,7 @@ typedef struct _pow_tilde
 
 static void *pow_tilde_new(t_floatarg f)
 {
-    t_pow_tilde *x = (t_pow_tilde *)pd_new(pow_tilde_class);
+    t_pow_tilde *x = (t_pow_tilde *) pd_new(pow_tilde_class);
     signalinlet_new(&x->x_obj, f);
     outlet_new(&x->x_obj, &s_signal);
     x->x_f = 0;
@@ -620,33 +652,33 @@ static void *pow_tilde_new(t_floatarg f)
 
 t_int *pow_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f1 = *in1++, f2 = *in2++;
-        *out++ = (f1 == 0 && f2 < 0) ||
-            (f1 < 0 && (f2 - (int)f2) != 0) ?
-                0 : pow(f1, f2);
+        *out++ = (f1 == 0 && f2 < 0) || (f1 < 0 && (f2 - (int) f2) != 0)
+                     ? 0
+                     : pow(f1, f2);
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void pow_tilde_dsp(t_pow_tilde *x, t_signal **sp)
 {
-    dsp_add(pow_tilde_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(pow_tilde_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 static void pow_tilde_setup(void)
 {
-    pow_tilde_class = class_new(gensym("pow~"), (t_newmethod)pow_tilde_new, 0,
+    pow_tilde_class = class_new(gensym("pow~"), (t_newmethod) pow_tilde_new, 0,
         sizeof(t_pow_tilde), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(pow_tilde_class, t_pow_tilde, x_f);
-    class_addmethod(pow_tilde_class, (t_method)pow_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        pow_tilde_class, (t_method) pow_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ----------------------------- exp ----------------------------- */
@@ -660,34 +692,34 @@ typedef struct _exp_tilde
 
 static void *exp_tilde_new(void)
 {
-    t_exp_tilde *x = (t_exp_tilde *)pd_new(exp_tilde_class);
+    t_exp_tilde *x = (t_exp_tilde *) pd_new(exp_tilde_class);
     outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
 
 t_int *exp_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
         *out++ = exp(*in1++);
-    return (w+4);
+    return (w + 4);
 }
 
 static void exp_tilde_dsp(t_exp_tilde *x, t_signal **sp)
 {
-    dsp_add(exp_tilde_perform, 3,
-        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        exp_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void exp_tilde_setup(void)
 {
-    exp_tilde_class = class_new(gensym("exp~"), (t_newmethod)exp_tilde_new, 0,
+    exp_tilde_class = class_new(gensym("exp~"), (t_newmethod) exp_tilde_new, 0,
         sizeof(t_exp_tilde), 0, 0);
     CLASS_MAINSIGNALIN(exp_tilde_class, t_exp_tilde, x_f);
-    class_addmethod(exp_tilde_class, (t_method)exp_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        exp_tilde_class, (t_method) exp_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ----------------------------- log ----------------------------- */
@@ -701,9 +733,10 @@ typedef struct _log_tilde
 
 static void *log_tilde_new(t_floatarg f)
 {
-    t_log_tilde *x = (t_log_tilde *)pd_new(log_tilde_class);
+    t_log_tilde *x = (t_log_tilde *) pd_new(log_tilde_class);
     pd_float(
-        (t_pd *)inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal), f);
+        (t_pd *) inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal),
+        f);
     outlet_new(&x->x_obj, &s_signal);
     x->x_f = 0;
     return (x);
@@ -711,36 +744,37 @@ static void *log_tilde_new(t_floatarg f)
 
 t_int *log_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
     {
         t_sample f = *in1++, g = *in2++;
-        if (f <= 0)
-            *out = -1000;   /* rather than blow up, output a number << 0 */
-        else if (g <= 0)
+        if(f <= 0)
+            *out = -1000; /* rather than blow up, output a number << 0 */
+        else if(g <= 0)
             *out = log(f);
-        else *out = log(f)/log(g);
+        else
+            *out = log(f) / log(g);
         out++;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 static void log_tilde_dsp(t_log_tilde *x, t_signal **sp)
 {
-    dsp_add(log_tilde_perform, 4,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(log_tilde_perform, 4, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        (t_int) sp[0]->s_n);
 }
 
 static void log_tilde_setup(void)
 {
-    log_tilde_class = class_new(gensym("log~"), (t_newmethod)log_tilde_new, 0,
+    log_tilde_class = class_new(gensym("log~"), (t_newmethod) log_tilde_new, 0,
         sizeof(t_log_tilde), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(log_tilde_class, t_log_tilde, x_f);
-    class_addmethod(log_tilde_class, (t_method)log_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        log_tilde_class, (t_method) log_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ----------------------------- abs ----------------------------- */
@@ -754,37 +788,37 @@ typedef struct _abs_tilde
 
 static void *abs_tilde_new(void)
 {
-    t_abs_tilde *x = (t_abs_tilde *)pd_new(abs_tilde_class);
+    t_abs_tilde *x = (t_abs_tilde *) pd_new(abs_tilde_class);
     outlet_new(&x->x_obj, &s_signal);
     return (x);
 }
 
 t_int *abs_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
     {
         t_sample f = *in1++;
         *out++ = (f >= 0 ? f : -f);
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void abs_tilde_dsp(t_abs_tilde *x, t_signal **sp)
 {
-    dsp_add(abs_tilde_perform, 3,
-        sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(
+        abs_tilde_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void abs_tilde_setup(void)
 {
-    abs_tilde_class = class_new(gensym("abs~"), (t_newmethod)abs_tilde_new, 0,
+    abs_tilde_class = class_new(gensym("abs~"), (t_newmethod) abs_tilde_new, 0,
         sizeof(t_abs_tilde), 0, 0);
     CLASS_MAINSIGNALIN(abs_tilde_class, t_abs_tilde, x_f);
-    class_addmethod(abs_tilde_class, (t_method)abs_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        abs_tilde_class, (t_method) abs_tilde_dsp, gensym("dsp"), A_CANT, 0);
 }
 
 /* ------------------------ global setup routine ------------------------- */
@@ -814,4 +848,3 @@ void d_math_setup(void)
     class_sethelpsymbol(dbtopow_tilde_class, s);
     class_sethelpsymbol(powtodb_tilde_class, s);
 }
-

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -114,9 +114,8 @@ t_float q8_rsqrt(t_float f0)
     u.f = f0;
     if(u.f < 0)
         return (0);
-    else
-        return (t_float) (rsqrt_exptab[(u.l >> 23) & 0xff] *
-                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
+    return (t_float) (rsqrt_exptab[(u.l >> 23) & 0xff] *
+                      rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
 }
 
 t_float q8_sqrt(t_float f0)
@@ -131,9 +130,8 @@ t_float q8_sqrt(t_float f0)
     u.f = f0;
     if(u.f < 0)
         return (0);
-    else
-        return (t_float) (u.f * rsqrt_exptab[(u.l >> 23) & 0xff] *
-                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
+    return (t_float) (u.f * rsqrt_exptab[(u.l >> 23) & 0xff] *
+                      rsqrt_mantissatab[(u.l >> 13) & 0x3ff]);
 }
 
 t_float qsqrt(t_float f) { return (q8_sqrt(f)); }

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -74,12 +74,11 @@ static float *rsqrt_exptab, *rsqrt_mantissatab;
 
 static void init_rsqrt(void)
 {
-    int i;
     if(!rsqrt_exptab)
     {
         rsqrt_exptab = (float *) getbytes(DUMTAB1SIZE * sizeof(float));
         rsqrt_mantissatab = (float *) getbytes(DUMTAB2SIZE * sizeof(float));
-        for(i = 0; i < DUMTAB1SIZE; i++)
+        for(int i = 0; i < DUMTAB1SIZE; i++)
         {
             union
             {
@@ -92,7 +91,7 @@ static void init_rsqrt(void)
             u.l = l;
             rsqrt_exptab[i] = 1. / sqrt(u.f);
         }
-        for(i = 0; i < DUMTAB2SIZE; i++)
+        for(int i = 0; i < DUMTAB2SIZE; i++)
         {
             float f = 1 + (1. / DUMTAB2SIZE) * i;
             rsqrt_mantissatab[i] = 1. / sqrt(f);

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -39,13 +39,13 @@ static t_int *clip_perform(t_int *w)
     t_clip *x = (t_clip *) (w[1]);
     t_sample *in = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in++;
+        t_sample f = in[i];
         if(f < x->x_lo) f = x->x_lo;
         if(f > x->x_hi) f = x->x_hi;
-        *out++ = f;
+        out[i] = f;
     }
     return (w + 5);
 }
@@ -158,10 +158,10 @@ static t_int *sigrsqrt_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    while(n--)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in++;
+        t_sample f = in[i];
 
         union
         {
@@ -172,13 +172,13 @@ static t_int *sigrsqrt_perform(t_int *w)
         u.f = f;
         if(f < 0)
         {
-            *out++ = 0;
+            out[i] = 0;
         }
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
-            *out++ = 1.5 * g - 0.5 * g * g * g * f;
+            out[i] = 1.5 * g - 0.5 * g * g * g * f;
         }
     }
     return (w + 4);
@@ -224,10 +224,10 @@ t_int *sigsqrt_perform(t_int *w) /* not static; also used in d_fft.c */
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    while(n--)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in++;
+        t_sample f = in[i];
 
         union
         {
@@ -238,13 +238,13 @@ t_int *sigsqrt_perform(t_int *w) /* not static; also used in d_fft.c */
         u.f = f;
         if(f < 0)
         {
-            *out++ = 0;
+            out[i] = 0;
         }
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
                          rsqrt_mantissatab[(u.l >> 13) & 0x3ff];
-            *out++ = f * (1.5 * g - 0.5 * g * g * g * f);
+            out[i] = f * (1.5 * g - 0.5 * g * g * g * f);
         }
     }
     return (w + 4);
@@ -287,20 +287,20 @@ static t_int *sigwrap_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    while(n--)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
         int k;
-        t_sample f = *in++;
+        t_sample f = in[i];
         f = (f > INT_MAX || f < INT_MIN) ? 0. : f;
         k = (int) f;
         if(k <= f)
         {
-            *out++ = f - k;
+            out[i] = f - k;
         }
         else
         {
-            *out++ = f - (k - 1);
+            out[i] = f - (k - 1);
         }
     }
     return (w + 4);
@@ -311,18 +311,18 @@ static t_int *sigwrap_old_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    while(n--)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in++;
+        t_sample f = in[i];
         int k = f;
         if(f > 0)
         {
-            *out++ = f - k;
+            out[i] = f - k;
         }
         else
         {
-            *out++ = f - (k - 1);
+            out[i] = f - (k - 1);
         }
     }
     return (w + 4);
@@ -366,18 +366,18 @@ static t_int *mtof_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
+        t_sample f = in[i];
         if(f <= -1500)
         {
-            *out = 0;
+            out[i] = 0;
         }
         else
         {
             if(f > 1499) f = 1499;
-            *out = 8.17579891564 * exp(.0577622650 * f);
+            out[i] = 8.17579891564 * exp(.0577622650 * f);
         }
     }
     return (w + 4);
@@ -420,11 +420,11 @@ static t_int *ftom_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
-        *out = (f > 0 ? 17.3123405046 * log(.12231220585 * f) : -1500);
+        t_sample f = in[i];
+        out[i] = (f > 0 ? 17.3123405046 * log(.12231220585 * f) : -1500);
     }
     return (w + 4);
 }
@@ -466,18 +466,18 @@ static t_int *dbtorms_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
+        t_sample f = in[i];
         if(f <= 0)
         {
-            *out = 0;
+            out[i] = 0;
         }
         else
         {
             if(f > 485) f = 485;
-            *out = exp((LOGTEN * 0.05) * (f - 100.));
+            out[i] = exp((LOGTEN * 0.05) * (f - 100.));
         }
     }
     return (w + 4);
@@ -520,18 +520,18 @@ static t_int *rmstodb_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
+        t_sample f = in[i];
         if(f <= 0)
         {
-            *out = 0;
+            out[i] = 0;
         }
         else
         {
             t_sample g = 100 + 20. / LOGTEN * log(f);
-            *out = (g < 0 ? 0 : g);
+            out[i] = (g < 0 ? 0 : g);
         }
     }
     return (w + 4);
@@ -574,18 +574,18 @@ static t_int *dbtopow_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
+        t_sample f = in[i];
         if(f <= 0)
         {
-            *out = 0;
+            out[i] = 0;
         }
         else
         {
             if(f > 870) f = 870;
-            *out = exp((LOGTEN * 0.1) * (f - 100.));
+            out[i] = exp((LOGTEN * 0.1) * (f - 100.));
         }
     }
     return (w + 4);
@@ -628,18 +628,18 @@ static t_int *powtodb_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *) w[1];
     t_sample *out = (t_sample *) w[2];
-    int n = (int) w[3];
-    for(; n--; in++, out++)
+    int num_samples = (int) w[3];
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in;
+        t_sample f = in[i];
         if(f <= 0)
         {
-            *out = 0;
+            out[i] = 0;
         }
         else
         {
             t_sample g = 100 + 10. / LOGTEN * log(f);
-            *out = (g < 0 ? 0 : g);
+            out[i] = (g < 0 ? 0 : g);
         }
     }
     return (w + 4);
@@ -684,12 +684,12 @@ t_int *pow_tilde_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f1 = *in1++;
-        t_sample f2 = *in2++;
-        *out++ = (f1 == 0 && f2 < 0) || (f1 < 0 && (f2 - (int) f2) != 0)
+        t_sample f1 = in1[i];
+        t_sample f2 = in2[i];
+        out[i] = (f1 == 0 && f2 < 0) || (f1 < 0 && (f2 - (int) f2) != 0)
                      ? 0
                      : pow(f1, f2);
     }
@@ -729,11 +729,13 @@ static void *exp_tilde_new(void)
 
 t_int *exp_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
-        *out++ = exp(*in1++);
+    int num_samples = (int) (w[3]);
+
+    for(int i = 0; i < num_samples; i++)
+        out[i] = exp(in[i]);
+
     return (w + 4);
 }
 
@@ -777,24 +779,23 @@ t_int *log_tilde_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1++;
-        t_sample g = *in2++;
+        t_sample f = in1[i];
+        t_sample g = in2[i];
         if(f <= 0)
         {
-            *out = -1000; /* rather than blow up, output a number << 0 */
+            out[i] = -1000; /* rather than blow up, output a number << 0 */
         }
         else if(g <= 0)
         {
-            *out = log(f);
+            out[i] = log(f);
         }
         else
         {
-            *out = log(f) / log(g);
+            out[i] = log(f) / log(g);
         }
-        out++;
     }
     return (w + 5);
 }
@@ -832,13 +833,13 @@ static void *abs_tilde_new(void)
 
 t_int *abs_tilde_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
     {
-        t_sample f = *in1++;
-        *out++ = (f >= 0 ? f : -f);
+        t_sample f = in[i];
+        out[i] = (f >= 0 ? f : -f);
     }
     return (w + 4);
 }

--- a/src/d_math.c
+++ b/src/d_math.c
@@ -172,7 +172,9 @@ static t_int *sigrsqrt_perform(t_int *w)
 
         u.f = f;
         if(f < 0)
+        {
             *out++ = 0;
+        }
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
@@ -236,7 +238,9 @@ t_int *sigsqrt_perform(t_int *w) /* not static; also used in d_fft.c */
 
         u.f = f;
         if(f < 0)
+        {
             *out++ = 0;
+        }
         else
         {
             t_sample g = rsqrt_exptab[(u.l >> 23) & 0xff] *
@@ -292,9 +296,13 @@ static t_int *sigwrap_perform(t_int *w)
         f = (f > INT_MAX || f < INT_MIN) ? 0. : f;
         k = (int) f;
         if(k <= f)
+        {
             *out++ = f - k;
+        }
         else
+        {
             *out++ = f - (k - 1);
+        }
     }
     return (w + 4);
 }
@@ -310,9 +318,13 @@ static t_int *sigwrap_old_perform(t_int *w)
         t_sample f = *in++;
         int k = f;
         if(f > 0)
+        {
             *out++ = f - k;
+        }
         else
+        {
             *out++ = f - (k - 1);
+        }
     }
     return (w + 4);
 }
@@ -360,7 +372,9 @@ static t_int *mtof_tilde_perform(t_int *w)
     {
         t_sample f = *in;
         if(f <= -1500)
+        {
             *out = 0;
+        }
         else
         {
             if(f > 1499) f = 1499;
@@ -458,7 +472,9 @@ static t_int *dbtorms_tilde_perform(t_int *w)
     {
         t_sample f = *in;
         if(f <= 0)
+        {
             *out = 0;
+        }
         else
         {
             if(f > 485) f = 485;
@@ -510,7 +526,9 @@ static t_int *rmstodb_tilde_perform(t_int *w)
     {
         t_sample f = *in;
         if(f <= 0)
+        {
             *out = 0;
+        }
         else
         {
             t_sample g = 100 + 20. / LOGTEN * log(f);
@@ -562,7 +580,9 @@ static t_int *dbtopow_tilde_perform(t_int *w)
     {
         t_sample f = *in;
         if(f <= 0)
+        {
             *out = 0;
+        }
         else
         {
             if(f > 870) f = 870;
@@ -614,7 +634,9 @@ static t_int *powtodb_tilde_perform(t_int *w)
     {
         t_sample f = *in;
         if(f <= 0)
+        {
             *out = 0;
+        }
         else
         {
             t_sample g = 100 + 10. / LOGTEN * log(f);
@@ -762,11 +784,17 @@ t_int *log_tilde_perform(t_int *w)
         t_sample f = *in1++;
         t_sample g = *in2++;
         if(f <= 0)
+        {
             *out = -1000; /* rather than blow up, output a number << 0 */
+        }
         else if(g <= 0)
+        {
             *out = log(f);
+        }
         else
+        {
             *out = log(f) / log(g);
+        }
         out++;
     }
     return (w + 5);

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -27,9 +27,8 @@ static t_int *print_perform(t_int *w)
     int n = (int) (w[3]);
     if(x->x_count)
     {
-        int i = 0;
         startpost("%s:", x->x_sym->s_name);
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             if(i % 8 == 0) endpost();
             startpost("%.4g  ", in[i]);

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  miscellaneous: print~; more to come.
-*/
+ */
 
 #include "m_pd.h"
 #include <stdio.h>
@@ -22,43 +22,41 @@ typedef struct _print
 
 static t_int *print_perform(t_int *w)
 {
-    t_print *x = (t_print *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    if (x->x_count)
+    t_print *x = (t_print *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    if(x->x_count)
     {
-        int i=0;
+        int i = 0;
         startpost("%s:", x->x_sym->s_name);
-        for(i=0; i<n; i++) {
-          if(i%8==0)endpost();
-          startpost("%.4g  ", in[i]);
+        for(i = 0; i < n; i++)
+        {
+            if(i % 8 == 0) endpost();
+            startpost("%.4g  ", in[i]);
         }
         endpost();
         x->x_count--;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 static void print_dsp(t_print *x, t_signal **sp)
 {
-    dsp_add(print_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(print_perform, 3, x, sp[0]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void print_float(t_print *x, t_float f)
 {
-    if (f < 0) f = 0;
+    if(f < 0) f = 0;
     x->x_count = f;
 }
 
-static void print_bang(t_print *x)
-{
-    x->x_count = 1;
-}
+static void print_bang(t_print *x) { x->x_count = 1; }
 
 static void *print_new(t_symbol *s)
 {
-    t_print *x = (t_print *)pd_new(print_class);
-    x->x_sym = (s->s_name[0]? s : gensym("print~"));
+    t_print *x = (t_print *) pd_new(print_class);
+    x->x_sym = (s->s_name[0] ? s : gensym("print~"));
     x->x_count = 0;
     x->x_f = 0;
     return (x);
@@ -66,10 +64,11 @@ static void *print_new(t_symbol *s)
 
 static void print_setup(void)
 {
-    print_class = class_new(gensym("print~"), (t_newmethod)print_new, 0,
+    print_class = class_new(gensym("print~"), (t_newmethod) print_new, 0,
         sizeof(t_print), 0, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(print_class, t_print, x_f);
-    class_addmethod(print_class, (t_method)print_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        print_class, (t_method) print_dsp, gensym("dsp"), A_CANT, 0);
     class_addbang(print_class, print_bang);
     class_addfloat(print_class, print_float);
 }
@@ -86,9 +85,9 @@ typedef struct _bang
 
 static t_int *bang_tilde_perform(t_int *w)
 {
-    t_bang *x = (t_bang *)(w[1]);
+    t_bang *x = (t_bang *) (w[1]);
     clock_delay(x->x_clock, 0);
-    return (w+2);
+    return (w + 2);
 }
 
 static void bang_tilde_dsp(t_bang *x, t_signal **sp)
@@ -96,32 +95,25 @@ static void bang_tilde_dsp(t_bang *x, t_signal **sp)
     dsp_add(bang_tilde_perform, 1, x);
 }
 
-static void bang_tilde_tick(t_bang *x)
-{
-    outlet_bang(x->x_obj.ob_outlet);
-}
+static void bang_tilde_tick(t_bang *x) { outlet_bang(x->x_obj.ob_outlet); }
 
-static void bang_tilde_free(t_bang *x)
-{
-    clock_free(x->x_clock);
-}
+static void bang_tilde_free(t_bang *x) { clock_free(x->x_clock); }
 
 static void *bang_tilde_new(t_symbol *s)
 {
-    t_bang *x = (t_bang *)pd_new(bang_tilde_class);
-    x->x_clock = clock_new(x, (t_method)bang_tilde_tick);
+    t_bang *x = (t_bang *) pd_new(bang_tilde_class);
+    x->x_clock = clock_new(x, (t_method) bang_tilde_tick);
     outlet_new(&x->x_obj, &s_bang);
     return (x);
 }
 
 static void bang_tilde_setup(void)
 {
-    bang_tilde_class = class_new(gensym("bang~"), (t_newmethod)bang_tilde_new,
-        (t_method)bang_tilde_free, sizeof(t_bang), 0, 0);
-    class_addmethod(bang_tilde_class, (t_method)bang_tilde_dsp,
-        gensym("dsp"), 0);
+    bang_tilde_class = class_new(gensym("bang~"), (t_newmethod) bang_tilde_new,
+        (t_method) bang_tilde_free, sizeof(t_bang), 0, 0);
+    class_addmethod(
+        bang_tilde_class, (t_method) bang_tilde_dsp, gensym("dsp"), 0);
 }
-
 
 /* ------------------------ global setup routine ------------------------- */
 
@@ -130,7 +122,3 @@ void d_misc_setup(void)
     print_setup();
     bang_tilde_setup();
 }
-
-
-
-

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -24,11 +24,11 @@ static t_int *print_perform(t_int *w)
 {
     t_print *x = (t_print *) (w[1]);
     t_sample *in = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
     if(x->x_count)
     {
         startpost("%s:", x->x_sym->s_name);
-        for(int i = 0; i < n; i++)
+        for(int i = 0; i < num_samples; i++)
         {
             if(i % 8 == 0) endpost();
             startpost("%.4g  ", in[i]);

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -147,8 +147,11 @@ static t_int *cos_perform(t_int *w)
     t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
     int n = (int) (w[3]);
-    float *tab = cos_table, *addr;
-    t_float f1, f2, frac;
+    float *tab = cos_table;
+    float *addr;
+    t_float f1;
+    t_float f2;
+    t_float frac;
     double dphase;
     int normhipart;
     union tabfudge tf;
@@ -201,7 +204,9 @@ static void cos_dsp(t_cos *x, t_signal **sp)
 static void cos_maketable(void)
 {
     int i;
-    float *fp, phase, phsinc = (2. * 3.14159) / COSTABSIZE;
+    float *fp;
+    float phase;
+    float phsinc = (2. * 3.14159) / COSTABSIZE;
     union tabfudge tf;
 
     if(cos_table) return;
@@ -263,8 +268,11 @@ static t_int *osc_perform(t_int *w)
     t_sample *in = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
     int n = (int) (w[4]);
-    float *tab = cos_table, *addr;
-    t_float f1, f2, frac;
+    float *tab = cos_table;
+    float *addr;
+    t_float f1;
+    t_float f2;
+    t_float frac;
     double dphase = x->x_phase + UNITBIT32;
     int normhipart;
     union tabfudge tf;
@@ -384,16 +392,23 @@ static t_int *sigvcf_perform(t_int *w)
     t_vcfctl *c = (t_vcfctl *) (w[5]);
     int n = (int) w[6];
     int i;
-    t_float re = c->c_re, re2;
+    t_float re = c->c_re;
+    t_float re2;
     t_float im = c->c_im;
     t_float q = c->c_q;
     t_float isr = c->c_isr;
     t_float qinv = (q > 0 ? 1.0f / q : 0);
     t_float ampcorrect = 2. - 2. / (q + 2.);
-    t_float coefr, coefi;
-    float *tab = cos_table, *addr, f1, f2, frac;
+    t_float coefr;
+    t_float coefi;
+    float *tab = cos_table;
+    float *addr;
+    float f1;
+    float f2;
+    float frac;
     double dphase;
-    int normhipart, tabindex;
+    int normhipart;
+    int tabindex;
     union tabfudge tf;
 
     tf.tf_d = UNITBIT32;
@@ -401,7 +416,10 @@ static t_int *sigvcf_perform(t_int *w)
 
     for(i = 0; i < n; i++)
     {
-        float cf, cfindx, r, oneminusr;
+        float cf;
+        float cfindx;
+        float r;
+        float oneminusr;
         cf = *in2++ * isr;
         if(cf < 0) cf = 0;
         cfindx = cf * (float) (COSTABSIZE / 6.28318f);

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -1,19 +1,18 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* sinusoidal oscillator and table lookup; see also tabosc4~ in d_array.c.
-*/
+ */
 
 #include "m_pd.h"
 #include "math.h"
 
 #define BIGFLOAT 1.0e+19
-#define UNITBIT32 1572864.  /* 3*2^19; bit 32 has place value 1 */
+#define UNITBIT32 1572864. /* 3*2^19; bit 32 has place value 1 */
 
-
-#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
-    || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__) || \
+    defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
 #include <machine/endian.h>
 #endif
 
@@ -37,11 +36,11 @@
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-# define HIOFFSET 1
-# define LOWOFFSET 0
+#define HIOFFSET 1
+#define LOWOFFSET 0
 #else
-# define HIOFFSET 0    /* word offset to find MSB */
-# define LOWOFFSET 1    /* word offset to find LSB */
+#define HIOFFSET 0  /* word offset to find MSB */
+#define LOWOFFSET 1 /* word offset to find LSB */
 #endif
 
 union tabfudge
@@ -53,19 +52,19 @@ union tabfudge
 /* -------------------------- phasor~ ------------------------------ */
 static t_class *phasor_class;
 
-#if 1   /* in the style of R. Hoeldrich (ICMC 1995 Banff) */
+#if 1 /* in the style of R. Hoeldrich (ICMC 1995 Banff) */
 
 typedef struct _phasor
 {
     t_object x_obj;
     double x_phase;
     t_float x_conv;
-    t_float x_f;						// scalar frequency
+    t_float x_f; // scalar frequency
 } t_phasor;
 
 static void *phasor_new(t_floatarg f)
 {
-    t_phasor *x = (t_phasor *)pd_new(phasor_class);
+    t_phasor *x = (t_phasor *) pd_new(phasor_class);
     x->x_f = f;
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_float, gensym("ft1"));
     x->x_phase = 0;
@@ -76,11 +75,11 @@ static void *phasor_new(t_floatarg f)
 
 static t_int *phasor_perform(t_int *w)
 {
-    t_phasor *x = (t_phasor *)(w[1]);
-    t_sample *in = (t_float *)(w[2]);
-    t_sample *out = (t_float *)(w[3]);
-    int n = (int)(w[4]);
-    double dphase = x->x_phase + (double)UNITBIT32;
+    t_phasor *x = (t_phasor *) (w[1]);
+    t_sample *in = (t_float *) (w[2]);
+    t_sample *out = (t_float *) (w[3]);
+    int n = (int) (w[4]);
+    double dphase = x->x_phase + (double) UNITBIT32;
     union tabfudge tf;
     int normhipart;
     t_float conv = x->x_conv;
@@ -89,7 +88,7 @@ static t_int *phasor_perform(t_int *w)
     normhipart = tf.tf_i[HIOFFSET];
     tf.tf_d = dphase;
 
-    while (n--)
+    while(n--)
     {
         tf.tf_i[HIOFFSET] = normhipart;
         dphase += *in++ * conv;
@@ -98,32 +97,30 @@ static t_int *phasor_perform(t_int *w)
     }
     tf.tf_i[HIOFFSET] = normhipart;
     x->x_phase = tf.tf_d - UNITBIT32;
-    return (w+5);
+    return (w + 5);
 }
 
 static void phasor_dsp(t_phasor *x, t_signal **sp)
 {
-    x->x_conv = 1./sp[0]->s_sr;
-    dsp_add(phasor_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    x->x_conv = 1. / sp[0]->s_sr;
+    dsp_add(
+        phasor_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
-static void phasor_ft1(t_phasor *x, t_float f)
-{
-    x->x_phase = (double)f;
-}
+static void phasor_ft1(t_phasor *x, t_float f) { x->x_phase = (double) f; }
 
 static void phasor_setup(void)
 {
-    phasor_class = class_new(gensym("phasor~"), (t_newmethod)phasor_new, 0,
+    phasor_class = class_new(gensym("phasor~"), (t_newmethod) phasor_new, 0,
         sizeof(t_phasor), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(phasor_class, t_phasor, x_f);
-    class_addmethod(phasor_class, (t_method)phasor_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(phasor_class, (t_method)phasor_ft1,
-        gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(
+        phasor_class, (t_method) phasor_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        phasor_class, (t_method) phasor_ft1, gensym("ft1"), A_FLOAT, 0);
 }
 
-#endif  /* Hoeldrich version */
+#endif /* Hoeldrich version */
 
 /* ------------------------ cos~ ----------------------------- */
 
@@ -134,12 +131,12 @@ static t_class *cos_class;
 typedef struct _cos
 {
     t_object x_obj;
-    t_float x_f;			// scalar frequency
+    t_float x_f; // scalar frequency
 } t_cos;
 
 static void *cos_new(t_floatarg f)
 {
-    t_cos *x = (t_cos *)pd_new(cos_class);
+    t_cos *x = (t_cos *) pd_new(cos_class);
     outlet_new(&x->x_obj, gensym("signal"));
     x->x_f = f;
     return (x);
@@ -147,9 +144,9 @@ static void *cos_new(t_floatarg f)
 
 static t_int *cos_perform(t_int *w)
 {
-    t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sample *in = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
     float *tab = cos_table, *addr;
     t_float f1, f2, frac;
     double dphase;
@@ -159,7 +156,7 @@ static t_int *cos_perform(t_int *w)
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
 
-#if 0           /* this is the readable version of the code. */
+#if 0 /* this is the readable version of the code. */
     while (n--)
     {
         dphase = (double)(*in++ * (float)(COSTABSIZE)) + UNITBIT32;
@@ -172,33 +169,33 @@ static t_int *cos_perform(t_int *w)
         *out++ = f1 + frac * (f2 - f1);
     }
 #endif
-#if 1           /* this is the same, unwrapped by hand. */
-        dphase = (double)(*in++ * (float)(COSTABSIZE)) + UNITBIT32;
-        tf.tf_d = dphase;
-        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE-1));
-        tf.tf_i[HIOFFSET] = normhipart;
-    while (--n)
+#if 1 /* this is the same, unwrapped by hand. */
+    dphase = (double) (*in++ * (float) (COSTABSIZE)) + UNITBIT32;
+    tf.tf_d = dphase;
+    addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE - 1));
+    tf.tf_i[HIOFFSET] = normhipart;
+    while(--n)
     {
-        dphase = (double)(*in++ * (float)(COSTABSIZE)) + UNITBIT32;
-            frac = tf.tf_d - UNITBIT32;
+        dphase = (double) (*in++ * (float) (COSTABSIZE)) + UNITBIT32;
+        frac = tf.tf_d - UNITBIT32;
         tf.tf_d = dphase;
-            f1 = addr[0];
-            f2 = addr[1];
-        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE-1));
-            *out++ = f1 + frac * (f2 - f1);
+        f1 = addr[0];
+        f2 = addr[1];
+        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE - 1));
+        *out++ = f1 + frac * (f2 - f1);
         tf.tf_i[HIOFFSET] = normhipart;
     }
-            frac = tf.tf_d - UNITBIT32;
-            f1 = addr[0];
-            f2 = addr[1];
-            *out++ = f1 + frac * (f2 - f1);
+    frac = tf.tf_d - UNITBIT32;
+    f1 = addr[0];
+    f2 = addr[1];
+    *out++ = f1 + frac * (f2 - f1);
 #endif
-    return (w+4);
+    return (w + 4);
 }
 
 static void cos_dsp(t_cos *x, t_signal **sp)
 {
-    dsp_add(cos_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(cos_perform, 3, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
 static void cos_maketable(void)
@@ -207,33 +204,33 @@ static void cos_maketable(void)
     float *fp, phase, phsinc = (2. * 3.14159) / COSTABSIZE;
     union tabfudge tf;
 
-    if (cos_table) return;
-    cos_table = (float *)getbytes(sizeof(float) * (COSTABSIZE+1));
-    for (i = COSTABSIZE + 1, fp = cos_table, phase = 0; i--;
+    if(cos_table) return;
+    cos_table = (float *) getbytes(sizeof(float) * (COSTABSIZE + 1));
+    for(i = COSTABSIZE + 1, fp = cos_table, phase = 0; i--;
         fp++, phase += phsinc)
-            *fp = cos(phase);
+        *fp = cos(phase);
 
-        /* here we check at startup whether the byte alignment
-            is as we declared it.  If not, the code has to be
-            recompiled the other way. */
+    /* here we check at startup whether the byte alignment
+        is as we declared it.  If not, the code has to be
+        recompiled the other way. */
     tf.tf_d = UNITBIT32 + 0.5;
-    if ((unsigned)tf.tf_i[LOWOFFSET] != 0x80000000)
+    if((unsigned) tf.tf_i[LOWOFFSET] != 0x80000000)
         bug("cos~: unexpected machine alignment");
 }
 
 static void cos_cleanup(t_class *c)
 {
-    freebytes(cos_table, sizeof(float) * (COSTABSIZE+1));
+    freebytes(cos_table, sizeof(float) * (COSTABSIZE + 1));
     cos_table = 0;
 }
 
 static void cos_setup(void)
 {
-    cos_class = class_new(gensym("cos~"), (t_newmethod)cos_new, 0,
+    cos_class = class_new(gensym("cos~"), (t_newmethod) cos_new, 0,
         sizeof(t_cos), 0, A_DEFFLOAT, 0);
     class_setfreefn(cos_class, cos_cleanup);
     CLASS_MAINSIGNALIN(cos_class, t_cos, x_f);
-    class_addmethod(cos_class, (t_method)cos_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(cos_class, (t_method) cos_dsp, gensym("dsp"), A_CANT, 0);
     cos_maketable();
 }
 
@@ -246,12 +243,12 @@ typedef struct _osc
     t_object x_obj;
     double x_phase;
     t_float x_conv;
-    t_float x_f;						// scalar frequency
+    t_float x_f; // scalar frequency
 } t_osc;
 
 static void *osc_new(t_floatarg f)
 {
-    t_osc *x = (t_osc *)pd_new(osc_class);
+    t_osc *x = (t_osc *) pd_new(osc_class);
     x->x_f = f;
     outlet_new(&x->x_obj, gensym("signal"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_float, gensym("ft1"));
@@ -262,10 +259,10 @@ static void *osc_new(t_floatarg f)
 
 static t_int *osc_perform(t_int *w)
 {
-    t_osc *x = (t_osc *)(w[1]);
-    t_sample *in = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
+    t_osc *x = (t_osc *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
     float *tab = cos_table, *addr;
     t_float f1, f2, frac;
     double dphase = x->x_phase + UNITBIT32;
@@ -289,25 +286,25 @@ static t_int *osc_perform(t_int *w)
     }
 #endif
 #if 1
-        tf.tf_d = dphase;
-        dphase += *in++ * conv;
-        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE-1));
-        tf.tf_i[HIOFFSET] = normhipart;
-        frac = tf.tf_d - UNITBIT32;
-    while (--n)
+    tf.tf_d = dphase;
+    dphase += *in++ * conv;
+    addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE - 1));
+    tf.tf_i[HIOFFSET] = normhipart;
+    frac = tf.tf_d - UNITBIT32;
+    while(--n)
     {
         tf.tf_d = dphase;
-            f1 = addr[0];
+        f1 = addr[0];
         dphase += *in++ * conv;
-            f2 = addr[1];
-        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE-1));
+        f2 = addr[1];
+        addr = tab + (tf.tf_i[HIOFFSET] & (COSTABSIZE - 1));
         tf.tf_i[HIOFFSET] = normhipart;
-            *out++ = f1 + frac * (f2 - f1);
+        *out++ = f1 + frac * (f2 - f1);
         frac = tf.tf_d - UNITBIT32;
     }
-            f1 = addr[0];
-            f2 = addr[1];
-            *out++ = f1 + frac * (f2 - f1);
+    f1 = addr[0];
+    f2 = addr[1];
+    *out++ = f1 + frac * (f2 - f1);
 #endif
 
     tf.tf_d = UNITBIT32 * COSTABSIZE;
@@ -315,27 +312,24 @@ static t_int *osc_perform(t_int *w)
     tf.tf_d = dphase + (UNITBIT32 * COSTABSIZE - UNITBIT32);
     tf.tf_i[HIOFFSET] = normhipart;
     x->x_phase = tf.tf_d - UNITBIT32 * COSTABSIZE;
-    return (w+5);
+    return (w + 5);
 }
 
 static void osc_dsp(t_osc *x, t_signal **sp)
 {
-    x->x_conv = COSTABSIZE/sp[0]->s_sr;
-    dsp_add(osc_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
+    x->x_conv = COSTABSIZE / sp[0]->s_sr;
+    dsp_add(osc_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int) sp[0]->s_n);
 }
 
-static void osc_ft1(t_osc *x, t_float f)
-{
-    x->x_phase = COSTABSIZE * f;
-}
+static void osc_ft1(t_osc *x, t_float f) { x->x_phase = COSTABSIZE * f; }
 
 static void osc_setup(void)
 {
-    osc_class = class_new(gensym("osc~"), (t_newmethod)osc_new, 0,
+    osc_class = class_new(gensym("osc~"), (t_newmethod) osc_new, 0,
         sizeof(t_osc), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(osc_class, t_osc, x_f);
-    class_addmethod(osc_class, (t_method)osc_dsp, gensym("dsp"), A_CANT, 0);
-    class_addmethod(osc_class, (t_method)osc_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(osc_class, (t_method) osc_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(osc_class, (t_method) osc_ft1, gensym("ft1"), A_FLOAT, 0);
 
     cos_maketable();
 }
@@ -361,7 +355,7 @@ t_class *sigvcf_class;
 
 static void *sigvcf_new(t_floatarg q)
 {
-    t_sigvcf *x = (t_sigvcf *)pd_new(sigvcf_class);
+    t_sigvcf *x = (t_sigvcf *) pd_new(sigvcf_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
     outlet_new(&x->x_obj, gensym("signal"));
@@ -383,18 +377,18 @@ static void sigvcf_ft1(t_sigvcf *x, t_float f)
 
 static t_int *sigvcf_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out1 = (t_sample *)(w[3]);
-    t_sample *out2 = (t_sample *)(w[4]);
-    t_vcfctl *c = (t_vcfctl *)(w[5]);
-    int n = (int)w[6];
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out1 = (t_sample *) (w[3]);
+    t_sample *out2 = (t_sample *) (w[4]);
+    t_vcfctl *c = (t_vcfctl *) (w[5]);
+    int n = (int) w[6];
     int i;
     t_float re = c->c_re, re2;
     t_float im = c->c_im;
     t_float q = c->c_q;
     t_float isr = c->c_isr;
-    t_float qinv = (q > 0? 1.0f/q : 0);
+    t_float qinv = (q > 0 ? 1.0f / q : 0);
     t_float ampcorrect = 2. - 2. / (q + 2.);
     t_float coefr, coefi;
     float *tab = cos_table, *addr, f1, f2, frac;
@@ -405,18 +399,18 @@ static t_int *sigvcf_perform(t_int *w)
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
 
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         float cf, cfindx, r, oneminusr;
         cf = *in2++ * isr;
-        if (cf < 0) cf = 0;
-        cfindx = cf * (float)(COSTABSIZE/6.28318f);
+        if(cf < 0) cf = 0;
+        cfindx = cf * (float) (COSTABSIZE / 6.28318f);
         r = (qinv > 0 ? 1 - cf * qinv : 0);
-        if (r < 0) r = 0;
+        if(r < 0) r = 0;
         oneminusr = 1.0f - r;
-        dphase = ((double)(cfindx)) + UNITBIT32;
+        dphase = ((double) (cfindx)) + UNITBIT32;
         tf.tf_d = dphase;
-        tabindex = tf.tf_i[HIOFFSET] & (COSTABSIZE-1);
+        tabindex = tf.tf_i[HIOFFSET] & (COSTABSIZE - 1);
         addr = tab + tabindex;
         tf.tf_i[HIOFFSET] = normhipart;
         frac = tf.tf_d - UNITBIT32;
@@ -424,44 +418,39 @@ static t_int *sigvcf_perform(t_int *w)
         f2 = addr[1];
         coefr = r * (f1 + frac * (f2 - f1));
 
-        addr = tab + ((tabindex - (COSTABSIZE/4)) & (COSTABSIZE-1));
+        addr = tab + ((tabindex - (COSTABSIZE / 4)) & (COSTABSIZE - 1));
         f1 = addr[0];
         f2 = addr[1];
         coefi = r * (f1 + frac * (f2 - f1));
 
         f1 = *in1++;
         re2 = re;
-        *out1++ = re = ampcorrect * oneminusr * f1
-            + coefr * re2 - coefi * im;
+        *out1++ = re = ampcorrect * oneminusr * f1 + coefr * re2 - coefi * im;
         *out2++ = im = coefi * re2 + coefr * im;
     }
-    if (PD_BIGORSMALL(re))
-        re = 0;
-    if (PD_BIGORSMALL(im))
-        im = 0;
+    if(PD_BIGORSMALL(re)) re = 0;
+    if(PD_BIGORSMALL(im)) im = 0;
     c->c_re = re;
     c->c_im = im;
-    return (w+7);
+    return (w + 7);
 }
 
 static void sigvcf_dsp(t_sigvcf *x, t_signal **sp)
 {
-    x->x_cspace.c_isr = 6.28318f/sp[0]->s_sr;
-    dsp_add(sigvcf_perform, 6,
-        sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec,
-            &x->x_cspace, (t_int)sp[0]->s_n);
+    x->x_cspace.c_isr = 6.28318f / sp[0]->s_sr;
+    dsp_add(sigvcf_perform, 6, sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec,
+        sp[3]->s_vec, &x->x_cspace, (t_int) sp[0]->s_n);
 }
 
-static
-void sigvcf_setup(void)
+static void sigvcf_setup(void)
 {
-    sigvcf_class = class_new(gensym("vcf~"), (t_newmethod)sigvcf_new, 0,
+    sigvcf_class = class_new(gensym("vcf~"), (t_newmethod) sigvcf_new, 0,
         sizeof(t_sigvcf), 0, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigvcf_class, t_sigvcf, x_f);
-    class_addmethod(sigvcf_class, (t_method)sigvcf_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(sigvcf_class, (t_method)sigvcf_ft1,
-        gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(
+        sigvcf_class, (t_method) sigvcf_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        sigvcf_class, (t_method) sigvcf_ft1, gensym("ft1"), A_FLOAT, 0);
 }
 
 /* -------------------------- noise~ ------------------------------ */
@@ -475,9 +464,9 @@ typedef struct _noise
 
 static void *noise_new(void)
 {
-    t_noise *x = (t_noise *)pd_new(noise_class);
-        /* seed each instance differently.  Once in a blue moon two threads
-        could grab the same seed value.  We can live with that. */
+    t_noise *x = (t_noise *) pd_new(noise_class);
+    /* seed each instance differently.  Once in a blue moon two threads
+    could grab the same seed value.  We can live with that. */
     static int init = 307;
     x->x_val = (init *= 1319);
     outlet_new(&x->x_obj, gensym("signal"));
@@ -486,39 +475,39 @@ static void *noise_new(void)
 
 static t_int *noise_perform(t_int *w)
 {
-    t_sample *out = (t_sample *)(w[1]);
-    int *vp = (int *)(w[2]);
-    int n = (int)(w[3]);
+    t_sample *out = (t_sample *) (w[1]);
+    int *vp = (int *) (w[2]);
+    int n = (int) (w[3]);
     int val = *vp;
-    while (n--)
+    while(n--)
     {
-        *out++ = ((t_sample)((val & 0x7fffffff) - 0x40000000)) *
-            (t_sample)(1.0 / 0x40000000);
+        *out++ = ((t_sample) ((val & 0x7fffffff) - 0x40000000)) *
+                 (t_sample) (1.0 / 0x40000000);
         val = val * 435898247 + 382842987;
     }
     *vp = val;
-    return (w+4);
+    return (w + 4);
 }
 
 static void noise_dsp(t_noise *x, t_signal **sp)
 {
-    dsp_add(noise_perform, 3, sp[0]->s_vec, &x->x_val, (t_int)sp[0]->s_n);
+    dsp_add(noise_perform, 3, sp[0]->s_vec, &x->x_val, (t_int) sp[0]->s_n);
 }
 
 static void noise_float(t_noise *x, t_float f)
 {
     /* set the seed */
-    x->x_val = (int)f;
+    x->x_val = (int) f;
 }
 
 static void noise_setup(void)
 {
-    noise_class = class_new(gensym("noise~"), (t_newmethod)noise_new, 0,
+    noise_class = class_new(gensym("noise~"), (t_newmethod) noise_new, 0,
         sizeof(t_noise), 0, A_DEFFLOAT, 0);
-    class_addmethod(noise_class, (t_method)noise_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(noise_class, (t_method)noise_float,
-        gensym("seed"), A_FLOAT, 0);
+    class_addmethod(
+        noise_class, (t_method) noise_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        noise_class, (t_method) noise_float, gensym("seed"), A_FLOAT, 0);
 }
 
 /* ----------------------- global setup routine ---------------- */

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -391,7 +391,6 @@ static t_int *sigvcf_perform(t_int *w)
     t_sample *out2 = (t_sample *) (w[4]);
     t_vcfctl *c = (t_vcfctl *) (w[5]);
     int n = (int) w[6];
-    int i;
     t_float re = c->c_re;
     t_float re2;
     t_float im = c->c_im;
@@ -414,7 +413,7 @@ static t_int *sigvcf_perform(t_int *w)
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         float cf;
         float cfindx;

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -78,7 +78,7 @@ static t_int *phasor_perform(t_int *w)
     t_phasor *x = (t_phasor *) (w[1]);
     t_sample *in = (t_float *) (w[2]);
     t_sample *out = (t_float *) (w[3]);
-    int n = (int) (w[4]);
+    int num_samples = (int) (w[4]);
     double dphase = x->x_phase + (double) UNITBIT32;
     union tabfudge tf;
     int normhipart;
@@ -88,11 +88,11 @@ static t_int *phasor_perform(t_int *w)
     normhipart = tf.tf_i[HIOFFSET];
     tf.tf_d = dphase;
 
-    while(n--)
+    for(int i = 0; i < num_samples; i++)
     {
         tf.tf_i[HIOFFSET] = normhipart;
-        dphase += *in++ * conv;
-        *out++ = tf.tf_d - UNITBIT32;
+        dphase += in[i] * conv;
+        out[i] = tf.tf_d - UNITBIT32;
         tf.tf_d = dphase;
     }
     tf.tf_i[HIOFFSET] = normhipart;
@@ -390,7 +390,7 @@ static t_int *sigvcf_perform(t_int *w)
     t_sample *out1 = (t_sample *) (w[3]);
     t_sample *out2 = (t_sample *) (w[4]);
     t_vcfctl *c = (t_vcfctl *) (w[5]);
-    int n = (int) w[6];
+    int num_samples = (int) w[6];
     t_float re = c->c_re;
     t_float re2;
     t_float im = c->c_im;
@@ -413,13 +413,13 @@ static t_int *sigvcf_perform(t_int *w)
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
 
-    for(int i = 0; i < n; i++)
+    for(int i = 0; i < num_samples; i++)
     {
         float cf;
         float cfindx;
         float r;
         float oneminusr;
-        cf = *in2++ * isr;
+        cf = in2[i] * isr;
         if(cf < 0) cf = 0;
         cfindx = cf * (float) (COSTABSIZE / 6.28318f);
         r = (qinv > 0 ? 1 - cf * qinv : 0);
@@ -440,10 +440,10 @@ static t_int *sigvcf_perform(t_int *w)
         f2 = addr[1];
         coefi = r * (f1 + frac * (f2 - f1));
 
-        f1 = *in1++;
+        f1 = in1[i];
         re2 = re;
-        *out1++ = re = ampcorrect * oneminusr * f1 + coefr * re2 - coefi * im;
-        *out2++ = im = coefi * re2 + coefr * im;
+        out1[i] = re = ampcorrect * oneminusr * f1 + coefr * re2 - coefi * im;
+        out2[i] = im = coefi * re2 + coefr * im;
     }
     if(PD_BIGORSMALL(re)) re = 0;
     if(PD_BIGORSMALL(im)) im = 0;
@@ -494,11 +494,11 @@ static t_int *noise_perform(t_int *w)
 {
     t_sample *out = (t_sample *) (w[1]);
     int *vp = (int *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
     int val = *vp;
-    while(n--)
+    for(int i = 0; i < num_samples; i++)
     {
-        *out++ = ((t_sample) ((val & 0x7fffffff) - 0x40000000)) *
+        out[i] = ((t_sample) ((val & 0x7fffffff) - 0x40000000)) *
                  (t_sample) (1.0 / 0x40000000);
         val = val * 435898247 + 382842987;
     }

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -53,7 +53,7 @@ t_int *upsampling_perform_hold(t_int *w)
     {
         for(int j = 0; j < up; j++)
         {
-            out[i * up + j] = in[i]
+            out[i * up + j] = in[i];
         }
     }
     return (w + 5);
@@ -66,7 +66,7 @@ t_int *upsampling_perform_linear(t_int *w)
     t_sample *out = (t_sample *) (w[3]); /* upsampled signal    */
     int up = (int) (w[4]);               /* upsampling factor   */
     int in_num_samples = (int) (w[5]);   /* original vectorsize */
-    int out_num_samples = parent * up;
+    int out_num_samples = in_num_samples * up;
 
     t_sample a = *x->buffer;
     t_sample b = in[0];
@@ -74,7 +74,7 @@ t_int *upsampling_perform_linear(t_int *w)
     for(int i = 0; i < out_num_samples; i++)
     {
         t_sample f_in_idx = (t_sample) (i + 1) / up;
-        int i_in_idx = (int) f_source_idx;
+        int i_in_idx = (int) f_in_idx;
         t_sample frac = f_in_idx - (t_sample) i_in_idx;
         if(frac == 0.)
             frac = 1.;

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -83,7 +83,8 @@ t_int *upsampling_perform_linear(t_int *w)
     int length = parent * up;
     int n;
     t_sample *fp;
-    t_sample a = *x->buffer, b = *in;
+    t_sample a = *x->buffer;
+    t_sample b = *in;
 
     for(n = 0; n < length; n++)
     {

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -2,99 +2,103 @@
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
-
 #include "m_pd.h"
 
 /* --------------------- up/down-sampling --------------------- */
 t_int *downsampling_perform_0(t_int *w)
 {
-  t_sample *in  = (t_sample *)(w[1]); /* original signal     */
-  t_sample *out = (t_sample *)(w[2]); /* downsampled signal  */
-  int down     = (int)(w[3]);       /* downsampling factor */
-  int parent   = (int)(w[4]);       /* original vectorsize */
+    t_sample *in = (t_sample *) (w[1]);  /* original signal     */
+    t_sample *out = (t_sample *) (w[2]); /* downsampled signal  */
+    int down = (int) (w[3]);             /* downsampling factor */
+    int parent = (int) (w[4]);           /* original vectorsize */
 
-  int n=parent/down;
+    int n = parent / down;
 
-  while(n--){
-    *out++=*in;
-    in+=down;
-  }
+    while(n--)
+    {
+        *out++ = *in;
+        in += down;
+    }
 
-  return (w+5);
+    return (w + 5);
 }
 
 t_int *upsampling_perform_0(t_int *w)
 {
-  t_sample *in  = (t_sample *)(w[1]); /* original signal     */
-  t_sample *out = (t_sample *)(w[2]); /* upsampled signal    */
-  int up       = (int)(w[3]);       /* upsampling factor   */
-  int parent   = (int)(w[4]);       /* original vectorsize */
+    t_sample *in = (t_sample *) (w[1]);  /* original signal     */
+    t_sample *out = (t_sample *) (w[2]); /* upsampled signal    */
+    int up = (int) (w[3]);               /* upsampling factor   */
+    int parent = (int) (w[4]);           /* original vectorsize */
 
-  int n=parent*up;
-  t_sample *dummy = out;
+    int n = parent * up;
+    t_sample *dummy = out;
 
-  while(n--)*out++=0;
+    while(n--)
+        *out++ = 0;
 
-  n = parent;
-  out = dummy;
-  while(n--){
-    *out=*in++;
-    out+=up;
-  }
+    n = parent;
+    out = dummy;
+    while(n--)
+    {
+        *out = *in++;
+        out += up;
+    }
 
-  return (w+5);
+    return (w + 5);
 }
 
 t_int *upsampling_perform_hold(t_int *w)
 {
-  t_sample *in  = (t_sample *)(w[1]); /* original signal     */
-  t_sample *out = (t_sample *)(w[2]); /* upsampled signal    */
-  int up       = (int)(w[3]);       /* upsampling factor   */
-  int parent   = (int)(w[4]);       /* original vectorsize */
-  int i=up;
+    t_sample *in = (t_sample *) (w[1]);  /* original signal     */
+    t_sample *out = (t_sample *) (w[2]); /* upsampled signal    */
+    int up = (int) (w[3]);               /* upsampling factor   */
+    int parent = (int) (w[4]);           /* original vectorsize */
+    int i = up;
 
-  int n=parent;
-  t_sample *dum_out = out;
-  t_sample *dum_in  = in;
+    int n = parent;
+    t_sample *dum_out = out;
+    t_sample *dum_in = in;
 
-  while (i--) {
-    n = parent;
-    out = dum_out+i;
-    in  = dum_in;
-    while(n--){
-      *out=*in++;
-      out+=up;
+    while(i--)
+    {
+        n = parent;
+        out = dum_out + i;
+        in = dum_in;
+        while(n--)
+        {
+            *out = *in++;
+            out += up;
+        }
     }
-  }
-  return (w+5);
+    return (w + 5);
 }
 
 t_int *upsampling_perform_linear(t_int *w)
 {
-  t_resample *x= (t_resample *)(w[1]);
-  t_sample *in  = (t_sample *)(w[2]); /* original signal     */
-  t_sample *out = (t_sample *)(w[3]); /* upsampled signal    */
-  int up       = (int)(w[4]);       /* upsampling factor   */
-  int parent   = (int)(w[5]);       /* original vectorsize */
-  int length   = parent*up;
-  int n;
-  t_sample *fp;
-  t_sample a=*x->buffer, b=*in;
+    t_resample *x = (t_resample *) (w[1]);
+    t_sample *in = (t_sample *) (w[2]);  /* original signal     */
+    t_sample *out = (t_sample *) (w[3]); /* upsampled signal    */
+    int up = (int) (w[4]);               /* upsampling factor   */
+    int parent = (int) (w[5]);           /* original vectorsize */
+    int length = parent * up;
+    int n;
+    t_sample *fp;
+    t_sample a = *x->buffer, b = *in;
 
+    for(n = 0; n < length; n++)
+    {
+        t_sample findex = (t_sample) (n + 1) / up;
+        int index = findex;
+        t_sample frac = findex - index;
+        if(frac == 0.) frac = 1.;
+        *out++ = frac * b + (1. - frac) * a;
+        fp = in + index;
+        b = *fp;
+        a = (index) ? *(fp - 1) : a;
+    }
 
-  for (n=0; n<length; n++) {
-    t_sample findex = (t_sample)(n+1)/up;
-    int     index  = findex;
-    t_sample frac=findex - index;
-    if (frac==0.)frac=1.;
-    *out++ = frac * b + (1.-frac) * a;
-    fp = in+index;
-    b=*fp;
-    a=(index)?*(fp-1):a;
-  }
-
-  *x->buffer = a;
-  return (w+6);
+    *x->buffer = a;
+    return (w + 6);
 }
 
 /* ----------------------- public -------------------------------- */
@@ -103,114 +107,124 @@ t_int *upsampling_perform_linear(t_int *w)
 
 void resample_init(t_resample *x)
 {
-  x->method=0;
+    x->method = 0;
 
-  x->downsample=x->upsample=1;
+    x->downsample = x->upsample = 1;
 
-  x->s_n = x->coefsize = x->bufsize = 0;
-  x->s_vec = x->coeffs = x->buffer  = 0;
+    x->s_n = x->coefsize = x->bufsize = 0;
+    x->s_vec = x->coeffs = x->buffer = 0;
 }
 
 void resample_free(t_resample *x)
 {
-  if (x->s_n) t_freebytes(x->s_vec, x->s_n*sizeof(*x->s_vec));
-  if (x->coefsize) t_freebytes(x->coeffs, x->coefsize*sizeof(*x->coeffs));
-  if (x->bufsize) t_freebytes(x->buffer, x->bufsize*sizeof(*x->buffer));
+    if(x->s_n) t_freebytes(x->s_vec, x->s_n * sizeof(*x->s_vec));
+    if(x->coefsize) t_freebytes(x->coeffs, x->coefsize * sizeof(*x->coeffs));
+    if(x->bufsize) t_freebytes(x->buffer, x->bufsize * sizeof(*x->buffer));
 
-  x->s_n = x->coefsize = x->bufsize = 0;
-  x->s_vec = x->coeffs = x->buffer  = 0;
+    x->s_n = x->coefsize = x->bufsize = 0;
+    x->s_vec = x->coeffs = x->buffer = 0;
 }
-
 
 /* dsp-adding */
 
-void resample_dsp(t_resample *x,
-                  t_sample* in,  int insize,
-                  t_sample* out, int outsize,
-                  int method)
+void resample_dsp(t_resample *x, t_sample *in, int insize, t_sample *out,
+    int outsize, int method)
 {
-  if (insize == outsize){
-    bug("nothing to be done");
-    return;
-  }
-
-  if (insize > outsize) { /* downsampling */
-    if (insize % outsize) {
-      pd_error(0, "bad downsampling factor");
-      return;
-    }
-    switch (method) {
-    default:
-      dsp_add(downsampling_perform_0, 4, in, out, (t_int)(insize/outsize), (t_int)insize);
+    if(insize == outsize)
+    {
+        bug("nothing to be done");
+        return;
     }
 
-
-  } else { /* upsampling */
-    if (outsize % insize) {
-      pd_error(0, "bad upsampling factor");
-      return;
+    if(insize > outsize)
+    { /* downsampling */
+        if(insize % outsize)
+        {
+            pd_error(0, "bad downsampling factor");
+            return;
+        }
+        switch(method)
+        {
+            default:
+                dsp_add(downsampling_perform_0, 4, in, out,
+                    (t_int) (insize / outsize), (t_int) insize);
+        }
     }
-    switch (method) {
-    case 1:
-      dsp_add(upsampling_perform_hold, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
-      break;
-    case 2:
-      if (x->bufsize != 1) {
-        t_freebytes(x->buffer, x->bufsize*sizeof(*x->buffer));
-        x->bufsize = 1;
-        x->buffer = t_getbytes(x->bufsize*sizeof(*x->buffer));
-      }
-      dsp_add(upsampling_perform_linear, 5, x, in, out, (t_int)(outsize/insize), (t_int)insize);
-      break;
-    default:
-      dsp_add(upsampling_perform_0, 4, in, out, (t_int)(outsize/insize), (t_int)insize);
+    else
+    { /* upsampling */
+        if(outsize % insize)
+        {
+            pd_error(0, "bad upsampling factor");
+            return;
+        }
+        switch(method)
+        {
+            case 1:
+                dsp_add(upsampling_perform_hold, 4, in, out,
+                    (t_int) (outsize / insize), (t_int) insize);
+                break;
+            case 2:
+                if(x->bufsize != 1)
+                {
+                    t_freebytes(x->buffer, x->bufsize * sizeof(*x->buffer));
+                    x->bufsize = 1;
+                    x->buffer = t_getbytes(x->bufsize * sizeof(*x->buffer));
+                }
+                dsp_add(upsampling_perform_linear, 5, x, in, out,
+                    (t_int) (outsize / insize), (t_int) insize);
+                break;
+            default:
+                dsp_add(upsampling_perform_0, 4, in, out,
+                    (t_int) (outsize / insize), (t_int) insize);
+        }
     }
-  }
 }
 
-void resamplefrom_dsp(t_resample *x,
-                           t_sample *in,
-                           int insize, int outsize, int method)
+void resamplefrom_dsp(
+    t_resample *x, t_sample *in, int insize, int outsize, int method)
 {
-  if (insize==outsize) {
-   t_freebytes(x->s_vec, x->s_n * sizeof(*x->s_vec));
-    x->s_n = 0;
-    x->s_vec = in;
+    if(insize == outsize)
+    {
+        t_freebytes(x->s_vec, x->s_n * sizeof(*x->s_vec));
+        x->s_n = 0;
+        x->s_vec = in;
+        return;
+    }
+
+    if(x->s_n != outsize)
+    {
+        t_sample *buf = x->s_vec;
+        t_freebytes(buf, x->s_n * sizeof(*buf));
+        buf = (t_sample *) t_getbytes(outsize * sizeof(*buf));
+        x->s_vec = buf;
+        x->s_n = outsize;
+    }
+
+    resample_dsp(x, in, insize, x->s_vec, x->s_n, method);
     return;
-  }
-
-  if (x->s_n != outsize) {
-    t_sample *buf=x->s_vec;
-    t_freebytes(buf, x->s_n * sizeof(*buf));
-    buf = (t_sample *)t_getbytes(outsize * sizeof(*buf));
-    x->s_vec = buf;
-    x->s_n   = outsize;
-  }
-
-  resample_dsp(x, in, insize, x->s_vec, x->s_n, method);
-  return;
 }
 
-void resampleto_dsp(t_resample *x,
-                         t_sample *out,
-                         int insize, int outsize, int method)
+void resampleto_dsp(
+    t_resample *x, t_sample *out, int insize, int outsize, int method)
 {
-  if (insize==outsize) {
-    if (x->s_n)t_freebytes(x->s_vec, x->s_n * sizeof(*x->s_vec));
-    x->s_n = 0;
-    x->s_vec = out;
+    if(insize == outsize)
+    {
+        if(x->s_n) t_freebytes(x->s_vec, x->s_n * sizeof(*x->s_vec));
+        x->s_n = 0;
+        x->s_vec = out;
+        return;
+    }
+
+    if(x->s_n != insize)
+    {
+        t_sample *buf = x->s_vec;
+        t_freebytes(buf, x->s_n * sizeof(*buf));
+        buf = (t_sample *) t_getbytes(insize * sizeof(*buf));
+        x->s_vec = buf;
+        x->s_n = insize;
+    }
+
+    resample_dsp(x, x->s_vec, x->s_n, out, outsize, method);
+
     return;
-  }
-
-  if (x->s_n != insize) {
-    t_sample *buf=x->s_vec;
-    t_freebytes(buf, x->s_n * sizeof(*buf));
-    buf = (t_sample *)t_getbytes(insize * sizeof(*buf));
-    x->s_vec = buf;
-    x->s_n   = insize;
-  }
-
-  resample_dsp(x, x->s_vec, x->s_n, out, outsize, method);
-
-  return;
 }

--- a/src/d_resample.c
+++ b/src/d_resample.c
@@ -202,7 +202,6 @@ void resamplefrom_dsp(
     }
 
     resample_dsp(x, in, insize, x->s_vec, x->s_n, method);
-    return;
 }
 
 void resampleto_dsp(
@@ -226,6 +225,4 @@ void resampleto_dsp(
     }
 
     resample_dsp(x, x->s_vec, x->s_n, out, outsize, method);
-
-    return;
 }

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1860,8 +1860,7 @@ static void *readsf_child_main(void *zz)
 #endif
                         continue;
                     }
-                    else
-                        wantbytes = READSIZE;
+                    wantbytes = READSIZE;
                     if(sf.sf_bytelimit >= 0 &&
                         wantbytes > (size_t) sf.sf_bytelimit)
                         wantbytes = sf.sf_bytelimit;
@@ -1883,7 +1882,7 @@ static void *readsf_child_main(void *zz)
                     x->x_fileerror = errno;
                     break;
                 }
-                else if(bytesread == 0)
+                if(bytesread == 0)
                 {
                     x->x_eof = 1;
                     break;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette. Updated 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* this file contains, first, a collection of soundfile access routines, a
 sort of soundfile library.  Second, the "soundfiler" object is defined which
@@ -31,18 +31,18 @@ objects use Posix-like threads. */
 
 /* MSVC uses different naming for these */
 #ifdef _MSC_VER
-#define O_CREAT  _O_CREAT
-#define O_TRUNC  _O_TRUNC
+#define O_CREAT _O_CREAT
+#define O_TRUNC _O_TRUNC
 #define O_WRONLY _O_WRONLY
 #endif
 
 #define SCALE (1. / (1024. * 1024. * 1024. * 2.))
 
-    /* float sample conversion wrapper */
+/* float sample conversion wrapper */
 typedef union _floatuint
 {
-  float f;
-  uint32_t ui;
+    float f;
+    uint32_t ui;
 } t_floatuint;
 
 /* ----- soundfile ----- */
@@ -57,7 +57,7 @@ void soundfile_clear(t_soundfile *sf)
 
 void soundfile_copy(t_soundfile *dst, const t_soundfile *src)
 {
-    memcpy((char *)dst, (char *)src, sizeof(t_soundfile));
+    memcpy((char *) dst, (char *) src, sizeof(t_soundfile));
 }
 
 int soundfile_needsbyteswap(const t_soundfile *sf)
@@ -65,9 +65,9 @@ int soundfile_needsbyteswap(const t_soundfile *sf)
     return sf->sf_bigendian != sys_isbigendian();
 }
 
-const char* soundfile_strerror(int errnum)
+const char *soundfile_strerror(int errnum)
 {
-    switch (errnum)
+    switch(errnum)
     {
         case SOUNDFILE_ERRUNKNOWN:
             return "unknown header format";
@@ -82,24 +82,24 @@ const char* soundfile_strerror(int errnum)
     }
 }
 
-    /** output soundfile format info as a list */
+/** output soundfile format info as a list */
 static void outlet_soundfileinfo(t_outlet *out, t_soundfile *sf)
 {
     t_atom info_list[5];
-    SETFLOAT((t_atom *)info_list, (t_float)sf->sf_samplerate);
-    SETFLOAT((t_atom *)info_list+1,
-        (t_float)(sf->sf_headersize < 0 ? 0 : sf->sf_headersize));
-    SETFLOAT((t_atom *)info_list+2, (t_float)sf->sf_nchannels);
-    SETFLOAT((t_atom *)info_list+3, (t_float)sf->sf_bytespersample);
-    SETSYMBOL((t_atom *)info_list+4, gensym((sf->sf_bigendian ? "b" : "l")));
-    outlet_list(out, &s_list, 5, (t_atom *)info_list);
+    SETFLOAT((t_atom *) info_list, (t_float) sf->sf_samplerate);
+    SETFLOAT((t_atom *) info_list + 1,
+        (t_float) (sf->sf_headersize < 0 ? 0 : sf->sf_headersize));
+    SETFLOAT((t_atom *) info_list + 2, (t_float) sf->sf_nchannels);
+    SETFLOAT((t_atom *) info_list + 3, (t_float) sf->sf_bytespersample);
+    SETSYMBOL((t_atom *) info_list + 4, gensym((sf->sf_bigendian ? "b" : "l")));
+    outlet_list(out, &s_list, 5, (t_atom *) info_list);
 }
 
-    /* post soundfile error, try to print type name */
+/* post soundfile error, try to print type name */
 static void object_sferror(const void *x, const char *header,
     const char *filename, int errnum, const t_soundfile *sf)
 {
-    if (sf && sf->sf_type)
+    if(sf && sf->sf_type)
         pd_error(x, "%s %s: %s: %s", header, sf->sf_type->t_name, filename,
             soundfile_strerror(errnum));
     else
@@ -112,26 +112,26 @@ static void object_sferror(const void *x, const char *header,
 
 /* should these globals be PERTHREAD? */
 
-    /** supported type implementations */
+/** supported type implementations */
 static t_soundfile_type *sf_types[SFMAXTYPES] = {0};
 
-    /** number of types */
+/** number of types */
 static size_t sf_numtypes = 0;
 
-    /** min required header size, largest among the current types */
+/** min required header size, largest among the current types */
 static size_t sf_minheadersize = 0;
 
-    /** printable type argument list,
-       dash prepended and separated by spaces */
+/** printable type argument list,
+   dash prepended and separated by spaces */
 static char sf_typeargs[MAXPDSTRING] = {0};
 
-    /* built-in type implementations */
+/* built-in type implementations */
 void soundfile_wave_setup(void);
 void soundfile_aiff_setup(void);
 void soundfile_caf_setup(void);
 void soundfile_next_setup(void);
 
-    /** set up built-in types */
+/** set up built-in types */
 void soundfile_type_setup(void)
 {
     soundfile_wave_setup(); /* default first */
@@ -143,40 +143,36 @@ void soundfile_type_setup(void)
 int soundfile_addtype(const t_soundfile_type *type)
 {
     int i;
-    if (sf_numtypes == SFMAXTYPES)
+    if(sf_numtypes == SFMAXTYPES)
     {
         pd_error(0, "soundfile: max number of type implementations reached");
         return 0;
     }
-    sf_types[sf_numtypes] = (t_soundfile_type *)type;
+    sf_types[sf_numtypes] = (t_soundfile_type *) type;
     sf_numtypes++;
-    if (type->t_minheadersize > sf_minheadersize)
+    if(type->t_minheadersize > sf_minheadersize)
         sf_minheadersize = type->t_minheadersize;
     strcat(sf_typeargs, (sf_numtypes > 1 ? " -" : "-"));
     strcat(sf_typeargs, type->t_name);
     return 1;
 }
 
-    /** return type list head pointer */
-static t_soundfile_type **soundfile_firsttype(void)
-{
-    return &sf_types[0];
-}
+/** return type list head pointer */
+static t_soundfile_type **soundfile_firsttype(void) { return &sf_types[0]; }
 
-    /** return next type list pointer or NULL if at the end */
+/** return next type list pointer or NULL if at the end */
 static t_soundfile_type **soundfile_nexttype(t_soundfile_type **t)
 {
-    return (t == &sf_types[sf_numtypes-1] ? NULL : ++t);
+    return (t == &sf_types[sf_numtypes - 1] ? NULL : ++t);
 }
 
-    /** find type by name, returns NULL if not found */
+/** find type by name, returns NULL if not found */
 static t_soundfile_type *soundfile_findtype(const char *name)
 {
     t_soundfile_type **t = soundfile_firsttype();
-    while (t)
+    while(t)
     {
-        if (!strcmp(name, (*t)->t_name))
-            break;
+        if(!strcmp(name, (*t)->t_name)) break;
         t = soundfile_nexttype(t);
     }
     return (t ? *t : NULL);
@@ -184,7 +180,7 @@ static t_soundfile_type *soundfile_findtype(const char *name)
 
 /* ----- ASCII ----- */
 
-    /** compound ascii read/write args  */
+/** compound ascii read/write args  */
 typedef struct _asciiargs
 {
     ssize_t aa_onsetframe;  /* start frame */
@@ -200,16 +196,14 @@ typedef struct _asciiargs
 static int ascii_hasextension(const char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len >= 5 && !strncmp(filename + (len - 4), ".txt", 4))
-        return 1;
+    if(len >= 5 && !strncmp(filename + (len - 4), ".txt", 4)) return 1;
     return 0;
 }
 
 static int ascii_addextension(char *filename, size_t size)
 {
     size_t len = strnlen(filename, size);
-    if (len + 4 >= size)
-        return 0;
+    if(len + 4 >= size) return 0;
     strcpy(filename + len, ".txt");
     return 1;
 }
@@ -218,15 +212,13 @@ static int ascii_addextension(char *filename, size_t size)
 
 ssize_t fd_read(int fd, off_t offset, void *dst, size_t size)
 {
-    if (lseek(fd, offset, SEEK_SET) != offset)
-        return -1;
+    if(lseek(fd, offset, SEEK_SET) != offset) return -1;
     return read(fd, dst, size);
 }
 
 ssize_t fd_write(int fd, off_t offset, const void *src, size_t size)
 {
-    if (lseek(fd, offset, SEEK_SET) != offset)
-        return -1;
+    if(lseek(fd, offset, SEEK_SET) != offset) return -1;
     return write(fd, src, size);
 }
 
@@ -235,18 +227,18 @@ ssize_t fd_write(int fd, off_t offset, const void *src, size_t size)
 int sys_isbigendian(void)
 {
     unsigned short s = 1;
-    unsigned char c = *(char *)(&s);
+    unsigned char c = *(char *) (&s);
     return (c == 0);
 }
 
 uint64_t swap8(uint64_t n, int doit)
 {
-    if (doit)
+    if(doit)
         return (((n >> 56) & 0x00000000000000ffULL) |
                 ((n >> 40) & 0x000000000000ff00ULL) |
                 ((n >> 24) & 0x0000000000ff0000ULL) |
-                ((n >>  8) & 0x00000000ff000000ULL) |
-                ((n <<  8) & 0x000000ff00000000ULL) |
+                ((n >> 8) & 0x00000000ff000000ULL) |
+                ((n << 8) & 0x000000ff00000000ULL) |
                 ((n << 24) & 0x0000ff0000000000ULL) |
                 ((n << 40) & 0x00ff000000000000ULL) |
                 ((n << 56) & 0xff00000000000000ULL));
@@ -255,12 +247,12 @@ uint64_t swap8(uint64_t n, int doit)
 
 int64_t swap8s(int64_t n, int doit)
 {
-    if (doit)
+    if(doit)
     {
-        n = ((n <<  8) & 0xff00ff00ff00ff00ULL) |
-            ((n >>  8) & 0x00ff00ff00ff00ffULL);
+        n = ((n << 8) & 0xff00ff00ff00ff00ULL) |
+            ((n >> 8) & 0x00ff00ff00ff00ffULL);
         n = ((n << 16) & 0xffff0000ffff0000ULL) |
-            ((n >> 16) & 0x0000ffff0000ffffULL );
+            ((n >> 16) & 0x0000ffff0000ffffULL);
         return (n << 32) | ((n >> 32) & 0xffffffffULL);
     }
     return n;
@@ -268,15 +260,15 @@ int64_t swap8s(int64_t n, int doit)
 
 uint32_t swap4(uint32_t n, int doit)
 {
-    if (doit)
-        return (((n & 0x0000ff) << 24) | ((n & 0x0000ff00) <<  8) |
-                ((n & 0xff0000) >>  8) | ((n & 0xff000000) >> 24));
+    if(doit)
+        return (((n & 0x0000ff) << 24) | ((n & 0x0000ff00) << 8) |
+                ((n & 0xff0000) >> 8) | ((n & 0xff000000) >> 24));
     return n;
 }
 
 int32_t swap4s(int32_t n, int doit)
 {
-    if (doit)
+    if(doit)
     {
         n = ((n << 8) & 0xff00ff00) | ((n >> 8) & 0xff00ff);
         return (n << 16) | ((n >> 16) & 0xffff);
@@ -286,54 +278,60 @@ int32_t swap4s(int32_t n, int doit)
 
 uint16_t swap2(uint16_t n, int doit)
 {
-    if (doit)
-        return (((n & 0x00ff) << 8) | ((n & 0xff00) >> 8));
+    if(doit) return (((n & 0x00ff) << 8) | ((n & 0xff00) >> 8));
     return n;
 }
 
 void swapstring4(char *foo, int doit)
 {
-    if (doit)
+    if(doit)
     {
         char a = foo[0], b = foo[1], c = foo[2], d = foo[3];
-        foo[0] = d; foo[1] = c; foo[2] = b; foo[3] = a;
+        foo[0] = d;
+        foo[1] = c;
+        foo[2] = b;
+        foo[3] = a;
     }
 }
 
 void swapstring8(char *foo, int doit)
 {
-    if (doit)
+    if(doit)
     {
-        char a = foo[0], b = foo[1], c = foo[2], d = foo[3],
-        e = foo[4], f = foo[5], g = foo[6], h = foo[7];
-        foo[0] = h; foo[1] = g; foo[2] = f; foo[3] = e;
-        foo[4] = d; foo[5] = c; foo[6] = b; foo[7] = a;
+        char a = foo[0], b = foo[1], c = foo[2], d = foo[3], e = foo[4],
+             f = foo[5], g = foo[6], h = foo[7];
+        foo[0] = h;
+        foo[1] = g;
+        foo[2] = f;
+        foo[3] = e;
+        foo[4] = d;
+        foo[5] = c;
+        foo[6] = b;
+        foo[7] = a;
     }
 }
 
 /* ----------------------- soundfile access routines ----------------------- */
 
-    /** This routine opens a file, looks for a supported file format
-        header, seeks to end of it, and fills in the soundfile header info
-        values. Only 2- and 3-byte fixed-point samples and 4-byte floating point
-        samples are supported.  If sf->sf_headersize is nonzero, the caller
-        should supply the number of channels, endinanness, and bytes per sample;
-        the header is ignored.  If sf->sf_type is non-NULL, the given type
-        implementation is used. Otherwise, the routine tries to read the header
-        and fill in the properties. Fills sf struct on success, closes fd on
-        failure. */
+/** This routine opens a file, looks for a supported file format
+    header, seeks to end of it, and fills in the soundfile header info
+    values. Only 2- and 3-byte fixed-point samples and 4-byte floating point
+    samples are supported.  If sf->sf_headersize is nonzero, the caller
+    should supply the number of channels, endinanness, and bytes per sample;
+    the header is ignored.  If sf->sf_type is non-NULL, the given type
+    implementation is used. Otherwise, the routine tries to read the header
+    and fill in the properties. Fills sf struct on success, closes fd on
+    failure. */
 int open_soundfile_via_fd(int fd, t_soundfile *sf, size_t skipframes)
 {
     off_t offset;
     errno = 0;
-    if (sf->sf_headersize >= 0) /* header detection overridden */
+    if(sf->sf_headersize >= 0) /* header detection overridden */
     {
-            /* interpret data size from file size */
+        /* interpret data size from file size */
         ssize_t bytelimit = lseek(fd, 0, SEEK_END);
-        if (bytelimit < 0)
-            goto badheader;
-        if (bytelimit > SFMAXBYTES || bytelimit < 0)
-            bytelimit = SFMAXBYTES;
+        if(bytelimit < 0) goto badheader;
+        if(bytelimit > SFMAXBYTES || bytelimit < 0) bytelimit = SFMAXBYTES;
         sf->sf_bytelimit = bytelimit;
         sf->sf_fd = fd;
     }
@@ -342,17 +340,16 @@ int open_soundfile_via_fd(int fd, t_soundfile *sf, size_t skipframes)
         char buf[SFHDRBUFSIZE];
         ssize_t bytesread = read(fd, buf, sf_minheadersize);
 
-        if (!sf->sf_type)
+        if(!sf->sf_type)
         {
-                /* check header for type */
+            /* check header for type */
             t_soundfile_type **t = soundfile_firsttype();
-            while (t)
+            while(t)
             {
-                if ((*t)->t_isheaderfn(buf, bytesread))
-                    break;
+                if((*t)->t_isheaderfn(buf, bytesread)) break;
                 t = soundfile_nexttype(t);
             }
-            if (!t) /* not recognized */
+            if(!t) /* not recognized */
             {
                 errno = SOUNDFILE_ERRUNKNOWN;
                 goto badheader;
@@ -361,8 +358,8 @@ int open_soundfile_via_fd(int fd, t_soundfile *sf, size_t skipframes)
         }
         else
         {
-                /* check header using given type */
-            if (!sf->sf_type->t_isheaderfn(buf, bytesread))
+            /* check header using given type */
+            if(!sf->sf_type->t_isheaderfn(buf, bytesread))
             {
                 errno = SOUNDFILE_ERRUNKNOWN;
                 goto badheader;
@@ -370,63 +367,55 @@ int open_soundfile_via_fd(int fd, t_soundfile *sf, size_t skipframes)
         }
         sf->sf_fd = fd;
 
-            /* rewind and read header */
-        if (lseek(sf->sf_fd, 0, SEEK_SET) < 0)
-            goto badheader;
-        if (!sf->sf_type->t_readheaderfn(sf))
-            goto badheader;
+        /* rewind and read header */
+        if(lseek(sf->sf_fd, 0, SEEK_SET) < 0) goto badheader;
+        if(!sf->sf_type->t_readheaderfn(sf)) goto badheader;
     }
 
-        /* seek past header and any sample frames to skip */
+    /* seek past header and any sample frames to skip */
     offset = sf->sf_headersize + (skipframes * sf->sf_bytesperframe);
-    if (lseek(sf->sf_fd, offset, 0) < offset)
-        goto badheader;
+    if(lseek(sf->sf_fd, offset, 0) < offset) goto badheader;
     sf->sf_bytelimit -= skipframes * sf->sf_bytesperframe;
-    if (sf->sf_bytelimit < 0)
-        sf->sf_bytelimit = 0;
+    if(sf->sf_bytelimit < 0) sf->sf_bytelimit = 0;
 
-        /* copy sample format back to caller */
+    /* copy sample format back to caller */
     return fd;
 
 badheader:
-        /* the header wasn't recognized.  We're threadable here so let's not
-        print out the error... */
-    if (!errno)
-        errno = SOUNDFILE_ERRMALFORMED;
+    /* the header wasn't recognized.  We're threadable here so let's not
+    print out the error... */
+    if(!errno) errno = SOUNDFILE_ERRMALFORMED;
     sf->sf_fd = -1;
-    if (fd >= 0)
-        sys_close(fd);
+    if(fd >= 0) sys_close(fd);
     return -1;
 }
 
-    /** open a soundfile, using open_via_path().  This is used by readsf~ in
-        a not-perfectly-threadsafe way.  LATER replace with a thread-hardened
-        version of open_soundfile_via_canvas().
-        returns number of frames in the soundfile */
+/** open a soundfile, using open_via_path().  This is used by readsf~ in
+    a not-perfectly-threadsafe way.  LATER replace with a thread-hardened
+    version of open_soundfile_via_canvas().
+    returns number of frames in the soundfile */
 int open_soundfile_via_path(const char *dirname, const char *filename,
     t_soundfile *sf, size_t skipframes)
 {
     char buf[MAXPDSTRING], *dummy;
     int fd, sf_fd;
     fd = open_via_path(dirname, filename, "", buf, &dummy, MAXPDSTRING, 1);
-    if (fd < 0)
-        return -1;
+    if(fd < 0) return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
     return sf_fd;
 }
 
-    /** open a soundfile, using open_via_canvas().  This is used by readsf~ in
-        a not-perfectly-threadsafe way.  LATER replace with a thread-hardened
-        version of open_soundfile_via_canvas().
-        returns number of frames in the soundfile */
-int open_soundfile_via_canvas(t_canvas *canvas, const char *filename,
-    t_soundfile *sf, size_t skipframes)
+/** open a soundfile, using open_via_canvas().  This is used by readsf~ in
+    a not-perfectly-threadsafe way.  LATER replace with a thread-hardened
+    version of open_soundfile_via_canvas().
+    returns number of frames in the soundfile */
+int open_soundfile_via_canvas(
+    t_canvas *canvas, const char *filename, t_soundfile *sf, size_t skipframes)
 {
     char buf[MAXPDSTRING], *dummy;
     int fd, sf_fd;
     fd = canvas_open(canvas, filename, "", buf, &dummy, MAXPDSTRING, 1);
-    if (fd < 0)
-        return -1;
+    if(fd < 0) return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
     return sf_fd;
 }
@@ -438,68 +427,68 @@ static void soundfile_xferin_sample(const t_soundfile *sf, int nvecs,
     size_t j;
     unsigned char *sp, *sp2;
     t_sample *fp;
-    for (i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
+    for(i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
     {
-        if (sf->sf_bytespersample == 2)
+        if(sf->sf_bytespersample == 2)
         {
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
-                        *fp = SCALE * ((sp2[0] << 24) | (sp2[1] << 16));
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
+                    *fp = SCALE * ((sp2[0] << 24) | (sp2[1] << 16));
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
-                        *fp = SCALE * ((sp2[1] << 24) | (sp2[0] << 16));
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
+                    *fp = SCALE * ((sp2[1] << 24) | (sp2[0] << 16));
             }
         }
-        else if (sf->sf_bytespersample == 3)
+        else if(sf->sf_bytespersample == 3)
         {
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
-                        *fp = SCALE * ((sp2[0] << 24) | (sp2[1] << 16) |
-                                       (sp2[2] << 8));
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
+                    *fp = SCALE *
+                          ((sp2[0] << 24) | (sp2[1] << 16) | (sp2[2] << 8));
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
-                        *fp = SCALE * ((sp2[2] << 24) | (sp2[1] << 16) |
-                                       (sp2[0] << 8));
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
+                    *fp = SCALE *
+                          ((sp2[2] << 24) | (sp2[1] << 16) | (sp2[0] << 8));
             }
         }
-        else if (sf->sf_bytespersample == 4)
+        else if(sf->sf_bytespersample == 4)
         {
             t_floatuint alias;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     alias.ui = ((sp2[0] << 24) | (sp2[1] << 16) |
-                                (sp2[2] << 8)  |  sp2[3]);
-                    *fp = (t_sample)alias.f;
+                                (sp2[2] << 8) | sp2[3]);
+                    *fp = (t_sample) alias.f;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     alias.ui = ((sp2[3] << 24) | (sp2[2] << 16) |
-                                (sp2[1] << 8)  |  sp2[0]);
-                    *fp = (t_sample)alias.f;
+                                (sp2[1] << 8) | sp2[0]);
+                    *fp = (t_sample) alias.f;
                 }
             }
         }
     }
-        /* zero out other outputs */
-    for (i = sf->sf_nchannels; i < nvecs; i++)
-        for (j = nframes, fp = vecs[i]; j--;)
+    /* zero out other outputs */
+    for(i = sf->sf_nchannels; i < nvecs; i++)
+        for(j = nframes, fp = vecs[i]; j--;)
             *fp++ = 0;
 }
 
@@ -510,112 +499,111 @@ static void soundfile_xferin_words(const t_soundfile *sf, int nvecs,
     t_word *wp;
     int nchannels = (sf->sf_nchannels < nvecs ? sf->sf_nchannels : nvecs), i;
     size_t j;
-    for (i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
+    for(i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
     {
-        if (sf->sf_bytespersample == 2)
+        if(sf->sf_bytespersample == 2)
         {
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
-                        wp->w_float = SCALE * ((sp2[0] << 24) | (sp2[1] << 16));
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
+                    wp->w_float = SCALE * ((sp2[0] << 24) | (sp2[1] << 16));
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
-                        wp->w_float = SCALE * ((sp2[1] << 24) | (sp2[0] << 16));
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
+                    wp->w_float = SCALE * ((sp2[1] << 24) | (sp2[0] << 16));
             }
         }
-        else if (sf->sf_bytespersample == 3)
+        else if(sf->sf_bytespersample == 3)
         {
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
-                        wp->w_float = SCALE * ((sp2[0] << 24) | (sp2[1] << 16) |
-                                               (sp2[2] << 8));
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
+                    wp->w_float = SCALE * ((sp2[0] << 24) | (sp2[1] << 16) |
+                                              (sp2[2] << 8));
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
-                        wp->w_float = SCALE * ((sp2[2] << 24) | (sp2[1] << 16) |
-                                               (sp2[0] << 8));
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
+                    wp->w_float = SCALE * ((sp2[2] << 24) | (sp2[1] << 16) |
+                                              (sp2[0] << 8));
             }
         }
-        else if (sf->sf_bytespersample == 4)
+        else if(sf->sf_bytespersample == 4)
         {
             t_floatuint alias;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     alias.ui = ((sp2[0] << 24) | (sp2[1] << 16) |
-                                (sp2[2] << 8)  |  sp2[3]);
-                    wp->w_float = (t_float)alias.f;
+                                (sp2[2] << 8) | sp2[3]);
+                    wp->w_float = (t_float) alias.f;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + framesread;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     alias.ui = ((sp2[3] << 24) | (sp2[2] << 16) |
-                                (sp2[1] << 8)  |  sp2[0]);
-                    wp->w_float = (t_float)alias.f;
+                                (sp2[1] << 8) | sp2[0]);
+                    wp->w_float = (t_float) alias.f;
                 }
             }
         }
     }
-        /* zero out other outputs */
-    for (i = sf->sf_nchannels; i < nvecs; i++)
-        for (j = nframes, wp = vecs[i]; j--;)
+    /* zero out other outputs */
+    for(i = sf->sf_nchannels; i < nvecs; i++)
+        for(j = nframes, wp = vecs[i]; j--;)
             (wp++)->w_float = 0;
 }
 
-    /* soundfiler_write ...
+/* soundfiler_write ...
 
-       usage: write [flags] filename table ...
-       flags:
-         -nframes <frames>
-         -skip <frames>
-         -bytes <bytespersample>
-         -rate / -r <samplerate>
-         -normalize
-         -wave
-         -aiff
-         -caf
-         -next / -nextstep
-         -ascii
-         -big
-         -little
-    */
+   usage: write [flags] filename table ...
+   flags:
+     -nframes <frames>
+     -skip <frames>
+     -bytes <bytespersample>
+     -rate / -r <samplerate>
+     -normalize
+     -wave
+     -aiff
+     -caf
+     -next / -nextstep
+     -ascii
+     -big
+     -little
+*/
 
-    /** parsed write arguments */
+/** parsed write arguments */
 typedef struct _soundfiler_writeargs
 {
-    t_symbol *wa_filesym;             /* file path symbol */
-    t_soundfile_type *wa_type;        /* type implementation */
-    int wa_samplerate;                /* sample rate */
-    int wa_bytespersample;            /* number of bytes per sample */
-    int wa_bigendian;                 /* is sample data bigendian? */
-    size_t wa_nframes;                /* number of sample frames to write */
-    size_t wa_onsetframes;            /* sample frame onset when writing */
-    int wa_normalize;                 /* normalize samples? */
-    int wa_ascii;                     /* write ascii? */
+    t_symbol *wa_filesym;      /* file path symbol */
+    t_soundfile_type *wa_type; /* type implementation */
+    int wa_samplerate;         /* sample rate */
+    int wa_bytespersample;     /* number of bytes per sample */
+    int wa_bigendian;          /* is sample data bigendian? */
+    size_t wa_nframes;         /* number of sample frames to write */
+    size_t wa_onsetframes;     /* sample frame onset when writing */
+    int wa_normalize;          /* normalize samples? */
+    int wa_ascii;              /* write ascii? */
 } t_soundfiler_writeargs;
-
 
 /* the routine which actually does the work should LATER also be called
 from garray_write16. */
 
-    /** Parse arguments for writing.  The "obj" argument is only for flagging
-        errors.  For streaming to a file the "normalize" and "nframes"
-        arguments shouldn't be set but the calling routine flags this. */
-static int soundfiler_parsewriteargs(void *obj, int *p_argc, t_atom **p_argv,
-    t_soundfiler_writeargs *wa)
+/** Parse arguments for writing.  The "obj" argument is only for flagging
+    errors.  For streaming to a file the "normalize" and "nframes"
+    arguments shouldn't be set but the calling routine flags this. */
+static int soundfiler_parsewriteargs(
+    void *obj, int *p_argc, t_atom **p_argv, t_soundfiler_writeargs *wa)
 {
     int argc = *p_argc;
     t_atom *argv = *p_argv;
@@ -625,109 +613,115 @@ static int soundfiler_parsewriteargs(void *obj, int *p_argc, t_atom **p_argv,
     t_symbol *filesym;
     t_soundfile_type *type = NULL;
 
-    while (argc > 0 && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(argc > 0 && argv->a_type == A_SYMBOL &&
+          *argv->a_w.w_symbol->s_name == '-')
     {
         const char *flag = argv->a_w.w_symbol->s_name + 1;
-        if (!strcmp(flag, "skip"))
+        if(!strcmp(flag, "skip"))
         {
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
+            if(argc < 2 || argv[1].a_type != A_FLOAT ||
                 (argv[1].a_w.w_float) < 0)
-                    return -1;
+                return -1;
             onsetframes = argv[1].a_w.w_float;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(flag, "nframes"))
+        else if(!strcmp(flag, "nframes"))
         {
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
-                argv[1].a_w.w_float < 0)
-                    return -1;
+            if(argc < 2 || argv[1].a_type != A_FLOAT || argv[1].a_w.w_float < 0)
+                return -1;
             nframes = argv[1].a_w.w_float;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(flag, "bytes"))
+        else if(!strcmp(flag, "bytes"))
         {
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
+            if(argc < 2 || argv[1].a_type != A_FLOAT ||
                 ((bytespersample = argv[1].a_w.w_float) < 2) ||
-                    bytespersample > 4)
-                        return -1;
-            argc -= 2; argv += 2;
+                bytespersample > 4)
+                return -1;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(flag, "normalize"))
+        else if(!strcmp(flag, "normalize"))
         {
             normalize = 1;
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "big"))
+        else if(!strcmp(flag, "big"))
         {
             endianness = 1;
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "little"))
+        else if(!strcmp(flag, "little"))
         {
             endianness = 0;
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "rate") || !strcmp(flag, "r"))
+        else if(!strcmp(flag, "rate") || !strcmp(flag, "r"))
         {
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
+            if(argc < 2 || argv[1].a_type != A_FLOAT ||
                 ((samplerate = argv[1].a_w.w_float) <= 0))
-                    return -1;
-            argc -= 2; argv += 2;
+                return -1;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(flag, "ascii"))
+        else if(!strcmp(flag, "ascii"))
         {
             ascii = 1;
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "nextstep"))
+        else if(!strcmp(flag, "nextstep"))
         {
-                /* handle old "-nextstep" alias */
+            /* handle old "-nextstep" alias */
             type = soundfile_findtype("next");
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
         else
         {
-                /* check for type by name */
-            if (!(type = soundfile_findtype(flag)))
-                return -1; /* unknown flag */
-            ascii = 0; /* replaced */
-            argc -= 1; argv += 1;
+            /* check for type by name */
+            if(!(type = soundfile_findtype(flag))) return -1; /* unknown flag */
+            ascii = 0;                                        /* replaced */
+            argc -= 1;
+            argv += 1;
         }
     }
-    if (!argc || argv->a_type != A_SYMBOL)
-        return -1;
+    if(!argc || argv->a_type != A_SYMBOL) return -1;
     filesym = argv->a_w.w_symbol;
 
-        /* deduce from filename extension? */
-    if (!type)
+    /* deduce from filename extension? */
+    if(!type)
     {
         t_soundfile_type **t = soundfile_firsttype();
-        while (t)
+        while(t)
         {
-            if ((*t)->t_hasextensionfn(filesym->s_name, MAXPDSTRING))
-                break;
+            if((*t)->t_hasextensionfn(filesym->s_name, MAXPDSTRING)) break;
             t = soundfile_nexttype(t);
         }
-        if (!t)
+        if(!t)
         {
-            if (!ascii)
-                ascii = ascii_hasextension(filesym->s_name, MAXPDSTRING);
+            if(!ascii) ascii = ascii_hasextension(filesym->s_name, MAXPDSTRING);
             t = soundfile_firsttype(); /* default if unknown */
         }
         type = *t;
     }
 
-        /* check requested endianness */
+    /* check requested endianness */
     bigendian = type->t_endiannessfn(endianness);
-    if (endianness != -1 && endianness != bigendian)
+    if(endianness != -1 && endianness != bigendian)
     {
         post("%s: forced to %s endian", type->t_name,
             (bigendian ? "big" : "little"));
     }
 
-        /* return to caller */
-    argc--; argv++;
+    /* return to caller */
+    argc--;
+    argv++;
     *p_argc = argc;
     *p_argv = argv;
     wa->wa_filesym = filesym;
@@ -742,110 +736,100 @@ static int soundfiler_parsewriteargs(void *obj, int *p_argc, t_atom **p_argv,
     return 0;
 }
 
-    /** sets sf fd & headerisze on success and returns fd or -1 on failure */
-static int create_soundfile(t_canvas *canvas, const char *filename,
-    t_soundfile *sf, size_t nframes)
+/** sets sf fd & headerisze on success and returns fd or -1 on failure */
+static int create_soundfile(
+    t_canvas *canvas, const char *filename, t_soundfile *sf, size_t nframes)
 {
     char filenamebuf[MAXPDSTRING], pathbuf[MAXPDSTRING];
     ssize_t headersize = -1;
     int fd;
 
-        /* create file */
+    /* create file */
     strncpy(filenamebuf, filename, MAXPDSTRING);
-    if (!sf->sf_type->t_hasextensionfn(filenamebuf, MAXPDSTRING-10))
-        if (!sf->sf_type->t_addextensionfn(filenamebuf, MAXPDSTRING-10))
+    if(!sf->sf_type->t_hasextensionfn(filenamebuf, MAXPDSTRING - 10))
+        if(!sf->sf_type->t_addextensionfn(filenamebuf, MAXPDSTRING - 10))
             return -1;
-    filenamebuf[MAXPDSTRING-10] = 0; /* FIXME: what is the 10 for? */
+    filenamebuf[MAXPDSTRING - 10] = 0; /* FIXME: what is the 10 for? */
     canvas_makefilename(canvas, filenamebuf, pathbuf, MAXPDSTRING);
-    if ((fd = sys_open(pathbuf, O_WRONLY | O_CREAT | O_TRUNC, 0666)) < 0)
+    if((fd = sys_open(pathbuf, O_WRONLY | O_CREAT | O_TRUNC, 0666)) < 0)
         return -1;
     sf->sf_fd = fd;
 
-        /* write header */
+    /* write header */
     headersize = sf->sf_type->t_writeheaderfn(sf, nframes);
-    if (headersize < 0)
-        goto badcreate;
+    if(headersize < 0) goto badcreate;
     sf->sf_headersize = headersize;
     return fd;
 
 badcreate:
     sf->sf_fd = -1;
-    if (fd >= 0)
-        sys_close(fd);
+    if(fd >= 0) sys_close(fd);
     return -1;
 }
 
 static void soundfile_finishwrite(void *obj, const char *filename,
     t_soundfile *sf, size_t nframes, size_t frameswritten)
 {
-    if (frameswritten >= nframes) return;
-    if (nframes < SFMAXFRAMES)
+    if(frameswritten >= nframes) return;
+    if(nframes < SFMAXFRAMES)
         pd_error(obj, "soundfiler write: %ld out of %ld frames written",
-            (long)frameswritten, (long)nframes);
-    if (sf->sf_type->t_updateheaderfn(sf, frameswritten))
-        return;
+            (long) frameswritten, (long) nframes);
+    if(sf->sf_type->t_updateheaderfn(sf, frameswritten)) return;
     object_sferror(obj, "soundfiler write", filename, errno, sf);
 }
 
-static void soundfile_xferout_sample(const t_soundfile *sf,
-    t_sample **vecs, unsigned char *buf, size_t nframes, size_t onsetframes,
+static void soundfile_xferout_sample(const t_soundfile *sf, t_sample **vecs,
+    unsigned char *buf, size_t nframes, size_t onsetframes,
     t_sample normalfactor)
 {
     int i;
     size_t j;
     unsigned char *sp, *sp2;
     t_sample *fp;
-    for (i = 0, sp = buf; i < sf->sf_nchannels; i++,
-        sp += sf->sf_bytespersample)
+    for(i = 0, sp = buf; i < sf->sf_nchannels; i++, sp += sf->sf_bytespersample)
     {
-        if (sf->sf_bytespersample == 2)
+        if(sf->sf_bytespersample == 2)
         {
             t_sample ff = normalfactor * 32768.;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     int xx = 32768. + (*fp * ff);
                     xx -= 32768;
-                    if (xx < -32767)
-                        xx = -32767;
-                    if (xx > 32767)
-                        xx = 32767;
+                    if(xx < -32767) xx = -32767;
+                    if(xx > 32767) xx = 32767;
                     sp2[0] = (xx >> 8);
                     sp2[1] = xx;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     int xx = 32768. + (*fp * ff);
                     xx -= 32768;
-                    if (xx < -32767)
-                        xx = -32767;
-                    if (xx > 32767)
-                        xx = 32767;
+                    if(xx < -32767) xx = -32767;
+                    if(xx > 32767) xx = 32767;
                     sp2[1] = (xx >> 8);
                     sp2[0] = xx;
                 }
             }
         }
-        else if (sf->sf_bytespersample == 3)
+        else if(sf->sf_bytespersample == 3)
         {
             t_sample ff = normalfactor * 8388608.;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     int xx = 8388608. + (*fp * ff);
                     xx -= 8388608;
-                    if (xx < -8388607)
-                        xx = -8388607;
-                    if (xx > 8388607)
-                        xx = 8388607;
+                    if(xx < -8388607) xx = -8388607;
+                    if(xx > 8388607) xx = 8388607;
                     sp2[0] = (xx >> 16);
                     sp2[1] = (xx >> 8);
                     sp2[2] = xx;
@@ -853,42 +837,44 @@ static void soundfile_xferout_sample(const t_soundfile *sf,
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     int xx = 8388608. + (*fp * ff);
                     xx -= 8388608;
-                    if (xx < -8388607)
-                        xx = -8388607;
-                    if (xx > 8388607)
-                        xx = 8388607;
+                    if(xx < -8388607) xx = -8388607;
+                    if(xx > 8388607) xx = 8388607;
                     sp2[2] = (xx >> 16);
                     sp2[1] = (xx >> 8);
                     sp2[0] = xx;
                 }
             }
         }
-        else if (sf->sf_bytespersample == 4)
+        else if(sf->sf_bytespersample == 4)
         {
             t_floatuint f2;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     f2.f = *fp * normalfactor;
-                    sp2[0] = (f2.ui >> 24); sp2[1] = (f2.ui >> 16);
-                    sp2[2] = (f2.ui >> 8);  sp2[3] = f2.ui;
+                    sp2[0] = (f2.ui >> 24);
+                    sp2[1] = (f2.ui >> 16);
+                    sp2[2] = (f2.ui >> 8);
+                    sp2[3] = f2.ui;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, fp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, fp++)
+                for(j = 0, sp2 = sp, fp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, fp++)
                 {
                     f2.f = *fp * normalfactor;
-                    sp2[3] = (f2.ui >> 24); sp2[2] = (f2.ui >> 16);
-                    sp2[1] = (f2.ui >> 8);  sp2[0] = f2.ui;
+                    sp2[3] = (f2.ui >> 24);
+                    sp2[2] = (f2.ui >> 16);
+                    sp2[1] = (f2.ui >> 8);
+                    sp2[0] = f2.ui;
                 }
             }
         }
@@ -903,57 +889,50 @@ static void soundfile_xferout_words(const t_soundfile *sf, t_word **vecs,
     size_t j;
     unsigned char *sp, *sp2;
     t_word *wp;
-    for (i = 0, sp = buf; i < sf->sf_nchannels;
-         i++, sp += sf->sf_bytespersample)
+    for(i = 0, sp = buf; i < sf->sf_nchannels; i++, sp += sf->sf_bytespersample)
     {
-        if (sf->sf_bytespersample == 2)
+        if(sf->sf_bytespersample == 2)
         {
             t_sample ff = normalfactor * 32768.;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     int xx = 32768. + (wp->w_float * ff);
                     xx -= 32768;
-                    if (xx < -32767)
-                        xx = -32767;
-                    if (xx > 32767)
-                        xx = 32767;
+                    if(xx < -32767) xx = -32767;
+                    if(xx > 32767) xx = 32767;
                     sp2[0] = (xx >> 8);
                     sp2[1] = xx;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     int xx = 32768. + (wp->w_float * ff);
                     xx -= 32768;
-                    if (xx < -32767)
-                        xx = -32767;
-                    if (xx > 32767)
-                        xx = 32767;
+                    if(xx < -32767) xx = -32767;
+                    if(xx > 32767) xx = 32767;
                     sp2[1] = (xx >> 8);
                     sp2[0] = xx;
                 }
             }
         }
-        else if (sf->sf_bytespersample == 3)
+        else if(sf->sf_bytespersample == 3)
         {
             t_sample ff = normalfactor * 8388608.;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     int xx = 8388608. + (wp->w_float * ff);
                     xx -= 8388608;
-                    if (xx < -8388607)
-                        xx = -8388607;
-                    if (xx > 8388607)
-                        xx = 8388607;
+                    if(xx < -8388607) xx = -8388607;
+                    if(xx > 8388607) xx = 8388607;
                     sp2[0] = (xx >> 16);
                     sp2[1] = (xx >> 8);
                     sp2[2] = xx;
@@ -961,42 +940,44 @@ static void soundfile_xferout_words(const t_soundfile *sf, t_word **vecs,
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     int xx = 8388608. + (wp->w_float * ff);
                     xx -= 8388608;
-                    if (xx < -8388607)
-                        xx = -8388607;
-                    if (xx > 8388607)
-                        xx = 8388607;
+                    if(xx < -8388607) xx = -8388607;
+                    if(xx > 8388607) xx = 8388607;
                     sp2[2] = (xx >> 16);
                     sp2[1] = (xx >> 8);
                     sp2[0] = xx;
                 }
             }
         }
-        else if (sf->sf_bytespersample == 4)
+        else if(sf->sf_bytespersample == 4)
         {
             t_floatuint f2;
-            if (sf->sf_bigendian)
+            if(sf->sf_bigendian)
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     f2.f = wp->w_float * normalfactor;
-                    sp2[0] = (f2.ui >> 24); sp2[1] = (f2.ui >> 16);
-                    sp2[2] = (f2.ui >> 8);  sp2[3] = f2.ui;
+                    sp2[0] = (f2.ui >> 24);
+                    sp2[1] = (f2.ui >> 16);
+                    sp2[2] = (f2.ui >> 8);
+                    sp2[3] = f2.ui;
                 }
             }
             else
             {
-                for (j = 0, sp2 = sp, wp = vecs[i] + onsetframes;
-                    j < nframes; j++, sp2 += sf->sf_bytesperframe, wp++)
+                for(j = 0, sp2 = sp, wp = vecs[i] + onsetframes; j < nframes;
+                    j++, sp2 += sf->sf_bytesperframe, wp++)
                 {
                     f2.f = wp->w_float * normalfactor;
-                    sp2[3] = (f2.ui >> 24); sp2[2] = (f2.ui >> 16);
-                    sp2[1] = (f2.ui >> 8);  sp2[0] = f2.ui;
+                    sp2[3] = (f2.ui >> 24);
+                    sp2[2] = (f2.ui >> 16);
+                    sp2[1] = (f2.ui >> 8);
+                    sp2[0] = f2.ui;
                 }
             }
         }
@@ -1018,21 +999,21 @@ typedef struct _soundfiler
 
 static t_soundfiler *soundfiler_new(void)
 {
-    t_soundfiler *x = (t_soundfiler *)pd_new(soundfiler_class);
+    t_soundfiler *x = (t_soundfiler *) pd_new(soundfiler_class);
     x->x_canvas = canvas_getcurrent();
     outlet_new(&x->x_obj, &s_float);
     x->x_out2 = outlet_new(&x->x_obj, &s_float);
     return x;
 }
 
-static int soundfiler_readascii(t_soundfiler *x, const char *filename,
-    t_asciiargs *a)
+static int soundfiler_readascii(
+    t_soundfiler *x, const char *filename, t_asciiargs *a)
 {
     t_binbuf *b = binbuf_new();
     int i, j, vecsize;
     ssize_t framesinfile, nframes = a->aa_nframes;
     t_atom *atoms, *ap;
-    if (binbuf_read_via_canvas(b, filename, x->x_canvas, 0))
+    if(binbuf_read_via_canvas(b, filename, x->x_canvas, 0))
     {
         nframes = 0;
         goto done;
@@ -1043,28 +1024,29 @@ static int soundfiler_readascii(t_soundfiler *x, const char *filename,
     post("ascii: read 1 natoms %d frames %d onset %d channels %d",
         binbuf_getnatom(b), nframes, a->aa_onsetframe, a->aa_nchannels);
 #endif
-    if (framesinfile < 1)
+    if(framesinfile < 1)
     {
-        pd_error(x, "soundfiler read: %s: empty or very short ascii file",
-            filename);
+        pd_error(
+            x, "soundfiler read: %s: empty or very short ascii file", filename);
         nframes = 0;
         goto done;
     }
-    if (a->aa_resize)
+    if(a->aa_resize)
     {
-        if ((size_t)framesinfile > a->aa_maxsize)
+        if((size_t) framesinfile > a->aa_maxsize)
         {
             pd_error(x, "soundfiler read: truncated to %ld elements",
-                (long)a->aa_maxsize);
+                (long) a->aa_maxsize);
             framesinfile = a->aa_maxsize;
         }
         nframes = framesinfile - a->aa_onsetframe;
-        for (i = 0; i < a->aa_nchannels; i++)
+        for(i = 0; i < a->aa_nchannels; i++)
         {
             garray_resize_long(a->aa_garrays[i], nframes);
             garray_setsaveit(a->aa_garrays[i], 0);
-            if (!garray_getfloatwords(a->aa_garrays[i], &vecsize,
-                &a->aa_vectors[i]) || (vecsize != nframes))
+            if(!garray_getfloatwords(
+                   a->aa_garrays[i], &vecsize, &a->aa_vectors[i]) ||
+                (vecsize != nframes))
             {
                 pd_error(x, "soundfiler read: resize failed");
                 nframes = 0;
@@ -1072,24 +1054,23 @@ static int soundfiler_readascii(t_soundfiler *x, const char *filename,
             }
         }
     }
-    else if (nframes > framesinfile)
+    else if(nframes > framesinfile)
         nframes = framesinfile - a->aa_onsetframe;
 #ifdef DEBUG_SOUNDFILE
     post("ascii: read 2 frames %d", nframes);
 #endif
-    if (a->aa_onsetframe > 0)
-        atoms += a->aa_onsetframe * a->aa_nchannels;
-    for (j = 0, ap = atoms; j < nframes; j++)
-        for (i = 0; i < a->aa_nchannels; i++)
+    if(a->aa_onsetframe > 0) atoms += a->aa_onsetframe * a->aa_nchannels;
+    for(j = 0, ap = atoms; j < nframes; j++)
+        for(i = 0; i < a->aa_nchannels; i++)
             a->aa_vectors[i][j].w_float = atom_getfloat(ap++);
-        /* zero out remaining elements of vectors */
-    for (i = 0; i < a->aa_nchannels; i++)
+    /* zero out remaining elements of vectors */
+    for(i = 0; i < a->aa_nchannels; i++)
     {
-        if (garray_getfloatwords(a->aa_garrays[i], &vecsize, &a->aa_vectors[i]))
-            for (j = nframes; j < vecsize; j++)
+        if(garray_getfloatwords(a->aa_garrays[i], &vecsize, &a->aa_vectors[i]))
+            for(j = nframes; j < vecsize; j++)
                 a->aa_vectors[i][j].w_float = 0;
     }
-    for (i = 0; i < a->aa_nchannels; i++)
+    for(i = 0; i < a->aa_nchannels; i++)
         garray_redraw(a->aa_garrays[i]);
 #ifdef DEBUG_SOUNDFILE
     post("ascii: read 3");
@@ -1099,28 +1080,28 @@ done:
     return nframes;
 }
 
-    /* soundfiler_read ...
+/* soundfiler_read ...
 
-       usage: read [flags] filename [tablename] ...
-       flags:
-           -skip <frames> ... frames to skip in file
-           -raw <headersize channels bytespersample endian>
-           -resize
-           -maxsize <maxsize>
-           -wave
-           -aiff
-           -caf
-           -next
-           -ascii
-    */
+   usage: read [flags] filename [tablename] ...
+   flags:
+       -skip <frames> ... frames to skip in file
+       -raw <headersize channels bytespersample endian>
+       -resize
+       -maxsize <maxsize>
+       -wave
+       -aiff
+       -caf
+       -next
+       -ascii
+*/
 
-static void soundfiler_read(t_soundfiler *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void soundfiler_read(
+    t_soundfiler *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_soundfile sf = {0};
     int fd = -1, resize = 0, ascii = 0, raw = 0, i;
-    size_t skipframes = 0, finalsize = 0, maxsize = SFMAXFRAMES,
-           framesread = 0, bufframes, j;
+    size_t skipframes = 0, finalsize = 0, maxsize = SFMAXFRAMES, framesread = 0,
+           bufframes, j;
     ssize_t nframes, framesinfile;
     char endianness;
     const char *filename;
@@ -1130,134 +1111,135 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
 
     soundfile_clear(&sf);
     sf.sf_headersize = -1;
-    while (argc > 0 && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(argc > 0 && argv->a_type == A_SYMBOL &&
+          *argv->a_w.w_symbol->s_name == '-')
     {
         const char *flag = argv->a_w.w_symbol->s_name + 1;
-        if (!strcmp(flag, "skip"))
+        if(!strcmp(flag, "skip"))
         {
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
+            if(argc < 2 || argv[1].a_type != A_FLOAT ||
                 (argv[1].a_w.w_float) < 0)
-                    goto usage;
+                goto usage;
             skipframes = argv[1].a_w.w_float;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(flag, "ascii"))
+        else if(!strcmp(flag, "ascii"))
         {
-            if (sf.sf_headersize >= 0)
-                post("'-ascii' overridden by '-raw'");
+            if(sf.sf_headersize >= 0) post("'-ascii' overridden by '-raw'");
             ascii = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(flag, "raw"))
+        else if(!strcmp(flag, "raw"))
         {
-            if (ascii)
+            if(ascii)
                 post("'-ascii' overridden by '-raw'");
-            else if (sf.sf_type)
+            else if(sf.sf_type)
                 post("'-%s' overridden by '-raw'", sf.sf_type->t_name);
-            if (argc < 5 ||
-                argv[1].a_type != A_FLOAT ||
+            if(argc < 5 || argv[1].a_type != A_FLOAT ||
                 ((sf.sf_headersize = argv[1].a_w.w_float) < 0) ||
                 argv[2].a_type != A_FLOAT ||
                 ((sf.sf_nchannels = argv[2].a_w.w_float) < 1) ||
-                (sf.sf_nchannels > MAXSFCHANS) ||
-                argv[3].a_type != A_FLOAT ||
+                (sf.sf_nchannels > MAXSFCHANS) || argv[3].a_type != A_FLOAT ||
                 ((sf.sf_bytespersample = argv[3].a_w.w_float) < 2) ||
-                    (sf.sf_bytespersample > 4) ||
-                argv[4].a_type != A_SYMBOL ||
-                    ((endianness = argv[4].a_w.w_symbol->s_name[0]) != 'b'
-                    && endianness != 'l' && endianness != 'n'))
-                        goto usage;
-            if (endianness == 'b')
+                (sf.sf_bytespersample > 4) || argv[4].a_type != A_SYMBOL ||
+                ((endianness = argv[4].a_w.w_symbol->s_name[0]) != 'b' &&
+                    endianness != 'l' && endianness != 'n'))
+                goto usage;
+            if(endianness == 'b')
                 sf.sf_bigendian = 1;
-            else if (endianness == 'l')
+            else if(endianness == 'l')
                 sf.sf_bigendian = 0;
             else
                 sf.sf_bigendian = sys_isbigendian();
             sf.sf_samplerate = sys_getsr();
             sf.sf_bytesperframe = sf.sf_nchannels * sf.sf_bytespersample;
             raw = 1;
-            argc -= 5; argv += 5;
+            argc -= 5;
+            argv += 5;
         }
-        else if (!strcmp(flag, "resize"))
+        else if(!strcmp(flag, "resize"))
         {
             resize = 1;
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "maxsize"))
+        else if(!strcmp(flag, "maxsize"))
         {
             ssize_t tmp;
-            if (argc < 2 || argv[1].a_type != A_FLOAT ||
-                ((tmp = (argv[1].a_w.w_float > SFMAXFRAMES ?
-                SFMAXFRAMES : argv[1].a_w.w_float)) < 0))
-                    goto usage;
-            maxsize = (size_t)tmp;
-            resize = 1;     /* maxsize implies resize */
-            argc -= 2; argv += 2;
+            if(argc < 2 || argv[1].a_type != A_FLOAT ||
+                ((tmp = (argv[1].a_w.w_float > SFMAXFRAMES
+                             ? SFMAXFRAMES
+                             : argv[1].a_w.w_float)) < 0))
+                goto usage;
+            maxsize = (size_t) tmp;
+            resize = 1; /* maxsize implies resize */
+            argc -= 2;
+            argv += 2;
         }
         else
         {
-                /* check for type by name */
-            if (!(sf.sf_type = soundfile_findtype(flag)))
+            /* check for type by name */
+            if(!(sf.sf_type = soundfile_findtype(flag)))
                 goto usage; /* unknown flag */
-            ascii = 0; /* replaced */
-            if (sf.sf_headersize >= 0)
+            ascii = 0;      /* replaced */
+            if(sf.sf_headersize >= 0)
                 post("'-%s' overridden by '-raw'", sf.sf_type->t_name);
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
     }
-    if (sf.sf_headersize >= 0)
+    if(sf.sf_headersize >= 0)
     {
         ascii = 0;
         sf.sf_type = NULL;
     }
-    if (argc < 1 ||                           /* no filename or tables */
-        argc > MAXSFCHANS + 1 ||              /* too many tables */
-        argv[0].a_type != A_SYMBOL)           /* bad filename */
-            goto usage;
+    if(argc < 1 ||                  /* no filename or tables */
+        argc > MAXSFCHANS + 1 ||    /* too many tables */
+        argv[0].a_type != A_SYMBOL) /* bad filename */
+        goto usage;
     filename = argv[0].a_w.w_symbol->s_name;
-    argc--; argv++;
+    argc--;
+    argv++;
 
-        /* check for implicit ascii */
-    if (!ascii && !sf.sf_type && sf.sf_headersize < 0)
+    /* check for implicit ascii */
+    if(!ascii && !sf.sf_type && sf.sf_headersize < 0)
         ascii = ascii_hasextension(filename, MAXPDSTRING);
 
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
         int vecsize;
-        if (argv[i].a_type != A_SYMBOL)
-            goto usage;
-        if (!(garrays[i] =
-            (t_garray *)pd_findbyclass(argv[i].a_w.w_symbol, garray_class)))
+        if(argv[i].a_type != A_SYMBOL) goto usage;
+        if(!(garrays[i] = (t_garray *) pd_findbyclass(
+                 argv[i].a_w.w_symbol, garray_class)))
         {
             pd_error(x, "soundfiler read: %s: no such table",
                 argv[i].a_w.w_symbol->s_name);
             goto done;
         }
-        else if (!garray_getfloatwords(garrays[i], &vecsize,
-                &vecs[i]))
+        else if(!garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
             pd_error(x, "soundfiler read: %s: bad template for tabwrite",
                 argv[i].a_w.w_symbol->s_name);
-        if (finalsize && finalsize != (size_t)vecsize && !resize)
+        if(finalsize && finalsize != (size_t) vecsize && !resize)
         {
             post("arrays have different lengths, resizing...");
             resize = 1;
         }
         finalsize = vecsize;
     }
-    if (ascii)
+    if(ascii)
     {
-        t_asciiargs a =
-            {skipframes, finalsize, argc, vecs, garrays, resize, maxsize, 0};
-        if (!argc)
+        t_asciiargs a = {
+            skipframes, finalsize, argc, vecs, garrays, resize, maxsize, 0};
+        if(!argc)
         {
             pd_error(x, "soundfiler read: "
                         "'-ascii' requires at least one table");
             goto done;
         }
-        if ((framesread = soundfiler_readascii(x, filename, &a)) == 0)
-            goto done;
-            /* fill in for info outlet */
+        if((framesread = soundfiler_readascii(x, filename, &a)) == 0) goto done;
+        /* fill in for info outlet */
         sf.sf_samplerate = sys_getsr();
         sf.sf_headersize = 0;
         sf.sf_nchannels = argc;
@@ -1267,30 +1249,30 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
     }
 
     fd = open_soundfile_via_canvas(x->x_canvas, filename, &sf, skipframes);
-    if (fd < 0)
+    if(fd < 0)
     {
         object_sferror(x, "soundfiler read", filename, errno, &sf);
         goto done;
     }
     framesinfile = sf.sf_bytelimit / sf.sf_bytesperframe;
 
-    if (resize)
+    if(resize)
     {
-            /* figure out what to resize to using header info */
-        if ((size_t)framesinfile > maxsize)
+        /* figure out what to resize to using header info */
+        if((size_t) framesinfile > maxsize)
         {
             pd_error(x, "soundfiler read: truncated to %ld elements",
-                (long)maxsize);
+                (long) maxsize);
             framesinfile = maxsize;
         }
         finalsize = framesinfile;
-        for (i = 0; i < argc; i++)
+        for(i = 0; i < argc; i++)
         {
             int vecsize;
             garray_resize_long(garrays[i], finalsize);
-                /* for sanity's sake let's clear the save-in-patch flag here */
+            /* for sanity's sake let's clear the save-in-patch flag here */
             garray_setsaveit(garrays[i], 0);
-            if (!garray_getfloatwords(garrays[i], &vecsize, &vecs[i])
+            if(!garray_getfloatwords(garrays[i], &vecsize, &vecs[i])
                 /* if the resize failed, garray_resize reported the error */
                 || (vecsize != framesinfile))
             {
@@ -1300,58 +1282,57 @@ static void soundfiler_read(t_soundfiler *x, t_symbol *s,
         }
     }
 
-    if (!finalsize) finalsize = SFMAXFRAMES;
-    if (framesinfile >= 0 && finalsize > (size_t)framesinfile)
+    if(!finalsize) finalsize = SFMAXFRAMES;
+    if(framesinfile >= 0 && finalsize > (size_t) framesinfile)
         finalsize = framesinfile;
 
-        /* no tablenames, try to use header info instead of reading */
-    if (argc == 0 &&
-        !(raw ||                     /* read if raw */
-          finalsize == SFMAXFRAMES)) /* read if unknown size */
+    /* no tablenames, try to use header info instead of reading */
+    if(argc == 0 && !(raw ||                       /* read if raw */
+                        finalsize == SFMAXFRAMES)) /* read if unknown size */
     {
         framesread = finalsize;
 #ifdef DEBUG_SOUNDFILE
-    post("skipped reading frames");
+        post("skipped reading frames");
 #endif
         goto done;
     }
 
-        /* read */
+    /* read */
 #ifdef DEBUG_SOUNDFILE
     post("reading frames");
 #endif
     bufframes = SAMPBUFSIZE / sf.sf_bytesperframe;
-    for (framesread = 0; framesread < finalsize;)
+    for(framesread = 0; framesread < finalsize;)
     {
         size_t thisread = finalsize - framesread;
         thisread = (thisread > bufframes ? bufframes : thisread);
-        nframes = read(sf.sf_fd, sampbuf,
-            thisread * sf.sf_bytesperframe) / sf.sf_bytesperframe;
-        if (nframes <= 0) break;
-        soundfile_xferin_words(&sf, argc, vecs, framesread,
-            (unsigned char *)sampbuf, nframes);
+        nframes = read(sf.sf_fd, sampbuf, thisread * sf.sf_bytesperframe) /
+                  sf.sf_bytesperframe;
+        if(nframes <= 0) break;
+        soundfile_xferin_words(
+            &sf, argc, vecs, framesread, (unsigned char *) sampbuf, nframes);
         framesread += nframes;
     }
 
-        /* zero out remaining elements of vectors */
-    for (i = 0; i < argc; i++)
+    /* zero out remaining elements of vectors */
+    for(i = 0; i < argc; i++)
     {
         int vecsize;
-        if (garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
-            for (j = framesread; j < (size_t)vecsize; j++)
+        if(garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
+            for(j = framesread; j < (size_t) vecsize; j++)
                 vecs[i][j].w_float = 0;
     }
-        /* zero out vectors in excess of number of channels */
-    for (i = sf.sf_nchannels; i < argc; i++)
+    /* zero out vectors in excess of number of channels */
+    for(i = sf.sf_nchannels; i < argc; i++)
     {
         int vecsize;
         t_word *foo;
-        if (garray_getfloatwords(garrays[i], &vecsize, &foo))
-            for (j = 0; j < (size_t)vecsize; j++)
+        if(garray_getfloatwords(garrays[i], &vecsize, &foo))
+            for(j = 0; j < (size_t) vecsize; j++)
                 foo[j].w_float = 0;
     }
-        /* do all graphics updates */
-    for (i = 0; i < argc; i++)
+    /* do all graphics updates */
+    for(i = 0; i < argc; i++)
         garray_redraw(garrays[i]);
     goto done;
 usage:
@@ -1361,31 +1342,30 @@ usage:
          "<endian (b, l, or n)>");
 done:
     sf.sf_fd = -1;
-    if (fd >= 0)
-        sys_close(fd);
+    if(fd >= 0) sys_close(fd);
     outlet_soundfileinfo(x->x_out2, &sf);
-    outlet_float(x->x_obj.ob_outlet, (t_float)framesread);
+    outlet_float(x->x_obj.ob_outlet, (t_float) framesread);
 }
 
-    /** write to an ascii text file, channels (nvecs) are interleaved,
-        assumes all vectors are at least nframes in length
-        adapted from garray_savecontentsto()
-        returns frames written on success or 0 on error */
+/** write to an ascii text file, channels (nvecs) are interleaved,
+    assumes all vectors are at least nframes in length
+    adapted from garray_savecontentsto()
+    returns frames written on success or 0 on error */
 int soundfiler_writeascii(t_soundfiler *x, const char *filename, t_asciiargs *a)
 {
     char path[MAXPDSTRING];
     t_binbuf *b = binbuf_new();
     int i, j, frameswritten = 0, ret = 1;
 #ifdef DEBUG_SOUNDFILE
-    post("ascii write: frames %d onset %d channels %d",
-        a->aa_nframes, a->aa_onsetframe, a->aa_nchannels);
+    post("ascii write: frames %d onset %d channels %d", a->aa_nframes,
+        a->aa_onsetframe, a->aa_nchannels);
 #endif
     canvas_makefilename(x->x_canvas, filename, path, MAXPDSTRING);
-    if (a->aa_nframes > 200000)
+    if(a->aa_nframes > 200000)
         post("warning: writing %d table points to ascii file!");
-    for (i = a->aa_onsetframe; frameswritten < a->aa_nframes; ++i)
+    for(i = a->aa_onsetframe; frameswritten < a->aa_nframes; ++i)
     {
-        for (j = 0; j < a->aa_nchannels; ++j)
+        for(j = 0; j < a->aa_nchannels; ++j)
             binbuf_addv(b, "f", a->aa_vectors[j][i].w_float * a->aa_normfactor);
         frameswritten++;
     }
@@ -1395,10 +1375,10 @@ int soundfiler_writeascii(t_soundfiler *x, const char *filename, t_asciiargs *a)
     return (ret == 0 ? frameswritten : 0);
 }
 
-    /** this is broken out from soundfiler_write below so garray_write can
-        call it too... not done yet though. */
-size_t soundfiler_dowrite(void *obj, t_canvas *canvas,
-    int argc, t_atom *argv, t_soundfile *sf)
+/** this is broken out from soundfiler_write below so garray_write can
+    call it too... not done yet though. */
+size_t soundfiler_dowrite(
+    void *obj, t_canvas *canvas, int argc, t_atom *argv, t_soundfile *sf)
 {
     t_soundfiler_writeargs wa = {0};
     int fd = -1, i;
@@ -1409,131 +1389,125 @@ size_t soundfiler_dowrite(void *obj, t_canvas *canvas,
     t_sample normfactor = 1, biggest = 0;
 
     soundfile_clear(sf);
-    if (soundfiler_parsewriteargs(obj, &argc, &argv, &wa))
-        goto usage;
+    if(soundfiler_parsewriteargs(obj, &argc, &argv, &wa)) goto usage;
     sf->sf_type = (wa.wa_ascii ? NULL : wa.wa_type);
     sf->sf_nchannels = argc;
     sf->sf_samplerate = wa.wa_samplerate;
     sf->sf_bytespersample = wa.wa_bytespersample;
     sf->sf_bigendian = wa.wa_bigendian;
     sf->sf_bytesperframe = argc * wa.wa_bytespersample;
-    if (sf->sf_nchannels < 1 || sf->sf_nchannels > MAXSFCHANS)
-        goto usage;
-    if (sf->sf_samplerate <= 0)
-        sf->sf_samplerate = sys_getsr();
-    for (i = 0; i < sf->sf_nchannels; i++)
+    if(sf->sf_nchannels < 1 || sf->sf_nchannels > MAXSFCHANS) goto usage;
+    if(sf->sf_samplerate <= 0) sf->sf_samplerate = sys_getsr();
+    for(i = 0; i < sf->sf_nchannels; i++)
     {
         int vecsize;
-        if (argv[i].a_type != A_SYMBOL)
-            goto usage;
-        if (!(garrays[i] =
-            (t_garray *)pd_findbyclass(argv[i].a_w.w_symbol, garray_class)))
+        if(argv[i].a_type != A_SYMBOL) goto usage;
+        if(!(garrays[i] = (t_garray *) pd_findbyclass(
+                 argv[i].a_w.w_symbol, garray_class)))
         {
             pd_error(obj, "soundfiler write: %s: no such table",
                 argv[i].a_w.w_symbol->s_name);
             goto fail;
         }
-        else if (!garray_getfloatwords(garrays[i], &vecsize, &vectors[i]))
+        else if(!garray_getfloatwords(garrays[i], &vecsize, &vectors[i]))
             pd_error(obj, "soundfiler write: %s: bad template for tabwrite",
                 argv[i].a_w.w_symbol->s_name);
-        if (wa.wa_nframes > vecsize - wa.wa_onsetframes)
+        if(wa.wa_nframes > vecsize - wa.wa_onsetframes)
             wa.wa_nframes = vecsize - wa.wa_onsetframes;
     }
-    if (wa.wa_nframes <= 0)
+    if(wa.wa_nframes <= 0)
     {
         pd_error(obj, "soundfiler write: no samples at onset %ld",
-            (long)wa.wa_onsetframes);
+            (long) wa.wa_onsetframes);
         goto fail;
     }
 
-        /* find biggest sample for normalizing */
-    for (i = 0; i < sf->sf_nchannels; i++)
+    /* find biggest sample for normalizing */
+    for(i = 0; i < sf->sf_nchannels; i++)
     {
-        for (j = wa.wa_onsetframes; j < wa.wa_nframes + wa.wa_onsetframes; j++)
+        for(j = wa.wa_onsetframes; j < wa.wa_nframes + wa.wa_onsetframes; j++)
         {
-            if (vectors[i][j].w_float > biggest)
+            if(vectors[i][j].w_float > biggest)
                 biggest = vectors[i][j].w_float;
-            else if (-vectors[i][j].w_float > biggest)
+            else if(-vectors[i][j].w_float > biggest)
                 biggest = -vectors[i][j].w_float;
         }
     }
 
-        /* write to ascii text file? */
-    if (wa.wa_ascii)
+    /* write to ascii text file? */
+    if(wa.wa_ascii)
     {
         char filenamebuf[MAXPDSTRING];
-        t_asciiargs a =
-            {wa.wa_onsetframes, wa.wa_nframes, sf->sf_nchannels, vectors, 0,
-                0, 0, 0};
+        t_asciiargs a = {wa.wa_onsetframes, wa.wa_nframes, sf->sf_nchannels,
+            vectors, 0, 0, 0, 0};
         strcpy(filenamebuf, wa.wa_filesym->s_name);
-        if (!ascii_hasextension(filenamebuf, MAXPDSTRING))
+        if(!ascii_hasextension(filenamebuf, MAXPDSTRING))
             ascii_addextension(filenamebuf, MAXPDSTRING);
-        if (wa.wa_normalize)
-            a.aa_normfactor = (biggest > 0 ? 32767./(32768. * biggest) : 1);
+        if(wa.wa_normalize)
+            a.aa_normfactor = (biggest > 0 ? 32767. / (32768. * biggest) : 1);
         else
             a.aa_normfactor = 1;
-        if ((frameswritten = soundfiler_writeascii(obj, filenamebuf, &a)) == 0)
+        if((frameswritten = soundfiler_writeascii(obj, filenamebuf, &a)) == 0)
         {
             pd_error(obj, "soundfiler write: writing ascii failed");
             goto fail;
         }
-            /* fill in for info outlet */
+        /* fill in for info outlet */
         sf->sf_headersize = 0;
         sf->sf_bytespersample = 4;
         sf->sf_bigendian = sys_isbigendian();
         return frameswritten;
     }
 
-        /* create file and detect if int samples should be normalized */
-    if ((fd = create_soundfile(canvas, wa.wa_filesym->s_name,
-        sf, wa.wa_nframes)) < 0)
+    /* create file and detect if int samples should be normalized */
+    if((fd = create_soundfile(
+            canvas, wa.wa_filesym->s_name, sf, wa.wa_nframes)) < 0)
     {
-        object_sferror(obj, "soundfiler write",
-            wa.wa_filesym->s_name, errno, sf);
+        object_sferror(
+            obj, "soundfiler write", wa.wa_filesym->s_name, errno, sf);
         goto fail;
     }
-    if (!wa.wa_normalize)
+    if(!wa.wa_normalize)
     {
-        if (sf->sf_bytespersample != 4 && biggest > 1)
+        if(sf->sf_bytespersample != 4 && biggest > 1)
         {
-            post("%s: reducing max amplitude %f to 1",
-                wa.wa_filesym->s_name, biggest);
+            post("%s: reducing max amplitude %f to 1", wa.wa_filesym->s_name,
+                biggest);
             wa.wa_normalize = 1;
         }
-        else post("%s: biggest amplitude = %f",
-            wa.wa_filesym->s_name, biggest);
+        else
+            post("%s: biggest amplitude = %f", wa.wa_filesym->s_name, biggest);
     }
-    if (wa.wa_normalize)
-        normfactor = (biggest > 0 ? 32767./(32768. * biggest) : 1);
+    if(wa.wa_normalize)
+        normfactor = (biggest > 0 ? 32767. / (32768. * biggest) : 1);
 
-        /* write samples */
+    /* write samples */
     bufframes = SAMPBUFSIZE / sf->sf_bytesperframe;
-    for (frameswritten = 0; frameswritten < wa.wa_nframes;)
+    for(frameswritten = 0; frameswritten < wa.wa_nframes;)
     {
-        size_t thiswrite = wa.wa_nframes - frameswritten,
-               datasize;
+        size_t thiswrite = wa.wa_nframes - frameswritten, datasize;
         ssize_t byteswritten;
         thiswrite = (thiswrite > bufframes ? bufframes : thiswrite);
         datasize = sf->sf_bytesperframe * thiswrite;
-        soundfile_xferout_words(sf, vectors, (unsigned char *)sampbuf,
+        soundfile_xferout_words(sf, vectors, (unsigned char *) sampbuf,
             thiswrite, wa.wa_onsetframes, normfactor);
         byteswritten = write(sf->sf_fd, sampbuf, datasize);
-        if (byteswritten < 0 || (size_t)byteswritten < datasize)
+        if(byteswritten < 0 || (size_t) byteswritten < datasize)
         {
-            object_sferror(obj, "soundfiler write",
-                wa.wa_filesym->s_name, errno, sf);
-            if (byteswritten > 0)
+            object_sferror(
+                obj, "soundfiler write", wa.wa_filesym->s_name, errno, sf);
+            if(byteswritten > 0)
                 frameswritten += byteswritten / sf->sf_bytesperframe;
             break;
         }
         frameswritten += thiswrite;
         wa.wa_onsetframes += thiswrite;
     }
-        /* update header frame size */
-    if (fd >= 0)
+    /* update header frame size */
+    if(fd >= 0)
     {
-        soundfile_finishwrite(obj, wa.wa_filesym->s_name, sf,
-                wa.wa_nframes, frameswritten);
+        soundfile_finishwrite(
+            obj, wa.wa_filesym->s_name, sf, wa.wa_nframes, frameswritten);
         sys_close(fd);
     }
     sf->sf_fd = -1;
@@ -1545,29 +1519,27 @@ usage:
     post("(defaults to a 16 bit wave file)");
 fail:
     soundfile_clear(sf); /* clear any bad data */
-    if (fd >= 0)
-        sys_close(fd);
+    if(fd >= 0) sys_close(fd);
     return 0;
 }
 
-static void soundfiler_write(t_soundfiler *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void soundfiler_write(
+    t_soundfiler *x, t_symbol *s, int argc, t_atom *argv)
 {
     size_t frameswritten;
     t_soundfile sf = {0};
     frameswritten = soundfiler_dowrite(x, x->x_canvas, argc, argv, &sf);
     outlet_soundfileinfo(x->x_out2, &sf);
-    outlet_float(x->x_obj.ob_outlet, (t_float)frameswritten);
+    outlet_float(x->x_obj.ob_outlet, (t_float) frameswritten);
 }
 
 static void soundfiler_setup(void)
 {
     soundfiler_class = class_new(gensym("soundfiler"),
-        (t_newmethod)soundfiler_new, 0,
-        sizeof(t_soundfiler), 0, 0);
-    class_addmethod(soundfiler_class, (t_method)soundfiler_read,
+        (t_newmethod) soundfiler_new, 0, sizeof(t_soundfiler), 0, 0);
+    class_addmethod(soundfiler_class, (t_method) soundfiler_read,
         gensym("read"), A_GIMME, 0);
-    class_addmethod(soundfiler_class, (t_method)soundfiler_write,
+    class_addmethod(soundfiler_class, (t_method) soundfiler_write,
         gensym("write"), A_GIMME, 0);
 }
 
@@ -1592,24 +1564,24 @@ areas.
 #define WRITESIZE 65536
 #define DEFBUFPERCHAN 262144
 #define MINBUFSIZE (4 * READSIZE)
-#define MAXBUFSIZE 16777216     /* arbitrary; just don't want to hang malloc */
+#define MAXBUFSIZE 16777216 /* arbitrary; just don't want to hang malloc */
 
-    /* read/write thread request type */
+/* read/write thread request type */
 typedef enum _soundfile_request
 {
     REQUEST_NOTHING = 0,
-    REQUEST_OPEN    = 1,
-    REQUEST_CLOSE   = 2,
-    REQUEST_QUIT    = 3,
-    REQUEST_BUSY    = 4
+    REQUEST_OPEN = 1,
+    REQUEST_CLOSE = 2,
+    REQUEST_QUIT = 3,
+    REQUEST_BUSY = 4
 } t_soundfile_request;
 
-    /* read/write thread state */
+/* read/write thread state */
 typedef enum _soundfile_state
 {
-    STATE_IDLE    = 0,
+    STATE_IDLE = 0,
     STATE_STARTUP = 1,
-    STATE_STREAM  = 2
+    STATE_STREAM = 2
 } t_soundfile_state;
 
 static t_class *readsf_class;
@@ -1627,40 +1599,41 @@ typedef struct _readsf
     t_outlet *x_bangout;              /**< bang-on-done outlet */
     t_soundfile_state x_state;        /**< opened, running, or idle */
     t_float x_insamplerate;           /**< input signal sample rate, if known */
-        /* parameters to communicate with subthread */
+    /* parameters to communicate with subthread */
     t_soundfile_request x_requestcode; /**< pending request to I/O thread */
-    const char *x_filename;   /**< file to open (string permanently allocated) */
-    int x_fileerror;          /**< slot for "errno" return */
-    t_soundfile x_sf;         /**< soundfile fd, type, and format info */
-    size_t x_onsetframes;     /**< number of sample frames to skip */
-    int x_fifosize;           /**< buffer size appropriately rounded down */
-    int x_fifohead;           /**< index of next byte to get from file */
-    int x_fifotail;           /**< index of next byte the ugen will read */
-    int x_eof;                /**< true if fifohead has stopped changing */
-    int x_sigcountdown;       /**< counter for signaling child for more data */
-    int x_sigperiod;          /**< number of ticks per signal */
-    size_t x_frameswritten;   /**< writesf~ only; frames written */
-    t_float x_f;              /**< writesf~ only; scalar for signal inlet */
+    const char *x_filename; /**< file to open (string permanently allocated) */
+    int x_fileerror;        /**< slot for "errno" return */
+    t_soundfile x_sf;       /**< soundfile fd, type, and format info */
+    size_t x_onsetframes;   /**< number of sample frames to skip */
+    int x_fifosize;         /**< buffer size appropriately rounded down */
+    int x_fifohead;         /**< index of next byte to get from file */
+    int x_fifotail;         /**< index of next byte the ugen will read */
+    int x_eof;              /**< true if fifohead has stopped changing */
+    int x_sigcountdown;     /**< counter for signaling child for more data */
+    int x_sigperiod;        /**< number of ticks per signal */
+    size_t x_frameswritten; /**< writesf~ only; frames written */
+    t_float x_f;            /**< writesf~ only; scalar for signal inlet */
     pthread_mutex_t x_mutex;
     pthread_cond_t x_requestcondition;
     pthread_cond_t x_answercondition;
     pthread_t x_childthread;
 #ifdef PDINSTANCE
-    t_pdinstance *x_pd_this;  /**< pointer to the owner pd instance */
+    t_pdinstance *x_pd_this; /**< pointer to the owner pd instance */
 #endif
 } t_readsf;
 
 /* ----- the child thread which performs file I/O ----- */
 
-    /** thread state debug prints to stderr */
+/** thread state debug prints to stderr */
 //#define DEBUG_SOUNDFILE_THREADS
 
 #if 1
 #define sfread_cond_wait pthread_cond_wait
 #define sfread_cond_signal pthread_cond_signal
 #else
-#include <sys/time.h>    /* debugging version... */
+#include <sys/time.h> /* debugging version... */
 #include <sys/types.h>
+
 static void readsf_fakewait(pthread_mutex_t *b)
 {
     struct timeval timeout;
@@ -1671,7 +1644,7 @@ static void readsf_fakewait(pthread_mutex_t *b)
     pthread_mutex_lock(b);
 }
 
-#define sfread_cond_wait(a,b) readsf_fakewait(b)
+#define sfread_cond_wait(a, b) readsf_fakewait(b)
 #define sfread_cond_signal(a)
 #endif
 
@@ -1687,14 +1660,14 @@ static void *readsf_child_main(void *zz)
     fprintf(stderr, "readsf~: 1\n");
 #endif
     pthread_mutex_lock(&x->x_mutex);
-    while (1)
+    while(1)
     {
         int fifohead;
         char *buf;
 #ifdef DEBUG_SOUNDFILE_THREADS
         fprintf(stderr, "readsf~: 0\n");
 #endif
-        if (x->x_requestcode == REQUEST_NOTHING)
+        if(x->x_requestcode == REQUEST_NOTHING)
         {
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: wait 2\n");
@@ -1705,13 +1678,13 @@ static void *readsf_child_main(void *zz)
             fprintf(stderr, "readsf~: 3\n");
 #endif
         }
-        else if (x->x_requestcode == REQUEST_OPEN)
+        else if(x->x_requestcode == REQUEST_OPEN)
         {
             ssize_t bytesread;
             size_t wantbytes;
 
-                /* copy file stuff out of the data structure so we can
-                relinquish the mutex while we're in open_soundfile_via_path() */
+            /* copy file stuff out of the data structure so we can
+            relinquish the mutex while we're in open_soundfile_via_path() */
             size_t onsetframes = x->x_onsetframes;
             const char *filename = x->x_filename;
             const char *dirname = canvas_getdir(x->x_canvas)->s_name;
@@ -1719,27 +1692,26 @@ static void *readsf_child_main(void *zz)
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: 4\n");
 #endif
-                /* alter the request code so that an ensuing "open" will get
-                noticed. */
+            /* alter the request code so that an ensuing "open" will get
+            noticed. */
             x->x_requestcode = REQUEST_BUSY;
             x->x_fileerror = 0;
 
-                /* if there's already a file open, close it */
-            if (sf.sf_fd >= 0)
+            /* if there's already a file open, close it */
+            if(sf.sf_fd >= 0)
             {
                 pthread_mutex_unlock(&x->x_mutex);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
                 pthread_mutex_lock(&x->x_mutex);
                 x->x_sf.sf_fd = -1;
-                if (x->x_requestcode != REQUEST_BUSY)
-                    goto lost;
+                if(x->x_requestcode != REQUEST_BUSY) goto lost;
             }
-                /* cache sf *after* closing as x->sf's type
-                    may have changed in readsf_open() */
+            /* cache sf *after* closing as x->sf's type
+                may have changed in readsf_open() */
             soundfile_copy(&sf, &x->x_sf);
 
-                /* open the soundfile with the mutex unlocked */
+            /* open the soundfile with the mutex unlocked */
             pthread_mutex_unlock(&x->x_mutex);
             open_soundfile_via_path(dirname, filename, &sf, onsetframes);
             pthread_mutex_lock(&x->x_mutex);
@@ -1747,64 +1719,62 @@ static void *readsf_child_main(void *zz)
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: 5\n");
 #endif
-            if (sf.sf_fd < 0)
+            if(sf.sf_fd < 0)
             {
                 x->x_fileerror = errno;
                 x->x_eof = 1;
 #ifdef DEBUG_SOUNDFILE_THREADS
-                fprintf(stderr, "readsf~: open failed %s %s\n",
-                    filename, dirname);
+                fprintf(
+                    stderr, "readsf~: open failed %s %s\n", filename, dirname);
 #endif
                 goto lost;
             }
-                /* copy back into the instance structure. */
+            /* copy back into the instance structure. */
             soundfile_copy(&x->x_sf, &sf);
-                /* check if another request has been made; if so, field it */
-            if (x->x_requestcode != REQUEST_BUSY)
-                goto lost;
+            /* check if another request has been made; if so, field it */
+            if(x->x_requestcode != REQUEST_BUSY) goto lost;
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: 6\n");
 #endif
             x->x_fifohead = 0;
-                    /* set fifosize from bufsize.  fifosize must be a
-                    multiple of the number of bytes eaten for each DSP
-                    tick.  We pessimistically assume MAXVECSIZE samples
-                    per tick since that could change.  There could be a
-                    problem here if the vector size increases while a
-                    soundfile is being played...  */
-            x->x_fifosize = x->x_bufsize - (x->x_bufsize %
-                (sf.sf_bytesperframe * MAXVECSIZE));
-                    /* arrange for the "request" condition to be signaled 16
-                    times per buffer */
+            /* set fifosize from bufsize.  fifosize must be a
+            multiple of the number of bytes eaten for each DSP
+            tick.  We pessimistically assume MAXVECSIZE samples
+            per tick since that could change.  There could be a
+            problem here if the vector size increases while a
+            soundfile is being played...  */
+            x->x_fifosize = x->x_bufsize -
+                            (x->x_bufsize % (sf.sf_bytesperframe * MAXVECSIZE));
+            /* arrange for the "request" condition to be signaled 16
+            times per buffer */
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: fifosize %d\n", x->x_fifosize);
 #endif
-            x->x_sigcountdown = x->x_sigperiod = (x->x_fifosize /
-                (16 * sf.sf_bytesperframe * x->x_vecsize));
-                /* in a loop, wait for the fifo to get hungry and feed it */
+            x->x_sigcountdown = x->x_sigperiod =
+                (x->x_fifosize / (16 * sf.sf_bytesperframe * x->x_vecsize));
+            /* in a loop, wait for the fifo to get hungry and feed it */
 
-            while (x->x_requestcode == REQUEST_BUSY)
+            while(x->x_requestcode == REQUEST_BUSY)
             {
                 int fifosize = x->x_fifosize;
 #ifdef DEBUG_SOUNDFILE_THREADS
                 fprintf(stderr, "readsf~: 77\n");
 #endif
-                if (x->x_eof)
-                    break;
-                if (x->x_fifohead >= x->x_fifotail)
+                if(x->x_eof) break;
+                if(x->x_fifohead >= x->x_fifotail)
                 {
-                        /* if the head is >= the tail, we can immediately read
-                        to the end of the fifo.  Unless, that is, we would
-                        read all the way to the end of the buffer and the
-                        "tail" is zero; this would fill the buffer completely
-                        which isn't allowed because you can't tell a completely
-                        full buffer from an empty one. */
-                    if (x->x_fifotail || (fifosize - x->x_fifohead > READSIZE))
+                    /* if the head is >= the tail, we can immediately read
+                    to the end of the fifo.  Unless, that is, we would
+                    read all the way to the end of the buffer and the
+                    "tail" is zero; this would fill the buffer completely
+                    which isn't allowed because you can't tell a completely
+                    full buffer from an empty one. */
+                    if(x->x_fifotail || (fifosize - x->x_fifohead > READSIZE))
                     {
                         wantbytes = fifosize - x->x_fifohead;
-                        if (wantbytes > READSIZE)
-                            wantbytes = READSIZE;
-                        if (sf.sf_bytelimit >= 0 && wantbytes > (size_t)sf.sf_bytelimit)
+                        if(wantbytes > READSIZE) wantbytes = READSIZE;
+                        if(sf.sf_bytelimit >= 0 &&
+                            wantbytes > (size_t) sf.sf_bytelimit)
                             wantbytes = sf.sf_bytelimit;
 #ifdef DEBUG_SOUNDFILE_THREADS
                         fprintf(stderr, "readsf~: head %d, tail %d, size %ld\n",
@@ -1829,10 +1799,10 @@ static void *readsf_child_main(void *zz)
                 }
                 else
                 {
-                        /* otherwise check if there are at least READSIZE
-                        bytes to read.  If not, wait and loop back. */
-                    wantbytes =  x->x_fifotail - x->x_fifohead - 1;
-                    if (wantbytes < READSIZE)
+                    /* otherwise check if there are at least READSIZE
+                    bytes to read.  If not, wait and loop back. */
+                    wantbytes = x->x_fifotail - x->x_fifohead - 1;
+                    if(wantbytes < READSIZE)
                     {
 #ifdef DEBUG_SOUNDFILE_THREADS
                         fprintf(stderr, "readsf~: wait 7...\n");
@@ -1844,8 +1814,10 @@ static void *readsf_child_main(void *zz)
 #endif
                         continue;
                     }
-                    else wantbytes = READSIZE;
-                    if (sf.sf_bytelimit >= 0 && wantbytes > (size_t)sf.sf_bytelimit)
+                    else
+                        wantbytes = READSIZE;
+                    if(sf.sf_bytelimit >= 0 &&
+                        wantbytes > (size_t) sf.sf_bytelimit)
                         wantbytes = sf.sf_bytelimit;
                 }
 #ifdef DEBUG_SOUNDFILE_THREADS
@@ -1856,9 +1828,8 @@ static void *readsf_child_main(void *zz)
                 pthread_mutex_unlock(&x->x_mutex);
                 bytesread = read(sf.sf_fd, buf + fifohead, wantbytes);
                 pthread_mutex_lock(&x->x_mutex);
-                if (x->x_requestcode != REQUEST_BUSY)
-                    break;
-                if (bytesread < 0)
+                if(x->x_requestcode != REQUEST_BUSY) break;
+                if(bytesread < 0)
                 {
 #ifdef DEBUG_SOUNDFILE_THREADS
                     fprintf(stderr, "readsf~: fileerror %d\n", errno);
@@ -1866,7 +1837,7 @@ static void *readsf_child_main(void *zz)
                     x->x_fileerror = errno;
                     break;
                 }
-                else if (bytesread == 0)
+                else if(bytesread == 0)
                 {
                     x->x_eof = 1;
                     break;
@@ -1875,9 +1846,8 @@ static void *readsf_child_main(void *zz)
                 {
                     x->x_fifohead += bytesread;
                     sf.sf_bytelimit -= bytesread;
-                    if (x->x_fifohead == fifosize)
-                        x->x_fifohead = 0;
-                    if (sf.sf_bytelimit <= 0)
+                    if(x->x_fifohead == fifosize) x->x_fifohead = 0;
+                    if(sf.sf_bytelimit <= 0)
                     {
                         x->x_eof = 1;
                         break;
@@ -1887,21 +1857,21 @@ static void *readsf_child_main(void *zz)
                 fprintf(stderr, "readsf~: after, head %d tail %d\n",
                     x->x_fifohead, x->x_fifotail);
 #endif
-                    /* signal parent in case it's waiting for data */
+                /* signal parent in case it's waiting for data */
                 sfread_cond_signal(&x->x_answercondition);
             }
 
         lost:
-            if (x->x_requestcode == REQUEST_BUSY)
+            if(x->x_requestcode == REQUEST_BUSY)
                 x->x_requestcode = REQUEST_NOTHING;
 #ifdef DEBUG_SOUNDFILE_THREADS
-                fprintf(stderr, "readsf~: lost\n");
+            fprintf(stderr, "readsf~: lost\n");
 #endif
-                /* fell out of read loop: close file if necessary,
-                set EOF and signal once more */
-            if (sf.sf_fd >= 0)
+            /* fell out of read loop: close file if necessary,
+            set EOF and signal once more */
+            if(sf.sf_fd >= 0)
             {
-                    /* use cached sf */
+                /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
@@ -1911,26 +1881,26 @@ static void *readsf_child_main(void *zz)
             }
             sfread_cond_signal(&x->x_answercondition);
         }
-        else if (x->x_requestcode == REQUEST_CLOSE)
+        else if(x->x_requestcode == REQUEST_CLOSE)
         {
-            if (sf.sf_fd >= 0)
+            if(sf.sf_fd >= 0)
             {
-                    /* use cached sf */
+                /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
                 pthread_mutex_lock(&x->x_mutex);
                 x->x_sf.sf_fd = -1;
             }
-            if (x->x_requestcode == REQUEST_CLOSE)
+            if(x->x_requestcode == REQUEST_CLOSE)
                 x->x_requestcode = REQUEST_NOTHING;
             sfread_cond_signal(&x->x_answercondition);
         }
-        else if (x->x_requestcode == REQUEST_QUIT)
+        else if(x->x_requestcode == REQUEST_QUIT)
         {
-            if (sf.sf_fd >= 0)
+            if(sf.sf_fd >= 0)
             {
-                    /* use cached sf */
+                /* use cached sf */
                 pthread_mutex_unlock(&x->x_mutex);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
@@ -1965,21 +1935,22 @@ static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     int nchannels = fnchannels, bufsize = fbufsize, i;
     char *buf;
 
-    if (nchannels < 1)
+    if(nchannels < 1)
         nchannels = 1;
-    else if (nchannels > MAXSFCHANS)
+    else if(nchannels > MAXSFCHANS)
         nchannels = MAXSFCHANS;
-    if (bufsize <= 0) bufsize = DEFBUFPERCHAN * nchannels;
-    else if (bufsize < MINBUFSIZE)
+    if(bufsize <= 0)
+        bufsize = DEFBUFPERCHAN * nchannels;
+    else if(bufsize < MINBUFSIZE)
         bufsize = MINBUFSIZE;
-    else if (bufsize > MAXBUFSIZE)
+    else if(bufsize > MAXBUFSIZE)
         bufsize = MAXBUFSIZE;
     buf = getbytes(bufsize);
-    if (!buf) return 0;
+    if(!buf) return 0;
 
-    x = (t_readsf *)pd_new(readsf_class);
+    x = (t_readsf *) pd_new(readsf_class);
 
-    for (i = 0; i < nchannels; i++)
+    for(i = 0; i < nchannels; i++)
         outlet_new(&x->x_obj, gensym("signal"));
     x->x_noutlets = nchannels;
     x->x_bangout = outlet_new(&x->x_obj, &s_bang);
@@ -1988,7 +1959,7 @@ static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     pthread_cond_init(&x->x_answercondition, 0);
     x->x_vecsize = MAXVECSIZE;
     x->x_state = STATE_IDLE;
-    x->x_clock = clock_new(x, (t_method)readsf_tick);
+    x->x_clock = clock_new(x, (t_method) readsf_tick);
     x->x_canvas = canvas_getcurrent();
     soundfile_clear(&x->x_sf);
     x->x_sf.sf_bytespersample = 2;
@@ -2004,33 +1975,30 @@ static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     return x;
 }
 
-static void readsf_tick(t_readsf *x)
-{
-    outlet_bang(x->x_bangout);
-}
+static void readsf_tick(t_readsf *x) { outlet_bang(x->x_bangout); }
 
 static t_int *readsf_perform(t_int *w)
 {
-    t_readsf *x = (t_readsf *)(w[1]);
+    t_readsf *x = (t_readsf *) (w[1]);
     t_soundfile sf = {0};
     int vecsize = x->x_vecsize, noutlets = x->x_noutlets, i;
     size_t j;
     t_sample *fp;
     soundfile_copy(&sf, &x->x_sf);
-    if (x->x_state == STATE_STREAM)
+    if(x->x_state == STATE_STREAM)
     {
         int wantbytes;
         pthread_mutex_lock(&x->x_mutex);
         wantbytes = vecsize * sf.sf_bytesperframe;
-        while (!x->x_eof && x->x_fifohead >= x->x_fifotail &&
-                x->x_fifohead < x->x_fifotail + wantbytes-1)
+        while(!x->x_eof && x->x_fifohead >= x->x_fifotail &&
+              x->x_fifohead < x->x_fifotail + wantbytes - 1)
         {
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "readsf~: wait...\n");
 #endif
             sfread_cond_signal(&x->x_requestcondition);
             sfread_cond_wait(&x->x_answercondition, &x->x_mutex);
-                /* resync local variables -- bug fix thanks to Shahrokh */
+            /* resync local variables -- bug fix thanks to Shahrokh */
             vecsize = x->x_vecsize;
             soundfile_copy(&sf, &x->x_sf);
             wantbytes = vecsize * sf.sf_bytesperframe;
@@ -2038,28 +2006,28 @@ static t_int *readsf_perform(t_int *w)
             fprintf(stderr, "readsf~: ... done\n");
 #endif
         }
-        if (x->x_eof && x->x_fifohead >= x->x_fifotail &&
-            x->x_fifohead < x->x_fifotail + wantbytes-1)
+        if(x->x_eof && x->x_fifohead >= x->x_fifotail &&
+            x->x_fifohead < x->x_fifotail + wantbytes - 1)
         {
             int xfersize;
-            if (x->x_fileerror)
-                object_sferror(x, "readsf~", x->x_filename,
-                    x->x_fileerror, &x->x_sf);
+            if(x->x_fileerror)
+                object_sferror(
+                    x, "readsf~", x->x_filename, x->x_fileerror, &x->x_sf);
             clock_delay(x->x_clock, 0);
             x->x_state = STATE_IDLE;
 
-                /* if there's a partial buffer left, copy it out */
-            xfersize = (x->x_fifohead - x->x_fifotail + 1) /
-                       sf.sf_bytesperframe;
-            if (xfersize)
+            /* if there's a partial buffer left, copy it out */
+            xfersize =
+                (x->x_fifohead - x->x_fifotail + 1) / sf.sf_bytesperframe;
+            if(xfersize)
             {
                 soundfile_xferin_sample(&sf, noutlets, x->x_outvec, 0,
-                    (unsigned char *)(x->x_buf + x->x_fifotail), xfersize);
+                    (unsigned char *) (x->x_buf + x->x_fifotail), xfersize);
                 vecsize -= xfersize;
             }
-                /* then zero out the (rest of the) output */
-            for (i = 0; i < noutlets; i++)
-                for (j = vecsize, fp = x->x_outvec[i] + xfersize; j--;)
+            /* then zero out the (rest of the) output */
+            for(i = 0; i < noutlets; i++)
+                for(j = vecsize, fp = x->x_outvec[i] + xfersize; j--;)
                     *fp++ = 0;
 
             sfread_cond_signal(&x->x_requestcondition);
@@ -2068,12 +2036,11 @@ static t_int *readsf_perform(t_int *w)
         }
 
         soundfile_xferin_sample(&sf, noutlets, x->x_outvec, 0,
-            (unsigned char *)(x->x_buf + x->x_fifotail), vecsize);
+            (unsigned char *) (x->x_buf + x->x_fifotail), vecsize);
 
         x->x_fifotail += wantbytes;
-        if (x->x_fifotail >= x->x_fifosize)
-            x->x_fifotail = 0;
-        if ((--x->x_sigcountdown) <= 0)
+        if(x->x_fifotail >= x->x_fifosize) x->x_fifotail = 0;
+        if((--x->x_sigcountdown) <= 0)
         {
             sfread_cond_signal(&x->x_requestcondition);
             x->x_sigcountdown = x->x_sigperiod;
@@ -2082,23 +2049,24 @@ static t_int *readsf_perform(t_int *w)
     }
     else
     {
-        for (i = 0; i < noutlets; i++)
-            for (j = vecsize, fp = x->x_outvec[i]; j--;)
+        for(i = 0; i < noutlets; i++)
+            for(j = vecsize, fp = x->x_outvec[i]; j--;)
                 *fp++ = 0;
     }
     return w + 2;
 }
 
-    /** start making output.  If we're in the "startup" state change
-        to the "running" state. */
+/** start making output.  If we're in the "startup" state change
+    to the "running" state. */
 static void readsf_start(t_readsf *x)
 {
-    if (x->x_state == STATE_STARTUP)
+    if(x->x_state == STATE_STARTUP)
         x->x_state = STATE_STREAM;
-    else pd_error(x, "readsf~: start requested with no prior 'open'");
+    else
+        pd_error(x, "readsf~: start requested with no prior 'open'");
 }
 
-    /** LATER rethink whether you need the mutex just to set a variable? */
+/** LATER rethink whether you need the mutex just to set a variable? */
 static void readsf_stop(t_readsf *x)
 {
     pthread_mutex_lock(&x->x_mutex);
@@ -2110,30 +2078,31 @@ static void readsf_stop(t_readsf *x)
 
 static void readsf_float(t_readsf *x, t_floatarg f)
 {
-    if (f != 0)
+    if(f != 0)
         readsf_start(x);
-    else readsf_stop(x);
+    else
+        readsf_stop(x);
 }
 
-    /** open method.  Called as:
-        open [flags] filename [onsetframes headersize channels bytes endianness]
-        (if headersize is zero, header is taken to be automatically detected;
-        thus, use the special "-1" to mean a truly headerless file.)
-        if type implementation is set, pass this to open unless headersize is -1 */
+/** open method.  Called as:
+    open [flags] filename [onsetframes headersize channels bytes endianness]
+    (if headersize is zero, header is taken to be automatically detected;
+    thus, use the special "-1" to mean a truly headerless file.)
+    if type implementation is set, pass this to open unless headersize is -1 */
 static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *filesym, *endian;
     t_float onsetframes, headersize, nchannels, bytespersample;
     t_soundfile_type *type = NULL;
 
-    while (argc > 0 && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(argc > 0 && argv->a_type == A_SYMBOL &&
+          *argv->a_w.w_symbol->s_name == '-')
     {
-            /* check for type by name */
+        /* check for type by name */
         const char *flag = argv->a_w.w_symbol->s_name + 1;
-        if (!(type = soundfile_findtype(flag)))
-            goto usage; /* unknown flag */
-        argc -= 1; argv += 1;
+        if(!(type = soundfile_findtype(flag))) goto usage; /* unknown flag */
+        argc -= 1;
+        argv += 1;
     }
     filesym = atom_getsymbolarg(0, argc, argv);
     onsetframes = atom_getfloatarg(1, argc, argv);
@@ -2141,8 +2110,7 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
     nchannels = atom_getfloatarg(3, argc, argv);
     bytespersample = atom_getfloatarg(4, argc, argv);
     endian = atom_getsymbolarg(5, argc, argv);
-    if (!*filesym->s_name)
-        return; /* no filename */
+    if(!*filesym->s_name) return; /* no filename */
 
     pthread_mutex_lock(&x->x_mutex);
     soundfile_clear(&x->x_sf);
@@ -2150,20 +2118,21 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
     x->x_filename = filesym->s_name;
     x->x_fifotail = 0;
     x->x_fifohead = 0;
-    if (*endian->s_name == 'b')
-         x->x_sf.sf_bigendian = 1;
-    else if (*endian->s_name == 'l')
-         x->x_sf.sf_bigendian = 0;
-    else if (*endian->s_name)
+    if(*endian->s_name == 'b')
+        x->x_sf.sf_bigendian = 1;
+    else if(*endian->s_name == 'l')
+        x->x_sf.sf_bigendian = 0;
+    else if(*endian->s_name)
         pd_error(x, "readsf~ open: endianness neither 'b' nor 'l'");
-    else x->x_sf.sf_bigendian = sys_isbigendian();
+    else
+        x->x_sf.sf_bigendian = sys_isbigendian();
     x->x_onsetframes = (onsetframes > 0 ? onsetframes : 0);
-    x->x_sf.sf_headersize = (headersize > 0 ? headersize :
-        (headersize == 0 ? -1 : 0));
+    x->x_sf.sf_headersize =
+        (headersize > 0 ? headersize : (headersize == 0 ? -1 : 0));
     x->x_sf.sf_nchannels = (nchannels >= 1 ? nchannels : 1);
     x->x_sf.sf_bytespersample = (bytespersample > 2 ? bytespersample : 2);
     x->x_sf.sf_bytesperframe = x->x_sf.sf_nchannels * x->x_sf.sf_bytespersample;
-    if (type && x->x_sf.sf_headersize >= 0)
+    if(type && x->x_sf.sf_headersize >= 0)
     {
         post("'-%s' overridden by headersize", type->t_name);
         x->x_sf.sf_type = NULL;
@@ -2188,7 +2157,7 @@ static void readsf_dsp(t_readsf *x, t_signal **sp)
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
     x->x_sigperiod = x->x_fifosize / (x->x_sf.sf_bytesperframe * x->x_vecsize);
-    for (i = 0; i < noutlets; i++)
+    for(i = 0; i < noutlets; i++)
         x->x_outvec[i] = sp[i]->s_vec;
     pthread_mutex_unlock(&x->x_mutex);
     dsp_add(readsf_perform, 1, x);
@@ -2204,20 +2173,20 @@ static void readsf_print(t_readsf *x)
     post("eof %d", x->x_eof);
 }
 
-    /** request QUIT and wait for acknowledge */
+/** request QUIT and wait for acknowledge */
 static void readsf_free(t_readsf *x)
 {
     void *threadrtn;
     pthread_mutex_lock(&x->x_mutex);
     x->x_requestcode = REQUEST_QUIT;
     sfread_cond_signal(&x->x_requestcondition);
-    while (x->x_requestcode != REQUEST_NOTHING)
+    while(x->x_requestcode != REQUEST_NOTHING)
     {
         sfread_cond_signal(&x->x_requestcondition);
         sfread_cond_wait(&x->x_answercondition, &x->x_mutex);
     }
     pthread_mutex_unlock(&x->x_mutex);
-    if (pthread_join(x->x_childthread, &threadrtn))
+    if(pthread_join(x->x_childthread, &threadrtn))
         pd_error(x, "readsf_free: join failed");
 
     pthread_cond_destroy(&x->x_requestcondition);
@@ -2229,17 +2198,16 @@ static void readsf_free(t_readsf *x)
 
 static void readsf_setup(void)
 {
-    readsf_class = class_new(gensym("readsf~"),
-        (t_newmethod)readsf_new, (t_method)readsf_free,
-        sizeof(t_readsf), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addfloat(readsf_class, (t_method)readsf_float);
-    class_addmethod(readsf_class, (t_method)readsf_start, gensym("start"), 0);
-    class_addmethod(readsf_class, (t_method)readsf_stop, gensym("stop"), 0);
-    class_addmethod(readsf_class, (t_method)readsf_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(readsf_class, (t_method)readsf_open,
-        gensym("open"), A_GIMME, 0);
-    class_addmethod(readsf_class, (t_method)readsf_print, gensym("print"), 0);
+    readsf_class = class_new(gensym("readsf~"), (t_newmethod) readsf_new,
+        (t_method) readsf_free, sizeof(t_readsf), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addfloat(readsf_class, (t_method) readsf_float);
+    class_addmethod(readsf_class, (t_method) readsf_start, gensym("start"), 0);
+    class_addmethod(readsf_class, (t_method) readsf_stop, gensym("stop"), 0);
+    class_addmethod(
+        readsf_class, (t_method) readsf_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        readsf_class, (t_method) readsf_open, gensym("open"), A_GIMME, 0);
+    class_addmethod(readsf_class, (t_method) readsf_print, gensym("print"), 0);
 }
 
 /* ------------------------- writesf ------------------------- */
@@ -2262,12 +2230,12 @@ static void *writesf_child_main(void *zz)
     fprintf(stderr, "writesf~: 1\n");
 #endif
     pthread_mutex_lock(&x->x_mutex);
-    while (1)
+    while(1)
     {
 #ifdef DEBUG_SOUNDFILE_THREADS
         fprintf(stderr, "writesf~: 0\n");
 #endif
-        if (x->x_requestcode == REQUEST_NOTHING)
+        if(x->x_requestcode == REQUEST_NOTHING)
         {
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "writesf~: wait 2\n");
@@ -2278,35 +2246,35 @@ static void *writesf_child_main(void *zz)
             fprintf(stderr, "writesf~: 3\n");
 #endif
         }
-        else if (x->x_requestcode == REQUEST_OPEN)
+        else if(x->x_requestcode == REQUEST_OPEN)
         {
             ssize_t byteswritten;
             size_t writebytes;
 
-                /* copy file stuff out of the data structure so we can
-                relinquish the mutex while we're in open_soundfile_via_path() */
+            /* copy file stuff out of the data structure so we can
+            relinquish the mutex while we're in open_soundfile_via_path() */
             const char *filename = x->x_filename;
             t_canvas *canvas = x->x_canvas;
             soundfile_copy(&sf, &x->x_sf);
 
-                /* alter the request code so that an ensuing "open" will get
-                noticed. */
+            /* alter the request code so that an ensuing "open" will get
+            noticed. */
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "writesf~: 4\n");
 #endif
             x->x_requestcode = REQUEST_BUSY;
             x->x_fileerror = 0;
 
-                /* if there's already a file open, close it.  This
-                should never happen since writesf_open() calls stop if
-                needed and then waits until we're idle. */
-            if (sf.sf_fd >= 0)
+            /* if there's already a file open, close it.  This
+            should never happen since writesf_open() calls stop if
+            needed and then waits until we're idle. */
+            if(sf.sf_fd >= 0)
             {
                 size_t frameswritten = x->x_frameswritten;
 
                 pthread_mutex_unlock(&x->x_mutex);
-                soundfile_finishwrite(x, filename, &sf,
-                    SFMAXFRAMES, frameswritten);
+                soundfile_finishwrite(
+                    x, filename, &sf, SFMAXFRAMES, frameswritten);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
                 pthread_mutex_lock(&x->x_mutex);
@@ -2314,14 +2282,13 @@ static void *writesf_child_main(void *zz)
 #ifdef DEBUG_SOUNDFILE_THREADS
                 fprintf(stderr, "writesf~: bug? ditched %ld\n", frameswritten);
 #endif
-                if (x->x_requestcode != REQUEST_BUSY)
-                    continue;
+                if(x->x_requestcode != REQUEST_BUSY) continue;
             }
-                /* cache sf *after* closing as x->sf's type
-                    may have changed in readsf_open() */
+            /* cache sf *after* closing as x->sf's type
+                may have changed in readsf_open() */
             soundfile_copy(&sf, &x->x_sf);
 
-                /* open the soundfile with the mutex unlocked */
+            /* open the soundfile with the mutex unlocked */
             pthread_mutex_unlock(&x->x_mutex);
             create_soundfile(canvas, filename, &sf, 0);
             pthread_mutex_lock(&x->x_mutex);
@@ -2330,7 +2297,7 @@ static void *writesf_child_main(void *zz)
             fprintf(stderr, "writesf~: 5\n");
 #endif
 
-            if (sf.sf_fd < 0)
+            if(sf.sf_fd < 0)
             {
                 x->x_sf.sf_fd = -1;
                 x->x_eof = 1;
@@ -2340,40 +2307,40 @@ static void *writesf_child_main(void *zz)
 #endif
                 goto bail;
             }
-                /* check if another request has been made; if so, field it */
-            if (x->x_requestcode != REQUEST_BUSY)
-                continue;
+            /* check if another request has been made; if so, field it */
+            if(x->x_requestcode != REQUEST_BUSY) continue;
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "writesf~: 6\n");
 #endif
-                /* copy back into the instance structure. */
+            /* copy back into the instance structure. */
             soundfile_copy(&x->x_sf, &sf);
             x->x_fifotail = 0;
             x->x_frameswritten = 0;
-                /* in a loop, wait for the fifo to have data and write it
-                    to disk */
-            while (x->x_requestcode == REQUEST_BUSY ||
-                (x->x_requestcode == REQUEST_CLOSE &&
-                    x->x_fifohead != x->x_fifotail))
+            /* in a loop, wait for the fifo to have data and write it
+                to disk */
+            while(x->x_requestcode == REQUEST_BUSY ||
+                  (x->x_requestcode == REQUEST_CLOSE &&
+                      x->x_fifohead != x->x_fifotail))
             {
                 int fifosize = x->x_fifosize, fifotail;
                 char *buf = x->x_buf;
 #ifdef DEBUG_SOUNDFILE_THREADS
                 fprintf(stderr, "writesf~: 77\n");
 #endif
-                    /* if the head is < the tail, we can immediately write
-                    from tail to end of fifo to disk; otherwise we hold off
-                    writing until there are at least WRITESIZE bytes in the
-                    buffer */
-                if (x->x_fifohead < x->x_fifotail ||
-                    x->x_fifohead >= x->x_fifotail + WRITESIZE
-                    || (x->x_requestcode == REQUEST_CLOSE &&
+                /* if the head is < the tail, we can immediately write
+                from tail to end of fifo to disk; otherwise we hold off
+                writing until there are at least WRITESIZE bytes in the
+                buffer */
+                if(x->x_fifohead < x->x_fifotail ||
+                    x->x_fifohead >= x->x_fifotail + WRITESIZE ||
+                    (x->x_requestcode == REQUEST_CLOSE &&
                         x->x_fifohead != x->x_fifotail))
                 {
-                    writebytes = (x->x_fifohead < x->x_fifotail ?
-                        fifosize : x->x_fifohead) - x->x_fifotail;
-                    if (writebytes > READSIZE)
-                        writebytes = READSIZE;
+                    writebytes =
+                        (x->x_fifohead < x->x_fifotail ? fifosize
+                                                       : x->x_fifohead) -
+                        x->x_fifotail;
+                    if(writebytes > READSIZE) writebytes = READSIZE;
                 }
                 else
                 {
@@ -2384,8 +2351,7 @@ static void *writesf_child_main(void *zz)
 #ifdef DEBUG_SOUNDFILE_THREADS
                     fprintf(stderr, "writesf~: signaled...\n");
 #endif
-                    sfread_cond_wait(&x->x_requestcondition,
-                        &x->x_mutex);
+                    sfread_cond_wait(&x->x_requestcondition, &x->x_mutex);
 #ifdef DEBUG_SOUNDFILE_THREADS
                     fprintf(stderr, "writesf~: 7a ... done\n");
 #endif
@@ -2399,10 +2365,10 @@ static void *writesf_child_main(void *zz)
                 pthread_mutex_unlock(&x->x_mutex);
                 byteswritten = write(sf.sf_fd, buf + fifotail, writebytes);
                 pthread_mutex_lock(&x->x_mutex);
-                if (x->x_requestcode != REQUEST_BUSY &&
+                if(x->x_requestcode != REQUEST_BUSY &&
                     x->x_requestcode != REQUEST_CLOSE)
-                        break;
-                if (byteswritten < 0 || (size_t)byteswritten < writebytes)
+                    break;
+                if(byteswritten < 0 || (size_t) byteswritten < writebytes)
                 {
 #ifdef DEBUG_SOUNDFILE_THREADS
                     fprintf(stderr, "writesf~: fileerror %d\n", errno);
@@ -2413,47 +2379,46 @@ static void *writesf_child_main(void *zz)
                 else
                 {
                     x->x_fifotail += byteswritten;
-                    if (x->x_fifotail == fifosize)
-                        x->x_fifotail = 0;
+                    if(x->x_fifotail == fifosize) x->x_fifotail = 0;
                 }
                 x->x_frameswritten += byteswritten / sf.sf_bytesperframe;
 #ifdef DEBUG_SOUNDFILE_THREADS
                 fprintf(stderr, "writesf~: after head %d tail %d written %ld\n",
                     x->x_fifohead, x->x_fifotail, x->x_frameswritten);
 #endif
-                    /* signal parent in case it's waiting for data */
+                /* signal parent in case it's waiting for data */
                 sfread_cond_signal(&x->x_answercondition);
                 continue;
 
-             bail:
-                 if (x->x_requestcode == REQUEST_BUSY)
-                     x->x_requestcode = REQUEST_NOTHING;
-                     /* hit an error; close file if necessary,
-                     set EOF and signal once more */
-                 if (sf.sf_fd >= 0)
-                 {
-                     pthread_mutex_unlock(&x->x_mutex);
-                     sys_close(sf.sf_fd);
-                     sf.sf_fd = -1;
-                     pthread_mutex_lock(&x->x_mutex);
-                     x->x_eof = 1;
-                     x->x_sf.sf_fd = -1;
-                 }
-                 sfread_cond_signal(&x->x_answercondition);
+            bail:
+                if(x->x_requestcode == REQUEST_BUSY)
+                    x->x_requestcode = REQUEST_NOTHING;
+                /* hit an error; close file if necessary,
+                set EOF and signal once more */
+                if(sf.sf_fd >= 0)
+                {
+                    pthread_mutex_unlock(&x->x_mutex);
+                    sys_close(sf.sf_fd);
+                    sf.sf_fd = -1;
+                    pthread_mutex_lock(&x->x_mutex);
+                    x->x_eof = 1;
+                    x->x_sf.sf_fd = -1;
+                }
+                sfread_cond_signal(&x->x_answercondition);
             }
         }
-        else if (x->x_requestcode == REQUEST_CLOSE ||
-            x->x_requestcode == REQUEST_QUIT)
+        else if(x->x_requestcode == REQUEST_CLOSE ||
+                x->x_requestcode == REQUEST_QUIT)
         {
             int quit = (x->x_requestcode == REQUEST_QUIT);
-            if (sf.sf_fd >= 0)
+            if(sf.sf_fd >= 0)
             {
                 const char *filename = x->x_filename;
                 size_t frameswritten = x->x_frameswritten;
                 soundfile_copy(&sf, &x->x_sf);
                 pthread_mutex_unlock(&x->x_mutex);
-                soundfile_finishwrite(x, filename, &sf,
-                    SFMAXFRAMES, frameswritten);
+                soundfile_finishwrite(
+                    x, filename, &sf, SFMAXFRAMES, frameswritten);
                 sys_close(sf.sf_fd);
                 sf.sf_fd = -1;
                 pthread_mutex_lock(&x->x_mutex);
@@ -2461,8 +2426,7 @@ static void *writesf_child_main(void *zz)
             }
             x->x_requestcode = REQUEST_NOTHING;
             sfread_cond_signal(&x->x_answercondition);
-            if (quit)
-                break;
+            if(quit) break;
         }
         else
         {
@@ -2488,22 +2452,23 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     int nchannels = fnchannels, bufsize = fbufsize, i;
     char *buf;
 
-    if (nchannels < 1)
+    if(nchannels < 1)
         nchannels = 1;
-    else if (nchannels > MAXSFCHANS)
+    else if(nchannels > MAXSFCHANS)
         nchannels = MAXSFCHANS;
-    if (bufsize <= 0) bufsize = DEFBUFPERCHAN * nchannels;
-    else if (bufsize < MINBUFSIZE)
+    if(bufsize <= 0)
+        bufsize = DEFBUFPERCHAN * nchannels;
+    else if(bufsize < MINBUFSIZE)
         bufsize = MINBUFSIZE;
-    else if (bufsize > MAXBUFSIZE)
+    else if(bufsize > MAXBUFSIZE)
         bufsize = MAXBUFSIZE;
     buf = getbytes(bufsize);
-    if (!buf) return 0;
+    if(!buf) return 0;
 
-    x = (t_writesf *)pd_new(writesf_class);
+    x = (t_writesf *) pd_new(writesf_class);
 
-    for (i = 1; i < nchannels; i++)
-        inlet_new(&x->x_obj,  &x->x_obj.ob_pd, &s_signal, &s_signal);
+    for(i = 1; i < nchannels; i++)
+        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
 
     x->x_f = 0;
     pthread_mutex_init(&x->x_mutex, 0);
@@ -2512,7 +2477,7 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     x->x_vecsize = MAXVECSIZE;
     x->x_insamplerate = 0;
     x->x_state = STATE_IDLE;
-    x->x_clock = 0;     /* no callback needed here */
+    x->x_clock = 0; /* no callback needed here */
     x->x_canvas = canvas_getcurrent();
     soundfile_clear(&x->x_sf);
     x->x_sf.sf_nchannels = nchannels;
@@ -2530,37 +2495,35 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 
 static t_int *writesf_perform(t_int *w)
 {
-    t_writesf *x = (t_writesf *)(w[1]);
+    t_writesf *x = (t_writesf *) (w[1]);
     t_soundfile sf = {0};
     int vecsize = x->x_vecsize;
     soundfile_copy(&sf, &x->x_sf);
-    if (x->x_state == STATE_STREAM)
+    if(x->x_state == STATE_STREAM)
     {
         size_t roominfifo;
         size_t wantbytes;
         pthread_mutex_lock(&x->x_mutex);
         wantbytes = vecsize * sf.sf_bytesperframe;
         roominfifo = x->x_fifotail - x->x_fifohead;
-        if (roominfifo <= 0)
-            roominfifo += x->x_fifosize;
-        while (!x->x_eof && roominfifo < wantbytes + 1)
+        if(roominfifo <= 0) roominfifo += x->x_fifosize;
+        while(!x->x_eof && roominfifo < wantbytes + 1)
         {
             fprintf(stderr, "writesf waiting for disk write..\n");
             fprintf(stderr, "(head %d, tail %d, room %d, want %ld)\n",
-                (int)x->x_fifohead, (int)x->x_fifotail,
-                (int)roominfifo, (long)wantbytes);
+                (int) x->x_fifohead, (int) x->x_fifotail, (int) roominfifo,
+                (long) wantbytes);
             sfread_cond_signal(&x->x_requestcondition);
             sfread_cond_wait(&x->x_answercondition, &x->x_mutex);
             fprintf(stderr, "... done waiting.\n");
             roominfifo = x->x_fifotail - x->x_fifohead;
-            if (roominfifo <= 0)
-                roominfifo += x->x_fifosize;
+            if(roominfifo <= 0) roominfifo += x->x_fifosize;
         }
-        if (x->x_eof)
+        if(x->x_eof)
         {
-            if (x->x_fileerror)
-                object_sferror(x, "writesf~", x->x_filename,
-                    x->x_fileerror, &x->x_sf);
+            if(x->x_fileerror)
+                object_sferror(
+                    x, "writesf~", x->x_filename, x->x_fileerror, &x->x_sf);
             x->x_state = STATE_IDLE;
             sfread_cond_signal(&x->x_requestcondition);
             pthread_mutex_unlock(&x->x_mutex);
@@ -2568,12 +2531,11 @@ static t_int *writesf_perform(t_int *w)
         }
 
         soundfile_xferout_sample(&sf, x->x_outvec,
-            (unsigned char *)(x->x_buf + x->x_fifohead), vecsize, 0, 1.);
+            (unsigned char *) (x->x_buf + x->x_fifohead), vecsize, 0, 1.);
 
         x->x_fifohead += wantbytes;
-        if (x->x_fifohead >= x->x_fifosize)
-            x->x_fifohead = 0;
-        if ((--x->x_sigcountdown) <= 0)
+        if(x->x_fifohead >= x->x_fifosize) x->x_fifohead = 0;
+        if((--x->x_sigcountdown) <= 0)
         {
 #ifdef DEBUG_SOUNDFILE_THREADS
             fprintf(stderr, "writesf~: signal 1\n");
@@ -2586,17 +2548,17 @@ static t_int *writesf_perform(t_int *w)
     return w + 2;
 }
 
-    /** start making output.  If we're in the "startup" state change
-        to the "running" state. */
+/** start making output.  If we're in the "startup" state change
+    to the "running" state. */
 static void writesf_start(t_writesf *x)
 {
-    if (x->x_state == STATE_STARTUP)
+    if(x->x_state == STATE_STARTUP)
         x->x_state = STATE_STREAM;
     else
         pd_error(x, "writesf~: start requested with no prior 'open'");
 }
 
-    /** LATER rethink whether you need the mutex just to set a variable? */
+/** LATER rethink whether you need the mutex just to set a variable? */
 static void writesf_stop(t_writesf *x)
 {
     pthread_mutex_lock(&x->x_mutex);
@@ -2609,36 +2571,35 @@ static void writesf_stop(t_writesf *x)
     pthread_mutex_unlock(&x->x_mutex);
 }
 
-    /** open method.  Called as: open [flags] filename with args as in
-        soundfiler_parsewriteargs(). */
+/** open method.  Called as: open [flags] filename with args as in
+    soundfiler_parsewriteargs(). */
 static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_soundfiler_writeargs wa = {0};
-    if (x->x_state != STATE_IDLE)
-        writesf_stop(x);
-    if (soundfiler_parsewriteargs(x, &argc, &argv, &wa) || wa.wa_ascii)
+    if(x->x_state != STATE_IDLE) writesf_stop(x);
+    if(soundfiler_parsewriteargs(x, &argc, &argv, &wa) || wa.wa_ascii)
     {
         pd_error(x, "usage: open [flags] filename...");
         post("flags: -bytes <n> %s -big -little -rate <n>", sf_typeargs);
         return;
     }
-    if (wa.wa_normalize || wa.wa_onsetframes || (wa.wa_nframes != SFMAXFRAMES))
+    if(wa.wa_normalize || wa.wa_onsetframes || (wa.wa_nframes != SFMAXFRAMES))
         pd_error(x, "writesf~ open: normalize/onset/nframes argument ignored");
-    if (argc)
-        pd_error(x, "writesf~ open: extra argument(s) ignored");
+    if(argc) pd_error(x, "writesf~ open: extra argument(s) ignored");
     pthread_mutex_lock(&x->x_mutex);
-    while (x->x_requestcode != REQUEST_NOTHING)
+    while(x->x_requestcode != REQUEST_NOTHING)
     {
         sfread_cond_signal(&x->x_requestcondition);
         sfread_cond_wait(&x->x_answercondition, &x->x_mutex);
     }
     x->x_filename = wa.wa_filesym->s_name;
     x->x_sf.sf_type = wa.wa_type;
-    if (wa.wa_samplerate > 0)
+    if(wa.wa_samplerate > 0)
         x->x_sf.sf_samplerate = wa.wa_samplerate;
-    else if (x->x_insamplerate > 0)
+    else if(x->x_insamplerate > 0)
         x->x_sf.sf_samplerate = x->x_insamplerate;
-    else x->x_sf.sf_samplerate = sys_getsr();
+    else
+        x->x_sf.sf_samplerate = sys_getsr();
     x->x_sf.sf_bytespersample =
         (wa.wa_bytespersample > 2 ? wa.wa_bytespersample : 2);
     x->x_sf.sf_bigendian = wa.wa_bigendian;
@@ -2650,15 +2611,15 @@ static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
     x->x_eof = 0;
     x->x_fileerror = 0;
     x->x_state = STATE_STARTUP;
-        /* set fifosize from bufsize.  fifosize must be a
-        multiple of the number of bytes eaten for each DSP
-        tick.  */
-    x->x_fifosize = x->x_bufsize - (x->x_bufsize %
-        (x->x_sf.sf_bytesperframe * MAXVECSIZE));
-        /* arrange for the "request" condition to be signaled 16
-            times per buffer */
-    x->x_sigcountdown = x->x_sigperiod = (x->x_fifosize /
-            (16 * (x->x_sf.sf_bytesperframe * x->x_vecsize)));
+    /* set fifosize from bufsize.  fifosize must be a
+    multiple of the number of bytes eaten for each DSP
+    tick.  */
+    x->x_fifosize =
+        x->x_bufsize - (x->x_bufsize % (x->x_sf.sf_bytesperframe * MAXVECSIZE));
+    /* arrange for the "request" condition to be signaled 16
+        times per buffer */
+    x->x_sigcountdown = x->x_sigperiod =
+        (x->x_fifosize / (16 * (x->x_sf.sf_bytesperframe * x->x_vecsize)));
     sfread_cond_signal(&x->x_requestcondition);
     pthread_mutex_unlock(&x->x_mutex);
 }
@@ -2668,9 +2629,9 @@ static void writesf_dsp(t_writesf *x, t_signal **sp)
     int i, ninlets = x->x_sf.sf_nchannels;
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
-    x->x_sigperiod = (x->x_fifosize /
-            (16 * x->x_sf.sf_bytesperframe * x->x_vecsize));
-    for (i = 0; i < ninlets; i++)
+    x->x_sigperiod =
+        (x->x_fifosize / (16 * x->x_sf.sf_bytesperframe * x->x_vecsize));
+    for(i = 0; i < ninlets; i++)
         x->x_outvec[i] = sp[i]->s_vec;
     x->x_insamplerate = sp[0]->s_sr;
     pthread_mutex_unlock(&x->x_mutex);
@@ -2687,7 +2648,7 @@ static void writesf_print(t_writesf *x)
     post("eof %d", x->x_eof);
 }
 
-    /** request QUIT and wait for acknowledge */
+/** request QUIT and wait for acknowledge */
 static void writesf_free(t_writesf *x)
 {
     void *threadrtn;
@@ -2697,7 +2658,7 @@ static void writesf_free(t_writesf *x)
     fprintf(stderr, "writesf~: stopping thread...\n");
 #endif
     sfread_cond_signal(&x->x_requestcondition);
-    while (x->x_requestcode != REQUEST_NOTHING)
+    while(x->x_requestcode != REQUEST_NOTHING)
     {
 #ifdef DEBUG_SOUNDFILE_THREADS
         fprintf(stderr, "writesf~: signaling...\n");
@@ -2706,7 +2667,7 @@ static void writesf_free(t_writesf *x)
         sfread_cond_wait(&x->x_answercondition, &x->x_mutex);
     }
     pthread_mutex_unlock(&x->x_mutex);
-    if (pthread_join(x->x_childthread, &threadrtn))
+    if(pthread_join(x->x_childthread, &threadrtn))
         pd_error(x, "writesf_free: join failed");
 #ifdef DEBUG_SOUNDFILE_THREADS
     fprintf(stderr, "writesf~: ... done\n");
@@ -2720,16 +2681,18 @@ static void writesf_free(t_writesf *x)
 
 static void writesf_setup(void)
 {
-    writesf_class = class_new(gensym("writesf~"),
-        (t_newmethod)writesf_new, (t_method)writesf_free,
-        sizeof(t_writesf), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(writesf_class, (t_method)writesf_start, gensym("start"), 0);
-    class_addmethod(writesf_class, (t_method)writesf_stop, gensym("stop"), 0);
-    class_addmethod(writesf_class, (t_method)writesf_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(writesf_class, (t_method)writesf_open,
-        gensym("open"), A_GIMME, 0);
-    class_addmethod(writesf_class, (t_method)writesf_print, gensym("print"), 0);
+    writesf_class = class_new(gensym("writesf~"), (t_newmethod) writesf_new,
+        (t_method) writesf_free, sizeof(t_writesf), 0, A_DEFFLOAT, A_DEFFLOAT,
+        0);
+    class_addmethod(
+        writesf_class, (t_method) writesf_start, gensym("start"), 0);
+    class_addmethod(writesf_class, (t_method) writesf_stop, gensym("stop"), 0);
+    class_addmethod(
+        writesf_class, (t_method) writesf_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        writesf_class, (t_method) writesf_open, gensym("open"), A_GIMME, 0);
+    class_addmethod(
+        writesf_class, (t_method) writesf_print, gensym("print"), 0);
     CLASS_MAINSIGNALIN(writesf_class, t_writesf, x_f);
 }
 

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -100,10 +100,14 @@ static void object_sferror(const void *x, const char *header,
     const char *filename, int errnum, const t_soundfile *sf)
 {
     if(sf && sf->sf_type)
+    {
         pd_error(x, "%s %s: %s: %s", header, sf->sf_type->t_name, filename,
             soundfile_strerror(errnum));
+    }
     else
+    {
         pd_error(x, "%s: %s: %s", header, filename, soundfile_strerror(errnum));
+    }
 }
 
 /* ----- soundfile type ----- */
@@ -234,6 +238,7 @@ int sys_isbigendian(void)
 uint64_t swap8(uint64_t n, int doit)
 {
     if(doit)
+    {
         return (((n >> 56) & 0x00000000000000ffULL) |
                 ((n >> 40) & 0x000000000000ff00ULL) |
                 ((n >> 24) & 0x0000000000ff0000ULL) |
@@ -242,6 +247,7 @@ uint64_t swap8(uint64_t n, int doit)
                 ((n << 24) & 0x0000ff0000000000ULL) |
                 ((n << 40) & 0x00ff000000000000ULL) |
                 ((n << 56) & 0xff00000000000000ULL));
+    }
     return n;
 }
 
@@ -261,8 +267,10 @@ int64_t swap8s(int64_t n, int doit)
 uint32_t swap4(uint32_t n, int doit)
 {
     if(doit)
+    {
         return (((n & 0x0000ff) << 24) | ((n & 0x0000ff00) << 8) |
                 ((n & 0xff0000) >> 8) | ((n & 0xff000000) >> 24));
+    }
     return n;
 }
 
@@ -465,15 +473,19 @@ static void soundfile_xferin_sample(const t_soundfile *sf, int nvecs,
             {
                 for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
                     j++, sp2 += sf->sf_bytesperframe, fp++)
+                {
                     *fp = SCALE *
                           ((sp2[0] << 24) | (sp2[1] << 16) | (sp2[2] << 8));
+                }
             }
             else
             {
                 for(j = 0, sp2 = sp, fp = vecs[i] + framesread; j < nframes;
                     j++, sp2 += sf->sf_bytesperframe, fp++)
+                {
                     *fp = SCALE *
                           ((sp2[2] << 24) | (sp2[1] << 16) | (sp2[0] << 8));
+                }
             }
         }
         else if(sf->sf_bytespersample == 4)
@@ -503,8 +515,10 @@ static void soundfile_xferin_sample(const t_soundfile *sf, int nvecs,
     }
     /* zero out other outputs */
     for(i = sf->sf_nchannels; i < nvecs; i++)
+    {
         for(j = nframes, fp = vecs[i]; j--;)
             *fp++ = 0;
+    }
 }
 
 static void soundfile_xferin_words(const t_soundfile *sf, int nvecs,
@@ -539,15 +553,19 @@ static void soundfile_xferin_words(const t_soundfile *sf, int nvecs,
             {
                 for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
                     j++, sp2 += sf->sf_bytesperframe, wp++)
+                {
                     wp->w_float = SCALE * ((sp2[0] << 24) | (sp2[1] << 16) |
                                               (sp2[2] << 8));
+                }
             }
             else
             {
                 for(j = 0, sp2 = sp, wp = vecs[i] + framesread; j < nframes;
                     j++, sp2 += sf->sf_bytesperframe, wp++)
+                {
                     wp->w_float = SCALE * ((sp2[2] << 24) | (sp2[1] << 16) |
                                               (sp2[0] << 8));
+                }
             }
         }
         else if(sf->sf_bytespersample == 4)
@@ -577,8 +595,10 @@ static void soundfile_xferin_words(const t_soundfile *sf, int nvecs,
     }
     /* zero out other outputs */
     for(i = sf->sf_nchannels; i < nvecs; i++)
+    {
         for(j = nframes, wp = vecs[i]; j--;)
             (wp++)->w_float = 0;
+    }
 }
 
 /* soundfiler_write ...
@@ -770,8 +790,10 @@ static int create_soundfile(
     /* create file */
     strncpy(filenamebuf, filename, MAXPDSTRING);
     if(!sf->sf_type->t_hasextensionfn(filenamebuf, MAXPDSTRING - 10))
+    {
         if(!sf->sf_type->t_addextensionfn(filenamebuf, MAXPDSTRING - 10))
             return -1;
+    }
     filenamebuf[MAXPDSTRING - 10] = 0; /* FIXME: what is the 10 for? */
     canvas_makefilename(canvas, filenamebuf, pathbuf, MAXPDSTRING);
     if((fd = sys_open(pathbuf, O_WRONLY | O_CREAT | O_TRUNC, 0666)) < 0)
@@ -795,8 +817,10 @@ static void soundfile_finishwrite(void *obj, const char *filename,
 {
     if(frameswritten >= nframes) return;
     if(nframes < SFMAXFRAMES)
+    {
         pd_error(obj, "soundfiler write: %ld out of %ld frames written",
             (long) frameswritten, (long) nframes);
+    }
     if(sf->sf_type->t_updateheaderfn(sf, frameswritten)) return;
     object_sferror(obj, "soundfiler write", filename, errno, sf);
 }
@@ -1090,14 +1114,18 @@ static int soundfiler_readascii(
 #endif
     if(a->aa_onsetframe > 0) atoms += a->aa_onsetframe * a->aa_nchannels;
     for(j = 0, ap = atoms; j < nframes; j++)
+    {
         for(i = 0; i < a->aa_nchannels; i++)
             a->aa_vectors[i][j].w_float = atom_getfloat(ap++);
+    }
     /* zero out remaining elements of vectors */
     for(i = 0; i < a->aa_nchannels; i++)
     {
         if(garray_getfloatwords(a->aa_garrays[i], &vecsize, &a->aa_vectors[i]))
+        {
             for(j = nframes; j < vecsize; j++)
                 a->aa_vectors[i][j].w_float = 0;
+        }
     }
     for(i = 0; i < a->aa_nchannels; i++)
         garray_redraw(a->aa_garrays[i]);
@@ -1172,9 +1200,13 @@ static void soundfiler_read(
         else if(!strcmp(flag, "raw"))
         {
             if(ascii)
+            {
                 post("'-ascii' overridden by '-raw'");
+            }
             else if(sf.sf_type)
+            {
                 post("'-%s' overridden by '-raw'", sf.sf_type->t_name);
+            }
             if(argc < 5 || argv[1].a_type != A_FLOAT ||
                 ((sf.sf_headersize = argv[1].a_w.w_float) < 0) ||
                 argv[2].a_type != A_FLOAT ||
@@ -1186,11 +1218,17 @@ static void soundfiler_read(
                     endianness != 'l' && endianness != 'n'))
                 goto usage;
             if(endianness == 'b')
+            {
                 sf.sf_bigendian = 1;
+            }
             else if(endianness == 'l')
+            {
                 sf.sf_bigendian = 0;
+            }
             else
+            {
                 sf.sf_bigendian = sys_isbigendian();
+            }
             sf.sf_samplerate = sys_getsr();
             sf.sf_bytesperframe = sf.sf_nchannels * sf.sf_bytespersample;
             raw = 1;
@@ -1257,8 +1295,10 @@ static void soundfiler_read(
             goto done;
         }
         else if(!garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
+        {
             pd_error(x, "soundfiler read: %s: bad template for tabwrite",
                 argv[i].a_w.w_symbol->s_name);
+        }
         if(finalsize && finalsize != (size_t) vecsize && !resize)
         {
             post("arrays have different lengths, resizing...");
@@ -1357,8 +1397,10 @@ static void soundfiler_read(
     {
         int vecsize;
         if(garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
+        {
             for(j = framesread; j < (size_t) vecsize; j++)
                 vecs[i][j].w_float = 0;
+        }
     }
     /* zero out vectors in excess of number of channels */
     for(i = sf.sf_nchannels; i < argc; i++)
@@ -1366,8 +1408,10 @@ static void soundfiler_read(
         int vecsize;
         t_word *foo;
         if(garray_getfloatwords(garrays[i], &vecsize, &foo))
+        {
             for(j = 0; j < (size_t) vecsize; j++)
                 foo[j].w_float = 0;
+        }
     }
     /* do all graphics updates */
     for(i = 0; i < argc; i++)
@@ -1455,8 +1499,10 @@ size_t soundfiler_dowrite(
             goto fail;
         }
         else if(!garray_getfloatwords(garrays[i], &vecsize, &vectors[i]))
+        {
             pd_error(obj, "soundfiler write: %s: bad template for tabwrite",
                 argv[i].a_w.w_symbol->s_name);
+        }
         if(wa.wa_nframes > vecsize - wa.wa_onsetframes)
             wa.wa_nframes = vecsize - wa.wa_onsetframes;
     }
@@ -1473,9 +1519,13 @@ size_t soundfiler_dowrite(
         for(j = wa.wa_onsetframes; j < wa.wa_nframes + wa.wa_onsetframes; j++)
         {
             if(vectors[i][j].w_float > biggest)
+            {
                 biggest = vectors[i][j].w_float;
+            }
             else if(-vectors[i][j].w_float > biggest)
+            {
                 biggest = -vectors[i][j].w_float;
+            }
         }
     }
 
@@ -1489,9 +1539,13 @@ size_t soundfiler_dowrite(
         if(!ascii_hasextension(filenamebuf, MAXPDSTRING))
             ascii_addextension(filenamebuf, MAXPDSTRING);
         if(wa.wa_normalize)
+        {
             a.aa_normfactor = (biggest > 0 ? 32767. / (32768. * biggest) : 1);
+        }
         else
+        {
             a.aa_normfactor = 1;
+        }
         if((frameswritten = soundfiler_writeascii(obj, filenamebuf, &a)) == 0)
         {
             pd_error(obj, "soundfiler write: writing ascii failed");
@@ -1983,15 +2037,25 @@ static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     char *buf;
 
     if(nchannels < 1)
+    {
         nchannels = 1;
+    }
     else if(nchannels > MAXSFCHANS)
+    {
         nchannels = MAXSFCHANS;
+    }
     if(bufsize <= 0)
+    {
         bufsize = DEFBUFPERCHAN * nchannels;
+    }
     else if(bufsize < MINBUFSIZE)
+    {
         bufsize = MINBUFSIZE;
+    }
     else if(bufsize > MAXBUFSIZE)
+    {
         bufsize = MAXBUFSIZE;
+    }
     buf = getbytes(bufsize);
     if(!buf) return 0;
 
@@ -2060,8 +2124,10 @@ static t_int *readsf_perform(t_int *w)
         {
             int xfersize;
             if(x->x_fileerror)
+            {
                 object_sferror(
                     x, "readsf~", x->x_filename, x->x_fileerror, &x->x_sf);
+            }
             clock_delay(x->x_clock, 0);
             x->x_state = STATE_IDLE;
 
@@ -2076,8 +2142,10 @@ static t_int *readsf_perform(t_int *w)
             }
             /* then zero out the (rest of the) output */
             for(i = 0; i < noutlets; i++)
+            {
                 for(j = vecsize, fp = x->x_outvec[i] + xfersize; j--;)
                     *fp++ = 0;
+            }
 
             sfread_cond_signal(&x->x_requestcondition);
             pthread_mutex_unlock(&x->x_mutex);
@@ -2099,8 +2167,10 @@ static t_int *readsf_perform(t_int *w)
     else
     {
         for(i = 0; i < noutlets; i++)
+        {
             for(j = vecsize, fp = x->x_outvec[i]; j--;)
                 *fp++ = 0;
+        }
     }
     return w + 2;
 }
@@ -2110,9 +2180,13 @@ static t_int *readsf_perform(t_int *w)
 static void readsf_start(t_readsf *x)
 {
     if(x->x_state == STATE_STARTUP)
+    {
         x->x_state = STATE_STREAM;
+    }
     else
+    {
         pd_error(x, "readsf~: start requested with no prior 'open'");
+    }
 }
 
 /** LATER rethink whether you need the mutex just to set a variable? */
@@ -2128,9 +2202,13 @@ static void readsf_stop(t_readsf *x)
 static void readsf_float(t_readsf *x, t_floatarg f)
 {
     if(f != 0)
+    {
         readsf_start(x);
+    }
     else
+    {
         readsf_stop(x);
+    }
 }
 
 /** open method.  Called as:
@@ -2172,13 +2250,21 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
     x->x_fifotail = 0;
     x->x_fifohead = 0;
     if(*endian->s_name == 'b')
+    {
         x->x_sf.sf_bigendian = 1;
+    }
     else if(*endian->s_name == 'l')
+    {
         x->x_sf.sf_bigendian = 0;
+    }
     else if(*endian->s_name)
+    {
         pd_error(x, "readsf~ open: endianness neither 'b' nor 'l'");
+    }
     else
+    {
         x->x_sf.sf_bigendian = sys_isbigendian();
+    }
     x->x_onsetframes = (onsetframes > 0 ? onsetframes : 0);
     x->x_sf.sf_headersize =
         (headersize > 0 ? headersize : (headersize == 0 ? -1 : 0));
@@ -2510,15 +2596,25 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     char *buf;
 
     if(nchannels < 1)
+    {
         nchannels = 1;
+    }
     else if(nchannels > MAXSFCHANS)
+    {
         nchannels = MAXSFCHANS;
+    }
     if(bufsize <= 0)
+    {
         bufsize = DEFBUFPERCHAN * nchannels;
+    }
     else if(bufsize < MINBUFSIZE)
+    {
         bufsize = MINBUFSIZE;
+    }
     else if(bufsize > MAXBUFSIZE)
+    {
         bufsize = MAXBUFSIZE;
+    }
     buf = getbytes(bufsize);
     if(!buf) return 0;
 
@@ -2579,8 +2675,10 @@ static t_int *writesf_perform(t_int *w)
         if(x->x_eof)
         {
             if(x->x_fileerror)
+            {
                 object_sferror(
                     x, "writesf~", x->x_filename, x->x_fileerror, &x->x_sf);
+            }
             x->x_state = STATE_IDLE;
             sfread_cond_signal(&x->x_requestcondition);
             pthread_mutex_unlock(&x->x_mutex);
@@ -2610,9 +2708,13 @@ static t_int *writesf_perform(t_int *w)
 static void writesf_start(t_writesf *x)
 {
     if(x->x_state == STATE_STARTUP)
+    {
         x->x_state = STATE_STREAM;
+    }
     else
+    {
         pd_error(x, "writesf~: start requested with no prior 'open'");
+    }
 }
 
 /** LATER rethink whether you need the mutex just to set a variable? */
@@ -2652,11 +2754,17 @@ static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
     x->x_filename = wa.wa_filesym->s_name;
     x->x_sf.sf_type = wa.wa_type;
     if(wa.wa_samplerate > 0)
+    {
         x->x_sf.sf_samplerate = wa.wa_samplerate;
+    }
     else if(x->x_insamplerate > 0)
+    {
         x->x_sf.sf_samplerate = x->x_insamplerate;
+    }
     else
+    {
         x->x_sf.sf_samplerate = sys_getsr();
+    }
     x->x_sf.sf_bytespersample =
         (wa.wa_bytespersample > 2 ? wa.wa_bytespersample : 2);
     x->x_sf.sf_bigendian = wa.wa_bigendian;

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -1059,8 +1059,6 @@ static int soundfiler_readascii(
     t_soundfiler *x, const char *filename, t_asciiargs *a)
 {
     t_binbuf *b = binbuf_new();
-    int i;
-    int j;
     int vecsize;
     ssize_t framesinfile;
     ssize_t nframes = a->aa_nframes;
@@ -1093,7 +1091,7 @@ static int soundfiler_readascii(
             framesinfile = a->aa_maxsize;
         }
         nframes = framesinfile - a->aa_onsetframe;
-        for(i = 0; i < a->aa_nchannels; i++)
+        for(int i = 0; i < a->aa_nchannels; i++)
         {
             garray_resize_long(a->aa_garrays[i], nframes);
             garray_setsaveit(a->aa_garrays[i], 0);
@@ -1113,21 +1111,21 @@ static int soundfiler_readascii(
     post("ascii: read 2 frames %d", nframes);
 #endif
     if(a->aa_onsetframe > 0) atoms += a->aa_onsetframe * a->aa_nchannels;
-    for(j = 0, ap = atoms; j < nframes; j++)
+    for(int j = 0, ap = atoms; j < nframes; j++)
     {
-        for(i = 0; i < a->aa_nchannels; i++)
+        for(int i = 0; i < a->aa_nchannels; i++)
             a->aa_vectors[i][j].w_float = atom_getfloat(ap++);
     }
     /* zero out remaining elements of vectors */
-    for(i = 0; i < a->aa_nchannels; i++)
+    for(int i = 0; i < a->aa_nchannels; i++)
     {
         if(garray_getfloatwords(a->aa_garrays[i], &vecsize, &a->aa_vectors[i]))
         {
-            for(j = nframes; j < vecsize; j++)
+            for(int j = nframes; j < vecsize; j++)
                 a->aa_vectors[i][j].w_float = 0;
         }
     }
-    for(i = 0; i < a->aa_nchannels; i++)
+    for(int i = 0; i < a->aa_nchannels; i++)
         garray_redraw(a->aa_garrays[i]);
 #ifdef DEBUG_SOUNDFILE
     post("ascii: read 3");
@@ -1160,13 +1158,11 @@ static void soundfiler_read(
     int resize = 0;
     int ascii = 0;
     int raw = 0;
-    int i;
     size_t skipframes = 0;
     size_t finalsize = 0;
     size_t maxsize = SFMAXFRAMES;
     size_t framesread = 0;
     size_t bufframes;
-    size_t j;
     ssize_t nframes;
     ssize_t framesinfile;
     char endianness;
@@ -1283,7 +1279,7 @@ static void soundfiler_read(
     if(!ascii && !sf.sf_type && sf.sf_headersize < 0)
         ascii = ascii_hasextension(filename, MAXPDSTRING);
 
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         int vecsize;
         if(argv[i].a_type != A_SYMBOL) goto usage;
@@ -1344,7 +1340,7 @@ static void soundfiler_read(
             framesinfile = maxsize;
         }
         finalsize = framesinfile;
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
         {
             int vecsize;
             garray_resize_long(garrays[i], finalsize);
@@ -1393,28 +1389,28 @@ static void soundfiler_read(
     }
 
     /* zero out remaining elements of vectors */
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         int vecsize;
         if(garray_getfloatwords(garrays[i], &vecsize, &vecs[i]))
         {
-            for(j = framesread; j < (size_t) vecsize; j++)
+            for(size_t j = framesread; j < (size_t) vecsize; j++)
                 vecs[i][j].w_float = 0;
         }
     }
     /* zero out vectors in excess of number of channels */
-    for(i = sf.sf_nchannels; i < argc; i++)
+    for(int i = sf.sf_nchannels; i < argc; i++)
     {
         int vecsize;
         t_word *foo;
         if(garray_getfloatwords(garrays[i], &vecsize, &foo))
         {
-            for(j = 0; j < (size_t) vecsize; j++)
+            for(size_t j = 0; j < (size_t) vecsize; j++)
                 foo[j].w_float = 0;
         }
     }
     /* do all graphics updates */
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         garray_redraw(garrays[i]);
     goto done;
 usage:
@@ -1467,10 +1463,8 @@ size_t soundfiler_dowrite(
 {
     t_soundfiler_writeargs wa = {0};
     int fd = -1;
-    int i;
     size_t bufframes;
     size_t frameswritten = 0;
-    size_t j;
     t_garray *garrays[MAXSFCHANS];
     t_word *vectors[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
@@ -1487,7 +1481,7 @@ size_t soundfiler_dowrite(
     sf->sf_bytesperframe = argc * wa.wa_bytespersample;
     if(sf->sf_nchannels < 1 || sf->sf_nchannels > MAXSFCHANS) goto usage;
     if(sf->sf_samplerate <= 0) sf->sf_samplerate = sys_getsr();
-    for(i = 0; i < sf->sf_nchannels; i++)
+    for(int i = 0; i < sf->sf_nchannels; i++)
     {
         int vecsize;
         if(argv[i].a_type != A_SYMBOL) goto usage;
@@ -1514,9 +1508,9 @@ size_t soundfiler_dowrite(
     }
 
     /* find biggest sample for normalizing */
-    for(i = 0; i < sf->sf_nchannels; i++)
+    for(int i = 0; i < sf->sf_nchannels; i++)
     {
-        for(j = wa.wa_onsetframes; j < wa.wa_nframes + wa.wa_onsetframes; j++)
+        for(size_t j = wa.wa_onsetframes; j < wa.wa_nframes + wa.wa_onsetframes; j++)
         {
             if(vectors[i][j].w_float > biggest)
             {
@@ -2061,7 +2055,7 @@ static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 
     x = (t_readsf *) pd_new(readsf_class);
 
-    for(i = 0; i < nchannels; i++)
+    for(int i = 0; i < nchannels; i++)
         outlet_new(&x->x_obj, gensym("signal"));
     x->x_noutlets = nchannels;
     x->x_bangout = outlet_new(&x->x_obj, &s_bang);
@@ -2094,8 +2088,6 @@ static t_int *readsf_perform(t_int *w)
     t_soundfile sf = {0};
     int vecsize = x->x_vecsize;
     int noutlets = x->x_noutlets;
-    int i;
-    size_t j;
     t_sample *fp;
     soundfile_copy(&sf, &x->x_sf);
     if(x->x_state == STATE_STREAM)
@@ -2141,8 +2133,9 @@ static t_int *readsf_perform(t_int *w)
                 vecsize -= xfersize;
             }
             /* then zero out the (rest of the) output */
-            for(i = 0; i < noutlets; i++)
+            for(int i = 0; i < noutlets; i++)
             {
+                size_t j;
                 for(j = vecsize, fp = x->x_outvec[i] + xfersize; j--;)
                     *fp++ = 0;
             }
@@ -2166,8 +2159,9 @@ static t_int *readsf_perform(t_int *w)
     }
     else
     {
-        for(i = 0; i < noutlets; i++)
+        for(int i = 0; i < noutlets; i++)
         {
+            size_t j;
             for(j = vecsize, fp = x->x_outvec[i]; j--;)
                 *fp++ = 0;
         }
@@ -2277,7 +2271,9 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
         x->x_sf.sf_type = NULL;
     }
     else
+    {
         x->x_sf.sf_type = type;
+    }
     x->x_eof = 0;
     x->x_fileerror = 0;
     x->x_state = STATE_STARTUP;
@@ -2297,7 +2293,7 @@ static void readsf_dsp(t_readsf *x, t_signal **sp)
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
     x->x_sigperiod = x->x_fifosize / (x->x_sf.sf_bytesperframe * x->x_vecsize);
-    for(i = 0; i < noutlets; i++)
+    for(int i = 0; i < noutlets; i++)
         x->x_outvec[i] = sp[i]->s_vec;
     pthread_mutex_unlock(&x->x_mutex);
     dsp_add(readsf_perform, 1, x);
@@ -2592,7 +2588,6 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
     t_writesf *x;
     int nchannels = fnchannels;
     int bufsize = fbufsize;
-    int i;
     char *buf;
 
     if(nchannels < 1)
@@ -2620,7 +2615,7 @@ static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 
     x = (t_writesf *) pd_new(writesf_class);
 
-    for(i = 1; i < nchannels; i++)
+    for(int i = 1; i < nchannels; i++)
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
 
     x->x_f = 0;
@@ -2791,13 +2786,12 @@ static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
 
 static void writesf_dsp(t_writesf *x, t_signal **sp)
 {
-    int i;
     int ninlets = x->x_sf.sf_nchannels;
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
     x->x_sigperiod =
         (x->x_fifosize / (16 * x->x_sf.sf_bytesperframe * x->x_vecsize));
-    for(i = 0; i < ninlets; i++)
+    for(int i = 0; i < ninlets; i++)
         x->x_outvec[i] = sp[i]->s_vec;
     x->x_insamplerate = sp[0]->s_sr;
     pthread_mutex_unlock(&x->x_mutex);

--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -286,7 +286,10 @@ void swapstring4(char *foo, int doit)
 {
     if(doit)
     {
-        char a = foo[0], b = foo[1], c = foo[2], d = foo[3];
+        char a = foo[0];
+        char b = foo[1];
+        char c = foo[2];
+        char d = foo[3];
         foo[0] = d;
         foo[1] = c;
         foo[2] = b;
@@ -298,8 +301,14 @@ void swapstring8(char *foo, int doit)
 {
     if(doit)
     {
-        char a = foo[0], b = foo[1], c = foo[2], d = foo[3], e = foo[4],
-             f = foo[5], g = foo[6], h = foo[7];
+        char a = foo[0];
+        char b = foo[1];
+        char c = foo[2];
+        char d = foo[3];
+        char e = foo[4];
+        char f = foo[5];
+        char g = foo[6];
+        char h = foo[7];
         foo[0] = h;
         foo[1] = g;
         foo[2] = f;
@@ -397,8 +406,10 @@ badheader:
 int open_soundfile_via_path(const char *dirname, const char *filename,
     t_soundfile *sf, size_t skipframes)
 {
-    char buf[MAXPDSTRING], *dummy;
-    int fd, sf_fd;
+    char buf[MAXPDSTRING];
+    char *dummy;
+    int fd;
+    int sf_fd;
     fd = open_via_path(dirname, filename, "", buf, &dummy, MAXPDSTRING, 1);
     if(fd < 0) return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
@@ -412,8 +423,10 @@ int open_soundfile_via_path(const char *dirname, const char *filename,
 int open_soundfile_via_canvas(
     t_canvas *canvas, const char *filename, t_soundfile *sf, size_t skipframes)
 {
-    char buf[MAXPDSTRING], *dummy;
-    int fd, sf_fd;
+    char buf[MAXPDSTRING];
+    char *dummy;
+    int fd;
+    int sf_fd;
     fd = canvas_open(canvas, filename, "", buf, &dummy, MAXPDSTRING, 1);
     if(fd < 0) return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
@@ -423,9 +436,11 @@ int open_soundfile_via_canvas(
 static void soundfile_xferin_sample(const t_soundfile *sf, int nvecs,
     t_sample **vecs, size_t framesread, unsigned char *buf, size_t nframes)
 {
-    int nchannels = (sf->sf_nchannels < nvecs ? sf->sf_nchannels : nvecs), i;
+    int nchannels = (sf->sf_nchannels < nvecs ? sf->sf_nchannels : nvecs);
+    int i;
     size_t j;
-    unsigned char *sp, *sp2;
+    unsigned char *sp;
+    unsigned char *sp2;
     t_sample *fp;
     for(i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
     {
@@ -495,9 +510,11 @@ static void soundfile_xferin_sample(const t_soundfile *sf, int nvecs,
 static void soundfile_xferin_words(const t_soundfile *sf, int nvecs,
     t_word **vecs, size_t framesread, unsigned char *buf, size_t nframes)
 {
-    unsigned char *sp, *sp2;
+    unsigned char *sp;
+    unsigned char *sp2;
     t_word *wp;
-    int nchannels = (sf->sf_nchannels < nvecs ? sf->sf_nchannels : nvecs), i;
+    int nchannels = (sf->sf_nchannels < nvecs ? sf->sf_nchannels : nvecs);
+    int i;
     size_t j;
     for(i = 0, sp = buf; i < nchannels; i++, sp += sf->sf_bytespersample)
     {
@@ -607,9 +624,14 @@ static int soundfiler_parsewriteargs(
 {
     int argc = *p_argc;
     t_atom *argv = *p_argv;
-    int samplerate = -1, bytespersample = 2, bigendian = 0, endianness = -1;
-    size_t nframes = SFMAXFRAMES, onsetframes = 0;
-    int normalize = 0, ascii = 0;
+    int samplerate = -1;
+    int bytespersample = 2;
+    int bigendian = 0;
+    int endianness = -1;
+    size_t nframes = SFMAXFRAMES;
+    size_t onsetframes = 0;
+    int normalize = 0;
+    int ascii = 0;
     t_symbol *filesym;
     t_soundfile_type *type = NULL;
 
@@ -740,7 +762,8 @@ static int soundfiler_parsewriteargs(
 static int create_soundfile(
     t_canvas *canvas, const char *filename, t_soundfile *sf, size_t nframes)
 {
-    char filenamebuf[MAXPDSTRING], pathbuf[MAXPDSTRING];
+    char filenamebuf[MAXPDSTRING];
+    char pathbuf[MAXPDSTRING];
     ssize_t headersize = -1;
     int fd;
 
@@ -784,7 +807,8 @@ static void soundfile_xferout_sample(const t_soundfile *sf, t_sample **vecs,
 {
     int i;
     size_t j;
-    unsigned char *sp, *sp2;
+    unsigned char *sp;
+    unsigned char *sp2;
     t_sample *fp;
     for(i = 0, sp = buf; i < sf->sf_nchannels; i++, sp += sf->sf_bytespersample)
     {
@@ -887,7 +911,8 @@ static void soundfile_xferout_words(const t_soundfile *sf, t_word **vecs,
 {
     int i;
     size_t j;
-    unsigned char *sp, *sp2;
+    unsigned char *sp;
+    unsigned char *sp2;
     t_word *wp;
     for(i = 0, sp = buf; i < sf->sf_nchannels; i++, sp += sf->sf_bytespersample)
     {
@@ -1010,9 +1035,13 @@ static int soundfiler_readascii(
     t_soundfiler *x, const char *filename, t_asciiargs *a)
 {
     t_binbuf *b = binbuf_new();
-    int i, j, vecsize;
-    ssize_t framesinfile, nframes = a->aa_nframes;
-    t_atom *atoms, *ap;
+    int i;
+    int j;
+    int vecsize;
+    ssize_t framesinfile;
+    ssize_t nframes = a->aa_nframes;
+    t_atom *atoms;
+    t_atom *ap;
     if(binbuf_read_via_canvas(b, filename, x->x_canvas, 0))
     {
         nframes = 0;
@@ -1099,10 +1128,19 @@ static void soundfiler_read(
     t_soundfiler *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_soundfile sf = {0};
-    int fd = -1, resize = 0, ascii = 0, raw = 0, i;
-    size_t skipframes = 0, finalsize = 0, maxsize = SFMAXFRAMES, framesread = 0,
-           bufframes, j;
-    ssize_t nframes, framesinfile;
+    int fd = -1;
+    int resize = 0;
+    int ascii = 0;
+    int raw = 0;
+    int i;
+    size_t skipframes = 0;
+    size_t finalsize = 0;
+    size_t maxsize = SFMAXFRAMES;
+    size_t framesread = 0;
+    size_t bufframes;
+    size_t j;
+    ssize_t nframes;
+    ssize_t framesinfile;
     char endianness;
     const char *filename;
     t_garray *garrays[MAXSFCHANS];
@@ -1355,7 +1393,10 @@ int soundfiler_writeascii(t_soundfiler *x, const char *filename, t_asciiargs *a)
 {
     char path[MAXPDSTRING];
     t_binbuf *b = binbuf_new();
-    int i, j, frameswritten = 0, ret = 1;
+    int i;
+    int j;
+    int frameswritten = 0;
+    int ret = 1;
 #ifdef DEBUG_SOUNDFILE
     post("ascii write: frames %d onset %d channels %d", a->aa_nframes,
         a->aa_onsetframe, a->aa_nchannels);
@@ -1381,12 +1422,16 @@ size_t soundfiler_dowrite(
     void *obj, t_canvas *canvas, int argc, t_atom *argv, t_soundfile *sf)
 {
     t_soundfiler_writeargs wa = {0};
-    int fd = -1, i;
-    size_t bufframes, frameswritten = 0, j;
+    int fd = -1;
+    int i;
+    size_t bufframes;
+    size_t frameswritten = 0;
+    size_t j;
     t_garray *garrays[MAXSFCHANS];
     t_word *vectors[MAXSFCHANS];
     char sampbuf[SAMPBUFSIZE];
-    t_sample normfactor = 1, biggest = 0;
+    t_sample normfactor = 1;
+    t_sample biggest = 0;
 
     soundfile_clear(sf);
     if(soundfiler_parsewriteargs(obj, &argc, &argv, &wa)) goto usage;
@@ -1485,7 +1530,8 @@ size_t soundfiler_dowrite(
     bufframes = SAMPBUFSIZE / sf->sf_bytesperframe;
     for(frameswritten = 0; frameswritten < wa.wa_nframes;)
     {
-        size_t thiswrite = wa.wa_nframes - frameswritten, datasize;
+        size_t thiswrite = wa.wa_nframes - frameswritten;
+        size_t datasize;
         ssize_t byteswritten;
         thiswrite = (thiswrite > bufframes ? bufframes : thiswrite);
         datasize = sf->sf_bytesperframe * thiswrite;
@@ -1932,7 +1978,9 @@ static void readsf_tick(t_readsf *x);
 static void *readsf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 {
     t_readsf *x;
-    int nchannels = fnchannels, bufsize = fbufsize, i;
+    int nchannels = fnchannels;
+    int bufsize = fbufsize;
+    int i;
     char *buf;
 
     if(nchannels < 1)
@@ -1981,7 +2029,9 @@ static t_int *readsf_perform(t_int *w)
 {
     t_readsf *x = (t_readsf *) (w[1]);
     t_soundfile sf = {0};
-    int vecsize = x->x_vecsize, noutlets = x->x_noutlets, i;
+    int vecsize = x->x_vecsize;
+    int noutlets = x->x_noutlets;
+    int i;
     size_t j;
     t_sample *fp;
     soundfile_copy(&sf, &x->x_sf);
@@ -2091,8 +2141,12 @@ static void readsf_float(t_readsf *x, t_floatarg f)
     if type implementation is set, pass this to open unless headersize is -1 */
 static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_symbol *filesym, *endian;
-    t_float onsetframes, headersize, nchannels, bytespersample;
+    t_symbol *filesym;
+    t_symbol *endian;
+    t_float onsetframes;
+    t_float headersize;
+    t_float nchannels;
+    t_float bytespersample;
     t_soundfile_type *type = NULL;
 
     while(argc > 0 && argv->a_type == A_SYMBOL &&
@@ -2153,7 +2207,8 @@ usage:
 
 static void readsf_dsp(t_readsf *x, t_signal **sp)
 {
-    int i, noutlets = x->x_noutlets;
+    int i;
+    int noutlets = x->x_noutlets;
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
     x->x_sigperiod = x->x_fifosize / (x->x_sf.sf_bytesperframe * x->x_vecsize);
@@ -2322,7 +2377,8 @@ static void *writesf_child_main(void *zz)
                   (x->x_requestcode == REQUEST_CLOSE &&
                       x->x_fifohead != x->x_fifotail))
             {
-                int fifosize = x->x_fifosize, fifotail;
+                int fifosize = x->x_fifosize;
+                int fifotail;
                 char *buf = x->x_buf;
 #ifdef DEBUG_SOUNDFILE_THREADS
                 fprintf(stderr, "writesf~: 77\n");
@@ -2449,7 +2505,9 @@ static void writesf_tick(t_writesf *x);
 static void *writesf_new(t_floatarg fnchannels, t_floatarg fbufsize)
 {
     t_writesf *x;
-    int nchannels = fnchannels, bufsize = fbufsize, i;
+    int nchannels = fnchannels;
+    int bufsize = fbufsize;
+    int i;
     char *buf;
 
     if(nchannels < 1)
@@ -2626,7 +2684,8 @@ static void writesf_open(t_writesf *x, t_symbol *s, int argc, t_atom *argv)
 
 static void writesf_dsp(t_writesf *x, t_signal **sp)
 {
-    int i, ninlets = x->x_sf.sf_nchannels;
+    int i;
+    int ninlets = x->x_sf.sf_nchannels;
     pthread_mutex_lock(&x->x_mutex);
     x->x_vecsize = sp[0]->s_n;
     x->x_sigperiod =

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* soundfile formats and helper functions */
 
@@ -35,24 +35,24 @@ typedef SSIZE_T ssize_t;
 #endif /* SSIZE_MAX */
 #endif /* _MSC_VER */
 
-    /** should be large enough for all file type min sizes */
+/** should be large enough for all file type min sizes */
 #define SFHDRBUFSIZE 128
 
-#define SFMAXFRAMES SIZE_MAX  /**< default max sample frames, unsigned */
-#define SFMAXBYTES  SSIZE_MAX /**< default max sample bytes, signed */
+#define SFMAXFRAMES SIZE_MAX /**< default max sample frames, unsigned */
+#define SFMAXBYTES SSIZE_MAX /**< default max sample bytes, signed */
 
-    /** sound file read/write debug posts */
+/** sound file read/write debug posts */
 //#define DEBUG_SOUNDFILE
 
 /* ----- soundfile ----- */
 
-    /** soundfile file descriptor, backend type, and format info
-        note: headersize and bytelimit are signed as they are used for < 0
-              comparisons, hopefully ssize_t is large enough
-        "headersize" can also be thought of as the audio data byte offset */
+/** soundfile file descriptor, backend type, and format info
+    note: headersize and bytelimit are signed as they are used for < 0
+          comparisons, hopefully ssize_t is large enough
+    "headersize" can also be thought of as the audio data byte offset */
 typedef struct _soundfile
 {
-    int sf_fd;             /**< file descriptor, >= 0 : open, -1 : closed */
+    int sf_fd; /**< file descriptor, >= 0 : open, -1 : closed */
     struct _soundfile_type *sf_type; /**< type implementation             */
     /* format info */
     int sf_samplerate;     /**< read: file sr, write: pd sr               */
@@ -64,64 +64,64 @@ typedef struct _soundfile
     ssize_t sf_bytelimit;  /**< number of sound data bytes to read/write  */
 } t_soundfile;
 
-    /** clear soundfile struct to defaults, does not close or free */
+/** clear soundfile struct to defaults, does not close or free */
 void soundfile_clear(t_soundfile *sf);
 
-    /** copy src soundfile info into dst */
+/** copy src soundfile info into dst */
 void soundfile_copy(t_soundfile *dst, const t_soundfile *src);
 
-    /** returns 1 if bytes need to be swapped due to endianness, otherwise 0 */
+/** returns 1 if bytes need to be swapped due to endianness, otherwise 0 */
 int soundfile_needsbyteswap(const t_soundfile *sf);
 
-    /** generic soundfile errors */
+/** generic soundfile errors */
 typedef enum _soundfile_errno
 {
-    SOUNDFILE_ERRUNKNOWN   = -1000, /* unknown header */
+    SOUNDFILE_ERRUNKNOWN = -1000,   /* unknown header */
     SOUNDFILE_ERRMALFORMED = -1001, /* bad header */
-    SOUNDFILE_ERRVERSION   = -1002, /* header ok, unsupported version */
+    SOUNDFILE_ERRVERSION = -1002,   /* header ok, unsupported version */
     SOUNDFILE_ERRSAMPLEFMT = -1003  /* header ok, unsupported sample format */
 } t_soundfile_errno;
 
-    /** returns a soundfile error string, otherwise calls C strerror */
-const char* soundfile_strerror(int errnum);
+/** returns a soundfile error string, otherwise calls C strerror */
+const char *soundfile_strerror(int errnum);
 
 /* ----- soundfile type ----- */
 
-    /** returns 1 if buffer is the beginning of a supported file header,
-        size will be at least minheadersize
-        this may be called in a background thread */
+/** returns 1 if buffer is the beginning of a supported file header,
+    size will be at least minheadersize
+    this may be called in a background thread */
 typedef int (*t_soundfile_isheaderfn)(const char *buf, size_t size);
 
-    /** read format info from soundfile header,
-        returns 1 on success or 0 on error
-        note: set sf_bytelimit = sound data size, optionally set errno
-        this may be called in a background thread */
+/** read format info from soundfile header,
+    returns 1 on success or 0 on error
+    note: set sf_bytelimit = sound data size, optionally set errno
+    this may be called in a background thread */
 typedef int (*t_soundfile_readheaderfn)(t_soundfile *sf);
 
-    /** write header to beginning of an open file from an info struct
-        returns header bytes written or < 0 on error
-        note: optionally set errno
-        this may be called in a background thread */
+/** write header to beginning of an open file from an info struct
+    returns header bytes written or < 0 on error
+    note: optionally set errno
+    this may be called in a background thread */
 typedef int (*t_soundfile_writeheaderfn)(t_soundfile *sf, size_t nframes);
 
-    /** update file header data size, returns 1 on success or 0 on error
-        this may be called in a background thread */
+/** update file header data size, returns 1 on success or 0 on error
+    this may be called in a background thread */
 typedef int (*t_soundfile_updateheaderfn)(t_soundfile *sf, size_t nframes);
 
-    /** returns 1 if the filename has a supported file extension, otherwise 0
-        this may be called in a background thread */
+/** returns 1 if the filename has a supported file extension, otherwise 0
+    this may be called in a background thread */
 typedef int (*t_soundfile_hasextensionfn)(const char *filename, size_t size);
 
-    /** appends the default file extension, returns 1 on success
-        this may be called in a background thread */
+/** appends the default file extension, returns 1 on success
+    this may be called in a background thread */
 typedef int (*t_soundfile_addextensionfn)(char *filename, size_t size);
 
-    /** returns the type's preferred sample endianness based on the
-        requested endianness (0 little, 1 big, -1 unspecified)
-        returns 1 for big endian, 0 for little endian */
+/** returns the type's preferred sample endianness based on the
+    requested endianness (0 little, 1 big, -1 unspecified)
+    returns 1 for big endian, 0 for little endian */
 typedef int (*t_soundfile_endiannessfn)(int endianness);
 
-    /* type implementation for a single file format */
+/* type implementation for a single file format */
 typedef struct _soundfile_type
 {
     char *t_name;           /**< type name, unique & w/o white spaces       */
@@ -135,43 +135,43 @@ typedef struct _soundfile_type
     t_soundfile_endiannessfn t_endiannessfn;     /**< must be non-NULL      */
 } t_soundfile_type;
 
-    /** add a new type implementation
-        returns 1 on success or 0 if max types has been reached */
+/** add a new type implementation
+    returns 1 on success or 0 if max types has been reached */
 int soundfile_addtype(const t_soundfile_type *t);
 
 /* ----- read/write helpers ----- */
 
-    /** seek to offset in file fd and read size bytes into dst,
-        returns bytes written on success or -1 on failure */
+/** seek to offset in file fd and read size bytes into dst,
+    returns bytes written on success or -1 on failure */
 ssize_t fd_read(int fd, off_t offset, void *dst, size_t size);
 
-    /** seek to offset in file fd and write size bytes from dst,
-        returns number of bytes written on success or -1 if seek or write
-        failed */
+/** seek to offset in file fd and write size bytes from dst,
+    returns number of bytes written on success or -1 if seek or write
+    failed */
 ssize_t fd_write(int fd, off_t offset, const void *src, size_t size);
 
 /* ----- byte swappers ----- */
 
-    /** returns 1 if system is bigendian */
+/** returns 1 if system is bigendian */
 int sys_isbigendian(void);
 
-    /** swap 8 bytes and return if doit = 1, otherwise return n */
+/** swap 8 bytes and return if doit = 1, otherwise return n */
 uint64_t swap8(uint64_t n, int doit);
 
-    /** swap a 64 bit signed int and return if doit = 1, otherwise return n */
+/** swap a 64 bit signed int and return if doit = 1, otherwise return n */
 int64_t swap8s(int64_t n, int doit);
 
-    /** swap 4 bytes and return if doit = 1, otherwise return n */
+/** swap 4 bytes and return if doit = 1, otherwise return n */
 uint32_t swap4(uint32_t n, int doit);
 
-    /** swap a 32 bit signed int and return if doit = 1, otherwise return n */
+/** swap a 32 bit signed int and return if doit = 1, otherwise return n */
 int32_t swap4s(int32_t n, int doit);
 
-    /** swap 2 bytes and return if doit = 1, otherwise return n */
+/** swap 2 bytes and return if doit = 1, otherwise return n */
 uint16_t swap2(uint16_t n, int doit);
 
-    /** swap a 4 byte string in place if doit = 1, otherwise do nothing */
+/** swap a 4 byte string in place if doit = 1, otherwise do nothing */
 void swapstring4(char *foo, int doit);
 
-    /** swap an 8 byte string in place if doit = 1, otherwise do nothing */
+/** swap an 8 byte string in place if doit = 1, otherwise do nothing */
 void swapstring8(char *foo, int doit);

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -162,8 +162,11 @@ static void aiff_set4(uint8_t *dst, uint32_t ui, int swap)
 /** read sample rate from comm chunk 80-bit AIFF-compatible number */
 static double aiff_getsamplerate(const uint8_t *src, int swap)
 {
-    unsigned char temp[10], *p = temp, exponent;
-    unsigned long mantissa, last = 0;
+    unsigned char temp[10];
+    unsigned char *p = temp;
+    unsigned char exponent;
+    unsigned long mantissa;
+    unsigned long last = 0;
 
     memcpy(temp, src, 10);
     swapstring4((char *) p + 2, swap);
@@ -271,8 +274,13 @@ static int aiff_isheader(const char *buf, size_t size)
 /** loop through chunks to find comm and data */
 static int aiff_readheader(t_soundfile *sf)
 {
-    int nchannels = 1, bytespersample = 2, samplerate = 44100, bigendian = 1,
-        swap = !sys_isbigendian(), isaiffc = 0, commfound = 0;
+    int nchannels = 1;
+    int bytespersample = 2;
+    int samplerate = 44100;
+    int bigendian = 1;
+    int swap = !sys_isbigendian();
+    int isaiffc = 0;
+    int commfound = 0;
     off_t headersize = AIFFHEADSIZE;
     size_t bytelimit = AIFFMAXBYTES;
 
@@ -326,7 +334,8 @@ static int aiff_readheader(t_soundfile *sf)
         else if(!strncmp(chunk->c_id, "COMM", 4))
         {
             /* common chunk */
-            int bitspersample, isfloat = 0;
+            int bitspersample;
+            int isfloat = 0;
             t_commchunk *comm = &buf.b_commchunk;
             if(fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
                    buf.b_c + AIFFCHUNKSIZE, chunksize) < chunksize)
@@ -447,8 +456,10 @@ static int aiff_readheader(t_soundfile *sf)
 /** write basic header with order: head [ver] comm data */
 static int aiff_writeheader(t_soundfile *sf, size_t nframes)
 {
-    int isaiffc = aiff_isaiffc(sf), swap = !sys_isbigendian();
-    size_t commsize = AIFFCOMMSIZE, datasize = nframes * sf->sf_bytesperframe;
+    int isaiffc = aiff_isaiffc(sf);
+    int swap = !sys_isbigendian();
+    size_t commsize = AIFFCOMMSIZE;
+    size_t datasize = nframes * sf->sf_bytesperframe;
     off_t headersize = 0;
     ssize_t byteswritten = 0;
     char buf[SFHDRBUFSIZE] = {0};
@@ -525,9 +536,11 @@ static int aiff_writeheader(t_soundfile *sf, size_t nframes)
  * AIFF-C: head version comm data, comm chunk size variable due to str */
 static int aiff_updateheader(t_soundfile *sf, size_t nframes)
 {
-    int isaiffc = aiff_isaiffc(sf), swap = !sys_isbigendian();
-    size_t datasize = nframes * sf->sf_bytesperframe, headersize = AIFFHEADSIZE,
-           commsize = AIFFCOMMSIZE;
+    int isaiffc = aiff_isaiffc(sf);
+    int swap = !sys_isbigendian();
+    size_t datasize = nframes * sf->sf_bytesperframe;
+    size_t headersize = AIFFHEADSIZE;
+    size_t commsize = AIFFCOMMSIZE;
     uint32_t uinttmp;
     int32_t inttmp;
 

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -548,9 +548,13 @@ static int aiff_updateheader(t_soundfile *sf, size_t nframes)
     {
         /* AIFF-C compression info */
         if(sf->sf_bytespersample == 4)
+        {
             commsize += 4 + AIFF_FL32_LEN;
+        }
         else
+        {
             commsize += 4 + AIFF_NONE_LEN;
+        }
         headersize += AIFFVERSIZE;
     }
 

--- a/src/d_soundfile_aiff.c
+++ b/src/d_soundfile_aiff.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette. Updated 2020 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/AIFF.html */
 
@@ -46,97 +46,97 @@
 
 */
 
-    /* explicit byte sizes, sizeof(struct) may return alignment-padded values */
-#define AIFFCHUNKSIZE  8 /**< chunk header only */
-#define AIFFHEADSIZE  12 /**< chunk header and file format only */
-#define AIFFVERSIZE   12 /**< chunk header and data */
-#define AIFFCOMMSIZE  26 /**< chunk header and data */
-#define AIFFDATASIZE  16 /**< chunk header, offset, and block size data */
+/* explicit byte sizes, sizeof(struct) may return alignment-padded values */
+#define AIFFCHUNKSIZE 8 /**< chunk header only */
+#define AIFFHEADSIZE 12 /**< chunk header and file format only */
+#define AIFFVERSIZE 12  /**< chunk header and data */
+#define AIFFCOMMSIZE 26 /**< chunk header and data */
+#define AIFFDATASIZE 16 /**< chunk header, offset, and block size data */
 
-#define AIFFCVER1    0xA2805140 /**< 2726318400 decimal */
+#define AIFFCVER1 0xA2805140    /**< 2726318400 decimal */
 #define AIFFMAXBYTES 0x7fffffff /**< max signed 32 bit size */
 
-     /* compression string defines */
+/* compression string defines */
 #define AIFF_NONE_STR "not compressed"
 #define AIFF_FL32_STR "32-bit floating point"
 
 #define AIFF_NONE_LEN 16 /**< 1 len byte + 15 bytes + 1 \0 pad byte */
 #define AIFF_FL32_LEN 22 /**< 1 len byte + 22 bytes, no pad byte */
 
-    /** basic chunk header, 8 bytes */
+/** basic chunk header, 8 bytes */
 typedef struct _chunk
 {
-    char c_id[4];                    /**< chunk id                     */
-    int32_t c_size;                  /**< chunk data length            */
+    char c_id[4];   /**< chunk id                     */
+    int32_t c_size; /**< chunk data length            */
 } t_chunk;
 
-    /** file head container chunk, 12 bytes */
+/** file head container chunk, 12 bytes */
 typedef struct _head
 {
-    char h_id[4];                    /**< chunk id "FORM"              */
-    int32_t h_size;                  /**< chunk data length            */
-    char h_formtype[4];              /**< format: "AIFF" or "AIFC"     */
+    char h_id[4];       /**< chunk id "FORM"              */
+    int32_t h_size;     /**< chunk data length            */
+    char h_formtype[4]; /**< format: "AIFF" or "AIFC"     */
 } t_head;
 
-    /** common chunk, 26 (AIFF) or 30+ (AIFC) bytes
-        note: sample frames is split to avoid struct alignment padding */
+/** common chunk, 26 (AIFF) or 30+ (AIFC) bytes
+    note: sample frames is split to avoid struct alignment padding */
 typedef struct _commchunk
 {
-    char cc_id[4];                   /**< chunk id "COMM"              */
-    int32_t cc_size;                 /**< chunk data length            */
-    uint16_t cc_nchannels;           /**< number of channels           */
-    uint8_t cc_nframes[4];           /**< # of sample frames, uint32_t */
-    uint16_t cc_bitspersample;       /**< bits per sample              */
-    uint8_t cc_samplerate[10];       /**< sample rate, 80-bit float!   */
+    char cc_id[4];             /**< chunk id "COMM"              */
+    int32_t cc_size;           /**< chunk data length            */
+    uint16_t cc_nchannels;     /**< number of channels           */
+    uint8_t cc_nframes[4];     /**< # of sample frames, uint32_t */
+    uint16_t cc_bitspersample; /**< bits per sample              */
+    uint8_t cc_samplerate[10]; /**< sample rate, 80-bit float!   */
     /* AIFF-C */
-    char cc_comptype[4];             /**< compression type             */
-    char cc_compname[256];           /**< compression name, pascal str */
+    char cc_comptype[4];   /**< compression type             */
+    char cc_compname[256]; /**< compression name, pascal str */
 } t_commchunk;
 
-    /** sound data chunk, min 16 bytes before data */
+/** sound data chunk, min 16 bytes before data */
 typedef struct _datachunk
 {
-    char dc_id[4];                  /**< chunk id "SSND"               */
-    int32_t dc_size;                /**< chunk data length             */
-    uint32_t dc_offset;             /**< additional offset in bytes    */
-    uint32_t dc_block;              /**< block size                    */
+    char dc_id[4];      /**< chunk id "SSND"               */
+    int32_t dc_size;    /**< chunk data length             */
+    uint32_t dc_offset; /**< additional offset in bytes    */
+    uint32_t dc_block;  /**< block size                    */
 } t_datachunk;
 
-    /** AIFF-C format version chunk, 12 bytes */
+/** AIFF-C format version chunk, 12 bytes */
 typedef struct _verchunk
 {
-    char vc_id[4];                  /**< chunk id "FVER"               */
-    int32_t vc_size;                /**< chunk data length, 4 bytes    */
-    uint32_t vc_timestamp;          /**< AIFF-C version timestamp      */
+    char vc_id[4];         /**< chunk id "FVER"               */
+    int32_t vc_size;       /**< chunk data length, 4 bytes    */
+    uint32_t vc_timestamp; /**< AIFF-C version timestamp      */
 } t_verchunk;
 
 /* ----- helpers ----- */
 
-    /** returns 1 if format requires AIFF-C */
+/** returns 1 if format requires AIFF-C */
 static int aiff_isaiffc(const t_soundfile *sf)
 {
     return (!sf->sf_bigendian || sf->sf_bytespersample == 4);
 }
 
-    /** pascal string to c string, max size 256, returns *total* pstring size */
-static int aiff_getpstring(const char* pstring, char *cstring)
+/** pascal string to c string, max size 256, returns *total* pstring size */
+static int aiff_getpstring(const char *pstring, char *cstring)
 {
-    uint8_t len = (uint8_t)pstring[0];
+    uint8_t len = (uint8_t) pstring[0];
     memcpy(cstring, pstring + 1, len);
     cstring[len] = '\0';
-    len++; /* length byte */
-    if (len & 1) len++; /* pad byte */
+    len++;             /* length byte */
+    if(len & 1) len++; /* pad byte */
     return len;
 }
 
-    /** c string to pascal string, max size 256, returns *total* pstring size */
+/** c string to pascal string, max size 256, returns *total* pstring size */
 static int aiff_setpstring(char *pstring, const char *cstring)
 {
     uint8_t len = strlen(cstring);
     pstring[0] = len;
     memcpy(pstring + 1, cstring, len);
     len++; /* length byte */
-    if (len & 1)
+    if(len & 1)
     {
         pstring[len] = '\0'; /* pad byte */
         len++;
@@ -144,7 +144,7 @@ static int aiff_setpstring(char *pstring, const char *cstring)
     return len;
 }
 
-    /** read byte buffer to unsigned 32 bit int */
+/** read byte buffer to unsigned 32 bit int */
 static uint32_t aiff_get4(const uint8_t *src, int swap)
 {
     uint32_t uinttmp = 0;
@@ -152,34 +152,34 @@ static uint32_t aiff_get4(const uint8_t *src, int swap)
     return swap4(uinttmp, swap);
 }
 
-    /** write unsigned 32 bit int to byte buffer */
-static void aiff_set4(uint8_t* dst, uint32_t ui, int swap)
+/** write unsigned 32 bit int to byte buffer */
+static void aiff_set4(uint8_t *dst, uint32_t ui, int swap)
 {
     ui = swap4(ui, swap);
     memcpy(dst, &ui, 4);
 }
 
-    /** read sample rate from comm chunk 80-bit AIFF-compatible number */
+/** read sample rate from comm chunk 80-bit AIFF-compatible number */
 static double aiff_getsamplerate(const uint8_t *src, int swap)
 {
     unsigned char temp[10], *p = temp, exponent;
     unsigned long mantissa, last = 0;
 
     memcpy(temp, src, 10);
-    swapstring4((char *)p + 2, swap);
+    swapstring4((char *) p + 2, swap);
 
-    mantissa = (uint32_t) *((uint32_t *)(p + 2));
+    mantissa = (uint32_t) * ((uint32_t *) (p + 2));
     exponent = 30 - *(p + 1);
-    while (exponent--)
+    while(exponent--)
     {
         last = mantissa;
         mantissa >>= 1;
     }
-    if (last & 0x00000001) mantissa++;
+    if(last & 0x00000001) mantissa++;
     return mantissa;
 }
 
-    /** write a sample rate to comm chunk 80-bit AIFF-compatible number */
+/** write a sample rate to comm chunk 80-bit AIFF-compatible number */
 static void aiff_setsamplerate(uint8_t *dst, double sr)
 {
     int exponent;
@@ -194,55 +194,55 @@ static void aiff_setsamplerate(uint8_t *dst, double sr)
     dst[6] = dst[7] = dst[8] = dst[9] = 0;
 }
 
-    /** read first chunk, returns filled chunk and offset on success or -1 */
+/** read first chunk, returns filled chunk and offset on success or -1 */
 static off_t aiff_firstchunk(const t_soundfile *sf, t_chunk *chunk)
 {
-    if (fd_read(sf->sf_fd, AIFFHEADSIZE, (char *)chunk,
-        AIFFCHUNKSIZE) < AIFFCHUNKSIZE)
+    if(fd_read(sf->sf_fd, AIFFHEADSIZE, (char *) chunk, AIFFCHUNKSIZE) <
+        AIFFCHUNKSIZE)
         return -1;
     return AIFFHEADSIZE;
 }
 
-    /** read next chunk, chunk should be filled when calling
-        returns fills chunk offset on success or -1 */
+/** read next chunk, chunk should be filled when calling
+    returns fills chunk offset on success or -1 */
 static off_t aiff_nextchunk(const t_soundfile *sf, off_t offset, t_chunk *chunk)
 {
     int32_t chunksize = swap4s(chunk->c_size, !sys_isbigendian());
     off_t seekto = offset + AIFFCHUNKSIZE + chunksize;
-    if (seekto & 1) /* pad up to even number of bytes */
+    if(seekto & 1) /* pad up to even number of bytes */
         seekto++;
-    if (fd_read(sf->sf_fd, seekto, (char *)chunk,
-        AIFFCHUNKSIZE) < AIFFCHUNKSIZE)
+    if(fd_read(sf->sf_fd, seekto, (char *) chunk, AIFFCHUNKSIZE) <
+        AIFFCHUNKSIZE)
         return -1;
     return seekto;
 }
 
 #ifdef DEBUG_SOUNDFILE
 
-    /** post chunk info for debugging */
+/** post chunk info for debugging */
 static void aiff_postchunk(const t_chunk *chunk, int swap)
 {
     post("%.4s %d", chunk->c_id, swap4s(chunk->c_size, swap));
 }
 
-    /** post head info for debugging */
+/** post head info for debugging */
 static void aiff_posthead(const t_head *head, int swap)
 {
-    aiff_postchunk((const t_chunk *)head, swap);
+    aiff_postchunk((const t_chunk *) head, swap);
     post("  %.4s", head->h_formtype);
 }
 
-    /** post comm info for debugging */
+/** post comm info for debugging */
 static void aiff_postcomm(const t_commchunk *comm, int isaiffc, int swap)
 {
-    aiff_postchunk((const t_chunk *)comm, swap);
+    aiff_postchunk((const t_chunk *) comm, swap);
     post("  channels %u", swap2(comm->cc_nchannels, swap));
     post("  frames %u", aiff_get4(comm->cc_nframes, swap));
     post("  bits per sample %u", swap2(comm->cc_bitspersample, swap));
     post("  sample rate %g", aiff_getsamplerate(comm->cc_samplerate, swap));
-    if (isaiffc)
+    if(isaiffc)
     {
-            /* handle pascal string */
+        /* handle pascal string */
         char name[256];
         aiff_getpstring(comm->cc_compname, name);
         post("  comp type %.4s", comm->cc_comptype);
@@ -250,10 +250,10 @@ static void aiff_postcomm(const t_commchunk *comm, int isaiffc, int swap)
     }
 }
 
-    /** post sata info for debugging */
+/** post sata info for debugging */
 static void aiff_postdata(const t_datachunk *data, int swap)
 {
-    aiff_postchunk((const t_chunk *)data, swap);
+    aiff_postchunk((const t_chunk *) data, swap);
     post("  offset %u", swap4(data->dc_offset, swap));
     post("  block size %u", swap4(data->dc_block, swap));
 }
@@ -264,17 +264,18 @@ static void aiff_postdata(const t_datachunk *data, int swap)
 
 static int aiff_isheader(const char *buf, size_t size)
 {
-    if (size < 4) return 0;
+    if(size < 4) return 0;
     return !strncmp(buf, "FORM", 4);
 }
 
-    /** loop through chunks to find comm and data */
+/** loop through chunks to find comm and data */
 static int aiff_readheader(t_soundfile *sf)
 {
     int nchannels = 1, bytespersample = 2, samplerate = 44100, bigendian = 1,
         swap = !sys_isbigendian(), isaiffc = 0, commfound = 0;
     off_t headersize = AIFFHEADSIZE;
     size_t bytelimit = AIFFMAXBYTES;
+
     union
     {
         char b_c[SFHDRBUFSIZE];
@@ -284,64 +285,68 @@ static int aiff_readheader(t_soundfile *sf)
         t_verchunk b_verchunk;
         t_datachunk b_datachunk;
     } buf = {0};
+
     t_head *head = &buf.b_head;
     t_chunk *chunk = &buf.b_chunk;
 
-        /* file header */
-    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
-        return 0;
-    if (strncmp(head->h_formtype, "AIFF", 4))
+    /* file header */
+    if(fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize) return 0;
+    if(strncmp(head->h_formtype, "AIFF", 4))
     {
-        if (strncmp(head->h_formtype, "AIFC", 4))
-            return 0;
+        if(strncmp(head->h_formtype, "AIFC", 4)) return 0;
         isaiffc = 1;
     }
 #ifdef DEBUG_SOUNDFILE
     aiff_posthead(head, swap);
 #endif
 
-        /* read chunks in loop until we find the sound data chunk */
-    if ((headersize = aiff_firstchunk(sf, chunk)) == -1)
-        return 0;
-    while (1)
+    /* read chunks in loop until we find the sound data chunk */
+    if((headersize = aiff_firstchunk(sf, chunk)) == -1) return 0;
+    while(1)
     {
         int32_t chunksize = swap4s(chunk->c_size, swap);
         /* post("chunk %.4s seek %d", chunk->c_id, seekto); */
-        if (!strncmp(chunk->c_id, "FVER", 4))
+        if(!strncmp(chunk->c_id, "FVER", 4))
         {
-                /* AIFF-C format version chunk */
-            if (!isaiffc)
+            /* AIFF-C format version chunk */
+            if(!isaiffc)
             {
                 errno = SOUNDFILE_ERRMALFORMED;
                 return 0;
             }
-            if (fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
-                    buf.b_c + AIFFCHUNKSIZE, chunksize) < chunksize)
+            if(fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
+                   buf.b_c + AIFFCHUNKSIZE, chunksize) < chunksize)
                 return 0;
-            if (swap4(buf.b_verchunk.vc_timestamp, swap) != AIFFCVER1)
+            if(swap4(buf.b_verchunk.vc_timestamp, swap) != AIFFCVER1)
             {
                 errno = SOUNDFILE_ERRVERSION;
                 return 0;
             }
         }
-        else if (!strncmp(chunk->c_id, "COMM", 4))
+        else if(!strncmp(chunk->c_id, "COMM", 4))
         {
-                /* common chunk */
+            /* common chunk */
             int bitspersample, isfloat = 0;
             t_commchunk *comm = &buf.b_commchunk;
-            if (fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
-                    buf.b_c + AIFFCHUNKSIZE, chunksize) < chunksize)
+            if(fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
+                   buf.b_c + AIFFCHUNKSIZE, chunksize) < chunksize)
                 return 0;
 #ifdef DEBUG_SOUNDFILE
             aiff_postcomm(comm, isaiffc, swap);
 #endif
             nchannels = swap2(comm->cc_nchannels, swap);
             bitspersample = swap2(comm->cc_bitspersample, swap);
-            switch (bitspersample)
+            switch(bitspersample)
             {
-                case 16: bytespersample = 2; break;
-                case 24: bytespersample = 3; break;
-                case 32: bytespersample = 4; break;
+                case 16:
+                    bytespersample = 2;
+                    break;
+                case 24:
+                    bytespersample = 3;
+                    break;
+                case 32:
+                    bytespersample = 4;
+                    break;
                 default:
                 {
                     errno = SOUNDFILE_ERRSAMPLEFMT;
@@ -349,21 +354,21 @@ static int aiff_readheader(t_soundfile *sf)
                 }
             }
             samplerate = aiff_getsamplerate(comm->cc_samplerate, swap);
-            if (isaiffc)
+            if(isaiffc)
             {
-                if (!strncmp(comm->cc_comptype, "NONE", 4))
+                if(!strncmp(comm->cc_comptype, "NONE", 4))
                 {
-                        /* big endian */
+                    /* big endian */
                 }
-                else if (!strncmp(comm->cc_comptype, "sowt", 4))
+                else if(!strncmp(comm->cc_comptype, "sowt", 4))
                 {
-                        /* little endian */
+                    /* little endian */
                     bigendian = 0;
                 }
-                else if (!strncmp(comm->cc_comptype, "fl32", 4) ||
-                         !strncmp(comm->cc_comptype, "FL32", 4))
+                else if(!strncmp(comm->cc_comptype, "fl32", 4) ||
+                        !strncmp(comm->cc_comptype, "FL32", 4))
                 {
-                    if (bytespersample != 4)
+                    if(bytespersample != 4)
                     {
                         errno = SOUNDFILE_ERRMALFORMED;
                         return 0;
@@ -376,21 +381,21 @@ static int aiff_readheader(t_soundfile *sf)
                     return 0;
                 }
             }
-            if (bytespersample == 4 && !isfloat)
+            if(bytespersample == 4 && !isfloat)
             {
-                    /* 32 bit int */
+                /* 32 bit int */
                 errno = SOUNDFILE_ERRSAMPLEFMT;
                 return 0;
             }
             commfound = 1;
         }
-        else if (!strncmp(chunk->c_id, "SSND", 4))
+        else if(!strncmp(chunk->c_id, "SSND", 4))
         {
-                /* uncompressed sound data chunk */
+            /* uncompressed sound data chunk */
 #ifdef DEBUG_SOUNDFILE
             t_datachunk *data = &buf.b_datachunk;
-            if (fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
-                    buf.b_c + AIFFCHUNKSIZE, 8) < 8)
+            if(fd_read(sf->sf_fd, headersize + AIFFCHUNKSIZE,
+                   buf.b_c + AIFFCHUNKSIZE, 8) < 8)
                 return 0;
             aiff_postdata(data, swap);
 #endif
@@ -398,37 +403,36 @@ static int aiff_readheader(t_soundfile *sf)
             headersize += AIFFDATASIZE;
             break;
         }
-        else if (!strncmp(chunk->c_id, "CSND", 4))
+        else if(!strncmp(chunk->c_id, "CSND", 4))
         {
-                /* AIFF-C compressed sound data chunk */
+            /* AIFF-C compressed sound data chunk */
             errno = SOUNDFILE_ERRSAMPLEFMT;
             return 0;
         }
 #ifdef DEBUG_SOUNDFILE
         else
         {
-                /* everything else */
+            /* everything else */
             aiff_postchunk(chunk, swap);
         }
 #endif
-        if ((headersize = aiff_nextchunk(sf, headersize, chunk)) == -1)
-            return 0;
+        if((headersize = aiff_nextchunk(sf, headersize, chunk)) == -1) return 0;
     }
-    if (!commfound)
+    if(!commfound)
     {
         errno = SOUNDFILE_ERRMALFORMED;
         return 0;
     }
 
-        /* interpret data size from file size? this is not supported by the
-            AIFF spec, but let's do it just in case */
-    if (bytelimit == AIFFMAXBYTES)
+    /* interpret data size from file size? this is not supported by the
+        AIFF spec, but let's do it just in case */
+    if(bytelimit == AIFFMAXBYTES)
     {
         bytelimit = lseek(sf->sf_fd, 0, SEEK_END) - headersize;
-            bytelimit = AIFFMAXBYTES;
+        bytelimit = AIFFMAXBYTES;
     }
 
-        /* copy sample format back to caller */
+    /* copy sample format back to caller */
     sf->sf_samplerate = samplerate;
     sf->sf_nchannels = nchannels;
     sf->sf_bytespersample = bytespersample;
@@ -440,7 +444,7 @@ static int aiff_readheader(t_soundfile *sf)
     return 1;
 }
 
-    /** write basic header with order: head [ver] comm data */
+/** write basic header with order: head [ver] comm data */
 static int aiff_writeheader(t_soundfile *sf, size_t nframes)
 {
     int isaiffc = aiff_isaiffc(sf), swap = !sys_isbigendian();
@@ -450,23 +454,21 @@ static int aiff_writeheader(t_soundfile *sf, size_t nframes)
     char buf[SFHDRBUFSIZE] = {0};
     t_head head = {"FORM", 0, "AIFF"};
     t_commchunk comm = {
-        "COMM", swap4s(18, swap),
-        swap2(sf->sf_nchannels, swap),          /* channels         */
-        {0},                                      /* sample frames    */
+        "COMM", swap4s(18, swap), swap2(sf->sf_nchannels, swap), /* channels */
+        {0},                                    /* sample frames    */
         swap2(sf->sf_bytespersample / 8, swap), /* bits per sample  */
-        {0},                                      /* sample rate      */
-        {0}, {0}                                    /* comp info        */
+        {0},                                    /* sample rate      */
+        {0}, {0}                                /* comp info        */
     };
     t_datachunk data = {"SSND", swap4s(8, swap), 0, 0};
 
-        /* file header */
-    if (isaiffc)
-        strncpy(head.h_formtype, "AIFC", 4);
+    /* file header */
+    if(isaiffc) strncpy(head.h_formtype, "AIFC", 4);
     memcpy(buf + headersize, &head, AIFFHEADSIZE);
     headersize += AIFFHEADSIZE;
 
-        /* format ver chunk */
-    if (isaiffc)
+    /* format ver chunk */
+    if(isaiffc)
     {
         t_verchunk ver = {
             "FVER", swap4s(4, swap),
@@ -476,15 +478,15 @@ static int aiff_writeheader(t_soundfile *sf, size_t nframes)
         headersize += AIFFVERSIZE;
     }
 
-        /* comm chunk */
+    /* comm chunk */
     comm.cc_nchannels = swap2(sf->sf_nchannels, swap);
     aiff_set4(comm.cc_nframes, nframes, swap);
     comm.cc_bitspersample = swap2(8 * sf->sf_bytespersample, swap);
     aiff_setsamplerate(comm.cc_samplerate, sf->sf_samplerate);
-    if (isaiffc)
+    if(isaiffc)
     {
-            /* AIFF-C compression info */
-        if (sf->sf_bytespersample == 4)
+        /* AIFF-C compression info */
+        if(sf->sf_bytespersample == 4)
         {
             strncpy(comm.cc_comptype, "fl32", 4);
             commsize += 4 + aiff_setpstring(comm.cc_compname, AIFF_FL32_STR);
@@ -499,13 +501,13 @@ static int aiff_writeheader(t_soundfile *sf, size_t nframes)
     memcpy(buf + headersize, &comm, commsize);
     headersize += commsize;
 
-        /* data chunk (+ offset & block) */
-    data.dc_size = swap4((uint32_t)(datasize + 8), swap);
+    /* data chunk (+ offset & block) */
+    data.dc_size = swap4((uint32_t) (datasize + 8), swap);
     memcpy(buf + headersize, &data, AIFFDATASIZE);
     headersize += AIFFDATASIZE;
 
-        /* update file header chunk size (- chunk header) */
-    head.h_size = swap4s((int32_t)(headersize + datasize - 8), swap);
+    /* update file header chunk size (- chunk header) */
+    head.h_size = swap4s((int32_t) (headersize + datasize - 8), swap);
     memcpy(buf + 4, &head.h_size, 4);
 
 #ifdef DEBUG_SOUNDFILE
@@ -518,43 +520,40 @@ static int aiff_writeheader(t_soundfile *sf, size_t nframes)
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
-    /** assumes chunk order:
-        * AIFF  : head comm data
-        * AIFF-C: head version comm data, comm chunk size variable due to str */
+/** assumes chunk order:
+ * AIFF  : head comm data
+ * AIFF-C: head version comm data, comm chunk size variable due to str */
 static int aiff_updateheader(t_soundfile *sf, size_t nframes)
 {
     int isaiffc = aiff_isaiffc(sf), swap = !sys_isbigendian();
-    size_t datasize = nframes * sf->sf_bytesperframe,
-           headersize = AIFFHEADSIZE, commsize = AIFFCOMMSIZE;
+    size_t datasize = nframes * sf->sf_bytesperframe, headersize = AIFFHEADSIZE,
+           commsize = AIFFCOMMSIZE;
     uint32_t uinttmp;
     int32_t inttmp;
 
-    if (isaiffc)
+    if(isaiffc)
     {
-            /* AIFF-C compression info */
-        if (sf->sf_bytespersample == 4)
+        /* AIFF-C compression info */
+        if(sf->sf_bytespersample == 4)
             commsize += 4 + AIFF_FL32_LEN;
         else
             commsize += 4 + AIFF_NONE_LEN;
         headersize += AIFFVERSIZE;
     }
 
-        /* num frames */
-    uinttmp = swap4((uint32_t)nframes, swap);
-    if (fd_write(sf->sf_fd, headersize + 10, &uinttmp, 4) < 4)
-        return 0;
+    /* num frames */
+    uinttmp = swap4((uint32_t) nframes, swap);
+    if(fd_write(sf->sf_fd, headersize + 10, &uinttmp, 4) < 4) return 0;
     headersize += commsize;
 
-        /* data chunk size (+ offset & block) */
-    inttmp = swap4s((int32_t)datasize + 8, swap);
-    if (fd_write(sf->sf_fd, headersize + 4, &inttmp, 4) < 4)
-        return 0;
+    /* data chunk size (+ offset & block) */
+    inttmp = swap4s((int32_t) datasize + 8, swap);
+    if(fd_write(sf->sf_fd, headersize + 4, &inttmp, 4) < 4) return 0;
     headersize += AIFFDATASIZE;
 
-        /* file header chunk size (- chunk header) */
-    inttmp = swap4s((int32_t)(headersize + datasize - 8), swap);
-    if (fd_write(sf->sf_fd, 4, &inttmp, 4) < 4)
-        return 0;
+    /* file header chunk size (- chunk header) */
+    inttmp = swap4s((int32_t) (headersize + datasize - 8), swap);
+    if(fd_write(sf->sf_fd, 4, &inttmp, 4) < 4) return 0;
 
 #ifdef DEBUG_SOUNDFILE
     post("FORM %d", headersize + datasize - 8);
@@ -570,15 +569,13 @@ static int aiff_updateheader(t_soundfile *sf, size_t nframes)
 static int aiff_hasextension(const char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len >= 5 &&
-        (!strncmp(filename + (len - 4), ".aif", 4) ||
-         !strncmp(filename + (len - 4), ".AIF", 4)))
+    if(len >= 5 && (!strncmp(filename + (len - 4), ".aif", 4) ||
+                       !strncmp(filename + (len - 4), ".AIF", 4)))
         return 1;
-    if (len >= 6 &&
-        (!strncmp(filename + (len - 5), ".aiff", 5) ||
-         !strncmp(filename + (len - 5), ".aifc", 5) ||
-         !strncmp(filename + (len - 5), ".AIFF", 5) ||
-         !strncmp(filename + (len - 5), ".AIFC", 5)))
+    if(len >= 6 && (!strncmp(filename + (len - 5), ".aiff", 5) ||
+                       !strncmp(filename + (len - 5), ".aifc", 5) ||
+                       !strncmp(filename + (len - 5), ".AIFF", 5) ||
+                       !strncmp(filename + (len - 5), ".AIFC", 5)))
         return 1;
     return 0;
 }
@@ -586,35 +583,23 @@ static int aiff_hasextension(const char *filename, size_t size)
 static int aiff_addextension(char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len + 4 >= size)
-        return 0;
+    if(len + 4 >= size) return 0;
     strcpy(filename + len, ".aif");
     return 1;
 }
 
-    /* default to big endian unless overridden */
+/* default to big endian unless overridden */
 static int aiff_endianness(int endianness)
 {
-    if (endianness == 0)
-        return 0;
+    if(endianness == 0) return 0;
     return 1;
 }
 
 /* ------------------------- setup routine ------------------------ */
 
-static const t_soundfile_type aiff = {
-    "aiff",
-    AIFFHEADSIZE + AIFFCOMMSIZE + AIFFDATASIZE,
-    aiff_isheader,
-    aiff_readheader,
-    aiff_writeheader,
-    aiff_updateheader,
-    aiff_hasextension,
-    aiff_addextension,
-    aiff_endianness
-};
+static const t_soundfile_type aiff = {"aiff",
+    AIFFHEADSIZE + AIFFCOMMSIZE + AIFFDATASIZE, aiff_isheader, aiff_readheader,
+    aiff_writeheader, aiff_updateheader, aiff_hasextension, aiff_addextension,
+    aiff_endianness};
 
-void soundfile_aiff_setup( void)
-{
-    soundfile_addtype(&aiff);
-}
+void soundfile_aiff_setup(void) { soundfile_addtype(&aiff); }

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -197,8 +197,12 @@ static int caf_isheader(const char *buf, size_t size)
 
 static int caf_readheader(t_soundfile *sf)
 {
-    int nchannels = 1, bytespersample = 2, samplerate = 44100, bigendian = 1,
-        fmtflags, swap = !sys_isbigendian();
+    int nchannels = 1;
+    int bytespersample = 2;
+    int samplerate = 44100;
+    int bigendian = 1;
+    int fmtflags;
+    int swap = !sys_isbigendian();
     off_t headersize = CAFHEADSIZE + CAFDESCSIZE;
     ssize_t bytelimit = CAFMAXBYTES;
 
@@ -274,7 +278,8 @@ static int caf_readheader(t_soundfile *sf)
     while(1)
     {
         int64_t chunksize = caf_getchunksize(chunk, swap);
-        off_t seekto = headersize + CAFCHUNKSIZE + chunksize, seekout;
+        off_t seekto = headersize + CAFCHUNKSIZE + chunksize;
+        off_t seekout;
         if(seekto & 1) /* pad up to even number of bytes */
             seekto++;
         /* post("chunk %.4s seek %d", chunk->c_id, seekto); */

--- a/src/d_soundfile_caf.c
+++ b/src/d_soundfile_caf.c
@@ -1,8 +1,10 @@
 /* Copyright (c) 2020 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
-/* ref: https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_spec/CAF_spec.html */
+/* ref:
+ * https://developer.apple.com/library/archive/documentation/MusicAudio/Reference/CAFSpec/CAF_spec/CAF_spec.html
+ */
 
 #include "d_soundfile.h"
 #include <math.h>
@@ -36,39 +38,43 @@
 
 */
 
-    /* explicit byte sizes, sizeof(struct) can return alignment padded values */
-#define CAFHEADSIZE     8 /**< chunk header only */
-#define CAFCHUNKSIZE   12 /**< chunk header and format */
-#define CAFDESCSIZE    44 /**< chunk header and data */
-#define CAFDATASIZE    16 /**< chunk header and edit count data */
+/* explicit byte sizes, sizeof(struct) can return alignment padded values */
+#define CAFHEADSIZE 8   /**< chunk header only */
+#define CAFCHUNKSIZE 12 /**< chunk header and format */
+#define CAFDESCSIZE 44  /**< chunk header and data */
+#define CAFDATASIZE 16  /**< chunk header and edit count data */
 
 #define CAFMAXBYTES SFMAXBYTES /** max signed 64 bit size */
 
 #define CAF_UNKNOWN_SIZE 0xffffffffffffffff /** aka -1 */
 
-    /** Apple-style description format flags */
-enum {
-    kCAFLinearPCMFormatFlagIsFloat        = (1L << 0),
+/** Apple-style description format flags */
+enum
+{
+    kCAFLinearPCMFormatFlagIsFloat = (1L << 0),
     kCAFLinearPCMFormatFlagIsLittleEndian = (1L << 1)
 };
 
-    /** basic chunk header, 12 bytes
-        note: size is split to avoid struct alignment padding */
-typedef struct _chunk {
-    char c_id[4];                /**< chunk id                        */
-    uint8_t c_size[8];           /**< chunk data length, int64_t      */
+/** basic chunk header, 12 bytes
+    note: size is split to avoid struct alignment padding */
+typedef struct _chunk
+{
+    char c_id[4];      /**< chunk id                        */
+    uint8_t c_size[8]; /**< chunk data length, int64_t      */
 } t_chunk;
 
-    /** file head container chunk, 8 bytes */
-typedef struct _head {
-    char h_id[4];                /**< file id "caff"                  */
-    uint16_t h_version;          /**< file version, probably 1        */
-    uint16_t h_flags;            /**< format flags, 0 for CAF v1      */
+/** file head container chunk, 8 bytes */
+typedef struct _head
+{
+    char h_id[4];       /**< file id "caff"                  */
+    uint16_t h_version; /**< file version, probably 1        */
+    uint16_t h_flags;   /**< format flags, 0 for CAF v1      */
 } t_head;
 
-    /** description chunk, 44 bytes
-        note: size and samplerate are split to avoid struct alignment padding */
-typedef struct _descchunk {
+/** description chunk, 44 bytes
+    note: size and samplerate are split to avoid struct alignment padding */
+typedef struct _descchunk
+{
     char ds_id[4];               /**< chunk id "desc"                 */
     uint8_t ds_size[8];          /**< chunk data length, int64_t      */
     uint8_t ds_samplerate[8];    /**< sample rate, double             */
@@ -80,12 +86,13 @@ typedef struct _descchunk {
     uint32_t ds_bitsperchannel;  /**< bits per chan in 1 sample frame */
 } t_descchunk;
 
-    /** data chunk, min 16 bytes
-        note: size is split to avoid struct alignment padding */
-typedef struct _datachunk {
-    char dc_id[4];               /**< chunk id "data"                 */
-    uint8_t dc_size[8];          /**< chunk data length, int64_t      */
-    uint32_t dc_editcount;       /**< edit count, set 0 for none      */
+/** data chunk, min 16 bytes
+    note: size is split to avoid struct alignment padding */
+typedef struct _datachunk
+{
+    char dc_id[4];         /**< chunk id "data"                 */
+    uint8_t dc_size[8];    /**< chunk data length, int64_t      */
+    uint32_t dc_editcount; /**< edit count, set 0 for none      */
 } t_datachunk;
 
 /* ----- helpers ----- */
@@ -107,42 +114,41 @@ static double caf_getsamplerate(const t_descchunk *desc, int swap)
 {
     double sr = 0;
     memcpy(&sr, desc->ds_samplerate, 8);
-    swapstring8((char *)&sr, swap);
+    swapstring8((char *) &sr, swap);
     return sr;
 }
 
 static void caf_setsamplerate(t_descchunk *desc, double sr, int swap)
 {
     memcpy(desc->ds_samplerate, &sr, 8);
-    swapstring8((char *)desc->ds_samplerate, swap);
+    swapstring8((char *) desc->ds_samplerate, swap);
 }
 
-    /** read first chunk, returns filled chunk and offset on success or -1 */
+/** read first chunk, returns filled chunk and offset on success or -1 */
 static off_t caf_firstchunk(const t_soundfile *sf, t_chunk *chunk)
 {
-    if (fd_read(sf->sf_fd, CAFHEADSIZE, (char *)chunk,
-        CAFCHUNKSIZE) < CAFCHUNKSIZE)
+    if(fd_read(sf->sf_fd, CAFHEADSIZE, (char *) chunk, CAFCHUNKSIZE) <
+        CAFCHUNKSIZE)
         return -1;
     return CAFHEADSIZE;
 }
 
-    /** read next chunk, chunk should be filled when calling
-        returns fills chunk offset on success or -1 */
+/** read next chunk, chunk should be filled when calling
+    returns fills chunk offset on success or -1 */
 static off_t caf_nextchunk(const t_soundfile *sf, off_t offset, t_chunk *chunk)
 {
     int64_t chunksize = caf_getchunksize(chunk, !sys_isbigendian());
     off_t seekto = offset + CAFCHUNKSIZE + chunksize;
-    if (seekto & 1) /* pad up to even number of bytes */
+    if(seekto & 1) /* pad up to even number of bytes */
         seekto++;
-    if (fd_read(sf->sf_fd, seekto, (char *)chunk,
-        CAFCHUNKSIZE) < CAFCHUNKSIZE)
+    if(fd_read(sf->sf_fd, seekto, (char *) chunk, CAFCHUNKSIZE) < CAFCHUNKSIZE)
         return -1;
     return seekto;
 }
 
 #ifdef DEBUG_SOUNDFILE
 
-    /** post head info for debugging */
+/** post head info for debugging */
 static void caf_posthead(const t_head *head, int swap)
 {
     post("%.4s", head->h_id);
@@ -150,17 +156,17 @@ static void caf_posthead(const t_head *head, int swap)
     post("  flags %d", swap2(head->h_flags, swap));
 }
 
-    /** post chunk info for debugging */
+/** post chunk info for debugging */
 static void caf_postchunk(const t_chunk *chunk, int swap)
 {
     post("%.4s %" PRId64, chunk->c_id, caf_getchunksize(chunk, swap));
 }
 
-    /** post desc info for debugging */
+/** post desc info for debugging */
 static void caf_postdesc(const t_descchunk *desc, int swap)
 {
     uint32_t fmtflags = swap4(desc->ds_fmtflags, swap);
-    caf_postchunk((t_chunk *)desc, swap);
+    caf_postchunk((t_chunk *) desc, swap);
     post("  sample rate %g", caf_getsamplerate(desc, swap));
     post("  fmt id %.4s", desc->ds_fmtid);
     post("  fmt flags %d (%s %s)", fmtflags,
@@ -172,10 +178,10 @@ static void caf_postdesc(const t_descchunk *desc, int swap)
     post("  bits per channel %d", swap4(desc->ds_bitsperchannel, swap));
 }
 
-    /** post data header info for debugging, currently edit count only */
+/** post data header info for debugging, currently edit count only */
 static void caf_postdata(const t_datachunk *data, int swap)
 {
-    caf_postchunk((t_chunk *)data, swap);
+    caf_postchunk((t_chunk *) data, swap);
     post("  edit count %d", swap4(data->dc_editcount, swap));
 }
 
@@ -185,7 +191,7 @@ static void caf_postdata(const t_datachunk *data, int swap)
 
 static int caf_isheader(const char *buf, size_t size)
 {
-    if (size < 4) return 0;
+    if(size < 4) return 0;
     return !strncmp(buf, "caff", 4);
 }
 
@@ -195,6 +201,7 @@ static int caf_readheader(t_soundfile *sf)
         fmtflags, swap = !sys_isbigendian();
     off_t headersize = CAFHEADSIZE + CAFDESCSIZE;
     ssize_t bytelimit = CAFMAXBYTES;
+
     union
     {
         char b_c[SFHDRBUFSIZE];
@@ -203,23 +210,22 @@ static int caf_readheader(t_soundfile *sf)
         t_descchunk b_descchunk;
         t_datachunk b_datachunk;
     } buf = {0};
+
     t_head *head = &buf.b_head;
     t_chunk *chunk = &buf.b_chunk;
     t_descchunk *desc = &buf.b_descchunk;
 
-        /* file header */
-    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
-        return 0;
-    if (strncmp(head->h_id, "caff", 4))
-        return 0;
-    if (swap2(head->h_version, swap) != 1)
+    /* file header */
+    if(fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize) return 0;
+    if(strncmp(head->h_id, "caff", 4)) return 0;
+    if(swap2(head->h_version, swap) != 1)
     {
         errno = SOUNDFILE_ERRVERSION;
         return 0;
     }
-    if (swap2(head->h_flags, swap) != 0)
+    if(swap2(head->h_flags, swap) != 0)
     {
-            /* current spec says these should be empty */
+        /* current spec says these should be empty */
         errno = SOUNDFILE_ERRVERSION;
         return 0;
     }
@@ -227,18 +233,17 @@ static int caf_readheader(t_soundfile *sf)
     caf_posthead(head, swap);
 #endif
 
-        /* copy the first chunk header to beginning of buffer,
-           use memmove as src & dst are the same */
+    /* copy the first chunk header to beginning of buffer,
+       use memmove as src & dst are the same */
     memmove(buf.b_c, buf.b_c + CAFHEADSIZE, CAFDESCSIZE);
     headersize = CAFHEADSIZE;
 
-        /* first chunk must be description */
-    if (strncmp(desc->ds_id, "desc", 4))
-        return 0;
+    /* first chunk must be description */
+    if(strncmp(desc->ds_id, "desc", 4)) return 0;
 #ifdef DEBUG_SOUNDFILE
     caf_postdesc(desc, swap);
 #endif
-    if (strncmp(desc->ds_fmtid, "lpcm", 4))
+    if(strncmp(desc->ds_fmtid, "lpcm", 4))
     {
         errno = SOUNDFILE_ERRSAMPLEFMT;
         return 0;
@@ -246,14 +251,17 @@ static int caf_readheader(t_soundfile *sf)
     nchannels = swap4(desc->ds_nchannels, swap);
     fmtflags = swap4(desc->ds_fmtflags, swap);
     bytespersample = swap4(desc->ds_bitsperchannel, swap) / 8;
-    switch (bytespersample)
+    switch(bytespersample)
     {
-        case 2: case 3: case 4: break;
+        case 2:
+        case 3:
+        case 4:
+            break;
         default:
             errno = SOUNDFILE_ERRSAMPLEFMT;
             return 0;
     }
-    if (bytespersample == 4 && !(fmtflags & kCAFLinearPCMFormatFlagIsFloat))
+    if(bytespersample == 4 && !(fmtflags & kCAFLinearPCMFormatFlagIsFloat))
     {
         errno = SOUNDFILE_ERRSAMPLEFMT;
         return 0;
@@ -261,32 +269,31 @@ static int caf_readheader(t_soundfile *sf)
     bigendian = !(fmtflags & kCAFLinearPCMFormatFlagIsLittleEndian);
     samplerate = caf_getsamplerate(desc, swap);
 
-        /* read chunks in loop until we find the sound data chunk */
-    if ((headersize = caf_nextchunk(sf, headersize, chunk)) == -1)
-        return 0;
-    while (1)
+    /* read chunks in loop until we find the sound data chunk */
+    if((headersize = caf_nextchunk(sf, headersize, chunk)) == -1) return 0;
+    while(1)
     {
         int64_t chunksize = caf_getchunksize(chunk, swap);
         off_t seekto = headersize + CAFCHUNKSIZE + chunksize, seekout;
-        if (seekto & 1) /* pad up to even number of bytes */
+        if(seekto & 1) /* pad up to even number of bytes */
             seekto++;
         /* post("chunk %.4s seek %d", chunk->c_id, seekto); */
-        if (!strncmp(chunk->c_id, "data", 4))
+        if(!strncmp(chunk->c_id, "data", 4))
         {
-                /* sound data chunk */
+            /* sound data chunk */
 #ifdef DEBUG_SOUNDFILE
             t_datachunk *data = &buf.b_datachunk;
-            if (fd_read(sf->sf_fd, headersize + CAFCHUNKSIZE,
-                    buf.b_c + CAFCHUNKSIZE, 4) < 4)
+            if(fd_read(sf->sf_fd, headersize + CAFCHUNKSIZE,
+                   buf.b_c + CAFCHUNKSIZE, 4) < 4)
                 return 0;
             caf_postdata(data, swap);
 #endif
             headersize += CAFDATASIZE;
-            if (chunksize == CAF_UNKNOWN_SIZE)
+            if(chunksize == CAF_UNKNOWN_SIZE)
             {
-                    /* interpret data size from file size */
+                /* interpret data size from file size */
                 bytelimit = lseek(sf->sf_fd, 0, SEEK_END) - headersize;
-                if (bytelimit > CAFMAXBYTES || bytelimit < 0)
+                if(bytelimit > CAFMAXBYTES || bytelimit < 0)
                     bytelimit = CAFMAXBYTES;
             }
             else
@@ -296,15 +303,14 @@ static int caf_readheader(t_soundfile *sf)
 #ifdef DEBUG_SOUNDFILE
         else
         {
-                /* everything else */
+            /* everything else */
             caf_postchunk(chunk, swap);
         }
 #endif
-        if ((headersize = caf_nextchunk(sf, headersize, chunk)) == -1)
-            return 0;
+        if((headersize = caf_nextchunk(sf, headersize, chunk)) == -1) return 0;
     }
 
-        /* copy sample format back to caller */
+    /* copy sample format back to caller */
     sf->sf_samplerate = samplerate;
     sf->sf_nchannels = nchannels;
     sf->sf_bytespersample = bytespersample;
@@ -329,18 +335,16 @@ static int caf_writeheader(t_soundfile *sf, size_t nframes)
     t_descchunk desc = {"desc", {0}, {0}};
     t_datachunk data = {"data", {0}, 0};
 
-        /* file header */
+    /* file header */
     memcpy(buf + headersize, &head, CAFHEADSIZE);
     headersize += CAFHEADSIZE;
 
-        /* description chunk */
-    caf_setchunksize((t_chunk *)&desc, CAFDESCSIZE - CAFCHUNKSIZE, swap);
+    /* description chunk */
+    caf_setchunksize((t_chunk *) &desc, CAFDESCSIZE - CAFCHUNKSIZE, swap);
     caf_setsamplerate(&desc, sf->sf_samplerate, swap);
     strncpy(desc.ds_fmtid, "lpcm", 4);
-    if (sf->sf_bytespersample == 4)
-        uinttmp |= kCAFLinearPCMFormatFlagIsFloat;
-    if (!sf->sf_bigendian)
-        uinttmp |= kCAFLinearPCMFormatFlagIsLittleEndian;
+    if(sf->sf_bytespersample == 4) uinttmp |= kCAFLinearPCMFormatFlagIsFloat;
+    if(!sf->sf_bigendian) uinttmp |= kCAFLinearPCMFormatFlagIsLittleEndian;
     desc.ds_fmtflags = swap4(uinttmp, swap);
     desc.ds_bytesperpacket = swap4(sf->sf_bytesperframe, swap);
     desc.ds_framesperpacket = swap4(1, swap);
@@ -349,8 +353,8 @@ static int caf_writeheader(t_soundfile *sf, size_t nframes)
     memcpy(buf + headersize, &desc, CAFDESCSIZE);
     headersize += CAFDESCSIZE;
 
-        /* data chunk (+ edit count) */
-    caf_setchunksize((t_chunk *)&data, datasize + 4, swap);
+    /* data chunk (+ edit count) */
+    caf_setchunksize((t_chunk *) &data, datasize + 4, swap);
     memcpy(buf + headersize, &data, CAFDATASIZE);
     headersize += CAFDATASIZE;
 
@@ -364,14 +368,14 @@ static int caf_writeheader(t_soundfile *sf, size_t nframes)
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
-    /** assumes chunk order: head desc data */
+/** assumes chunk order: head desc data */
 static int caf_updateheader(t_soundfile *sf, size_t nframes)
 {
     int swap = !sys_isbigendian();
     int64_t datasize = swap8s((nframes * sf->sf_bytesperframe) + 4, swap);
 
-        /* data chunk size (+ edit count) */
-    if (fd_write(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4, &datasize, 8) < 8)
+    /* data chunk size (+ edit count) */
+    if(fd_write(sf->sf_fd, CAFHEADSIZE + CAFDESCSIZE + 4, &datasize, 8) < 8)
         return 0;
 
 #ifdef DEBUG_SOUNDFILE
@@ -385,9 +389,8 @@ static int caf_updateheader(t_soundfile *sf, size_t nframes)
 static int caf_hasextension(const char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len >= 5 &&
-        (!strncmp(filename + (len - 4), ".caf", 4) ||
-         !strncmp(filename + (len - 4), ".CAF", 4)))
+    if(len >= 5 && (!strncmp(filename + (len - 4), ".caf", 4) ||
+                       !strncmp(filename + (len - 4), ".CAF", 4)))
         return 1;
     return 0;
 }
@@ -395,35 +398,23 @@ static int caf_hasextension(const char *filename, size_t size)
 static int caf_addextension(char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len + 4 >= size)
-        return 0;
+    if(len + 4 >= size) return 0;
     strcpy(filename + len, ".caf");
     return 1;
 }
 
-    /* default to big endian if not specified */
+/* default to big endian if not specified */
 static int caf_endianness(int endianness)
 {
-    if (endianness == -1)
-        return 1;
+    if(endianness == -1) return 1;
     return endianness;
 }
 
 /* ------------------------- setup routine ------------------------ */
 
-static const t_soundfile_type caf = {
-    "caf",
-    CAFHEADSIZE + CAFDESCSIZE + CAFDATASIZE,
-    caf_isheader,
-    caf_readheader,
-    caf_writeheader,
-    caf_updateheader,
-    caf_hasextension,
-    caf_addextension,
-    caf_endianness
-};
+static const t_soundfile_type caf = {"caf",
+    CAFHEADSIZE + CAFDESCSIZE + CAFDATASIZE, caf_isheader, caf_readheader,
+    caf_writeheader, caf_updateheader, caf_hasextension, caf_addextension,
+    caf_endianness};
 
-void soundfile_caf_setup( void)
-{
-    soundfile_addtype(&caf);
-}
+void soundfile_caf_setup(void) { soundfile_addtype(&caf); }

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -119,7 +119,10 @@ static int next_isheader(const char *buf, size_t size)
 
 static int next_readheader(t_soundfile *sf)
 {
-    int format, bytespersample, bigendian = 1, swap = 0;
+    int format;
+    int bytespersample;
+    int bigendian = 1;
+    int swap = 0;
     off_t headersize = NEXTHEADSIZE;
     size_t bytelimit = NEXTMAXBYTES;
 

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -65,8 +65,7 @@ static int next_isbigendian(const t_nextstep *next)
 {
     if(!strncmp(next->ns_id, ".snd", 4))
         return 1;
-    else if(!strncmp(next->ns_id, "dns.", 4))
-        return 0;
+    if(!strncmp(next->ns_id, "dns.", 4)) return 0;
     return -1;
 }
 

--- a/src/d_soundfile_next.c
+++ b/src/d_soundfile_next.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette. Updated 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* refs: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AU/AU.html
          https://pubs.opengroup.org/external/auformat.html
@@ -36,14 +36,14 @@
 
 */
 
-    /* explicit byte sizes, sizeof(struct) may return alignment padded values */
+/* explicit byte sizes, sizeof(struct) may return alignment padded values */
 #define NEXTHEADSIZE 28 /**< min valid header size + info string */
 
 #define NEXTMAXBYTES 0xffffffff /**< max unsigned 32 bit size */
 
 #define NEXT_FORMAT_LINEAR_16 3 /**< 16 bit int */
 #define NEXT_FORMAT_LINEAR_24 4 /**< 24 bit int */
-#define NEXT_FORMAT_FLOAT     6 /**< 32 bit float */
+#define NEXT_FORMAT_FLOAT 6     /**< 32 bit float */
 
 #define NEXT_UNKNOWN_SIZE 0xffffffff /** aka -1 */
 
@@ -60,10 +60,10 @@ typedef struct _nextstep
 
 /* ----- helpers ----- */
 
-    /** returns 1 if big endian, 0 if little endian, or -1 for bad header */
+/** returns 1 if big endian, 0 if little endian, or -1 for bad header */
 static int next_isbigendian(const t_nextstep *next)
 {
-    if (!strncmp(next->ns_id, ".snd", 4))
+    if(!strncmp(next->ns_id, ".snd", 4))
         return 1;
     else if(!strncmp(next->ns_id, "dns.", 4))
         return 0;
@@ -72,7 +72,7 @@ static int next_isbigendian(const t_nextstep *next)
 
 #ifdef DEBUG_SOUNDFILE
 
-    /** post head info for debugging */
+/** post head info for debugging */
 static void next_posthead(const t_nextstep *next, int swap)
 {
     uint32_t onset = swap4(next->ns_onset, swap),
@@ -81,11 +81,11 @@ static void next_posthead(const t_nextstep *next, int swap)
     post("next %.4s (%s)", next->ns_id,
         (next_isbigendian(next) ? "big" : "little"));
     post("  data onset %d", onset);
-    if (datasize == NEXT_UNKNOWN_SIZE)
+    if(datasize == NEXT_UNKNOWN_SIZE)
         post("  data length -1");
     else
         post("  data length %d", datasize);
-    switch (format)
+    switch(format)
     {
         case NEXT_FORMAT_LINEAR_16:
             post("  format %d (16 bit int)", format);
@@ -102,8 +102,8 @@ static void next_posthead(const t_nextstep *next, int swap)
     }
     post("  sample rate %d", swap4(next->ns_samplerate, swap));
     post("  channels %d", swap4(next->ns_nchannels, swap));
-    post("  info \"%.4s%s\"",
-        next->ns_info, (onset > NEXTHEADSIZE ? "..." : ""));
+    post("  info \"%.4s%s\"", next->ns_info,
+        (onset > NEXTHEADSIZE ? "..." : ""));
 }
 
 #endif /* DEBUG_SOUNDFILE */
@@ -112,9 +112,8 @@ static void next_posthead(const t_nextstep *next, int swap)
 
 static int next_isheader(const char *buf, size_t size)
 {
-    if (size < 4) return 0;
-    if (!strncmp(buf, ".snd", 4) || !strncmp(buf, "dns.", 4))
-        return 1;
+    if(size < 4) return 0;
+    if(!strncmp(buf, ".snd", 4) || !strncmp(buf, "dns.", 4)) return 1;
     return 0;
 }
 
@@ -123,40 +122,45 @@ static int next_readheader(t_soundfile *sf)
     int format, bytespersample, bigendian = 1, swap = 0;
     off_t headersize = NEXTHEADSIZE;
     size_t bytelimit = NEXTMAXBYTES;
+
     union
     {
         char b_c[SFHDRBUFSIZE];
         t_nextstep b_nextstep;
     } buf = {0};
+
     t_nextstep *next = &buf.b_nextstep;
 
-    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
-        return 0;
+    if(fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize) return 0;
 
     bigendian = next_isbigendian(next);
-    if (bigendian < 0)
-        return 0;
+    if(bigendian < 0) return 0;
     swap = (bigendian != sys_isbigendian());
 
     headersize = swap4(next->ns_onset, swap);
-    if (headersize < NEXTHEADSIZE - 4) /* min valid header w/o info string */
+    if(headersize < NEXTHEADSIZE - 4) /* min valid header w/o info string */
         return 0;
 
     bytelimit = swap4(next->ns_length, swap);
-    if (bytelimit == NEXT_UNKNOWN_SIZE)
+    if(bytelimit == NEXT_UNKNOWN_SIZE)
     {
-            /* interpret data size from file size */
+        /* interpret data size from file size */
         bytelimit = lseek(sf->sf_fd, 0, SEEK_END) - headersize;
-        if (bytelimit > NEXTMAXBYTES || bytelimit < 0)
-            bytelimit = NEXTMAXBYTES;
+        if(bytelimit > NEXTMAXBYTES || bytelimit < 0) bytelimit = NEXTMAXBYTES;
     }
 
     format = swap4(next->ns_format, swap);
-    switch (format)
+    switch(format)
     {
-        case NEXT_FORMAT_LINEAR_16: bytespersample = 2; break;
-        case NEXT_FORMAT_LINEAR_24: bytespersample = 3; break;
-        case NEXT_FORMAT_FLOAT:     bytespersample = 4; break;
+        case NEXT_FORMAT_LINEAR_16:
+            bytespersample = 2;
+            break;
+        case NEXT_FORMAT_LINEAR_24:
+            bytespersample = 3;
+            break;
+        case NEXT_FORMAT_FLOAT:
+            bytespersample = 4;
+            break;
         default:
             errno = SOUNDFILE_ERRSAMPLEFMT;
             return 0;
@@ -166,7 +170,7 @@ static int next_readheader(t_soundfile *sf)
     next_posthead(next, swap);
 #endif
 
-        /* copy sample format back to caller */
+    /* copy sample format back to caller */
     sf->sf_samplerate = swap4(next->ns_samplerate, swap);
     sf->sf_nchannels = swap4(next->ns_nchannels, swap);
     sf->sf_bytespersample = bytespersample;
@@ -186,18 +190,17 @@ static int next_writeheader(t_soundfile *sf, size_t nframes)
     off_t headersize = NEXTHEADSIZE;
     ssize_t byteswritten = 0;
     t_nextstep next = {
-        ".snd",                                   /* id          */
-        swap4((uint32_t)headersize, swap),        /* data onset  */
-        swap4((uint32_t)datasize, swap),          /* data length */
-        0,                                        /* format      */
-        swap4((uint32_t)sf->sf_samplerate, swap), /* sample rate */
-        swap4((uint32_t)sf->sf_nchannels, swap),  /* channels    */
-        "Pd "                                     /* info string */
+        ".snd",                                    /* id          */
+        swap4((uint32_t) headersize, swap),        /* data onset  */
+        swap4((uint32_t) datasize, swap),          /* data length */
+        0,                                         /* format      */
+        swap4((uint32_t) sf->sf_samplerate, swap), /* sample rate */
+        swap4((uint32_t) sf->sf_nchannels, swap),  /* channels    */
+        "Pd "                                      /* info string */
     };
 
-    if (!sf->sf_bigendian)
-        swapstring4(next.ns_id, 1);
-    switch (sf->sf_bytespersample)
+    if(!sf->sf_bigendian) swapstring4(next.ns_id, 1);
+    switch(sf->sf_bytespersample)
     {
         case 2:
             next.ns_format = swap4(NEXT_FORMAT_LINEAR_16, swap);
@@ -220,24 +223,22 @@ static int next_writeheader(t_soundfile *sf, size_t nframes)
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
-    /** the data length is limited to 4 bytes, so if the size is too large,
-        do it the lazy way: just set the size field to "unknown size" */
+/** the data length is limited to 4 bytes, so if the size is too large,
+    do it the lazy way: just set the size field to "unknown size" */
 static int next_updateheader(t_soundfile *sf, size_t nframes)
 {
     int swap = soundfile_needsbyteswap(sf);
     size_t datasize = nframes * sf->sf_bytesperframe;
 
-    if (datasize > NEXTMAXBYTES)
-        datasize = NEXT_UNKNOWN_SIZE;
+    if(datasize > NEXTMAXBYTES) datasize = NEXT_UNKNOWN_SIZE;
     datasize = swap4(datasize, swap);
-    if (fd_write(sf->sf_fd, 8, &datasize, 4) < 4)
-        return 0;
+    if(fd_write(sf->sf_fd, 8, &datasize, 4) < 4) return 0;
 
 #ifdef DEBUG_SOUNDFILE
     datasize = swap4(datasize, swap);
     post("next %.4s (%s)", (sf->sf_bigendian ? ".snd" : "dns."),
         (sf->sf_bigendian ? "big" : "little"));
-    if (datasize == NEXT_UNKNOWN_SIZE)
+    if(datasize == NEXT_UNKNOWN_SIZE)
         post("  data length -1");
     else
         post("  data length %d", datasize);
@@ -249,13 +250,11 @@ static int next_updateheader(t_soundfile *sf, size_t nframes)
 static int next_hasextension(const char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len >= 4 &&
-        (!strncmp(filename + (len - 3), ".au", 3) ||
-         !strncmp(filename + (len - 3), ".AU", 3)))
+    if(len >= 4 && (!strncmp(filename + (len - 3), ".au", 3) ||
+                       !strncmp(filename + (len - 3), ".AU", 3)))
         return 1;
-    if (len >= 5 &&
-        (!strncmp(filename + (len - 4), ".snd", 4) ||
-         !strncmp(filename + (len - 4), ".SND", 4)))
+    if(len >= 5 && (!strncmp(filename + (len - 4), ".snd", 4) ||
+                       !strncmp(filename + (len - 4), ".SND", 4)))
         return 1;
     return 0;
 }
@@ -263,35 +262,22 @@ static int next_hasextension(const char *filename, size_t size)
 static int next_addextension(char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len + 4 >= size)
-        return 0;
+    if(len + 4 >= size) return 0;
     strcpy(filename + len, ".snd");
     return 1;
 }
 
-    /* machine native if not specified */
+/* machine native if not specified */
 static int next_endianness(int endianness)
 {
-    if (endianness == -1)
-        return sys_isbigendian();
+    if(endianness == -1) return sys_isbigendian();
     return endianness;
 }
 
 /* ------------------------- setup routine ------------------------ */
 
-t_soundfile_type next = {
-    "next",
-    NEXTHEADSIZE - 4, /* - info string */
-    next_isheader,
-    next_readheader,
-    next_writeheader,
-    next_updateheader,
-    next_hasextension,
-    next_addextension,
-    next_endianness
-};
+t_soundfile_type next = {"next", NEXTHEADSIZE - 4, /* - info string */
+    next_isheader, next_readheader, next_writeheader, next_updateheader,
+    next_hasextension, next_addextension, next_endianness};
 
-void soundfile_next_setup( void)
-{
-    soundfile_addtype(&next);
-}
+void soundfile_next_setup(void) { soundfile_addtype(&next); }

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette. Updated 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* ref: http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html */
 
@@ -47,17 +47,17 @@
 
 */
 
-    /* explicit byte sizes, sizeof(struct) may return alignment-padded values */
-#define WAVECHUNKSIZE   8 /**< chunk header only */
-#define WAVEHEADSIZE   12 /**< chunk header and file format only */
+/* explicit byte sizes, sizeof(struct) may return alignment-padded values */
+#define WAVECHUNKSIZE 8   /**< chunk header only */
+#define WAVEHEADSIZE 12   /**< chunk header and file format only */
 #define WAVEFORMATSIZE 24 /**< chunk header and data */
-#define WAVEFACTSIZE   12 /**< chunk header and data */
+#define WAVEFACTSIZE 12   /**< chunk header and data */
 
 #define WAVEMAXBYTES 0xffffffff /**< max unsigned 32 bit size */
 
-#define WAVE_FORMAT_PCM   0x0001 /**< 16 or 24 bit int */
+#define WAVE_FORMAT_PCM 0x0001   /**< 16 or 24 bit int */
 #define WAVE_FORMAT_FLOAT 0x0003 /**< 32 bit float */
-#define WAVE_FORMAT_EXT   0xfffe /**< extended, see format chunk subformat */
+#define WAVE_FORMAT_EXT 0xfffe   /**< extended, see format chunk subformat */
 
 /** extended format header and data length */
 #define WAVE_EXT_SIZE 24
@@ -65,99 +65,99 @@
 /** 14 byte extended subformat GUID */
 #define WAVE_EXT_GUID "\x00\x00\x00\x00\x10\x00\x80\x00\x00\xAA\x00\x38\x9B\x71"
 
-    /** basic chunk header, 8 bytes */
+/** basic chunk header, 8 bytes */
 typedef struct _chunk
 {
-    char c_id[4];                  /**< data chunk id                   */
-    uint32_t c_size;               /**< length of data chunk            */
+    char c_id[4];    /**< data chunk id                   */
+    uint32_t c_size; /**< length of data chunk            */
 } t_chunk;
 
-    /** file head container chunk, 12 bytes */
+/** file head container chunk, 12 bytes */
 typedef struct _head
 {
-    char h_id[4];                   /**< chunk id "RIFF"                */
-    uint32_t h_size;                /**< chunk data length              */
-    char h_formtype[4];             /**< format: "WAVE"                 */
+    char h_id[4];       /**< chunk id "RIFF"                */
+    uint32_t h_size;    /**< chunk data length              */
+    char h_formtype[4]; /**< format: "WAVE"                 */
 } t_head;
 
-    /** format chunk, 24 (basic) or 48 (extended) */
+/** format chunk, 24 (basic) or 48 (extended) */
 typedef struct _formatchunk
 {
-    char fc_id[4];                   /**< chunk id "fmt "               */
-    uint32_t fc_size;                /**< chunk data length             */
-    uint16_t fc_fmttag;              /**< format tag                    */
-    uint16_t fc_nchannels;           /**< number of channels            */
-    uint32_t fc_samplerate;          /**< sample rate in hz             */
-    uint32_t fc_bytespersecond;      /**< average bytes per second      */
-    uint16_t fc_blockalign;          /**< number of bytes per frame     */
-    uint16_t fc_bitspersample;       /**< number of bits in a sample    */
+    char fc_id[4];              /**< chunk id "fmt "               */
+    uint32_t fc_size;           /**< chunk data length             */
+    uint16_t fc_fmttag;         /**< format tag                    */
+    uint16_t fc_nchannels;      /**< number of channels            */
+    uint32_t fc_samplerate;     /**< sample rate in hz             */
+    uint32_t fc_bytespersecond; /**< average bytes per second      */
+    uint16_t fc_blockalign;     /**< number of bytes per frame     */
+    uint16_t fc_bitspersample;  /**< number of bits in a sample    */
     /* extended format */
-    uint16_t fc_extsize;             /**< extended format info length   */
-    uint16_t fc_validbitspersample;  /**< number of valid bits          */
-    uint32_t fc_channelmask;         /**< speaker pos channel mask      */
-    char fc_subformat[16];           /**< format tag is bytes 0 & 1     */
+    uint16_t fc_extsize;            /**< extended format info length   */
+    uint16_t fc_validbitspersample; /**< number of valid bits          */
+    uint32_t fc_channelmask;        /**< speaker pos channel mask      */
+    char fc_subformat[16];          /**< format tag is bytes 0 & 1     */
 } t_formatchunk;
 
-    /** fact chunk, 12 bytes */
+/** fact chunk, 12 bytes */
 typedef struct _factchunk
 {
-    char fc_id[4];                   /**< chunk id "fact"               */
-    uint32_t fc_size;                /**< chunk data length             */
-    uint32_t fc_samplelength;        /**< number of samples per channel */
+    char fc_id[4];            /**< chunk id "fact"               */
+    uint32_t fc_size;         /**< chunk data length             */
+    uint32_t fc_samplelength; /**< number of samples per channel */
 } t_factchunk;
 
 /* ----- helpers ----- */
 
-    /** returns 1 if format requires extended format and fact chunk */
+/** returns 1 if format requires extended format and fact chunk */
 static int wave_isextended(const t_soundfile *sf)
 {
     return sf->sf_bytespersample == 4;
 }
 
-    /** read first chunk, returns filled chunk and offset on success or -1 */
+/** read first chunk, returns filled chunk and offset on success or -1 */
 static off_t wave_firstchunk(const t_soundfile *sf, t_chunk *chunk)
 {
-    if (fd_read(sf->sf_fd, WAVEHEADSIZE, (char *)chunk,
-        WAVECHUNKSIZE) < WAVECHUNKSIZE)
+    if(fd_read(sf->sf_fd, WAVEHEADSIZE, (char *) chunk, WAVECHUNKSIZE) <
+        WAVECHUNKSIZE)
         return -1;
     return WAVEHEADSIZE;
 }
 
-    /** read next chunk, chunk should be filled when calling
-        returns fills chunk offset on success or -1 */
+/** read next chunk, chunk should be filled when calling
+    returns fills chunk offset on success or -1 */
 static off_t wave_nextchunk(const t_soundfile *sf, off_t offset, t_chunk *chunk)
 {
     uint32_t chunksize = swap4(chunk->c_size, sys_isbigendian());
     off_t seekto = offset + WAVECHUNKSIZE + chunksize;
-    if (seekto & 1) /* pad up to even number of bytes */
+    if(seekto & 1) /* pad up to even number of bytes */
         seekto++;
-    if (fd_read(sf->sf_fd, seekto, (char *)chunk,
-        WAVECHUNKSIZE) < WAVECHUNKSIZE)
+    if(fd_read(sf->sf_fd, seekto, (char *) chunk, WAVECHUNKSIZE) <
+        WAVECHUNKSIZE)
         return -1;
     return seekto;
 }
 
 #ifdef DEBUG_SOUNDFILE
 
-    /** post chunk info for debugging */
+/** post chunk info for debugging */
 static void wave_postchunk(const t_chunk *chunk, int swap)
 {
     post("%.4s %d", chunk->c_id, swap4s(chunk->c_size, swap));
 }
 
-    /** post head info for debugging */
+/** post head info for debugging */
 static void wave_posthead(const t_head *head, int swap)
 {
-    wave_postchunk((const t_chunk *)head, swap);
+    wave_postchunk((const t_chunk *) head, swap);
     post("  %.4s", head->h_formtype);
 }
 
-    /** post format info for debugging */
+/** post format info for debugging */
 static void wave_postformat(const t_formatchunk *format, int swap)
 {
     uint16_t formattag = swap2(format->fc_fmttag, swap);
-    wave_postchunk((const t_chunk *)format, swap);
-    switch (formattag)
+    wave_postchunk((const t_chunk *) format, swap);
+    switch(formattag)
     {
         case WAVE_FORMAT_PCM:
             post("  format %d (PCM)", formattag);
@@ -177,14 +177,14 @@ static void wave_postformat(const t_formatchunk *format, int swap)
     post("  bytes per sec %d", swap4(format->fc_bytespersecond, swap));
     post("  block align %d", swap2(format->fc_blockalign, swap));
     post("  bits per sample %u", swap2(format->fc_bitspersample, swap));
-    if (formattag == WAVE_FORMAT_EXT)
+    if(formattag == WAVE_FORMAT_EXT)
     {
-        formattag = swap2(*(uint16_t *)&format->fc_subformat, swap);
+        formattag = swap2(*(uint16_t *) &format->fc_subformat, swap);
         post("  ext size %d", swap2(format->fc_extsize, swap));
         post("  ext valid bits per sample %d",
             swap2(format->fc_validbitspersample, swap));
         post("  ext channel mask 0x%04x", swap4(format->fc_channelmask, swap));
-        switch (formattag)
+        switch(formattag)
         {
             case WAVE_FORMAT_PCM:
                 post("  ext format %d (PCM)", formattag);
@@ -199,10 +199,10 @@ static void wave_postformat(const t_formatchunk *format, int swap)
     }
 }
 
-    /** post fact info for debugging */
+/** post fact info for debugging */
 static void wave_postfact(const t_factchunk *fact, int swap)
 {
-    wave_postchunk((const t_chunk *)fact, swap);
+    wave_postchunk((const t_chunk *) fact, swap);
     post("  sample length %d", swap4(fact->fc_samplelength, swap));
 }
 
@@ -212,7 +212,7 @@ static void wave_postfact(const t_factchunk *fact, int swap)
 
 static int wave_isheader(const char *buf, size_t size)
 {
-    if (size < 4) return 0;
+    if(size < 4) return 0;
     return !strncmp(buf, "RIFF", 4);
 }
 
@@ -222,6 +222,7 @@ static int wave_readheader(t_soundfile *sf)
         swap = (bigendian != sys_isbigendian()), formatfound = 1;
     off_t headersize = WAVEHEADSIZE;
     size_t bytelimit = WAVEMAXBYTES;
+
     union
     {
         char b_c[SFHDRBUFSIZE];
@@ -230,31 +231,29 @@ static int wave_readheader(t_soundfile *sf)
         t_formatchunk b_formatchunk;
         t_factchunk b_factchunk;
     } buf = {0};
+
     t_chunk *chunk = &buf.b_chunk;
 
-        /* file header */
-    if (fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize)
-        return 0;
-    if (strncmp(buf.b_c + 8, "WAVE", 4))
-        return 0;
+    /* file header */
+    if(fd_read(sf->sf_fd, 0, buf.b_c, headersize) < headersize) return 0;
+    if(strncmp(buf.b_c + 8, "WAVE", 4)) return 0;
 #ifdef DEBUG_SOUNDFILE
-        wave_posthead(&buf.b_head, swap);
+    wave_posthead(&buf.b_head, swap);
 #endif
 
-        /* read chunks in loop until we find the sound data chunk */
-    if ((headersize = wave_firstchunk(sf, chunk)) == -1)
-        return 0;
-    while (1)
+    /* read chunks in loop until we find the sound data chunk */
+    if((headersize = wave_firstchunk(sf, chunk)) == -1) return 0;
+    while(1)
     {
         uint32_t chunksize = swap4(chunk->c_size, swap);
         /* post("chunk %.4s seek %d", chunk->c_id, seekto); */
-        if (!strncmp(chunk->c_id, "fmt ", 4))
+        if(!strncmp(chunk->c_id, "fmt ", 4))
         {
-                /* format chunk */
+            /* format chunk */
             int formattag;
             t_formatchunk *format = &buf.b_formatchunk;
-            if (fd_read(sf->sf_fd, headersize + 8,
-                    buf.b_c + 8, chunksize) < chunksize)
+            if(fd_read(sf->sf_fd, headersize + 8, buf.b_c + 8, chunksize) <
+                chunksize)
                 return 0;
 #ifdef DEBUG_SOUNDFILE
             wave_postformat(format, swap);
@@ -262,19 +261,22 @@ static int wave_readheader(t_soundfile *sf)
             nchannels = swap2(format->fc_nchannels, swap);
             samplerate = swap4(format->fc_samplerate, swap);
             formattag = swap2(format->fc_fmttag, swap);
-            if (formattag == WAVE_FORMAT_EXT && chunksize == WAVEFORMATSIZE)
+            if(formattag == WAVE_FORMAT_EXT && chunksize == WAVEFORMATSIZE)
             {
                 errno = SOUNDFILE_ERRSAMPLEFMT;
                 return 0;
             }
-            switch (formattag)
+            switch(formattag)
             {
-                case WAVE_FORMAT_PCM: case WAVE_FORMAT_FLOAT: break;
+                case WAVE_FORMAT_PCM:
+                case WAVE_FORMAT_FLOAT:
+                    break;
                 case WAVE_FORMAT_EXT:
-                    formattag = swap2(*(uint16_t *)&format->fc_subformat, swap);
-                    if (formattag == WAVE_FORMAT_PCM ||
+                    formattag =
+                        swap2(*(uint16_t *) &format->fc_subformat, swap);
+                    if(formattag == WAVE_FORMAT_PCM ||
                         formattag == WAVE_FORMAT_FLOAT)
-                            break;
+                        break;
                 default:
                 {
                     errno = SOUNDFILE_ERRSAMPLEFMT;
@@ -282,11 +284,13 @@ static int wave_readheader(t_soundfile *sf)
                 }
             }
             bytespersample = swap2(format->fc_bitspersample, swap) / 8;
-            switch (bytespersample)
+            switch(bytespersample)
             {
-                case 2: case 3: break;
+                case 2:
+                case 3:
+                    break;
                 case 4:
-                    if (formattag == WAVE_FORMAT_FLOAT) /* 32 bit int? */
+                    if(formattag == WAVE_FORMAT_FLOAT) /* 32 bit int? */
                         break;
                 default:
                     errno = SOUNDFILE_ERRSAMPLEFMT;
@@ -297,7 +301,7 @@ static int wave_readheader(t_soundfile *sf)
         }
         else if(!strncmp(chunk->c_id, "data", 4))
         {
-                /* sound data chunk */
+            /* sound data chunk */
             bytelimit = swap4(chunk->c_size, swap);
             headersize += WAVECHUNKSIZE;
 #ifdef DEBUG_SOUNDFILE
@@ -306,35 +310,33 @@ static int wave_readheader(t_soundfile *sf)
             break;
         }
 #ifdef DEBUG_SOUNDFILE
-        else if (!strncmp(chunk->c_id, "fact", 4))
+        else if(!strncmp(chunk->c_id, "fact", 4))
         {
-                /* extended format fact chunk */
+            /* extended format fact chunk */
             wave_postfact(&buf.b_factchunk, swap);
         }
         else
         {
-                /* everything else */
+            /* everything else */
             wave_postchunk(chunk, swap);
         }
 #endif
-        if ((headersize = wave_nextchunk(sf, headersize, chunk)) == -1)
-            return 0;
+        if((headersize = wave_nextchunk(sf, headersize, chunk)) == -1) return 0;
     }
-    if (!formatfound)
+    if(!formatfound)
     {
         errno = SOUNDFILE_ERRMALFORMED;
         return 0;
     }
 
-        /* interpret data size from file size? */
-    if (bytelimit == WAVEMAXBYTES)
+    /* interpret data size from file size? */
+    if(bytelimit == WAVEMAXBYTES)
     {
         bytelimit = lseek(sf->sf_fd, 0, SEEK_END) - headersize;
-        if (bytelimit > WAVEMAXBYTES || bytelimit < 0)
-            bytelimit = WAVEMAXBYTES;
+        if(bytelimit > WAVEMAXBYTES || bytelimit < 0) bytelimit = WAVEMAXBYTES;
     }
 
-        /* copy sample format back to caller */
+    /* copy sample format back to caller */
     sf->sf_samplerate = samplerate;
     sf->sf_nchannels = nchannels;
     sf->sf_bytespersample = bytespersample;
@@ -356,26 +358,26 @@ static int wave_writeheader(t_soundfile *sf, size_t nframes)
     char buf[SFHDRBUFSIZE] = {0};
     t_head head = {"RIFF", 0, "WAVE"};
     t_formatchunk format = {
-        "fmt ", swap4(16, swap),
-        WAVE_FORMAT_PCM,                                  /* format tag      */
-        swap2((uint16_t)sf->sf_nchannels, swap),          /* channels        */
-        swap4((uint32_t)sf->sf_samplerate, swap),         /* sample rate     */
-        swap4((uint32_t)(sf->sf_samplerate *              /* bytes per sec   */
-                         sf->sf_bytesperframe), swap),
-        swap2((uint16_t)sf->sf_bytesperframe, swap),      /* block align     */
-        swap2((uint16_t)sf->sf_bytespersample * 8, swap), /* bits per sample */
-        0                                                 /* extended format */
+        "fmt ", swap4(16, swap), WAVE_FORMAT_PCM,  /* format tag      */
+        swap2((uint16_t) sf->sf_nchannels, swap),  /* channels        */
+        swap4((uint32_t) sf->sf_samplerate, swap), /* sample rate     */
+        swap4((uint32_t) (sf->sf_samplerate *      /* bytes per sec   */
+                          sf->sf_bytesperframe),
+            swap),
+        swap2((uint16_t) sf->sf_bytesperframe, swap),      /* block align     */
+        swap2((uint16_t) sf->sf_bytespersample * 8, swap), /* bits per sample */
+        0                                                  /* extended format */
     };
-    t_chunk data = {"data", swap4((uint32_t)datasize, swap)};
+    t_chunk data = {"data", swap4((uint32_t) datasize, swap)};
 
-        /* file header */
+    /* file header */
     memcpy(buf + headersize, &head, WAVEHEADSIZE);
     headersize += WAVEHEADSIZE;
 
-        /* format chunk */
-    if (sf->sf_bytespersample == 4)
+    /* format chunk */
+    if(sf->sf_bytespersample == 4)
         format.fc_fmttag = swap2(WAVE_FORMAT_FLOAT, swap);
-    if (isextended)
+    if(isextended)
     {
         format.fc_extsize = swap2(WAVE_EXT_SIZE - 2, swap); /* - fmttag */
         format.fc_validbitspersample = format.fc_bitspersample;
@@ -389,28 +391,26 @@ static int wave_writeheader(t_soundfile *sf, size_t nframes)
     memcpy(buf + headersize, &format, formatsize);
     headersize += formatsize;
 
-        /* fact chunk */
-    if (isextended)
+    /* fact chunk */
+    if(isextended)
     {
-        t_factchunk fact = {
-            "fact", swap4(4, swap),
-            swap4((uint32_t)(sf->sf_nchannels * nframes), swap)
-        };
+        t_factchunk fact = {"fact", swap4(4, swap),
+            swap4((uint32_t) (sf->sf_nchannels * nframes), swap)};
         memcpy(buf + headersize, &fact, WAVEFACTSIZE);
         headersize += WAVEFACTSIZE;
     }
 
-        /* data chunk */
-    if (datasize & 1)
+    /* data chunk */
+    if(datasize & 1)
     {
-            /* add pad byte */
-        data.c_size = swap4((uint32_t)datasize + 1, swap);
+        /* add pad byte */
+        data.c_size = swap4((uint32_t) datasize + 1, swap);
     }
     memcpy(buf + headersize, &data, WAVECHUNKSIZE);
     headersize += WAVECHUNKSIZE;
 
-        /* update file header chunk size (- chunk header) */
-    head.h_size = swap4s((int32_t)(datasize + headersize - 8), swap);
+    /* update file header chunk size (- chunk header) */
+    head.h_size = swap4s((int32_t) (datasize + headersize - 8), swap);
     memcpy(buf + 4, &head.h_size, 4);
 
 #ifdef DEBUG_SOUNDFILE
@@ -423,9 +423,9 @@ static int wave_writeheader(t_soundfile *sf, size_t nframes)
     return (byteswritten < headersize ? -1 : byteswritten);
 }
 
-    /** assumes chunk order:
-        * basic:    head format data
-        * extended: head format+ext fact data */
+/** assumes chunk order:
+ * basic:    head format data
+ * extended: head format+ext fact data */
 static int wave_updateheader(t_soundfile *sf, size_t nframes)
 {
     int isextended = wave_isextended(sf), swap = soundfile_needsbyteswap(sf);
@@ -434,41 +434,38 @@ static int wave_updateheader(t_soundfile *sf, size_t nframes)
     int padbyte = (datasize & 1);
     uint32_t uinttmp;
 
-    if (isextended)
+    if(isextended)
     {
         headersize += WAVE_EXT_SIZE;
 
-            /* fact chunk sample length */
-        uinttmp = swap4((uint32_t)(nframes * sf->sf_nchannels), swap);
-        if (fd_write(sf->sf_fd, headersize + 8, &uinttmp, 4) < 4)
-            return 0;
+        /* fact chunk sample length */
+        uinttmp = swap4((uint32_t) (nframes * sf->sf_nchannels), swap);
+        if(fd_write(sf->sf_fd, headersize + 8, &uinttmp, 4) < 4) return 0;
         headersize += WAVEFACTSIZE;
     }
 
-        /* sound data chunk size */
+    /* sound data chunk size */
     datasize += padbyte;
-    uinttmp = swap4((uint32_t)datasize, swap);
-    if (fd_write(sf->sf_fd, headersize + 4, &uinttmp, 4) < 4)
-        return 0;
+    uinttmp = swap4((uint32_t) datasize, swap);
+    if(fd_write(sf->sf_fd, headersize + 4, &uinttmp, 4) < 4) return 0;
     headersize += WAVECHUNKSIZE;
 
-        /* add pad byte */
-    if (padbyte)
+    /* add pad byte */
+    if(padbyte)
     {
         uinttmp = 0;
-        if (fd_write(sf->sf_fd, headersize + datasize - 1, &uinttmp, 1) < 1)
+        if(fd_write(sf->sf_fd, headersize + datasize - 1, &uinttmp, 1) < 1)
             return 0;
     }
 
-        /* file header chunk size (- chunk header) */
-    uinttmp = swap4((uint32_t)(headersize + datasize - 8), swap);
-    if (fd_write(sf->sf_fd, 4, &uinttmp, 4) < 4)
-        return 0;
+    /* file header chunk size (- chunk header) */
+    uinttmp = swap4((uint32_t) (headersize + datasize - 8), swap);
+    if(fd_write(sf->sf_fd, 4, &uinttmp, 4) < 4) return 0;
 
 #ifdef DEBUG_SOUNDFILE
-        post("RIFF %d", headersize + datasize - 8);
-        post("  WAVE");
-        post("data %d", datasize);
+    post("RIFF %d", headersize + datasize - 8);
+    post("  WAVE");
+    post("data %d", datasize);
 #endif
 
     return 1;
@@ -477,13 +474,11 @@ static int wave_updateheader(t_soundfile *sf, size_t nframes)
 static int wave_hasextension(const char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len >= 5 &&
-        (!strncmp(filename + (len - 4), ".wav", 4) ||
-         !strncmp(filename + (len - 4), ".WAV", 4)))
+    if(len >= 5 && (!strncmp(filename + (len - 4), ".wav", 4) ||
+                       !strncmp(filename + (len - 4), ".WAV", 4)))
         return 1;
-    if (len >= 6 &&
-        (!strncmp(filename + (len - 5), ".wave", 5) ||
-         !strncmp(filename + (len - 5), ".WAVE", 5)))
+    if(len >= 6 && (!strncmp(filename + (len - 5), ".wave", 5) ||
+                       !strncmp(filename + (len - 5), ".WAVE", 5)))
         return 1;
     return 0;
 }
@@ -491,33 +486,18 @@ static int wave_hasextension(const char *filename, size_t size)
 static int wave_addextension(char *filename, size_t size)
 {
     int len = strnlen(filename, size);
-    if (len + 4 >= size)
-        return 0;
+    if(len + 4 >= size) return 0;
     strcpy(filename + len, ".wav");
     return 1;
 }
 
-    /* force little endian */
-static int wave_endianness(int endianness)
-{
-    return 0;
-}
+/* force little endian */
+static int wave_endianness(int endianness) { return 0; }
 
 /* ------------------------- setup routine ------------------------ */
 
-t_soundfile_type wave = {
-    "wave",
-    WAVEHEADSIZE + WAVEFORMATSIZE + WAVECHUNKSIZE,
-    wave_isheader,
-    wave_readheader,
-    wave_writeheader,
-    wave_updateheader,
-    wave_hasextension,
-    wave_addextension,
-    wave_endianness
-};
+t_soundfile_type wave = {"wave", WAVEHEADSIZE + WAVEFORMATSIZE + WAVECHUNKSIZE,
+    wave_isheader, wave_readheader, wave_writeheader, wave_updateheader,
+    wave_hasextension, wave_addextension, wave_endianness};
 
-void soundfile_wave_setup( void)
-{
-    soundfile_addtype(&wave);
-}
+void soundfile_wave_setup(void) { soundfile_addtype(&wave); }

--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -218,8 +218,12 @@ static int wave_isheader(const char *buf, size_t size)
 
 static int wave_readheader(t_soundfile *sf)
 {
-    int nchannels = 1, bytespersample = 2, samplerate = 44100, bigendian = 0,
-        swap = (bigendian != sys_isbigendian()), formatfound = 1;
+    int nchannels = 1;
+    int bytespersample = 2;
+    int samplerate = 44100;
+    int bigendian = 0;
+    int swap = (bigendian != sys_isbigendian());
+    int formatfound = 1;
     off_t headersize = WAVEHEADSIZE;
     size_t bytelimit = WAVEMAXBYTES;
 
@@ -350,9 +354,10 @@ static int wave_readheader(t_soundfile *sf)
 
 static int wave_writeheader(t_soundfile *sf, size_t nframes)
 {
-    int isextended = wave_isextended(sf), swap = soundfile_needsbyteswap(sf);
-    size_t formatsize = WAVEFORMATSIZE,
-           datasize = nframes * sf->sf_bytesperframe;
+    int isextended = wave_isextended(sf);
+    int swap = soundfile_needsbyteswap(sf);
+    size_t formatsize = WAVEFORMATSIZE;
+    size_t datasize = nframes * sf->sf_bytesperframe;
     off_t headersize = 0;
     ssize_t byteswritten = 0;
     char buf[SFHDRBUFSIZE] = {0};
@@ -428,9 +433,10 @@ static int wave_writeheader(t_soundfile *sf, size_t nframes)
  * extended: head format+ext fact data */
 static int wave_updateheader(t_soundfile *sf, size_t nframes)
 {
-    int isextended = wave_isextended(sf), swap = soundfile_needsbyteswap(sf);
-    size_t datasize = nframes * sf->sf_bytesperframe,
-           headersize = WAVEHEADSIZE + WAVEFORMATSIZE;
+    int isextended = wave_isextended(sf);
+    int swap = soundfile_needsbyteswap(sf);
+    size_t datasize = nframes * sf->sf_bytesperframe;
+    size_t headersize = WAVEHEADSIZE + WAVEFORMATSIZE;
     int padbyte = (datasize & 1);
     uint32_t uinttmp;
 

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  These routines build a copy of the DSP portion of a graph, which is
     then sorted into a linear list of DSP operations which are added to
@@ -21,25 +21,25 @@ extern t_class *vinlet_class, *voutlet_class, *canvas_class, *text_class;
 EXTERN_STRUCT _vinlet;
 EXTERN_STRUCT _voutlet;
 
-void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs,
-    int myvecsize, int calcsize, int phase, int period, int frequency,
-    int downsample, int upsample,  int reblock, int switched);
-void voutlet_dspprolog(struct _voutlet *x, t_signal **parentsigs,
-    int myvecsize, int calcsize, int phase, int period, int frequency,
-    int downsample, int upsample, int reblock, int switched);
-void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs,
-    int myvecsize, int calcsize, int phase, int period, int frequency,
-    int downsample, int upsample, int reblock, int switched);
+void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs, int myvecsize,
+    int calcsize, int phase, int period, int frequency, int downsample,
+    int upsample, int reblock, int switched);
+void voutlet_dspprolog(struct _voutlet *x, t_signal **parentsigs, int myvecsize,
+    int calcsize, int phase, int period, int frequency, int downsample,
+    int upsample, int reblock, int switched);
+void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs, int myvecsize,
+    int calcsize, int phase, int period, int frequency, int downsample,
+    int upsample, int reblock, int switched);
 
 struct _instanceugen
 {
-    t_int *u_dspchain;         /* DSP chain */
-    int u_dspchainsize;        /* number of elements in DSP chain */
-    t_signal *u_signals;       /* list of signals used by DSP chain */
-    int u_sortno;              /* number of DSP sortings so far */
-        /* list of signals which can be reused, sorted by buffer size */
-    t_signal *u_freelist[MAXLOGSIG+1];
-        /* list of reusable "borrowed" signals (which don't own sample buffers) */
+    t_int *u_dspchain;   /* DSP chain */
+    int u_dspchainsize;  /* number of elements in DSP chain */
+    t_signal *u_signals; /* list of signals used by DSP chain */
+    int u_sortno;        /* number of DSP sortings so far */
+    /* list of signals which can be reused, sorted by buffer size */
+    t_signal *u_freelist[MAXLOGSIG + 1];
+    /* list of reusable "borrowed" signals (which don't own sample buffers) */
     t_signal *u_freeborrowed;
     int u_phase;
     int u_loud;
@@ -56,25 +56,23 @@ void d_ugen_newpdinstance(void)
     THIS->u_signals = 0;
 }
 
-void d_ugen_freepdinstance(void)
-{
-    freebytes(THIS, sizeof(*THIS));
-}
+void d_ugen_freepdinstance(void) { freebytes(THIS, sizeof(*THIS)); }
 
-t_int *zero_perform(t_int *w)   /* zero out a vector */
+t_int *zero_perform(t_int *w) /* zero out a vector */
 {
-    t_sample *out = (t_sample *)(w[1]);
-    int n = (int)(w[2]);
-    while (n--) *out++ = 0;
-    return (w+3);
+    t_sample *out = (t_sample *) (w[1]);
+    int n = (int) (w[2]);
+    while(n--)
+        *out++ = 0;
+    return (w + 3);
 }
 
 t_int *zero_perf8(t_int *w)
 {
-    t_sample *out = (t_sample *)(w[1]);
-    int n = (int)(w[2]);
+    t_sample *out = (t_sample *) (w[1]);
+    int n = (int) (w[2]);
 
-    for (; n; n -= 8, out += 8)
+    for(; n; n -= 8, out += 8)
     {
         out[0] = 0;
         out[1] = 0;
@@ -85,15 +83,15 @@ t_int *zero_perf8(t_int *w)
         out[6] = 0;
         out[7] = 0;
     }
-    return (w+3);
+    return (w + 3);
 }
 
 void dsp_add_zero(t_sample *out, int n)
 {
-    if (n&7)
-        dsp_add(zero_perform, 2, out, (t_int)n);
+    if(n & 7)
+        dsp_add(zero_perform, 2, out, (t_int) n);
     else
-        dsp_add(zero_perf8, 2, out, (t_int)n);
+        dsp_add(zero_perf8, 2, out, (t_int) n);
 }
 
 /* ---------------------------- block~ ----------------------------- */
@@ -131,8 +129,8 @@ static t_class *block_class;
 typedef struct _block
 {
     t_object x_obj;
-    int x_vecsize;      /* size of audio signals in this block */
-    int x_calcsize;     /* number of samples actually to compute */
+    int x_vecsize;  /* size of audio signals in this block */
+    int x_calcsize; /* number of samples actually to compute */
     int x_overlap;
     int x_phase;        /* from 0 to period-1; when zero we run the block */
     int x_period;       /* submultiple of containing canvas */
@@ -149,13 +147,13 @@ typedef struct _block
     int x_return;       /* stop right after this block (for one-shots) */
 } t_block;
 
-static void block_set(t_block *x, t_floatarg fvecsize, t_floatarg foverlap,
-    t_floatarg fupsample);
+static void block_set(
+    t_block *x, t_floatarg fvecsize, t_floatarg foverlap, t_floatarg fupsample);
 
-static void *block_new(t_floatarg fvecsize, t_floatarg foverlap,
-                       t_floatarg fupsample)
+static void *block_new(
+    t_floatarg fvecsize, t_floatarg foverlap, t_floatarg fupsample)
 {
-    t_block *x = (t_block *)pd_new(block_class);
+    t_block *x = (t_block *) pd_new(block_class);
     x->x_phase = 0;
     x->x_period = 1;
     x->x_frequency = 1;
@@ -165,54 +163,54 @@ static void *block_new(t_floatarg fvecsize, t_floatarg foverlap,
     return (x);
 }
 
-static void block_set(t_block *x, t_floatarg fcalcsize, t_floatarg foverlap,
-    t_floatarg fupsample)
+static void block_set(
+    t_block *x, t_floatarg fcalcsize, t_floatarg foverlap, t_floatarg fupsample)
 {
     int upsample, downsample;
     int calcsize = fcalcsize;
     int overlap = foverlap;
     int dspstate = canvas_suspend_dsp();
     int vecsize;
-    if (overlap < 1)
-        overlap = 1;
-    if (calcsize < 0)
-        calcsize = 0;    /* this means we'll get it from parent later. */
+    if(overlap < 1) overlap = 1;
+    if(calcsize < 0)
+        calcsize = 0; /* this means we'll get it from parent later. */
 
-    if (fupsample <= 0)
+    if(fupsample <= 0)
         upsample = downsample = 1;
-    else if (fupsample >= 1) {
+    else if(fupsample >= 1)
+    {
         upsample = fupsample;
-        downsample   = 1;
+        downsample = 1;
     }
     else
     {
         downsample = 1.0 / fupsample;
-        upsample   = 1;
+        upsample = 1;
     }
 
-        /* vecsize is smallest power of 2 large enough to hold calcsize */
-    if (calcsize)
+    /* vecsize is smallest power of 2 large enough to hold calcsize */
+    if(calcsize)
     {
-        if ((vecsize = (1 << ilog2(calcsize))) != calcsize)
-            vecsize *= 2;
+        if((vecsize = (1 << ilog2(calcsize))) != calcsize) vecsize *= 2;
     }
-    else vecsize = 0;
-    if (vecsize && (vecsize != (1 << ilog2(vecsize))))
+    else
+        vecsize = 0;
+    if(vecsize && (vecsize != (1 << ilog2(vecsize))))
     {
         pd_error(x, "block~: vector size not a power of 2");
         vecsize = 64;
     }
-    if (overlap != (1 << ilog2(overlap)))
+    if(overlap != (1 << ilog2(overlap)))
     {
         pd_error(x, "block~: overlap not a power of 2");
         overlap = 1;
     }
-    if (downsample != (1 << ilog2(downsample)))
+    if(downsample != (1 << ilog2(downsample)))
     {
         pd_error(x, "block~: downsampling not a power of 2");
         downsample = 1;
     }
-    if (upsample != (1 << ilog2(upsample)))
+    if(upsample != (1 << ilog2(upsample)))
     {
         pd_error(x, "block~: upsampling not a power of 2");
         upsample = 1;
@@ -226,10 +224,10 @@ static void block_set(t_block *x, t_floatarg fcalcsize, t_floatarg foverlap,
     canvas_resume_dsp(dspstate);
 }
 
-static void *switch_new(t_floatarg fvecsize, t_floatarg foverlap,
-                        t_floatarg fupsample)
+static void *switch_new(
+    t_floatarg fvecsize, t_floatarg foverlap, t_floatarg fupsample)
 {
-    t_block *x = (t_block *)(block_new(fvecsize, foverlap, fupsample));
+    t_block *x = (t_block *) (block_new(fvecsize, foverlap, fupsample));
     x->x_switched = 1;
     x->x_switchon = 0;
     return (x);
@@ -237,135 +235,130 @@ static void *switch_new(t_floatarg fvecsize, t_floatarg foverlap,
 
 static void block_float(t_block *x, t_floatarg f)
 {
-    if (x->x_switched)
-        x->x_switchon = (f != 0);
+    if(x->x_switched) x->x_switchon = (f != 0);
 }
 
 static void block_bang(t_block *x)
 {
-    if (x->x_switched && !x->x_switchon && THIS->u_dspchain)
+    if(x->x_switched && !x->x_switchon && THIS->u_dspchain)
     {
         t_int *ip;
         x->x_return = 1;
-        for (ip = THIS->u_dspchain + x->x_chainonset; ip; )
-            ip = (*(t_perfroutine)(*ip))(ip);
+        for(ip = THIS->u_dspchain + x->x_chainonset; ip;)
+            ip = (*(t_perfroutine) (*ip))(ip);
         x->x_return = 0;
     }
-    else pd_error(x, "bang to block~ or on-state switch~ has no effect");
+    else
+        pd_error(x, "bang to block~ or on-state switch~ has no effect");
 }
-
 
 #define PROLOGCALL 2
 #define EPILOGCALL 2
 
 static t_int *block_prolog(t_int *w)
 {
-    t_block *x = (t_block *)w[1];
+    t_block *x = (t_block *) w[1];
     int phase = x->x_phase;
-        /* if we're switched off, jump past the epilog code */
-    if (!x->x_switchon)
-        return (w + x->x_blocklength);
-    if (phase)
+    /* if we're switched off, jump past the epilog code */
+    if(!x->x_switchon) return (w + x->x_blocklength);
+    if(phase)
     {
         phase++;
-        if (phase == x->x_period) phase = 0;
+        if(phase == x->x_period) phase = 0;
         x->x_phase = phase;
-        return (w + x->x_blocklength);  /* skip block; jump past epilog */
+        return (w + x->x_blocklength); /* skip block; jump past epilog */
     }
     else
     {
         x->x_count = x->x_frequency;
         x->x_phase = (x->x_period > 1 ? 1 : 0);
-        return (w + PROLOGCALL);        /* beginning of block is next ugen */
+        return (w + PROLOGCALL); /* beginning of block is next ugen */
     }
 }
 
 static t_int *block_epilog(t_int *w)
 {
-    t_block *x = (t_block *)w[1];
+    t_block *x = (t_block *) w[1];
     int count = x->x_count - 1;
-    if (x->x_return)
-        return (0);
-    if (!x->x_reblock)
-        return (w + x->x_epiloglength + EPILOGCALL);
-    if (count)
+    if(x->x_return) return (0);
+    if(!x->x_reblock) return (w + x->x_epiloglength + EPILOGCALL);
+    if(count)
     {
         x->x_count = count;
-        return (w - (x->x_blocklength -
-            (PROLOGCALL + EPILOGCALL)));   /* go to ugen after prolog */
+        return (
+            w - (x->x_blocklength -
+                    (PROLOGCALL + EPILOGCALL))); /* go to ugen after prolog */
     }
-    else return (w + EPILOGCALL);
+    else
+        return (w + EPILOGCALL);
 }
 
 static void block_dsp(t_block *x, t_signal **sp)
-{
-    /* do nothing here */
+{ /* do nothing here */
 }
 
 void block_tilde_setup(void)
 {
-    block_class = class_new(gensym("block~"), (t_newmethod)block_new, 0,
-            sizeof(t_block), 0, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addcreator((t_newmethod)switch_new, gensym("switch~"),
+    block_class = class_new(gensym("block~"), (t_newmethod) block_new, 0,
+        sizeof(t_block), 0, A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addcreator((t_newmethod) switch_new, gensym("switch~"), A_DEFFLOAT,
+        A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addmethod(block_class, (t_method) block_set, gensym("set"),
         A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(block_class, (t_method)block_set, gensym("set"),
-        A_DEFFLOAT, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(block_class, (t_method)block_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        block_class, (t_method) block_dsp, gensym("dsp"), A_CANT, 0);
     class_addfloat(block_class, block_float);
     class_addbang(block_class, block_bang);
 }
 
 /* ------------------ DSP call list ----------------------- */
 
-static t_int dsp_done(t_int *w)
-{
-    return (0);
-}
+static t_int dsp_done(t_int *w) { return (0); }
 
 void dsp_add(t_perfroutine f, int n, ...)
 {
-    int newsize = THIS->u_dspchainsize + n+1, i;
+    int newsize = THIS->u_dspchainsize + n + 1, i;
     va_list ap;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
-        THIS->u_dspchainsize * sizeof (t_int), newsize * sizeof (t_int));
-    THIS->u_dspchain[THIS->u_dspchainsize-1] = (t_int)f;
-    if (THIS->u_loud)
-        post("add to chain: %lx",
-            THIS->u_dspchain[THIS->u_dspchainsize-1]);
+        THIS->u_dspchainsize * sizeof(t_int), newsize * sizeof(t_int));
+    THIS->u_dspchain[THIS->u_dspchainsize - 1] = (t_int) f;
+    if(THIS->u_loud)
+        post("add to chain: %lx", THIS->u_dspchain[THIS->u_dspchainsize - 1]);
     va_start(ap, n);
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         THIS->u_dspchain[THIS->u_dspchainsize + i] = va_arg(ap, t_int);
-        if (THIS->u_loud)
+        if(THIS->u_loud)
             post("add to chain: %lx",
                 THIS->u_dspchain[THIS->u_dspchainsize + i]);
     }
     va_end(ap);
-    THIS->u_dspchain[newsize-1] = (t_int)dsp_done;
+    THIS->u_dspchain[newsize - 1] = (t_int) dsp_done;
     THIS->u_dspchainsize = newsize;
 }
 
-    /* at Guenter's suggestion, here's a vectorized version */
+/* at Guenter's suggestion, here's a vectorized version */
 void dsp_addv(t_perfroutine f, int n, t_int *vec)
 {
-    int newsize = THIS->u_dspchainsize + n+1, i;
+    int newsize = THIS->u_dspchainsize + n + 1, i;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
-        THIS->u_dspchainsize * sizeof (t_int), newsize * sizeof (t_int));
-    THIS->u_dspchain[THIS->u_dspchainsize-1] = (t_int)f;
-    for (i = 0; i < n; i++)
+        THIS->u_dspchainsize * sizeof(t_int), newsize * sizeof(t_int));
+    THIS->u_dspchain[THIS->u_dspchainsize - 1] = (t_int) f;
+    for(i = 0; i < n; i++)
         THIS->u_dspchain[THIS->u_dspchainsize + i] = vec[i];
-    THIS->u_dspchain[newsize-1] = (t_int)dsp_done;
+    THIS->u_dspchain[newsize - 1] = (t_int) dsp_done;
     THIS->u_dspchainsize = newsize;
 }
 
 void dsp_tick(void)
 {
-    if (THIS->u_dspchain)
+    if(THIS->u_dspchain)
     {
         t_int *ip;
-        for (ip = THIS->u_dspchain; ip; ) ip = (*(t_perfroutine)(*ip))(ip);
+        for(ip = THIS->u_dspchain; ip;)
+            ip = (*(t_perfroutine) (*ip))(ip);
         THIS->u_phase++;
     }
 }
@@ -375,8 +368,8 @@ void dsp_tick(void)
 int ilog2(int n)
 {
     int r = -1;
-    if (n <= 0) return(0);
-    while (n)
+    if(n <= 0) return (0);
+    while(n)
     {
         r++;
         n >>= 1;
@@ -384,101 +377,96 @@ int ilog2(int n)
     return (r);
 }
 
-
-    /* call this when DSP is stopped to free all the signals */
+/* call this when DSP is stopped to free all the signals */
 static void signal_cleanup(void)
 {
     t_signal *sig;
     int i;
-    while ((sig = THIS->u_signals))
+    while((sig = THIS->u_signals))
     {
         THIS->u_signals = sig->s_nextused;
-        if (!sig->s_isborrowed)
-            t_freebytes(sig->s_vec, sig->s_vecsize * sizeof (*sig->s_vec));
+        if(!sig->s_isborrowed)
+            t_freebytes(sig->s_vec, sig->s_vecsize * sizeof(*sig->s_vec));
         t_freebytes(sig, sizeof *sig);
     }
-    for (i = 0; i <= MAXLOGSIG; i++)
+    for(i = 0; i <= MAXLOGSIG; i++)
         THIS->u_freelist[i] = 0;
     THIS->u_freeborrowed = 0;
 }
 
-    /* mark the signal "reusable." */
+/* mark the signal "reusable." */
 void signal_makereusable(t_signal *sig)
 {
     int logn = ilog2(sig->s_vecsize);
 #if 1
     t_signal *s5;
-    for (s5 = THIS->u_freeborrowed; s5; s5 = s5->s_nextfree)
+    for(s5 = THIS->u_freeborrowed; s5; s5 = s5->s_nextfree)
     {
-        if (s5 == sig)
+        if(s5 == sig)
         {
             bug("signal_free 3");
             return;
         }
     }
-    for (s5 = THIS->u_freelist[logn]; s5; s5 = s5->s_nextfree)
+    for(s5 = THIS->u_freelist[logn]; s5; s5 = s5->s_nextfree)
     {
-        if (s5 == sig)
+        if(s5 == sig)
         {
             bug("signal_free 4");
             return;
         }
     }
 #endif
-    if (THIS->u_loud) post("free %lx: %d", sig, sig->s_isborrowed);
-    if (sig->s_isborrowed)
+    if(THIS->u_loud) post("free %lx: %d", sig, sig->s_isborrowed);
+    if(sig->s_isborrowed)
     {
-            /* if the signal is borrowed, decrement the borrowed-from signal's
-                reference count, possibly marking it reusable too */
+        /* if the signal is borrowed, decrement the borrowed-from signal's
+            reference count, possibly marking it reusable too */
         t_signal *s2 = sig->s_borrowedfrom;
-        if ((s2 == sig) || !s2)
-            bug("signal_free");
+        if((s2 == sig) || !s2) bug("signal_free");
         s2->s_refcount--;
-        if (!s2->s_refcount)
-            signal_makereusable(s2);
+        if(!s2->s_refcount) signal_makereusable(s2);
         sig->s_nextfree = THIS->u_freeborrowed;
         THIS->u_freeborrowed = sig;
     }
     else
     {
-            /* if it's a real signal (not borrowed), put it on the free list
-                so we can reuse it. */
-        if (THIS->u_freelist[logn] == sig) bug("signal_free 2");
+        /* if it's a real signal (not borrowed), put it on the free list
+            so we can reuse it. */
+        if(THIS->u_freelist[logn] == sig) bug("signal_free 2");
         sig->s_nextfree = THIS->u_freelist[logn];
         THIS->u_freelist[logn] = sig;
     }
 }
 
-    /* reclaim or make an audio signal.  If n is zero, return a "borrowed"
-    signal whose buffer and size will be obtained later via
-    signal_setborrowed(). */
+/* reclaim or make an audio signal.  If n is zero, return a "borrowed"
+signal whose buffer and size will be obtained later via
+signal_setborrowed(). */
 
 static t_signal *signal_new(int n, t_float sr)
 {
     int logn, vecsize = 0;
     t_signal *ret, **whichlist;
     logn = ilog2(n);
-    if (n)
+    if(n)
     {
-        if ((vecsize = (1<<logn)) != n)
-            vecsize *= 2;
-        if (logn > MAXLOGSIG)
-            bug("signal buffer too large");
+        if((vecsize = (1 << logn)) != n) vecsize *= 2;
+        if(logn > MAXLOGSIG) bug("signal buffer too large");
         whichlist = THIS->u_freelist + logn;
     }
     else
         whichlist = &THIS->u_freeborrowed;
 
-        /* first try to reclaim one from the free list */
-    if ((ret = *whichlist))
+    /* first try to reclaim one from the free list */
+    if((ret = *whichlist))
         *whichlist = ret->s_nextfree;
     else
     {
-            /* LATER figure out what to do for out-of-space here! */
-        ret = (t_signal *)t_getbytes(sizeof *ret);
-        if (n)
+        /* LATER figure out what to do for out-of-space here! */
+        ret = (t_signal *) t_getbytes(sizeof *ret);
+        if(n)
         {
-            ret->s_vec = (t_sample *)getbytes(vecsize * sizeof (*ret->s_vec));
+            ret->s_vec = (t_sample *) getbytes(vecsize * sizeof(*ret->s_vec));
             ret->s_isborrowed = 0;
         }
         else
@@ -494,7 +482,7 @@ static t_signal *signal_new(int n, t_float sr)
     ret->s_sr = sr;
     ret->s_refcount = 0;
     ret->s_borrowedfrom = 0;
-    if (THIS->u_loud) post("new %lx: %lx", ret, ret->s_vec);
+    if(THIS->u_loud) post("new %lx: %lx", ret, ret->s_vec);
     return (ret);
 }
 
@@ -505,15 +493,13 @@ static t_signal *signal_newlike(const t_signal *sig)
 
 void signal_setborrowed(t_signal *sig, t_signal *sig2)
 {
-    if (!sig->s_isborrowed || sig->s_borrowedfrom)
-        bug("signal_setborrowed");
-    if (sig == sig2)
-        bug("signal_setborrowed 2");
+    if(!sig->s_isborrowed || sig->s_borrowedfrom) bug("signal_setborrowed");
+    if(sig == sig2) bug("signal_setborrowed 2");
     sig->s_borrowedfrom = sig2;
     sig->s_vec = sig2->s_vec;
     sig->s_n = sig2->s_n;
     sig->s_vecsize = sig2->s_vecsize;
-    if (THIS->u_loud) post("set borrowed %lx: %lx", sig, sig->s_vec);
+    if(THIS->u_loud) post("set borrowed %lx: %lx", sig, sig->s_vec);
 }
 
 static int signal_compatible(t_signal *s1, t_signal *s2)
@@ -557,7 +543,6 @@ typedef struct _sigoutlet
     t_sigoutconnect *o_connections;
 } t_sigoutlet;
 
-
 struct _dspcontext
 {
     struct _ugenbox *dc_ugenlist;
@@ -566,48 +551,43 @@ struct _dspcontext
     int dc_noutlets;
     t_signal **dc_iosigs;
     t_float dc_srate;
-    int dc_vecsize;         /* vector size, power of two */
-    int dc_calcsize;        /* number of elements to calculate */
-    char dc_toplevel;       /* true if "iosigs" is invalid. */
-    char dc_reblock;        /* true if we have to reblock inlets/outlets */
-    char dc_switched;       /* true if we're switched */
+    int dc_vecsize;   /* vector size, power of two */
+    int dc_calcsize;  /* number of elements to calculate */
+    char dc_toplevel; /* true if "iosigs" is invalid. */
+    char dc_reblock;  /* true if we have to reblock inlets/outlets */
+    char dc_switched; /* true if we're switched */
 };
 
 #define t_dspcontext struct _dspcontext
 
-    /* get a new signal for the current context - used by clone~ object */
+/* get a new signal for the current context - used by clone~ object */
 t_signal *signal_newfromcontext(int borrowed)
 {
-    return (signal_new((borrowed? 0 : THIS->u_context->dc_calcsize),
+    return (signal_new((borrowed ? 0 : THIS->u_context->dc_calcsize),
         THIS->u_context->dc_srate));
 }
 
 void ugen_stop(void)
 {
-    if (THIS->u_dspchain)
+    if(THIS->u_dspchain)
     {
-        freebytes(THIS->u_dspchain,
-            THIS->u_dspchainsize * sizeof (t_int));
+        freebytes(THIS->u_dspchain, THIS->u_dspchainsize * sizeof(t_int));
         THIS->u_dspchain = 0;
     }
     signal_cleanup();
-
 }
 
 void ugen_start(void)
 {
     ugen_stop();
     THIS->u_sortno++;
-    THIS->u_dspchain = (t_int *)getbytes(sizeof(*THIS->u_dspchain));
-    THIS->u_dspchain[0] = (t_int)dsp_done;
+    THIS->u_dspchain = (t_int *) getbytes(sizeof(*THIS->u_dspchain));
+    THIS->u_dspchain[0] = (t_int) dsp_done;
     THIS->u_dspchainsize = 1;
-    if (THIS->u_context) bug("ugen_start");
+    if(THIS->u_context) bug("ugen_start");
 }
 
-int ugen_getsortno(void)
-{
-    return (THIS->u_sortno);
-}
+int ugen_getsortno(void) { return (THIS->u_sortno); }
 
 #if 0
 void glob_ugen_printstate(void *dummy, t_symbol *s, int argc, t_atom *argv)
@@ -635,18 +615,17 @@ void glob_ugen_printstate(void *dummy, t_symbol *s, int argc, t_atom *argv)
 }
 #endif
 
-    /* start building the graph for a canvas */
-t_dspcontext *ugen_start_graph(int toplevel, t_signal **sp,
-    int ninlets, int noutlets)
+/* start building the graph for a canvas */
+t_dspcontext *ugen_start_graph(
+    int toplevel, t_signal **sp, int ninlets, int noutlets)
 {
-    t_dspcontext *dc = (t_dspcontext *)getbytes(sizeof(*dc));
+    t_dspcontext *dc = (t_dspcontext *) getbytes(sizeof(*dc));
 
-    if (THIS->u_loud) post("ugen_start_graph...");
+    if(THIS->u_loud) post("ugen_start_graph...");
 
     /* protect against invalid numsignals.  This might happen if we have
     an abstraction with inlet~/outlet~  opened as a toplevel patch */
-    if (toplevel)
-        ninlets = noutlets = 0;
+    if(toplevel) ninlets = noutlets = 0;
 
     dc->dc_ugenlist = 0;
     dc->dc_toplevel = toplevel;
@@ -658,10 +637,10 @@ t_dspcontext *ugen_start_graph(int toplevel, t_signal **sp,
     return (dc);
 }
 
-    /* first the canvas calls this to create all the boxes... */
+/* first the canvas calls this to create all the boxes... */
 void ugen_add(t_dspcontext *dc, t_object *obj)
 {
-    t_ugenbox *x = (t_ugenbox *)getbytes(sizeof *x);
+    t_ugenbox *x = (t_ugenbox *) getbytes(sizeof *x);
     int i;
     t_sigoutlet *uout;
     t_siginlet *uin;
@@ -670,18 +649,18 @@ void ugen_add(t_dspcontext *dc, t_object *obj)
     dc->dc_ugenlist = x;
     x->u_obj = obj;
     x->u_nin = obj_nsiginlets(obj);
-    x->u_in = getbytes(x->u_nin * sizeof (*x->u_in));
-    for (uin = x->u_in, i = x->u_nin; i--; uin++)
+    x->u_in = getbytes(x->u_nin * sizeof(*x->u_in));
+    for(uin = x->u_in, i = x->u_nin; i--; uin++)
         uin->i_nconnect = 0;
     x->u_nout = obj_nsigoutlets(obj);
-    x->u_out = getbytes(x->u_nout * sizeof (*x->u_out));
-    for (uout = x->u_out, i = x->u_nout; i--; uout++)
+    x->u_out = getbytes(x->u_nout * sizeof(*x->u_out));
+    for(uout = x->u_out, i = x->u_nout; i--; uout++)
         uout->o_connections = 0, uout->o_nconnect = 0;
 }
 
-    /* and then this to make all the connections. */
-void ugen_connect(t_dspcontext *dc, t_object *x1, int outno, t_object *x2,
-    int inno)
+/* and then this to make all the connections. */
+void ugen_connect(
+    t_dspcontext *dc, t_object *x1, int outno, t_object *x2, int inno)
 {
     t_ugenbox *u1, *u2;
     t_sigoutlet *uout;
@@ -689,57 +668,56 @@ void ugen_connect(t_dspcontext *dc, t_object *x1, int outno, t_object *x2,
     t_sigoutconnect *oc;
     int sigoutno = obj_sigoutletindex(x1, outno);
     int siginno = obj_siginletindex(x2, inno);
-    if (THIS->u_loud)
-        post("%s -> %s: %d->%d",
-            class_getname(x1->ob_pd),
-                class_getname(x2->ob_pd), outno, inno);
-    for (u1 = dc->dc_ugenlist; u1 && u1->u_obj != x1; u1 = u1->u_next);
-    for (u2 = dc->dc_ugenlist; u2 && u2->u_obj != x2; u2 = u2->u_next);
-    if (!u1 || !u2 || siginno < 0 || !u2->u_nin)
+    if(THIS->u_loud)
+        post("%s -> %s: %d->%d", class_getname(x1->ob_pd),
+            class_getname(x2->ob_pd), outno, inno);
+    for(u1 = dc->dc_ugenlist; u1 && u1->u_obj != x1; u1 = u1->u_next)
+        ;
+    for(u2 = dc->dc_ugenlist; u2 && u2->u_obj != x2; u2 = u2->u_next)
+        ;
+    if(!u1 || !u2 || siginno < 0 || !u2->u_nin)
     {
-        if (!u1)
-            pd_error(0, "object with signal outlets but no DSP method?");
-                /* check if it's a "text" (i.e., object wasn't created) -
-                if so fail silently */
-        else if (!(x2 && (pd_class(&x2->ob_pd) == text_class)))
+        if(!u1) pd_error(0, "object with signal outlets but no DSP method?");
+        /* check if it's a "text" (i.e., object wasn't created) -
+        if so fail silently */
+        else if(!(x2 && (pd_class(&x2->ob_pd) == text_class)))
             pd_error(u1->u_obj,
                 "audio signal outlet connected to nonsignal inlet (ignored)");
         return;
     }
-    if (sigoutno < 0 || sigoutno >= u1->u_nout || siginno >= u2->u_nin)
+    if(sigoutno < 0 || sigoutno >= u1->u_nout || siginno >= u2->u_nin)
     {
-        bug("ugen_connect %s %s %d %d (%d %d)",
-            class_getname(x1->ob_pd),
-            class_getname(x2->ob_pd), sigoutno, siginno, u1->u_nout,
-                u2->u_nin);
+        bug("ugen_connect %s %s %d %d (%d %d)", class_getname(x1->ob_pd),
+            class_getname(x2->ob_pd), sigoutno, siginno, u1->u_nout, u2->u_nin);
     }
     uout = u1->u_out + sigoutno;
     uin = u2->u_in + siginno;
 
-        /* add a new connection to the outlet's list */
-    oc = (t_sigoutconnect *)getbytes(sizeof *oc);
+    /* add a new connection to the outlet's list */
+    oc = (t_sigoutconnect *) getbytes(sizeof *oc);
     oc->oc_next = uout->o_connections;
     uout->o_connections = oc;
     oc->oc_who = u2;
     oc->oc_inno = siginno;
-        /* update inlet and outlet counts  */
+    /* update inlet and outlet counts  */
     uout->o_nconnect++;
     uin->i_nconnect++;
 }
 
-    /* get the index of a ugenbox or -1 if it's not on the list */
+/* get the index of a ugenbox or -1 if it's not on the list */
 static int ugen_index(t_dspcontext *dc, t_ugenbox *x)
 {
     int ret;
     t_ugenbox *u;
-    for (u = dc->dc_ugenlist, ret = 0; u; u = u->u_next, ret++)
-        if (u == x) return (ret);
+    for(u = dc->dc_ugenlist, ret = 0; u; u = u->u_next, ret++)
+        if(u == x) return (ret);
     return (-1);
 }
+
 extern t_class *clone_class;
 
-    /* put a ugenbox on the chain, recursively putting any others on that
-    this one might uncover. */
+/* put a ugenbox on the chain, recursively putting any others on that
+this one might uncover. */
 static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
 {
     t_sigoutlet *uout;
@@ -747,33 +725,34 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
     t_sigoutconnect *oc;
     t_class *class = pd_class(&u->u_obj->ob_pd);
     int i, n;
-        /* suppress creating new signals for the outputs of signal
-        inlets and subpatches; except in the case we're an inlet and "blocking"
-        is set.  We don't yet know if a subcanvas will be "blocking" so there
-        we delay new signal creation, which will be handled by calling
-        signal_setborrowed in the ugen_done_graph routine below. */
+    /* suppress creating new signals for the outputs of signal
+    inlets and subpatches; except in the case we're an inlet and "blocking"
+    is set.  We don't yet know if a subcanvas will be "blocking" so there
+    we delay new signal creation, which will be handled by calling
+    signal_setborrowed in the ugen_done_graph routine below. */
     int nonewsigs = (class == canvas_class ||
-        ((class == vinlet_class) && !(dc->dc_reblock)));
-        /* when we encounter a subcanvas or a signal outlet, suppress freeing
-        the input signals as they may be "borrowed" for the super or sub
-        patch; same exception as above, but also if we're "switched" we
-        have to do a copy rather than a borrow.  */
-    int nofreesigs = (class == canvas_class || class == clone_class ||
-        ((class == voutlet_class) &&  !(dc->dc_reblock || dc->dc_switched)));
+                     ((class == vinlet_class) && !(dc->dc_reblock)));
+    /* when we encounter a subcanvas or a signal outlet, suppress freeing
+    the input signals as they may be "borrowed" for the super or sub
+    patch; same exception as above, but also if we're "switched" we
+    have to do a copy rather than a borrow.  */
+    int nofreesigs =
+        (class == canvas_class || class == clone_class ||
+            ((class == voutlet_class) && !(dc->dc_reblock || dc->dc_switched)));
     t_signal **insig, **outsig, **sig, *s1, *s2, *s3;
     t_ugenbox *u2;
 
-    if (THIS->u_loud) post("doit %s %d %d", class_getname(class), nofreesigs,
-        nonewsigs);
-    for (i = 0, uin = u->u_in; i < u->u_nin; i++, uin++)
+    if(THIS->u_loud)
+        post("doit %s %d %d", class_getname(class), nofreesigs, nonewsigs);
+    for(i = 0, uin = u->u_in; i < u->u_nin; i++, uin++)
     {
-        if (!uin->i_nconnect)
+        if(!uin->i_nconnect)
         {
             t_float *scalar;
             s3 = signal_new(dc->dc_calcsize, dc->dc_srate);
             /* post("%s: unconnected signal inlet set to zero",
                 class_getname(u->u_obj->ob_pd)); */
-            if ((scalar = obj_findsignalscalar(u->u_obj, i)))
+            if((scalar = obj_findsignalscalar(u->u_obj, i)))
                 dsp_add_scalarcopy(scalar, s3->s_vec, s3->s_n);
             else
                 dsp_add_zero(s3->s_vec, s3->s_n);
@@ -781,83 +760,83 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
             s3->s_refcount = 1;
         }
     }
-    insig = (t_signal **)getbytes((u->u_nin + u->u_nout) * sizeof(t_signal *));
+    insig = (t_signal **) getbytes((u->u_nin + u->u_nout) * sizeof(t_signal *));
     outsig = insig + u->u_nin;
-    for (sig = insig, uin = u->u_in, i = u->u_nin; i--; sig++, uin++)
+    for(sig = insig, uin = u->u_in, i = u->u_nin; i--; sig++, uin++)
     {
         int newrefcount;
         *sig = uin->i_signal;
         newrefcount = --(*sig)->s_refcount;
-            /* if the reference count went to zero, we free the signal now,
-            unless it's a subcanvas or outlet; these might keep the
-            signal around to send to objects connected to them.  In this
-            case we increment the reference count; the corresponding decrement
-            is in sig_makereusable(). */
-        if (nofreesigs)
+        /* if the reference count went to zero, we free the signal now,
+        unless it's a subcanvas or outlet; these might keep the
+        signal around to send to objects connected to them.  In this
+        case we increment the reference count; the corresponding decrement
+        is in sig_makereusable(). */
+        if(nofreesigs)
             (*sig)->s_refcount++;
-        else if (!newrefcount)
+        else if(!newrefcount)
             signal_makereusable(*sig);
     }
-    for (sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
+    for(sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
     {
-            /* similarly, for outlets of subcanvases we delay creating
-            them; instead we create "borrowed" ones so that the refcount
-            is known.  The subcanvas replaces the fake signal with one showing
-            where the output data actually is, to avoid having to copy it.
-            For any other object, we just allocate a new output vector;
-            since we've already freed the inputs the objects might get called
-            "in place." */
-        if (nonewsigs)
+        /* similarly, for outlets of subcanvases we delay creating
+        them; instead we create "borrowed" ones so that the refcount
+        is known.  The subcanvas replaces the fake signal with one showing
+        where the output data actually is, to avoid having to copy it.
+        For any other object, we just allocate a new output vector;
+        since we've already freed the inputs the objects might get called
+        "in place." */
+        if(nonewsigs)
         {
-            *sig = uout->o_signal =
-                signal_new(0, dc->dc_srate);
+            *sig = uout->o_signal = signal_new(0, dc->dc_srate);
         }
         else
             *sig = uout->o_signal = signal_new(dc->dc_calcsize, dc->dc_srate);
         (*sig)->s_refcount = uout->o_nconnect;
     }
-        /* now call the DSP scheduling routine for the ugen.  This
-        routine must fill in "borrowed" signal outputs in case it's either
-        a subcanvas or a signal inlet. */
+    /* now call the DSP scheduling routine for the ugen.  This
+    routine must fill in "borrowed" signal outputs in case it's either
+    a subcanvas or a signal inlet. */
     mess1(&u->u_obj->ob_pd, gensym("dsp"), insig);
 
-        /* if any output signals aren't connected to anyone, free them
-        now; otherwise they'll either get freed when the reference count
-        goes back to zero, or even later as explained above. */
+    /* if any output signals aren't connected to anyone, free them
+    now; otherwise they'll either get freed when the reference count
+    goes back to zero, or even later as explained above. */
 
-    for (sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
+    for(sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
     {
-        if (!(*sig)->s_refcount)
-            signal_makereusable(*sig);
+        if(!(*sig)->s_refcount) signal_makereusable(*sig);
     }
-    if (THIS->u_loud)
+    if(THIS->u_loud)
     {
-        if (u->u_nin + u->u_nout == 0) post("put %s %d",
-            class_getname(u->u_obj->ob_pd), ugen_index(dc, u));
-        else if (u->u_nin + u->u_nout == 1) post("put %s %d (%lx)",
-            class_getname(u->u_obj->ob_pd), ugen_index(dc, u), sig[0]);
-        else if (u->u_nin + u->u_nout == 2) post("put %s %d (%lx %lx)",
-            class_getname(u->u_obj->ob_pd), ugen_index(dc, u),
-                sig[0], sig[1]);
-        else post("put %s %d (%lx %lx %lx ...)",
-            class_getname(u->u_obj->ob_pd), ugen_index(dc, u),
-                sig[0], sig[1], sig[2]);
+        if(u->u_nin + u->u_nout == 0)
+            post(
+                "put %s %d", class_getname(u->u_obj->ob_pd), ugen_index(dc, u));
+        else if(u->u_nin + u->u_nout == 1)
+            post("put %s %d (%lx)", class_getname(u->u_obj->ob_pd),
+                ugen_index(dc, u), sig[0]);
+        else if(u->u_nin + u->u_nout == 2)
+            post("put %s %d (%lx %lx)", class_getname(u->u_obj->ob_pd),
+                ugen_index(dc, u), sig[0], sig[1]);
+        else
+            post("put %s %d (%lx %lx %lx ...)", class_getname(u->u_obj->ob_pd),
+                ugen_index(dc, u), sig[0], sig[1], sig[2]);
     }
 
-        /* pass it on and trip anyone whose last inlet was filled */
-    for (uout = u->u_out, i = u->u_nout; i--; uout++)
+    /* pass it on and trip anyone whose last inlet was filled */
+    for(uout = u->u_out, i = u->u_nout; i--; uout++)
     {
         s1 = uout->o_signal;
-        for (oc = uout->o_connections; oc; oc = oc->oc_next)
+        for(oc = uout->o_connections; oc; oc = oc->oc_next)
         {
             u2 = oc->oc_who;
             uin = &u2->u_in[oc->oc_inno];
-                /* if there's already someone here, sum the two */
-            if ((s2 = uin->i_signal))
+            /* if there's already someone here, sum the two */
+            if((s2 = uin->i_signal))
             {
                 s1->s_refcount--;
                 s2->s_refcount--;
-                if (!signal_compatible(s1, s2))
+                if(!signal_compatible(s1, s2))
                 {
                     pd_error(u->u_obj, "%s: incompatible signal inputs",
                         class_getname(u->u_obj->ob_pd));
@@ -867,33 +846,33 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
                 dsp_add_plus(s1->s_vec, s2->s_vec, s3->s_vec, s1->s_n);
                 uin->i_signal = s3;
                 s3->s_refcount = 1;
-                if (!s1->s_refcount) signal_makereusable(s1);
-                if (!s2->s_refcount) signal_makereusable(s2);
+                if(!s1->s_refcount) signal_makereusable(s1);
+                if(!s2->s_refcount) signal_makereusable(s2);
             }
-            else uin->i_signal = s1;
+            else
+                uin->i_signal = s1;
             uin->i_ngot++;
-                /* if we didn't fill this inlet don't bother yet */
-            if (uin->i_ngot < uin->i_nconnect)
-                goto notyet;
-                /* if there's more than one, check them all */
-            if (u2->u_nin > 1)
+            /* if we didn't fill this inlet don't bother yet */
+            if(uin->i_ngot < uin->i_nconnect) goto notyet;
+            /* if there's more than one, check them all */
+            if(u2->u_nin > 1)
             {
-                for (uin = u2->u_in, n = u2->u_nin; n--; uin++)
-                    if (uin->i_ngot < uin->i_nconnect) goto notyet;
+                for(uin = u2->u_in, n = u2->u_nin; n--; uin++)
+                    if(uin->i_ngot < uin->i_nconnect) goto notyet;
             }
-                /* so now we can schedule the ugen.  */
+            /* so now we can schedule the ugen.  */
             ugen_doit(dc, u2);
-        notyet: ;
+        notyet:;
         }
     }
-    t_freebytes(insig,(u->u_nin + u->u_nout) * sizeof(t_signal *));
+    t_freebytes(insig, (u->u_nin + u->u_nout) * sizeof(t_signal *));
     u->u_done = 1;
 }
 
-    /* once the DSP graph is built, we call this routine to sort it.
-    This routine also deletes the graph; later we might want to leave the
-    graph around, in case the user is editing the DSP network, to save having
-    to recreate it all the time.  But not today.  */
+/* once the DSP graph is built, we call this routine to sort it.
+This routine also deletes the graph; later we might want to leave the
+graph around, in case the user is editing the DSP network, to save having
+to recreate it all the time.  But not today.  */
 
 void ugen_done_graph(t_dspcontext *dc)
 {
@@ -908,43 +887,45 @@ void ugen_done_graph(t_dspcontext *dc)
     int parent_vecsize;
     int period, frequency, phase, vecsize, calcsize;
     t_float srate;
-    int chainblockbegin;    /* DSP chain onset before block prolog code */
-    int chainblockend;      /* and after block epilog code */
-    int chainafterall;      /* and after signal outlet epilog */
+    int chainblockbegin; /* DSP chain onset before block prolog code */
+    int chainblockend;   /* and after block epilog code */
+    int chainafterall;   /* and after signal outlet epilog */
     int reblock = 0, switched;
     int downsample = 1, upsample = 1;
     /* debugging printout */
 
-    if (THIS->u_loud)
+    if(THIS->u_loud)
     {
         post("ugen_done_graph...");
-        for (u = dc->dc_ugenlist; u; u = u->u_next)
+        for(u = dc->dc_ugenlist; u; u = u->u_next)
         {
             post("ugen: %s", class_getname(u->u_obj->ob_pd));
-            for (uout = u->u_out, i = 0; i < u->u_nout; uout++, i++)
-                for (oc = uout->o_connections; oc; oc = oc->oc_next)
-            {
-                post("... out %d to %s, index %d, inlet %d", i,
-                    class_getname(oc->oc_who->u_obj->ob_pd),
+            for(uout = u->u_out, i = 0; i < u->u_nout; uout++, i++)
+                for(oc = uout->o_connections; oc; oc = oc->oc_next)
+                {
+                    post("... out %d to %s, index %d, inlet %d", i,
+                        class_getname(oc->oc_who->u_obj->ob_pd),
                         ugen_index(dc, oc->oc_who), oc->oc_inno);
-            }
+                }
         }
     }
 
-        /* search for an object of class "block~" */
-    for (u = dc->dc_ugenlist, blk = 0; u; u = u->u_next)
+    /* search for an object of class "block~" */
+    for(u = dc->dc_ugenlist, blk = 0; u; u = u->u_next)
     {
         t_pd *zz = &u->u_obj->ob_pd;
-        if (pd_class(zz) == block_class)
+        if(pd_class(zz) == block_class)
         {
-            if (blk)
-                pd_error(blk, "conflicting block~ and/or switch~ objects in same window");
-            else blk = (t_block *)zz;
+            if(blk)
+                pd_error(blk,
+                    "conflicting block~ and/or switch~ objects in same window");
+            else
+                blk = (t_block *) zz;
         }
     }
 
-        /* figure out block size, calling frequency, sample rate */
-    if (parent_context)
+    /* figure out block size, calling frequency, sample rate */
+    if(parent_context)
     {
         parent_srate = parent_context->dc_srate;
         parent_vecsize = parent_context->dc_vecsize;
@@ -954,36 +935,32 @@ void ugen_done_graph(t_dspcontext *dc)
         parent_srate = sys_getsr();
         parent_vecsize = sys_getblksize();
     }
-    if (blk)
+    if(blk)
     {
         int realoverlap;
         vecsize = blk->x_vecsize;
-        if (vecsize == 0)
-            vecsize = parent_vecsize;
+        if(vecsize == 0) vecsize = parent_vecsize;
         calcsize = blk->x_calcsize;
-        if (calcsize == 0)
-            calcsize = vecsize;
+        if(calcsize == 0) calcsize = vecsize;
         realoverlap = blk->x_overlap;
-        if (realoverlap > vecsize) realoverlap = vecsize;
+        if(realoverlap > vecsize) realoverlap = vecsize;
         downsample = blk->x_downsample;
-        upsample   = blk->x_upsample;
-        if (downsample > parent_vecsize)
-            downsample = parent_vecsize;
-        period = (vecsize * downsample)/
-            (parent_vecsize * realoverlap * upsample);
-        frequency = (parent_vecsize * realoverlap * upsample)/
-            (vecsize * downsample);
+        upsample = blk->x_upsample;
+        if(downsample > parent_vecsize) downsample = parent_vecsize;
+        period =
+            (vecsize * downsample) / (parent_vecsize * realoverlap * upsample);
+        frequency =
+            (parent_vecsize * realoverlap * upsample) / (vecsize * downsample);
         phase = blk->x_phase;
         srate = parent_srate * realoverlap * upsample / downsample;
-        if (period < 1) period = 1;
-        if (frequency < 1) frequency = 1;
+        if(period < 1) period = 1;
+        if(frequency < 1) frequency = 1;
         blk->x_frequency = frequency;
         blk->x_period = period;
         blk->x_phase = THIS->u_phase & (period - 1);
-        if (! parent_context || (realoverlap != 1) ||
-            (vecsize != parent_vecsize) ||
-                (downsample != 1) || (upsample != 1))
-                    reblock = 1;
+        if(!parent_context || (realoverlap != 1) ||
+            (vecsize != parent_vecsize) || (downsample != 1) || (upsample != 1))
+            reblock = 1;
         switched = blk->x_switched;
     }
     else
@@ -994,7 +971,7 @@ void ugen_done_graph(t_dspcontext *dc)
         downsample = upsample = 1;
         period = frequency = 1;
         phase = 0;
-        if (!parent_context) reblock = 1;
+        if(!parent_context) reblock = 1;
         switched = 0;
     }
     dc->dc_reblock = reblock;
@@ -1003,184 +980,182 @@ void ugen_done_graph(t_dspcontext *dc)
     dc->dc_vecsize = vecsize;
     dc->dc_calcsize = calcsize;
 
-        /* if we're reblocking or switched, we now have to create output
-        signals to fill in for the "borrowed" ones we have now.  This
-        is also possibly true even if we're not blocked/switched, in
-        the case that there was a signal loop.  But we don't know this
-        yet.  */
+    /* if we're reblocking or switched, we now have to create output
+    signals to fill in for the "borrowed" ones we have now.  This
+    is also possibly true even if we're not blocked/switched, in
+    the case that there was a signal loop.  But we don't know this
+    yet.  */
 
-    if (dc->dc_iosigs && (switched || reblock))
+    if(dc->dc_iosigs && (switched || reblock))
     {
         t_signal **sigp;
-        for (i = 0, sigp = dc->dc_iosigs + dc->dc_ninlets; i < dc->dc_noutlets;
+        for(i = 0, sigp = dc->dc_iosigs + dc->dc_ninlets; i < dc->dc_noutlets;
             i++, sigp++)
         {
-            if ((*sigp)->s_isborrowed && !(*sigp)->s_borrowedfrom)
+            if((*sigp)->s_isborrowed && !(*sigp)->s_borrowedfrom)
             {
-                signal_setborrowed(*sigp,
-                    signal_new(parent_vecsize, parent_srate));
+                signal_setborrowed(
+                    *sigp, signal_new(parent_vecsize, parent_srate));
                 (*sigp)->s_refcount++;
 
-                if (THIS->u_loud) post("set %lx->%lx", *sigp,
-                    (*sigp)->s_borrowedfrom);
+                if(THIS->u_loud)
+                    post("set %lx->%lx", *sigp, (*sigp)->s_borrowedfrom);
             }
         }
     }
 
-    if (THIS->u_loud)
-        post("reblock %d, switched %d", reblock, switched);
+    if(THIS->u_loud) post("reblock %d, switched %d", reblock, switched);
 
-        /* schedule prologs for inlets and outlets.  If the "reblock" flag
-        is set, an inlet will put code on the DSP chain to copy its input
-        into an internal buffer here, before any unit generators' DSP code
-        gets scheduled.  If we don't "reblock", inlets will need to get
-        pointers to their corresponding inlets/outlets on the box we're inside,
-        if any.  Outlets will also need pointers, unless we're switched, in
-        which case outlet epilog code will kick in. */
+    /* schedule prologs for inlets and outlets.  If the "reblock" flag
+    is set, an inlet will put code on the DSP chain to copy its input
+    into an internal buffer here, before any unit generators' DSP code
+    gets scheduled.  If we don't "reblock", inlets will need to get
+    pointers to their corresponding inlets/outlets on the box we're inside,
+    if any.  Outlets will also need pointers, unless we're switched, in
+    which case outlet epilog code will kick in. */
 
-    for (u = dc->dc_ugenlist; u; u = u->u_next)
+    for(u = dc->dc_ugenlist; u; u = u->u_next)
     {
         t_pd *zz = &u->u_obj->ob_pd;
         t_signal **outsigs = dc->dc_iosigs;
-        if (outsigs) outsigs += dc->dc_ninlets;
+        if(outsigs) outsigs += dc->dc_ninlets;
 
-        if (pd_class(zz) == vinlet_class)
-            vinlet_dspprolog((struct _vinlet *)zz,
-                dc->dc_iosigs, vecsize, calcsize, THIS->u_phase, period, frequency,
-                    downsample, upsample, reblock, switched);
-        else if (pd_class(zz) == voutlet_class)
-            voutlet_dspprolog((struct _voutlet *)zz,
-                outsigs, vecsize, calcsize, THIS->u_phase, period, frequency,
-                    downsample, upsample, reblock, switched);
+        if(pd_class(zz) == vinlet_class)
+            vinlet_dspprolog((struct _vinlet *) zz, dc->dc_iosigs, vecsize,
+                calcsize, THIS->u_phase, period, frequency, downsample,
+                upsample, reblock, switched);
+        else if(pd_class(zz) == voutlet_class)
+            voutlet_dspprolog((struct _voutlet *) zz, outsigs, vecsize,
+                calcsize, THIS->u_phase, period, frequency, downsample,
+                upsample, reblock, switched);
     }
     chainblockbegin = THIS->u_dspchainsize;
 
-    if (blk && (reblock || switched))   /* add the block DSP prolog */
+    if(blk && (reblock || switched)) /* add the block DSP prolog */
     {
         dsp_add(block_prolog, 1, blk);
         blk->x_chainonset = THIS->u_dspchainsize - 1;
     }
-        /* Initialize for sorting */
-    for (u = dc->dc_ugenlist; u; u = u->u_next)
+    /* Initialize for sorting */
+    for(u = dc->dc_ugenlist; u; u = u->u_next)
     {
         u->u_done = 0;
-        for (uout = u->u_out, i = u->u_nout; i--; uout++)
+        for(uout = u->u_out, i = u->u_nout; i--; uout++)
             uout->o_nsent = 0;
-        for (uin = u->u_in, i = u->u_nin; i--; uin++)
+        for(uin = u->u_in, i = u->u_nin; i--; uin++)
             uin->i_ngot = 0, uin->i_signal = 0;
-   }
+    }
 
-        /* Do the sort */
+    /* Do the sort */
 
-    for (u = dc->dc_ugenlist; u; u = u->u_next)
+    for(u = dc->dc_ugenlist; u; u = u->u_next)
     {
-            /* check that we have no connected signal inlets */
-        if (u->u_done) continue;
-        for (uin = u->u_in, i = u->u_nin; i--; uin++)
-            if (uin->i_nconnect) goto next;
+        /* check that we have no connected signal inlets */
+        if(u->u_done) continue;
+        for(uin = u->u_in, i = u->u_nin; i--; uin++)
+            if(uin->i_nconnect) goto next;
 
         ugen_doit(dc, u);
-    next: ;
+    next:;
     }
 
-        /* check for a DSP loop, which is evidenced here by the presence
-        of ugens not yet scheduled. */
+    /* check for a DSP loop, which is evidenced here by the presence
+    of ugens not yet scheduled. */
 
-    for (u = dc->dc_ugenlist; u; u = u->u_next)
-        if (!u->u_done)
-    {
-        t_signal **sigp;
-        pd_error(u->u_obj,
-            "DSP loop detected (some tilde objects not scheduled)");
-                /* this might imply that we have unfilled "borrowed" outputs
-                which we'd better fill in now. */
-        for (i = 0, sigp = dc->dc_iosigs + dc->dc_ninlets; i < dc->dc_noutlets;
-            i++, sigp++)
+    for(u = dc->dc_ugenlist; u; u = u->u_next)
+        if(!u->u_done)
         {
-            if ((*sigp)->s_isborrowed && !(*sigp)->s_borrowedfrom)
+            t_signal **sigp;
+            pd_error(u->u_obj,
+                "DSP loop detected (some tilde objects not scheduled)");
+            /* this might imply that we have unfilled "borrowed" outputs
+            which we'd better fill in now. */
+            for(i = 0, sigp = dc->dc_iosigs + dc->dc_ninlets;
+                i < dc->dc_noutlets; i++, sigp++)
             {
-                t_signal *s3 = signal_new(parent_vecsize, parent_srate);
-                signal_setborrowed(*sigp, s3);
-                (*sigp)->s_refcount++;
-                dsp_add_zero(s3->s_vec, s3->s_n);
-                if (THIS->u_loud)
-                    post("oops, belatedly set %lx->%lx", *sigp,
-                        (*sigp)->s_borrowedfrom);
+                if((*sigp)->s_isborrowed && !(*sigp)->s_borrowedfrom)
+                {
+                    t_signal *s3 = signal_new(parent_vecsize, parent_srate);
+                    signal_setborrowed(*sigp, s3);
+                    (*sigp)->s_refcount++;
+                    dsp_add_zero(s3->s_vec, s3->s_n);
+                    if(THIS->u_loud)
+                        post("oops, belatedly set %lx->%lx", *sigp,
+                            (*sigp)->s_borrowedfrom);
+                }
             }
+            break; /* don't need to keep looking. */
         }
-        break;   /* don't need to keep looking. */
-    }
 
-    if (blk && (reblock || switched))    /* add block DSP epilog */
+    if(blk && (reblock || switched)) /* add block DSP epilog */
         dsp_add(block_epilog, 1, blk);
     chainblockend = THIS->u_dspchainsize;
 
-        /* add epilogs for outlets.  */
+    /* add epilogs for outlets.  */
 
-    for (u = dc->dc_ugenlist; u; u = u->u_next)
+    for(u = dc->dc_ugenlist; u; u = u->u_next)
     {
         t_pd *zz = &u->u_obj->ob_pd;
-        if (pd_class(zz) == voutlet_class)
+        if(pd_class(zz) == voutlet_class)
         {
             t_signal **iosigs = dc->dc_iosigs;
-            if (iosigs) iosigs += dc->dc_ninlets;
-            voutlet_dspepilog((struct _voutlet *)zz,
-                iosigs, vecsize, calcsize, THIS->u_phase, period, frequency,
-                    downsample, upsample, reblock, switched);
+            if(iosigs) iosigs += dc->dc_ninlets;
+            voutlet_dspepilog((struct _voutlet *) zz, iosigs, vecsize, calcsize,
+                THIS->u_phase, period, frequency, downsample, upsample, reblock,
+                switched);
         }
     }
 
     chainafterall = THIS->u_dspchainsize;
-    if (blk)
+    if(blk)
     {
         blk->x_blocklength = chainblockend - chainblockbegin;
         blk->x_epiloglength = chainafterall - chainblockend;
         blk->x_reblock = reblock;
     }
 
-    if (THIS->u_loud)
+    if(THIS->u_loud)
     {
         t_int *ip;
-        if (!dc->dc_parentcontext)
-            for (i = THIS->u_dspchainsize, ip = THIS->u_dspchain;
-                i--; ip++)
-                    post("chain %lx", *ip);
+        if(!dc->dc_parentcontext)
+            for(i = THIS->u_dspchainsize, ip = THIS->u_dspchain; i--; ip++)
+                post("chain %lx", *ip);
         post("... ugen_done_graph done.");
     }
-        /* now delete everything. */
-    while (dc->dc_ugenlist)
+    /* now delete everything. */
+    while(dc->dc_ugenlist)
     {
-        for (uout = dc->dc_ugenlist->u_out, n = dc->dc_ugenlist->u_nout;
-            n--; uout++)
+        for(uout = dc->dc_ugenlist->u_out, n = dc->dc_ugenlist->u_nout; n--;
+            uout++)
         {
             oc = uout->o_connections;
-            while (oc)
+            while(oc)
             {
                 oc2 = oc->oc_next;
                 freebytes(oc, sizeof *oc);
                 oc = oc2;
             }
         }
-        freebytes(dc->dc_ugenlist->u_out, dc->dc_ugenlist->u_nout *
-            sizeof (*dc->dc_ugenlist->u_out));
-        freebytes(dc->dc_ugenlist->u_in, dc->dc_ugenlist->u_nin *
-            sizeof(*dc->dc_ugenlist->u_in));
+        freebytes(dc->dc_ugenlist->u_out,
+            dc->dc_ugenlist->u_nout * sizeof(*dc->dc_ugenlist->u_out));
+        freebytes(dc->dc_ugenlist->u_in,
+            dc->dc_ugenlist->u_nin * sizeof(*dc->dc_ugenlist->u_in));
         u = dc->dc_ugenlist;
         dc->dc_ugenlist = u->u_next;
         freebytes(u, sizeof *u);
     }
-    if (THIS->u_context == dc)
+    if(THIS->u_context == dc)
         THIS->u_context = dc->dc_parentcontext;
-    else bug("THIS->u_context");
+    else
+        bug("THIS->u_context");
     freebytes(dc, sizeof(*dc));
-
 }
 
 static t_signal *ugen_getiosig(int index, int inout)
 {
-    if (!THIS->u_context) bug("ugen_getiosig");
-    if (THIS->u_context->dc_toplevel) return (0);
-    if (inout) index += THIS->u_context->dc_ninlets;
+    if(!THIS->u_context) bug("ugen_getiosig");
+    if(THIS->u_context->dc_toplevel) return (0);
+    if(inout) index += THIS->u_context->dc_ninlets;
     return (THIS->u_context->dc_iosigs[index]);
 }
 
@@ -1188,21 +1163,22 @@ static t_signal *ugen_getiosig(int index, int inout)
 
 t_int *plus_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    while (n--) *out++ = *in1++ + *in2++;
-    return (w+5);
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    while(n--)
+        *out++ = *in1++ + *in2++;
+    return (w + 5);
 }
 
 t_int *plus_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *in2 = (t_sample *)(w[2]);
-    t_sample *out = (t_sample *)(w[3]);
-    int n = (int)(w[4]);
-    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in2 = (t_sample *) (w[2]);
+    t_sample *out = (t_sample *) (w[3]);
+    int n = (int) (w[4]);
+    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
         t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
@@ -1210,36 +1186,43 @@ t_int *plus_perf8(t_int *w)
         t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
         t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
 
-        out[0] = f0 + g0; out[1] = f1 + g1; out[2] = f2 + g2; out[3] = f3 + g3;
-        out[4] = f4 + g4; out[5] = f5 + g5; out[6] = f6 + g6; out[7] = f7 + g7;
+        out[0] = f0 + g0;
+        out[1] = f1 + g1;
+        out[2] = f2 + g2;
+        out[3] = f3 + g3;
+        out[4] = f4 + g4;
+        out[5] = f5 + g5;
+        out[6] = f6 + g6;
+        out[7] = f7 + g7;
     }
-    return (w+5);
+    return (w + 5);
 }
 
 void dsp_add_plus(t_sample *in1, t_sample *in2, t_sample *out, int n)
 {
-    if (n&7)
-        dsp_add(plus_perform, 4, in1, in2, out, (t_int)n);
+    if(n & 7)
+        dsp_add(plus_perform, 4, in1, in2, out, (t_int) n);
     else
-        dsp_add(plus_perf8, 4, in1, in2, out, (t_int)n);
+        dsp_add(plus_perf8, 4, in1, in2, out, (t_int) n);
 }
 
 t_int *copy_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--) *out++ = *in1++;
-    return (w+4);
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
+        *out++ = *in1++;
+    return (w + 4);
 }
 
 static t_int *copy_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
 
-    for (; n; n -= 8, in1 += 8, out += 8)
+    for(; n; n -= 8, in1 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -1259,34 +1242,34 @@ static t_int *copy_perf8(t_int *w)
         out[6] = f6;
         out[7] = f7;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 void dsp_add_copy(t_sample *in, t_sample *out, int n)
 {
-    if (n&7)
-        dsp_add(copy_perform, 3, in, out, (t_int)n);
+    if(n & 7)
+        dsp_add(copy_perform, 3, in, out, (t_int) n);
     else
-        dsp_add(copy_perf8, 3, in, out, (t_int)n);
+        dsp_add(copy_perf8, 3, in, out, (t_int) n);
 }
 
 static t_int *sig_tilde_perform(t_int *w)
 {
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
-    while (n--)
+    t_float f = *(t_float *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
+    while(n--)
         *out++ = f;
-    return (w+4);
+    return (w + 4);
 }
 
 static t_int *sig_tilde_perf8(t_int *w)
 {
-    t_float f = *(t_float *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    t_float f = *(t_float *) (w[1]);
+    t_sample *out = (t_sample *) (w[2]);
+    int n = (int) (w[3]);
 
-    for (; n; n -= 8, out += 8)
+    for(; n; n -= 8, out += 8)
     {
         out[0] = f;
         out[1] = f;
@@ -1297,15 +1280,15 @@ static t_int *sig_tilde_perf8(t_int *w)
         out[6] = f;
         out[7] = f;
     }
-    return (w+4);
+    return (w + 4);
 }
 
 void dsp_add_scalarcopy(t_float *in, t_sample *out, int n)
 {
-    if (n&7)
-        dsp_add(sig_tilde_perform, 3, in, out, (t_int)n);
+    if(n & 7)
+        dsp_add(sig_tilde_perform, 3, in, out, (t_int) n);
     else
-        dsp_add(sig_tilde_perf8, 3, in, out, (t_int)n);
+        dsp_add(sig_tilde_perf8, 3, in, out, (t_int) n);
 }
 
 /* ------------------------ samplerate~~ -------------------------- */
@@ -1325,18 +1308,17 @@ static void samplerate_tilde_bang(t_samplerate *x)
 {
     t_float srate = sys_getsr();
     t_canvas *canvas = x->x_canvas;
-    while (canvas)
+    while(canvas)
     {
-        t_block *b = (t_block *)canvas_getblock(block_class, &canvas);
-        if (b)
-            srate *= (t_float)(b->x_upsample) / (t_float)(b->x_downsample);
+        t_block *b = (t_block *) canvas_getblock(block_class, &canvas);
+        if(b) srate *= (t_float) (b->x_upsample) / (t_float) (b->x_downsample);
     }
     outlet_float(x->x_obj.ob_outlet, srate);
 }
 
 static void *samplerate_tilde_new(t_symbol *s)
 {
-    t_samplerate *x = (t_samplerate *)pd_new(samplerate_tilde_class);
+    t_samplerate *x = (t_samplerate *) pd_new(samplerate_tilde_class);
     outlet_new(&x->x_obj, &s_float);
     x->x_canvas = canvas_getcurrent();
     return (x);
@@ -1345,7 +1327,7 @@ static void *samplerate_tilde_new(t_symbol *s)
 static void samplerate_tilde_setup(void)
 {
     samplerate_tilde_class = class_new(gensym("samplerate~"),
-        (t_newmethod)samplerate_tilde_new, 0, sizeof(t_samplerate), 0, 0);
+        (t_newmethod) samplerate_tilde_new, 0, sizeof(t_samplerate), 0, 0);
     class_addbang(samplerate_tilde_class, samplerate_tilde_bang);
 }
 
@@ -1356,4 +1338,3 @@ void d_ugen_setup(void)
     block_tilde_setup();
     samplerate_tilde_setup();
 }
-

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -269,12 +269,10 @@ static t_int *block_prolog(t_int *w)
         x->x_phase = phase;
         return (w + x->x_blocklength); /* skip block; jump past epilog */
     }
-    else
-    {
-        x->x_count = x->x_frequency;
-        x->x_phase = (x->x_period > 1 ? 1 : 0);
-        return (w + PROLOGCALL); /* beginning of block is next ugen */
-    }
+
+    x->x_count = x->x_frequency;
+    x->x_phase = (x->x_period > 1 ? 1 : 0);
+    return (w + PROLOGCALL); /* beginning of block is next ugen */
 }
 
 static t_int *block_epilog(t_int *w)
@@ -290,8 +288,7 @@ static t_int *block_epilog(t_int *w)
             w - (x->x_blocklength -
                     (PROLOGCALL + EPILOGCALL))); /* go to ugen after prolog */
     }
-    else
-        return (w + EPILOGCALL);
+    return (w + EPILOGCALL);
 }
 
 static void block_dsp(t_block *x, t_signal **sp)

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -166,7 +166,8 @@ static void *block_new(
 static void block_set(
     t_block *x, t_floatarg fcalcsize, t_floatarg foverlap, t_floatarg fupsample)
 {
-    int upsample, downsample;
+    int upsample;
+    int downsample;
     int calcsize = fcalcsize;
     int overlap = foverlap;
     int dspstate = canvas_suspend_dsp();
@@ -317,7 +318,8 @@ static t_int dsp_done(t_int *w) { return (0); }
 
 void dsp_add(t_perfroutine f, int n, ...)
 {
-    int newsize = THIS->u_dspchainsize + n + 1, i;
+    int newsize = THIS->u_dspchainsize + n + 1;
+    int i;
     va_list ap;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
@@ -341,7 +343,8 @@ void dsp_add(t_perfroutine f, int n, ...)
 /* at Guenter's suggestion, here's a vectorized version */
 void dsp_addv(t_perfroutine f, int n, t_int *vec)
 {
-    int newsize = THIS->u_dspchainsize + n + 1, i;
+    int newsize = THIS->u_dspchainsize + n + 1;
+    int i;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
         THIS->u_dspchainsize * sizeof(t_int), newsize * sizeof(t_int));
@@ -445,8 +448,10 @@ signal_setborrowed(). */
 
 static t_signal *signal_new(int n, t_float sr)
 {
-    int logn, vecsize = 0;
-    t_signal *ret, **whichlist;
+    int logn;
+    int vecsize = 0;
+    t_signal *ret;
+    t_signal **whichlist;
     logn = ilog2(n);
     if(n)
     {
@@ -662,7 +667,8 @@ void ugen_add(t_dspcontext *dc, t_object *obj)
 void ugen_connect(
     t_dspcontext *dc, t_object *x1, int outno, t_object *x2, int inno)
 {
-    t_ugenbox *u1, *u2;
+    t_ugenbox *u1;
+    t_ugenbox *u2;
     t_sigoutlet *uout;
     t_siginlet *uin;
     t_sigoutconnect *oc;
@@ -724,7 +730,8 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
     t_siginlet *uin;
     t_sigoutconnect *oc;
     t_class *class = pd_class(&u->u_obj->ob_pd);
-    int i, n;
+    int i;
+    int n;
     /* suppress creating new signals for the outputs of signal
     inlets and subpatches; except in the case we're an inlet and "blocking"
     is set.  We don't yet know if a subcanvas will be "blocking" so there
@@ -739,7 +746,12 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
     int nofreesigs =
         (class == canvas_class || class == clone_class ||
             ((class == voutlet_class) && !(dc->dc_reblock || dc->dc_switched)));
-    t_signal **insig, **outsig, **sig, *s1, *s2, *s3;
+    t_signal **insig;
+    t_signal **outsig;
+    t_signal **sig;
+    t_signal *s1;
+    t_signal *s2;
+    t_signal *s3;
     t_ugenbox *u2;
 
     if(THIS->u_loud)
@@ -879,19 +891,27 @@ void ugen_done_graph(t_dspcontext *dc)
     t_ugenbox *u;
     t_sigoutlet *uout;
     t_siginlet *uin;
-    t_sigoutconnect *oc, *oc2;
-    int i, n;
+    t_sigoutconnect *oc;
+    t_sigoutconnect *oc2;
+    int i;
+    int n;
     t_block *blk;
     t_dspcontext *parent_context = dc->dc_parentcontext;
     t_float parent_srate;
     int parent_vecsize;
-    int period, frequency, phase, vecsize, calcsize;
+    int period;
+    int frequency;
+    int phase;
+    int vecsize;
+    int calcsize;
     t_float srate;
     int chainblockbegin; /* DSP chain onset before block prolog code */
     int chainblockend;   /* and after block epilog code */
     int chainafterall;   /* and after signal outlet epilog */
-    int reblock = 0, switched;
-    int downsample = 1, upsample = 1;
+    int reblock = 0;
+    int switched;
+    int downsample = 1;
+    int upsample = 1;
     /* debugging printout */
 
     if(THIS->u_loud)
@@ -1180,11 +1200,23 @@ t_int *plus_perf8(t_int *w)
     int n = (int) (w[4]);
     for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
     {
-        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
-        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+        t_sample f0 = in1[0];
+        t_sample f1 = in1[1];
+        t_sample f2 = in1[2];
+        t_sample f3 = in1[3];
+        t_sample f4 = in1[4];
+        t_sample f5 = in1[5];
+        t_sample f6 = in1[6];
+        t_sample f7 = in1[7];
 
-        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
-        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+        t_sample g0 = in2[0];
+        t_sample g1 = in2[1];
+        t_sample g2 = in2[2];
+        t_sample g3 = in2[3];
+        t_sample g4 = in2[4];
+        t_sample g5 = in2[5];
+        t_sample g6 = in2[6];
+        t_sample g7 = in2[7];
 
         out[0] = f0 + g0;
         out[1] = f1 + g1;

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -61,18 +61,18 @@ void d_ugen_freepdinstance(void) { freebytes(THIS, sizeof(*THIS)); }
 t_int *zero_perform(t_int *w) /* zero out a vector */
 {
     t_sample *out = (t_sample *) (w[1]);
-    int n = (int) (w[2]);
-    while(n--)
-        *out++ = 0;
+    int num_samples = (int) (w[2]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = 0;
     return (w + 3);
 }
 
 t_int *zero_perf8(t_int *w)
 {
     t_sample *out = (t_sample *) (w[1]);
-    int n = (int) (w[2]);
+    int num_samples = (int) (w[2]);
 
-    for(; n; n -= 8, out += 8)
+    for(int i = 0; i < num_samples; i += 8, out += 8)
     {
         out[0] = 0;
         out[1] = 0;
@@ -1233,9 +1233,9 @@ t_int *plus_perform(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    while(n--)
-        *out++ = *in1++ + *in2++;
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in1[i] + in2[i];
     return (w + 5);
 }
 
@@ -1244,8 +1244,8 @@ t_int *plus_perf8(t_int *w)
     t_sample *in1 = (t_sample *) (w[1]);
     t_sample *in2 = (t_sample *) (w[2]);
     t_sample *out = (t_sample *) (w[3]);
-    int n = (int) (w[4]);
-    for(; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    int num_samples = (int) (w[4]);
+    for(int i = 0; i < num_samples; i += 8, in1 += 8, in2 += 8, out += 8)
     {
         t_sample f0 = in1[0];
         t_sample f1 = in1[1];
@@ -1291,30 +1291,30 @@ void dsp_add_plus(t_sample *in1, t_sample *in2, t_sample *out, int n)
 
 t_int *copy_perform(t_int *w)
 {
-    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
-        *out++ = *in1++;
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = in[i];
     return (w + 4);
 }
 
 static t_int *copy_perf8(t_int *w)
 {
-    t_sample *in1 = (t_sample *) (w[1]);
+    t_sample *in = (t_sample *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
 
-    for(; n; n -= 8, in1 += 8, out += 8)
+    for(int i = 0; i < num_samples; i += 8, in += 8, out += 8)
     {
-        t_sample f0 = in1[0];
-        t_sample f1 = in1[1];
-        t_sample f2 = in1[2];
-        t_sample f3 = in1[3];
-        t_sample f4 = in1[4];
-        t_sample f5 = in1[5];
-        t_sample f6 = in1[6];
-        t_sample f7 = in1[7];
+        t_sample f0 = in[0];
+        t_sample f1 = in[1];
+        t_sample f2 = in[2];
+        t_sample f3 = in[3];
+        t_sample f4 = in[4];
+        t_sample f5 = in[5];
+        t_sample f6 = in[6];
+        t_sample f7 = in[7];
 
         out[0] = f0;
         out[1] = f1;
@@ -1344,9 +1344,9 @@ static t_int *sig_tilde_perform(t_int *w)
 {
     t_float f = *(t_float *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    while(n--)
-        *out++ = f;
+    int num_samples = (int) (w[3]);
+    for(int i = 0; i < num_samples; i++)
+        out[i] = f;
     return (w + 4);
 }
 
@@ -1354,9 +1354,9 @@ static t_int *sig_tilde_perf8(t_int *w)
 {
     t_float f = *(t_float *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
+    int num_samples = (int) (w[3]);
 
-    for(; n; n -= 8, out += 8)
+    for(int i = 0; i < num_samples; i += 8, out += 8)
     {
         out[0] = f;
         out[1] = f;

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -89,9 +89,13 @@ t_int *zero_perf8(t_int *w)
 void dsp_add_zero(t_sample *out, int n)
 {
     if(n & 7)
+    {
         dsp_add(zero_perform, 2, out, (t_int) n);
+    }
     else
+    {
         dsp_add(zero_perf8, 2, out, (t_int) n);
+    }
 }
 
 /* ---------------------------- block~ ----------------------------- */
@@ -177,7 +181,9 @@ static void block_set(
         calcsize = 0; /* this means we'll get it from parent later. */
 
     if(fupsample <= 0)
+    {
         upsample = downsample = 1;
+    }
     else if(fupsample >= 1)
     {
         upsample = fupsample;
@@ -329,8 +335,10 @@ void dsp_add(t_perfroutine f, int n, ...)
     {
         THIS->u_dspchain[THIS->u_dspchainsize + i] = va_arg(ap, t_int);
         if(THIS->u_loud)
+        {
             post("add to chain: %lx",
                 THIS->u_dspchain[THIS->u_dspchainsize + i]);
+        }
     }
     va_end(ap);
     THIS->u_dspchain[newsize - 1] = (t_int) dsp_done;
@@ -461,7 +469,9 @@ static t_signal *signal_new(int n, t_float sr)
 
     /* first try to reclaim one from the free list */
     if((ret = *whichlist))
+    {
         *whichlist = ret->s_nextfree;
+    }
     else
     {
         /* LATER figure out what to do for out-of-space here! */
@@ -672,20 +682,27 @@ void ugen_connect(
     int sigoutno = obj_sigoutletindex(x1, outno);
     int siginno = obj_siginletindex(x2, inno);
     if(THIS->u_loud)
+    {
         post("%s -> %s: %d->%d", class_getname(x1->ob_pd),
             class_getname(x2->ob_pd), outno, inno);
+    }
     for(u1 = dc->dc_ugenlist; u1 && u1->u_obj != x1; u1 = u1->u_next)
         ;
     for(u2 = dc->dc_ugenlist; u2 && u2->u_obj != x2; u2 = u2->u_next)
         ;
     if(!u1 || !u2 || siginno < 0 || !u2->u_nin)
     {
-        if(!u1) pd_error(0, "object with signal outlets but no DSP method?");
-        /* check if it's a "text" (i.e., object wasn't created) -
-        if so fail silently */
+        if(!u1)
+        {
+            pd_error(0, "object with signal outlets but no DSP method?");
+            /* check if it's a "text" (i.e., object wasn't created) -
+            if so fail silently */
+        }
         else if(!(x2 && (pd_class(&x2->ob_pd) == text_class)))
+        {
             pd_error(u1->u_obj,
                 "audio signal outlet connected to nonsignal inlet (ignored)");
+        }
         return;
     }
     if(sigoutno < 0 || sigoutno >= u1->u_nout || siginno >= u2->u_nin)
@@ -762,9 +779,13 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
             /* post("%s: unconnected signal inlet set to zero",
                 class_getname(u->u_obj->ob_pd)); */
             if((scalar = obj_findsignalscalar(u->u_obj, i)))
+            {
                 dsp_add_scalarcopy(scalar, s3->s_vec, s3->s_n);
+            }
             else
+            {
                 dsp_add_zero(s3->s_vec, s3->s_n);
+            }
             uin->i_signal = s3;
             s3->s_refcount = 1;
         }
@@ -782,9 +803,13 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
         case we increment the reference count; the corresponding decrement
         is in sig_makereusable(). */
         if(nofreesigs)
+        {
             (*sig)->s_refcount++;
+        }
         else if(!newrefcount)
+        {
             signal_makereusable(*sig);
+        }
     }
     for(sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
     {
@@ -819,17 +844,25 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
     if(THIS->u_loud)
     {
         if(u->u_nin + u->u_nout == 0)
+        {
             post(
                 "put %s %d", class_getname(u->u_obj->ob_pd), ugen_index(dc, u));
+        }
         else if(u->u_nin + u->u_nout == 1)
+        {
             post("put %s %d (%lx)", class_getname(u->u_obj->ob_pd),
                 ugen_index(dc, u), sig[0]);
+        }
         else if(u->u_nin + u->u_nout == 2)
+        {
             post("put %s %d (%lx %lx)", class_getname(u->u_obj->ob_pd),
                 ugen_index(dc, u), sig[0], sig[1]);
+        }
         else
+        {
             post("put %s %d (%lx %lx %lx ...)", class_getname(u->u_obj->ob_pd),
                 ugen_index(dc, u), sig[0], sig[1], sig[2]);
+        }
     }
 
     /* pass it on and trip anyone whose last inlet was filled */
@@ -918,12 +951,14 @@ void ugen_done_graph(t_dspcontext *dc)
         {
             post("ugen: %s", class_getname(u->u_obj->ob_pd));
             for(uout = u->u_out, i = 0; i < u->u_nout; uout++, i++)
+            {
                 for(oc = uout->o_connections; oc; oc = oc->oc_next)
                 {
                     post("... out %d to %s, index %d, inlet %d", i,
                         class_getname(oc->oc_who->u_obj->ob_pd),
                         ugen_index(dc, oc->oc_who), oc->oc_inno);
                 }
+            }
         }
     }
 
@@ -934,10 +969,14 @@ void ugen_done_graph(t_dspcontext *dc)
         if(pd_class(zz) == block_class)
         {
             if(blk)
+            {
                 pd_error(blk,
                     "conflicting block~ and/or switch~ objects in same window");
+            }
             else
+            {
                 blk = (t_block *) zz;
+            }
         }
     }
 
@@ -1038,13 +1077,17 @@ void ugen_done_graph(t_dspcontext *dc)
         if(outsigs) outsigs += dc->dc_ninlets;
 
         if(pd_class(zz) == vinlet_class)
+        {
             vinlet_dspprolog((struct _vinlet *) zz, dc->dc_iosigs, vecsize,
                 calcsize, THIS->u_phase, period, frequency, downsample,
                 upsample, reblock, switched);
+        }
         else if(pd_class(zz) == voutlet_class)
+        {
             voutlet_dspprolog((struct _voutlet *) zz, outsigs, vecsize,
                 calcsize, THIS->u_phase, period, frequency, downsample,
                 upsample, reblock, switched);
+        }
     }
     chainblockbegin = THIS->u_dspchainsize;
 
@@ -1080,6 +1123,7 @@ void ugen_done_graph(t_dspcontext *dc)
     of ugens not yet scheduled. */
 
     for(u = dc->dc_ugenlist; u; u = u->u_next)
+    {
         if(!u->u_done)
         {
             t_signal **sigp;
@@ -1097,12 +1141,15 @@ void ugen_done_graph(t_dspcontext *dc)
                     (*sigp)->s_refcount++;
                     dsp_add_zero(s3->s_vec, s3->s_n);
                     if(THIS->u_loud)
+                    {
                         post("oops, belatedly set %lx->%lx", *sigp,
                             (*sigp)->s_borrowedfrom);
+                    }
                 }
             }
             break; /* don't need to keep looking. */
         }
+    }
 
     if(blk && (reblock || switched)) /* add block DSP epilog */
         dsp_add(block_epilog, 1, blk);
@@ -1135,8 +1182,10 @@ void ugen_done_graph(t_dspcontext *dc)
     {
         t_int *ip;
         if(!dc->dc_parentcontext)
+        {
             for(i = THIS->u_dspchainsize, ip = THIS->u_dspchain; i--; ip++)
                 post("chain %lx", *ip);
+        }
         post("... ugen_done_graph done.");
     }
     /* now delete everything. */
@@ -1162,9 +1211,13 @@ void ugen_done_graph(t_dspcontext *dc)
         freebytes(u, sizeof *u);
     }
     if(THIS->u_context == dc)
+    {
         THIS->u_context = dc->dc_parentcontext;
+    }
     else
+    {
         bug("THIS->u_context");
+    }
     freebytes(dc, sizeof(*dc));
 }
 
@@ -1230,9 +1283,13 @@ t_int *plus_perf8(t_int *w)
 void dsp_add_plus(t_sample *in1, t_sample *in2, t_sample *out, int n)
 {
     if(n & 7)
+    {
         dsp_add(plus_perform, 4, in1, in2, out, (t_int) n);
+    }
     else
+    {
         dsp_add(plus_perf8, 4, in1, in2, out, (t_int) n);
+    }
 }
 
 t_int *copy_perform(t_int *w)
@@ -1277,9 +1334,13 @@ static t_int *copy_perf8(t_int *w)
 void dsp_add_copy(t_sample *in, t_sample *out, int n)
 {
     if(n & 7)
+    {
         dsp_add(copy_perform, 3, in, out, (t_int) n);
+    }
     else
+    {
         dsp_add(copy_perf8, 3, in, out, (t_int) n);
+    }
 }
 
 static t_int *sig_tilde_perform(t_int *w)
@@ -1315,9 +1376,13 @@ static t_int *sig_tilde_perf8(t_int *w)
 void dsp_add_scalarcopy(t_float *in, t_sample *out, int n)
 {
     if(n & 7)
+    {
         dsp_add(sig_tilde_perform, 3, in, out, (t_int) n);
+    }
     else
+    {
         dsp_add(sig_tilde_perf8, 3, in, out, (t_int) n);
+    }
 }
 
 /* ------------------------ samplerate~~ -------------------------- */

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -322,7 +322,6 @@ static t_int dsp_done(t_int *w) { return (0); }
 void dsp_add(t_perfroutine f, int n, ...)
 {
     int newsize = THIS->u_dspchainsize + n + 1;
-    int i;
     va_list ap;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
@@ -331,7 +330,7 @@ void dsp_add(t_perfroutine f, int n, ...)
     if(THIS->u_loud)
         post("add to chain: %lx", THIS->u_dspchain[THIS->u_dspchainsize - 1]);
     va_start(ap, n);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         THIS->u_dspchain[THIS->u_dspchainsize + i] = va_arg(ap, t_int);
         if(THIS->u_loud)
@@ -349,12 +348,11 @@ void dsp_add(t_perfroutine f, int n, ...)
 void dsp_addv(t_perfroutine f, int n, t_int *vec)
 {
     int newsize = THIS->u_dspchainsize + n + 1;
-    int i;
 
     THIS->u_dspchain = t_resizebytes(THIS->u_dspchain,
         THIS->u_dspchainsize * sizeof(t_int), newsize * sizeof(t_int));
     THIS->u_dspchain[THIS->u_dspchainsize - 1] = (t_int) f;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         THIS->u_dspchain[THIS->u_dspchainsize + i] = vec[i];
     THIS->u_dspchain[newsize - 1] = (t_int) dsp_done;
     THIS->u_dspchainsize = newsize;
@@ -389,7 +387,6 @@ int ilog2(int n)
 static void signal_cleanup(void)
 {
     t_signal *sig;
-    int i;
     while((sig = THIS->u_signals))
     {
         THIS->u_signals = sig->s_nextused;
@@ -397,7 +394,7 @@ static void signal_cleanup(void)
             t_freebytes(sig->s_vec, sig->s_vecsize * sizeof(*sig->s_vec));
         t_freebytes(sig, sizeof *sig);
     }
-    for(i = 0; i <= MAXLOGSIG; i++)
+    for(int i = 0; i <= MAXLOGSIG; i++)
         THIS->u_freelist[i] = 0;
     THIS->u_freeborrowed = 0;
 }

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -128,7 +128,8 @@ int iemgui_modulo_color(int col)
 t_symbol *iemgui_dollar2raute(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING + 1], *s2;
+    char buf[MAXPDSTRING + 1];
+    char *s2;
     if(strlen(s->s_name) >= MAXPDSTRING) return (s);
     for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
@@ -143,7 +144,8 @@ t_symbol *iemgui_dollar2raute(t_symbol *s)
 t_symbol *iemgui_raute2dollar(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING + 1], *s2;
+    char buf[MAXPDSTRING + 1];
+    char *s2;
     if(strlen(s->s_name) >= MAXPDSTRING) return (s);
     for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
@@ -158,7 +160,8 @@ t_symbol *iemgui_raute2dollar(t_symbol *s)
 t_symbol *iemgui_put_in_braces(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING + 1], *s2;
+    char buf[MAXPDSTRING + 1];
+    char *s2;
     int i = 0;
     if(strlen(s->s_name) >= MAXPDSTRING) return (s);
     for(s1 = s->s_name, s2 = buf;; s1++, s2++, i++)
@@ -390,7 +393,8 @@ void iemgui_all_put_in_braces(t_symbol **srlsym)
 
 void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 {
-    int sndable = 1, oldsndrcvable = 0;
+    int sndable = 1;
+    int oldsndrcvable = 0;
 
     if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
     if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
@@ -408,7 +412,8 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
 {
     t_symbol *rcv;
-    int rcvable = 1, oldsndrcvable = 0;
+    int rcvable = 1;
+    int oldsndrcvable = 0;
 
     if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
     if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
@@ -649,7 +654,9 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     int bcol = (int) iemgui_getcolorarg(14, argc, argv);
     int fcol = (int) iemgui_getcolorarg(15, argc, argv);
     int lcol = (int) iemgui_getcolorarg(16, argc, argv);
-    int sndable = 1, rcvable = 1, oldsndrcvable = 0;
+    int sndable = 1;
+    int rcvable = 1;
+    int oldsndrcvable = 0;
 
     if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
     if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -196,7 +196,7 @@ t_symbol *iemgui_new_dogetname(t_iemgui *iemgui, int indx, t_atom *argv)
 {
     if(IS_A_SYMBOL(argv, indx))
         return (atom_getsymbolarg(indx, 100000, argv));
-    else if(IS_A_FLOAT(argv, indx))
+    if(IS_A_FLOAT(argv, indx))
     {
         char str[80];
         sprintf(str, "%d", (int) atom_getfloatarg(indx, 100000, argv));
@@ -364,8 +364,7 @@ int iemgui_compatible_colorarg(int index, int argc, t_atom *argv)
             int idx = iemgui_modulo_color(col);
             return (iemgui_color_hex[(idx)]);
         }
-        else
-            return ((-1 - col) & 0xffffff);
+        return ((-1 - col) & 0xffffff);
     }
     return iemgui_getcolorarg(index, argc, argv);
 }

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -786,8 +786,7 @@ void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom *argv)
     } while(0)
     t_float zoom = iemgui->x_glist->gl_zoom;
     t_symbol *srl[3];
-    int i;
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         SETFLOAT(argv + i, -1); /* initialize */
 
     iemgui_properties(iemgui, srl);

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -5,7 +5,6 @@
 /* g_7_guis.c written by Thomas Musil (c) IEM KUG Graz Austria 2000-2001 */
 /* thanks to Miller Puckette, Guenther Geiger and Krzystof Czaja */
 
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -31,51 +30,29 @@
 
 /*------------------ global variables -------------------------*/
 
-int iemgui_color_hex[]=
-{
-    16579836, 10526880, 4210752, 16572640, 16572608,
-    16579784, 14220504, 14220540, 14476540, 16308476,
-    14737632, 8158332, 2105376, 16525352, 16559172,
-    15263784, 1370132, 2684148, 3952892, 16003312,
-    12369084, 6316128, 0, 9177096, 5779456,
-    7874580, 2641940, 17488, 5256, 5767248
-};
+int iemgui_color_hex[] = {16579836, 10526880, 4210752, 16572640, 16572608,
+    16579784, 14220504, 14220540, 14476540, 16308476, 14737632, 8158332,
+    2105376, 16525352, 16559172, 15263784, 1370132, 2684148, 3952892, 16003312,
+    12369084, 6316128, 0, 9177096, 5779456, 7874580, 2641940, 17488, 5256,
+    5767248};
 
-int iemgui_vu_db2i[]=
-{
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
-    6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-    7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-    8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-    9, 9, 9, 9, 9,10,10,10,10,10,
-    11,11,11,11,11,12,12,12,12,12,
-    13,13,13,13,14,14,14,14,15,15,
-    15,15,16,16,16,16,17,17,17,18,
-    18,18,19,19,19,20,20,20,21,21,
-    22,22,23,23,24,24,25,26,27,28,
-    29,30,31,32,33,33,34,34,35,35,
-    36,36,37,37,37,38,38,38,39,39,
-    39,39,39,39,40,40
-};
+int iemgui_vu_db2i[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 9, 9, 9, 9,
+    9, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 13, 13, 13,
+    13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18,
+    19, 19, 19, 20, 20, 20, 21, 21, 22, 22, 23, 23, 24, 24, 25, 26, 27, 28, 29,
+    30, 31, 32, 33, 33, 34, 34, 35, 35, 36, 36, 37, 37, 37, 38, 38, 38, 39, 39,
+    39, 39, 39, 39, 40, 40};
 
-int iemgui_vu_col[]=
-{
-    0,17,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,
-    15,15,15,15,15,15,15,15,15,15,14,14,13,13,13,13,13,13,13,13,13,13,13,19,19,19
-};
+int iemgui_vu_col[] = {0, 17, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
+    16, 16, 16, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 14, 13, 13, 13, 13,
+    13, 13, 13, 13, 13, 13, 13, 19, 19, 19};
 
-char *iemgui_vu_scale_str[]=
-{
+char *iemgui_vu_scale_str[] = {
     "",
     "<-99",
     "",
@@ -125,22 +102,18 @@ char *iemgui_vu_scale_str[]=
     "",
 };
 
-
 /*------------------ global functions -------------------------*/
-
 
 int iemgui_clip_size(int size)
 {
-    if(size < IEM_GUI_MINSIZE)
-        size = IEM_GUI_MINSIZE;
-    return(size);
+    if(size < IEM_GUI_MINSIZE) size = IEM_GUI_MINSIZE;
+    return (size);
 }
 
 int iemgui_clip_font(int size)
 {
-    if(size < IEM_FONT_MINSIZE)
-        size = IEM_FONT_MINSIZE;
-    return(size);
+    if(size < IEM_FONT_MINSIZE) size = IEM_FONT_MINSIZE;
+    return (size);
 }
 
 int iemgui_modulo_color(int col)
@@ -149,56 +122,53 @@ int iemgui_modulo_color(int col)
         col -= IEM_GUI_MAX_COLOR;
     while(col < 0)
         col += IEM_GUI_MAX_COLOR;
-    return(col);
+    return (col);
 }
 
 t_symbol *iemgui_dollar2raute(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING+1], *s2;
-    if (strlen(s->s_name) >= MAXPDSTRING)
-        return (s);
-    for (s1 = s->s_name, s2 = buf; ; s1++, s2++)
+    char buf[MAXPDSTRING + 1], *s2;
+    if(strlen(s->s_name) >= MAXPDSTRING) return (s);
+    for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
-        if (*s1 == '$')
+        if(*s1 == '$')
             *s2 = '#';
-        else if (!(*s2 = *s1))
+        else if(!(*s2 = *s1))
             break;
     }
-    return(gensym(buf));
+    return (gensym(buf));
 }
 
 t_symbol *iemgui_raute2dollar(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING+1], *s2;
-    if (strlen(s->s_name) >= MAXPDSTRING)
-        return (s);
-    for (s1 = s->s_name, s2 = buf; ; s1++, s2++)
+    char buf[MAXPDSTRING + 1], *s2;
+    if(strlen(s->s_name) >= MAXPDSTRING) return (s);
+    for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
-        if (*s1 == '#')
+        if(*s1 == '#')
             *s2 = '$';
-        else if (!(*s2 = *s1))
+        else if(!(*s2 = *s1))
             break;
     }
-    return(gensym(buf));
+    return (gensym(buf));
 }
 
 t_symbol *iemgui_put_in_braces(t_symbol *s)
 {
     const char *s1;
-    char buf[MAXPDSTRING+1], *s2;
+    char buf[MAXPDSTRING + 1], *s2;
     int i = 0;
-    if (strlen(s->s_name) >= MAXPDSTRING)
-        return (s);
-    for (s1 = s->s_name, s2 = buf; ; s1++, s2++, i++)
+    if(strlen(s->s_name) >= MAXPDSTRING) return (s);
+    for(s1 = s->s_name, s2 = buf;; s1++, s2++, i++)
     {
-        if (i == 0)
+        if(i == 0)
         {
             *s2 = '{';
             s2++;
         }
-        if (!(*s2 = *s1))
+        if(!(*s2 = *s1))
         {
             *s2 = '}';
             s2++;
@@ -206,7 +176,7 @@ t_symbol *iemgui_put_in_braces(t_symbol *s)
             break;
         }
     }
-    return(gensym(buf));
+    return (gensym(buf));
 }
 
 void iemgui_verify_snd_ne_rcv(t_iemgui *iemgui)
@@ -221,36 +191,38 @@ void iemgui_verify_snd_ne_rcv(t_iemgui *iemgui)
 
 t_symbol *iemgui_new_dogetname(t_iemgui *iemgui, int indx, t_atom *argv)
 {
-    if (IS_A_SYMBOL(argv, indx))
+    if(IS_A_SYMBOL(argv, indx))
         return (atom_getsymbolarg(indx, 100000, argv));
-    else if (IS_A_FLOAT(argv, indx))
+    else if(IS_A_FLOAT(argv, indx))
     {
         char str[80];
-        sprintf(str, "%d", (int)atom_getfloatarg(indx, 100000, argv));
+        sprintf(str, "%d", (int) atom_getfloatarg(indx, 100000, argv));
         return (gensym(str));
     }
-    else return (gensym("empty"));
+    else
+        return (gensym("empty"));
 }
 
 void iemgui_new_getnames(t_iemgui *iemgui, int indx, t_atom *argv)
 {
-    if (argv)
+    if(argv)
     {
         iemgui->x_snd = iemgui_new_dogetname(iemgui, indx, argv);
-        iemgui->x_rcv = iemgui_new_dogetname(iemgui, indx+1, argv);
-        iemgui->x_lab = iemgui_new_dogetname(iemgui, indx+2, argv);
+        iemgui->x_rcv = iemgui_new_dogetname(iemgui, indx + 1, argv);
+        iemgui->x_lab = iemgui_new_dogetname(iemgui, indx + 2, argv);
     }
-    else iemgui->x_snd = iemgui->x_rcv = iemgui->x_lab = gensym("empty");
+    else
+        iemgui->x_snd = iemgui->x_rcv = iemgui->x_lab = gensym("empty");
     iemgui->x_snd_unexpanded = iemgui->x_rcv_unexpanded =
         iemgui->x_lab_unexpanded = 0;
     iemgui->x_binbufindex = indx;
     iemgui->x_labelbindex = indx + 3;
 }
 
-    /* convert symbols in "$" form to the expanded symbols */
+/* convert symbols in "$" form to the expanded symbols */
 void iemgui_all_dollararg2sym(t_iemgui *iemgui, t_symbol **srlsym)
 {
-        /* save unexpanded ones for later */
+    /* save unexpanded ones for later */
     iemgui->x_snd_unexpanded = srlsym[0];
     iemgui->x_rcv_unexpanded = srlsym[1];
     iemgui->x_lab_unexpanded = srlsym[2];
@@ -259,35 +231,36 @@ void iemgui_all_dollararg2sym(t_iemgui *iemgui, t_symbol **srlsym)
     srlsym[2] = canvas_realizedollar(iemgui->x_glist, srlsym[2]);
 }
 
-    /* initialize a single symbol in unexpanded form.  We reach into the
-    binbuf to grab them; if there's nothing there, set it to the
-    fallback; if still nothing, set to "empty". */
-static void iemgui_init_sym2dollararg(t_iemgui *iemgui, t_symbol **symp,
-    int indx, t_symbol *fallback)
+/* initialize a single symbol in unexpanded form.  We reach into the
+binbuf to grab them; if there's nothing there, set it to the
+fallback; if still nothing, set to "empty". */
+static void iemgui_init_sym2dollararg(
+    t_iemgui *iemgui, t_symbol **symp, int indx, t_symbol *fallback)
 {
-    if (!*symp)
+    if(!*symp)
     {
         t_binbuf *b = iemgui->x_obj.ob_binbuf;
-        if (binbuf_getnatom(b) > indx)
+        if(binbuf_getnatom(b) > indx)
         {
             char buf[80];
             atom_string(binbuf_getvec(b) + indx, buf, 80);
             *symp = gensym(buf);
         }
-        else if (fallback)
+        else if(fallback)
             *symp = fallback;
-        else *symp = gensym("empty");
+        else
+            *symp = gensym("empty");
     }
 }
 
-    /* get the unexpanded versions of the symbols; initialize them if
-    necessary. */
+/* get the unexpanded versions of the symbols; initialize them if
+necessary. */
 void iemgui_all_sym2dollararg(t_iemgui *iemgui, t_symbol **srlsym)
 {
     iemgui_init_sym2dollararg(iemgui, &iemgui->x_snd_unexpanded,
-        iemgui->x_binbufindex+1, iemgui->x_snd);
+        iemgui->x_binbufindex + 1, iemgui->x_snd);
     iemgui_init_sym2dollararg(iemgui, &iemgui->x_rcv_unexpanded,
-        iemgui->x_binbufindex+2, iemgui->x_rcv);
+        iemgui->x_binbufindex + 2, iemgui->x_rcv);
     iemgui_init_sym2dollararg(iemgui, &iemgui->x_lab_unexpanded,
         iemgui->x_labelbindex, iemgui->x_lab);
     srlsym[0] = iemgui->x_snd_unexpanded;
@@ -295,67 +268,71 @@ void iemgui_all_sym2dollararg(t_iemgui *iemgui, t_symbol **srlsym)
     srlsym[2] = iemgui->x_lab_unexpanded;
 }
 
-static t_symbol* color2symbol(int col) {
-    const int  compat = (pd_compatibilitylevel < 48) ? 1 : 0;
+static t_symbol *color2symbol(int col)
+{
+    const int compat = (pd_compatibilitylevel < 48) ? 1 : 0;
 
     char colname[MAXPDSTRING];
-    colname[0] = colname[MAXPDSTRING-1] = 0;
+    colname[0] = colname[MAXPDSTRING - 1] = 0;
 
-    if (compat)
+    if(compat)
     {
-            /* compatibility with Pd<=0.47: saves colors as numbers with limited resolution */
-        int col2 = -1 - (((0xfc0000 & col) >> 6)|((0xfc00 & col) >> 4)|((0xfc & col) >> 2));
-        snprintf(colname, MAXPDSTRING-1, "%d", col2);
-    } else {
-        snprintf(colname, MAXPDSTRING-1, "#%06x", col);
+        /* compatibility with Pd<=0.47: saves colors as numbers with limited
+         * resolution */
+        int col2 = -1 - (((0xfc0000 & col) >> 6) | ((0xfc00 & col) >> 4) |
+                            ((0xfc & col) >> 2));
+        snprintf(colname, MAXPDSTRING - 1, "%d", col2);
+    }
+    else
+    {
+        snprintf(colname, MAXPDSTRING - 1, "#%06x", col);
     }
     return gensym(colname);
 }
 
-void iemgui_all_col2save(t_iemgui *iemgui, t_symbol**bflcol)
+void iemgui_all_col2save(t_iemgui *iemgui, t_symbol **bflcol)
 {
     bflcol[0] = color2symbol(iemgui->x_bcol);
     bflcol[1] = color2symbol(iemgui->x_fcol);
     bflcol[2] = color2symbol(iemgui->x_lcol);
 }
 
-static int iemgui_getcolorarg(int index, int argc, t_atom*argv)
+static int iemgui_getcolorarg(int index, int argc, t_atom *argv)
 {
-    if(index < 0 || index >= argc)
-        return 0;
-    if(IS_A_FLOAT(argv,index))
-        return atom_getfloatarg(index, argc, argv);
-    if(IS_A_SYMBOL(argv,index))
+    if(index < 0 || index >= argc) return 0;
+    if(IS_A_FLOAT(argv, index)) return atom_getfloatarg(index, argc, argv);
+    if(IS_A_SYMBOL(argv, index))
     {
-        t_symbol*s=atom_getsymbolarg(index, argc, argv);
-        if ('#' == s->s_name[0])
+        t_symbol *s = atom_getsymbolarg(index, argc, argv);
+        if('#' == s->s_name[0])
         {
-            int col = (int)strtol(s->s_name+1, 0, 16);
+            int col = (int) strtol(s->s_name + 1, 0, 16);
             return col & 0xFFFFFF;
         }
     }
     return 0;
 }
 
-static int colfromatomload(t_atom*colatom)
+static int colfromatomload(t_atom *colatom)
 {
     int color;
-        /* old-fashioned color argument, either a number or symbol
-        evaluating to an integer */
-    if (colatom->a_type == A_FLOAT)
+    /* old-fashioned color argument, either a number or symbol
+    evaluating to an integer */
+    if(colatom->a_type == A_FLOAT)
         color = atom_getfloat(colatom);
-    else if (colatom->a_type == A_SYMBOL &&
-        (isdigit(colatom->a_w.w_symbol->s_name[0]) ||
-            colatom->a_w.w_symbol->s_name[0] == '-'))
-                color = atoi(colatom->a_w.w_symbol->s_name);
+    else if(colatom->a_type == A_SYMBOL &&
+            (isdigit(colatom->a_w.w_symbol->s_name[0]) ||
+                colatom->a_w.w_symbol->s_name[0] == '-'))
+        color = atoi(colatom->a_w.w_symbol->s_name);
 
-        /* symbolic color */
-    else return (iemgui_getcolorarg(0, 1, colatom));
-    if (color < 0)
+    /* symbolic color */
+    else
+        return (iemgui_getcolorarg(0, 1, colatom));
+    if(color < 0)
     {
         color = -1 - color;
-        color = ((color & 0x3f000) << 6)|((color & 0xfc0) << 4)|
-            ((color & 0x3f) << 2);
+        color = ((color & 0x3f000) << 6) | ((color & 0xfc0) << 4) |
+                ((color & 0x3f) << 2);
     }
     else
     {
@@ -365,28 +342,28 @@ static int colfromatomload(t_atom*colatom)
     return (color);
 }
 
-void iemgui_all_loadcolors(t_iemgui *iemgui, t_atom*bcol, t_atom*fcol, t_atom*lcol)
+void iemgui_all_loadcolors(
+    t_iemgui *iemgui, t_atom *bcol, t_atom *fcol, t_atom *lcol)
 {
-    if(bcol)iemgui->x_bcol = colfromatomload(bcol);
-    if(fcol)iemgui->x_fcol = colfromatomload(fcol);
-    if(lcol)iemgui->x_lcol = colfromatomload(lcol);
+    if(bcol) iemgui->x_bcol = colfromatomload(bcol);
+    if(fcol) iemgui->x_fcol = colfromatomload(fcol);
+    if(lcol) iemgui->x_lcol = colfromatomload(lcol);
 }
 
-int iemgui_compatible_colorarg(int index, int argc, t_atom* argv)
+int iemgui_compatible_colorarg(int index, int argc, t_atom *argv)
 {
-    if (index < 0 || index >= argc)
-        return 0;
-    if(IS_A_FLOAT(argv,index))
+    if(index < 0 || index >= argc) return 0;
+    if(IS_A_FLOAT(argv, index))
+    {
+        int col = atom_getfloatarg(index, argc, argv);
+        if(col >= 0)
         {
-            int col=atom_getfloatarg(index, argc, argv);
-            if(col >= 0)
-            {
-                int idx = iemgui_modulo_color(col);
-                return(iemgui_color_hex[(idx)]);
-            }
-            else
-               return((-1 -col)&0xffffff);
+            int idx = iemgui_modulo_color(col);
+            return (iemgui_color_hex[(idx)]);
         }
+        else
+            return ((-1 - col) & 0xffffff);
+    }
     return iemgui_getcolorarg(index, argc, argv);
 }
 
@@ -413,12 +390,10 @@ void iemgui_all_put_in_braces(t_symbol **srlsym)
 
 void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
 {
-    int sndable=1, oldsndrcvable=0;
+    int sndable = 1, oldsndrcvable = 0;
 
-    if(iemgui->x_fsf.x_rcv_able)
-        oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
-    if(iemgui->x_fsf.x_snd_able)
-        oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
+    if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
+    if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
 
     if(!strcmp(s->s_name, "empty")) sndable = 0;
     iemgui->x_snd_unexpanded = s;
@@ -426,18 +401,17 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_fsf.x_snd_able = sndable;
     iemgui_verify_snd_ne_rcv(iemgui);
     if(glist_isvisible(iemgui->x_glist))
-        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+        (*iemgui->x_draw)(
+            x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
 }
 
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
 {
     t_symbol *rcv;
-    int rcvable=1, oldsndrcvable=0;
+    int rcvable = 1, oldsndrcvable = 0;
 
-    if(iemgui->x_fsf.x_rcv_able)
-        oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
-    if(iemgui->x_fsf.x_snd_able)
-        oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
+    if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
+    if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
 
     if(!strcmp(s->s_name, "empty")) rcvable = 0;
     rcv = s;
@@ -461,7 +435,8 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_fsf.x_rcv_able = rcvable;
     iemgui_verify_snd_ne_rcv(iemgui);
     if(glist_isvisible(iemgui->x_glist))
-        (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+        (*iemgui->x_draw)(
+            x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
 }
 
 void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -469,57 +444,62 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
     t_symbol *old;
     char lab_escaped[MAXPDSTRING];
 
-        /* tb: fix for empty label { */
-        if (s == gensym(""))
-                s = gensym("empty");
-        /* tb } */
+    /* tb: fix for empty label { */
+    if(s == gensym("")) s = gensym("empty");
+    /* tb } */
 
     old = iemgui->x_lab;
     iemgui->x_lab_unexpanded = s;
-    iemgui->x_lab = canvas_realizedollar(iemgui->x_glist, iemgui->x_lab_unexpanded);
+    iemgui->x_lab =
+        canvas_realizedollar(iemgui->x_glist, iemgui->x_lab_unexpanded);
 
-    lab_escaped[MAXPDSTRING-1] = 0;
-    pdgui_strnescape( lab_escaped, MAXPDSTRING, iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name) );
+    lab_escaped[MAXPDSTRING - 1] = 0;
+    pdgui_strnescape(lab_escaped, MAXPDSTRING, iemgui->x_lab->s_name,
+        strlen(iemgui->x_lab->s_name));
 
     if(glist_isvisible(iemgui->x_glist) && iemgui->x_lab != old)
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape \"%s \"] \n",
-                 glist_getcanvas(iemgui->x_glist), x,
-                 strcmp(s->s_name, "empty")?lab_escaped:"");
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape "
+                 "\"%s \"] \n",
+            glist_getcanvas(iemgui->x_glist), x,
+            strcmp(s->s_name, "empty") ? lab_escaped : "");
 }
 
-void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
+void iemgui_label_pos(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     int zoom = glist_getzoom(iemgui->x_glist);
-    iemgui->x_ldx = (int)atom_getfloatarg(0, ac, av);
-    iemgui->x_ldy = (int)atom_getfloatarg(1, ac, av);
+    iemgui->x_ldx = (int) atom_getfloatarg(0, ac, av);
+    iemgui->x_ldy = (int) atom_getfloatarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
         sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-                 glist_getcanvas(iemgui->x_glist), x,
-                 text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom,
-                 text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom);
+            glist_getcanvas(iemgui->x_glist), x,
+            text_xpix((t_object *) x, iemgui->x_glist) + iemgui->x_ldx * zoom,
+            text_ypix((t_object *) x, iemgui->x_glist) + iemgui->x_ldy * zoom);
 }
 
-void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
+void iemgui_label_font(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     int zoom = glist_getzoom(iemgui->x_glist);
-    int f = (int)atom_getfloatarg(0, ac, av);
+    int f = (int) atom_getfloatarg(0, ac, av);
 
-    if(f == 1) strcpy(iemgui->x_font, "helvetica");
-    else if(f == 2) strcpy(iemgui->x_font, "times");
+    if(f == 1)
+        strcpy(iemgui->x_font, "helvetica");
+    else if(f == 2)
+        strcpy(iemgui->x_font, "times");
     else
     {
         f = 0;
         strcpy(iemgui->x_font, sys_font);
     }
     iemgui->x_fsf.x_font_style = f;
-    f = (int)atom_getfloatarg(1, ac, av);
-    if(f < 4)
-        f = 4;
+    f = (int) atom_getfloatarg(1, ac, av);
+    if(f < 4) f = 4;
     iemgui->x_fontsize = f;
     if(glist_isvisible(iemgui->x_glist))
         sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s}\n",
-                 glist_getcanvas(iemgui->x_glist), x, iemgui->x_font,
-                 iemgui->x_fontsize*zoom, sys_fontweight);
+            glist_getcanvas(iemgui->x_glist), x, iemgui->x_font,
+            iemgui->x_fontsize * zoom, sys_fontweight);
 }
 
 void iemgui_size(void *x, t_iemgui *iemgui)
@@ -527,91 +507,89 @@ void iemgui_size(void *x, t_iemgui *iemgui)
     if(glist_isvisible(iemgui->x_glist))
     {
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(iemgui->x_glist, (t_text*)x);
+        canvas_fixlinesfor(iemgui->x_glist, (t_text *) x);
     }
 }
 
 void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     int zoom = glist_getzoom(iemgui->x_glist);
-    iemgui->x_obj.te_xpix += (int)atom_getfloatarg(0, ac, av);
-    iemgui->x_obj.te_ypix += (int)atom_getfloatarg(1, ac, av);
+    iemgui->x_obj.te_xpix += (int) atom_getfloatarg(0, ac, av);
+    iemgui->x_obj.te_ypix += (int) atom_getfloatarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
     {
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(iemgui->x_glist, (t_text*)x);
+        canvas_fixlinesfor(iemgui->x_glist, (t_text *) x);
     }
 }
 
 void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     int zoom = glist_getzoom(iemgui->x_glist);
-    iemgui->x_obj.te_xpix = (int)atom_getfloatarg(0, ac, av);
-    iemgui->x_obj.te_ypix = (int)atom_getfloatarg(1, ac, av);
+    iemgui->x_obj.te_xpix = (int) atom_getfloatarg(0, ac, av);
+    iemgui->x_obj.te_ypix = (int) atom_getfloatarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
     {
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(iemgui->x_glist, (t_text*)x);
+        canvas_fixlinesfor(iemgui->x_glist, (t_text *) x);
     }
 }
 
 void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    if (ac >= 1)
-        iemgui->x_bcol = iemgui_compatible_colorarg(0, ac, av);
-    if (ac == 2 && pd_compatibilitylevel < 47)
-            /* old versions of Pd updated foreground and label color
-            if only two args; now we do it more coherently. */
+    if(ac >= 1) iemgui->x_bcol = iemgui_compatible_colorarg(0, ac, av);
+    if(ac == 2 && pd_compatibilitylevel < 47)
+        /* old versions of Pd updated foreground and label color
+        if only two args; now we do it more coherently. */
         iemgui->x_lcol = iemgui_compatible_colorarg(1, ac, av);
-    else if (ac >= 2)
+    else if(ac >= 2)
         iemgui->x_fcol = iemgui_compatible_colorarg(1, ac, av);
-    if (ac >= 3)
-        iemgui->x_lcol = iemgui_compatible_colorarg(2, ac, av);
+    if(ac >= 3) iemgui->x_lcol = iemgui_compatible_colorarg(2, ac, av);
     if(glist_isvisible(iemgui->x_glist))
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_CONFIG);
 }
 
 void iemgui_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
-    t_iemgui *x = (t_iemgui *)z;
+    t_iemgui *x = (t_iemgui *) z;
 
     x->x_obj.te_xpix += dx;
     x->x_obj.te_ypix += dy;
     if(glist_isvisible(x->x_glist))
     {
-        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(glist, (t_text *)z);
+        (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_MOVE);
+        canvas_fixlinesfor(glist, (t_text *) z);
     }
 }
 
 void iemgui_select(t_gobj *z, t_glist *glist, int selected)
 {
-    t_iemgui *x = (t_iemgui *)z;
+    t_iemgui *x = (t_iemgui *) z;
 
     x->x_fsf.x_selected = selected;
     if(glist_isvisible(x->x_glist))
-        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_SELECT);
+        (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_SELECT);
 }
 
 void iemgui_delete(t_gobj *z, t_glist *glist)
 {
-    canvas_deletelinesfor(glist, (t_text *)z);
+    canvas_deletelinesfor(glist, (t_text *) z);
 }
 
 void iemgui_vis(t_gobj *z, t_glist *glist, int vis)
 {
-    t_iemgui *x = (t_iemgui *)z;
+    t_iemgui *x = (t_iemgui *) z;
 
-    if (vis)
-        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_NEW);
+    if(vis)
+        (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_NEW);
     else
     {
-        (*x->x_draw)((void *)z, glist, IEM_GUI_DRAW_MODE_ERASE);
+        (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_ERASE);
         sys_unqueuegui(z);
     }
 }
 
-void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol**bflcol)
+void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol **bflcol)
 {
     srl[0] = iemgui->x_snd;
     srl[1] = iemgui->x_rcv;
@@ -620,26 +598,25 @@ void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol**bflcol)
     iemgui_all_col2save(iemgui, bflcol);
 }
 
-    /* inform GUIs that glist's zoom is about to change.  The glist will
-    take care of x,y locations but we have to adjust width and height */
+/* inform GUIs that glist's zoom is about to change.  The glist will
+take care of x,y locations but we have to adjust width and height */
 void iemgui_zoom(t_iemgui *iemgui, t_floatarg zoom)
 {
     int oldzoom = iemgui->x_glist->gl_zoom;
-    if (oldzoom < 1)
-        oldzoom = 1;
-    iemgui->x_w = (int)(iemgui->x_w)/oldzoom*(int)zoom;
-    iemgui->x_h = (int)(iemgui->x_h)/oldzoom*(int)zoom;
+    if(oldzoom < 1) oldzoom = 1;
+    iemgui->x_w = (int) (iemgui->x_w) / oldzoom * (int) zoom;
+    iemgui->x_h = (int) (iemgui->x_h) / oldzoom * (int) zoom;
 }
 
-    /* when creating a new GUI from menu onto a zoomed canvas, pretend to
-    change the canvas's zoom so we'll get properly sized */
+/* when creating a new GUI from menu onto a zoomed canvas, pretend to
+change the canvas's zoom so we'll get properly sized */
 void iemgui_newzoom(t_iemgui *iemgui)
 {
-    if (iemgui->x_glist->gl_zoom != 1)
+    if(iemgui->x_glist->gl_zoom != 1)
     {
         int newzoom = iemgui->x_glist->gl_zoom;
         iemgui->x_glist->gl_zoom = 1;
-        iemgui_zoom(iemgui, (t_floatarg)newzoom);
+        iemgui_zoom(iemgui, (t_floatarg) newzoom);
         iemgui->x_glist->gl_zoom = newzoom;
     }
 }
@@ -652,8 +629,8 @@ void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
     srl[1] = iemgui->x_rcv;
 
     strcpy(label, iemgui->x_lab->s_name);
-    pdgui_strnescape(label, MAXPDSTRING,
-                    iemgui->x_lab->s_name, strlen(iemgui->x_lab->s_name));
+    pdgui_strnescape(label, MAXPDSTRING, iemgui->x_lab->s_name,
+        strlen(iemgui->x_lab->s_name));
     srl[2] = gensym(label);
 
     iemgui_all_dollar2raute(srl);
@@ -664,39 +641,37 @@ void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
 {
     char str[144];
-    int init = (int)atom_getfloatarg(5, argc, argv);
-    int ldx = (int)atom_getfloatarg(10, argc, argv);
-    int ldy = (int)atom_getfloatarg(11, argc, argv);
-    int f = (int)atom_getfloatarg(12, argc, argv);
-    int fs = (int)atom_getfloatarg(13, argc, argv);
-    int bcol = (int)iemgui_getcolorarg(14, argc, argv);
-    int fcol = (int)iemgui_getcolorarg(15, argc, argv);
-    int lcol = (int)iemgui_getcolorarg(16, argc, argv);
-    int sndable=1, rcvable=1, oldsndrcvable=0;
+    int init = (int) atom_getfloatarg(5, argc, argv);
+    int ldx = (int) atom_getfloatarg(10, argc, argv);
+    int ldy = (int) atom_getfloatarg(11, argc, argv);
+    int f = (int) atom_getfloatarg(12, argc, argv);
+    int fs = (int) atom_getfloatarg(13, argc, argv);
+    int bcol = (int) iemgui_getcolorarg(14, argc, argv);
+    int fcol = (int) iemgui_getcolorarg(15, argc, argv);
+    int lcol = (int) iemgui_getcolorarg(16, argc, argv);
+    int sndable = 1, rcvable = 1, oldsndrcvable = 0;
 
-    if(iemgui->x_fsf.x_rcv_able)
-        oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
-    if(iemgui->x_fsf.x_snd_able)
-        oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
-    if(IS_A_SYMBOL(argv,7))
+    if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
+    if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
+    if(IS_A_SYMBOL(argv, 7))
         srl[0] = atom_getsymbolarg(7, argc, argv);
-    else if(IS_A_FLOAT(argv,7))
+    else if(IS_A_FLOAT(argv, 7))
     {
-        sprintf(str, "%d", (int)atom_getfloatarg(7, argc, argv));
+        sprintf(str, "%d", (int) atom_getfloatarg(7, argc, argv));
         srl[0] = gensym(str);
     }
-    if(IS_A_SYMBOL(argv,8))
+    if(IS_A_SYMBOL(argv, 8))
         srl[1] = atom_getsymbolarg(8, argc, argv);
-    else if(IS_A_FLOAT(argv,8))
+    else if(IS_A_FLOAT(argv, 8))
     {
-        sprintf(str, "%d", (int)atom_getfloatarg(8, argc, argv));
+        sprintf(str, "%d", (int) atom_getfloatarg(8, argc, argv));
         srl[1] = gensym(str);
     }
-    if(IS_A_SYMBOL(argv,9))
+    if(IS_A_SYMBOL(argv, 9))
         srl[2] = atom_getsymbolarg(9, argc, argv);
-    else if(IS_A_FLOAT(argv,9))
+    else if(IS_A_FLOAT(argv, 9))
     {
-        sprintf(str, "%d", (int)atom_getfloatarg(9, argc, argv));
+        sprintf(str, "%d", (int) atom_getfloatarg(9, argc, argv));
         srl[2] = gensym(str);
     }
     if(init != 0) init = 1;
@@ -728,49 +703,56 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     iemgui->x_lab = srl[2];
     iemgui->x_ldx = ldx;
     iemgui->x_ldy = ldy;
-    if(f == 1) strcpy(iemgui->x_font, "helvetica");
-    else if(f == 2) strcpy(iemgui->x_font, "times");
+    if(f == 1)
+        strcpy(iemgui->x_font, "helvetica");
+    else if(f == 2)
+        strcpy(iemgui->x_font, "times");
     else
     {
         f = 0;
         strcpy(iemgui->x_font, sys_font);
     }
     iemgui->x_fsf.x_font_style = f;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     iemgui->x_fontsize = fs;
     iemgui_verify_snd_ne_rcv(iemgui);
     canvas_dirty(iemgui->x_glist, 1);
-    return(oldsndrcvable);
+    return (oldsndrcvable);
 }
 
-void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
+void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom *argv)
 {
-#define SETCOLOR(a, col) do {char color[MAXPDSTRING]; snprintf(color, MAXPDSTRING-1, "#%06x", 0xffffff & col); color[MAXPDSTRING-1] = 0; SETSYMBOL(a, gensym(color));} while(0)
+#define SETCOLOR(a, col)                                           \
+    do                                                             \
+    {                                                              \
+        char color[MAXPDSTRING];                                   \
+        snprintf(color, MAXPDSTRING - 1, "#%06x", 0xffffff & col); \
+        color[MAXPDSTRING - 1] = 0;                                \
+        SETSYMBOL(a, gensym(color));                               \
+    } while(0)
     t_float zoom = iemgui->x_glist->gl_zoom;
     t_symbol *srl[3];
     int i;
-    for(i=0; i<argc; i++)
-        SETFLOAT(argv+i, -1); /* initialize */
+    for(i = 0; i < argc; i++)
+        SETFLOAT(argv + i, -1); /* initialize */
 
     iemgui_properties(iemgui, srl);
 
-    if(argc> 0) SETFLOAT (argv+ 0, iemgui->x_w/zoom);
-    if(argc> 1) SETFLOAT (argv+ 1, iemgui->x_h/zoom);
-    if(argc> 5) SETFLOAT (argv+ 5, iemgui->x_isa.x_loadinit);
-    if(argc> 6) SETFLOAT (argv+ 6, 1); /* num */
-    if(argc> 7) SETSYMBOL(argv+ 7, srl[0]);
-    if(argc> 8) SETSYMBOL(argv+ 8, srl[1]);
-    if(argc> 9) SETSYMBOL(argv+ 9, srl[2]);
-    if(argc>10) SETFLOAT (argv+10, iemgui->x_ldx);
-    if(argc>11) SETFLOAT (argv+11, iemgui->x_ldy);
-    if(argc>12) SETFLOAT (argv+12, iemgui->x_fsf.x_font_style);
-    if(argc>13) SETFLOAT (argv+13, iemgui->x_fontsize);
-    if(argc>14) SETCOLOR (argv+14, iemgui->x_bcol);
-    if(argc>15) SETCOLOR (argv+15, iemgui->x_fcol);
-    if(argc>16) SETCOLOR (argv+16, iemgui->x_lcol);
+    if(argc > 0) SETFLOAT(argv + 0, iemgui->x_w / zoom);
+    if(argc > 1) SETFLOAT(argv + 1, iemgui->x_h / zoom);
+    if(argc > 5) SETFLOAT(argv + 5, iemgui->x_isa.x_loadinit);
+    if(argc > 6) SETFLOAT(argv + 6, 1); /* num */
+    if(argc > 7) SETSYMBOL(argv + 7, srl[0]);
+    if(argc > 8) SETSYMBOL(argv + 8, srl[1]);
+    if(argc > 9) SETSYMBOL(argv + 9, srl[2]);
+    if(argc > 10) SETFLOAT(argv + 10, iemgui->x_ldx);
+    if(argc > 11) SETFLOAT(argv + 11, iemgui->x_ldy);
+    if(argc > 12) SETFLOAT(argv + 12, iemgui->x_fsf.x_font_style);
+    if(argc > 13) SETFLOAT(argv + 13, iemgui->x_fontsize);
+    if(argc > 14) SETCOLOR(argv + 14, iemgui->x_bcol);
+    if(argc > 15) SETCOLOR(argv + 15, iemgui->x_fcol);
+    if(argc > 16) SETCOLOR(argv + 16, iemgui->x_lcol);
 }
-
 
 /* pre-0.46 the flags were 1 for 'loadinit' and 1<<20 for 'scale'.
 Starting in 0.46, take either 1<<20 or 1<<1 for 'scale' and save to both
@@ -778,13 +760,13 @@ bits (so that old versions can read files we write).  In the future (2015?)
 we can stop writing the annoying  1<<20 bit. */
 #define LOADINIT 1
 #define SCALE 2
-#define SCALEBIS (1<<20)
+#define SCALEBIS (1 << 20)
 
 void iem_inttosymargs(t_iem_init_symargs *symargp, int n)
 {
     memset(symargp, 0, sizeof(*symargp));
     symargp->x_loadinit = ((n & LOADINIT) != 0);
-    symargp->x_scale = ((n & SCALE) || (n & SCALEBIS)) ;
+    symargp->x_scale = ((n & SCALE) || (n & SCALEBIS));
     symargp->x_flashed = 0;
     symargp->x_locked = 0;
 }
@@ -792,7 +774,7 @@ void iem_inttosymargs(t_iem_init_symargs *symargp, int n)
 int iem_symargstoint(t_iem_init_symargs *symargp)
 {
     return ((symargp->x_loadinit ? LOADINIT : 0) |
-        (symargp->x_scale ? (SCALE | SCALEBIS) : 0));
+            (symargp->x_scale ? (SCALE | SCALEBIS) : 0));
 }
 
 void iem_inttofstyle(t_iem_fstyle_flags *fstylep, int n)
@@ -814,11 +796,11 @@ int iem_fstyletoint(t_iem_fstyle_flags *fstylep)
     return ((fstylep->x_font_style << 0) & 63);
 }
 
-    /* for compatibility with pre-0.47 unofficial IEM GUIS like "knob". */
+/* for compatibility with pre-0.47 unofficial IEM GUIS like "knob". */
 void iemgui_all_colfromload(t_iemgui *iemgui, int *bflcol)
 {
     static int warned;
-    if (!warned)
+    if(!warned)
     {
         post("warning:\
 external GUI object uses obsolete Pd function iemgui_all_colfromload()");
@@ -827,8 +809,8 @@ external GUI object uses obsolete Pd function iemgui_all_colfromload()");
     if(bflcol[0] < 0)
     {
         bflcol[0] = -1 - bflcol[0];
-        iemgui->x_bcol = ((bflcol[0] & 0x3f000) << 6)|((bflcol[0] & 0xfc0) << 4)|
-            ((bflcol[0] & 0x3f) << 2);
+        iemgui->x_bcol = ((bflcol[0] & 0x3f000) << 6) |
+                         ((bflcol[0] & 0xfc0) << 4) | ((bflcol[0] & 0x3f) << 2);
     }
     else
     {
@@ -838,8 +820,8 @@ external GUI object uses obsolete Pd function iemgui_all_colfromload()");
     if(bflcol[1] < 0)
     {
         bflcol[1] = -1 - bflcol[1];
-        iemgui->x_fcol = ((bflcol[1] & 0x3f000) << 6)|((bflcol[1] & 0xfc0) << 4)|
-            ((bflcol[1] & 0x3f) << 2);
+        iemgui->x_fcol = ((bflcol[1] & 0x3f000) << 6) |
+                         ((bflcol[1] & 0xfc0) << 4) | ((bflcol[1] & 0x3f) << 2);
     }
     else
     {
@@ -849,8 +831,8 @@ external GUI object uses obsolete Pd function iemgui_all_colfromload()");
     if(bflcol[2] < 0)
     {
         bflcol[2] = -1 - bflcol[2];
-        iemgui->x_lcol = ((bflcol[2] & 0x3f000) << 6)|((bflcol[2] & 0xfc0) << 4)|
-            ((bflcol[2] & 0x3f) << 2);
+        iemgui->x_lcol = ((bflcol[2] & 0x3f000) << 6) |
+                         ((bflcol[2] & 0xfc0) << 4) | ((bflcol[2] & 0x3f) << 2);
     }
     else
     {
@@ -858,4 +840,3 @@ external GUI object uses obsolete Pd function iemgui_all_colfromload()");
         iemgui->x_lcol = iemgui_color_hex[bflcol[2]];
     }
 }
-

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -134,9 +134,13 @@ t_symbol *iemgui_dollar2raute(t_symbol *s)
     for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
         if(*s1 == '$')
+        {
             *s2 = '#';
+        }
         else if(!(*s2 = *s1))
+        {
             break;
+        }
     }
     return (gensym(buf));
 }
@@ -150,9 +154,13 @@ t_symbol *iemgui_raute2dollar(t_symbol *s)
     for(s1 = s->s_name, s2 = buf;; s1++, s2++)
     {
         if(*s1 == '#')
+        {
             *s2 = '$';
+        }
         else if(!(*s2 = *s1))
+        {
             break;
+        }
     }
     return (gensym(buf));
 }
@@ -250,9 +258,13 @@ static void iemgui_init_sym2dollararg(
             *symp = gensym(buf);
         }
         else if(fallback)
+        {
             *symp = fallback;
+        }
         else
+        {
             *symp = gensym("empty");
+        }
     }
 }
 
@@ -322,15 +334,21 @@ static int colfromatomload(t_atom *colatom)
     /* old-fashioned color argument, either a number or symbol
     evaluating to an integer */
     if(colatom->a_type == A_FLOAT)
+    {
         color = atom_getfloat(colatom);
+    }
     else if(colatom->a_type == A_SYMBOL &&
             (isdigit(colatom->a_w.w_symbol->s_name[0]) ||
                 colatom->a_w.w_symbol->s_name[0] == '-'))
+    {
         color = atoi(colatom->a_w.w_symbol->s_name);
 
     /* symbolic color */
+    }
     else
+    {
         return (iemgui_getcolorarg(0, 1, colatom));
+    }
     if(color < 0)
     {
         color = -1 - color;
@@ -404,8 +422,10 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_fsf.x_snd_able = sndable;
     iemgui_verify_snd_ne_rcv(iemgui);
     if(glist_isvisible(iemgui->x_glist))
+    {
         (*iemgui->x_draw)(
             x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    }
 }
 
 void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -439,8 +459,10 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
     iemgui->x_fsf.x_rcv_able = rcvable;
     iemgui_verify_snd_ne_rcv(iemgui);
     if(glist_isvisible(iemgui->x_glist))
+    {
         (*iemgui->x_draw)(
             x, iemgui->x_glist, IEM_GUI_DRAW_MODE_IO + oldsndrcvable);
+    }
 }
 
 void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
@@ -462,10 +484,12 @@ void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s)
         strlen(iemgui->x_lab->s_name));
 
     if(glist_isvisible(iemgui->x_glist) && iemgui->x_lab != old)
+    {
         sys_vgui(".x%lx.c itemconfigure %lxLABEL -text [::pdtk_text::unescape "
                  "\"%s \"] \n",
             glist_getcanvas(iemgui->x_glist), x,
             strcmp(s->s_name, "empty") ? lab_escaped : "");
+    }
 }
 
 void iemgui_label_pos(
@@ -475,10 +499,12 @@ void iemgui_label_pos(
     iemgui->x_ldx = (int) atom_getfloatarg(0, ac, av);
     iemgui->x_ldy = (int) atom_getfloatarg(1, ac, av);
     if(glist_isvisible(iemgui->x_glist))
+    {
         sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
             glist_getcanvas(iemgui->x_glist), x,
             text_xpix((t_object *) x, iemgui->x_glist) + iemgui->x_ldx * zoom,
             text_ypix((t_object *) x, iemgui->x_glist) + iemgui->x_ldy * zoom);
+    }
 }
 
 void iemgui_label_font(
@@ -488,9 +514,13 @@ void iemgui_label_font(
     int f = (int) atom_getfloatarg(0, ac, av);
 
     if(f == 1)
+    {
         strcpy(iemgui->x_font, "helvetica");
+    }
     else if(f == 2)
+    {
         strcpy(iemgui->x_font, "times");
+    }
     else
     {
         f = 0;
@@ -501,9 +531,11 @@ void iemgui_label_font(
     if(f < 4) f = 4;
     iemgui->x_fontsize = f;
     if(glist_isvisible(iemgui->x_glist))
+    {
         sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s}\n",
             glist_getcanvas(iemgui->x_glist), x, iemgui->x_font,
             iemgui->x_fontsize * zoom, sys_fontweight);
+    }
 }
 
 void iemgui_size(void *x, t_iemgui *iemgui)
@@ -543,11 +575,15 @@ void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     if(ac >= 1) iemgui->x_bcol = iemgui_compatible_colorarg(0, ac, av);
     if(ac == 2 && pd_compatibilitylevel < 47)
+    {
         /* old versions of Pd updated foreground and label color
         if only two args; now we do it more coherently. */
         iemgui->x_lcol = iemgui_compatible_colorarg(1, ac, av);
+    }
     else if(ac >= 2)
+    {
         iemgui->x_fcol = iemgui_compatible_colorarg(1, ac, av);
+    }
     if(ac >= 3) iemgui->x_lcol = iemgui_compatible_colorarg(2, ac, av);
     if(glist_isvisible(iemgui->x_glist))
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_CONFIG);
@@ -585,7 +621,9 @@ void iemgui_vis(t_gobj *z, t_glist *glist, int vis)
     t_iemgui *x = (t_iemgui *) z;
 
     if(vis)
+    {
         (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_NEW);
+    }
     else
     {
         (*x->x_draw)((void *) z, glist, IEM_GUI_DRAW_MODE_ERASE);
@@ -660,21 +698,27 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     if(iemgui->x_fsf.x_rcv_able) oldsndrcvable += IEM_GUI_OLD_RCV_FLAG;
     if(iemgui->x_fsf.x_snd_able) oldsndrcvable += IEM_GUI_OLD_SND_FLAG;
     if(IS_A_SYMBOL(argv, 7))
+    {
         srl[0] = atom_getsymbolarg(7, argc, argv);
+    }
     else if(IS_A_FLOAT(argv, 7))
     {
         sprintf(str, "%d", (int) atom_getfloatarg(7, argc, argv));
         srl[0] = gensym(str);
     }
     if(IS_A_SYMBOL(argv, 8))
+    {
         srl[1] = atom_getsymbolarg(8, argc, argv);
+    }
     else if(IS_A_FLOAT(argv, 8))
     {
         sprintf(str, "%d", (int) atom_getfloatarg(8, argc, argv));
         srl[1] = gensym(str);
     }
     if(IS_A_SYMBOL(argv, 9))
+    {
         srl[2] = atom_getsymbolarg(9, argc, argv);
+    }
     else if(IS_A_FLOAT(argv, 9))
     {
         sprintf(str, "%d", (int) atom_getfloatarg(9, argc, argv));
@@ -710,9 +754,13 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     iemgui->x_ldx = ldx;
     iemgui->x_ldy = ldy;
     if(f == 1)
+    {
         strcpy(iemgui->x_font, "helvetica");
+    }
     else if(f == 2)
+    {
         strcpy(iemgui->x_font, "times");
+    }
     else
     {
         f = 0;

--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -1,98 +1,98 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution. */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution. */
 /* g_7_guis.h written by Thomas Musil (c) IEM KUG Graz Austria 2000-2001 */
 
 #ifndef __g_all_guis_h_
 
-#define IEM_GUI_COLNR_WHITE          0
-#define IEM_GUI_COLNR_ML_GREY        1
-#define IEM_GUI_COLNR_D_GREY         2
-#define IEM_GUI_COLNR_L_RED          3
-#define IEM_GUI_COLNR_L_ORANGE       4
-#define IEM_GUI_COLNR_L_YELLOW       5
-#define IEM_GUI_COLNR_L_GREEN        6
-#define IEM_GUI_COLNR_L_CYAN         7
-#define IEM_GUI_COLNR_L_BLUE         8
-#define IEM_GUI_COLNR_L_MAGENTA      9
+#define IEM_GUI_COLNR_WHITE 0
+#define IEM_GUI_COLNR_ML_GREY 1
+#define IEM_GUI_COLNR_D_GREY 2
+#define IEM_GUI_COLNR_L_RED 3
+#define IEM_GUI_COLNR_L_ORANGE 4
+#define IEM_GUI_COLNR_L_YELLOW 5
+#define IEM_GUI_COLNR_L_GREEN 6
+#define IEM_GUI_COLNR_L_CYAN 7
+#define IEM_GUI_COLNR_L_BLUE 8
+#define IEM_GUI_COLNR_L_MAGENTA 9
 
-#define IEM_GUI_COLNR_LL_GREY        10
-#define IEM_GUI_COLNR_M_GREY         11
-#define IEM_GUI_COLNR_DD_GREY        12
-#define IEM_GUI_COLNR_RED            13
-#define IEM_GUI_COLNR_ORANGE         14
-#define IEM_GUI_COLNR_YELLOW         15
-#define IEM_GUI_COLNR_GREEN          16
-#define IEM_GUI_COLNR_CYAN           17
-#define IEM_GUI_COLNR_BLUE           18
-#define IEM_GUI_COLNR_MAGENTA        19
+#define IEM_GUI_COLNR_LL_GREY 10
+#define IEM_GUI_COLNR_M_GREY 11
+#define IEM_GUI_COLNR_DD_GREY 12
+#define IEM_GUI_COLNR_RED 13
+#define IEM_GUI_COLNR_ORANGE 14
+#define IEM_GUI_COLNR_YELLOW 15
+#define IEM_GUI_COLNR_GREEN 16
+#define IEM_GUI_COLNR_CYAN 17
+#define IEM_GUI_COLNR_BLUE 18
+#define IEM_GUI_COLNR_MAGENTA 19
 
-#define IEM_GUI_COLNR_L_GREY         20
-#define IEM_GUI_COLNR_MD_GREY        21
-#define IEM_GUI_COLNR_BLACK          22
-#define IEM_GUI_COLNR_D_RED          23
-#define IEM_GUI_COLNR_D_ORANGE       24
-#define IEM_GUI_COLNR_D_YELLOW       25
-#define IEM_GUI_COLNR_D_GREEN        26
-#define IEM_GUI_COLNR_D_CYAN         27
-#define IEM_GUI_COLNR_D_BLUE         28
-#define IEM_GUI_COLNR_D_MAGENTA      29
+#define IEM_GUI_COLNR_L_GREY 20
+#define IEM_GUI_COLNR_MD_GREY 21
+#define IEM_GUI_COLNR_BLACK 22
+#define IEM_GUI_COLNR_D_RED 23
+#define IEM_GUI_COLNR_D_ORANGE 24
+#define IEM_GUI_COLNR_D_YELLOW 25
+#define IEM_GUI_COLNR_D_GREEN 26
+#define IEM_GUI_COLNR_D_CYAN 27
+#define IEM_GUI_COLNR_D_BLUE 28
+#define IEM_GUI_COLNR_D_MAGENTA 29
 
-#define IEM_GUI_COLOR_SELECTED       255
-#define IEM_GUI_COLOR_NORMAL         0
+#define IEM_GUI_COLOR_SELECTED 255
+#define IEM_GUI_COLOR_NORMAL 0
 
-#define IEM_GUI_MAX_COLOR            30
+#define IEM_GUI_MAX_COLOR 30
 
 #define IEM_GUI_DEFAULTSIZE 15
-#define IEM_GUI_MINSIZE     8
-#define IEM_GUI_MAXSIZE     1000
-#define IEM_SL_DEFAULTSIZE  128
-#define IEM_SL_MINSIZE      2
-#define IEM_FONT_MINSIZE    4
+#define IEM_GUI_MINSIZE 8
+#define IEM_GUI_MAXSIZE 1000
+#define IEM_SL_DEFAULTSIZE 128
+#define IEM_SL_MINSIZE 2
+#define IEM_FONT_MINSIZE 4
 
-#define IEM_BNG_DEFAULTHOLDFLASHTIME  250
+#define IEM_BNG_DEFAULTHOLDFLASHTIME 250
 #define IEM_BNG_DEFAULTBREAKFLASHTIME 50
-#define IEM_BNG_MINHOLDFLASHTIME      50
-#define IEM_BNG_MINBREAKFLASHTIME     10
+#define IEM_BNG_MINHOLDFLASHTIME 50
+#define IEM_BNG_MINBREAKFLASHTIME 10
 
 #define IEM_VU_DEFAULTSIZE 3
-#define IEM_VU_LARGESMALL  2
-#define IEM_VU_MINSIZE     2
-#define IEM_VU_MAXSIZE     25
-#define IEM_VU_STEPS       40
+#define IEM_VU_LARGESMALL 2
+#define IEM_VU_MINSIZE 2
+#define IEM_VU_MAXSIZE 25
+#define IEM_VU_STEPS 40
 
-#define IEM_VU_MINDB  -99.9
-#define IEM_VU_MAXDB  12.0
+#define IEM_VU_MINDB -99.9
+#define IEM_VU_MAXDB 12.0
 #define IEM_VU_OFFSET 100.0
 
 #define IEM_RADIO_MAX 128
 
-#define IEM_SYM_UNIQUE_SND  256
-#define IEM_SYM_UNIQUE_RCV  512
-#define IEM_SYM_UNIQUE_LAB  1024
-#define IEM_SYM_UNIQUE_ALL  1792
-#define IEM_FONT_STYLE_ALL  255
+#define IEM_SYM_UNIQUE_SND 256
+#define IEM_SYM_UNIQUE_RCV 512
+#define IEM_SYM_UNIQUE_LAB 1024
+#define IEM_SYM_UNIQUE_ALL 1792
+#define IEM_FONT_STYLE_ALL 255
 
 #define IEM_MAX_SYM_LEN 127
 
 #define IEM_GUI_DRAW_MODE_UPDATE 0
-#define IEM_GUI_DRAW_MODE_MOVE   1
-#define IEM_GUI_DRAW_MODE_NEW    2
+#define IEM_GUI_DRAW_MODE_MOVE 1
+#define IEM_GUI_DRAW_MODE_NEW 2
 #define IEM_GUI_DRAW_MODE_SELECT 3
-#define IEM_GUI_DRAW_MODE_ERASE  4
+#define IEM_GUI_DRAW_MODE_ERASE 4
 #define IEM_GUI_DRAW_MODE_CONFIG 5
-#define IEM_GUI_DRAW_MODE_IO     6
+#define IEM_GUI_DRAW_MODE_IO 6
 
 #define IEM_GUI_IOHEIGHT 2
 
-#define IS_A_POINTER(atom,index) ((atom+index)->a_type == A_POINTER)
-#define IS_A_FLOAT(atom,index) ((atom+index)->a_type == A_FLOAT)
-#define IS_A_SYMBOL(atom,index) ((atom+index)->a_type == A_SYMBOL)
-#define IS_A_DOLLAR(atom,index) ((atom+index)->a_type == A_DOLLAR)
-#define IS_A_DOLLSYM(atom,index) ((atom+index)->a_type == A_DOLLSYM)
+#define IS_A_POINTER(atom, index) ((atom + index)->a_type == A_POINTER)
+#define IS_A_FLOAT(atom, index) ((atom + index)->a_type == A_FLOAT)
+#define IS_A_SYMBOL(atom, index) ((atom + index)->a_type == A_SYMBOL)
+#define IS_A_DOLLAR(atom, index) ((atom + index)->a_type == A_DOLLAR)
+#define IS_A_DOLLSYM(atom, index) ((atom + index)->a_type == A_DOLLSYM)
 
 #define IEM_FSTYLE_FLAGS_ALL 0x007fffff
-#define IEM_INIT_ARGS_ALL    0x01ffffff
+#define IEM_INIT_ARGS_ALL 0x01ffffff
 
 #define IEM_GUI_OLD_SND_FLAG 1
 #define IEM_GUI_OLD_RCV_FLAG 2
@@ -104,169 +104,169 @@
 
 typedef struct _iem_fstyle_flags
 {
-    unsigned int x_font_style:6;
-    unsigned int x_rcv_able:1;
-    unsigned int x_snd_able:1;
-    unsigned int x_lab_is_unique:1;
-    unsigned int x_rcv_is_unique:1;
-    unsigned int x_snd_is_unique:1;
-    unsigned int x_lab_arg_tail_len:6;
-    unsigned int x_lab_is_arg_num:6;
-    unsigned int x_shiftdown:1;
-    unsigned int x_selected:1;
-    unsigned int x_finemoved:1;
-    unsigned int x_put_in2out:1;
-    unsigned int x_change:1;
-    unsigned int x_thick:1;
-    unsigned int x_lin0_log1:1;
-    unsigned int x_steady:1;
+    unsigned int x_font_style : 6;
+    unsigned int x_rcv_able : 1;
+    unsigned int x_snd_able : 1;
+    unsigned int x_lab_is_unique : 1;
+    unsigned int x_rcv_is_unique : 1;
+    unsigned int x_snd_is_unique : 1;
+    unsigned int x_lab_arg_tail_len : 6;
+    unsigned int x_lab_is_arg_num : 6;
+    unsigned int x_shiftdown : 1;
+    unsigned int x_selected : 1;
+    unsigned int x_finemoved : 1;
+    unsigned int x_put_in2out : 1;
+    unsigned int x_change : 1;
+    unsigned int x_thick : 1;
+    unsigned int x_lin0_log1 : 1;
+    unsigned int x_steady : 1;
 } t_iem_fstyle_flags;
 
 typedef struct _iem_init_symargs
 {
-    unsigned int x_loadinit:1;
-    unsigned int x_rcv_arg_tail_len:6;
-    unsigned int x_snd_arg_tail_len:6;
-    unsigned int x_rcv_is_arg_num:6;
-    unsigned int x_snd_is_arg_num:6;
-    unsigned int x_scale:1;
-    unsigned int x_flashed:1;
-    unsigned int x_locked:1;
+    unsigned int x_loadinit : 1;
+    unsigned int x_rcv_arg_tail_len : 6;
+    unsigned int x_snd_arg_tail_len : 6;
+    unsigned int x_rcv_is_arg_num : 6;
+    unsigned int x_snd_is_arg_num : 6;
+    unsigned int x_scale : 1;
+    unsigned int x_flashed : 1;
+    unsigned int x_locked : 1;
 } t_iem_init_symargs;
 
 typedef void (*t_iemfunptr)(void *x, t_glist *glist, int mode);
 
 typedef struct _iemgui
 {
-    t_object           x_obj;
-    t_glist            *x_glist;
-    t_iemfunptr        x_draw;
-    int                x_h;
-    int                x_w;
-    int                x_ldx;
-    int                x_ldy;
-    char               x_font[MAXPDSTRING]; /* font names can be long! */
+    t_object x_obj;
+    t_glist *x_glist;
+    t_iemfunptr x_draw;
+    int x_h;
+    int x_w;
+    int x_ldx;
+    int x_ldy;
+    char x_font[MAXPDSTRING]; /* font names can be long! */
     t_iem_fstyle_flags x_fsf;
-    int                x_fontsize;
+    int x_fontsize;
     t_iem_init_symargs x_isa;
-    int                x_fcol;
-    int                x_bcol;
-    int                x_lcol;
-    t_symbol           *x_snd;              /* send symbol */
-    t_symbol           *x_rcv;              /* receive */
-    t_symbol           *x_lab;              /* label */
-    t_symbol           *x_snd_unexpanded;   /* same 3, with '$' unexpanded */
-    t_symbol           *x_rcv_unexpanded;
-    t_symbol           *x_lab_unexpanded;
-    int                x_binbufindex;       /* where in binbuf to find these */
-    int                x_labelbindex;       /* where in binbuf to find label */
+    int x_fcol;
+    int x_bcol;
+    int x_lcol;
+    t_symbol *x_snd;            /* send symbol */
+    t_symbol *x_rcv;            /* receive */
+    t_symbol *x_lab;            /* label */
+    t_symbol *x_snd_unexpanded; /* same 3, with '$' unexpanded */
+    t_symbol *x_rcv_unexpanded;
+    t_symbol *x_lab_unexpanded;
+    int x_binbufindex; /* where in binbuf to find these */
+    int x_labelbindex; /* where in binbuf to find label */
 } t_iemgui;
 
 typedef struct _bng
 {
     t_iemgui x_gui;
-    int      x_flashed;
-    int      x_flashtime_break;
-    int      x_flashtime_hold;
-    t_clock  *x_clock_hld;
-    t_clock  *x_clock_brk;
-    t_clock  *x_clock_lck;
+    int x_flashed;
+    int x_flashtime_break;
+    int x_flashtime_hold;
+    t_clock *x_clock_hld;
+    t_clock *x_clock_brk;
+    t_clock *x_clock_lck;
     double x_lastflashtime;
 } t_bng;
 
 typedef struct _hslider
 {
     t_iemgui x_gui;
-    int      x_pos;
-    int      x_val;
-    int      x_lin0_log1;
-    int      x_steady;
-    double   x_min;
-    double   x_max;
-    double   x_k;
-    t_float  x_fval;
+    int x_pos;
+    int x_val;
+    int x_lin0_log1;
+    int x_steady;
+    double x_min;
+    double x_max;
+    double x_k;
+    t_float x_fval;
 } t_hslider;
 
 typedef struct _hdial
 {
     t_iemgui x_gui;
-    int      x_on;
-    int      x_on_old;  /* LATER delete this; it's used for old version */
-    int      x_change;
-    int      x_number;
-    int      x_drawn;
-    t_float  x_fval;
-    t_atom   x_at[2];
+    int x_on;
+    int x_on_old; /* LATER delete this; it's used for old version */
+    int x_change;
+    int x_number;
+    int x_drawn;
+    t_float x_fval;
+    t_atom x_at[2];
 } t_hdial;
 
 typedef struct _toggle
 {
     t_iemgui x_gui;
-    t_float    x_on;
-    t_float    x_nonzero;
+    t_float x_on;
+    t_float x_nonzero;
 } t_toggle;
 
 typedef struct _my_canvas
 {
     t_iemgui x_gui;
-    t_atom   x_at[3];
-    int      x_vis_w;
-    int      x_vis_h;
+    t_atom x_at[3];
+    int x_vis_w;
+    int x_vis_h;
 } t_my_canvas;
 
 typedef struct _vslider
 {
     t_iemgui x_gui;
-    int      x_pos;
-    int      x_val;
-    int      x_lin0_log1;
-    int      x_steady;
-    double   x_min;
-    double   x_max;
-    double   x_k;
-    t_float  x_fval;
+    int x_pos;
+    int x_val;
+    int x_lin0_log1;
+    int x_steady;
+    double x_min;
+    double x_max;
+    double x_k;
+    t_float x_fval;
 } t_vslider;
 
 typedef struct _vu
 {
     t_iemgui x_gui;
-    int      x_led_size;
-    int      x_peak;
-    int      x_rms;
-    t_float  x_fp;
-    t_float  x_fr;
-    int      x_scale;
-    void     *x_out_rms;
-    void     *x_out_peak;
-    unsigned int x_updaterms:1;
-    unsigned int x_updatepeak:1;
+    int x_led_size;
+    int x_peak;
+    int x_rms;
+    t_float x_fp;
+    t_float x_fr;
+    int x_scale;
+    void *x_out_rms;
+    void *x_out_peak;
+    unsigned int x_updaterms : 1;
+    unsigned int x_updatepeak : 1;
 } t_vu;
 
 typedef struct _my_numbox
 {
     t_iemgui x_gui;
-    t_clock  *x_clock_reset;
-    t_clock  *x_clock_wait;
-    t_float  x_val;
-    double   x_min;
-    double   x_max;
-    double   x_k;
-    int      x_lin0_log1;
-    char     x_buf[IEMGUI_MAX_NUM_LEN];
-    int      x_numwidth;
-    int      x_log_height;
+    t_clock *x_clock_reset;
+    t_clock *x_clock_wait;
+    t_float x_val;
+    double x_min;
+    double x_max;
+    double x_k;
+    int x_lin0_log1;
+    char x_buf[IEMGUI_MAX_NUM_LEN];
+    int x_numwidth;
+    int x_log_height;
 } t_my_numbox;
 
 typedef struct _vdial
 {
     t_iemgui x_gui;
-    int      x_on;
-    int      x_on_old;
-    int      x_change;
-    int      x_number;
-    int      x_drawn;
-    t_float  x_fval;
-    t_atom   x_at[2];
+    int x_on;
+    int x_on_old;
+    int x_change;
+    int x_number;
+    int x_drawn;
+    t_float x_fval;
+    t_atom x_at[2];
 } t_vdial;
 
 #define t_vradio t_vdial
@@ -279,24 +279,31 @@ extern char *iemgui_vu_scale_str[];
 
 EXTERN int iemgui_clip_size(int size);
 EXTERN int iemgui_clip_font(int size);
-EXTERN t_symbol *iemgui_dollararg2sym(t_symbol *s, int nth_arg, int tail_len, int pargc, t_atom *pargv);
+EXTERN t_symbol *iemgui_dollararg2sym(
+    t_symbol *s, int nth_arg, int tail_len, int pargc, t_atom *pargv);
 EXTERN void iemgui_verify_snd_ne_rcv(t_iemgui *iemgui);
 EXTERN void iemgui_all_sym2dollararg(t_iemgui *iemgui, t_symbol **srlsym);
 EXTERN t_symbol *iemgui_new_dogetname(t_iemgui *iemgui, int indx, t_atom *argv);
 EXTERN void iemgui_new_getnames(t_iemgui *iemgui, int indx, t_atom *argv);
 EXTERN void iemgui_all_dollararg2sym(t_iemgui *iemgui, t_symbol **srlsym);
-EXTERN void iemgui_all_loadcolors(t_iemgui *iemgui, t_atom*bcol, t_atom*fcol, t_atom*lcol);
+EXTERN void iemgui_all_loadcolors(
+    t_iemgui *iemgui, t_atom *bcol, t_atom *fcol, t_atom *lcol);
 EXTERN void iemgui_all_dollar2raute(t_symbol **srlsym);
 EXTERN void iemgui_all_raute2dollar(t_symbol **srlsym);
 EXTERN void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s);
 EXTERN void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s);
 EXTERN void iemgui_label(void *x, t_iemgui *iemgui, t_symbol *s);
-EXTERN void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
-EXTERN void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
+EXTERN void iemgui_label_pos(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
+EXTERN void iemgui_label_font(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
 EXTERN void iemgui_size(void *x, t_iemgui *iemgui);
-EXTERN void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
-EXTERN void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
-EXTERN void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
+EXTERN void iemgui_delta(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
+EXTERN void iemgui_pos(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
+EXTERN void iemgui_color(
+    void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av);
 EXTERN void iemgui_displace(t_gobj *z, t_glist *glist, int dx, int dy);
 EXTERN void iemgui_select(t_gobj *z, t_glist *glist, int selected);
 EXTERN void iemgui_delete(t_gobj *z, t_glist *glist);
@@ -305,8 +312,9 @@ EXTERN void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol **bflcol);
 EXTERN void iemgui_zoom(t_iemgui *iemgui, t_floatarg zoom);
 EXTERN void iemgui_newzoom(t_iemgui *iemgui);
 EXTERN void iemgui_properties(t_iemgui *iemgui, t_symbol **srl);
-EXTERN int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv);
-EXTERN void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv);
+EXTERN int iemgui_dialog(
+    t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv);
+EXTERN void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom *argv);
 
 EXTERN int canvas_getdollarzero(void);
 

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1,16 +1,17 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>      /* for read/write to files */
+#include <stdio.h> /* for read/write to files */
 #include "m_pd.h"
 #include "g_canvas.h"
 #include <math.h>
 
 /* jsarlo { */
-#define ARRAYPAGESIZE 1000  /* this should match the page size in u_main.tk */
+#define ARRAYPAGESIZE 1000 /* this should match the page size in u_main.tk */
+
 /* } jsarlo */
 
 /* --------- "pure" arrays with scalars for elements. --------------- */
@@ -21,25 +22,26 @@ scalars (g_scalar.c); their graphical behavior is defined accordingly. */
 
 t_array *array_new(t_symbol *templatesym, t_gpointer *parent)
 {
-    t_array *x = (t_array *)getbytes(sizeof (*x));
+    t_array *x = (t_array *) getbytes(sizeof(*x));
     t_template *template;
     template = template_findbyname(templatesym);
     x->a_templatesym = templatesym;
     x->a_n = 1;
     x->a_elemsize = sizeof(t_word) * template->t_n;
-    x->a_vec = (char *)getbytes(x->a_elemsize);
-        /* note here we blithely copy a gpointer instead of "setting" a
-        new one; this gpointer isn't accounted for and needn't be since
-        we'll be deleted before the thing pointed to gets deleted anyway;
-        see array_free. */
+    x->a_vec = (char *) getbytes(x->a_elemsize);
+    /* note here we blithely copy a gpointer instead of "setting" a
+    new one; this gpointer isn't accounted for and needn't be since
+    we'll be deleted before the thing pointed to gets deleted anyway;
+    see array_free. */
     x->a_gp = *parent;
     x->a_stub = gstub_new(0, x);
-    word_init((t_word *)(x->a_vec), template, parent);
+    word_init((t_word *) (x->a_vec), template, parent);
     return (x);
 }
 
 /* jsarlo { */
 static void garray_arrayviewlist_close(t_garray *x);
+
 /* } jsarlo */
 
 void array_resize(t_array *x, int n)
@@ -47,23 +49,21 @@ void array_resize(t_array *x, int n)
     int elemsize, oldn;
     char *tmp;
     t_template *template = template_findbyname(x->a_templatesym);
-    if (n < 1)
-        n = 1;
+    if(n < 1) n = 1;
     oldn = x->a_n;
     elemsize = sizeof(t_word) * template->t_n;
 
-    tmp = (char *)resizebytes(x->a_vec, oldn * elemsize, n * elemsize);
-    if (!tmp)
-        return;
+    tmp = (char *) resizebytes(x->a_vec, oldn * elemsize, n * elemsize);
+    if(!tmp) return;
     x->a_vec = tmp;
     x->a_n = n;
-    if (n > oldn)
+    if(n > oldn)
     {
         char *cp = x->a_vec + elemsize * oldn;
         int i = n - oldn;
-        for (; i--; cp += elemsize)
+        for(; i--; cp += elemsize)
         {
-            t_word *wp = (t_word *)cp;
+            t_word *wp = (t_word *) cp;
             word_init(wp, template, &x->a_gp);
         }
     }
@@ -74,13 +74,11 @@ void array_resize_and_redraw(t_array *array, t_glist *glist, int n)
 {
     t_array *a2 = array;
     int vis = glist_isvisible(glist);
-    while (a2->a_gp.gp_stub->gs_which == GP_ARRAY)
+    while(a2->a_gp.gp_stub->gs_which == GP_ARRAY)
         a2 = a2->a_gp.gp_stub->gs_un.gs_array;
-    if (vis)
-        gobj_vis(&a2->a_gp.gp_un.gp_scalar->sc_gobj, glist, 0);
+    if(vis) gobj_vis(&a2->a_gp.gp_un.gp_scalar->sc_gobj, glist, 0);
     array_resize(array, n);
-    if (vis)
-        gobj_vis(&a2->a_gp.gp_un.gp_scalar->sc_gobj, glist, 1);
+    if(vis) gobj_vis(&a2->a_gp.gp_un.gp_scalar->sc_gobj, glist, 1);
 }
 
 void word_free(t_word *wp, t_template *template);
@@ -90,9 +88,9 @@ void array_free(t_array *x)
     int i;
     t_template *scalartemplate = template_findbyname(x->a_templatesym);
     gstub_cutoff(x->a_stub);
-    for (i = 0; i < x->a_n; i++)
+    for(i = 0; i < x->a_n; i++)
     {
-        t_word *wp = (t_word *)(x->a_vec + x->a_elemsize * i);
+        t_word *wp = (t_word *) (x->a_vec + x->a_elemsize * i);
         word_free(wp, scalartemplate);
     }
     freebytes(x->a_vec, x->a_elemsize * x->a_n);
@@ -106,19 +104,19 @@ t_class *garray_class;
 struct _garray
 {
     t_gobj x_gobj;
-    t_scalar *x_scalar;     /* scalar "containing" the array */
-    t_glist *x_glist;       /* containing glist */
-    t_symbol *x_name;       /* unexpanded name (possibly with leading '$') */
-    t_symbol *x_realname;   /* expanded name (symbol we're bound to) */
-    unsigned int  x_usedindsp:1;    /* 1 if some DSP routine is using this */
-    unsigned int  x_saveit:1;       /* we should save this with parent */
-    unsigned int  x_savesize:1;     /* save size too */
-    unsigned int  x_listviewing:1;  /* list view window is open */
-    unsigned int  x_hidename:1;     /* don't print name above graph */
-    unsigned int  x_edit:1;         /* we can edit the array */
+    t_scalar *x_scalar;   /* scalar "containing" the array */
+    t_glist *x_glist;     /* containing glist */
+    t_symbol *x_name;     /* unexpanded name (possibly with leading '$') */
+    t_symbol *x_realname; /* expanded name (symbol we're bound to) */
+    unsigned int x_usedindsp : 1;   /* 1 if some DSP routine is using this */
+    unsigned int x_saveit : 1;      /* we should save this with parent */
+    unsigned int x_savesize : 1;    /* save size too */
+    unsigned int x_listviewing : 1; /* list view window is open */
+    unsigned int x_hidename : 1;    /* don't print name above graph */
+    unsigned int x_edit : 1;        /* we can edit the array */
 };
 
-static t_pd *garray_arraytemplatecanvas;  /* written at setup w/ global lock */
+static t_pd *garray_arraytemplatecanvas; /* written at setup w/ global lock */
 static const char garray_arraytemplatefile[] = "\
 canvas 0 0 458 153 10;\n\
 #X obj 43 31 struct float-array array z float float style\n\
@@ -158,19 +156,18 @@ arrays (the scalar will be of type "float-array").  Currently this is
 always called by graph_array() below; but when we make a more general way
 to save and create arrays this might get called more directly. */
 
-static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
-    int saveit, int savesize)
+static t_garray *graph_scalar(
+    t_glist *gl, t_symbol *s, t_symbol *templatesym, int saveit, int savesize)
 {
     t_garray *x;
-    if (!template_findbyname(templatesym))
-        return (0);
-    x = (t_garray *)pd_new(garray_class);
+    if(!template_findbyname(templatesym)) return (0);
+    x = (t_garray *) pd_new(garray_class);
     x->x_scalar = scalar_new(gl, templatesym);
     x->x_name = s;
     x->x_realname = canvas_realizedollar(gl, s);
     pd_bind(&x->x_gobj.g_pd, x->x_realname);
     x->x_usedindsp = 0;
-        /* when invoked this way, saving implies saving size too */
+    /* when invoked this way, saving implies saving size too */
     x->x_saveit = saveit;
     x->x_savesize = savesize;
     x->x_listviewing = 0;
@@ -180,7 +177,7 @@ static t_garray *graph_scalar(t_glist *gl, t_symbol *s, t_symbol *templatesym,
     return (x);
 }
 
-    /* get a garray's "array" structure. */
+/* get a garray's "array" structure. */
 t_array *garray_getarray(t_garray *x)
 {
     int zonset, ztype;
@@ -188,18 +185,18 @@ t_array *garray_getarray(t_garray *x)
     t_scalar *sc = x->x_scalar;
     t_symbol *templatesym = sc->sc_template;
     t_template *template = template_findbyname(templatesym);
-    if (!template)
+    if(!template)
     {
         pd_error(0, "array: couldn't find template %s", templatesym->s_name);
         return (0);
     }
-    if (!template_find_field(template, gensym("z"),
-        &zonset, &ztype, &zarraytype))
+    if(!template_find_field(
+           template, gensym("z"), &zonset, &ztype, &zarraytype))
     {
         pd_error(0, "array: template %s has no 'z' field", templatesym->s_name);
         return (0);
     }
-    if (ztype != DT_ARRAY)
+    if(ztype != DT_ARRAY)
     {
         pd_error(0, "array: template %s, 'z' field is not an array",
             templatesym->s_name);
@@ -208,64 +205,58 @@ t_array *garray_getarray(t_garray *x)
     return (sc->sc_vec[zonset].w_array);
 }
 
-    /* get the "array" structure and furthermore check it's float */
-static t_array *garray_getarray_floatonly(t_garray *x,
-    int *yonsetp, int *elemsizep)
+/* get the "array" structure and furthermore check it's float */
+static t_array *garray_getarray_floatonly(
+    t_garray *x, int *yonsetp, int *elemsizep)
 {
     t_array *a = garray_getarray(x);
     int yonset, type;
     t_symbol *arraytype;
     t_template *template = template_findbyname(a->a_templatesym);
-    if (!template_find_field(template, gensym("y"), &yonset,
-        &type, &arraytype) || type != DT_FLOAT)
-            return (0);
+    if(!template_find_field(
+           template, gensym("y"), &yonset, &type, &arraytype) ||
+        type != DT_FLOAT)
+        return (0);
     *yonsetp = yonset;
     *elemsizep = a->a_elemsize;
     return (a);
 }
 
-    /* get the array's name.  Return nonzero if it should be hidden */
+/* get the array's name.  Return nonzero if it should be hidden */
 int garray_getname(t_garray *x, t_symbol **namep)
 {
     *namep = x->x_name;
     return (x->x_hidename);
 }
 
-    /* get a garray's containing glist */
-t_glist *garray_getglist(t_garray *x)
-{
-    return (x->x_glist);
-}
+/* get a garray's containing glist */
+t_glist *garray_getglist(t_garray *x) { return (x->x_glist); }
 
-    /* get a garray's associated scalar */
-t_scalar *garray_getscalar(t_garray *x)
-{
-    return (x->x_scalar);
-}
+/* get a garray's associated scalar */
+t_scalar *garray_getscalar(t_garray *x) { return (x->x_scalar); }
 
-        /* if there is one garray in a graph, reset the graph's coordinates
-            to fit a new size and style for the garray */
+/* if there is one garray in a graph, reset the graph's coordinates
+    to fit a new size and style for the garray */
 static void garray_fittograph(t_garray *x, int n, int style)
 {
     t_array *array = garray_getarray(x);
     t_glist *gl = x->x_glist;
-    if (gl->gl_list == &x->x_gobj && !x->x_gobj.g_next)
+    if(gl->gl_list == &x->x_gobj && !x->x_gobj.g_next)
     {
-        vmess(&gl->gl_pd, gensym("bounds"), "ffff",
-            0., gl->gl_y1, (double)
-                (style == PLOTSTYLE_POINTS || n == 1 ? n : n-1),
-                    gl->gl_y2);
+        vmess(&gl->gl_pd, gensym("bounds"), "ffff", 0., gl->gl_y1,
+            (double) (style == PLOTSTYLE_POINTS || n == 1 ? n : n - 1),
+            gl->gl_y2);
 
-            /* hack - if the xlabels seem to want to be from 0 to table size-1,
-            update the second label */
-        if (gl->gl_nxlabels == 2 && !strcmp(gl->gl_xlabel[0]->s_name, "0"))
+        /* hack - if the xlabels seem to want to be from 0 to table size-1,
+        update the second label */
+        if(gl->gl_nxlabels == 2 && !strcmp(gl->gl_xlabel[0]->s_name, "0"))
         {
             t_atom a;
-            SETFLOAT(&a, n-1);
+            SETFLOAT(&a, n - 1);
             gl->gl_xlabel[1] = atom_gensym(&a);
             glist_redraw(gl);
         }
-            /* close any dialogs that might have the wrong info now... */
+        /* close any dialogs that might have the wrong info now... */
         gfxstub_deleteforkey(gl);
     }
 }
@@ -285,33 +276,35 @@ t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
     t_symbol *templatesym;
     int flags = fflags;
     int filestyle = ((flags & GRAPH_ARRAY_PLOTSTYLE) >> 1);
-    int style = (filestyle == 0 ? PLOTSTYLE_POLY :
-        (filestyle == 1 ? PLOTSTYLE_POINTS : filestyle));
-    if (templateargsym != &s_float)
+    int style =
+        (filestyle == 0 ? PLOTSTYLE_POLY
+                        : (filestyle == 1 ? PLOTSTYLE_POINTS : filestyle));
+    if(templateargsym != &s_float)
     {
-        pd_error(0, "array %s: only 'float' type understood", templateargsym->s_name);
+        pd_error(0, "array %s: only 'float' type understood",
+            templateargsym->s_name);
         return (0);
     }
     templatesym = gensym("pd-float-array");
     template = template_findbyname(templatesym);
-    if (!template)
+    if(!template)
     {
         pd_error(0, "array: couldn't find template %s", templatesym->s_name);
         return (0);
     }
-    if (!template_find_field(template, gensym("z"),
-        &zonset, &ztype, &zarraytype))
+    if(!template_find_field(
+           template, gensym("z"), &zonset, &ztype, &zarraytype))
     {
         pd_error(0, "array: template %s has no 'z' field", templatesym->s_name);
         return (0);
     }
-    if (ztype != DT_ARRAY)
+    if(ztype != DT_ARRAY)
     {
         pd_error(0, "array: template %s, 'z' field is not an array",
             templatesym->s_name);
         return (0);
     }
-    if (!(ztemplate = template_findbyname(zarraytype)))
+    if(!(ztemplate = template_findbyname(zarraytype)))
     {
         pd_error(0, "array: no template of type %s", zarraytype->s_name);
         return (0);
@@ -321,45 +314,42 @@ t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
     x = graph_scalar(gl, s, templatesym, saveit, savesize);
     x->x_hidename = ((flags & 8) >> 3);
 
-    if (n <= 0)
-        n = 100;
+    if(n <= 0) n = 100;
     array_resize(x->x_scalar->sc_vec[zonset].w_array, n);
 
-    template_setfloat(template, gensym("style"), x->x_scalar->sc_vec,
-        style, 1);
+    template_setfloat(template, gensym("style"), x->x_scalar->sc_vec, style, 1);
     template_setfloat(template, gensym("linewidth"), x->x_scalar->sc_vec,
         ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
     template_setfloat(template, gensym("v"), x->x_scalar->sc_vec, 1, 1);
 
-           /* bashily unbind #A -- this would create garbage if #A were
-           multiply bound but we believe in this context it's at most
-           bound to whichever textobj or array was created most recently */
+    /* bashily unbind #A -- this would create garbage if #A were
+    multiply bound but we believe in this context it's at most
+    bound to whichever textobj or array was created most recently */
     asym->s_thing = 0;
-        /* and now bind #A to us to receive following messages in the
-        saved file or copy buffer */
+    /* and now bind #A to us to receive following messages in the
+    saved file or copy buffer */
     pd_bind(&x->x_gobj.g_pd, asym);
     garray_fittograph(x, n, style);
     canvas_update_dsp();
     return (x);
 }
 
-    /* called from array menu item to create a new one */
+/* called from array menu item to create a new one */
 void canvas_menuarray(t_glist *canvas)
 {
-    t_glist *x = (t_glist *)canvas;
+    t_glist *x = (t_glist *) canvas;
     int gcount;
     char cmdbuf[200], arraybuf[80];
-    for (gcount = 1; gcount < 1000; gcount++)
+    for(gcount = 1; gcount < 1000; gcount++)
     {
         sprintf(arraybuf, "array%d", gcount);
-        if (!pd_findbyclass(gensym(arraybuf), garray_class))
-            break;
+        if(!pd_findbyclass(gensym(arraybuf), garray_class)) break;
     }
     sprintf(cmdbuf, "pdtk_array_dialog %%s array%d 100 3 1\n", gcount);
     gfxstub_new(&x->gl_pd, x, cmdbuf);
 }
 
-    /* called from graph_dialog to set properties */
+/* called from graph_dialog to set properties */
 void garray_properties(t_garray *x)
 {
     char cmdbuf[200];
@@ -367,89 +357,85 @@ void garray_properties(t_garray *x)
     t_scalar *sc = x->x_scalar;
     int style = template_getfloat(template_findbyname(sc->sc_template),
         gensym("style"), x->x_scalar->sc_vec, 1);
-    int filestyle = (style == 0 ? PLOTSTYLE_POLY :
-        (style == 1 ? PLOTSTYLE_POINTS : style));
+    int filestyle =
+        (style == 0 ? PLOTSTYLE_POLY : (style == 1 ? PLOTSTYLE_POINTS : style));
 
-    if (!a)
-        return;
+    if(!a) return;
     gfxstub_deleteforkey(x);
-        /* create dialog window.  LATER fix this to escape '$'
-        properly; right now we just detect a leading '$' and escape
-        it.  There should be a systematic way of doing this. */
-    sprintf(cmdbuf, "pdtk_array_dialog %%s {%s} %d %d 0\n",
-            x->x_name->s_name, a->a_n, x->x_saveit +
-            2 * filestyle);
+    /* create dialog window.  LATER fix this to escape '$'
+    properly; right now we just detect a leading '$' and escape
+    it.  There should be a systematic way of doing this. */
+    sprintf(cmdbuf, "pdtk_array_dialog %%s {%s} %d %d 0\n", x->x_name->s_name,
+        a->a_n, x->x_saveit + 2 * filestyle);
     gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
 }
 
-    /* this is called back from the dialog window to create a garray.
-    The otherflag requests that we find an existing graph to put it in. */
+/* this is called back from the dialog window to create a garray.
+The otherflag requests that we find an existing graph to put it in. */
 void glist_arraydialog(t_glist *parent, t_symbol *name, t_floatarg size,
     t_floatarg fflags, t_floatarg otherflag)
 {
     t_glist *gl;
     t_garray *a;
     int flags = fflags;
-    if (size < 1)
-        size = 1;
-    if (otherflag == 0 || (!(gl = glist_findgraph(parent))))
-        gl = glist_addglist(parent, &s_, 0, 1,
-            size, -1, 0, 0, 0, 0);
+    if(size < 1) size = 1;
+    if(otherflag == 0 || (!(gl = glist_findgraph(parent))))
+        gl = glist_addglist(parent, &s_, 0, 1, size, -1, 0, 0, 0, 0);
     a = graph_array(gl, name, &s_float, size, flags);
     canvas_dirty(parent, 1);
 }
 
-    /* this is called from the properties dialog window for an existing array */
+/* this is called from the properties dialog window for an existing array */
 void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
     t_floatarg fflags, t_floatarg deleteit)
 {
     int flags = fflags;
     int saveit = ((flags & 1) != 0);
     int filestyle = ((flags & 6) >> 1);
-    int style = (filestyle == 0 ? PLOTSTYLE_POLY :
-        (filestyle == 1 ? PLOTSTYLE_POINTS : filestyle));
-    t_float stylewas = template_getfloat(
-        template_findbyname(x->x_scalar->sc_template),
+    int style =
+        (filestyle == 0 ? PLOTSTYLE_POLY
+                        : (filestyle == 1 ? PLOTSTYLE_POINTS : filestyle));
+    t_float stylewas =
+        template_getfloat(template_findbyname(x->x_scalar->sc_template),
             gensym("style"), x->x_scalar->sc_vec, 1);
-    if (deleteit != 0)
+    if(deleteit != 0)
     {
         int wasused = x->x_usedindsp;
         glist_delete(x->x_glist, &x->x_gobj);
-        if (wasused)
-            canvas_update_dsp();
+        if(wasused) canvas_update_dsp();
     }
     else
     {
         long size;
         t_array *a = garray_getarray(x);
         t_template *scalartemplate;
-        if (!a)
+        if(!a)
         {
             pd_error(x, "can't find array\n");
             return;
         }
-        if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+        if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
         {
             pd_error(0, "array: no template of type %s",
                 x->x_scalar->sc_template->s_name);
             return;
         }
-        if (name != x->x_name)
+        if(name != x->x_name)
         {
             /* jsarlo { */
-            if (x->x_listviewing)
+            if(x->x_listviewing)
             {
-              garray_arrayviewlist_close(x);
+                garray_arrayviewlist_close(x);
             }
             /* } jsarlo */
             x->x_name = name;
             pd_unbind(&x->x_gobj.g_pd, x->x_realname);
             x->x_realname = canvas_realizedollar(x->x_glist, name);
             pd_bind(&x->x_gobj.g_pd, x->x_realname);
-                /* redraw the whole glist, just so the name change shows up */
-            if (x->x_glist->gl_havewindow)
+            /* redraw the whole glist, just so the name change shows up */
+            if(x->x_glist->gl_havewindow)
                 canvas_redraw(x->x_glist);
-            else if (glist_isvisible(x->x_glist->gl_owner))
+            else if(glist_isvisible(x->x_glist->gl_owner))
             {
                 gobj_vis(&x->x_glist->gl_gobj, x->x_glist->gl_owner, 0);
                 gobj_vis(&x->x_glist->gl_gobj, x->x_glist->gl_owner, 1);
@@ -457,16 +443,15 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
             canvas_update_dsp();
         }
         size = fsize;
-        if (size < 1)
-            size = 1;
-        if (size != a->a_n)
+        if(size < 1) size = 1;
+        if(size != a->a_n)
             garray_resize_long(x, size);
-        else if (style != stylewas)
-            garray_fittograph(x, (int)size, style);
-        template_setfloat(scalartemplate, gensym("style"),
-            x->x_scalar->sc_vec, (t_float)style, 0);
-        template_setfloat(scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec,
-            ((style == PLOTSTYLE_POINTS) ? 2 : 1), 0);
+        else if(style != stylewas)
+            garray_fittograph(x, (int) size, style);
+        template_setfloat(scalartemplate, gensym("style"), x->x_scalar->sc_vec,
+            (t_float) style, 0);
+        template_setfloat(scalartemplate, gensym("linewidth"),
+            x->x_scalar->sc_vec, ((style == PLOTSTYLE_POINTS) ? 2 : 1), 0);
 
         garray_setsaveit(x, (saveit != 0));
         garray_redraw(x);
@@ -475,61 +460,53 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
 }
 
 /* jsarlo { */
-static void garray_arrayviewlist_fillpage(t_garray *x,
-                                   t_float fPage,
-                                   t_float fTopItem)
+static void garray_arrayviewlist_fillpage(
+    t_garray *x, t_float fPage, t_float fTopItem)
 {
-    int i, size=0, topItem=(int)fTopItem;
-    int pagesize=ARRAYPAGESIZE, page=(int)fPage, maxpage;
-    t_word *data=0;
+    int i, size = 0, topItem = (int) fTopItem;
+    int pagesize = ARRAYPAGESIZE, page = (int) fPage, maxpage;
+    t_word *data = 0;
 
-    if(!garray_getfloatwords(x, &size, &data)) {
+    if(!garray_getfloatwords(x, &size, &data))
+    {
         pd_error(x, "error in %s()", __FUNCTION__);
         return;
     }
 
-        /* make sure the requested page is within range */
+    /* make sure the requested page is within range */
     maxpage = (size - 1) / pagesize;
-    if(page > maxpage)
-        page = maxpage;
-    if(page < 0)
-        page = 0;
+    if(page > maxpage) page = maxpage;
+    if(page < 0) page = 0;
 
     sys_vgui("::dialog_array::listview_setpage {%s} %d %d %d\n",
-        x->x_realname->s_name,
-        page, maxpage+1, pagesize);
+        x->x_realname->s_name, page, maxpage + 1, pagesize);
 
-    sys_vgui("::dialog_array::listview_setdata {%s} %ld",
-        x->x_realname->s_name,
-        (long long)(page * pagesize));
-    for (i = page * pagesize;
-         (i < (page + 1) * pagesize && i < size);
-         i++)
+    sys_vgui("::dialog_array::listview_setdata {%s} %ld", x->x_realname->s_name,
+        (long long) (page * pagesize));
+    for(i = page * pagesize; (i < (page + 1) * pagesize && i < size); i++)
     {
         sys_vgui(" %g", data[i].w_float);
     }
     sys_vgui("\n");
 
-    sys_vgui("::dialog_array::listview_focus {%s} %d\n",
-             x->x_realname->s_name,
-             topItem);
+    sys_vgui("::dialog_array::listview_focus {%s} %d\n", x->x_realname->s_name,
+        topItem);
 }
 
 static void garray_arrayviewlist_new(t_garray *x)
 {
     char cmdbuf[200];
-    int size=0;
-    t_word*data=0;
+    int size = 0;
+    t_word *data = 0;
 
-    if(!garray_getfloatwords(x, &size, &data)) {
+    if(!garray_getfloatwords(x, &size, &data))
+    {
         pd_error(x, "error in %s()", __FUNCTION__);
         return;
     }
     x->x_listviewing = 1;
-    sprintf(cmdbuf,
-            "pdtk_array_listview_new %%s {%s} %d\n",
-            x->x_realname->s_name,
-            0);
+    sprintf(cmdbuf, "pdtk_array_listview_new %%s {%s} %d\n",
+        x->x_realname->s_name, 0);
     gfxstub_new(&x->x_gobj.g_pd, x, cmdbuf);
 
     garray_arrayviewlist_fillpage(x, 0, 0);
@@ -538,25 +515,25 @@ static void garray_arrayviewlist_new(t_garray *x)
 static void garray_arrayviewlist_close(t_garray *x)
 {
     x->x_listviewing = 0;
-    sys_vgui("pdtk_array_listview_closeWindow {%s}\n",
-             x->x_realname->s_name);
+    sys_vgui("pdtk_array_listview_closeWindow {%s}\n", x->x_realname->s_name);
 }
+
 /* } jsarlo */
 
 static void garray_free(t_garray *x)
 {
     t_pd *x2;
-        sys_unqueuegui(&x->x_gobj);
+    sys_unqueuegui(&x->x_gobj);
     /* jsarlo { */
-    if (x->x_listviewing)
+    if(x->x_listviewing)
     {
         garray_arrayviewlist_close(x);
     }
     /* } jsarlo */
     gfxstub_deleteforkey(x);
     pd_unbind(&x->x_gobj.g_pd, x->x_realname);
-        /* just in case we're still bound to #A from loading... */
-    while ((x2 = pd_findbyclass(gensym("#A"), garray_class)))
+    /* just in case we're still bound to #A from loading... */
+    while((x2 = pd_findbyclass(gensym("#A"), garray_class)))
         pd_unbind(x2, gensym("#A"));
     pd_free(&x->x_scalar->sc_gobj.g_pd);
 }
@@ -565,78 +542,75 @@ static void garray_free(t_garray *x)
 
 void array_redraw(t_array *a, t_glist *glist)
 {
-    while (a->a_gp.gp_stub->gs_which == GP_ARRAY)
+    while(a->a_gp.gp_stub->gs_which == GP_ARRAY)
         a = a->a_gp.gp_stub->gs_un.gs_array;
     scalar_redraw(a->a_gp.gp_un.gp_scalar, glist);
 }
 
-    /* routine to get screen coordinates of a point in an array */
-void array_getcoordinate(t_glist *glist,
-    char *elem, int xonset, int yonset, int wonset, int indx,
-    t_float basex, t_float basey, t_float xinc,
+/* routine to get screen coordinates of a point in an array */
+void array_getcoordinate(t_glist *glist, char *elem, int xonset, int yonset,
+    int wonset, int indx, t_float basex, t_float basey, t_float xinc,
     t_fielddesc *xfielddesc, t_fielddesc *yfielddesc, t_fielddesc *wfielddesc,
     t_float *xp, t_float *yp, t_float *wp)
 {
     t_float xval, yval, ypix, wpix;
-    if (xonset >= 0)
-        xval = *(t_float *)(elem + xonset);
-    else xval = indx * xinc;
-    if (yonset >= 0)
-        yval = *(t_float *)(elem + yonset);
-    else yval = 0;
-    ypix = glist_ytopixels(glist, basey +
-        fielddesc_cvttocoord(yfielddesc, yval));
-    if (wonset >= 0)
+    if(xonset >= 0)
+        xval = *(t_float *) (elem + xonset);
+    else
+        xval = indx * xinc;
+    if(yonset >= 0)
+        yval = *(t_float *) (elem + yonset);
+    else
+        yval = 0;
+    ypix =
+        glist_ytopixels(glist, basey + fielddesc_cvttocoord(yfielddesc, yval));
+    if(wonset >= 0)
     {
-            /* found "w" field which controls linewidth. */
-        t_float wval = *(t_float *)(elem + wonset);
-        wpix = glist_ytopixels(glist, basey +
-            fielddesc_cvttocoord(yfielddesc, yval) +
-                fielddesc_cvttocoord(wfielddesc, wval)) - ypix;
-        if (wpix < 0)
-            wpix = -wpix;
+        /* found "w" field which controls linewidth. */
+        t_float wval = *(t_float *) (elem + wonset);
+        wpix = glist_ytopixels(
+                   glist, basey + fielddesc_cvttocoord(yfielddesc, yval) +
+                              fielddesc_cvttocoord(wfielddesc, wval)) -
+               ypix;
+        if(wpix < 0) wpix = -wpix;
     }
-    else wpix = 1;
-    *xp = glist_xtopixels(glist, basex +
-        fielddesc_cvttocoord(xfielddesc, xval));
+    else
+        wpix = 1;
+    *xp =
+        glist_xtopixels(glist, basex + fielddesc_cvttocoord(xfielddesc, xval));
     *yp = ypix;
     *wp = wpix;
 }
 
-static void array_getrect(t_array *array, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void array_getrect(
+    t_array *array, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_float x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff, y2 = -0x7fffffff;
+    t_float x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff,
+            y2 = -0x7fffffff;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     int elemsize, yonset, wonset, xonset, i;
 
-    if (!array_getfields(array->a_templatesym, &elemtemplatecanvas,
-        &elemtemplate, &elemsize, 0, 0, 0, &xonset, &yonset, &wonset))
+    if(!array_getfields(array->a_templatesym, &elemtemplatecanvas,
+           &elemtemplate, &elemsize, 0, 0, 0, &xonset, &yonset, &wonset))
     {
         int incr;
-            /* if it has more than 2000 points, just check 300 of them. */
-        if (array->a_n < 2000)
+        /* if it has more than 2000 points, just check 300 of them. */
+        if(array->a_n < 2000)
             incr = 1;
-        else incr = array->a_n / 300;
-        for (i = 0; i < array->a_n; i += incr)
+        else
+            incr = array->a_n / 300;
+        for(i = 0; i < array->a_n; i += incr)
         {
             t_float pxpix, pypix, pwpix;
-            array_getcoordinate(glist, (char *)(array->a_vec) +
-                i * elemsize,
-                xonset, yonset, wonset, i, 0, 0, 1,
-                0, 0, 0,
-                &pxpix, &pypix, &pwpix);
-            if (pwpix < 2)
-                pwpix = 2;
-            if (pxpix < x1)
-                x1 = pxpix;
-            if (pxpix > x2)
-                x2 = pxpix;
-            if (pypix - pwpix < y1)
-                y1 = pypix - pwpix;
-            if (pypix + pwpix > y2)
-                y2 = pypix + pwpix;
+            array_getcoordinate(glist, (char *) (array->a_vec) + i * elemsize,
+                xonset, yonset, wonset, i, 0, 0, 1, 0, 0, 0, &pxpix, &pypix,
+                &pwpix);
+            if(pwpix < 2) pwpix = 2;
+            if(pxpix < x1) x1 = pxpix;
+            if(pxpix > x2) x2 = pxpix;
+            if(pypix - pwpix < y1) y1 = pypix - pwpix;
+            if(pypix + pwpix > y2) y2 = pypix + pwpix;
         }
     }
     *xp1 = x1;
@@ -647,10 +621,10 @@ static void array_getrect(t_array *array, t_glist *glist,
 
 /* -------------------- widget behavior for garray ------------ */
 
-static void garray_getrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void garray_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_garray *x = (t_garray *)z;
+    t_garray *x = (t_garray *) z;
     gobj_getrect(&x->x_scalar->sc_gobj, glist, xp1, yp1, xp2, yp2);
 }
 
@@ -661,32 +635,29 @@ static void garray_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 
 static void garray_select(t_gobj *z, t_glist *glist, int state)
 {
-    t_garray *x = (t_garray *)z;
+    t_garray *x = (t_garray *) z;
     /* fill in later */
 }
 
-static void garray_activate(t_gobj *z, t_glist *glist, int state)
-{
-}
+static void garray_activate(t_gobj *z, t_glist *glist, int state) {}
 
 static void garray_delete(t_gobj *z, t_glist *glist)
-{
-    /* nothing to do */
+{ /* nothing to do */
 }
 
 static void garray_vis(t_gobj *z, t_glist *glist, int vis)
 {
-    t_garray *x = (t_garray *)z;
+    t_garray *x = (t_garray *) z;
     gobj_vis(&x->x_scalar->sc_gobj, glist, vis);
 }
 
-static int garray_click(t_gobj *z, t_glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int garray_click(t_gobj *z, t_glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_garray *x = (t_garray *)z;
-    if (x->x_edit)
-        return (gobj_click(&x->x_scalar->sc_gobj, glist,
-            xpix, ypix, shift, alt, dbl, doit));
+    t_garray *x = (t_garray *) z;
+    if(x->x_edit)
+        return (gobj_click(
+            &x->x_scalar->sc_gobj, glist, xpix, ypix, shift, alt, dbl, doit));
     else
         return (0);
 }
@@ -696,21 +667,21 @@ static int garray_click(t_gobj *z, t_glist *glist,
 void garray_savecontentsto(t_garray *x, t_binbuf *b)
 {
     t_array *array = garray_getarray(x);
-    if (x->x_savesize)
+    if(x->x_savesize)
         binbuf_addv(b, "ssi;", gensym("#A"), gensym("resize"), array->a_n);
-    if (x->x_saveit)
+    if(x->x_saveit)
     {
         int n = array->a_n, n2 = 0;
-        if (n > 200000)
+        if(n > 200000)
             post("warning: I'm saving an array with %d points!\n", n);
-        while (n2 < n)
+        while(n2 < n)
         {
             int chunk = n - n2, i;
-            if (chunk > ARRAYWRITECHUNKSIZE)
-                chunk = ARRAYWRITECHUNKSIZE;
+            if(chunk > ARRAYWRITECHUNKSIZE) chunk = ARRAYWRITECHUNKSIZE;
             binbuf_addv(b, "si", gensym("#A"), n2);
-            for (i = 0; i < chunk; i++)
-                binbuf_addv(b, "f", ((t_word *)(array->a_vec))[n2+i].w_float);
+            for(i = 0; i < chunk; i++)
+                binbuf_addv(
+                    b, "f", ((t_word *) (array->a_vec))[n2 + i].w_float);
             binbuf_addv(b, ";");
             n2 += chunk;
         }
@@ -720,34 +691,32 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b)
 static void garray_save(t_gobj *z, t_binbuf *b)
 {
     int style, filestyle;
-    t_garray *x = (t_garray *)z;
+    t_garray *x = (t_garray *) z;
     t_array *array = garray_getarray(x);
     t_template *scalartemplate;
-    if (x->x_scalar->sc_template != gensym("pd-float-array"))
+    if(x->x_scalar->sc_template != gensym("pd-float-array"))
     {
-            /* LATER "save" the scalar as such */
+        /* LATER "save" the scalar as such */
         pd_error(x, "can't save arrays of type %s yet",
             x->x_scalar->sc_template->s_name);
         return;
     }
-    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
         pd_error(0, "array: no template of type %s",
             x->x_scalar->sc_template->s_name);
         return;
     }
-    style = template_getfloat(scalartemplate, gensym("style"),
-            x->x_scalar->sc_vec, 0);
-    filestyle = (style == PLOTSTYLE_POINTS ? 1 :
-        (style == PLOTSTYLE_POLY ? 0 : style));
-    binbuf_addv(b, "sssisi;", gensym("#X"), gensym("array"),
-        x->x_name, array->a_n, &s_float,
-            x->x_saveit + 2 * filestyle + 8*x->x_hidename);
+    style = template_getfloat(
+        scalartemplate, gensym("style"), x->x_scalar->sc_vec, 0);
+    filestyle =
+        (style == PLOTSTYLE_POINTS ? 1 : (style == PLOTSTYLE_POLY ? 0 : style));
+    binbuf_addv(b, "sssisi;", gensym("#X"), gensym("array"), x->x_name,
+        array->a_n, &s_float, x->x_saveit + 2 * filestyle + 8 * x->x_hidename);
     garray_savecontentsto(x, b);
 }
 
-const t_widgetbehavior garray_widgetbehavior =
-{
+const t_widgetbehavior garray_widgetbehavior = {
     garray_getrect,
     garray_displace,
     garray_select,
@@ -759,15 +728,12 @@ const t_widgetbehavior garray_widgetbehavior =
 
 /* ----------------------- public functions -------------------- */
 
-void garray_usedindsp(t_garray *x)
-{
-    x->x_usedindsp = 1;
-}
+void garray_usedindsp(t_garray *x) { x->x_usedindsp = 1; }
 
 static void garray_doredraw(t_gobj *client, t_glist *glist)
 {
-    t_garray *x = (t_garray *)client;
-    if (glist_isvisible(x->x_glist) && gobj_shouldvis(client, glist))
+    t_garray *x = (t_garray *) client;
+    if(glist_isvisible(x->x_glist) && gobj_shouldvis(client, glist))
     {
         garray_vis(&x->x_gobj, x->x_glist, 0);
         garray_vis(&x->x_gobj, x->x_glist, 1);
@@ -776,30 +742,29 @@ static void garray_doredraw(t_gobj *client, t_glist *glist)
 
 void garray_redraw(t_garray *x)
 {
-    if (glist_isvisible(x->x_glist))
+    if(glist_isvisible(x->x_glist))
         sys_queuegui(&x->x_gobj, x->x_glist, garray_doredraw);
     /* jsarlo { */
     /* this happens in garray_vis() when array is visible for
        performance reasons */
     else
     {
-      if (x->x_listviewing)
-        sys_vgui("pdtk_array_listview_fillpage {%s}\n",
-                 x->x_realname->s_name);
+        if(x->x_listviewing)
+            sys_vgui(
+                "pdtk_array_listview_fillpage {%s}\n", x->x_realname->s_name);
     }
     /* } jsarlo */
 }
 
-   /* This functiopn gets the template of an array; if we can't figure
-   out what template an array's elements belong to we're in grave trouble
-   when it's time to free or resize it.  */
+/* This functiopn gets the template of an array; if we can't figure
+out what template an array's elements belong to we're in grave trouble
+when it's time to free or resize it.  */
 t_template *garray_template(t_garray *x)
 {
     t_array *array = garray_getarray(x);
     t_template *template =
         (array ? template_findbyname(array->a_templatesym) : 0);
-    if (!template)
-        bug("garray_template");
+    if(!template) bug("garray_template");
     return (template);
 }
 
@@ -812,52 +777,55 @@ int garray_npoints(t_garray *x) /* get the length */
 char *garray_vec(t_garray *x) /* get the contents */
 {
     t_array *array = garray_getarray(x);
-    return ((char *)(array->a_vec));
+    return ((char *) (array->a_vec));
 }
 
-    /* routine that checks if we're just an array of floats and if
-    so returns the goods */
+/* routine that checks if we're just an array of floats and if
+so returns the goods */
 
 int garray_getfloatwords(t_garray *x, int *size, t_word **vec)
 {
     int yonset, elemsize;
     t_array *a = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!a)
+    if(!a)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return (0);
     }
-    else if (elemsize != sizeof(t_word))
+    else if(elemsize != sizeof(t_word))
     {
         pd_error(0, "%s: has more than one field", x->x_realname->s_name);
         return (0);
     }
     *size = garray_npoints(x);
-    *vec =  (t_word *)garray_vec(x);
+    *vec = (t_word *) garray_vec(x);
     return (1);
 }
-    /* older, non-64-bit safe version, supplied for older externs */
+
+/* older, non-64-bit safe version, supplied for older externs */
 
 int garray_getfloatarray(t_garray *x, int *size, t_float **vec)
 {
-    if (sizeof(t_word) != sizeof(t_float))
+    if(sizeof(t_word) != sizeof(t_float))
     {
         t_symbol *patchname;
-        if (x->x_glist->gl_owner)
+        if(x->x_glist->gl_owner)
             patchname = x->x_glist->gl_owner->gl_name;
         else
             patchname = x->x_glist->gl_name;
         pd_error(0, "an operation on the array '%s' in the patch '%s'",
-              x->x_name->s_name, patchname->s_name);
-        pd_error(0, "failed since it uses garray_getfloatarray while running 64-bit");
+            x->x_name->s_name, patchname->s_name);
+        pd_error(0,
+            "failed since it uses garray_getfloatarray while running 64-bit");
     }
-    return (garray_getfloatwords(x, size, (t_word **)vec));
+    return (garray_getfloatwords(x, size, (t_word **) vec));
 }
 
-    /* set the "saveit" flag */
+/* set the "saveit" flag */
 void garray_setsaveit(t_garray *x, int saveit)
 {
-    if (x->x_saveit && !saveit)
+    if(x->x_saveit && !saveit)
         post("warning: array %s: clearing save-in-patch flag",
             x->x_name->s_name);
     x->x_saveit = saveit;
@@ -868,44 +836,44 @@ static void garray_const(t_garray *x, t_floatarg g)
 {
     int yonset, i, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
-    else for (i = 0; i < array->a_n; i++)
-        *((t_float *)((char *)array->a_vec
-            + elemsize * i) + yonset) = g;
+    if(!array)
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+    else
+        for(i = 0; i < array->a_n; i++)
+            *((t_float *) ((char *) array->a_vec + elemsize * i) + yonset) = g;
     garray_redraw(x);
 }
 
-    /* sum of Fourier components; called from routines below */
-static void garray_dofo(t_garray *x, long npoints, t_float dcval,
-    int nsin, t_float *vsin, int sineflag)
+/* sum of Fourier components; called from routines below */
+static void garray_dofo(t_garray *x, long npoints, t_float dcval, int nsin,
+    t_float *vsin, int sineflag)
 {
     double phase, phaseincr, fj;
     int yonset, i, j, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
+    if(!array)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return;
     }
-    if (npoints == 0)
-        npoints = 512;  /* dunno what a good default would be... */
-    if (npoints != (1 << ilog2((int)npoints)))
+    if(npoints == 0) npoints = 512; /* dunno what a good default would be... */
+    if(npoints != (1 << ilog2((int) npoints)))
         post("%s: rounding to %d points", array->a_templatesym->s_name,
-            (npoints = (1<<ilog2((int)npoints))));
+            (npoints = (1 << ilog2((int) npoints))));
     garray_resize_long(x, npoints + 3);
     phaseincr = 2. * 3.14159 / npoints;
-    for (i = 0, phase = -phaseincr; i < array->a_n; i++, phase += phaseincr)
+    for(i = 0, phase = -phaseincr; i < array->a_n; i++, phase += phaseincr)
     {
         double sum = dcval;
-        if (sineflag)
-            for (j = 0, fj = phase; j < nsin; j++, fj += phase)
+        if(sineflag)
+            for(j = 0, fj = phase; j < nsin; j++, fj += phase)
                 sum += vsin[j] * sin(fj);
         else
-            for (j = 0, fj = 0; j < nsin; j++, fj += phase)
+            for(j = 0, fj = 0; j < nsin; j++, fj += phase)
                 sum += vsin[j] * cos(fj);
-        *((t_float *)((array->a_vec + elemsize * i)) + yonset)
-            = sum;
+        *((t_float *) ((array->a_vec + elemsize * i)) + yonset) = sum;
     }
     garray_redraw(x);
 }
@@ -915,7 +883,7 @@ static void garray_sinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     t_float *svec;
     long npoints;
     int i;
-    if (argc < 2)
+    if(argc < 2)
     {
         pd_error(0, "sinesum: %s: need number of points and partial strengths",
             x->x_realname->s_name);
@@ -925,10 +893,10 @@ static void garray_sinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     npoints = atom_getfloatarg(0, argc, argv);
     argv++, argc--;
 
-    svec = (t_float *)t_getbytes(sizeof(t_float) * argc);
-    if (!svec) return;
+    svec = (t_float *) t_getbytes(sizeof(t_float) * argc);
+    if(!svec) return;
 
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
         svec[i] = atom_getfloatarg(i, argc, argv);
     garray_dofo(x, npoints, 0, argc, svec, 1);
     t_freebytes(svec, sizeof(t_float) * argc);
@@ -939,7 +907,7 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     t_float *svec;
     long npoints;
     int i;
-    if (argc < 2)
+    if(argc < 2)
     {
         pd_error(0, "sinesum: %s: need number of points and partial strengths",
             x->x_realname->s_name);
@@ -949,10 +917,10 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     npoints = atom_getfloatarg(0, argc, argv);
     argv++, argc--;
 
-    svec = (t_float *)t_getbytes(sizeof(t_float) * argc);
-    if (!svec) return;
+    svec = (t_float *) t_getbytes(sizeof(t_float) * argc);
+    if(!svec) return;
 
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
         svec[i] = atom_getfloatarg(i, argc, argv);
     garray_dofo(x, npoints, 0, argc, svec, 0);
     t_freebytes(svec, sizeof(t_float) * argc);
@@ -964,88 +932,86 @@ static void garray_normalize(t_garray *x, t_float f)
     double maxv, renormer;
     int yonset, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
+    if(!array)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return;
     }
 
-    if (f <= 0)
-        f = 1;
+    if(f <= 0) f = 1;
 
-    for (i = 0, maxv = 0; i < array->a_n; i++)
+    for(i = 0, maxv = 0; i < array->a_n; i++)
     {
-        double v = *((t_float *)(array->a_vec + elemsize * i)
-            + yonset);
-        if (v > maxv)
-            maxv = v;
-        if (-v > maxv)
-            maxv = -v;
+        double v = *((t_float *) (array->a_vec + elemsize * i) + yonset);
+        if(v > maxv) maxv = v;
+        if(-v > maxv) maxv = -v;
     }
-    if (maxv > 0)
+    if(maxv > 0)
     {
         renormer = f / maxv;
-        for (i = 0; i < array->a_n; i++)
-            *((t_float *)(array->a_vec + elemsize * i) + yonset)
-                *= renormer;
+        for(i = 0; i < array->a_n; i++)
+            *((t_float *) (array->a_vec + elemsize * i) + yonset) *= renormer;
     }
     garray_redraw(x);
 }
 
-    /* list -- the first value is an index; subsequent values are put in
-    the "y" slot of the array.  This generalizes Max's "table", sort of. */
+/* list -- the first value is an index; subsequent values are put in
+the "y" slot of the array.  This generalizes Max's "table", sort of. */
 static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     int yonset, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
+    if(!array)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return;
     }
-    if (argc < 2) return;
+    if(argc < 2)
+        return;
     else
     {
         int firstindex = atom_getfloat(argv);
         argc--;
         argv++;
-            /* drop negative x values */
-        if (firstindex < 0)
+        /* drop negative x values */
+        if(firstindex < 0)
         {
             argc += firstindex;
             argv -= firstindex;
             firstindex = 0;
-            if (argc <= 0) return;
+            if(argc <= 0) return;
         }
-        if (argc + firstindex > array->a_n)
+        if(argc + firstindex > array->a_n)
         {
             argc = array->a_n - firstindex;
-            if (argc <= 0) return;
+            if(argc <= 0) return;
         }
-        for (i = 0; i < argc; i++)
-            *((t_float *)(array->a_vec + elemsize * (i + firstindex)) + yonset)
-                = atom_getfloat(argv + i);
+        for(i = 0; i < argc; i++)
+            *((t_float *) (array->a_vec + elemsize * (i + firstindex)) +
+                yonset) = atom_getfloat(argv + i);
     }
     garray_redraw(x);
 }
 
-    /* forward a "bounds" message to the owning graph */
-static void garray_bounds(t_garray *x, t_floatarg x1, t_floatarg y1,
-    t_floatarg x2, t_floatarg y2)
+/* forward a "bounds" message to the owning graph */
+static void garray_bounds(
+    t_garray *x, t_floatarg x1, t_floatarg y1, t_floatarg x2, t_floatarg y2)
 {
     vmess(&x->x_glist->gl_pd, gensym("bounds"), "ffff", x1, y1, x2, y2);
 }
 
-    /* same for "xticks", etc */
-static void garray_xticks(t_garray *x,
-    t_floatarg point, t_floatarg inc, t_floatarg f)
+/* same for "xticks", etc */
+static void garray_xticks(
+    t_garray *x, t_floatarg point, t_floatarg inc, t_floatarg f)
 {
     vmess(&x->x_glist->gl_pd, gensym("xticks"), "fff", point, inc, f);
 }
 
-static void garray_yticks(t_garray *x,
-    t_floatarg point, t_floatarg inc, t_floatarg f)
+static void garray_yticks(
+    t_garray *x, t_floatarg point, t_floatarg inc, t_floatarg f)
 {
     vmess(&x->x_glist->gl_pd, gensym("yticks"), "fff", point, inc, f);
 }
@@ -1064,7 +1030,7 @@ static void garray_style(t_garray *x, t_floatarg fstyle)
 {
     int stylewas, style = fstyle;
     t_template *scalartemplate;
-    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
         pd_error(0, "array: no template of type %s",
             x->x_scalar->sc_template->s_name);
@@ -1072,22 +1038,22 @@ static void garray_style(t_garray *x, t_floatarg fstyle)
     }
     stylewas = template_getfloat(
         scalartemplate, gensym("style"), x->x_scalar->sc_vec, 1);
-    if (style != stylewas)
+    if(style != stylewas)
     {
         t_array *a = garray_getarray(x);
-        if (!a)
+        if(!a)
         {
             pd_error(x, "can't find array\n");
             return;
         }
-        if (style == PLOTSTYLE_POINTS || stylewas == PLOTSTYLE_POINTS)
+        if(style == PLOTSTYLE_POINTS || stylewas == PLOTSTYLE_POINTS)
             garray_fittograph(x, a->a_n, style);
-        template_setfloat(scalartemplate, gensym("style"),
-            x->x_scalar->sc_vec, (t_float)style, 0);
-    #if 1
-        template_setfloat(scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec,
-            ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
-    #endif
+        template_setfloat(scalartemplate, gensym("style"), x->x_scalar->sc_vec,
+            (t_float) style, 0);
+#if 1
+        template_setfloat(scalartemplate, gensym("linewidth"),
+            x->x_scalar->sc_vec, ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
+#endif
         garray_redraw(x);
     }
 }
@@ -1096,7 +1062,7 @@ static void garray_width(t_garray *x, t_floatarg width)
 {
     t_float widthwas;
     t_template *scalartemplate;
-    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
         pd_error(0, "array: no template of type %s",
             x->x_scalar->sc_template->s_name);
@@ -1104,11 +1070,11 @@ static void garray_width(t_garray *x, t_floatarg width)
     }
     widthwas = template_getfloat(
         scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, 1);
-    if (width < 1) width = 1;
-    if (width != widthwas)
+    if(width < 1) width = 1;
+    if(width != widthwas)
     {
-        template_setfloat(scalartemplate, gensym("linewidth"),
-            x->x_scalar->sc_vec, width, 0);
+        template_setfloat(
+            scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, width, 0);
         garray_redraw(x);
     }
 }
@@ -1117,7 +1083,7 @@ static void garray_color(t_garray *x, t_floatarg color)
 {
     t_float colorwas;
     t_template *scalartemplate;
-    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
         pd_error(0, "array: no template of type %s",
             x->x_scalar->sc_template->s_name);
@@ -1125,10 +1091,10 @@ static void garray_color(t_garray *x, t_floatarg color)
     }
     colorwas = template_getfloat(
         scalartemplate, gensym("color"), x->x_scalar->sc_vec, 1);
-    if (color != colorwas)
+    if(color != colorwas)
     {
-        template_setfloat(scalartemplate, gensym("color"),
-            x->x_scalar->sc_vec, color, 0);
+        template_setfloat(
+            scalartemplate, gensym("color"), x->x_scalar->sc_vec, color, 0);
         garray_redraw(x);
     }
 }
@@ -1137,27 +1103,27 @@ static void garray_vis_msg(t_garray *x, t_floatarg fvis)
 {
     int viswas, vis = fvis != 0;
     t_template *scalartemplate;
-    if (!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
+    if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
         pd_error(0, "array: no template of type %s",
             x->x_scalar->sc_template->s_name);
         return;
     }
-    viswas = template_getfloat(
-        scalartemplate, gensym("v"), x->x_scalar->sc_vec, 1);
-    if (vis != viswas)
+    viswas =
+        template_getfloat(scalartemplate, gensym("v"), x->x_scalar->sc_vec, 1);
+    if(vis != viswas)
     {
-        template_setfloat(scalartemplate, gensym("v"),
-            x->x_scalar->sc_vec, vis, 0);
+        template_setfloat(
+            scalartemplate, gensym("v"), x->x_scalar->sc_vec, vis, 0);
         garray_redraw(x);
     }
 }
 
-    /* change the name of a garray. */
+/* change the name of a garray. */
 static void garray_rename(t_garray *x, t_symbol *s)
 {
     /* jsarlo { */
-    if (x->x_listviewing)
+    if(x->x_listviewing)
     {
         garray_arrayviewlist_close(x);
     }
@@ -1174,33 +1140,34 @@ static void garray_read(t_garray *x, t_symbol *filename)
     char buf[MAXPDSTRING], *bufptr;
     int yonset, elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
+    if(!array)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return;
     }
     nelem = array->a_n;
-    if ((filedesc = canvas_open(glist_getcanvas(x->x_glist),
-            filename->s_name, "", buf, &bufptr, MAXPDSTRING, 0)) < 0
-                || !(fd = fdopen(filedesc, "r")))
+    if((filedesc = canvas_open(glist_getcanvas(x->x_glist), filename->s_name,
+            "", buf, &bufptr, MAXPDSTRING, 0)) < 0 ||
+        !(fd = fdopen(filedesc, "r")))
     {
         pd_error(0, "%s: can't open", filename->s_name);
         return;
     }
-    for (i = 0; i < nelem; i++)
+    for(i = 0; i < nelem; i++)
     {
         double f;
-        if (!fscanf(fd, "%lf", &f))
+        if(!fscanf(fd, "%lf", &f))
         {
-            post("%s: read %d elements into table of size %d",
-                filename->s_name, i, nelem);
+            post("%s: read %d elements into table of size %d", filename->s_name,
+                i, nelem);
             break;
         }
-        else *((t_float *)(array->a_vec + elemsize * i) + yonset) = f;
+        else
+            *((t_float *) (array->a_vec + elemsize * i) + yonset) = f;
     }
-    while (i < nelem)
-        *((t_float *)(array->a_vec +
-            elemsize * i) + yonset) = 0, i++;
+    while(i < nelem)
+        *((t_float *) (array->a_vec + elemsize * i) + yonset) = 0, i++;
     fclose(fd);
     garray_redraw(x);
 }
@@ -1211,22 +1178,24 @@ static void garray_write(t_garray *x, t_symbol *filename)
     char buf[MAXPDSTRING];
     int yonset, elemsize, i;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
-    if (!array)
+    if(!array)
     {
-        pd_error(0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+        pd_error(
+            0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return;
     }
-    canvas_makefilename(glist_getcanvas(x->x_glist), filename->s_name,
-        buf, MAXPDSTRING);
-    if (!(fd = sys_fopen(buf, "w")))
+    canvas_makefilename(
+        glist_getcanvas(x->x_glist), filename->s_name, buf, MAXPDSTRING);
+    if(!(fd = sys_fopen(buf, "w")))
     {
         pd_error(0, "%s: can't create", buf);
         return;
     }
-    for (i = 0; i < array->a_n; i++)
+    for(i = 0; i < array->a_n; i++)
     {
-        if (fprintf(fd, "%g\n",
-            *(t_float *)(((array->a_vec + sizeof(t_word) * i)) + yonset)) < 1)
+        if(fprintf(fd, "%g\n",
+               *(t_float *) (((array->a_vec + sizeof(t_word) * i)) + yonset)) <
+            1)
         {
             post("%s: write error", filename->s_name);
             break;
@@ -1238,96 +1207,85 @@ static void garray_write(t_garray *x, t_symbol *filename)
 void garray_resize_long(t_garray *x, long n)
 {
     t_array *array = garray_getarray(x);
-    if (n < 1)
-        n = 1;
-    if (n == array->a_n)
-        return;
-    garray_fittograph(x, (int)n, template_getfloat(
-        template_findbyname(x->x_scalar->sc_template),
+    if(n < 1) n = 1;
+    if(n == array->a_n) return;
+    garray_fittograph(x, (int) n,
+        template_getfloat(template_findbyname(x->x_scalar->sc_template),
             gensym("style"), x->x_scalar->sc_vec, 1));
-    array_resize_and_redraw(array, x->x_glist, (int)n);
-    if (x->x_usedindsp)
-        canvas_update_dsp();
+    array_resize_and_redraw(array, x->x_glist, (int) n);
+    if(x->x_usedindsp) canvas_update_dsp();
 }
 
-    /* float version to use as Pd method */
-void garray_resize(t_garray *x, t_floatarg f)
-{
-    garray_resize_long(x, f);
-}
+/* float version to use as Pd method */
+void garray_resize(t_garray *x, t_floatarg f) { garray_resize_long(x, f); }
 
 /* ignore zoom for now */
-static void garray_zoom(t_garray *x, t_floatarg f)
-{
-}
+static void garray_zoom(t_garray *x, t_floatarg f) {}
 
-static void garray_edit(t_garray *x, t_floatarg f)
-{
-    x->x_edit = (int)f;
-}
+static void garray_edit(t_garray *x, t_floatarg f) { x->x_edit = (int) f; }
 
 static void garray_print(t_garray *x)
 {
     t_array *array = garray_getarray(x);
-    post("garray %s: template %s, length %d",
-        x->x_realname->s_name, array->a_templatesym->s_name, array->a_n);
+    post("garray %s: template %s, length %d", x->x_realname->s_name,
+        array->a_templatesym->s_name, array->a_n);
 }
 
 void g_array_setup(void)
 {
-    garray_class = class_new(gensym("array"), 0, (t_method)garray_free,
+    garray_class = class_new(gensym("array"), 0, (t_method) garray_free,
         sizeof(t_garray), CLASS_GOBJ, 0);
     class_setwidget(garray_class, &garray_widgetbehavior);
-    class_addmethod(garray_class, (t_method)garray_const, gensym("const"),
+    class_addmethod(garray_class, (t_method) garray_const, gensym("const"),
         A_DEFFLOAT, A_NULL);
     class_addlist(garray_class, garray_list);
-    class_addmethod(garray_class, (t_method)garray_bounds, gensym("bounds"),
+    class_addmethod(garray_class, (t_method) garray_bounds, gensym("bounds"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_xticks, gensym("xticks"),
+    class_addmethod(garray_class, (t_method) garray_xticks, gensym("xticks"),
         A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_xlabel, gensym("xlabel"),
-        A_GIMME, 0);
-    class_addmethod(garray_class, (t_method)garray_yticks, gensym("yticks"),
+    class_addmethod(
+        garray_class, (t_method) garray_xlabel, gensym("xlabel"), A_GIMME, 0);
+    class_addmethod(garray_class, (t_method) garray_yticks, gensym("yticks"),
         A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_ylabel, gensym("ylabel"),
-        A_GIMME, 0);
-    class_addmethod(garray_class, (t_method)garray_style, gensym("style"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_width, gensym("width"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_color, gensym("color"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_vis_msg, gensym("vis"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_rename, gensym("rename"),
-        A_SYMBOL, 0);
-    class_addmethod(garray_class, (t_method)garray_read, gensym("read"),
+    class_addmethod(
+        garray_class, (t_method) garray_ylabel, gensym("ylabel"), A_GIMME, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_style, gensym("style"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_width, gensym("width"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_color, gensym("color"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_vis_msg, gensym("vis"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_rename, gensym("rename"), A_SYMBOL, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_read, gensym("read"), A_SYMBOL, A_NULL);
+    class_addmethod(garray_class, (t_method) garray_write, gensym("write"),
         A_SYMBOL, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_write, gensym("write"),
-        A_SYMBOL, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_resize, gensym("resize"),
+    class_addmethod(garray_class, (t_method) garray_resize, gensym("resize"),
         A_FLOAT, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_zoom, gensym("zoom"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_edit, gensym("edit"),
-        A_FLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_print, gensym("print"),
-        A_NULL);
-    class_addmethod(garray_class, (t_method)garray_sinesum, gensym("sinesum"),
-        A_GIMME, 0);
-    class_addmethod(garray_class, (t_method)garray_cosinesum,
+    class_addmethod(
+        garray_class, (t_method) garray_zoom, gensym("zoom"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_edit, gensym("edit"), A_FLOAT, 0);
+    class_addmethod(
+        garray_class, (t_method) garray_print, gensym("print"), A_NULL);
+    class_addmethod(
+        garray_class, (t_method) garray_sinesum, gensym("sinesum"), A_GIMME, 0);
+    class_addmethod(garray_class, (t_method) garray_cosinesum,
         gensym("cosinesum"), A_GIMME, 0);
-    class_addmethod(garray_class, (t_method)garray_normalize,
+    class_addmethod(garray_class, (t_method) garray_normalize,
         gensym("normalize"), A_DEFFLOAT, 0);
-    class_addmethod(garray_class, (t_method)garray_arraydialog,
+    class_addmethod(garray_class, (t_method) garray_arraydialog,
         gensym("arraydialog"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-/* jsarlo { */
-    class_addmethod(garray_class, (t_method)garray_arrayviewlist_new,
+    /* jsarlo { */
+    class_addmethod(garray_class, (t_method) garray_arrayviewlist_new,
         gensym("arrayviewlistnew"), A_NULL);
-    class_addmethod(garray_class, (t_method)garray_arrayviewlist_fillpage,
+    class_addmethod(garray_class, (t_method) garray_arrayviewlist_fillpage,
         gensym("arrayviewlistfillpage"), A_FLOAT, A_DEFFLOAT, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_arrayviewlist_close,
-      gensym("arrayviewclose"), A_NULL);
-/* } jsarlo */
+    class_addmethod(garray_class, (t_method) garray_arrayviewlist_close,
+        gensym("arrayviewclose"), A_NULL);
+    /* } jsarlo */
     class_setsavefn(garray_class, garray_save);
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -46,7 +46,8 @@ static void garray_arrayviewlist_close(t_garray *x);
 
 void array_resize(t_array *x, int n)
 {
-    int elemsize, oldn;
+    int elemsize;
+    int oldn;
     char *tmp;
     t_template *template = template_findbyname(x->a_templatesym);
     if(n < 1) n = 1;
@@ -180,7 +181,8 @@ static t_garray *graph_scalar(
 /* get a garray's "array" structure. */
 t_array *garray_getarray(t_garray *x)
 {
-    int zonset, ztype;
+    int zonset;
+    int ztype;
     t_symbol *zarraytype;
     t_scalar *sc = x->x_scalar;
     t_symbol *templatesym = sc->sc_template;
@@ -210,7 +212,8 @@ static t_array *garray_getarray_floatonly(
     t_garray *x, int *yonsetp, int *elemsizep)
 {
     t_array *a = garray_getarray(x);
-    int yonset, type;
+    int yonset;
+    int type;
     t_symbol *arraytype;
     t_template *template = template_findbyname(a->a_templatesym);
     if(!template_find_field(
@@ -269,10 +272,16 @@ by a more coherent (and general) invocation. */
 t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
     t_floatarg fsize, t_floatarg fflags)
 {
-    int n = fsize, zonset, ztype, saveit, savesize;
-    t_symbol *zarraytype, *asym = gensym("#A");
+    int n = fsize;
+    int zonset;
+    int ztype;
+    int saveit;
+    int savesize;
+    t_symbol *zarraytype;
+    t_symbol *asym = gensym("#A");
     t_garray *x;
-    t_template *template, *ztemplate;
+    t_template *template;
+    t_template *ztemplate;
     t_symbol *templatesym;
     int flags = fflags;
     int filestyle = ((flags & GRAPH_ARRAY_PLOTSTYLE) >> 1);
@@ -339,7 +348,8 @@ void canvas_menuarray(t_glist *canvas)
 {
     t_glist *x = (t_glist *) canvas;
     int gcount;
-    char cmdbuf[200], arraybuf[80];
+    char cmdbuf[200];
+    char arraybuf[80];
     for(gcount = 1; gcount < 1000; gcount++)
     {
         sprintf(arraybuf, "array%d", gcount);
@@ -463,8 +473,12 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
 static void garray_arrayviewlist_fillpage(
     t_garray *x, t_float fPage, t_float fTopItem)
 {
-    int i, size = 0, topItem = (int) fTopItem;
-    int pagesize = ARRAYPAGESIZE, page = (int) fPage, maxpage;
+    int i;
+    int size = 0;
+    int topItem = (int) fTopItem;
+    int pagesize = ARRAYPAGESIZE;
+    int page = (int) fPage;
+    int maxpage;
     t_word *data = 0;
 
     if(!garray_getfloatwords(x, &size, &data))
@@ -553,7 +567,10 @@ void array_getcoordinate(t_glist *glist, char *elem, int xonset, int yonset,
     t_fielddesc *xfielddesc, t_fielddesc *yfielddesc, t_fielddesc *wfielddesc,
     t_float *xp, t_float *yp, t_float *wp)
 {
-    t_float xval, yval, ypix, wpix;
+    t_float xval;
+    t_float yval;
+    t_float ypix;
+    t_float wpix;
     if(xonset >= 0)
         xval = *(t_float *) (elem + xonset);
     else
@@ -585,11 +602,17 @@ void array_getcoordinate(t_glist *glist, char *elem, int xonset, int yonset,
 static void array_getrect(
     t_array *array, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_float x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff,
-            y2 = -0x7fffffff;
+    t_float x1 = 0x7fffffff;
+    t_float y1 = 0x7fffffff;
+    t_float x2 = -0x7fffffff;
+    t_float y2 = -0x7fffffff;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
-    int elemsize, yonset, wonset, xonset, i;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
+    int i;
 
     if(!array_getfields(array->a_templatesym, &elemtemplatecanvas,
            &elemtemplate, &elemsize, 0, 0, 0, &xonset, &yonset, &wonset))
@@ -602,7 +625,9 @@ static void array_getrect(
             incr = array->a_n / 300;
         for(i = 0; i < array->a_n; i += incr)
         {
-            t_float pxpix, pypix, pwpix;
+            t_float pxpix;
+            t_float pypix;
+            t_float pwpix;
             array_getcoordinate(glist, (char *) (array->a_vec) + i * elemsize,
                 xonset, yonset, wonset, i, 0, 0, 1, 0, 0, 0, &pxpix, &pypix,
                 &pwpix);
@@ -671,12 +696,14 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b)
         binbuf_addv(b, "ssi;", gensym("#A"), gensym("resize"), array->a_n);
     if(x->x_saveit)
     {
-        int n = array->a_n, n2 = 0;
+        int n = array->a_n;
+        int n2 = 0;
         if(n > 200000)
             post("warning: I'm saving an array with %d points!\n", n);
         while(n2 < n)
         {
-            int chunk = n - n2, i;
+            int chunk = n - n2;
+            int i;
             if(chunk > ARRAYWRITECHUNKSIZE) chunk = ARRAYWRITECHUNKSIZE;
             binbuf_addv(b, "si", gensym("#A"), n2);
             for(i = 0; i < chunk; i++)
@@ -690,7 +717,8 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b)
 
 static void garray_save(t_gobj *z, t_binbuf *b)
 {
-    int style, filestyle;
+    int style;
+    int filestyle;
     t_garray *x = (t_garray *) z;
     t_array *array = garray_getarray(x);
     t_template *scalartemplate;
@@ -785,7 +813,8 @@ so returns the goods */
 
 int garray_getfloatwords(t_garray *x, int *size, t_word **vec)
 {
-    int yonset, elemsize;
+    int yonset;
+    int elemsize;
     t_array *a = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!a)
     {
@@ -834,7 +863,9 @@ void garray_setsaveit(t_garray *x, int saveit)
 /*------------------- Pd messages ------------------------ */
 static void garray_const(t_garray *x, t_floatarg g)
 {
-    int yonset, i, elemsize;
+    int yonset;
+    int i;
+    int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
         pd_error(
@@ -849,8 +880,13 @@ static void garray_const(t_garray *x, t_floatarg g)
 static void garray_dofo(t_garray *x, long npoints, t_float dcval, int nsin,
     t_float *vsin, int sineflag)
 {
-    double phase, phaseincr, fj;
-    int yonset, i, j, elemsize;
+    double phase;
+    double phaseincr;
+    double fj;
+    int yonset;
+    int i;
+    int j;
+    int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {
@@ -929,8 +965,10 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 static void garray_normalize(t_garray *x, t_float f)
 {
     int i;
-    double maxv, renormer;
-    int yonset, elemsize;
+    double maxv;
+    double renormer;
+    int yonset;
+    int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {
@@ -961,7 +999,8 @@ the "y" slot of the array.  This generalizes Max's "table", sort of. */
 static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    int yonset, elemsize;
+    int yonset;
+    int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {
@@ -1028,7 +1067,8 @@ static void garray_ylabel(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 
 static void garray_style(t_garray *x, t_floatarg fstyle)
 {
-    int stylewas, style = fstyle;
+    int stylewas;
+    int style = fstyle;
     t_template *scalartemplate;
     if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
@@ -1101,7 +1141,8 @@ static void garray_color(t_garray *x, t_floatarg color)
 
 static void garray_vis_msg(t_garray *x, t_floatarg fvis)
 {
-    int viswas, vis = fvis != 0;
+    int viswas;
+    int vis = fvis != 0;
     t_template *scalartemplate;
     if(!(scalartemplate = template_findbyname(x->x_scalar->sc_template)))
     {
@@ -1135,10 +1176,14 @@ static void garray_rename(t_garray *x, t_symbol *s)
 
 static void garray_read(t_garray *x, t_symbol *filename)
 {
-    int nelem, filedesc, i;
+    int nelem;
+    int filedesc;
+    int i;
     FILE *fd;
-    char buf[MAXPDSTRING], *bufptr;
-    int yonset, elemsize;
+    char buf[MAXPDSTRING];
+    char *bufptr;
+    int yonset;
+    int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {
@@ -1176,7 +1221,9 @@ static void garray_write(t_garray *x, t_symbol *filename)
 {
     FILE *fd;
     char buf[MAXPDSTRING];
-    int yonset, elemsize, i;
+    int yonset;
+    int elemsize;
+    int i;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -683,8 +683,7 @@ static int garray_click(t_gobj *z, t_glist *glist, int xpix, int ypix,
     if(x->x_edit)
         return (gobj_click(
             &x->x_scalar->sc_gobj, glist, xpix, ypix, shift, alt, dbl, doit));
-    else
-        return (0);
+    return (0);
 }
 
 #define ARRAYWRITECHUNKSIZE 1000
@@ -822,7 +821,7 @@ int garray_getfloatwords(t_garray *x, int *size, t_word **vec)
             0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
         return (0);
     }
-    else if(elemsize != sizeof(t_word))
+    if(elemsize != sizeof(t_word))
     {
         pd_error(0, "%s: has more than one field", x->x_realname->s_name);
         return (0);
@@ -1208,8 +1207,7 @@ static void garray_read(t_garray *x, t_symbol *filename)
                 i, nelem);
             break;
         }
-        else
-            *((t_float *) (array->a_vec + elemsize * i) + yonset) = f;
+        *((t_float *) (array->a_vec + elemsize * i) + yonset) = f;
     }
     while(i < nelem)
         *((t_float *) (array->a_vec + elemsize * i) + yonset) = 0, i++;

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -444,7 +444,9 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
             pd_bind(&x->x_gobj.g_pd, x->x_realname);
             /* redraw the whole glist, just so the name change shows up */
             if(x->x_glist->gl_havewindow)
+            {
                 canvas_redraw(x->x_glist);
+            }
             else if(glist_isvisible(x->x_glist->gl_owner))
             {
                 gobj_vis(&x->x_glist->gl_gobj, x->x_glist->gl_owner, 0);
@@ -455,9 +457,13 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
         size = fsize;
         if(size < 1) size = 1;
         if(size != a->a_n)
+        {
             garray_resize_long(x, size);
+        }
         else if(style != stylewas)
+        {
             garray_fittograph(x, (int) size, style);
+        }
         template_setfloat(scalartemplate, gensym("style"), x->x_scalar->sc_vec,
             (t_float) style, 0);
         template_setfloat(scalartemplate, gensym("linewidth"),
@@ -572,13 +578,21 @@ void array_getcoordinate(t_glist *glist, char *elem, int xonset, int yonset,
     t_float ypix;
     t_float wpix;
     if(xonset >= 0)
+    {
         xval = *(t_float *) (elem + xonset);
+    }
     else
+    {
         xval = indx * xinc;
+    }
     if(yonset >= 0)
+    {
         yval = *(t_float *) (elem + yonset);
+    }
     else
+    {
         yval = 0;
+    }
     ypix =
         glist_ytopixels(glist, basey + fielddesc_cvttocoord(yfielddesc, yval));
     if(wonset >= 0)
@@ -620,9 +634,13 @@ static void array_getrect(
         int incr;
         /* if it has more than 2000 points, just check 300 of them. */
         if(array->a_n < 2000)
+        {
             incr = 1;
+        }
         else
+        {
             incr = array->a_n / 300;
+        }
         for(i = 0; i < array->a_n; i += incr)
         {
             t_float pxpix;
@@ -681,8 +699,10 @@ static int garray_click(t_gobj *z, t_glist *glist, int xpix, int ypix,
 {
     t_garray *x = (t_garray *) z;
     if(x->x_edit)
+    {
         return (gobj_click(
             &x->x_scalar->sc_gobj, glist, xpix, ypix, shift, alt, dbl, doit));
+    }
     return (0);
 }
 
@@ -706,8 +726,10 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b)
             if(chunk > ARRAYWRITECHUNKSIZE) chunk = ARRAYWRITECHUNKSIZE;
             binbuf_addv(b, "si", gensym("#A"), n2);
             for(i = 0; i < chunk; i++)
+            {
                 binbuf_addv(
                     b, "f", ((t_word *) (array->a_vec))[n2 + i].w_float);
+            }
             binbuf_addv(b, ";");
             n2 += chunk;
         }
@@ -770,15 +792,19 @@ static void garray_doredraw(t_gobj *client, t_glist *glist)
 void garray_redraw(t_garray *x)
 {
     if(glist_isvisible(x->x_glist))
+    {
         sys_queuegui(&x->x_gobj, x->x_glist, garray_doredraw);
     /* jsarlo { */
     /* this happens in garray_vis() when array is visible for
        performance reasons */
+    }
     else
     {
         if(x->x_listviewing)
+        {
             sys_vgui(
                 "pdtk_array_listview_fillpage {%s}\n", x->x_realname->s_name);
+        }
     }
     /* } jsarlo */
 }
@@ -839,9 +865,13 @@ int garray_getfloatarray(t_garray *x, int *size, t_float **vec)
     {
         t_symbol *patchname;
         if(x->x_glist->gl_owner)
+        {
             patchname = x->x_glist->gl_owner->gl_name;
+        }
         else
+        {
             patchname = x->x_glist->gl_name;
+        }
         pd_error(0, "an operation on the array '%s' in the patch '%s'",
             x->x_name->s_name, patchname->s_name);
         pd_error(0,
@@ -854,8 +884,10 @@ int garray_getfloatarray(t_garray *x, int *size, t_float **vec)
 void garray_setsaveit(t_garray *x, int saveit)
 {
     if(x->x_saveit && !saveit)
+    {
         post("warning: array %s: clearing save-in-patch flag",
             x->x_name->s_name);
+    }
     x->x_saveit = saveit;
 }
 
@@ -867,11 +899,15 @@ static void garray_const(t_garray *x, t_floatarg g)
     int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
+    {
         pd_error(
             0, "%s: needs floating-point 'y' field", x->x_realname->s_name);
+    }
     else
+    {
         for(i = 0; i < array->a_n; i++)
             *((t_float *) ((char *) array->a_vec + elemsize * i) + yonset) = g;
+    }
     garray_redraw(x);
 }
 
@@ -895,19 +931,25 @@ static void garray_dofo(t_garray *x, long npoints, t_float dcval, int nsin,
     }
     if(npoints == 0) npoints = 512; /* dunno what a good default would be... */
     if(npoints != (1 << ilog2((int) npoints)))
+    {
         post("%s: rounding to %d points", array->a_templatesym->s_name,
             (npoints = (1 << ilog2((int) npoints))));
+    }
     garray_resize_long(x, npoints + 3);
     phaseincr = 2. * 3.14159 / npoints;
     for(i = 0, phase = -phaseincr; i < array->a_n; i++, phase += phaseincr)
     {
         double sum = dcval;
         if(sineflag)
+        {
             for(j = 0, fj = phase; j < nsin; j++, fj += phase)
                 sum += vsin[j] * sin(fj);
+        }
         else
+        {
             for(j = 0, fj = 0; j < nsin; j++, fj += phase)
                 sum += vsin[j] * cos(fj);
+        }
         *((t_float *) ((array->a_vec + elemsize * i)) + yonset) = sum;
     }
     garray_redraw(x);
@@ -1008,7 +1050,9 @@ static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
         return;
     }
     if(argc < 2)
+    {
         return;
+    }
     else
     {
         int firstindex = atom_getfloat(argv);
@@ -1028,8 +1072,10 @@ static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
             if(argc <= 0) return;
         }
         for(i = 0; i < argc; i++)
+        {
             *((t_float *) (array->a_vec + elemsize * (i + firstindex)) +
                 yonset) = atom_getfloat(argv + i);
+        }
     }
     garray_redraw(x);
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -86,10 +86,9 @@ void word_free(t_word *wp, t_template *template);
 
 void array_free(t_array *x)
 {
-    int i;
     t_template *scalartemplate = template_findbyname(x->a_templatesym);
     gstub_cutoff(x->a_stub);
-    for(i = 0; i < x->a_n; i++)
+    for(int i = 0; i < x->a_n; i++)
     {
         t_word *wp = (t_word *) (x->a_vec + x->a_elemsize * i);
         word_free(wp, scalartemplate);
@@ -626,7 +625,6 @@ static void array_getrect(
     int yonset;
     int wonset;
     int xonset;
-    int i;
 
     if(!array_getfields(array->a_templatesym, &elemtemplatecanvas,
            &elemtemplate, &elemsize, 0, 0, 0, &xonset, &yonset, &wonset))
@@ -641,7 +639,7 @@ static void array_getrect(
         {
             incr = array->a_n / 300;
         }
-        for(i = 0; i < array->a_n; i += incr)
+        for(int i = 0; i < array->a_n; i += incr)
         {
             t_float pxpix;
             t_float pypix;
@@ -722,10 +720,9 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b)
         while(n2 < n)
         {
             int chunk = n - n2;
-            int i;
             if(chunk > ARRAYWRITECHUNKSIZE) chunk = ARRAYWRITECHUNKSIZE;
             binbuf_addv(b, "si", gensym("#A"), n2);
-            for(i = 0; i < chunk; i++)
+            for(int i = 0; i < chunk; i++)
             {
                 binbuf_addv(
                     b, "f", ((t_word *) (array->a_vec))[n2 + i].w_float);
@@ -895,7 +892,6 @@ void garray_setsaveit(t_garray *x, int saveit)
 static void garray_const(t_garray *x, t_floatarg g)
 {
     int yonset;
-    int i;
     int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
@@ -905,7 +901,7 @@ static void garray_const(t_garray *x, t_floatarg g)
     }
     else
     {
-        for(i = 0; i < array->a_n; i++)
+        for(int i = 0; i < array->a_n; i++)
             *((t_float *) ((char *) array->a_vec + elemsize * i) + yonset) = g;
     }
     garray_redraw(x);
@@ -959,7 +955,6 @@ static void garray_sinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float *svec;
     long npoints;
-    int i;
     if(argc < 2)
     {
         pd_error(0, "sinesum: %s: need number of points and partial strengths",
@@ -973,7 +968,7 @@ static void garray_sinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     svec = (t_float *) t_getbytes(sizeof(t_float) * argc);
     if(!svec) return;
 
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         svec[i] = atom_getfloatarg(i, argc, argv);
     garray_dofo(x, npoints, 0, argc, svec, 1);
     t_freebytes(svec, sizeof(t_float) * argc);
@@ -983,7 +978,6 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float *svec;
     long npoints;
-    int i;
     if(argc < 2)
     {
         pd_error(0, "sinesum: %s: need number of points and partial strengths",
@@ -997,7 +991,7 @@ static void garray_cosinesum(t_garray *x, t_symbol *s, int argc, t_atom *argv)
     svec = (t_float *) t_getbytes(sizeof(t_float) * argc);
     if(!svec) return;
 
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         svec[i] = atom_getfloatarg(i, argc, argv);
     garray_dofo(x, npoints, 0, argc, svec, 0);
     t_freebytes(svec, sizeof(t_float) * argc);
@@ -1039,7 +1033,6 @@ static void garray_normalize(t_garray *x, t_float f)
 the "y" slot of the array.  This generalizes Max's "table", sort of. */
 static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     int yonset;
     int elemsize;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
@@ -1071,7 +1064,7 @@ static void garray_list(t_garray *x, t_symbol *s, int argc, t_atom *argv)
             argc = array->a_n - firstindex;
             if(argc <= 0) return;
         }
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
         {
             *((t_float *) (array->a_vec + elemsize * (i + firstindex)) +
                 yonset) = atom_getfloat(argv + i);
@@ -1267,7 +1260,6 @@ static void garray_write(t_garray *x, t_symbol *filename)
     char buf[MAXPDSTRING];
     int yonset;
     int elemsize;
-    int i;
     t_array *array = garray_getarray_floatonly(x, &yonset, &elemsize);
     if(!array)
     {
@@ -1282,7 +1274,7 @@ static void garray_write(t_garray *x, t_symbol *filename)
         pd_error(0, "%s: can't create", buf);
         return;
     }
-    for(i = 0; i < array->a_n; i++)
+    for(int i = 0; i < array->a_n; i++)
     {
         if(fprintf(fd, "%g\n",
                *(t_float *) (((array->a_vec + sizeof(t_word) * i)) + yonset)) <

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -56,14 +56,18 @@ void bng_draw_new(t_bng *x, t_glist *glist)
         canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
         IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
             xpos + iow, ypos + x->x_gui.x_h, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    }
     sys_vgui(
         ".x%lx.c create oval %d %d %d %d -width %d -fill #%6.6x -tags %lxBUT\n",
         canvas, xpos + inset, ypos + inset, xpos + x->x_gui.x_w - inset,
@@ -90,12 +94,16 @@ void bng_draw_move(t_bng *x, t_glist *glist)
     sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos, ypos,
         xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
             ypos + x->x_gui.x_h);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxBUT %d %d %d %d\n", canvas, x, xpos + inset,
         ypos + inset, xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
     sys_vgui(".x%lx.c itemconfigure %lxBUT -fill #%6.6x\n", canvas, x,
@@ -193,19 +201,33 @@ void bng_draw_select(t_bng *x, t_glist *glist)
 void bng_draw(t_bng *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         bng_draw_update(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         bng_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         bng_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         bng_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         bng_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         bng_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         bng_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ bng widgetbehaviour----------------------------- */
@@ -371,8 +393,10 @@ static int bng_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     int shift, int alt, int dbl, int doit)
 {
     if(doit)
+    {
         bng_click((t_bng *) z, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
+    }
     return (1);
 }
 
@@ -513,9 +537,13 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef _MSC_VER
-# define snprintf _snprintf
+#define snprintf _snprintf
 #endif
 
 /* --------------- bng     gui-bang ------------------------- */
@@ -50,35 +50,31 @@ void bng_draw_new(t_bng *x, t_glist *glist)
     int inset = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%6.6x -tags %lxBASE\n",
-             canvas, xpos, ypos,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
-             IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%6.6x "
+             "-tags %lxBASE\n",
+        canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
+        IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create oval %d %d %d %d -width %d -fill #%6.6x -tags %lxBUT\n",
-             canvas, xpos + inset, ypos + inset,
-             xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset,
-             IEMGUI_ZOOM(x),
-             (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol), x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    sys_vgui(
+        ".x%lx.c create oval %d %d %d %d -width %d -fill #%6.6x -tags %lxBUT\n",
+        canvas, xpos + inset, ypos + inset, xpos + x->x_gui.x_w - inset,
+        ypos + x->x_gui.x_h - inset, IEMGUI_ZOOM(x),
+        (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol), x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%6.6x -tags [list %lxLABEL label text]\n",
-             canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 void bng_draw_move(t_bng *x, t_glist *glist)
@@ -89,30 +85,25 @@ void bng_draw_move(t_bng *x, t_glist *glist)
     int inset = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x, xpos, ypos,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos, ypos,
+        xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
+            ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxBUT %d %d %d %d\n",
-             canvas, x, xpos + inset, ypos + inset,
-             xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxBUT %d %d %d %d\n", canvas, x, xpos + inset,
+        ypos + inset, xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
     sys_vgui(".x%lx.c itemconfigure %lxBUT -fill #%6.6x\n", canvas, x,
-             (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+        (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-void bng_draw_erase(t_bng* x, t_glist* glist)
+void bng_draw_erase(t_bng *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -125,43 +116,46 @@ void bng_draw_erase(t_bng* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void bng_draw_config(t_bng* x, t_glist* glist)
+void bng_draw_config(t_bng *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%6.6x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
-    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%6.6x\n", canvas, x, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%6.6x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name
+                                                 : ""));
+    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%6.6x\n", canvas, x,
+        x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxBUT -fill #%6.6x\n", canvas, x,
-             (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
+        (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
 }
 
-void bng_draw_io(t_bng* x, t_glist* glist, int old_snd_rcv_flags)
+void bng_draw_io(t_bng *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep above outlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 0);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep above inlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 0);
     }
@@ -169,21 +163,27 @@ void bng_draw_io(t_bng* x, t_glist* glist, int old_snd_rcv_flags)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void bng_draw_select(t_bng* x, t_glist* glist)
+void bng_draw_select(t_bng *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%6.6x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxBUT -outline #%6.6x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%6.6x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%6.6x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBUT -outline #%6.6x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%6.6x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%6.6x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxBUT -outline #%6.6x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%6.6x\n", canvas, x, x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%6.6x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxBUT -outline #%6.6x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%6.6x\n", canvas, x,
+            x->x_gui.x_lcol);
     }
 }
 
@@ -207,10 +207,10 @@ void bng_draw(t_bng *x, t_glist *glist, int mode)
 
 /* ------------------------ bng widgetbehaviour----------------------------- */
 
-static void bng_getrect(t_gobj *z, t_glist *glist,
-                        int *xp1, int *yp1, int *xp2, int *yp2)
+static void bng_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_bng *x = (t_bng *)z;
+    t_bng *x = (t_bng *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -220,20 +220,18 @@ static void bng_getrect(t_gobj *z, t_glist *glist,
 
 static void bng_save(t_gobj *z, t_binbuf *b)
 {
-    t_bng *x = (t_bng *)z;
+    t_bng *x = (t_bng *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
-    binbuf_addv(b, "ssiisiiiisssiiiisss", gensym("#X"),gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("bng"), x->x_gui.x_w/IEMGUI_ZOOM(x),
-                x->x_flashtime_hold, x->x_flashtime_break,
-                iem_symargstoint(&x->x_gui.x_isa),
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2]);
+    binbuf_addv(b, "ssiisiiiisssiiiisss", gensym("#X"), gensym("obj"),
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("bng"), x->x_gui.x_w / IEMGUI_ZOOM(x), x->x_flashtime_hold,
+        x->x_flashtime_break, iem_symargstoint(&x->x_gui.x_isa), srl[0], srl[1],
+        srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
+        iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize, bflcol[0],
+        bflcol[1], bflcol[2]);
     binbuf_addv(b, ";");
 }
 
@@ -247,17 +245,15 @@ void bng_check_minmax(t_bng *x, int ftbreak, int fthold)
         ftbreak = fthold;
         fthold = h;
     }
-    if(ftbreak < IEM_BNG_MINBREAKFLASHTIME)
-        ftbreak = IEM_BNG_MINBREAKFLASHTIME;
-    if(fthold < IEM_BNG_MINHOLDFLASHTIME)
-        fthold = IEM_BNG_MINHOLDFLASHTIME;
+    if(ftbreak < IEM_BNG_MINBREAKFLASHTIME) ftbreak = IEM_BNG_MINBREAKFLASHTIME;
+    if(fthold < IEM_BNG_MINHOLDFLASHTIME) fthold = IEM_BNG_MINHOLDFLASHTIME;
     x->x_flashtime_break = ftbreak;
     x->x_flashtime_hold = fthold;
 }
 
 static void bng_properties(t_gobj *z, t_glist *owner)
 {
-    t_bng *x = (t_bng *)z;
+    t_bng *x = (t_bng *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -270,13 +266,13 @@ static void bng_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_flashtime_break, x->x_flashtime_hold, 2,/*min_max_schedule+clip*/
-            -1, x->x_gui.x_isa.x_loadinit, -1, -1,/*no linlog, no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, x->x_flashtime_break,
+        x->x_flashtime_hold, 2,                /*min_max_schedule+clip*/
+        -1, x->x_gui.x_isa.x_loadinit, -1, -1, /*no linlog, no multi*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
@@ -285,10 +281,8 @@ static void bng_set(t_bng *x)
     int holdtime = x->x_flashtime_hold;
     int sincelast = clock_gettimesince(x->x_lastflashtime);
     x->x_lastflashtime = clock_getsystime();
-    if (sincelast < x->x_flashtime_hold*2)
-        holdtime = sincelast/2;
-    if (holdtime < x->x_flashtime_break)
-        holdtime = x->x_flashtime_break;
+    if(sincelast < x->x_flashtime_hold * 2) holdtime = sincelast / 2;
+    if(holdtime < x->x_flashtime_break) holdtime = x->x_flashtime_break;
     x->x_flashed = 1;
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
     clock_delay(x->x_clock_hld, holdtime);
@@ -302,7 +296,8 @@ static void bng_bout1(t_bng *x) /*wird nur mehr gesendet, wenn snd != rcv*/
         clock_delay(x->x_clock_lck, 2);
     }
     outlet_bang(x->x_gui.x_obj.ob_outlet);
-    if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing && x->x_gui.x_fsf.x_put_in2out)
+    if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing &&
+        x->x_gui.x_fsf.x_put_in2out)
         pd_bang(x->x_gui.x_snd->s_thing);
 }
 
@@ -339,19 +334,18 @@ static void bng_bang2(t_bng *x) /*wird immer gesendet, wenn moeglich*/
 static void bng_dialog(t_bng *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getfloatarg(0, argc, argv);
-    int fthold = (int)atom_getfloatarg(2, argc, argv);
-    int ftbreak = (int)atom_getfloatarg(3, argc, argv);
+    int a = (int) atom_getfloatarg(0, argc, argv);
+    int fthold = (int) atom_getfloatarg(2, argc, argv);
+    int ftbreak = (int) atom_getfloatarg(3, argc, argv);
     int sr_flags;
 
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT (undo+1, 0);
-    SETFLOAT (undo+2, x->x_flashtime_break);
-    SETFLOAT (undo+3, x->x_flashtime_hold);
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    SETFLOAT(undo + 1, 0);
+    SETFLOAT(undo + 2, x->x_flashtime_break);
+    SETFLOAT(undo + 3, x->x_flashtime_hold);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_w = iemgui_clip_size(a) * IEMGUI_ZOOM(x);
@@ -360,40 +354,44 @@ static void bng_dialog(t_bng *x, t_symbol *s, int argc, t_atom *argv)
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
-static void bng_click(t_bng *x, t_floatarg xpos, t_floatarg ypos, t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+static void bng_click(t_bng *x, t_floatarg xpos, t_floatarg ypos,
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     bng_set(x);
     bng_bout2(x);
 }
 
-static int bng_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int bng_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
     if(doit)
-        bng_click((t_bng *)z, (t_floatarg)xpix, (t_floatarg)ypix, (t_floatarg)shift, 0, (t_floatarg)alt);
+        bng_click((t_bng *) z, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
     return (1);
 }
 
-static void bng_float(t_bng *x, t_floatarg f)
-{bng_bang2(x);}
+static void bng_float(t_bng *x, t_floatarg f) { bng_bang2(x); }
 
-static void bng_symbol(t_bng *x, t_symbol *s)
-{bng_bang2(x);}
+static void bng_symbol(t_bng *x, t_symbol *s) { bng_bang2(x); }
 
-static void bng_pointer(t_bng *x, t_gpointer *gp)
-{bng_bang2(x);}
+static void bng_pointer(t_bng *x, t_gpointer *gp) { bng_bang2(x); }
 
 static void bng_list(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{bng_bang2(x);}
+{
+    bng_bang2(x);
+}
 
 static void bng_anything(t_bng *x, t_symbol *s, int argc, t_atom *argv)
-{bng_bang2(x);}
+{
+    bng_bang2(x);
+}
 
 static void bng_loadbang(t_bng *x, t_floatarg action)
 {
-    if (action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
     {
         bng_set(x);
         bng_bout2(x);
@@ -402,40 +400,54 @@ static void bng_loadbang(t_bng *x, t_floatarg action)
 
 static void bng_size(t_bng *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void bng_delta(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void bng_pos(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void bng_flashtime(t_bng *x, t_symbol *s, int ac, t_atom *av)
 {
-    bng_check_minmax(x, (int)atom_getfloatarg(0, ac, av),
-                        (int)atom_getfloatarg(1, ac, av));
+    bng_check_minmax(x, (int) atom_getfloatarg(0, ac, av),
+        (int) atom_getfloatarg(1, ac, av));
 }
 
 static void bng_color(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
-static void bng_send(t_bng *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+static void bng_send(t_bng *x, t_symbol *s) { iemgui_send(x, &x->x_gui, s); }
 
 static void bng_receive(t_bng *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void bng_label(t_bng *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void bng_label_pos(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void bng_label_font(t_bng *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void bng_init(t_bng *x, t_floatarg f)
 {
@@ -448,14 +460,11 @@ static void bng_tick_hld(t_bng *x)
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
 }
 
-static void bng_tick_lck(t_bng *x)
-{
-    x->x_gui.x_isa.x_locked = 0;
-}
+static void bng_tick_lck(t_bng *x) { x->x_gui.x_isa.x_locked = 0; }
 
 static void *bng_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_bng *x = (t_bng *)pd_new(bng_class);
+    t_bng *x = (t_bng *) pd_new(bng_class);
     int a = IEM_GUI_DEFAULTSIZE;
     int ldx = 17, ldy = 7;
     int fs = 10;
@@ -469,51 +478,52 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if((argc == 14)&&IS_A_FLOAT(argv,0)
-       &&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2)
-       &&IS_A_FLOAT(argv,3)
-       &&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4))
-       &&(IS_A_SYMBOL(argv,5)||IS_A_FLOAT(argv,5))
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10))
+    if((argc == 14) && IS_A_FLOAT(argv, 0) && IS_A_FLOAT(argv, 1) &&
+        IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) &&
+        (IS_A_SYMBOL(argv, 4) || IS_A_FLOAT(argv, 4)) &&
+        (IS_A_SYMBOL(argv, 5) || IS_A_FLOAT(argv, 5)) &&
+        (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) && IS_A_FLOAT(argv, 7) &&
+        IS_A_FLOAT(argv, 8) && IS_A_FLOAT(argv, 9) && IS_A_FLOAT(argv, 10))
     {
 
-        a = (int)atom_getfloatarg(0, argc, argv);
-        fthold = (int)atom_getfloatarg(1, argc, argv);
-        ftbreak = (int)atom_getfloatarg(2, argc, argv);
+        a = (int) atom_getfloatarg(0, argc, argv);
+        fthold = (int) atom_getfloatarg(1, argc, argv);
+        ftbreak = (int) atom_getfloatarg(2, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(3, argc, argv));
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getfloatarg(7, argc, argv);
-        ldy = (int)atom_getfloatarg(8, argc, argv);
+        ldx = (int) atom_getfloatarg(7, argc, argv);
+        ldy = (int) atom_getfloatarg(8, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(9, argc, argv));
-        fs = (int)atom_getfloatarg(10, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
+        fs = (int) atom_getfloatarg(10, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 11, argv + 12, argv + 13);
     }
-    else iemgui_new_getnames(&x->x_gui, 4, 0);
+    else
+        iemgui_new_getnames(&x->x_gui, 4, 0);
 
-    x->x_gui.x_draw = (t_iemfunptr)bng_draw;
+    x->x_gui.x_draw = (t_iemfunptr) bng_draw;
 
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
     x->x_flashed = 0;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if (!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
 
-    if (x->x_gui.x_fsf.x_rcv_able)
+    if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
 
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
@@ -521,8 +531,8 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_isa.x_locked = 0;
     iemgui_verify_snd_ne_rcv(&x->x_gui);
     x->x_lastflashtime = clock_getsystime();
-    x->x_clock_hld = clock_new(x, (t_method)bng_tick_hld);
-    x->x_clock_lck = clock_new(x, (t_method)bng_tick_lck);
+    x->x_clock_hld = clock_new(x, (t_method) bng_tick_hld);
+    x->x_clock_lck = clock_new(x, (t_method) bng_tick_lck);
     iemgui_newzoom(&x->x_gui);
     outlet_new(&x->x_gui.x_obj, &s_bang);
     return (x);
@@ -539,44 +549,41 @@ static void bng_ff(t_bng *x)
 
 void g_bang_setup(void)
 {
-    bng_class = class_new(gensym("bng"), (t_newmethod)bng_new,
-        (t_method)bng_ff, sizeof(t_bng), 0, A_GIMME, 0);
+    bng_class = class_new(gensym("bng"), (t_newmethod) bng_new,
+        (t_method) bng_ff, sizeof(t_bng), 0, A_GIMME, 0);
     class_addbang(bng_class, bng_bang);
     class_addfloat(bng_class, bng_float);
     class_addsymbol(bng_class, bng_symbol);
     class_addpointer(bng_class, bng_pointer);
     class_addlist(bng_class, bng_list);
     class_addanything(bng_class, bng_anything);
-    class_addmethod(bng_class, (t_method)bng_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(bng_class, (t_method)bng_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_loadbang,
-        gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(bng_class, (t_method)bng_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_flashtime,
-        gensym("flashtime"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(bng_class, (t_method)bng_receive,
-        gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(bng_class, (t_method)bng_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(bng_class, (t_method)bng_label_pos,
-        gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_label_font,
-        gensym("label_font"), A_GIMME, 0);
-    class_addmethod(bng_class, (t_method)bng_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(bng_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
+    class_addmethod(bng_class, (t_method) bng_click, gensym("click"), A_FLOAT,
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_loadbang, gensym("loadbang"), A_DEFFLOAT, 0);
+    class_addmethod(bng_class, (t_method) bng_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(bng_class, (t_method) bng_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_flashtime, gensym("flashtime"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_receive, gensym("receive"), A_DEFSYM, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_label_pos, gensym("label_pos"), A_GIMME, 0);
+    class_addmethod(
+        bng_class, (t_method) bng_label_font, gensym("label_font"), A_GIMME, 0);
+    class_addmethod(bng_class, (t_method) bng_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        bng_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     bng_widgetbehavior.w_getrectfn = bng_getrect;
     bng_widgetbehavior.w_displacefn = iemgui_displace;
     bng_widgetbehavior.w_selectfn = iemgui_select;

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -46,7 +46,8 @@ void bng_draw_new(t_bng *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int inset = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -81,7 +82,8 @@ void bng_draw_move(t_bng *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int inset = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -137,7 +139,8 @@ void bng_draw_io(t_bng *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -466,10 +469,11 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_bng *x = (t_bng *) pd_new(bng_class);
     int a = IEM_GUI_DEFAULTSIZE;
-    int ldx = 17, ldy = 7;
+    int ldx = 17;
+    int ldy = 7;
     int fs = 10;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
-        fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
+    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME;
+    int fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);
     iem_inttofstyle(&x->x_gui.x_fsf, 0);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2001 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* this file defines the "glist" class, also known as "canvas" (the two used
 to be different but are now unified except for some fossilized names.) */
@@ -23,15 +23,16 @@ to be different but are now unified except for some fossilized names.) */
 #define snprintf _snprintf
 #endif
 
-    /* LATER consider adding font size to this struct (see glist_getfont()) */
+/* LATER consider adding font size to this struct (see glist_getfont()) */
 struct _canvasenvironment
 {
-    t_symbol *ce_dir;      /* directory patch lives in */
-    int ce_argc;           /* number of "$" arguments */
-    t_atom *ce_argv;       /* array of "$" arguments */
-    int ce_dollarzero;     /* value of "$0" */
-    t_namelist *ce_path;   /* search path */
+    t_symbol *ce_dir;    /* directory patch lives in */
+    int ce_argc;         /* number of "$" arguments */
+    t_atom *ce_argv;     /* array of "$" arguments */
+    int ce_dollarzero;   /* value of "$0" */
+    t_namelist *ce_path; /* search path */
 };
+
 typedef struct _canvas_private
 {
     t_undo undo;
@@ -43,7 +44,7 @@ typedef struct _canvas_private
 /* ---------------------- variables --------------------------- */
 
 t_class *canvas_class;
-t_canvas *canvas_whichfind;         /* last canvas we did a find in */
+t_canvas *canvas_whichfind; /* last canvas we did a find in */
 
 /* ------------------ forward function declarations --------------- */
 static void canvas_start_dsp(void);
@@ -60,115 +61,115 @@ void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
 
 /* ---------------- generic widget behavior ------------------------- */
 
-void gobj_getrect(t_gobj *x, t_glist *glist, int *x1, int *y1,
-    int *x2, int *y2)
+void gobj_getrect(t_gobj *x, t_glist *glist, int *x1, int *y1, int *x2, int *y2)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_getrectfn)
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_getrectfn)
         (*x->g_pd->c_wb->w_getrectfn)(x, glist, x1, y1, x2, y2);
-    else *x1 = *y1 = 0, *x2 = *y2 = 10;
+    else
+        *x1 = *y1 = 0, *x2 = *y2 = 10;
 }
 
 void gobj_displace(t_gobj *x, t_glist *glist, int dx, int dy)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_displacefn)
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_displacefn)
         (*x->g_pd->c_wb->w_displacefn)(x, glist, dx, dy);
 }
 
-    /* here we add an extra check whether we're mapped, because some
-       editing moves are carried out on invisible windows (notably, re-creating
-       abstractions when one is saved).  Should any other widget finctions also
-       be doing this?  */
+/* here we add an extra check whether we're mapped, because some
+   editing moves are carried out on invisible windows (notably, re-creating
+   abstractions when one is saved).  Should any other widget finctions also
+   be doing this?  */
 void gobj_select(t_gobj *x, t_glist *glist, int state)
 {
-    if (glist->gl_mapped && x->g_pd->c_wb && x->g_pd->c_wb->w_selectfn)
+    if(glist->gl_mapped && x->g_pd->c_wb && x->g_pd->c_wb->w_selectfn)
         (*x->g_pd->c_wb->w_selectfn)(x, glist, state);
 }
 
 void gobj_activate(t_gobj *x, t_glist *glist, int state)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_activatefn)
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_activatefn)
         (*x->g_pd->c_wb->w_activatefn)(x, glist, state);
 }
 
 void gobj_delete(t_gobj *x, t_glist *glist)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_deletefn)
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_deletefn)
         (*x->g_pd->c_wb->w_deletefn)(x, glist);
 }
 
 int gobj_shouldvis(t_gobj *x, struct _glist *glist)
 {
     t_object *ob;
-    int has_parent = !glist->gl_havewindow && glist->gl_isgraph
-        && glist->gl_owner && !glist->gl_isclone;
-        /* if our parent is a graph, and if that graph itself isn't
-           visible, then we aren't either. */
-    if (has_parent && !gobj_shouldvis(&glist->gl_gobj, glist->gl_owner))
-            return (0);
-        /* if we're graphing-on-parent and the object falls outside the
-           graph rectangle, don't draw it. */
-    if (has_parent && glist->gl_goprect)
+    int has_parent = !glist->gl_havewindow && glist->gl_isgraph &&
+                     glist->gl_owner && !glist->gl_isclone;
+    /* if our parent is a graph, and if that graph itself isn't
+       visible, then we aren't either. */
+    if(has_parent && !gobj_shouldvis(&glist->gl_gobj, glist->gl_owner))
+        return (0);
+    /* if we're graphing-on-parent and the object falls outside the
+       graph rectangle, don't draw it. */
+    if(has_parent && glist->gl_goprect)
     {
         int x1, y1, x2, y2, gx1, gy1, gx2, gy2, m;
-            /* for some reason the bounds check on arrays and scalars
-               don't seem to apply here.  Perhaps this was in order to allow
-               arrays to reach outside their containers?  I no longer understand
-               this. */
-        if (pd_class(&x->g_pd) == scalar_class
-            || pd_class(&x->g_pd) == garray_class)
-                return (1);
+        /* for some reason the bounds check on arrays and scalars
+           don't seem to apply here.  Perhaps this was in order to allow
+           arrays to reach outside their containers?  I no longer understand
+           this. */
+        if(pd_class(&x->g_pd) == scalar_class ||
+            pd_class(&x->g_pd) == garray_class)
+            return (1);
         gobj_getrect(&glist->gl_gobj, glist->gl_owner, &x1, &y1, &x2, &y2);
-        if (x1 > x2)
-            m = x1, x1 = x2, x2 = m;
-        if (y1 > y2)
-            m = y1, y1 = y2, y2 = m;
+        if(x1 > x2) m = x1, x1 = x2, x2 = m;
+        if(y1 > y2) m = y1, y1 = y2, y2 = m;
         gobj_getrect(x, glist, &gx1, &gy1, &gx2, &gy2);
 #if 0
         post("graph %d %d %d %d, %s %d %d %d %d",
              x1, x2, y1, y2, class_gethelpname(x->g_pd), gx1, gx2, gy1, gy2);
 #endif
-        if (gx1 < x1 || gx1 > x2 || gx2 < x1 || gx2 > x2 ||
-            gy1 < y1 || gy1 > y2 || gy2 < y1 || gy2 > y2)
-                return (0);
+        if(gx1 < x1 || gx1 > x2 || gx2 < x1 || gx2 > x2 || gy1 < y1 ||
+            gy1 > y2 || gy2 < y1 || gy2 > y2)
+            return (0);
     }
-    if ((ob = pd_checkobject(&x->g_pd)))
+    if((ob = pd_checkobject(&x->g_pd)))
     {
-            /* return true if the text box should be drawn.  We don't show text
-               boxes inside graphs---except comments, if we're doing the new
-               (goprect) style. */
+        /* return true if the text box should be drawn.  We don't show text
+           boxes inside graphs---except comments, if we're doing the new
+           (goprect) style. */
         return (glist->gl_havewindow ||
-            (ob->te_pd != canvas_class &&
-                ob->te_pd->c_wb != &text_widgetbehavior) ||
-            (ob->te_pd == canvas_class && (((t_glist *)ob)->gl_isgraph)) ||
-            (glist->gl_goprect && (ob->te_type == T_TEXT)));
+                (ob->te_pd != canvas_class &&
+                    ob->te_pd->c_wb != &text_widgetbehavior) ||
+                (ob->te_pd == canvas_class && (((t_glist *) ob)->gl_isgraph)) ||
+                (glist->gl_goprect && (ob->te_type == T_TEXT)));
     }
-    else return (1);
+    else
+        return (1);
 }
 
 void gobj_vis(t_gobj *x, struct _glist *glist, int flag)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_visfn && gobj_shouldvis(x, glist))
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_visfn && gobj_shouldvis(x, glist))
         (*x->g_pd->c_wb->w_visfn)(x, glist, flag);
 }
 
-int gobj_click(t_gobj *x, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+int gobj_click(t_gobj *x, struct _glist *glist, int xpix, int ypix, int shift,
+    int alt, int dbl, int doit)
 {
-    if (x->g_pd->c_wb && x->g_pd->c_wb->w_clickfn)
-        return ((*x->g_pd->c_wb->w_clickfn)(x,
-            glist, xpix, ypix, shift, alt, dbl, doit));
-    else return (0);
+    if(x->g_pd->c_wb && x->g_pd->c_wb->w_clickfn)
+        return ((*x->g_pd->c_wb->w_clickfn)(
+            x, glist, xpix, ypix, shift, alt, dbl, doit));
+    else
+        return (0);
 }
 
-    /* maintain the list of visible toplevels for the GUI's "windows" menu */
+/* maintain the list of visible toplevels for the GUI's "windows" menu */
 void canvas_updatewindowlist(void)
 {
-            /* not if we're in a reload */
-    if (!THISGUI->i_reloadingabstraction)
+    /* not if we're in a reload */
+    if(!THISGUI->i_reloadingabstraction)
         sys_gui("::pd_menus::update_window_menu\n");
 }
 
-    /* add a glist the list of "root" canvases (toplevels without parents.) */
+/* add a glist the list of "root" canvases (toplevels without parents.) */
 static void canvas_addtolist(t_canvas *x)
 {
     x->gl_next = pd_this->pd_canvaslist;
@@ -177,37 +178,38 @@ static void canvas_addtolist(t_canvas *x)
 
 static void canvas_takeofflist(t_canvas *x)
 {
-        /* take it off the window list */
-    if (x == pd_this->pd_canvaslist) pd_this->pd_canvaslist = x->gl_next;
+    /* take it off the window list */
+    if(x == pd_this->pd_canvaslist)
+        pd_this->pd_canvaslist = x->gl_next;
     else
     {
         t_canvas *z;
-        for (z = pd_this->pd_canvaslist; z->gl_next != x; z = z->gl_next)
-            if (!z->gl_next) return;
+        for(z = pd_this->pd_canvaslist; z->gl_next != x; z = z->gl_next)
+            if(!z->gl_next) return;
         z->gl_next = x->gl_next;
     }
 }
 
-    /* turn message tracing on and off globally */
+/* turn message tracing on and off globally */
 
 void obj_dosettracing(t_object *ob, int onoff);
+
 static void canvas_dosettracing(t_canvas *x, int onoff)
 {
     t_gobj *y;
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
         t_object *ob;
-        if (pd_class(&y->g_pd) == canvas_class)
-            canvas_dosettracing((t_canvas *)y, onoff);
-        if ((ob = pd_checkobject(&y->g_pd)))
-            obj_dosettracing(ob, onoff);
+        if(pd_class(&y->g_pd) == canvas_class)
+            canvas_dosettracing((t_canvas *) y, onoff);
+        if((ob = pd_checkobject(&y->g_pd))) obj_dosettracing(ob, onoff);
     }
 }
 
 void canvas_settracing(int onoff)
 {
     t_glist *gl;
-    for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
+    for(gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         canvas_dosettracing(gl, onoff);
 }
 
@@ -215,10 +217,10 @@ void canvas_settracing(int onoff)
 
 void canvas_setargs(int argc, const t_atom *argv)
 {
-        /* if there's an old one lying around free it here.  This
-        happens if an abstraction is loaded but never gets as far
-        as calling canvas_new(). */
-    if (THISGUI->i_newargv)
+    /* if there's an old one lying around free it here.  This
+    happens if an abstraction is loaded but never gets as far
+    as calling canvas_new(). */
+    if(THISGUI->i_newargv)
         freebytes(THISGUI->i_newargv, THISGUI->i_newargc * sizeof(t_atom));
     THISGUI->i_newargc = argc;
     THISGUI->i_newargv = copybytes(argv, argc * sizeof(t_atom));
@@ -234,30 +236,23 @@ void glob_menunew(void *dummy, t_symbol *filesym, t_symbol *dirsym)
 {
     glob_setfilename(dummy, filesym, dirsym);
     canvas_new(0, 0, 0, 0);
-    canvas_pop((t_canvas *)s__X.s_thing, 1);
+    canvas_pop((t_canvas *) s__X.s_thing, 1);
 }
 
 t_canvas *canvas_getcurrent(void)
 {
-    return ((t_canvas *)pd_findbyclass(&s__X, canvas_class));
+    return ((t_canvas *) pd_findbyclass(&s__X, canvas_class));
 }
 
-void canvas_setcurrent(t_canvas *x)
-{
-    pd_pushsym(&x->gl_pd);
-}
+void canvas_setcurrent(t_canvas *x) { pd_pushsym(&x->gl_pd); }
 
-void canvas_unsetcurrent(t_canvas *x)
-{
-    pd_popsym(&x->gl_pd);
-}
+void canvas_unsetcurrent(t_canvas *x) { pd_popsym(&x->gl_pd); }
 
 t_canvasenvironment *canvas_getenv(const t_canvas *x)
 {
-    if (!x) bug("canvas_getenv");
-    while (!x->gl_env)
-        if (!(x = x->gl_owner))
-            bug("t_canvasenvironment");
+    if(!x) bug("canvas_getenv");
+    while(!x->gl_env)
+        if(!(x = x->gl_owner)) bug("t_canvasenvironment");
     return (x->gl_env);
 }
 
@@ -265,9 +260,10 @@ int canvas_getdollarzero(void)
 {
     t_canvas *x = canvas_getcurrent();
     t_canvasenvironment *env = (x ? canvas_getenv(x) : 0);
-    if (env)
+    if(env)
         return (env->ce_dollarzero);
-    else return (0);
+    else
+        return (0);
 }
 
 void canvas_getargs(int *argcp, t_atom **argvp)
@@ -282,14 +278,15 @@ t_symbol *canvas_realizedollar(t_canvas *x, t_symbol *s)
 {
     t_symbol *ret;
     const char *name = s->s_name;
-    if (strchr(name, '$'))
+    if(strchr(name, '$'))
     {
         t_canvasenvironment *env = canvas_getenv(x);
         canvas_setcurrent(x);
         ret = binbuf_realizedollsym(s, env->ce_argc, env->ce_argv, 1);
         canvas_unsetcurrent(x);
     }
-    else ret = s;
+    else
+        ret = s;
     return (ret);
 }
 
@@ -305,24 +302,25 @@ t_symbol *canvas_getdir(const t_canvas *x)
     return (e->ce_dir);
 }
 
-void canvas_makefilename(const t_canvas *x, const char *file, char *result, int resultsize)
+void canvas_makefilename(
+    const t_canvas *x, const char *file, char *result, int resultsize)
 {
     const char *dir = canvas_getenv(x)->ce_dir->s_name;
-    if (file[0] == '/' || (file[0] && file[1] == ':') || !*dir)
+    if(file[0] == '/' || (file[0] && file[1] == ':') || !*dir)
     {
         strncpy(result, file, resultsize);
-        result[resultsize-1] = 0;
+        result[resultsize - 1] = 0;
     }
     else
     {
         int nleft;
         strncpy(result, dir, resultsize);
-        result[resultsize-1] = 0;
-        nleft = resultsize - (int)strlen(result) - 1;
-        if (nleft <= 0) return;
+        result[resultsize - 1] = 0;
+        nleft = resultsize - (int) strlen(result) - 1;
+        if(nleft <= 0) return;
         strcat(result, "/");
         strncat(result, file, nleft);
-        result[resultsize-1] = 0;
+        result[resultsize - 1] = 0;
     }
 }
 
@@ -331,13 +329,12 @@ void canvas_rename(t_canvas *x, t_symbol *s, t_symbol *dir)
     canvas_unbind(x);
     x->gl_name = s;
     canvas_bind(x);
-    if (dir && dir != &s_)
+    if(dir && dir != &s_)
     {
         t_canvasenvironment *e = canvas_getenv(x);
         e->ce_dir = dir;
     }
-    if (x->gl_havewindow)
-        canvas_reflecttitle(x);
+    if(x->gl_havewindow) canvas_reflecttitle(x);
 }
 
 /* --------------- traversing the set of lines in a canvas ----------- */
@@ -346,7 +343,7 @@ int canvas_getindex(t_canvas *x, t_gobj *y)
 {
     t_gobj *y2;
     int indexno;
-    for (indexno = 0, y2 = x->gl_list; y2 && y2 != y; y2 = y2->g_next)
+    for(indexno = 0, y2 = x->gl_list; y2 && y2 != y; y2 = y2->g_next)
         indexno++;
     return (indexno);
 }
@@ -363,49 +360,51 @@ t_outconnect *linetraverser_next(t_linetraverser *t)
 {
     t_outconnect *rval = t->tr_nextoc;
     int outno;
-    while (!rval)
+    while(!rval)
     {
         outno = t->tr_nextoutno;
-        while (outno == t->tr_nout)
+        while(outno == t->tr_nout)
         {
             t_gobj *y;
             t_object *ob = 0;
-            if (!t->tr_ob) y = t->tr_x->gl_list;
-            else y = t->tr_ob->ob_g.g_next;
-            for (; y; y = y->g_next)
-                if ((ob = pd_checkobject(&y->g_pd))) break;
-            if (!ob) return (0);
+            if(!t->tr_ob)
+                y = t->tr_x->gl_list;
+            else
+                y = t->tr_ob->ob_g.g_next;
+            for(; y; y = y->g_next)
+                if((ob = pd_checkobject(&y->g_pd))) break;
+            if(!ob) return (0);
             t->tr_ob = ob;
             t->tr_nout = obj_noutlets(ob);
             outno = 0;
-            if (glist_isvisible(t->tr_x))
-                gobj_getrect(y, t->tr_x,
-                    &t->tr_x11, &t->tr_y11, &t->tr_x12, &t->tr_y12);
-            else t->tr_x11 = t->tr_y11 = t->tr_x12 = t->tr_y12 = 0;
+            if(glist_isvisible(t->tr_x))
+                gobj_getrect(
+                    y, t->tr_x, &t->tr_x11, &t->tr_y11, &t->tr_x12, &t->tr_y12);
+            else
+                t->tr_x11 = t->tr_y11 = t->tr_x12 = t->tr_y12 = 0;
         }
         t->tr_nextoutno = outno + 1;
         rval = obj_starttraverseoutlet(t->tr_ob, &t->tr_outlet, outno);
         t->tr_outno = outno;
     }
-    t->tr_nextoc = obj_nexttraverseoutlet(rval, &t->tr_ob2,
-        &t->tr_inlet, &t->tr_inno);
+    t->tr_nextoc =
+        obj_nexttraverseoutlet(rval, &t->tr_ob2, &t->tr_inlet, &t->tr_inno);
     t->tr_nin = obj_ninlets(t->tr_ob2);
-    if (!t->tr_nin) bug("drawline");
-    if (glist_isvisible(t->tr_x))
+    if(!t->tr_nin) bug("drawline");
+    if(glist_isvisible(t->tr_x))
     {
         int inplus = (t->tr_nin == 1 ? 1 : t->tr_nin - 1);
         int outplus = (t->tr_nout == 1 ? 1 : t->tr_nout - 1);
         int iow = IOWIDTH * t->tr_x->gl_zoom;
         int iom = IOMIDDLE * t->tr_x->gl_zoom;
-        gobj_getrect(&t->tr_ob2->ob_g, t->tr_x,
-            &t->tr_x21, &t->tr_y21, &t->tr_x22, &t->tr_y22);
+        gobj_getrect(&t->tr_ob2->ob_g, t->tr_x, &t->tr_x21, &t->tr_y21,
+            &t->tr_x22, &t->tr_y22);
         t->tr_lx1 = t->tr_x11 +
-            ((t->tr_x12 - t->tr_x11 - iow) * t->tr_outno) /
-                outplus + iom;
+                    ((t->tr_x12 - t->tr_x11 - iow) * t->tr_outno) / outplus +
+                    iom;
         t->tr_ly1 = t->tr_y12;
         t->tr_lx2 = t->tr_x21 +
-            ((t->tr_x22 - t->tr_x21 - iow) * t->tr_inno)/inplus +
-                iom;
+                    ((t->tr_x22 - t->tr_x21 - iow) * t->tr_inno) / inplus + iom;
         t->tr_ly2 = t->tr_y21;
     }
     else
@@ -428,21 +427,21 @@ int glist_valid = 10000;
 
 void glist_init(t_glist *x)
 {
-        /* zero out everyone except "pd" field */
-    memset(((char *)x) + sizeof(x->gl_pd), 0, sizeof(*x) - sizeof(x->gl_pd));
+    /* zero out everyone except "pd" field */
+    memset(((char *) x) + sizeof(x->gl_pd), 0, sizeof(*x) - sizeof(x->gl_pd));
     x->gl_stub = gstub_new(x, 0);
     x->gl_valid = ++glist_valid;
-    x->gl_xlabel = (t_symbol **)t_getbytes(0);
-    x->gl_ylabel = (t_symbol **)t_getbytes(0);
+    x->gl_xlabel = (t_symbol **) t_getbytes(0);
+    x->gl_ylabel = (t_symbol **) t_getbytes(0);
     x->gl_privatedata = getbytes(sizeof(t_canvas_private));
 }
 
-    /* make a new glist.  It will either be a "root" canvas or else
-    it appears as a "text" object in another window (canvas_getcurrent()
-    tells us which.) */
+/* make a new glist.  It will either be a "root" canvas or else
+it appears as a "text" object in another window (canvas_getcurrent()
+tells us which.) */
 t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
 {
-    t_canvas *x = (t_canvas *)pd_new(canvas_class);
+    t_canvas *x = (t_canvas *) pd_new(canvas_class);
     t_canvas *owner = canvas_getcurrent();
     t_symbol *s = &s_;
     int vis = 0, width = GLIST_DEFCANVASWIDTH, height = GLIST_DEFCANVASHEIGHT;
@@ -450,11 +449,10 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     int font = (owner ? owner->gl_font : sys_defaultfont);
     glist_init(x);
     x->gl_obj.te_type = T_OBJECT;
-    if (!owner)
-        canvas_addtolist(x);
+    if(!owner) canvas_addtolist(x);
     /* post("canvas %lx, owner %lx", x, owner); */
 
-    if (argc == 5)  /* toplevel: x, y, w, h, font */
+    if(argc == 5) /* toplevel: x, y, w, h, font */
     {
         xloc = atom_getfloatarg(0, argc, argv);
         yloc = atom_getfloatarg(1, argc, argv);
@@ -462,7 +460,7 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
         height = atom_getfloatarg(3, argc, argv);
         font = atom_getfloatarg(4, argc, argv);
     }
-    else if (argc == 6)  /* subwindow: x, y, w, h, name, vis */
+    else if(argc == 6) /* subwindow: x, y, w, h, name, vis */
     {
         xloc = atom_getfloatarg(0, argc, argv);
         yloc = atom_getfloatarg(1, argc, argv);
@@ -472,14 +470,12 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
         vis = atom_getfloatarg(5, argc, argv);
     }
 
-        /* (otherwise assume we're being created from the menu.) */
-    if (THISGUI->i_newdirectory &&
-        THISGUI->i_newdirectory->s_name[0])
+    /* (otherwise assume we're being created from the menu.) */
+    if(THISGUI->i_newdirectory && THISGUI->i_newdirectory->s_name[0])
     {
         t_canvasenvironment *env = x->gl_env =
-            (t_canvasenvironment *)getbytes(sizeof(*x->gl_env));
-        if (!THISGUI->i_newargv)
-            THISGUI->i_newargv = getbytes(0);
+            (t_canvasenvironment *) getbytes(sizeof(*x->gl_env));
+        if(!THISGUI->i_newargv) THISGUI->i_newargv = getbytes(0);
         env->ce_dir = THISGUI->i_newdirectory;
         env->ce_argc = THISGUI->i_newargc;
         env->ce_argv = THISGUI->i_newargv;
@@ -489,9 +485,10 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
         THISGUI->i_newargc = 0;
         THISGUI->i_newargv = 0;
     }
-    else x->gl_env = 0;
+    else
+        x->gl_env = 0;
 
-        /* initialize private data, like the undo-queue */
+    /* initialize private data, like the undo-queue */
     canvas_undo_init(x);
 
     x->gl_x1 = 0;
@@ -501,37 +498,37 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     canvas_dosetbounds(x, xloc, yloc, xloc + width, yloc + height);
     x->gl_owner = owner;
     x->gl_isclone = 0;
-    x->gl_name = (*s->s_name ? s :
-        (THISGUI->i_newfilename ? THISGUI->i_newfilename : gensym("Pd")));
+    x->gl_name = (*s->s_name ? s
+                             : (THISGUI->i_newfilename ? THISGUI->i_newfilename
+                                                       : gensym("Pd")));
     canvas_bind(x);
     x->gl_loading = 1;
-    x->gl_goprect = 0;      /* no GOP rectangle unless it's turned on later */
-        /* cancel "vis" flag if we're a subpatch of an
-         abstraction inside another patch.  A separate mechanism prevents
-         the toplevel abstraction from showing up. */
-    if (vis && gensym("#X")->s_thing &&
+    x->gl_goprect = 0; /* no GOP rectangle unless it's turned on later */
+    /* cancel "vis" flag if we're a subpatch of an
+     abstraction inside another patch.  A separate mechanism prevents
+     the toplevel abstraction from showing up. */
+    if(vis && gensym("#X")->s_thing &&
         ((*gensym("#X")->s_thing) == canvas_class))
     {
-        t_canvas *zzz = (t_canvas *)(gensym("#X")->s_thing);
-        while (zzz && !zzz->gl_env)
+        t_canvas *zzz = (t_canvas *) (gensym("#X")->s_thing);
+        while(zzz && !zzz->gl_env)
             zzz = zzz->gl_owner;
-        if (zzz && canvas_isabstraction(zzz) && zzz->gl_owner)
-            vis = 0;
+        if(zzz && canvas_isabstraction(zzz) && zzz->gl_owner) vis = 0;
     }
     x->gl_willvis = vis;
     x->gl_edit = !UNTITLED_STRNCMP(x->gl_name->s_name);
     x->gl_font = sys_nearestfontsize(font);
     x->gl_zoom = (owner ? owner->gl_zoom : 1);
     pd_pushsym(&x->gl_pd);
-    return(x);
+    return (x);
 }
 
 void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
 static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-          /* FIXME: this is a stopgap - we should always be using
-            glist_getzoom() and never gl_zoom in rest of code. */
+    /* FIXME: this is a stopgap - we should always be using
+      glist_getzoom() and never gl_zoom in rest of code. */
     x->gl_zoom = glist_getzoom(x);
     x->gl_x1 = atom_getfloatarg(0, argc, argv);
     x->gl_y1 = atom_getfloatarg(1, argc, argv);
@@ -539,7 +536,7 @@ static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     x->gl_y2 = atom_getfloatarg(3, argc, argv);
     x->gl_pixwidth = atom_getfloatarg(4, argc, argv);
     x->gl_pixheight = atom_getfloatarg(5, argc, argv);
-    if (argc <= 7)
+    if(argc <= 7)
         canvas_setgraph(x, atom_getfloatarg(6, argc, argv), 1);
     else
     {
@@ -549,35 +546,33 @@ static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     }
 }
 
-
-    /* make a new glist and add it to this glist.  It will appear as
-    a "graph", not a text object.  */
-t_glist *glist_addglist(t_glist *g, t_symbol *sym,
-    t_float x1, t_float y1, t_float x2, t_float y2,
-    t_float px1, t_float py1, t_float px2, t_float py2)
+/* make a new glist and add it to this glist.  It will appear as
+a "graph", not a text object.  */
+t_glist *glist_addglist(t_glist *g, t_symbol *sym, t_float x1, t_float y1,
+    t_float x2, t_float y2, t_float px1, t_float py1, t_float px2, t_float py2)
 {
-    static int gcount = 0;  /* it's OK if two threads get the same value */
+    static int gcount = 0; /* it's OK if two threads get the same value */
     int zz;
     int menu = 0;
     const char *str;
-    t_glist *x = (t_glist *)pd_new(canvas_class);
+    t_glist *x = (t_glist *) pd_new(canvas_class);
     glist_init(x);
     x->gl_obj.te_type = T_OBJECT;
-    if (!*sym->s_name)
+    if(!*sym->s_name)
     {
         char buf[40];
         sprintf(buf, "graph%d", ++gcount);
         sym = gensym(buf);
         menu = 1;
     }
-    else if (!strncmp((str = sym->s_name), "graph", 5)
-        && (zz = atoi(str + 5)) > gcount)
-            gcount = zz;
-        /* in 0.34 and earlier, the pixel rectangle and the y bounds were
-        reversed; this would behave the same, except that the dialog window
-        would be confusing.  The "correct" way is to have "py1" be the value
-        that is higher on the screen. */
-    if (py2 < py1)
+    else if(!strncmp((str = sym->s_name), "graph", 5) &&
+            (zz = atoi(str + 5)) > gcount)
+        gcount = zz;
+    /* in 0.34 and earlier, the pixel rectangle and the y bounds were
+    reversed; this would behave the same, except that the dialog window
+    would be confusing.  The "correct" way is to have "py1" be the value
+    that is higher on the screen. */
+    if(py2 < py1)
     {
         t_float zz;
         zz = y2;
@@ -587,11 +582,10 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
         py2 = py1;
         py1 = zz;
     }
-    if (x1 == x2 || y1 == y2)
-        x1 = 0, x2 = 100, y1 = 1, y2 = -1;
-    if (px1 >= px2 || py1 >= py2)
+    if(x1 == x2 || y1 == y2) x1 = 0, x2 = 100, y1 = 1, y2 = -1;
+    if(px1 >= px2 || py1 >= py2)
         px1 = 100, py1 = 20, px2 = 100 + GLIST_DEFGRAPHWIDTH,
-            py2 = 20 + GLIST_DEFGRAPHHEIGHT;
+        py2 = 20 + GLIST_DEFGRAPHHEIGHT;
     x->gl_name = sym;
     x->gl_x1 = x1;
     x->gl_x2 = x2;
@@ -601,8 +595,8 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_obj.te_ypix = py1;
     x->gl_pixwidth = px2 - px1;
     x->gl_pixheight = py2 - py1;
-    x->gl_font =  (canvas_getcurrent() ?
-        canvas_getcurrent()->gl_font : sys_defaultfont);
+    x->gl_font =
+        (canvas_getcurrent() ? canvas_getcurrent()->gl_font : sys_defaultfont);
     x->gl_zoom = g->gl_zoom;
     x->gl_screenx1 = GLIST_DEFCANVASXLOC;
     x->gl_screeny1 = GLIST_DEFCANVASYLOC;
@@ -613,17 +607,16 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_isgraph = 1;
     x->gl_goprect = 0;
     x->gl_obj.te_binbuf = binbuf_new();
-        /* initialize private data, like the undo-queue */
+    /* initialize private data, like the undo-queue */
     canvas_undo_init(x);
 
     binbuf_addv(x->gl_obj.te_binbuf, "s", gensym("graph"));
-    if (!menu)
-        pd_pushsym(&x->gl_pd);
+    if(!menu) pd_pushsym(&x->gl_pd);
     glist_add(g, &x->gl_gobj);
     return (x);
 }
 
-    /* call glist_addglist from a Pd message */
+/* call glist_addglist from a Pd message */
 void glist_glist(t_glist *g, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sym = atom_getsymbolarg(0, argc, argv);
@@ -636,24 +629,24 @@ void glist_glist(t_glist *g, t_symbol *s, int argc, t_atom *argv)
     t_float px2 = atom_getfloatarg(7, argc, argv);
     t_float py2 = atom_getfloatarg(8, argc, argv);
     glist_addglist(g, sym, x1, y1, x2, y2, px1, py1, px2, py2);
-    if (!canvas_undo_get(glist_getcanvas(g))->u_doing)
+    if(!canvas_undo_get(glist_getcanvas(g))->u_doing)
         canvas_undo_add(glist_getcanvas(g), UNDO_CREATE, "create",
-            (void *)canvas_undo_set_create(glist_getcanvas(g)));
+            (void *) canvas_undo_set_create(glist_getcanvas(g)));
 }
 
-    /* return true if the glist should appear as a graph on parent;
-    otherwise it appears as a text box. */
+/* return true if the glist should appear as a graph on parent;
+otherwise it appears as a text box. */
 int glist_isgraph(t_glist *x)
 {
-  return (x->gl_isgraph|(x->gl_hidetext<<1));
+    return (x->gl_isgraph | (x->gl_hidetext << 1));
 }
 
-    /* This is sent from the GUI to inform a toplevel that its window has been
-    moved or resized. */
-static void canvas_setbounds(t_canvas *x, t_float left, t_float top,
-                             t_float right, t_float bottom)
+/* This is sent from the GUI to inform a toplevel that its window has been
+moved or resized. */
+static void canvas_setbounds(
+    t_canvas *x, t_float left, t_float top, t_float right, t_float bottom)
 {
-    canvas_dosetbounds(x, (int)left, (int)top, (int)right, (int)bottom);
+    canvas_dosetbounds(x, (int) left, (int) top, (int) right, (int) bottom);
 }
 
 /* this is the internal version using ints */
@@ -661,28 +654,28 @@ static void canvas_dosetbounds(t_canvas *x, int x1, int y1, int x2, int y2)
 {
     int heightwas = y2 - y1;
     int heightchange = y2 - y1 - (x->gl_screeny2 - x->gl_screeny1);
-    if (x->gl_screenx1 == x1 && x->gl_screeny1 == y1 &&
-        x->gl_screenx2 == x2 && x->gl_screeny2 == y2)
-            return;
+    if(x->gl_screenx1 == x1 && x->gl_screeny1 == y1 && x->gl_screenx2 == x2 &&
+        x->gl_screeny2 == y2)
+        return;
     x->gl_screenx1 = x1;
     x->gl_screeny1 = y1;
     x->gl_screenx2 = x2;
     x->gl_screeny2 = y2;
-    if (!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
+    if(!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
     {
-            /* if it's flipped so that y grows upward,
-            fix so that zero is bottom edge and redraw.  This is
-            only appropriate if we're a regular "text" object on the
-            parent. */
+        /* if it's flipped so that y grows upward,
+        fix so that zero is bottom edge and redraw.  This is
+        only appropriate if we're a regular "text" object on the
+        parent. */
         t_float diff = x->gl_y1 - x->gl_y2;
         t_gobj *y;
-        x->gl_y1 = heightwas * diff/x->gl_zoom;
+        x->gl_y1 = heightwas * diff / x->gl_zoom;
         x->gl_y2 = x->gl_y1 - diff;
-            /* and move text objects accordingly; they should stick
-            to the bottom, not the top. */
-        for (y = x->gl_list; y; y = y->g_next)
-            if (pd_checkobject(&y->g_pd))
-                gobj_displace(y, x, 0, heightchange/x->gl_zoom);
+        /* and move text objects accordingly; they should stick
+        to the bottom, not the top. */
+        for(y = x->gl_list; y; y = y->g_next)
+            if(pd_checkobject(&y->g_pd))
+                gobj_displace(y, x, 0, heightchange / x->gl_zoom);
         canvas_redraw(x);
     }
 }
@@ -690,23 +683,23 @@ static void canvas_dosetbounds(t_canvas *x, int x1, int y1, int x2, int y2)
 t_symbol *canvas_makebindsym(t_symbol *s)
 {
     char buf[MAXPDSTRING];
-    snprintf(buf, MAXPDSTRING-1, "pd-%s", s->s_name);
-    buf[MAXPDSTRING-1] = 0;
+    snprintf(buf, MAXPDSTRING - 1, "pd-%s", s->s_name);
+    buf[MAXPDSTRING - 1] = 0;
     return (gensym(buf));
 }
 
-    /* functions to bind and unbind canvases to symbol "pd-blah".  As
-    discussed on Pd dev list there should be a way to defeat this for
-    abstractions.  (Claude Heiland et al. Aug 9 2013) */
+/* functions to bind and unbind canvases to symbol "pd-blah".  As
+discussed on Pd dev list there should be a way to defeat this for
+abstractions.  (Claude Heiland et al. Aug 9 2013) */
 static void canvas_bind(t_canvas *x)
 {
-    if (strcmp(x->gl_name->s_name, "Pd"))
+    if(strcmp(x->gl_name->s_name, "Pd"))
         pd_bind(&x->gl_pd, canvas_makebindsym(x->gl_name));
 }
 
 static void canvas_unbind(t_canvas *x)
 {
-    if (strcmp(x->gl_name->s_name, "Pd"))
+    if(strcmp(x->gl_name->s_name, "Pd"))
         pd_unbind(&x->gl_pd, canvas_makebindsym(x->gl_name));
 }
 
@@ -714,107 +707,103 @@ void canvas_reflecttitle(t_canvas *x)
 {
     char namebuf[MAXPDSTRING];
     t_canvasenvironment *env = canvas_getenv(x);
-    if (!x->gl_havewindow)
+    if(!x->gl_havewindow)
     {
         bug("canvas_reflecttitle");
         return;
     }
-    if (env->ce_argc)
+    if(env->ce_argc)
     {
         int i;
         strcpy(namebuf, " (");
-        for (i = 0; i < env->ce_argc; i++)
+        for(i = 0; i < env->ce_argc; i++)
         {
-            if (strlen(namebuf) > MAXPDSTRING/2 - 5)
-                break;
-            if (i != 0)
-                strcat(namebuf, " ");
-            atom_string(&env->ce_argv[i], namebuf + strlen(namebuf),
-                MAXPDSTRING/2);
+            if(strlen(namebuf) > MAXPDSTRING / 2 - 5) break;
+            if(i != 0) strcat(namebuf, " ");
+            atom_string(
+                &env->ce_argv[i], namebuf + strlen(namebuf), MAXPDSTRING / 2);
         }
         strcat(namebuf, ")");
     }
-    else namebuf[0] = 0;
-    if (x->gl_edit)
+    else
+        namebuf[0] = 0;
+    if(x->gl_edit)
     {
-        strncat(namebuf, " [edit]", MAXPDSTRING-strlen(namebuf)-1);
-        namebuf[MAXPDSTRING-1] = 0;
+        strncat(namebuf, " [edit]", MAXPDSTRING - strlen(namebuf) - 1);
+        namebuf[MAXPDSTRING - 1] = 0;
     }
-    sys_vgui("pdtk_canvas_reflecttitle .x%lx {%s} {%s} {%s} %d\n",
-        x, canvas_getdir(x)->s_name, x->gl_name->s_name, namebuf, x->gl_dirty);
+    sys_vgui("pdtk_canvas_reflecttitle .x%lx {%s} {%s} {%s} %d\n", x,
+        canvas_getdir(x)->s_name, x->gl_name->s_name, namebuf, x->gl_dirty);
 }
 
-    /* mark a glist dirty or clean */
+/* mark a glist dirty or clean */
 void canvas_dirty(t_canvas *x, t_floatarg f)
 {
     t_canvas *x2 = canvas_getrootfor(x);
     unsigned int n = f;
-    if (THISGUI->i_reloadingabstraction)
-        return;
-    if (n != x2->gl_dirty)
+    if(THISGUI->i_reloadingabstraction) return;
+    if(n != x2->gl_dirty)
     {
         x2->gl_dirty = n;
-        if (x2->gl_havewindow)
-            canvas_reflecttitle(x2);
+        if(x2->gl_havewindow) canvas_reflecttitle(x2);
     }
-    if(!n)
-        canvas_undo_cleardirty(x);
+    if(!n) canvas_undo_cleardirty(x);
 }
 
 void canvas_drawredrect(t_canvas *x, int doit)
 {
-    if (doit)
+    if(doit)
     {
         int x1 = x->gl_zoom * x->gl_xmargin,
             x2 = x1 + x->gl_zoom * x->gl_pixwidth,
             y1 = x->gl_zoom * x->gl_ymargin,
             y2 = y1 + x->gl_zoom * x->gl_pixheight;
         sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
-            "-fill #ff8080 -width %d -capstyle projecting -tags GOP\n",
+                 "-fill #ff8080 -width %d -capstyle projecting -tags GOP\n",
             glist_getcanvas(x), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1,
-                x->gl_zoom);
+            x->gl_zoom);
     }
-    else sys_vgui(".x%lx.c delete GOP\n",  glist_getcanvas(x));
+    else
+        sys_vgui(".x%lx.c delete GOP\n", glist_getcanvas(x));
 }
 
-    /* the window becomes "mapped" (visible and not miniaturized) or
-    "unmapped" (either miniaturized or just plain gone.)  This should be
-    called from the GUI after the fact to "notify" us that we're mapped. */
+/* the window becomes "mapped" (visible and not miniaturized) or
+"unmapped" (either miniaturized or just plain gone.)  This should be
+called from the GUI after the fact to "notify" us that we're mapped. */
 void canvas_map(t_canvas *x, t_floatarg f)
 {
     int flag = (f != 0);
     t_gobj *y;
-    if (flag)
+    if(flag)
     {
-        if (!glist_isvisible(x))
+        if(!glist_isvisible(x))
         {
             t_selection *sel;
-            if (!x->gl_havewindow)
+            if(!x->gl_havewindow)
             {
                 bug("canvas_map");
                 canvas_vis(x, 1);
             }
-            for (y = x->gl_list; y; y = y->g_next)
+            for(y = x->gl_list; y; y = y->g_next)
                 gobj_vis(y, x, 1);
             x->gl_mapped = 1;
-            for (sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+            for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
                 gobj_select(sel->sel_what, x, 1);
             canvas_drawlines(x);
-            if (x->gl_isgraph && x->gl_goprect)
-                canvas_drawredrect(x, 1);
+            if(x->gl_isgraph && x->gl_goprect) canvas_drawredrect(x, 1);
             sys_vgui("pdtk_canvas_getscroll .x%lx.c\n", x);
         }
     }
     else
     {
-        if (glist_isvisible(x))
+        if(glist_isvisible(x))
         {
-            if (!x->gl_havewindow)
+            if(!x->gl_havewindow)
             {
                 bug("canvas_map");
                 return;
             }
-                /* just clear out the whole canvas */
+            /* just clear out the whole canvas */
             sys_vgui(".x%lx.c delete all\n", x);
             x->gl_mapped = 0;
         }
@@ -823,32 +812,30 @@ void canvas_map(t_canvas *x, t_floatarg f)
 
 void canvas_redraw(t_canvas *x)
 {
-    if (glist_isvisible(x))
+    if(glist_isvisible(x))
     {
         canvas_map(x, 0);
         canvas_map(x, 1);
     }
 }
 
-
-    /* we call this on a non-toplevel glist to "open" it into its
-    own window. */
+/* we call this on a non-toplevel glist to "open" it into its
+own window. */
 void glist_menu_open(t_glist *x)
 {
-    if (glist_isvisible(x) && !glist_istoplevel(x))
+    if(glist_isvisible(x) && !glist_istoplevel(x))
     {
         t_glist *gl2 = x->gl_owner;
-        if (!gl2)
-            bug("glist_menu_open");  /* shouldn't happen but not dangerous */
+        if(!gl2)
+            bug("glist_menu_open"); /* shouldn't happen but not dangerous */
         else
         {
-                /* erase ourself in parent window */
+            /* erase ourself in parent window */
             gobj_vis(&x->gl_gobj, gl2, 0);
-                    /* get rid of our editor (and subeditors) */
-            if (x->gl_editor)
-                canvas_destroy_editor(x);
+            /* get rid of our editor (and subeditors) */
+            if(x->gl_editor) canvas_destroy_editor(x);
             x->gl_havewindow = 1;
-                    /* redraw ourself in parent window (blanked out this time) */
+            /* redraw ourself in parent window (blanked out this time) */
             gobj_vis(&x->gl_gobj, gl2, 1);
         }
     }
@@ -862,24 +849,23 @@ int glist_isvisible(t_glist *x)
 
 int glist_istoplevel(t_glist *x)
 {
-        /* we consider a graph "toplevel" if it has its own window
-        or if it appears as a box in its parent window so that we
-        don't draw the actual contents there. */
+    /* we consider a graph "toplevel" if it has its own window
+    or if it appears as a box in its parent window so that we
+    don't draw the actual contents there. */
     return (x->gl_havewindow || !x->gl_isgraph);
 }
 
 int glist_getfont(t_glist *x)
 {
-    while (!x->gl_env)
-        if (!(x = x->gl_owner))
-            bug("t_canvasenvironment");
+    while(!x->gl_env)
+        if(!(x = x->gl_owner)) bug("t_canvasenvironment");
     return (x->gl_font);
 }
 
 int glist_getzoom(t_glist *x)
 {
     t_glist *gl2 = x;
-    while (!glist_istoplevel(gl2) && gl2->gl_owner)
+    while(!glist_istoplevel(gl2) && gl2->gl_owner)
         gl2 = gl2->gl_owner;
     return (gl2->gl_zoom);
 }
@@ -897,21 +883,19 @@ int glist_fontheight(t_glist *x)
 void canvas_free(t_canvas *x)
 {
     t_gobj *y;
-    t_canvas_private*private = x->gl_privatedata;
+    t_canvas_private *private = x->gl_privatedata;
     int dspstate = canvas_suspend_dsp();
     canvas_noundo(x);
-    if (canvas_whichfind == x)
-        canvas_whichfind = 0;
+    if(canvas_whichfind == x) canvas_whichfind = 0;
     glist_noselect(x);
-    while ((y = x->gl_list))
+    while((y = x->gl_list))
         glist_delete(x, y);
-    if (x == glist_getcanvas(x))
-        canvas_vis(x, 0);
-    if (x->gl_editor)
-        canvas_destroy_editor(x);   /* bug workaround; should already be gone*/
+    if(x == glist_getcanvas(x)) canvas_vis(x, 0);
+    if(x->gl_editor)
+        canvas_destroy_editor(x); /* bug workaround; should already be gone*/
     canvas_unbind(x);
 
-    if (x->gl_env)
+    if(x->gl_env)
     {
         freebytes(x->gl_env->ce_argv, x->gl_env->ce_argc * sizeof(t_atom));
         freebytes(x->gl_env, sizeof(*x->gl_env));
@@ -922,9 +906,8 @@ void canvas_free(t_canvas *x)
     freebytes(x->gl_xlabel, x->gl_nxlabels * sizeof(*(x->gl_xlabel)));
     freebytes(x->gl_ylabel, x->gl_nylabels * sizeof(*(x->gl_ylabel)));
     gstub_cutoff(x->gl_stub);
-    gfxstub_deleteforkey(x);        /* probably unnecessary */
-    if (!x->gl_owner && !x->gl_isclone)
-        canvas_takeofflist(x);
+    gfxstub_deleteforkey(x); /* probably unnecessary */
+    if(!x->gl_owner && !x->gl_isclone) canvas_takeofflist(x);
 }
 
 /* ----------------- lines ---------- */
@@ -935,12 +918,12 @@ static void canvas_drawlines(t_canvas *x)
     t_outconnect *oc;
     {
         linetraverser_start(&t, x);
-        while ((oc = linetraverser_next(&t)))
-            sys_vgui(
-        ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-                glist_getcanvas(x),
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
-                (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1) * x->gl_zoom,
+        while((oc = linetraverser_next(&t)))
+            sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list "
+                     "l%lx cord]\n",
+                glist_getcanvas(x), t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
+                (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2 : 1) *
+                    x->gl_zoom,
                 oc);
     }
 }
@@ -949,55 +932,52 @@ void canvas_fixlinesfor(t_canvas *x, t_text *text)
 {
     t_linetraverser t;
     t_outconnect *oc;
-    
+
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
-        if (t.tr_ob == text || t.tr_ob2 == text)
+        if(t.tr_ob == text || t.tr_ob2 == text)
         {
-            sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
-                glist_getcanvas(x), oc,
-                t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
+            sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n", glist_getcanvas(x),
+                oc, t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
         }
     }
 }
 
-    /* kill all lines for the object */
+/* kill all lines for the object */
 void canvas_deletelinesfor(t_canvas *x, t_text *text)
 {
     t_linetraverser t;
     t_outconnect *oc;
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
-        if (t.tr_ob == text || t.tr_ob2 == text)
+        if(t.tr_ob == text || t.tr_ob2 == text)
         {
-            if (glist_isvisible(x))
+            if(glist_isvisible(x))
             {
-                sys_vgui(".x%lx.c delete l%lx\n",
-                    glist_getcanvas(x), oc);
+                sys_vgui(".x%lx.c delete l%lx\n", glist_getcanvas(x), oc);
             }
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
         }
     }
 }
 
-    /* kill all lines for one inlet or outlet */
-void canvas_deletelinesforio(t_canvas *x, t_text *text,
-    t_inlet *inp, t_outlet *outp)
+/* kill all lines for one inlet or outlet */
+void canvas_deletelinesforio(
+    t_canvas *x, t_text *text, t_inlet *inp, t_outlet *outp)
 {
     t_linetraverser t;
     t_outconnect *oc;
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
-        if ((t.tr_ob == text && t.tr_outlet == outp) ||
+        if((t.tr_ob == text && t.tr_outlet == outp) ||
             (t.tr_ob2 == text && t.tr_inlet == inp))
         {
-            if (glist_isvisible(x))
+            if(glist_isvisible(x))
             {
-                sys_vgui(".x%lx.c delete l%lx\n",
-                    glist_getcanvas(x), oc);
+                sys_vgui(".x%lx.c delete l%lx\n", glist_getcanvas(x), oc);
             }
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
         }
@@ -1008,14 +988,12 @@ typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
 
 static void canvas_pop(t_canvas *x, t_floatarg fvis)
 {
-    if (glist_istoplevel(x) && (sys_zoom_open == 2))
+    if(glist_istoplevel(x) && (sys_zoom_open == 2))
     {
-        t_zoomfn zoommethod = (t_zoomfn)zgetfn(&x->gl_pd, gensym("zoom"));
-        if (zoommethod)
-            (*zoommethod)(&x->gl_pd, (t_floatarg)2);
+        t_zoomfn zoommethod = (t_zoomfn) zgetfn(&x->gl_pd, gensym("zoom"));
+        if(zoommethod) (*zoommethod)(&x->gl_pd, (t_floatarg) 2);
     }
-    if (fvis != 0)
-        canvas_vis(x, 1);
+    if(fvis != 0) canvas_vis(x, 1);
     pd_popsym(&x->gl_pd);
     canvas_resortinlets(x);
     canvas_resortoutlets(x);
@@ -1024,27 +1002,30 @@ static void canvas_pop(t_canvas *x, t_floatarg fvis)
 
 void canvas_objfor(t_glist *gl, t_text *x, int argc, t_atom *argv);
 
-
 void canvas_restore(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_pd *z;
-    if (argc > 3)
+    if(argc > 3)
     {
-        t_atom *ap=argv+3;
-        if (ap->a_type == A_SYMBOL)
+        t_atom *ap = argv + 3;
+        if(ap->a_type == A_SYMBOL)
         {
             t_canvasenvironment *e = canvas_getenv(canvas_getcurrent());
-            canvas_rename(x, binbuf_realizedollsym(ap->a_w.w_symbol,
-                e->ce_argc, e->ce_argv, 1), 0);
+            canvas_rename(x,
+                binbuf_realizedollsym(
+                    ap->a_w.w_symbol, e->ce_argc, e->ce_argv, 1),
+                0);
         }
     }
     canvas_pop(x, x->gl_willvis);
 
-    if (!(z = gensym("#X")->s_thing)) pd_error(0, "canvas_restore: out of context");
-    else if (*z != canvas_class) pd_error(0, "canvas_restore: wasn't a canvas");
+    if(!(z = gensym("#X")->s_thing))
+        pd_error(0, "canvas_restore: out of context");
+    else if(*z != canvas_class)
+        pd_error(0, "canvas_restore: wasn't a canvas");
     else
     {
-        t_canvas *x2 = (t_canvas *)z;
+        t_canvas *x2 = (t_canvas *) z;
         x->gl_owner = x2;
         canvas_objfor(x2, &x->gl_obj, argc, argv);
     }
@@ -1054,18 +1035,17 @@ static void canvas_loadbangabstractions(t_canvas *x)
 {
     t_gobj *y;
     t_symbol *s = gensym("loadbang");
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class)
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class)
         {
-            if (canvas_isabstraction((t_canvas *)y))
-                canvas_loadbang((t_canvas *)y);
+            if(canvas_isabstraction((t_canvas *) y))
+                canvas_loadbang((t_canvas *) y);
             else
-                canvas_loadbangabstractions((t_canvas *)y);
+                canvas_loadbangabstractions((t_canvas *) y);
         }
-        else if ((pd_class(&y->g_pd) == clone_class) &&
-            zgetfn(&y->g_pd, s))
+        else if((pd_class(&y->g_pd) == clone_class) && zgetfn(&y->g_pd, s))
         {
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_LOAD);
+            pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_LOAD);
         }
 }
 
@@ -1073,18 +1053,17 @@ void canvas_loadbangsubpatches(t_canvas *x)
 {
     t_gobj *y;
     t_symbol *s = gensym("loadbang");
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class)
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class)
         {
-            if (!canvas_isabstraction((t_canvas *)y))
-                canvas_loadbangsubpatches((t_canvas *)y);
+            if(!canvas_isabstraction((t_canvas *) y))
+                canvas_loadbangsubpatches((t_canvas *) y);
         }
-    for (y = x->gl_list; y; y = y->g_next)
-        if ((pd_class(&y->g_pd) != canvas_class) &&
-            (pd_class(&y->g_pd) != clone_class) &&
-            zgetfn(&y->g_pd, s))
+    for(y = x->gl_list; y; y = y->g_next)
+        if((pd_class(&y->g_pd) != canvas_class) &&
+            (pd_class(&y->g_pd) != clone_class) && zgetfn(&y->g_pd, s))
         {
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_LOAD);
+            pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_LOAD);
         }
 }
 
@@ -1105,14 +1084,14 @@ void canvas_initbang(t_canvas *x)
     t_gobj *y;
     t_symbol *s = gensym("loadbang");
     /* run "initbang" for all subpatches, but NOT for the child abstractions */
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class &&
-            !canvas_isabstraction((t_canvas *)y))
-                canvas_initbang((t_canvas *)y);
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class &&
+            !canvas_isabstraction((t_canvas *) y))
+            canvas_initbang((t_canvas *) y);
     /* call the initbang()-method for objects that have one */
-    for (y = x->gl_list; y; y = y->g_next)
-        if ((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_INIT);
+    for(y = x->gl_list; y; y = y->g_next)
+        if((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
+            pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_INIT);
 }
 
 /* JMZ:
@@ -1128,26 +1107,25 @@ void canvas_closebang(t_canvas *x)
      * but NOT for subpatches/abstractions: these are called separately
      * from g_graph:glist_delete()
      */
-    for (y = x->gl_list; y; y = y->g_next)
-        if ((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_CLOSE);
+    for(y = x->gl_list; y; y = y->g_next)
+        if((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
+            pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_CLOSE);
 }
 
 /* no longer used by 'pd-gui', but kept here for backwards compatibility.  The
  * new method calls canvas_setbounds() directly. */
-static void canvas_relocate(t_canvas *x, t_symbol *canvasgeom,
-    t_symbol *topgeom)
+static void canvas_relocate(
+    t_canvas *x, t_symbol *canvasgeom, t_symbol *topgeom)
 {
     int cxpix, cypix, cw, ch, txpix, typix, tw, th;
-    if (sscanf(canvasgeom->s_name, "%dx%d+%d+%d", &cw, &ch, &cxpix, &cypix)
-        < 4 ||
+    if(sscanf(canvasgeom->s_name, "%dx%d+%d+%d", &cw, &ch, &cxpix, &cypix) <
+            4 ||
         sscanf(topgeom->s_name, "%dx%d+%d+%d", &tw, &th, &txpix, &typix) < 4)
         bug("canvas_relocate");
-            /* for some reason this is initially called with cw=ch=1 so
-            we just suppress that here. */
-    if (cw > 5 && ch > 5)
-        canvas_dosetbounds(x, txpix, typix,
-            txpix + cw, typix + ch);
+    /* for some reason this is initially called with cw=ch=1 so
+    we just suppress that here. */
+    if(cw > 5 && ch > 5)
+        canvas_dosetbounds(x, txpix, typix, txpix + cw, typix + ch);
 }
 
 void canvas_popabstraction(t_canvas *x)
@@ -1165,69 +1143,68 @@ void canvas_logerror(t_object *y)
 {
 #ifdef LATER
     canvas_vis(x, 1);
-    if (!glist_isselected(x, &y->ob_g))
-        glist_select(x, &y->ob_g);
+    if(!glist_isselected(x, &y->ob_g)) glist_select(x, &y->ob_g);
 #endif
 }
 
 /* -------------------------- subcanvases ---------------------- */
 
 extern void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
+
 static void *subcanvas_new(t_symbol *s)
 {
     t_atom a[6];
     t_canvas *x, *z = canvas_getcurrent();
 
-    if (!*s->s_name) s = gensym("/SUBPATCH/");
-    SETFLOAT(a+0, GLIST_DEFCANVASXLOC);
-    SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
-    SETFLOAT(a+2, GLIST_DEFCANVASWIDTH);
-    SETFLOAT(a+3, GLIST_DEFCANVASHEIGHT);
-    SETSYMBOL(a+4, s);
-    SETFLOAT(a+5, 1);
+    if(!*s->s_name) s = gensym("/SUBPATCH/");
+    SETFLOAT(a + 0, GLIST_DEFCANVASXLOC);
+    SETFLOAT(a + 1, GLIST_DEFCANVASYLOC);
+    SETFLOAT(a + 2, GLIST_DEFCANVASWIDTH);
+    SETFLOAT(a + 3, GLIST_DEFCANVASHEIGHT);
+    SETSYMBOL(a + 4, s);
+    SETFLOAT(a + 5, 1);
     x = canvas_new(0, 0, 6, a);
 
-        /* check if subpatch is supposed to be connected (on the 1st inlet) */
+    /* check if subpatch is supposed to be connected (on the 1st inlet) */
     if(z && z->gl_editor && z->gl_editor->e_connectbuf)
     {
-        t_atom*argv = binbuf_getvec(z->gl_editor->e_connectbuf);
+        t_atom *argv = binbuf_getvec(z->gl_editor->e_connectbuf);
         int argc = binbuf_getnatom(z->gl_editor->e_connectbuf);
         t_symbol *sob = 0;
-        if ((argc == 7)
-            && atom_getsymbolarg(0, argc, argv) == gensym("#X")
-            && atom_getsymbolarg(1, argc, argv) == gensym("connect"))
+        if((argc == 7) && atom_getsymbolarg(0, argc, argv) == gensym("#X") &&
+            atom_getsymbolarg(1, argc, argv) == gensym("connect"))
         {
             int index2 = canvas_getindex(z, &x->gl_gobj);
-            if (((int)atom_getfloat(argv+5) == 0)
-                && (int)atom_getfloat(argv+4) == index2)
+            if(((int) atom_getfloat(argv + 5) == 0) &&
+                (int) atom_getfloat(argv + 4) == index2)
+            {
+                int index1 = (int) atom_getfloat(argv + 2);
+                int outno = (int) atom_getfloat(argv + 3);
+                t_gobj *outobj = z->gl_list;
+                /* get handle to object */
+                while(index1-- > 0 && outobj)
+                    outobj = outobj->g_next;
+                if(outobj && pd_checkobject(&outobj->g_pd))
                 {
-                    int index1 = (int)atom_getfloat(argv+2);
-                    int outno = (int)atom_getfloat(argv+3);
-                    t_gobj*outobj=z->gl_list;
-                        /* get handle to object */
-                    while(index1-->0 && outobj)
-                        outobj=outobj->g_next;
-                    if(outobj && pd_checkobject(&outobj->g_pd))
-                    {
-                        if (obj_issignaloutlet(pd_checkobject(&outobj->g_pd), outno))
-                            sob = gensym("inlet~");
-                        else
-                            sob = gensym("inlet");
-                    }
+                    if(obj_issignaloutlet(pd_checkobject(&outobj->g_pd), outno))
+                        sob = gensym("inlet~");
+                    else
+                        sob = gensym("inlet");
                 }
+            }
         }
         if(sob)
         {
-                /* JMZ: weirdo hardcoded numbers, taken from
-                 * glist_getnextxy(): 40
-                 * and canvas_howputnew(): -3
-                 */
-            SETFLOAT(a+0, 37);
-            SETFLOAT(a+1, 37);
-            SETSYMBOL(a+2, sob);
+            /* JMZ: weirdo hardcoded numbers, taken from
+             * glist_getnextxy(): 40
+             * and canvas_howputnew(): -3
+             */
+            SETFLOAT(a + 0, 37);
+            SETFLOAT(a + 1, 37);
+            SETSYMBOL(a + 2, sob);
             canvas_obj(x, gensym("obj"), 3, a);
 
-                /* select the newly created inlet to continue autopatching */
+            /* select the newly created inlet to continue autopatching */
             canvas_create_editor(x);
             glist_noselect(x);
             glist_select(x, x->gl_list);
@@ -1238,74 +1215,70 @@ static void *subcanvas_new(t_symbol *s)
     return (x);
 }
 
-static void canvas_click(t_canvas *x,
-    t_floatarg xpos, t_floatarg ypos,
-        t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+static void canvas_click(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     canvas_vis(x, 1);
 }
 
-
-    /* find out from subcanvas contents how much to fatten the box */
-void canvas_fattensub(t_canvas *x,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+/* find out from subcanvas contents how much to fatten the box */
+void canvas_fattensub(t_canvas *x, int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_gobj *y;
-    *xp2 += 50;     /* fake for now */
+    *xp2 += 50; /* fake for now */
     *yp2 += 50;
 }
 
 static void canvas_rename_method(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
-    if (ac && av->a_type == A_SYMBOL)
+    if(ac && av->a_type == A_SYMBOL)
         canvas_rename(x, av->a_w.w_symbol, 0);
-    else if (ac && av->a_type == A_DOLLSYM)
+    else if(ac && av->a_type == A_DOLLSYM)
     {
         t_canvasenvironment *e = canvas_getenv(x);
         canvas_setcurrent(x);
-        canvas_rename(x, binbuf_realizedollsym(av->a_w.w_symbol,
-            e->ce_argc, e->ce_argv, 1), 0);
+        canvas_rename(x,
+            binbuf_realizedollsym(av->a_w.w_symbol, e->ce_argc, e->ce_argv, 1),
+            0);
         canvas_unsetcurrent(x);
     }
-    else canvas_rename(x, gensym("Pd"), 0);
+    else
+        canvas_rename(x, gensym("Pd"), 0);
 }
 
+/* return true if the "canvas" object is an abstraction (so we don't
+save its contents, for example.)  */
+int canvas_isabstraction(const t_canvas *x) { return (x->gl_env != 0); }
 
-    /* return true if the "canvas" object is an abstraction (so we don't
-    save its contents, for example.)  */
-int canvas_isabstraction(const t_canvas *x)
-{
-    return (x->gl_env != 0);
-}
-
-    /* return true if the "canvas" object should be treated as a text
-    object.  This is true for abstractions but also for "table"s... */
+/* return true if the "canvas" object should be treated as a text
+object.  This is true for abstractions but also for "table"s... */
 /* JMZ: add a flag to gop-abstractions to hide the title */
 int canvas_showtext(const t_canvas *x)
 {
-    t_atom *argv = (x->gl_obj.te_binbuf? binbuf_getvec(x->gl_obj.te_binbuf):0);
-    int argc = (x->gl_obj.te_binbuf? binbuf_getnatom(x->gl_obj.te_binbuf) : 0);
+    t_atom *argv =
+        (x->gl_obj.te_binbuf ? binbuf_getvec(x->gl_obj.te_binbuf) : 0);
+    int argc = (x->gl_obj.te_binbuf ? binbuf_getnatom(x->gl_obj.te_binbuf) : 0);
     int isarray = (argc && argv[0].a_type == A_SYMBOL &&
-        argv[0].a_w.w_symbol == gensym("graph"));
+                   argv[0].a_w.w_symbol == gensym("graph"));
     if(x->gl_hidetext)
-      return 0;
+        return 0;
     else
-      return (!isarray);
+        return (!isarray);
 }
 
-    /* get the document containing this canvas */
+/* get the document containing this canvas */
 t_canvas *canvas_getrootfor(t_canvas *x)
 {
-    if ((!x->gl_owner) || canvas_isabstraction(x))
+    if((!x->gl_owner) || canvas_isabstraction(x))
         return (x);
-    else return (canvas_getrootfor(x->gl_owner));
+    else
+        return (canvas_getrootfor(x->gl_owner));
 }
 
-t_undo* canvas_undo_get(t_canvas *x)
+t_undo *canvas_undo_get(t_canvas *x)
 {
-    t_canvas_private*private = x?(x->gl_privatedata):0;
-    if(private)
-        return &(private->undo);
+    t_canvas_private *private = x ? (x->gl_privatedata) : 0;
+    if(private) return &(private->undo);
     return 0;
 }
 
@@ -1317,16 +1290,16 @@ EXTERN_STRUCT _dspcontext;
 void ugen_start(void);
 void ugen_stop(void);
 
-t_dspcontext *ugen_start_graph(int toplevel, t_signal **sp,
-    int ninlets, int noutlets);
+t_dspcontext *ugen_start_graph(
+    int toplevel, t_signal **sp, int ninlets, int noutlets);
 void ugen_add(t_dspcontext *dc, t_object *x);
-void ugen_connect(t_dspcontext *dc, t_object *x1, int outno,
-    t_object *x2, int inno);
+void ugen_connect(
+    t_dspcontext *dc, t_object *x1, int outno, t_object *x2, int inno);
 void ugen_done_graph(t_dspcontext *dc);
 
-    /* schedule one canvas for DSP.  This is called below for all "root"
-    canvases, but is also called from the "dsp" method for sub-
-    canvases, which are treated almost like any other tilde object.  */
+/* schedule one canvas for DSP.  This is called below for all "root"
+canvases, but is also called from the "dsp" method for sub-
+canvases, which are treated almost like any other tilde object.  */
 
 void canvas_dodsp(t_canvas *x, int toplevel, t_signal **sp)
 {
@@ -1337,85 +1310,83 @@ void canvas_dodsp(t_canvas *x, int toplevel, t_signal **sp)
     t_symbol *dspsym = gensym("dsp");
     t_dspcontext *dc;
 
-        /* create a new "DSP graph" object to use in sorting this canvas.
-        If we aren't toplevel, there are already other dspcontexts around. */
+    /* create a new "DSP graph" object to use in sorting this canvas.
+    If we aren't toplevel, there are already other dspcontexts around. */
 
-    dc = ugen_start_graph(toplevel, sp,
-        obj_nsiginlets(&x->gl_obj),
-        obj_nsigoutlets(&x->gl_obj));
+    dc = ugen_start_graph(
+        toplevel, sp, obj_nsiginlets(&x->gl_obj), obj_nsigoutlets(&x->gl_obj));
 
-        /* find all the "dsp" boxes and add them to the graph */
+    /* find all the "dsp" boxes and add them to the graph */
 
-    for (y = x->gl_list; y; y = y->g_next)
-        if ((ob = pd_checkobject(&y->g_pd)) && zgetfn(&y->g_pd, dspsym))
+    for(y = x->gl_list; y; y = y->g_next)
+        if((ob = pd_checkobject(&y->g_pd)) && zgetfn(&y->g_pd, dspsym))
             ugen_add(dc, ob);
 
-        /* ... and all dsp interconnections */
+    /* ... and all dsp interconnections */
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
-        if (obj_issignaloutlet(t.tr_ob, t.tr_outno))
+    while((oc = linetraverser_next(&t)))
+        if(obj_issignaloutlet(t.tr_ob, t.tr_outno))
             ugen_connect(dc, t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
 
-        /* finally, sort them and add them to the DSP chain */
+    /* finally, sort them and add them to the DSP chain */
     ugen_done_graph(dc);
 }
 
-static void canvas_dsp(t_canvas *x, t_signal **sp)
-{
-    canvas_dodsp(x, 0, sp);
-}
+static void canvas_dsp(t_canvas *x, t_signal **sp) { canvas_dodsp(x, 0, sp); }
 
-int canvas_dspstate;    /* for back compatibility with externs - don't use */
+int canvas_dspstate; /* for back compatibility with externs - don't use */
 
-    /* this routine starts DSP for all root canvases. */
+/* this routine starts DSP for all root canvases. */
 static void canvas_start_dsp(void)
 {
     t_canvas *x;
-    if (THISGUI->i_dspstate) ugen_stop();
-    else sys_gui("pdtk_pd_dsp ON\n");
+    if(THISGUI->i_dspstate)
+        ugen_stop();
+    else
+        sys_gui("pdtk_pd_dsp ON\n");
     ugen_start();
 
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
         canvas_dodsp(x, 1, 0);
 
     canvas_dspstate = THISGUI->i_dspstate = 1;
-    if (gensym("pd-dsp-started")->s_thing)
+    if(gensym("pd-dsp-started")->s_thing)
         pd_bang(gensym("pd-dsp-started")->s_thing);
 }
 
 static void canvas_stop_dsp(void)
 {
-    if (THISGUI->i_dspstate)
+    if(THISGUI->i_dspstate)
     {
         ugen_stop();
         sys_gui("pdtk_pd_dsp OFF\n");
         canvas_dspstate = THISGUI->i_dspstate = 0;
-        if (gensym("pd-dsp-stopped")->s_thing)
+        if(gensym("pd-dsp-stopped")->s_thing)
             pd_bang(gensym("pd-dsp-stopped")->s_thing);
     }
 }
 
-    /* DSP can be suspended before, and resumed after, operations which
-    might affect the DSP chain.  For example, we suspend before loading and
-    resume afterward, so that DSP doesn't get resorted for every DSP object
-    int the patch. */
+/* DSP can be suspended before, and resumed after, operations which
+might affect the DSP chain.  For example, we suspend before loading and
+resume afterward, so that DSP doesn't get resorted for every DSP object
+int the patch. */
 
 int canvas_suspend_dsp(void)
 {
     int rval = THISGUI->i_dspstate;
-    if (rval) canvas_stop_dsp();
+    if(rval) canvas_stop_dsp();
     return (rval);
 }
 
 void canvas_resume_dsp(int oldstate)
 {
-    if (oldstate) canvas_start_dsp();
+    if(oldstate) canvas_start_dsp();
 }
 
-    /* this is equivalent to suspending and resuming in one step. */
+/* this is equivalent to suspending and resuming in one step. */
 void canvas_update_dsp(void)
 {
-    if (THISGUI->i_dspstate) canvas_start_dsp();
+    if(THISGUI->i_dspstate) canvas_start_dsp();
 }
 
 /* the "dsp" message to pd starts and stops DSP somputation, and, if
@@ -1430,22 +1401,22 @@ us that we should elide the step of closing audio when DSP is turned off.*/
 void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int newstate;
-    if (argc)
+    if(argc)
     {
         newstate = atom_getfloatarg(0, argc, argv);
-        if (newstate && !THISGUI->i_dspstate)
+        if(newstate && !THISGUI->i_dspstate)
         {
             sys_set_audio_state(1);
             canvas_start_dsp();
         }
-        else if (!newstate && THISGUI->i_dspstate)
+        else if(!newstate && THISGUI->i_dspstate)
         {
             canvas_stop_dsp();
-            if (!audio_shouldkeepopen())
-                sys_set_audio_state(0);
+            if(!audio_shouldkeepopen()) sys_set_audio_state(0);
         }
     }
-    else post("dsp state %d", THISGUI->i_dspstate);
+    else
+        post("dsp state %d", THISGUI->i_dspstate);
 }
 
 void *canvas_getblock(t_class *blockclass, t_canvas **canvasp)
@@ -1453,72 +1424,69 @@ void *canvas_getblock(t_class *blockclass, t_canvas **canvasp)
     t_canvas *canvas = *canvasp;
     t_gobj *g;
     void *ret = 0;
-    for (g = canvas->gl_list; g; g = g->g_next)
+    for(g = canvas->gl_list; g; g = g->g_next)
     {
-        if (g->g_pd == blockclass)
-            ret = g;
+        if(g->g_pd == blockclass) ret = g;
     }
     *canvasp = canvas->gl_owner;
-    return(ret);
+    return (ret);
 }
 
 /******************* redrawing  data *********************/
 
-    /* redraw all "scalars" (do this if a drawing command is changed.)
-    LATER we'll use the "template" information to select which ones we
-    redraw.   Action = 0 for redraw, 1 for draw only, 2 for erase. */
+/* redraw all "scalars" (do this if a drawing command is changed.)
+LATER we'll use the "template" information to select which ones we
+redraw.   Action = 0 for redraw, 1 for draw only, 2 for erase. */
 static void glist_redrawall(t_glist *gl, int action)
 {
     t_gobj *g;
     int vis = glist_isvisible(gl);
-    for (g = gl->gl_list; g; g = g->g_next)
+    for(g = gl->gl_list; g; g = g->g_next)
     {
-        if (vis && g->g_pd == scalar_class)
+        if(vis && g->g_pd == scalar_class)
         {
-            if (action == 1)
+            if(action == 1)
             {
-                if (glist_isvisible(gl))
-                    gobj_vis(g, gl, 1);
+                if(glist_isvisible(gl)) gobj_vis(g, gl, 1);
             }
-            else if (action == 2)
+            else if(action == 2)
             {
-                if (glist_isvisible(gl))
-                    gobj_vis(g, gl, 0);
+                if(glist_isvisible(gl)) gobj_vis(g, gl, 0);
             }
-            else scalar_redraw((t_scalar *)g, gl);
+            else
+                scalar_redraw((t_scalar *) g, gl);
         }
-        else if (g->g_pd == canvas_class)
-            glist_redrawall((t_glist *)g, action);
+        else if(g->g_pd == canvas_class)
+            glist_redrawall((t_glist *) g, action);
     }
 }
 
-    /* public interface for above. */
+/* public interface for above. */
 void canvas_redrawallfortemplate(t_template *template, int action)
 {
     t_canvas *x;
-        /* find all root canvases */
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    /* find all root canvases */
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
         glist_redrawall(x, action);
 }
 
-    /* find the template defined by a canvas, and redraw all elements
-    for that */
+/* find the template defined by a canvas, and redraw all elements
+for that */
 void canvas_redrawallfortemplatecanvas(t_canvas *x, int action)
 {
     t_gobj *g;
     t_template *tmpl;
     t_symbol *s1 = gensym("struct");
-    for (g = x->gl_list; g; g = g->g_next)
+    for(g = x->gl_list; g; g = g->g_next)
     {
         t_object *ob = pd_checkobject(&g->g_pd);
         t_atom *argv;
-        if (!ob || ob->te_type != T_OBJECT ||
-            binbuf_getnatom(ob->te_binbuf) < 2)
+        if(!ob || ob->te_type != T_OBJECT || binbuf_getnatom(ob->te_binbuf) < 2)
             continue;
         argv = binbuf_getvec(ob->te_binbuf);
-        if (argv[0].a_type != A_SYMBOL || argv[1].a_type != A_SYMBOL
-            || argv[0].a_w.w_symbol != s1)
-                continue;
+        if(argv[0].a_type != A_SYMBOL || argv[1].a_type != A_SYMBOL ||
+            argv[0].a_w.w_symbol != s1)
+            continue;
         tmpl = template_findbyname(argv[1].a_w.w_symbol);
         canvas_redrawallfortemplate(tmpl, action);
     }
@@ -1546,11 +1514,11 @@ typedef struct _declare
 
 static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_declare *x = (t_declare *)pd_new(declare_class);
+    t_declare *x = (t_declare *) pd_new(declare_class);
     x->x_useme = 1;
     x->x_canvas = canvas_getcurrent();
-        /* LATER update environment and/or load libraries */
-    if (!x->x_canvas->gl_loading)
+    /* LATER update environment and/or load libraries */
+    if(!x->x_canvas->gl_loading)
     {
         /* the object is created by the user (not by loading a patch),
          * so update canvas's properties on the fly */
@@ -1562,69 +1530,72 @@ static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 static void declare_free(t_declare *x)
 {
     x->x_useme = 0;
-        /* LATER update environment */
+    /* LATER update environment */
 }
 
 void canvas_savedeclarationsto(t_canvas *x, t_binbuf *b)
 {
     t_gobj *y;
 
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if (pd_class(&y->g_pd) == declare_class)
+        if(pd_class(&y->g_pd) == declare_class)
         {
             binbuf_addv(b, "s", gensym("#X"));
-            binbuf_addbinbuf(b, ((t_declare *)y)->x_obj.te_binbuf);
+            binbuf_addbinbuf(b, ((t_declare *) y)->x_obj.te_binbuf);
             binbuf_addv(b, ";");
         }
-            /* before 0.47 we also allowed abstractions to write out to the
-            parent's declarations; now we only allow non-abstraction subpatches
-            to do so. */
-        else if (pd_checkglist(&y->g_pd) &&
-            (pd_compatibilitylevel < 47 || !canvas_isabstraction((t_canvas *)y)))
-                canvas_savedeclarationsto((t_canvas *)y, b);
+        /* before 0.47 we also allowed abstractions to write out to the
+        parent's declarations; now we only allow non-abstraction subpatches
+        to do so. */
+        else if(pd_checkglist(&y->g_pd) &&
+                (pd_compatibilitylevel < 47 ||
+                    !canvas_isabstraction((t_canvas *) y)))
+            canvas_savedeclarationsto((t_canvas *) y, b);
     }
 }
 
-static void canvas_completepath(const char *from, char *to, int bufsize,
-    t_canvas *x)
+static void canvas_completepath(
+    const char *from, char *to, int bufsize, t_canvas *x)
 {
-    if (sys_isabsolutepath(from))
+    if(sys_isabsolutepath(from))
     {
         to[0] = '\0';
     }
-    else if (x)
+    else if(x)
     {
         /* append canvas dir */
         const char *dir = canvas_getdir(x)->s_name;
-        int dirlen = (int)strlen(dir);
-        strncpy(to, dir, bufsize-dirlen);
-        to[bufsize-dirlen-1] = '\0';
+        int dirlen = (int) strlen(dir);
+        strncpy(to, dir, bufsize - dirlen);
+        to[bufsize - dirlen - 1] = '\0';
         strcat(to, "/");
     }
-     else
-    {   /* append Pd lib dir */
-        strncpy(to, sys_libdir->s_name, bufsize-10);
-        to[bufsize-9] = '\0';
+    else
+    { /* append Pd lib dir */
+        strncpy(to, sys_libdir->s_name, bufsize - 10);
+        to[bufsize - 9] = '\0';
         strcat(to, "/extra/");
     }
-    strncat(to, from, bufsize-strlen(to));
-    to[bufsize-1] = '\0';
+    strncat(to, from, bufsize - strlen(to));
+    to[bufsize - 1] = '\0';
 }
 
-/* maybe we should rename check_exists() to sys_access() and move it to s_path */
+/* maybe we should rename check_exists() to sys_access() and move it to s_path
+ */
 #ifdef _WIN32
-static int check_exists(const char*path)
+static int check_exists(const char *path)
 {
     char pathbuf[MAXPDSTRING];
     wchar_t ucs2path[MAXPDSTRING];
     sys_bashfilename(path, pathbuf);
-    u8_utf8toucs2(ucs2path, MAXPDSTRING, pathbuf, MAXPDSTRING-1);
-    return (0 ==  _waccess(ucs2path, 0));
+    u8_utf8toucs2(ucs2path, MAXPDSTRING, pathbuf, MAXPDSTRING - 1);
+    return (0 == _waccess(ucs2path, 0));
 }
 #else
 #include <unistd.h>
-static int check_exists(const char*path)
+
+static int check_exists(const char *path)
 {
     char pathbuf[MAXPDSTRING];
     sys_bashfilename(path, pathbuf);
@@ -1636,80 +1607,79 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
-    if (sys_isabsolutepath(path))
+    if(sys_isabsolutepath(path))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
         return;
     }
 
-        /* explicit relative path, starts with ./ or ../ */
-    if ((strncmp("./", path, 2) == 0) || (strncmp("../", path, 3) == 0))
+    /* explicit relative path, starts with ./ or ../ */
+    if((strncmp("./", path, 2) == 0) || (strncmp("../", path, 3) == 0))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
         return;
     }
 
-        /* check if path is a subdir of the canvas-path */
+    /* check if path is a subdir of the canvas-path */
     canvas_completepath(path, strbuf, MAXPDSTRING, x);
-    if (check_exists(strbuf))
+    if(check_exists(strbuf))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
         return;
     }
 
-        /* check whether the given subdir is in one of the user search-paths */
-    for (nl=STUFF->st_searchpath; nl; nl=nl->nl_next)
+    /* check whether the given subdir is in one of the user search-paths */
+    for(nl = STUFF->st_searchpath; nl; nl = nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
-        strbuf[MAXPDSTRING-1]=0;
-        if (check_exists(strbuf))
+        snprintf(strbuf, MAXPDSTRING - 1, "%s/%s/", nl->nl_string, path);
+        strbuf[MAXPDSTRING - 1] = 0;
+        if(check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
             return;
         }
     }
 
-        /* check whether the given subdir is in one of the standard-paths */
-    for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
+    /* check whether the given subdir is in one of the standard-paths */
+    for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
-        strbuf[MAXPDSTRING-1]=0;
-        if (check_exists(strbuf))
+        snprintf(strbuf, MAXPDSTRING - 1, "%s/%s/", nl->nl_string, path);
+        strbuf[MAXPDSTRING - 1] = 0;
+        if(check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
             return;
         }
     }
 }
+
 static void canvas_lib(t_canvas *x, t_canvasenvironment *e, const char *lib)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
-    if (sys_isabsolutepath(lib))
+    if(sys_isabsolutepath(lib))
     {
         sys_load_lib(x, lib);
         return;
     }
 
-        /* explicit relative path, starts with ./ or ../ */
-    if ((strncmp("./", lib, 2) == 0) || (strncmp("../", lib, 3) == 0))
+    /* explicit relative path, starts with ./ or ../ */
+    if((strncmp("./", lib, 2) == 0) || (strncmp("../", lib, 3) == 0))
     {
         sys_load_lib(x, lib);
         return;
     }
 
-        /* prefix canvas-path */
+    /* prefix canvas-path */
     canvas_completepath(lib, strbuf, MAXPDSTRING, x);
-    if (sys_load_lib(x, lib))
-        return;
+    if(sys_load_lib(x, lib)) return;
 
     /* check whether the given lib is located in one of the user search-paths */
-    for (nl=STUFF->st_searchpath; nl; nl=nl->nl_next)
+    for(nl = STUFF->st_searchpath; nl; nl = nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, lib);
-        strbuf[MAXPDSTRING-1]=0;
-        if (sys_load_lib(x, strbuf))
-            return;
+        snprintf(strbuf, MAXPDSTRING - 1, "%s/%s", nl->nl_string, lib);
+        strbuf[MAXPDSTRING - 1] = 0;
+        if(sys_load_lib(x, strbuf)) return;
     }
 }
 
@@ -1717,65 +1687,61 @@ static void canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
-    if (sys_isabsolutepath(stdpath))
+    if(sys_isabsolutepath(stdpath))
     {
         e->ce_path = namelist_append(e->ce_path, stdpath, 0);
         return;
     }
 
-        /* strip "extra/"-prefix */
-    if (!strncmp("extra/", stdpath, 6))
-        stdpath+=6;
+    /* strip "extra/"-prefix */
+    if(!strncmp("extra/", stdpath, 6)) stdpath += 6;
 
     /* prefix full pd-path (including extra) */
     canvas_completepath(stdpath, strbuf, MAXPDSTRING, 0);
-    if (check_exists(strbuf))
+    if(check_exists(strbuf))
     {
         e->ce_path = namelist_append(e->ce_path, strbuf, 0);
         return;
     }
 
     /* check whether the given subdir is in one of the standard-paths */
-    for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
+    for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, stdpath);
-        strbuf[MAXPDSTRING-1]=0;
-        if (check_exists(strbuf))
+        snprintf(strbuf, MAXPDSTRING - 1, "%s/%s/", nl->nl_string, stdpath);
+        strbuf[MAXPDSTRING - 1] = 0;
+        if(check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
             return;
         }
     }
 }
+
 static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
-    if (sys_isabsolutepath(stdlib))
+    if(sys_isabsolutepath(stdlib))
     {
         sys_load_lib(0, stdlib);
         return;
     }
 
-        /* strip    "extra/"-prefix */
-    if (!strncmp("extra/", stdlib, 6))
-        stdlib+=6;
+    /* strip    "extra/"-prefix */
+    if(!strncmp("extra/", stdlib, 6)) stdlib += 6;
 
-        /* prefix full pd-path (including extra) */
+    /* prefix full pd-path (including extra) */
     canvas_completepath(stdlib, strbuf, MAXPDSTRING, 0);
-    if (sys_load_lib(0, strbuf))
-        return;
+    if(sys_load_lib(0, strbuf)) return;
 
     /* check whether the given lib is located in one of the standard-paths */
-    for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
+    for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, stdlib);
-        strbuf[MAXPDSTRING-1]=0;
-        if (sys_load_lib(0, strbuf))
-            return;
+        snprintf(strbuf, MAXPDSTRING - 1, "%s/%s", nl->nl_string, stdlib);
+        strbuf[MAXPDSTRING - 1] = 0;
+        if(sys_load_lib(0, strbuf)) return;
     }
 }
-
 
 void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
@@ -1786,31 +1752,33 @@ void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
     postatom(argc, argv);
     endpost();
 #endif
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
         const char *flag = atom_getsymbolarg(i, argc, argv)->s_name;
-        const char *item = (argc > i+1)?atom_getsymbolarg(i+1, argc, argv)->s_name:0;
-        if ((item) && !strcmp(flag, "-path"))
+        const char *item =
+            (argc > i + 1) ? atom_getsymbolarg(i + 1, argc, argv)->s_name : 0;
+        if((item) && !strcmp(flag, "-path"))
         {
             canvas_path(x, e, item);
             i++;
         }
-        else if ((item) && !strcmp(flag, "-stdpath"))
+        else if((item) && !strcmp(flag, "-stdpath"))
         {
             canvas_stdpath(e, item);
             i++;
         }
-        else if ((item) && !strcmp(flag, "-lib"))
+        else if((item) && !strcmp(flag, "-lib"))
         {
             canvas_lib(x, e, item);
             i++;
         }
-        else if ((item) && !strcmp(flag, "-stdlib"))
+        else if((item) && !strcmp(flag, "-stdlib"))
         {
             canvas_stdlib(e, item);
             i++;
         }
-        else post("declare: %s: unknown declaration", flag);
+        else
+            post("declare: %s: unknown declaration", flag);
     }
 }
 
@@ -1828,8 +1796,8 @@ typedef struct _canvasopen
 static int canvas_open_iter(const char *path, t_canvasopen *co)
 {
     int fd;
-    if ((fd = sys_trytoopenone(path, co->name, co->ext,
-        co->dirresult, co->nameresult, co->size, co->bin)) >= 0)
+    if((fd = sys_trytoopenone(path, co->name, co->ext, co->dirresult,
+            co->nameresult, co->size, co->bin)) >= 0)
     {
         co->fd = fd;
         return 0;
@@ -1837,29 +1805,29 @@ static int canvas_open_iter(const char *path, t_canvasopen *co)
     return 1;
 }
 
-    /* utility function to read a file, looking first down the canvas's search
-    path (set with "declare" objects in the patch and recursively in calling
-    patches), then down the system one.  The filename is the concatenation of
-    "name" and "ext".  "Name" may be absolute, or may be relative with
-    slashes.  If anything can be opened, the true directory
-    ais put in the buffer dirresult (provided by caller), which should
-    be "size" bytes.  The "nameresult" pointer will be set somewhere in
-    the interior of "dirresult" and will give the file basename (with
-    slashes trimmed).  If "bin" is set a 'binary' open is
-    attempted, otherwise ASCII (this only matters on Microsoft.)
-    If "x" is zero, the file is sought in the directory "." or in the
-    global path.*/
+/* utility function to read a file, looking first down the canvas's search
+path (set with "declare" objects in the patch and recursively in calling
+patches), then down the system one.  The filename is the concatenation of
+"name" and "ext".  "Name" may be absolute, or may be relative with
+slashes.  If anything can be opened, the true directory
+ais put in the buffer dirresult (provided by caller), which should
+be "size" bytes.  The "nameresult" pointer will be set somewhere in
+the interior of "dirresult" and will give the file basename (with
+slashes trimmed).  If "bin" is set a 'binary' open is
+attempted, otherwise ASCII (this only matters on Microsoft.)
+If "x" is zero, the file is sought in the directory "." or in the
+global path.*/
 int canvas_open(const t_canvas *x, const char *name, const char *ext,
     char *dirresult, char **nameresult, unsigned int size, int bin)
 {
     int fd = -1;
     t_canvasopen co;
 
-        /* first check if "name" is absolute (and if so, try to open) */
-    if (sys_open_absolute(name, ext, dirresult, nameresult, size, bin, &fd))
+    /* first check if "name" is absolute (and if so, try to open) */
+    if(sys_open_absolute(name, ext, dirresult, nameresult, size, bin, &fd))
         return (fd);
 
-        /* otherwise "name" is relative; iterate over all the search-paths */
+    /* otherwise "name" is relative; iterate over all the search-paths */
     co.name = name;
     co.ext = ext;
     co.dirresult = dirresult;
@@ -1868,7 +1836,7 @@ int canvas_open(const t_canvas *x, const char *name, const char *ext,
     co.bin = bin;
     co.fd = -1;
 
-    canvas_path_iterate(x, (t_canvas_path_iterator)canvas_open_iter, &co);
+    canvas_path_iterate(x, (t_canvas_path_iterator) canvas_open_iter, &co);
 
     return (co.fd);
 }
@@ -1878,63 +1846,58 @@ int canvas_open(const t_canvas *x, const char *name, const char *ext,
  * <data>.  The function is called with two arguments: a pathname to try to
  * open, and <data>.
  */
-int canvas_path_iterate(const t_canvas *x, t_canvas_path_iterator fun,
-    void *user_data)
+int canvas_path_iterate(
+    const t_canvas *x, t_canvas_path_iterator fun, void *user_data)
 {
     const t_canvas *y = 0;
     t_namelist *nl = 0;
     int count = 0;
-    if (!fun)
-        return 0;
-        /* iterate through canvas-local paths */
-    for (y = x; y; y = y->gl_owner)
-        if (y->gl_env)
-    {
-        const char *dir;
-        dir = canvas_getdir(y)->s_name;
-        for (nl = y->gl_env->ce_path; nl; nl = nl->nl_next)
+    if(!fun) return 0;
+    /* iterate through canvas-local paths */
+    for(y = x; y; y = y->gl_owner)
+        if(y->gl_env)
         {
-            char realname[MAXPDSTRING];
-            if (sys_isabsolutepath(nl->nl_string))
-                realname[0] = '\0';
-            else
-            {   /* if not absolute path, append Pd lib dir */
-                strncpy(realname, dir, MAXPDSTRING);
-                realname[MAXPDSTRING-3] = 0;
-                strcat(realname, "/");
+            const char *dir;
+            dir = canvas_getdir(y)->s_name;
+            for(nl = y->gl_env->ce_path; nl; nl = nl->nl_next)
+            {
+                char realname[MAXPDSTRING];
+                if(sys_isabsolutepath(nl->nl_string))
+                    realname[0] = '\0';
+                else
+                { /* if not absolute path, append Pd lib dir */
+                    strncpy(realname, dir, MAXPDSTRING);
+                    realname[MAXPDSTRING - 3] = 0;
+                    strcat(realname, "/");
+                }
+                strncat(
+                    realname, nl->nl_string, MAXPDSTRING - strlen(realname));
+                realname[MAXPDSTRING - 1] = 0;
+                if(!fun(realname, user_data)) return count + 1;
+                count++;
             }
-            strncat(realname, nl->nl_string, MAXPDSTRING-strlen(realname));
-            realname[MAXPDSTRING-1] = 0;
-            if (!fun(realname, user_data))
-                return count+1;
-            count++;
         }
-    }
     /* try canvas dir */
-    if (!fun((x ? canvas_getdir(x)->s_name : "."), user_data))
-        return count+1;
+    if(!fun((x ? canvas_getdir(x)->s_name : "."), user_data)) return count + 1;
     count++;
 
     /* now iterate through the global paths */
-    for (nl = STUFF->st_searchpath; nl; nl = nl->nl_next)
+    for(nl = STUFF->st_searchpath; nl; nl = nl->nl_next)
     {
-        if (!fun(nl->nl_string, user_data))
-            return count+1;
+        if(!fun(nl->nl_string, user_data)) return count + 1;
         count++;
     }
     /* and the temp paths from the commandline */
-    for (nl = STUFF->st_temppath; nl; nl = nl->nl_next)
+    for(nl = STUFF->st_temppath; nl; nl = nl->nl_next)
     {
-        if (!fun(nl->nl_string, user_data))
-            return count+1;
+        if(!fun(nl->nl_string, user_data)) return count + 1;
         count++;
     }
     /* and the default paths */
-    if (sys_usestdpath)
-        for (nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
+    if(sys_usestdpath)
+        for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
         {
-            if (!fun(nl->nl_string, user_data))
-                return count+1;
+            if(!fun(nl->nl_string, user_data)) return count + 1;
             count++;
         }
 
@@ -1946,19 +1909,18 @@ static void canvas_f(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
     static int warned;
     t_gobj *g, *g2;
     t_object *ob;
-    if (argc > 1 && !warned)
+    if(argc > 1 && !warned)
     {
         post("** ignoring width or font settings from future Pd version **");
         warned = 1;
     }
-    if (!x->gl_list)
-        return;
-    for (g = x->gl_list; (g2 = g->g_next); g = g2)
+    if(!x->gl_list) return;
+    for(g = x->gl_list; (g2 = g->g_next); g = g2)
         ;
-    if ((ob = pd_checkobject(&g->g_pd)))
+    if((ob = pd_checkobject(&g->g_pd)))
     {
         ob->te_width = atom_getfloatarg(0, argc, argv);
-        if (glist_isvisible(x))
+        if(glist_isvisible(x))
         {
             gobj_vis(g, x, 0);
             gobj_vis(g, x, 1);
@@ -1966,20 +1928,21 @@ static void canvas_f(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
     }
 }
 
-extern t_class *array_define_class;     /* LATER datum class too */
+extern t_class *array_define_class; /* LATER datum class too */
 
-    /* check if a pd can be treated as a glist - true if we're of any of
-    the glist classes, which all have 'glist' as the first item in struct */
+/* check if a pd can be treated as a glist - true if we're of any of
+the glist classes, which all have 'glist' as the first item in struct */
 t_glist *pd_checkglist(t_pd *x)
 {
-    if (*x == canvas_class || *x == array_define_class)
-        return ((t_canvas *)x);
-    else return (0);
+    if(*x == canvas_class || *x == array_define_class)
+        return ((t_canvas *) x);
+    else
+        return (0);
 }
 
 /* ------------------------------- setup routine ------------------------ */
 
-    /* why are some of these "glist" and others "canvas"? */
+/* why are some of these "glist" and others "canvas"? */
 extern void glist_text(t_glist *x, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_bng(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
@@ -1987,10 +1950,10 @@ extern void canvas_toggle(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_vslider(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_hslider(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_vdial(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
-    /* old version... */
+/* old version... */
 extern void canvas_hdial(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_hdial(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
-    /* new version: */
+/* new version: */
 extern void canvas_hradio(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_vradio(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
 extern void canvas_vumeter(t_glist *gl, t_symbol *s, int argc, t_atom *argv);
@@ -2009,134 +1972,132 @@ extern void canvas_properties(t_gobj *z, t_glist *canvas);
 
 void g_canvas_setup(void)
 {
-        /* we prevent the user from typing "canvas" in an object box
-        by sending 0 for a creator function. */
-    canvas_class = class_new(gensym("canvas"), 0,
-        (t_method)canvas_free, sizeof(t_canvas), CLASS_NOINLET, 0);
-            /* here is the real creator function, invoked in patch files
-            by sending the "canvas" message to #N, which is bound
-            to pd_camvasmaker. */
-    class_addmethod(pd_canvasmaker, (t_method)canvas_new, gensym("canvas"),
-        A_GIMME, 0);
-    class_addmethod(canvas_class, (t_method)canvas_restore,
-        gensym("restore"), A_GIMME, 0);
-    class_addmethod(canvas_class, (t_method)canvas_coords,
-        gensym("coords"), A_GIMME, 0);
+    /* we prevent the user from typing "canvas" in an object box
+    by sending 0 for a creator function. */
+    canvas_class = class_new(gensym("canvas"), 0, (t_method) canvas_free,
+        sizeof(t_canvas), CLASS_NOINLET, 0);
+    /* here is the real creator function, invoked in patch files
+    by sending the "canvas" message to #N, which is bound
+    to pd_camvasmaker. */
+    class_addmethod(
+        pd_canvasmaker, (t_method) canvas_new, gensym("canvas"), A_GIMME, 0);
+    class_addmethod(
+        canvas_class, (t_method) canvas_restore, gensym("restore"), A_GIMME, 0);
+    class_addmethod(
+        canvas_class, (t_method) canvas_coords, gensym("coords"), A_GIMME, 0);
 
-/* -------------------------- objects ----------------------------- */
-    class_addmethod(canvas_class, (t_method)canvas_obj,
-        gensym("obj"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_msg,
-        gensym("msg"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_floatatom,
+    /* -------------------------- objects ----------------------------- */
+    class_addmethod(
+        canvas_class, (t_method) canvas_obj, gensym("obj"), A_GIMME, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_msg, gensym("msg"), A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_floatatom,
         gensym("floatatom"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_listbox,
-        gensym("listbox"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_symbolatom,
-        gensym("symbolatom"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_text,
-        gensym("text"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_glist, gensym("graph"),
+    class_addmethod(canvas_class, (t_method) canvas_listbox, gensym("listbox"),
         A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_scalar,
-        gensym("scalar"), A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_symbolatom,
+        gensym("symbolatom"), A_GIMME, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) glist_text, gensym("text"), A_GIMME, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) glist_glist, gensym("graph"), A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) glist_scalar, gensym("scalar"),
+        A_GIMME, A_NULL);
 
-/* -------------- connect method used in reading files ------------------ */
-    class_addmethod(canvas_class, (t_method)canvas_connect,
-        gensym("connect"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+    /* -------------- connect method used in reading files ------------------ */
+    class_addmethod(canvas_class, (t_method) canvas_connect, gensym("connect"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
 
+    /* -------------- IEMGUI: button, toggle, slider, etc.  ------------ */
+    class_addmethod(
+        canvas_class, (t_method) canvas_bng, gensym("bng"), A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_toggle, gensym("toggle"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_vslider, gensym("vslider"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_hslider, gensym("hslider"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_hdial, gensym("hdial"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_vdial, gensym("vdial"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_hradio, gensym("hradio"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_vradio, gensym("vradio"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_vumeter, gensym("vumeter"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_mycnv, gensym("mycnv"),
+        A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_numbox, gensym("numbox"),
+        A_GIMME, A_NULL);
 
-/* -------------- IEMGUI: button, toggle, slider, etc.  ------------ */
-    class_addmethod(canvas_class, (t_method)canvas_bng, gensym("bng"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_toggle, gensym("toggle"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_vslider, gensym("vslider"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_hslider, gensym("hslider"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_hdial, gensym("hdial"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_vdial, gensym("vdial"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_hradio, gensym("hradio"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_vradio, gensym("vradio"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_vumeter, gensym("vumeter"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_mycnv, gensym("mycnv"),
-                    A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_numbox, gensym("numbox"),
-                    A_GIMME, A_NULL);
-
-/* ------------------------ gui stuff --------------------------- */
-    class_addmethod(canvas_class, (t_method)canvas_pop, gensym("pop"),
-        A_DEFFLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_loadbang,
-        gensym("loadbang"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_setbounds,
+    /* ------------------------ gui stuff --------------------------- */
+    class_addmethod(
+        canvas_class, (t_method) canvas_pop, gensym("pop"), A_DEFFLOAT, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_loadbang, gensym("loadbang"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_setbounds,
         gensym("setbounds"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_relocate,
+    class_addmethod(canvas_class, (t_method) canvas_relocate,
         gensym("relocate"), A_SYMBOL, A_SYMBOL, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_vis,
-        gensym("vis"), A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_menu_open,
-        gensym("menu-open"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_map,
-        gensym("map"), A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_dirty,
-        gensym("dirty"), A_FLOAT, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_vis, gensym("vis"), A_FLOAT, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) glist_menu_open, gensym("menu-open"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_map, gensym("map"), A_FLOAT, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_dirty, gensym("dirty"),
+        A_FLOAT, A_NULL);
     class_setpropertiesfn(canvas_class, canvas_properties);
 
-/* ---------------------- list handling ------------------------ */
-    class_addmethod(canvas_class, (t_method)glist_clear, gensym("clear"),
-        A_NULL);
+    /* ---------------------- list handling ------------------------ */
+    class_addmethod(
+        canvas_class, (t_method) glist_clear, gensym("clear"), A_NULL);
 
-/* ----- subcanvases, which you get by typing "pd" in a box ---- */
-    class_addcreator((t_newmethod)subcanvas_new, gensym("pd"), A_DEFSYMBOL, 0);
-    class_addcreator((t_newmethod)subcanvas_new, gensym("page"),  A_DEFSYMBOL, 0);
+    /* ----- subcanvases, which you get by typing "pd" in a box ---- */
+    class_addcreator((t_newmethod) subcanvas_new, gensym("pd"), A_DEFSYMBOL, 0);
+    class_addcreator(
+        (t_newmethod) subcanvas_new, gensym("page"), A_DEFSYMBOL, 0);
 
-    class_addmethod(canvas_class, (t_method)canvas_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_rename_method,
+    class_addmethod(canvas_class, (t_method) canvas_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(
+        canvas_class, (t_method) canvas_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(canvas_class, (t_method) canvas_rename_method,
         gensym("rename"), A_GIMME, 0);
 
-/*---------------------------- declare ------------------- */
-    declare_class = class_new(gensym("declare"), (t_newmethod)declare_new,
-        (t_method)declare_free, sizeof(t_declare), CLASS_NOINLET, A_GIMME, 0);
-    class_addmethod(canvas_class, (t_method)canvas_declare,
-        gensym("declare"), A_GIMME, 0);
+    /*---------------------------- declare ------------------- */
+    declare_class = class_new(gensym("declare"), (t_newmethod) declare_new,
+        (t_method) declare_free, sizeof(t_declare), CLASS_NOINLET, A_GIMME, 0);
+    class_addmethod(
+        canvas_class, (t_method) canvas_declare, gensym("declare"), A_GIMME, 0);
 
-/*--------------- future message to set formatting  -------------- */
-    class_addmethod(canvas_class, (t_method)canvas_f,
-        gensym("f"), A_GIMME, 0);
-/* -------------- setups from other files for canvas_class ---------------- */
+    /*--------------- future message to set formatting  -------------- */
+    class_addmethod(canvas_class, (t_method) canvas_f, gensym("f"), A_GIMME, 0);
+    /* -------------- setups from other files for canvas_class ----------------
+     */
     g_graph_setup();
     g_editor_setup();
     g_readwrite_setup();
 }
 
-    /* functions to add basic gui (e.g., clicking but not editing) to things
-    based on canvases that aren't editable, like "array define" object */
+/* functions to add basic gui (e.g., clicking but not editing) to things
+based on canvases that aren't editable, like "array define" object */
 void canvas_editor_for_class(t_class *c);
 void g_graph_setup_class(t_class *c);
 void canvas_readwrite_for_class(t_class *c);
 
 void canvas_add_for_class(t_class *c)
 {
-    class_addmethod(c, (t_method)canvas_restore,
-        gensym("restore"), A_GIMME, 0);
-    class_addmethod(c, (t_method)canvas_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(c, (t_method)canvas_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_addmethod(c, (t_method)canvas_map,
-        gensym("map"), A_FLOAT, A_NULL);
-    class_addmethod(c, (t_method)canvas_setbounds,
-        gensym("setbounds"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+    class_addmethod(
+        c, (t_method) canvas_restore, gensym("restore"), A_GIMME, 0);
+    class_addmethod(c, (t_method) canvas_click, gensym("click"), A_FLOAT,
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(c, (t_method) canvas_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(c, (t_method) canvas_map, gensym("map"), A_FLOAT, A_NULL);
+    class_addmethod(c, (t_method) canvas_setbounds, gensym("setbounds"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
     canvas_editor_for_class(c);
     canvas_readwrite_for_class(c);
     /* g_graph_setup_class(c); */
@@ -2162,56 +2123,51 @@ void g_canvas_freepdinstance(void)
     freebytes(THISGUI, sizeof(*THISGUI));
 }
 
-EXTERN int pd_getdspstate(void)
-{
-    return (THISGUI->i_dspstate);
-}
+EXTERN int pd_getdspstate(void) { return (THISGUI->i_dspstate); }
 
 void pd_doloadbang(void);
 
-    /* evaluate a file, which is expected to create a patch, and perform
-    post-evaluation cleanup and loadbang */
+/* evaluate a file, which is expected to create a patch, and perform
+post-evaluation cleanup and loadbang */
 t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir)
 {
     t_pd *x = 0, *boundx;
     int dspstate;
 
-        /* even though binbuf_evalfile appears to take care of dspstate,
-        we have to do it again here, because canvas_startdsp() assumes
-        that all toplevel canvases are visible.  LATER check if this
-        is still necessary -- probably not. */
+    /* even though binbuf_evalfile appears to take care of dspstate,
+    we have to do it again here, because canvas_startdsp() assumes
+    that all toplevel canvases are visible.  LATER check if this
+    is still necessary -- probably not. */
     dspstate = canvas_suspend_dsp();
     boundx = s__X.s_thing;
-        s__X.s_thing = 0;       /* don't save #X; we'll need to leave it bound
-                                for the caller to grab it. */
+    s__X.s_thing = 0; /* don't save #X; we'll need to leave it bound
+                      for the caller to grab it. */
     binbuf_evalfile(name, dir);
-    while ((x != s__X.s_thing) && s__X.s_thing)
+    while((x != s__X.s_thing) && s__X.s_thing)
     {
         x = s__X.s_thing;
         vmess(x, gensym("pop"), "i", 1);
     }
-    if (!sys_noloadbang)
-        pd_doloadbang();
+    if(!sys_noloadbang) pd_doloadbang();
     canvas_resume_dsp(dspstate);
     s__X.s_thing = boundx;
     return x;
 }
 
-    /* open a file as if from an open dialog from the GUI.  If the optional
-    argument "f" is nonzero, first check if the file is already open and if
-    so, just "vis" it.  This would be useful if you want merely to make sure a
-    patch is open, but don't want more than one copy. */
+/* open a file as if from an open dialog from the GUI.  If the optional
+argument "f" is nonzero, first check if the file is already open and if
+so, just "vis" it.  This would be useful if you want merely to make sure a
+patch is open, but don't want more than one copy. */
 void glob_open(t_pd *ignore, t_symbol *name, t_symbol *dir, t_floatarg f)
 {
     t_glist *gl;
-    if (f != 0)
-        for (gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
-            if (name == gl->gl_name && gl->gl_env && gl->gl_env->ce_dir == dir)
-    {
-            /* don't reopen already-open document, just vis it */
-        canvas_vis(gl, 1);
-        return;
-    }
-    if (!glob_evalfile(ignore, name, dir))
-        sys_vgui("::pdwindow::busyrelease\n");
+    if(f != 0)
+        for(gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
+            if(name == gl->gl_name && gl->gl_env && gl->gl_env->ce_dir == dir)
+            {
+                /* don't reopen already-open document, just vis it */
+                canvas_vis(gl, 1);
+                return;
+            }
+    if(!glob_evalfile(ignore, name, dir)) sys_vgui("::pdwindow::busyrelease\n");
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -149,8 +149,7 @@ int gobj_shouldvis(t_gobj *x, struct _glist *glist)
                 (ob->te_pd == canvas_class && (((t_glist *) ob)->gl_isgraph)) ||
                 (glist->gl_goprect && (ob->te_type == T_TEXT)));
     }
-    else
-        return (1);
+    return (1);
 }
 
 void gobj_vis(t_gobj *x, struct _glist *glist, int flag)
@@ -165,8 +164,7 @@ int gobj_click(t_gobj *x, struct _glist *glist, int xpix, int ypix, int shift,
     if(x->g_pd->c_wb && x->g_pd->c_wb->w_clickfn)
         return ((*x->g_pd->c_wb->w_clickfn)(
             x, glist, xpix, ypix, shift, alt, dbl, doit));
-    else
-        return (0);
+    return (0);
 }
 
 /* maintain the list of visible toplevels for the GUI's "windows" menu */
@@ -270,8 +268,7 @@ int canvas_getdollarzero(void)
     t_canvasenvironment *env = (x ? canvas_getenv(x) : 0);
     if(env)
         return (env->ce_dollarzero);
-    else
-        return (0);
+    return (0);
 }
 
 void canvas_getargs(int *argcp, t_atom **argvp)
@@ -1280,8 +1277,7 @@ int canvas_showtext(const t_canvas *x)
                    argv[0].a_w.w_symbol == gensym("graph"));
     if(x->gl_hidetext)
         return 0;
-    else
-        return (!isarray);
+    return (!isarray);
 }
 
 /* get the document containing this canvas */
@@ -1289,8 +1285,7 @@ t_canvas *canvas_getrootfor(t_canvas *x)
 {
     if((!x->gl_owner) || canvas_isabstraction(x))
         return (x);
-    else
-        return (canvas_getrootfor(x->gl_owner));
+    return (canvas_getrootfor(x->gl_owner));
 }
 
 t_undo *canvas_undo_get(t_canvas *x)
@@ -1955,8 +1950,7 @@ t_glist *pd_checkglist(t_pd *x)
 {
     if(*x == canvas_class || *x == array_define_class)
         return ((t_canvas *) x);
-    else
-        return (0);
+    return (0);
 }
 
 /* ------------------------------- setup routine ------------------------ */

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -110,7 +110,15 @@ int gobj_shouldvis(t_gobj *x, struct _glist *glist)
        graph rectangle, don't draw it. */
     if(has_parent && glist->gl_goprect)
     {
-        int x1, y1, x2, y2, gx1, gy1, gx2, gy2, m;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
+        int gx1;
+        int gy1;
+        int gx2;
+        int gy2;
+        int m;
         /* for some reason the bounds check on arrays and scalars
            don't seem to apply here.  Perhaps this was in order to allow
            arrays to reach outside their containers?  I no longer understand
@@ -444,8 +452,11 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     t_canvas *x = (t_canvas *) pd_new(canvas_class);
     t_canvas *owner = canvas_getcurrent();
     t_symbol *s = &s_;
-    int vis = 0, width = GLIST_DEFCANVASWIDTH, height = GLIST_DEFCANVASHEIGHT;
-    int xloc = GLIST_DEFCANVASXLOC, yloc = GLIST_DEFCANVASYLOC;
+    int vis = 0;
+    int width = GLIST_DEFCANVASWIDTH;
+    int height = GLIST_DEFCANVASHEIGHT;
+    int xloc = GLIST_DEFCANVASXLOC;
+    int yloc = GLIST_DEFCANVASYLOC;
     int font = (owner ? owner->gl_font : sys_defaultfont);
     glist_init(x);
     x->gl_obj.te_type = T_OBJECT;
@@ -754,10 +765,10 @@ void canvas_drawredrect(t_canvas *x, int doit)
 {
     if(doit)
     {
-        int x1 = x->gl_zoom * x->gl_xmargin,
-            x2 = x1 + x->gl_zoom * x->gl_pixwidth,
-            y1 = x->gl_zoom * x->gl_ymargin,
-            y2 = y1 + x->gl_zoom * x->gl_pixheight;
+        int x1 = x->gl_zoom * x->gl_xmargin;
+        int x2 = x1 + x->gl_zoom * x->gl_pixwidth;
+        int y1 = x->gl_zoom * x->gl_ymargin;
+        int y2 = y1 + x->gl_zoom * x->gl_pixheight;
         sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
                  "-fill #ff8080 -width %d -capstyle projecting -tags GOP\n",
             glist_getcanvas(x), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1,
@@ -1117,7 +1128,14 @@ void canvas_closebang(t_canvas *x)
 static void canvas_relocate(
     t_canvas *x, t_symbol *canvasgeom, t_symbol *topgeom)
 {
-    int cxpix, cypix, cw, ch, txpix, typix, tw, th;
+    int cxpix;
+    int cypix;
+    int cw;
+    int ch;
+    int txpix;
+    int typix;
+    int tw;
+    int th;
     if(sscanf(canvasgeom->s_name, "%dx%d+%d+%d", &cw, &ch, &cxpix, &cypix) <
             4 ||
         sscanf(topgeom->s_name, "%dx%d+%d+%d", &tw, &th, &txpix, &typix) < 4)
@@ -1907,7 +1925,8 @@ int canvas_path_iterate(
 static void canvas_f(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
     static int warned;
-    t_gobj *g, *g2;
+    t_gobj *g;
+    t_gobj *g2;
     t_object *ob;
     if(argc > 1 && !warned)
     {
@@ -2131,7 +2150,8 @@ void pd_doloadbang(void);
 post-evaluation cleanup and loadbang */
 t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir)
 {
-    t_pd *x = 0, *boundx;
+    t_pd *x = 0;
+    t_pd *boundx;
     int dspstate;
 
     /* even though binbuf_evalfile appears to take care of dspstate,

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -64,9 +64,13 @@ void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
 void gobj_getrect(t_gobj *x, t_glist *glist, int *x1, int *y1, int *x2, int *y2)
 {
     if(x->g_pd->c_wb && x->g_pd->c_wb->w_getrectfn)
+    {
         (*x->g_pd->c_wb->w_getrectfn)(x, glist, x1, y1, x2, y2);
+    }
     else
+    {
         *x1 = *y1 = 0, *x2 = *y2 = 10;
+    }
 }
 
 void gobj_displace(t_gobj *x, t_glist *glist, int dx, int dy)
@@ -162,8 +166,10 @@ int gobj_click(t_gobj *x, struct _glist *glist, int xpix, int ypix, int shift,
     int alt, int dbl, int doit)
 {
     if(x->g_pd->c_wb && x->g_pd->c_wb->w_clickfn)
+    {
         return ((*x->g_pd->c_wb->w_clickfn)(
             x, glist, xpix, ypix, shift, alt, dbl, doit));
+    }
     return (0);
 }
 
@@ -186,7 +192,9 @@ static void canvas_takeofflist(t_canvas *x)
 {
     /* take it off the window list */
     if(x == pd_this->pd_canvaslist)
+    {
         pd_this->pd_canvaslist = x->gl_next;
+    }
     else
     {
         t_canvas *z;
@@ -373,9 +381,13 @@ t_outconnect *linetraverser_next(t_linetraverser *t)
             t_gobj *y;
             t_object *ob = 0;
             if(!t->tr_ob)
+            {
                 y = t->tr_x->gl_list;
+            }
             else
+            {
                 y = t->tr_ob->ob_g.g_next;
+            }
             for(; y; y = y->g_next)
                 if((ob = pd_checkobject(&y->g_pd))) break;
             if(!ob) return (0);
@@ -383,10 +395,14 @@ t_outconnect *linetraverser_next(t_linetraverser *t)
             t->tr_nout = obj_noutlets(ob);
             outno = 0;
             if(glist_isvisible(t->tr_x))
+            {
                 gobj_getrect(
                     y, t->tr_x, &t->tr_x11, &t->tr_y11, &t->tr_x12, &t->tr_y12);
+            }
             else
+            {
                 t->tr_x11 = t->tr_y11 = t->tr_x12 = t->tr_y12 = 0;
+            }
         }
         t->tr_nextoutno = outno + 1;
         rval = obj_starttraverseoutlet(t->tr_ob, &t->tr_outlet, outno);
@@ -545,7 +561,9 @@ static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     x->gl_pixwidth = atom_getfloatarg(4, argc, argv);
     x->gl_pixheight = atom_getfloatarg(5, argc, argv);
     if(argc <= 7)
+    {
         canvas_setgraph(x, atom_getfloatarg(6, argc, argv), 1);
+    }
     else
     {
         x->gl_xmargin = atom_getfloatarg(7, argc, argv);
@@ -592,8 +610,10 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym, t_float x1, t_float y1,
     }
     if(x1 == x2 || y1 == y2) x1 = 0, x2 = 100, y1 = 1, y2 = -1;
     if(px1 >= px2 || py1 >= py2)
+    {
         px1 = 100, py1 = 20, px2 = 100 + GLIST_DEFGRAPHWIDTH,
         py2 = 20 + GLIST_DEFGRAPHHEIGHT;
+    }
     x->gl_name = sym;
     x->gl_x1 = x1;
     x->gl_x2 = x2;
@@ -638,8 +658,10 @@ void glist_glist(t_glist *g, t_symbol *s, int argc, t_atom *argv)
     t_float py2 = atom_getfloatarg(8, argc, argv);
     glist_addglist(g, sym, x1, y1, x2, y2, px1, py1, px2, py2);
     if(!canvas_undo_get(glist_getcanvas(g))->u_doing)
+    {
         canvas_undo_add(glist_getcanvas(g), UNDO_CREATE, "create",
             (void *) canvas_undo_set_create(glist_getcanvas(g)));
+    }
 }
 
 /* return true if the glist should appear as a graph on parent;
@@ -682,8 +704,10 @@ static void canvas_dosetbounds(t_canvas *x, int x1, int y1, int x2, int y2)
         /* and move text objects accordingly; they should stick
         to the bottom, not the top. */
         for(y = x->gl_list; y; y = y->g_next)
+        {
             if(pd_checkobject(&y->g_pd))
                 gobj_displace(y, x, 0, heightchange / x->gl_zoom);
+        }
         canvas_redraw(x);
     }
 }
@@ -835,7 +859,9 @@ void glist_menu_open(t_glist *x)
     {
         t_glist *gl2 = x->gl_owner;
         if(!gl2)
+        {
             bug("glist_menu_open"); /* shouldn't happen but not dangerous */
+        }
         else
         {
             /* erase ourself in parent window */
@@ -927,12 +953,14 @@ static void canvas_drawlines(t_canvas *x)
     {
         linetraverser_start(&t, x);
         while((oc = linetraverser_next(&t)))
+        {
             sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list "
                      "l%lx cord]\n",
                 glist_getcanvas(x), t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2,
                 (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2 : 1) *
                     x->gl_zoom,
                 oc);
+        }
     }
 }
 
@@ -1028,9 +1056,13 @@ void canvas_restore(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
     canvas_pop(x, x->gl_willvis);
 
     if(!(z = gensym("#X")->s_thing))
+    {
         pd_error(0, "canvas_restore: out of context");
+    }
     else if(*z != canvas_class)
+    {
         pd_error(0, "canvas_restore: wasn't a canvas");
+    }
     else
     {
         t_canvas *x2 = (t_canvas *) z;
@@ -1044,17 +1076,23 @@ static void canvas_loadbangabstractions(t_canvas *x)
     t_gobj *y;
     t_symbol *s = gensym("loadbang");
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class)
         {
             if(canvas_isabstraction((t_canvas *) y))
+            {
                 canvas_loadbang((t_canvas *) y);
+            }
             else
+            {
                 canvas_loadbangabstractions((t_canvas *) y);
+            }
         }
         else if((pd_class(&y->g_pd) == clone_class) && zgetfn(&y->g_pd, s))
         {
             pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_LOAD);
         }
+    }
 }
 
 void canvas_loadbangsubpatches(t_canvas *x)
@@ -1062,17 +1100,21 @@ void canvas_loadbangsubpatches(t_canvas *x)
     t_gobj *y;
     t_symbol *s = gensym("loadbang");
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class)
         {
             if(!canvas_isabstraction((t_canvas *) y))
                 canvas_loadbangsubpatches((t_canvas *) y);
         }
+    }
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if((pd_class(&y->g_pd) != canvas_class) &&
             (pd_class(&y->g_pd) != clone_class) && zgetfn(&y->g_pd, s))
         {
             pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_LOAD);
         }
+    }
 }
 
 void canvas_loadbang(t_canvas *x)
@@ -1093,13 +1135,17 @@ void canvas_initbang(t_canvas *x)
     t_symbol *s = gensym("loadbang");
     /* run "initbang" for all subpatches, but NOT for the child abstractions */
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class &&
             !canvas_isabstraction((t_canvas *) y))
             canvas_initbang((t_canvas *) y);
+    }
     /* call the initbang()-method for objects that have one */
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
             pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_INIT);
+    }
 }
 
 /* JMZ:
@@ -1116,8 +1162,10 @@ void canvas_closebang(t_canvas *x)
      * from g_graph:glist_delete()
      */
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if((pd_class(&y->g_pd) != canvas_class) && zgetfn(&y->g_pd, s))
             pd_vmess(&y->g_pd, s, "f", (t_floatarg) LB_CLOSE);
+    }
 }
 
 /* no longer used by 'pd-gui', but kept here for backwards compatibility.  The
@@ -1202,9 +1250,13 @@ static void *subcanvas_new(t_symbol *s)
                 if(outobj && pd_checkobject(&outobj->g_pd))
                 {
                     if(obj_issignaloutlet(pd_checkobject(&outobj->g_pd), outno))
+                    {
                         sob = gensym("inlet~");
+                    }
                     else
+                    {
                         sob = gensym("inlet");
+                    }
                 }
             }
         }
@@ -1247,7 +1299,9 @@ void canvas_fattensub(t_canvas *x, int *xp1, int *yp1, int *xp2, int *yp2)
 static void canvas_rename_method(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
     if(ac && av->a_type == A_SYMBOL)
+    {
         canvas_rename(x, av->a_w.w_symbol, 0);
+    }
     else if(ac && av->a_type == A_DOLLSYM)
     {
         t_canvasenvironment *e = canvas_getenv(x);
@@ -1332,14 +1386,18 @@ void canvas_dodsp(t_canvas *x, int toplevel, t_signal **sp)
     /* find all the "dsp" boxes and add them to the graph */
 
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if((ob = pd_checkobject(&y->g_pd)) && zgetfn(&y->g_pd, dspsym))
             ugen_add(dc, ob);
+    }
 
     /* ... and all dsp interconnections */
     linetraverser_start(&t, x);
     while((oc = linetraverser_next(&t)))
+    {
         if(obj_issignaloutlet(t.tr_ob, t.tr_outno))
             ugen_connect(dc, t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
+    }
 
     /* finally, sort them and add them to the DSP chain */
     ugen_done_graph(dc);
@@ -1354,9 +1412,13 @@ static void canvas_start_dsp(void)
 {
     t_canvas *x;
     if(THISGUI->i_dspstate)
+    {
         ugen_stop();
+    }
     else
+    {
         sys_gui("pdtk_pd_dsp ON\n");
+    }
     ugen_start();
 
     for(x = pd_getcanvaslist(); x; x = x->gl_next)
@@ -1868,6 +1930,7 @@ int canvas_path_iterate(
     if(!fun) return 0;
     /* iterate through canvas-local paths */
     for(y = x; y; y = y->gl_owner)
+    {
         if(y->gl_env)
         {
             const char *dir;
@@ -1876,7 +1939,9 @@ int canvas_path_iterate(
             {
                 char realname[MAXPDSTRING];
                 if(sys_isabsolutepath(nl->nl_string))
+                {
                     realname[0] = '\0';
+                }
                 else
                 { /* if not absolute path, append Pd lib dir */
                     strncpy(realname, dir, MAXPDSTRING);
@@ -1890,6 +1955,7 @@ int canvas_path_iterate(
                 count++;
             }
         }
+    }
     /* try canvas dir */
     if(!fun((x ? canvas_getdir(x)->s_name : "."), user_data)) return count + 1;
     count++;
@@ -1908,11 +1974,13 @@ int canvas_path_iterate(
     }
     /* and the default paths */
     if(sys_usestdpath)
+    {
         for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
         {
             if(!fun(nl->nl_string, user_data)) return count + 1;
             count++;
         }
+    }
 
     return count;
 }
@@ -2176,12 +2244,16 @@ void glob_open(t_pd *ignore, t_symbol *name, t_symbol *dir, t_floatarg f)
 {
     t_glist *gl;
     if(f != 0)
+    {
         for(gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
+        {
             if(name == gl->gl_name && gl->gl_env && gl->gl_env->ce_dir == dir)
             {
                 /* don't reopen already-open document, just vis it */
                 canvas_vis(gl, 1);
                 return;
             }
+        }
+    }
     if(!glob_evalfile(ignore, name, dir)) sys_vgui("::pdwindow::busyrelease\n");
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -746,9 +746,8 @@ void canvas_reflecttitle(t_canvas *x)
     }
     if(env->ce_argc)
     {
-        int i;
         strcpy(namebuf, " (");
-        for(i = 0; i < env->ce_argc; i++)
+        for(int i = 0; i < env->ce_argc; i++)
         {
             if(strlen(namebuf) > MAXPDSTRING / 2 - 5) break;
             if(i != 0) strcat(namebuf, " ");
@@ -1820,14 +1819,13 @@ static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
 
 void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     t_canvasenvironment *e = canvas_getenv(x);
 #if 0
     startpost("declare:: %s", s->s_name);
     postatom(argc, argv);
     endpost();
 #endif
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         const char *flag = atom_getsymbolarg(i, argc, argv)->s_name;
         const char *item =

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* this file defines the structure for "glists" and related structures and
 functions.  "Glists" and "canvases" and "graphs" used to be different
@@ -40,14 +40,15 @@ in future releases.  The public (stable) API is in m_pd.h. */
 #define G_CANVAS_H
 
 #if defined(_LANGUAGE_C_PLUS_PLUS) || defined(__cplusplus)
-extern "C" {
+extern "C"
+{
 #endif
 
 /* --------------------- geometry ---------------------------- */
-#define IOWIDTH 7       /* width of an inlet/outlet in pixels */
-#define IHEIGHT 3       /* height of an inlet in pixels */
-#define OHEIGHT 3       /* height of an outlet in pixels */
-#define IOMIDDLE ((IOWIDTH-1)/2)
+#define IOWIDTH 7 /* width of an inlet/outlet in pixels */
+#define IHEIGHT 3 /* height of an inlet in pixels */
+#define OHEIGHT 3 /* height of an outlet in pixels */
+#define IOMIDDLE ((IOWIDTH - 1) / 2)
 #define GLIST_DEFGRAPHWIDTH 200
 #define GLIST_DEFGRAPHHEIGHT 140
 
@@ -58,313 +59,317 @@ extern "C" {
 #define GLIST_DEFCANVASYLOC 50
 #endif
 
-/* ----------------------- data ------------------------------- */
+    /* ----------------------- data ------------------------------- */
 
-typedef struct _updateheader
-{
-    struct _updateheader *upd_next;
-    unsigned int upd_array:1;       /* true if array, false if glist */
-    unsigned int upd_queued:1;      /* true if we're queued */
-} t_updateheader;
+    typedef struct _updateheader
+    {
+        struct _updateheader *upd_next;
+        unsigned int upd_array : 1;  /* true if array, false if glist */
+        unsigned int upd_queued : 1; /* true if we're queued */
+    } t_updateheader;
 
     /* types to support glists grabbing mouse motion or keys from parent */
-typedef void (*t_glistmotionfn)(void *z, t_floatarg dx, t_floatarg dy,
-    t_floatarg up);
-typedef void (*t_glistkeyfn)(void *z, t_symbol *keysym, t_floatarg key);
+    typedef void (*t_glistmotionfn)(
+        void *z, t_floatarg dx, t_floatarg dy, t_floatarg up);
+    typedef void (*t_glistkeyfn)(void *z, t_symbol *keysym, t_floatarg key);
 
-EXTERN_STRUCT _rtext;
+    EXTERN_STRUCT _rtext;
 #define t_rtext struct _rtext
 
-EXTERN_STRUCT _gtemplate;
+    EXTERN_STRUCT _gtemplate;
 #define t_gtemplate struct _gtemplate
 
-EXTERN_STRUCT _guiconnect;
+    EXTERN_STRUCT _guiconnect;
 #define t_guiconnect struct _guiconnect
 
-EXTERN_STRUCT _tscalar;
+    EXTERN_STRUCT _tscalar;
 #define t_tscalar struct _tscalar
 
-EXTERN_STRUCT _canvasenvironment;
+    EXTERN_STRUCT _canvasenvironment;
 #define t_canvasenvironment struct _canvasenvironment
 
-EXTERN_STRUCT _fielddesc;
+    EXTERN_STRUCT _fielddesc;
 #define t_fielddesc struct _fielddesc
 
-typedef struct _selection
-{
-    t_gobj *sel_what;
-    struct _selection *sel_next;
-} t_selection;
+    typedef struct _selection
+    {
+        t_gobj *sel_what;
+        struct _selection *sel_next;
+    } t_selection;
 
     /* this structure is instantiated whenever a glist becomes visible. */
-typedef struct _editor
-{
-    t_updateheader e_upd;           /* update header structure */
-    t_selection *e_updlist;         /* list of objects to update */
-    t_rtext *e_rtext;               /* text responder linked list */
-    t_selection *e_selection;       /* head of the selection list */
-    t_rtext *e_textedfor;           /* the rtext if any that we are editing */
-    t_gobj *e_grab;                 /* object being "dragged" */
-    t_glistmotionfn e_motionfn;     /* ... motion callback */
-    t_glistkeyfn e_keyfn;           /* ... keypress callback */
-    t_binbuf *e_connectbuf;         /* connections to deleted objects */
-    t_binbuf *e_deleted;            /* last stuff we deleted */
-    t_guiconnect *e_guiconnect;     /* GUI connection for filtering messages */
-    struct _glist *e_glist;         /* glist which owns this */
-    int e_xwas;                     /* xpos on last mousedown or motion event */
-    int e_ywas;                     /* ypos, similarly */
-    int e_selectline_index1;        /* indices for the selected line if any */
-    int e_selectline_outno;         /* (only valid if e_selectedline is set) */
-    int e_selectline_index2;
-    int e_selectline_inno;
-    t_outconnect *e_selectline_tag;
-    unsigned int e_onmotion: 3;     /* action to take on motion */
-    unsigned int e_lastmoved: 1;    /* one if mouse has moved since click */
-    unsigned int e_textdirty: 1;    /* one if e_textedfor has changed */
-    unsigned int e_selectedline: 1; /* one if a line is selected */
-    t_clock *e_clock;               /* clock to filter GUI move messages */
-    int e_xnew;                     /* xpos for next move event */
-    int e_ynew;                     /* ypos, similarly */
-} t_editor;
+    typedef struct _editor
+    {
+        t_updateheader e_upd;       /* update header structure */
+        t_selection *e_updlist;     /* list of objects to update */
+        t_rtext *e_rtext;           /* text responder linked list */
+        t_selection *e_selection;   /* head of the selection list */
+        t_rtext *e_textedfor;       /* the rtext if any that we are editing */
+        t_gobj *e_grab;             /* object being "dragged" */
+        t_glistmotionfn e_motionfn; /* ... motion callback */
+        t_glistkeyfn e_keyfn;       /* ... keypress callback */
+        t_binbuf *e_connectbuf;     /* connections to deleted objects */
+        t_binbuf *e_deleted;        /* last stuff we deleted */
+        t_guiconnect *e_guiconnect; /* GUI connection for filtering messages */
+        struct _glist *e_glist;     /* glist which owns this */
+        int e_xwas;                 /* xpos on last mousedown or motion event */
+        int e_ywas;                 /* ypos, similarly */
+        int e_selectline_index1;    /* indices for the selected line if any */
+        int e_selectline_outno;     /* (only valid if e_selectedline is set) */
+        int e_selectline_index2;
+        int e_selectline_inno;
+        t_outconnect *e_selectline_tag;
+        unsigned int e_onmotion : 3;  /* action to take on motion */
+        unsigned int e_lastmoved : 1; /* one if mouse has moved since click */
+        unsigned int e_textdirty : 1; /* one if e_textedfor has changed */
+        unsigned int e_selectedline : 1; /* one if a line is selected */
+        t_clock *e_clock;                /* clock to filter GUI move messages */
+        int e_xnew;                      /* xpos for next move event */
+        int e_ynew;                      /* ypos, similarly */
+    } t_editor;
 
-#define MA_NONE    0    /* e_onmotion: do nothing on mouse motion */
-#define MA_MOVE    1    /* drag the selection around */
-#define MA_CONNECT 2    /* make a connection */
-#define MA_REGION  3    /* selection region */
-#define MA_PASSOUT 4    /* send on to e_grab */
-#define MA_DRAGTEXT 5   /* drag in text editor to alter selection */
-#define MA_RESIZE  6    /* drag to resize */
+#define MA_NONE 0     /* e_onmotion: do nothing on mouse motion */
+#define MA_MOVE 1     /* drag the selection around */
+#define MA_CONNECT 2  /* make a connection */
+#define MA_REGION 3   /* selection region */
+#define MA_PASSOUT 4  /* send on to e_grab */
+#define MA_DRAGTEXT 5 /* drag in text editor to alter selection */
+#define MA_RESIZE 6   /* drag to resize */
 
-/* editor structure for "garrays".  We don't bother to delete and regenerate
-this structure when the "garray" becomes invisible or visible, although we
-could do so if the structure gets big (like the "editor" above.) */
+    /* editor structure for "garrays".  We don't bother to delete and regenerate
+    this structure when the "garray" becomes invisible or visible, although we
+    could do so if the structure gets big (like the "editor" above.) */
 
-typedef struct _arrayvis
-{
-    t_updateheader av_upd;          /* update header structure */
-    t_garray *av_garray;            /* owning structure */
-} t_arrayvis;
+    typedef struct _arrayvis
+    {
+        t_updateheader av_upd; /* update header structure */
+        t_garray *av_garray;   /* owning structure */
+    } t_arrayvis;
 
-/* the t_tick structure describes where to draw x and y "ticks" for a glist */
+    /* the t_tick structure describes where to draw x and y "ticks" for a glist
+     */
 
-typedef struct _tick    /* where to put ticks on x or y axes */
-{
-    t_float k_point;      /* one point to draw a big tick at */
-    t_float k_inc;        /* x or y increment per little tick */
-    int k_lperb;        /* little ticks per big; 0 if no ticks to draw */
-} t_tick;
+    typedef struct _tick /* where to put ticks on x or y axes */
+    {
+        t_float k_point; /* one point to draw a big tick at */
+        t_float k_inc;   /* x or y increment per little tick */
+        int k_lperb;     /* little ticks per big; 0 if no ticks to draw */
+    } t_tick;
 
-/* the t_glist structure, which describes a list of elements that live on an
-area of a window.
+    /* the t_glist structure, which describes a list of elements that live on an
+    area of a window.
 
-*/
+    */
 
-struct _glist
-{
-    t_object gl_obj;            /* header in case we're a glist */
-    t_gobj *gl_list;            /* the actual data */
-    struct _gstub *gl_stub;     /* safe pointer handler */
-    int gl_valid;               /* incremented when pointers might be stale */
-    struct _glist *gl_owner;    /* parent glist, supercanvas, or 0 if none */
-    int gl_pixwidth;            /* width in pixels (on parent, if a graph) */
-    int gl_pixheight;
-    t_float gl_x1;                /* bounding rectangle in our own coordinates */
-    t_float gl_y1;
-    t_float gl_x2;
-    t_float gl_y2;
-    int gl_screenx1;            /* screen coordinates when toplevel */
-    int gl_screeny1;
-    int gl_screenx2;
-    int gl_screeny2;
-    int gl_xmargin;                /* origin for GOP rectangle */
-    int gl_ymargin;
-    t_tick gl_xtick;            /* ticks marking X values */
-    int gl_nxlabels;            /* number of X coordinate labels */
-    t_symbol **gl_xlabel;           /* ... an array to hold them */
-    t_float gl_xlabely;               /* ... and their Y coordinates */
-    t_tick gl_ytick;            /* same as above for Y ticks and labels */
-    int gl_nylabels;
-    t_symbol **gl_ylabel;
-    t_float gl_ylabelx;
-    t_editor *gl_editor;        /* editor structure when visible */
-    t_symbol *gl_name;          /* symbol bound here */
-    int gl_font;                /* nominal font size in points, e.g., 10 */
-    struct _glist *gl_next;         /* link in list of toplevels */
-    t_canvasenvironment *gl_env;    /* root canvases and abstractions only */
-    unsigned int gl_havewindow:1;   /* true if we own a window */
-    unsigned int gl_mapped:1;       /* true if, moreover, it's "mapped" */
-    unsigned int gl_dirty:1;        /* (root canvas only:) patch has changed */
-    unsigned int gl_loading:1;      /* am now loading from file */
-    unsigned int gl_willvis:1;      /* make me visible after loading */
-    unsigned int gl_edit:1;         /* edit mode */
-    unsigned int gl_isdeleting:1;   /* we're inside glist_delete -- hack! */
-    unsigned int gl_goprect:1;      /* draw rectangle for graph-on-parent */
-    unsigned int gl_isgraph:1;      /* show as graph on parent */
-    unsigned int gl_hidetext:1;     /* hide object-name + args when doing graph on parent */
-    unsigned int gl_private:1;      /* private flag used in x_scalar.c */
-    unsigned int gl_isclone:1;      /* exists as part of a clone object */
-    int gl_zoom;                    /* zoom factor (integer zoom-in only) */
-    void *gl_privatedata;           /* private data */
-};
+    struct _glist
+    {
+        t_object gl_obj;         /* header in case we're a glist */
+        t_gobj *gl_list;         /* the actual data */
+        struct _gstub *gl_stub;  /* safe pointer handler */
+        int gl_valid;            /* incremented when pointers might be stale */
+        struct _glist *gl_owner; /* parent glist, supercanvas, or 0 if none */
+        int gl_pixwidth;         /* width in pixels (on parent, if a graph) */
+        int gl_pixheight;
+        t_float gl_x1; /* bounding rectangle in our own coordinates */
+        t_float gl_y1;
+        t_float gl_x2;
+        t_float gl_y2;
+        int gl_screenx1; /* screen coordinates when toplevel */
+        int gl_screeny1;
+        int gl_screenx2;
+        int gl_screeny2;
+        int gl_xmargin; /* origin for GOP rectangle */
+        int gl_ymargin;
+        t_tick gl_xtick;      /* ticks marking X values */
+        int gl_nxlabels;      /* number of X coordinate labels */
+        t_symbol **gl_xlabel; /* ... an array to hold them */
+        t_float gl_xlabely;   /* ... and their Y coordinates */
+        t_tick gl_ytick;      /* same as above for Y ticks and labels */
+        int gl_nylabels;
+        t_symbol **gl_ylabel;
+        t_float gl_ylabelx;
+        t_editor *gl_editor;         /* editor structure when visible */
+        t_symbol *gl_name;           /* symbol bound here */
+        int gl_font;                 /* nominal font size in points, e.g., 10 */
+        struct _glist *gl_next;      /* link in list of toplevels */
+        t_canvasenvironment *gl_env; /* root canvases and abstractions only */
+        unsigned int gl_havewindow : 1; /* true if we own a window */
+        unsigned int gl_mapped : 1;     /* true if, moreover, it's "mapped" */
+        unsigned int gl_dirty : 1;   /* (root canvas only:) patch has changed */
+        unsigned int gl_loading : 1; /* am now loading from file */
+        unsigned int gl_willvis : 1; /* make me visible after loading */
+        unsigned int gl_edit : 1;    /* edit mode */
+        unsigned int gl_isdeleting : 1; /* we're inside glist_delete -- hack! */
+        unsigned int gl_goprect : 1;    /* draw rectangle for graph-on-parent */
+        unsigned int gl_isgraph : 1;    /* show as graph on parent */
+        unsigned int gl_hidetext : 1;   /* hide object-name + args when doing
+                                           graph on parent */
+        unsigned int gl_private : 1;    /* private flag used in x_scalar.c */
+        unsigned int gl_isclone : 1;    /* exists as part of a clone object */
+        int gl_zoom;                    /* zoom factor (integer zoom-in only) */
+        void *gl_privatedata;           /* private data */
+    };
 
 #define gl_gobj gl_obj.te_g
 #define gl_pd gl_gobj.g_pd
 
-/* a data structure to describe a field in a pure datum */
+    /* a data structure to describe a field in a pure datum */
 
 #define DT_FLOAT 0
 #define DT_SYMBOL 1
 #define DT_TEXT 2
 #define DT_ARRAY 3
 
-typedef struct _dataslot
-{
-    int ds_type;
-    t_symbol *ds_name;
-    t_symbol *ds_arraytemplate;     /* filled in for arrays only */
-} t_dataslot;
+    typedef struct _dataslot
+    {
+        int ds_type;
+        t_symbol *ds_name;
+        t_symbol *ds_arraytemplate; /* filled in for arrays only */
+    } t_dataslot;
 
-typedef struct _template
-{
-    t_pd t_pdobj;               /* header */
-    struct _gtemplate *t_list;  /* list of "struct"/gtemplate objects */
-    t_symbol *t_sym;            /* name */
-    int t_n;                    /* number of dataslots (fields) */
-    t_dataslot *t_vec;          /* array of dataslots */
-    struct _template *t_next;
-} t_template;
+    typedef struct _template
+    {
+        t_pd t_pdobj;              /* header */
+        struct _gtemplate *t_list; /* list of "struct"/gtemplate objects */
+        t_symbol *t_sym;           /* name */
+        int t_n;                   /* number of dataslots (fields) */
+        t_dataslot *t_vec;         /* array of dataslots */
+        struct _template *t_next;
+    } t_template;
 
-struct _array
-{
-    int a_n;            /* number of elements */
-    int a_elemsize;     /* size in bytes; LATER get this from template */
-    char *a_vec;        /* array of elements */
-    t_symbol *a_templatesym;    /* template for elements */
-    int a_valid;        /* protection against stale pointers into array */
-    t_gpointer a_gp;    /* pointer to scalar or array element we're in */
-    t_gstub *a_stub;    /* stub for pointing into this array */
-};
+    struct _array
+    {
+        int a_n;        /* number of elements */
+        int a_elemsize; /* size in bytes; LATER get this from template */
+        char *a_vec;    /* array of elements */
+        t_symbol *a_templatesym; /* template for elements */
+        int a_valid;     /* protection against stale pointers into array */
+        t_gpointer a_gp; /* pointer to scalar or array element we're in */
+        t_gstub *a_stub; /* stub for pointing into this array */
+    };
 
     /* structure for traversing all the connections in a glist */
-typedef struct _linetraverser
-{
-    t_canvas *tr_x;
-    t_object *tr_ob;
-    int tr_nout;
-    int tr_outno;
-    t_object *tr_ob2;
-    t_outlet *tr_outlet;
-    t_inlet *tr_inlet;
-    int tr_nin;
-    int tr_inno;
-    int tr_x11, tr_y11, tr_x12, tr_y12;
-    int tr_x21, tr_y21, tr_x22, tr_y22;
-    int tr_lx1, tr_ly1, tr_lx2, tr_ly2;
-    t_outconnect *tr_nextoc;
-    int tr_nextoutno;
-} t_linetraverser;
+    typedef struct _linetraverser
+    {
+        t_canvas *tr_x;
+        t_object *tr_ob;
+        int tr_nout;
+        int tr_outno;
+        t_object *tr_ob2;
+        t_outlet *tr_outlet;
+        t_inlet *tr_inlet;
+        int tr_nin;
+        int tr_inno;
+        int tr_x11, tr_y11, tr_x12, tr_y12;
+        int tr_x21, tr_y21, tr_x22, tr_y22;
+        int tr_lx1, tr_ly1, tr_lx2, tr_ly2;
+        t_outconnect *tr_nextoc;
+        int tr_nextoutno;
+    } t_linetraverser;
 
-struct _instancecanvas
-{
-    struct _instanceeditor *i_editor;
-    struct _instancetemplate *i_template;
-    t_symbol *i_newfilename;
-    t_symbol *i_newdirectory;
-    int i_newargc;
-    t_atom *i_newargv;
-    t_glist *i_reloadingabstraction;
-    int i_dspstate;
-    int i_dollarzero;
-    t_float i_graph_lastxpix, i_graph_lastypix;
-};
+    struct _instancecanvas
+    {
+        struct _instanceeditor *i_editor;
+        struct _instancetemplate *i_template;
+        t_symbol *i_newfilename;
+        t_symbol *i_newdirectory;
+        int i_newargc;
+        t_atom *i_newargv;
+        t_glist *i_reloadingabstraction;
+        int i_dspstate;
+        int i_dollarzero;
+        t_float i_graph_lastxpix, i_graph_lastypix;
+    };
 
-void g_editor_newpdinstance(void);
-void g_template_newpdinstance(void);
-void g_editor_freepdinstance(void);
-void g_template_freepdinstance(void);
+    void g_editor_newpdinstance(void);
+    void g_template_newpdinstance(void);
+    void g_editor_freepdinstance(void);
+    void g_template_freepdinstance(void);
 
 #define THISGUI (pd_this->pd_gui)
 #define EDITOR (pd_this->pd_gui->i_editor)
 #define TEMPLATE (pd_this->pd_gui->i_template)
 
-/* function types used to define graphical behavior for gobjs, a bit like X
-widgets.  We don't use Pd methods because Pd's typechecking can't specify the
-types of pointer arguments.  Also it's more convenient this way, since
-every "patchable" object can just get the "text" behaviors. */
+    /* function types used to define graphical behavior for gobjs, a bit like X
+    widgets.  We don't use Pd methods because Pd's typechecking can't specify
+    the types of pointer arguments.  Also it's more convenient this way, since
+    every "patchable" object can just get the "text" behaviors. */
 
-        /* Call this to get a gobj's bounding rectangle in pixels */
-typedef void (*t_getrectfn)(t_gobj *x, struct _glist *glist,
-    int *x1, int *y1, int *x2, int *y2);
-        /* and this to displace a gobj: */
-typedef void (*t_displacefn)(t_gobj *x, struct _glist *glist, int dx, int dy);
-        /* change color to show selection: */
-typedef void (*t_selectfn)(t_gobj *x, struct _glist *glist, int state);
-        /* change appearance to show activation/deactivation: */
-typedef void (*t_activatefn)(t_gobj *x, struct _glist *glist, int state);
-        /* warn a gobj it's about to be deleted */
-typedef void (*t_deletefn)(t_gobj *x, struct _glist *glist);
-        /*  making visible or invisible */
-typedef void (*t_visfn)(t_gobj *x, struct _glist *glist, int flag);
-        /* field a mouse click (when not in "edit" mode) */
-typedef int (*t_clickfn)(t_gobj *x, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit);
-        /* ... and later, resizing; getting/setting font or color... */
+    /* Call this to get a gobj's bounding rectangle in pixels */
+    typedef void (*t_getrectfn)(
+        t_gobj *x, struct _glist *glist, int *x1, int *y1, int *x2, int *y2);
+    /* and this to displace a gobj: */
+    typedef void (*t_displacefn)(
+        t_gobj *x, struct _glist *glist, int dx, int dy);
+    /* change color to show selection: */
+    typedef void (*t_selectfn)(t_gobj *x, struct _glist *glist, int state);
+    /* change appearance to show activation/deactivation: */
+    typedef void (*t_activatefn)(t_gobj *x, struct _glist *glist, int state);
+    /* warn a gobj it's about to be deleted */
+    typedef void (*t_deletefn)(t_gobj *x, struct _glist *glist);
+    /*  making visible or invisible */
+    typedef void (*t_visfn)(t_gobj *x, struct _glist *glist, int flag);
+    /* field a mouse click (when not in "edit" mode) */
+    typedef int (*t_clickfn)(t_gobj *x, struct _glist *glist, int xpix,
+        int ypix, int shift, int alt, int dbl, int doit);
 
-struct _widgetbehavior
-{
-    t_getrectfn w_getrectfn;
-    t_displacefn w_displacefn;
-    t_selectfn w_selectfn;
-    t_activatefn w_activatefn;
-    t_deletefn w_deletefn;
-    t_visfn w_visfn;
-    t_clickfn w_clickfn;
-};
+    /* ... and later, resizing; getting/setting font or color... */
 
-/* -------- behaviors for scalars defined by objects in template --------- */
-/* these are set by "drawing commands" in g_template.c which add appearance to
-scalars, which live in some other window.  If the scalar is just included
-in a canvas the "parent" is a misnomer.  There is also a text scalar object
-which really does draw the scalar on the parent window; see g_scalar.c. */
+    struct _widgetbehavior
+    {
+        t_getrectfn w_getrectfn;
+        t_displacefn w_displacefn;
+        t_selectfn w_selectfn;
+        t_activatefn w_activatefn;
+        t_deletefn w_deletefn;
+        t_visfn w_visfn;
+        t_clickfn w_clickfn;
+    };
 
-/* note how the click function wants the whole scalar, not the "data", so
-doesn't work on array elements... LATER reconsider this */
+    /* -------- behaviors for scalars defined by objects in template ---------
+     */
+    /* these are set by "drawing commands" in g_template.c which add appearance
+    to scalars, which live in some other window.  If the scalar is just included
+    in a canvas the "parent" is a misnomer.  There is also a text scalar object
+    which really does draw the scalar on the parent window; see g_scalar.c. */
 
-        /* bounding rectangle: */
-typedef void (*t_parentgetrectfn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_float basex, t_float basey,
-    int *x1, int *y1, int *x2, int *y2);
-        /* displace it */
-typedef void (*t_parentdisplacefn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_float basex, t_float basey,
-    int dx, int dy);
-        /* change color to show selection */
-typedef void (*t_parentselectfn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_float basex, t_float basey,
-    int state);
-        /* change appearance to show activation/deactivation: */
-typedef void (*t_parentactivatefn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_float basex, t_float basey,
-    int state);
-        /*  making visible or invisible */
-typedef void (*t_parentvisfn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_float basex, t_float basey,
-    int flag);
-        /*  field a mouse click */
-typedef int (*t_parentclickfn)(t_gobj *x, struct _glist *glist,
-    t_word *data, t_template *tmpl, t_scalar *sc, t_array *ap,
-    t_float basex, t_float basey,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit);
+    /* note how the click function wants the whole scalar, not the "data", so
+    doesn't work on array elements... LATER reconsider this */
 
-struct _parentwidgetbehavior
-{
-    t_parentgetrectfn w_parentgetrectfn;
-    t_parentdisplacefn w_parentdisplacefn;
-    t_parentselectfn w_parentselectfn;
-    t_parentactivatefn w_parentactivatefn;
-    t_parentvisfn w_parentvisfn;
-    t_parentclickfn w_parentclickfn;
-};
+    /* bounding rectangle: */
+    typedef void (*t_parentgetrectfn)(t_gobj *x, struct _glist *glist,
+        t_word *data, t_template *tmpl, t_float basex, t_float basey, int *x1,
+        int *y1, int *x2, int *y2);
+    /* displace it */
+    typedef void (*t_parentdisplacefn)(t_gobj *x, struct _glist *glist,
+        t_word *data, t_template *tmpl, t_float basex, t_float basey, int dx,
+        int dy);
+    /* change color to show selection */
+    typedef void (*t_parentselectfn)(t_gobj *x, struct _glist *glist,
+        t_word *data, t_template *tmpl, t_float basex, t_float basey,
+        int state);
+    /* change appearance to show activation/deactivation: */
+    typedef void (*t_parentactivatefn)(t_gobj *x, struct _glist *glist,
+        t_word *data, t_template *tmpl, t_float basex, t_float basey,
+        int state);
+    /*  making visible or invisible */
+    typedef void (*t_parentvisfn)(t_gobj *x, struct _glist *glist, t_word *data,
+        t_template *tmpl, t_float basex, t_float basey, int flag);
+    /*  field a mouse click */
+    typedef int (*t_parentclickfn)(t_gobj *x, struct _glist *glist,
+        t_word *data, t_template *tmpl, t_scalar *sc, t_array *ap,
+        t_float basex, t_float basey, int xpix, int ypix, int shift, int alt,
+        int dbl, int doit);
+
+    struct _parentwidgetbehavior
+    {
+        t_parentgetrectfn w_parentgetrectfn;
+        t_parentdisplacefn w_parentdisplacefn;
+        t_parentselectfn w_parentselectfn;
+        t_parentactivatefn w_parentactivatefn;
+        t_parentvisfn w_parentvisfn;
+        t_parentclickfn w_parentclickfn;
+    };
 
     /* cursor definitions; used as return value for t_parentclickfn */
 #define CURSOR_RUNMODE_NOTHING 0
@@ -375,88 +380,91 @@ struct _parentwidgetbehavior
 #define CURSOR_EDITMODE_CONNECT 5
 #define CURSOR_EDITMODE_DISCONNECT 6
 #define CURSOR_EDITMODE_RESIZE 7
-EXTERN void canvas_setcursor(t_glist *x, unsigned int cursornum);
+    EXTERN void canvas_setcursor(t_glist *x, unsigned int cursornum);
 
-extern t_canvas *canvas_whichfind;  /* last canvas we did a find in */
-extern t_class *vinlet_class, *voutlet_class;
-extern int glist_valid;         /* incremented when pointers might be stale */
+    extern t_canvas *canvas_whichfind; /* last canvas we did a find in */
+    extern t_class *vinlet_class, *voutlet_class;
+    extern int glist_valid; /* incremented when pointers might be stale */
 
-#define PLOTSTYLE_POINTS 0     /* plotting styles for arrays */
+#define PLOTSTYLE_POINTS 0 /* plotting styles for arrays */
 #define PLOTSTYLE_POLY 1
 #define PLOTSTYLE_BEZ 2
 
-/* ------------------- functions on any gobj ----------------------------- */
-EXTERN void gobj_getrect(t_gobj *x, t_glist *owner, int *x1, int *y1,
-    int *x2, int *y2);
-EXTERN void gobj_displace(t_gobj *x, t_glist *owner, int dx, int dy);
-EXTERN void gobj_select(t_gobj *x, t_glist *owner, int state);
-EXTERN void gobj_activate(t_gobj *x, t_glist *owner, int state);
-EXTERN void gobj_delete(t_gobj *x, t_glist *owner);
-EXTERN void gobj_vis(t_gobj *x, t_glist *glist, int flag);
-EXTERN int gobj_click(t_gobj *x, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit);
-EXTERN void gobj_save(t_gobj *x, t_binbuf *b);
-EXTERN int gobj_shouldvis(t_gobj *x, struct _glist *glist);
+    /* ------------------- functions on any gobj -----------------------------
+     */
+    EXTERN void gobj_getrect(
+        t_gobj *x, t_glist *owner, int *x1, int *y1, int *x2, int *y2);
+    EXTERN void gobj_displace(t_gobj *x, t_glist *owner, int dx, int dy);
+    EXTERN void gobj_select(t_gobj *x, t_glist *owner, int state);
+    EXTERN void gobj_activate(t_gobj *x, t_glist *owner, int state);
+    EXTERN void gobj_delete(t_gobj *x, t_glist *owner);
+    EXTERN void gobj_vis(t_gobj *x, t_glist *glist, int flag);
+    EXTERN int gobj_click(t_gobj *x, struct _glist *glist, int xpix, int ypix,
+        int shift, int alt, int dbl, int doit);
+    EXTERN void gobj_save(t_gobj *x, t_binbuf *b);
+    EXTERN int gobj_shouldvis(t_gobj *x, struct _glist *glist);
 
-/* -------------------- functions on glists --------------------- */
-EXTERN void glist_init(t_glist *x);
-EXTERN void glist_add(t_glist *x, t_gobj *g);
+    /* -------------------- functions on glists --------------------- */
+    EXTERN void glist_init(t_glist *x);
+    EXTERN void glist_add(t_glist *x, t_gobj *g);
 
-EXTERN void glist_clear(t_glist *x);
-EXTERN t_canvas *glist_getcanvas(t_glist *x);
-EXTERN int glist_isselected(t_glist *x, t_gobj *y);
-EXTERN void glist_select(t_glist *x, t_gobj *y);
-EXTERN void glist_deselect(t_glist *x, t_gobj *y);
-EXTERN void glist_noselect(t_glist *x);
-EXTERN void glist_selectall(t_glist *x);
-EXTERN void glist_delete(t_glist *x, t_gobj *y);
-EXTERN void glist_retext(t_glist *x, t_text *y);
-EXTERN void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
-    t_glistkeyfn keyfn, int xpos, int ypos);
-EXTERN int glist_isvisible(t_glist *x);
-EXTERN int glist_istoplevel(t_glist *x);
-EXTERN t_glist *glist_findgraph(t_glist *x);
-EXTERN int glist_getfont(t_glist *x);
-EXTERN int glist_fontwidth(t_glist *x);
-EXTERN int glist_fontheight(t_glist *x);
-EXTERN int glist_getzoom(t_glist *x);
-EXTERN void glist_sort(t_glist *canvas);
-EXTERN void glist_read(t_glist *x, t_symbol *filename, t_symbol *format);
-EXTERN void glist_mergefile(t_glist *x, t_symbol *filename, t_symbol *format);
+    EXTERN void glist_clear(t_glist *x);
+    EXTERN t_canvas *glist_getcanvas(t_glist *x);
+    EXTERN int glist_isselected(t_glist *x, t_gobj *y);
+    EXTERN void glist_select(t_glist *x, t_gobj *y);
+    EXTERN void glist_deselect(t_glist *x, t_gobj *y);
+    EXTERN void glist_noselect(t_glist *x);
+    EXTERN void glist_selectall(t_glist *x);
+    EXTERN void glist_delete(t_glist *x, t_gobj *y);
+    EXTERN void glist_retext(t_glist *x, t_text *y);
+    EXTERN void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
+        t_glistkeyfn keyfn, int xpos, int ypos);
+    EXTERN int glist_isvisible(t_glist *x);
+    EXTERN int glist_istoplevel(t_glist *x);
+    EXTERN t_glist *glist_findgraph(t_glist *x);
+    EXTERN int glist_getfont(t_glist *x);
+    EXTERN int glist_fontwidth(t_glist *x);
+    EXTERN int glist_fontheight(t_glist *x);
+    EXTERN int glist_getzoom(t_glist *x);
+    EXTERN void glist_sort(t_glist *canvas);
+    EXTERN void glist_read(t_glist *x, t_symbol *filename, t_symbol *format);
+    EXTERN void glist_mergefile(
+        t_glist *x, t_symbol *filename, t_symbol *format);
 
-EXTERN t_float glist_pixelstox(t_glist *x, t_float xpix);
-EXTERN t_float glist_pixelstoy(t_glist *x, t_float ypix);
-EXTERN t_float glist_xtopixels(t_glist *x, t_float xval);
-EXTERN t_float glist_ytopixels(t_glist *x, t_float yval);
-EXTERN t_float glist_dpixtodx(t_glist *x, t_float dxpix);
-EXTERN t_float glist_dpixtody(t_glist *x, t_float dypix);
+    EXTERN t_float glist_pixelstox(t_glist *x, t_float xpix);
+    EXTERN t_float glist_pixelstoy(t_glist *x, t_float ypix);
+    EXTERN t_float glist_xtopixels(t_glist *x, t_float xval);
+    EXTERN t_float glist_ytopixels(t_glist *x, t_float yval);
+    EXTERN t_float glist_dpixtodx(t_glist *x, t_float dxpix);
+    EXTERN t_float glist_dpixtody(t_glist *x, t_float dypix);
 
-EXTERN void glist_getnextxy(t_glist *gl, int *xval, int *yval);
-EXTERN void glist_glist(t_glist *g, t_symbol *s, int argc, t_atom *argv);
-EXTERN t_glist *glist_addglist(t_glist *g, t_symbol *sym,
-    t_float x1, t_float y1, t_float x2, t_float y2,
-    t_float px1, t_float py1, t_float px2, t_float py2);
-EXTERN void glist_arraydialog(t_glist *parent, t_symbol *name,
-    t_floatarg size, t_floatarg saveit, t_floatarg newgraph);
-EXTERN t_binbuf *glist_writetobinbuf(t_glist *x, int wholething);
-EXTERN int glist_isgraph(t_glist *x);
-EXTERN void glist_redraw(t_glist *x);
-EXTERN void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
-    const char *tag, int x1, int y1, int x2, int y2);
-EXTERN void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag);
-EXTERN void canvas_create_editor(t_glist *x);
-EXTERN void canvas_destroy_editor(t_glist *x);
-void canvas_deletelinesforio(t_canvas *x, t_text *text,
-    t_inlet *inp, t_outlet *outp);
+    EXTERN void glist_getnextxy(t_glist *gl, int *xval, int *yval);
+    EXTERN void glist_glist(t_glist *g, t_symbol *s, int argc, t_atom *argv);
+    EXTERN t_glist *glist_addglist(t_glist *g, t_symbol *sym, t_float x1,
+        t_float y1, t_float x2, t_float y2, t_float px1, t_float py1,
+        t_float px2, t_float py2);
+    EXTERN void glist_arraydialog(t_glist *parent, t_symbol *name,
+        t_floatarg size, t_floatarg saveit, t_floatarg newgraph);
+    EXTERN t_binbuf *glist_writetobinbuf(t_glist *x, int wholething);
+    EXTERN int glist_isgraph(t_glist *x);
+    EXTERN void glist_redraw(t_glist *x);
+    EXTERN void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
+        const char *tag, int x1, int y1, int x2, int y2);
+    EXTERN void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag);
+    EXTERN void canvas_create_editor(t_glist *x);
+    EXTERN void canvas_destroy_editor(t_glist *x);
+    void canvas_deletelinesforio(
+        t_canvas *x, t_text *text, t_inlet *inp, t_outlet *outp);
 
-/* -------------------- functions on texts ------------------------- */
-EXTERN void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize);
-EXTERN void text_drawborder(t_text *x, t_glist *glist, const char *tag,
-    int width, int height, int firsttime);
-EXTERN void text_eraseborder(t_text *x, t_glist *glist, const char *tag);
-EXTERN int text_xpix(t_text *x, t_glist *glist);
-EXTERN int text_ypix(t_text *x, t_glist *glist);
-extern const t_widgetbehavior text_widgetbehavior;
+    /* -------------------- functions on texts ------------------------- */
+    EXTERN void text_setto(
+        t_text *x, t_glist *glist, const char *buf, int bufsize);
+    EXTERN void text_drawborder(t_text *x, t_glist *glist, const char *tag,
+        int width, int height, int firsttime);
+    EXTERN void text_eraseborder(t_text *x, t_glist *glist, const char *tag);
+    EXTERN int text_xpix(t_text *x, t_glist *glist);
+    EXTERN int text_ypix(t_text *x, t_glist *glist);
+    extern const t_widgetbehavior text_widgetbehavior;
 
 /* -------------------- functions on rtexts ------------------------- */
 #define RTEXT_DOWN 1
@@ -464,192 +472,190 @@ extern const t_widgetbehavior text_widgetbehavior;
 #define RTEXT_DBL 3
 #define RTEXT_SHIFT 4
 
-EXTERN t_rtext *rtext_new(t_glist *glist, t_text *who);
-EXTERN t_rtext *glist_findrtext(t_glist *gl, t_text *who);
-EXTERN void rtext_draw(t_rtext *x);
-EXTERN void rtext_erase(t_rtext *x);
-EXTERN int rtext_height(t_rtext *x);
-EXTERN void rtext_displace(t_rtext *x, int dx, int dy);
-EXTERN void rtext_select(t_rtext *x, int state);
-EXTERN void rtext_activate(t_rtext *x, int state);
-EXTERN void rtext_free(t_rtext *x);
-EXTERN void rtext_key(t_rtext *x, int n, t_symbol *s);
-EXTERN void rtext_mouse(t_rtext *x, int xval, int yval, int flag);
-EXTERN void rtext_retext(t_rtext *x);
-EXTERN int rtext_width(t_rtext *x);
-EXTERN const char *rtext_gettag(t_rtext *x);
-EXTERN void rtext_gettext(t_rtext *x, char **buf, int *bufsize);
-EXTERN void rtext_getseltext(t_rtext *x, char **buf, int *bufsize);
-EXTERN t_text *rtext_getowner(t_rtext *x);
+    EXTERN t_rtext *rtext_new(t_glist *glist, t_text *who);
+    EXTERN t_rtext *glist_findrtext(t_glist *gl, t_text *who);
+    EXTERN void rtext_draw(t_rtext *x);
+    EXTERN void rtext_erase(t_rtext *x);
+    EXTERN int rtext_height(t_rtext *x);
+    EXTERN void rtext_displace(t_rtext *x, int dx, int dy);
+    EXTERN void rtext_select(t_rtext *x, int state);
+    EXTERN void rtext_activate(t_rtext *x, int state);
+    EXTERN void rtext_free(t_rtext *x);
+    EXTERN void rtext_key(t_rtext *x, int n, t_symbol *s);
+    EXTERN void rtext_mouse(t_rtext *x, int xval, int yval, int flag);
+    EXTERN void rtext_retext(t_rtext *x);
+    EXTERN int rtext_width(t_rtext *x);
+    EXTERN const char *rtext_gettag(t_rtext *x);
+    EXTERN void rtext_gettext(t_rtext *x, char **buf, int *bufsize);
+    EXTERN void rtext_getseltext(t_rtext *x, char **buf, int *bufsize);
+    EXTERN t_text *rtext_getowner(t_rtext *x);
 
-/* -------------------- functions on canvases ------------------------ */
-EXTERN t_class *canvas_class;
+    /* -------------------- functions on canvases ------------------------ */
+    EXTERN t_class *canvas_class;
 
-EXTERN t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv);
-EXTERN t_symbol *canvas_makebindsym(t_symbol *s);
-EXTERN void canvas_fixlinesfor(t_canvas *x, t_text *text);
-EXTERN void canvas_deletelinesfor(t_canvas *x, t_text *text);
-EXTERN void canvas_stowconnections(t_canvas *x);
-EXTERN void canvas_restoreconnections(t_canvas *x);
-EXTERN void canvas_redraw(t_canvas *x);
-EXTERN void canvas_closebang(t_canvas *x);
-EXTERN void canvas_initbang(t_canvas *x);
+    EXTERN t_canvas *canvas_new(
+        void *dummy, t_symbol *sel, int argc, t_atom *argv);
+    EXTERN t_symbol *canvas_makebindsym(t_symbol *s);
+    EXTERN void canvas_fixlinesfor(t_canvas *x, t_text *text);
+    EXTERN void canvas_deletelinesfor(t_canvas *x, t_text *text);
+    EXTERN void canvas_stowconnections(t_canvas *x);
+    EXTERN void canvas_restoreconnections(t_canvas *x);
+    EXTERN void canvas_redraw(t_canvas *x);
+    EXTERN void canvas_closebang(t_canvas *x);
+    EXTERN void canvas_initbang(t_canvas *x);
 
-EXTERN t_inlet *canvas_addinlet(t_canvas *x, t_pd *who, t_symbol *sym);
-EXTERN void canvas_rminlet(t_canvas *x, t_inlet *ip);
-EXTERN t_outlet *canvas_addoutlet(t_canvas *x, t_pd *who, t_symbol *sym);
-EXTERN void canvas_rmoutlet(t_canvas *x, t_outlet *op);
-EXTERN void canvas_redrawallfortemplate(t_template *tmpl, int action);
-EXTERN void canvas_redrawallfortemplatecanvas(t_canvas *x, int action);
-EXTERN void canvas_setcurrent(t_canvas *x);
-EXTERN void canvas_unsetcurrent(t_canvas *x);
-EXTERN t_symbol *canvas_realizedollar(t_canvas *x, t_symbol *s);
-EXTERN t_canvas *canvas_getrootfor(t_canvas *x);
-EXTERN void canvas_dirty(t_canvas *x, t_floatarg n);
-typedef int (*t_canvasapply)(t_canvas *x, t_int x1, t_int x2, t_int x3);
+    EXTERN t_inlet *canvas_addinlet(t_canvas *x, t_pd *who, t_symbol *sym);
+    EXTERN void canvas_rminlet(t_canvas *x, t_inlet *ip);
+    EXTERN t_outlet *canvas_addoutlet(t_canvas *x, t_pd *who, t_symbol *sym);
+    EXTERN void canvas_rmoutlet(t_canvas *x, t_outlet *op);
+    EXTERN void canvas_redrawallfortemplate(t_template *tmpl, int action);
+    EXTERN void canvas_redrawallfortemplatecanvas(t_canvas *x, int action);
+    EXTERN void canvas_setcurrent(t_canvas *x);
+    EXTERN void canvas_unsetcurrent(t_canvas *x);
+    EXTERN t_symbol *canvas_realizedollar(t_canvas *x, t_symbol *s);
+    EXTERN t_canvas *canvas_getrootfor(t_canvas *x);
+    EXTERN void canvas_dirty(t_canvas *x, t_floatarg n);
+    typedef int (*t_canvasapply)(t_canvas *x, t_int x1, t_int x2, t_int x3);
 
-EXTERN void canvas_resortinlets(t_canvas *x);
-EXTERN void canvas_resortoutlets(t_canvas *x);
-EXTERN void canvas_free(t_canvas *x);
-EXTERN void canvas_updatewindowlist(void);
-EXTERN void canvas_editmode(t_canvas *x, t_floatarg state);
-EXTERN int canvas_isabstraction(const t_canvas *x);
-EXTERN int canvas_istable(const t_canvas *x);
-EXTERN int canvas_showtext(const t_canvas *x);
-EXTERN void canvas_vis(t_canvas *x, t_floatarg f);
-EXTERN t_canvasenvironment *canvas_getenv(const t_canvas *x);
-EXTERN void canvas_rename(t_canvas *x, t_symbol *s, t_symbol *dir);
-EXTERN void canvas_loadbang(t_canvas *x);
-EXTERN int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos,
-    int *x1p, int *y1p, int *x2p, int *y2p);
-EXTERN int canvas_setdeleting(t_canvas *x, int flag);
+    EXTERN void canvas_resortinlets(t_canvas *x);
+    EXTERN void canvas_resortoutlets(t_canvas *x);
+    EXTERN void canvas_free(t_canvas *x);
+    EXTERN void canvas_updatewindowlist(void);
+    EXTERN void canvas_editmode(t_canvas *x, t_floatarg state);
+    EXTERN int canvas_isabstraction(const t_canvas *x);
+    EXTERN int canvas_istable(const t_canvas *x);
+    EXTERN int canvas_showtext(const t_canvas *x);
+    EXTERN void canvas_vis(t_canvas *x, t_floatarg f);
+    EXTERN t_canvasenvironment *canvas_getenv(const t_canvas *x);
+    EXTERN void canvas_rename(t_canvas *x, t_symbol *s, t_symbol *dir);
+    EXTERN void canvas_loadbang(t_canvas *x);
+    EXTERN int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos,
+        int *x1p, int *y1p, int *x2p, int *y2p);
+    EXTERN int canvas_setdeleting(t_canvas *x, int flag);
 
-#define LB_LOAD 0       /* "loadbang" actions - 0 for original meaning */
-#define LB_INIT 1       /* loaded but not yet connected to parent patch */
-#define LB_CLOSE 2      /* about to close */
+#define LB_LOAD 0  /* "loadbang" actions - 0 for original meaning */
+#define LB_INIT 1  /* loaded but not yet connected to parent patch */
+#define LB_CLOSE 2 /* about to close */
 
-typedef int (*t_undofn)(t_canvas *canvas, void *buf,
-    int action);        /* a function that does UNDO/REDO */
-#define UNDO_FREE 0                     /* free current undo/redo buffer */
-#define UNDO_UNDO 1                     /* undo */
-#define UNDO_REDO 2                     /* redo */
-EXTERN void canvas_setundo(t_canvas *x, t_undofn undofn, void *buf,
-    const char *name);
-EXTERN void canvas_noundo(t_canvas *x);
-EXTERN int canvas_getindex(t_canvas *x, t_gobj *y);
+    typedef int (*t_undofn)(t_canvas *canvas, void *buf,
+        int action); /* a function that does UNDO/REDO */
+#define UNDO_FREE 0  /* free current undo/redo buffer */
+#define UNDO_UNDO 1  /* undo */
+#define UNDO_REDO 2  /* redo */
+    EXTERN void canvas_setundo(
+        t_canvas *x, t_undofn undofn, void *buf, const char *name);
+    EXTERN void canvas_noundo(t_canvas *x);
+    EXTERN int canvas_getindex(t_canvas *x, t_gobj *y);
 
-EXTERN void canvas_connect(t_canvas *x,
-    t_floatarg fwhoout, t_floatarg foutno, t_floatarg fwhoin, t_floatarg finno);
-EXTERN void canvas_disconnect(t_canvas *x,
-    t_float index1, t_float outno, t_float index2, t_float inno);
-EXTERN int canvas_isconnected (t_canvas *x,
-    t_text *ob1, int n1, t_text *ob2, int n2);
-EXTERN void canvas_selectinrect(t_canvas *x, int lox, int loy, int hix, int hiy);
+    EXTERN void canvas_connect(t_canvas *x, t_floatarg fwhoout,
+        t_floatarg foutno, t_floatarg fwhoin, t_floatarg finno);
+    EXTERN void canvas_disconnect(t_canvas *x, t_float index1, t_float outno,
+        t_float index2, t_float inno);
+    EXTERN int canvas_isconnected(
+        t_canvas *x, t_text *ob1, int n1, t_text *ob2, int n2);
+    EXTERN void canvas_selectinrect(
+        t_canvas *x, int lox, int loy, int hix, int hiy);
 
-EXTERN t_glist *pd_checkglist(t_pd *x);
-typedef int (*t_canvas_path_iterator)(const char *path, void *user_data);
-EXTERN int canvas_path_iterate(const t_canvas *x, t_canvas_path_iterator fun,
-    void *user_data);
+    EXTERN t_glist *pd_checkglist(t_pd *x);
+    typedef int (*t_canvas_path_iterator)(const char *path, void *user_data);
+    EXTERN int canvas_path_iterate(
+        const t_canvas *x, t_canvas_path_iterator fun, void *user_data);
 
 /* check string for untitled canvas filename prefix */
 #define UNTITLED_STRNCMP(s) strncmp(s, "PDUNTITLED", 10)
 
-/* ---- functions on canvasses as objects  --------------------- */
+    /* ---- functions on canvasses as objects  --------------------- */
 
-EXTERN void linetraverser_start(t_linetraverser *t, t_canvas *x);
-EXTERN t_outconnect *linetraverser_next(t_linetraverser *t);
-EXTERN void linetraverser_skipobject(t_linetraverser *t);
+    EXTERN void linetraverser_start(t_linetraverser *t, t_canvas *x);
+    EXTERN t_outconnect *linetraverser_next(t_linetraverser *t);
+    EXTERN void linetraverser_skipobject(t_linetraverser *t);
 
-/* --------- functions on garrays (graphical arrays) -------------------- */
+    /* --------- functions on garrays (graphical arrays) -------------------- */
 
-EXTERN t_template *garray_template(t_garray *x);
+    EXTERN t_template *garray_template(t_garray *x);
 
 /* -------------------- arrays --------------------- */
 #define GRAPH_ARRAY_SAVE 1      /* flags for graph_array() below */
 #define GRAPH_ARRAY_PLOTSTYLE 6 /* 2-bit field, PLOTSTYLE_POINTS, etc */
 #define GRAPH_ARRAY_SAVESIZE 8  /* save size as well as contents */
 
-EXTERN t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *tmpl,
-    t_floatarg f, t_floatarg flags);
-EXTERN t_array *array_new(t_symbol *templatesym, t_gpointer *parent);
-EXTERN void array_resize(t_array *x, int n);
-EXTERN void array_free(t_array *x);
-EXTERN void array_redraw(t_array *a, t_glist *glist);
-EXTERN void array_resize_and_redraw(t_array *array, t_glist *glist, int n);
+    EXTERN t_garray *graph_array(t_glist *gl, t_symbol *s, t_symbol *tmpl,
+        t_floatarg f, t_floatarg flags);
+    EXTERN t_array *array_new(t_symbol *templatesym, t_gpointer *parent);
+    EXTERN void array_resize(t_array *x, int n);
+    EXTERN void array_free(t_array *x);
+    EXTERN void array_redraw(t_array *a, t_glist *glist);
+    EXTERN void array_resize_and_redraw(t_array *array, t_glist *glist, int n);
 
-/* --------------------- gpointers and stubs ---------------- */
-EXTERN t_gstub *gstub_new(t_glist *gl, t_array *a);
-EXTERN void gstub_cutoff(t_gstub *gs);
-EXTERN void gpointer_setglist(t_gpointer *gp, t_glist *glist, t_scalar *x);
-EXTERN void gpointer_setarray(t_gpointer *gp, t_array *array, t_word *w);
+    /* --------------------- gpointers and stubs ---------------- */
+    EXTERN t_gstub *gstub_new(t_glist *gl, t_array *a);
+    EXTERN void gstub_cutoff(t_gstub *gs);
+    EXTERN void gpointer_setglist(t_gpointer *gp, t_glist *glist, t_scalar *x);
+    EXTERN void gpointer_setarray(t_gpointer *gp, t_array *array, t_word *w);
 
-/* --------------------- scalars ------------------------- */
-EXTERN void word_init(t_word *wp, t_template *tmpl, t_gpointer *gp);
-EXTERN void word_restore(t_word *wp, t_template *tmpl,
-    int argc, t_atom *argv);
-EXTERN t_scalar *scalar_new(t_glist *owner,
-    t_symbol *templatesym);
-EXTERN void word_free(t_word *wp, t_template *tmpl);
-EXTERN void scalar_getbasexy(t_scalar *x, t_float *basex, t_float *basey);
-EXTERN void scalar_redraw(t_scalar *x, t_glist *glist);
-EXTERN void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
-    int amarrayelement);
-EXTERN int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
-    int *p_nextmsg, int selectit);
+    /* --------------------- scalars ------------------------- */
+    EXTERN void word_init(t_word *wp, t_template *tmpl, t_gpointer *gp);
+    EXTERN void word_restore(
+        t_word *wp, t_template *tmpl, int argc, t_atom *argv);
+    EXTERN t_scalar *scalar_new(t_glist *owner, t_symbol *templatesym);
+    EXTERN void word_free(t_word *wp, t_template *tmpl);
+    EXTERN void scalar_getbasexy(t_scalar *x, t_float *basex, t_float *basey);
+    EXTERN void scalar_redraw(t_scalar *x, t_glist *glist);
+    EXTERN void canvas_writescalar(
+        t_symbol *templatesym, t_word *w, t_binbuf *b, int amarrayelement);
+    EXTERN int canvas_readscalar(
+        t_glist *x, int natoms, t_atom *vec, int *p_nextmsg, int selectit);
 
-/* ------helper routines for "garrays" and "plots" -------------- */
-EXTERN void array_getcoordinate(t_glist *glist,
-    char *elem, int xonset, int yonset, int wonset, int indx,
-    t_float basex, t_float basey, t_float xinc,
-    t_fielddesc *xfielddesc, t_fielddesc *yfielddesc, t_fielddesc *wfielddesc,
-    t_float *xp, t_float *yp, t_float *wp);
+    /* ------helper routines for "garrays" and "plots" -------------- */
+    EXTERN void array_getcoordinate(t_glist *glist, char *elem, int xonset,
+        int yonset, int wonset, int indx, t_float basex, t_float basey,
+        t_float xinc, t_fielddesc *xfielddesc, t_fielddesc *yfielddesc,
+        t_fielddesc *wfielddesc, t_float *xp, t_float *yp, t_float *wp);
 
-EXTERN int array_getfields(t_symbol *elemtemplatesym,
-    t_canvas **elemtemplatecanvasp,
-    t_template **elemtemplatep, int *elemsizep,
-    t_fielddesc *xfielddesc, t_fielddesc *yfielddesc, t_fielddesc *wfielddesc,
-    int *xonsetp, int *yonsetp, int *wonsetp);
+    EXTERN int array_getfields(t_symbol *elemtemplatesym,
+        t_canvas **elemtemplatecanvasp, t_template **elemtemplatep,
+        int *elemsizep, t_fielddesc *xfielddesc, t_fielddesc *yfielddesc,
+        t_fielddesc *wfielddesc, int *xonsetp, int *yonsetp, int *wonsetp);
 
-/* --------------------- templates ------------------------- */
-EXTERN t_template *template_new(t_symbol *sym, int argc, t_atom *argv);
-EXTERN void template_free(t_template *x);
-EXTERN int template_match(t_template *x1, t_template *x2);
-EXTERN int template_find_field(t_template *x, t_symbol *name, int *p_onset,
-    int *p_type, t_symbol **p_arraytype);
-EXTERN t_float template_getfloat(t_template *x, t_symbol *fieldname, t_word *wp,
-    int loud);
-EXTERN void template_setfloat(t_template *x, t_symbol *fieldname, t_word *wp,
-    t_float f, int loud);
-EXTERN t_symbol *template_getsymbol(t_template *x, t_symbol *fieldname,
-    t_word *wp, int loud);
-EXTERN void template_setsymbol(t_template *x, t_symbol *fieldname,
-    t_word *wp, t_symbol *s, int loud);
+    /* --------------------- templates ------------------------- */
+    EXTERN t_template *template_new(t_symbol *sym, int argc, t_atom *argv);
+    EXTERN void template_free(t_template *x);
+    EXTERN int template_match(t_template *x1, t_template *x2);
+    EXTERN int template_find_field(t_template *x, t_symbol *name, int *p_onset,
+        int *p_type, t_symbol **p_arraytype);
+    EXTERN t_float template_getfloat(
+        t_template *x, t_symbol *fieldname, t_word *wp, int loud);
+    EXTERN void template_setfloat(
+        t_template *x, t_symbol *fieldname, t_word *wp, t_float f, int loud);
+    EXTERN t_symbol *template_getsymbol(
+        t_template *x, t_symbol *fieldname, t_word *wp, int loud);
+    EXTERN void template_setsymbol(
+        t_template *x, t_symbol *fieldname, t_word *wp, t_symbol *s, int loud);
 
-EXTERN t_template *gtemplate_get(t_gtemplate *x);
-EXTERN t_template *template_findbyname(t_symbol *s);
-EXTERN t_canvas *template_findcanvas(t_template *tmpl);
-EXTERN void template_notify(t_template *tmpl,
-    t_symbol *s, int argc, t_atom *argv);
+    EXTERN t_template *gtemplate_get(t_gtemplate *x);
+    EXTERN t_template *template_findbyname(t_symbol *s);
+    EXTERN t_canvas *template_findcanvas(t_template *tmpl);
+    EXTERN void template_notify(
+        t_template *tmpl, t_symbol *s, int argc, t_atom *argv);
 
-EXTERN t_float fielddesc_getcoord(t_fielddesc *f, t_template *tmpl,
-    t_word *wp, int loud);
-EXTERN void fielddesc_setcoord(t_fielddesc *f, t_template *tmpl,
-    t_word *wp, t_float pix, int loud);
-EXTERN t_float fielddesc_cvttocoord(t_fielddesc *f, t_float val);
-EXTERN t_float fielddesc_cvtfromcoord(t_fielddesc *f, t_float coord);
+    EXTERN t_float fielddesc_getcoord(
+        t_fielddesc *f, t_template *tmpl, t_word *wp, int loud);
+    EXTERN void fielddesc_setcoord(
+        t_fielddesc *f, t_template *tmpl, t_word *wp, t_float pix, int loud);
+    EXTERN t_float fielddesc_cvttocoord(t_fielddesc *f, t_float val);
+    EXTERN t_float fielddesc_cvtfromcoord(t_fielddesc *f, t_float coord);
 
+    /* ----------------------- guiconnects, g_guiconnect.c --------- */
+    EXTERN t_guiconnect *guiconnect_new(t_pd *who, t_symbol *sym);
+    EXTERN void guiconnect_notarget(t_guiconnect *x, double timedelay);
 
-/* ----------------------- guiconnects, g_guiconnect.c --------- */
-EXTERN t_guiconnect *guiconnect_new(t_pd *who, t_symbol *sym);
-EXTERN void guiconnect_notarget(t_guiconnect *x, double timedelay);
+    /* ------------- IEMGUI routines used in other g_ files ---------------- */
+    EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
+    EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
+    EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
 
-/* ------------- IEMGUI routines used in other g_ files ---------------- */
-EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
-EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
-EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
-
-/*-------------  g_clone.c ------------- */
-extern t_class *clone_class;
+    /*-------------  g_clone.c ------------- */
+    extern t_class *clone_class;
 
 #if defined(_LANGUAGE_C_PLUS_PLUS) || defined(__cplusplus)
 }

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -133,8 +133,7 @@ static void clone_in_set(t_in *x, t_floatarg f)
 static void clone_in_all(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int phasewas = x->i_owner->x_phase;
-    int i;
-    for(i = 0; i < x->i_owner->x_n; i++)
+    for(int i = 0; i < x->i_owner->x_n; i++)
     {
         x->i_owner->x_phase = i;
         clone_in_this(x, s, argc, argv);
@@ -182,17 +181,16 @@ static void clone_free(t_clone *x)
 {
     if(x->x_vec)
     {
-        int i;
         int voicetovis = -1;
         if(THISGUI->i_reloadingabstraction)
         {
-            for(i = 0; i < x->x_n; i++)
+            for(int i = 0; i < x->x_n; i++)
             {
                 if(x->x_vec[i].c_gl == THISGUI->i_reloadingabstraction)
                     voicetovis = i;
             }
         }
-        for(i = 0; i < x->x_n; i++)
+        for(int i = 0; i < x->x_n; i++)
         {
             canvas_closebang(x->x_vec[i].c_gl);
             pd_free(&x->x_vec[i].c_gl->gl_pd);
@@ -300,15 +298,14 @@ static void clone_click(t_clone *x, t_floatarg xpos, t_floatarg ypos,
 
 static void clone_loadbang(t_clone *x, t_floatarg f)
 {
-    int i;
     if(f == LB_LOAD)
     {
-        for(i = 0; i < x->x_n; i++)
+        for(int i = 0; i < x->x_n; i++)
             canvas_loadbang(x->x_vec[i].c_gl);
     }
     else if(f == LB_CLOSE)
     {
-        for(i = 0; i < x->x_n; i++)
+        for(int i = 0; i < x->x_n; i++)
             canvas_closebang(x->x_vec[i].c_gl);
     }
 }
@@ -319,18 +316,16 @@ void signal_makereusable(t_signal *sig);
 
 static void clone_dsp(t_clone *x, t_signal **sp)
 {
-    int i;
-    int j;
     int nin;
     int nout;
     t_signal **tempsigs;
     t_signal **tempio;
     if(!x->x_n) return;
-    for(i = nin = 0; i < x->x_nin; i++)
+    for(int i = nin = 0; i < x->x_nin; i++)
         if(x->x_invec[i].i_signal) nin++;
-    for(i = nout = 0; i < x->x_nout; i++)
+    for(int i = nout = 0; i < x->x_nout; i++)
         if(x->x_outvec[0][i].o_signal) nout++;
-    for(j = 0; j < x->x_n; j++)
+    for(int j = 0; j < x->x_n; j++)
     {
         if(obj_ninlets(&x->x_vec[j].c_gl->gl_obj) != x->x_nin ||
             obj_noutlets(&x->x_vec[j].c_gl->gl_obj) != x->x_nout ||
@@ -338,7 +333,7 @@ static void clone_dsp(t_clone *x, t_signal **sp)
             obj_nsigoutlets(&x->x_vec[j].c_gl->gl_obj) != nout)
         {
             pd_error(x, "clone: can't do DSP until edited copy is saved");
-            for(i = 0; i < nout; i++)
+            for(int i = 0; i < nout; i++)
                 dsp_add_zero(sp[nin + i]->s_vec, sp[nin + i]->s_n);
             return;
         }
@@ -346,7 +341,7 @@ static void clone_dsp(t_clone *x, t_signal **sp)
     tempsigs = (t_signal **) alloca((nin + 2 * nout) * sizeof(*tempsigs));
     tempio = tempsigs + nout;
     /* load input signals into signal vector to send subpatches */
-    for(i = 0; i < nin; i++)
+    for(int i = 0; i < nin; i++)
     {
         /* we already have one reference "counted" for our presumed
         use of this input signal but add one for each additional copy. */
@@ -354,15 +349,15 @@ static void clone_dsp(t_clone *x, t_signal **sp)
         tempio[i] = sp[i];
     }
     /* for first copy, write output to first nout temp sigs */
-    for(i = 0; i < nout; i++)
+    for(int i = 0; i < nout; i++)
         tempsigs[i] = signal_newfromcontext(0);
 
-    for(j = 0; j < x->x_n; j++)
+    for(int j = 0; j < x->x_n; j++)
     {
-        for(i = 0; i < nout; i++)
+        for(int i = 0; i < nout; i++)
             tempio[nin + i] = signal_newfromcontext(1);
         canvas_dodsp(x->x_vec[j].c_gl, 0, tempio);
-        for(i = 0; i < nout; i++)
+        for(int i = 0; i < nout; i++)
         {
             if(j == 0)
             {
@@ -378,7 +373,7 @@ static void clone_dsp(t_clone *x, t_signal **sp)
         }
     }
     /* copy to output signsls */
-    for(i = 0; i < nout; i++)
+    for(int i = 0; i < nout; i++)
     {
         dsp_add_copy(tempsigs[i]->s_vec, sp[nin + i]->s_vec, tempsigs[i]->s_n);
         signal_makereusable(tempsigs[i]);
@@ -391,7 +386,6 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
     t_canvas *c;
     int wantn;
     int dspstate;
-    int i;
     int voicetovis = clone_voicetovis;
     t_out *outvec;
     x->x_invec = 0;
@@ -453,7 +447,7 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
     x->x_n = 1;
     x->x_nin = obj_ninlets(&x->x_vec[0].c_gl->gl_obj);
     x->x_invec = (t_in *) getbytes(x->x_nin * sizeof(*x->x_invec));
-    for(i = 0; i < x->x_nin; i++)
+    for(int i = 0; i < x->x_nin; i++)
     {
         x->x_invec[i].i_pd = clone_in_class;
         x->x_invec[i].i_owner = x;
@@ -472,7 +466,7 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
     x->x_nout = obj_noutlets(&x->x_vec[0].c_gl->gl_obj);
     x->x_outvec = (t_out **) getbytes(sizeof(*x->x_outvec));
     x->x_outvec[0] = outvec = (t_out *) getbytes(x->x_nout * sizeof(*outvec));
-    for(i = 0; i < x->x_nout; i++)
+    for(int i = 0; i < x->x_nout; i++)
     {
         outvec[i].o_pd = clone_out_class;
         outvec[i].o_signal = obj_issignaloutlet(&x->x_vec[0].c_gl->gl_obj, i);

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -6,18 +6,19 @@
 /* ---------- clone - maintain copies of a patch ----------------- */
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 #define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
 
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < LIST_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#define ATOMS_ALLOCA(x, n)                                                \
+    ((x) = (t_atom *) ((n) < LIST_NGETBYTE ? alloca((n) * sizeof(t_atom)) \
+                                           : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) \
+    (((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 
 t_class *clone_class;
 static t_class *clone_in_class, *clone_out_class;
@@ -25,7 +26,7 @@ static t_class *clone_in_class, *clone_out_class;
 typedef struct _copy
 {
     t_glist *c_gl;
-    int c_on;           /* DSP running */
+    int c_on; /* DSP running */
 } t_copy;
 
 typedef struct _in
@@ -47,27 +48,26 @@ typedef struct _out
 typedef struct _clone
 {
     t_object x_obj;
-    int x_n;            /* number of copies */
-    t_copy *x_vec;      /* the copies */
+    int x_n;       /* number of copies */
+    t_copy *x_vec; /* the copies */
     int x_nin;
-    t_in *x_invec;      /* inlet proxies */
+    t_in *x_invec; /* inlet proxies */
     int x_nout;
-    t_out **x_outvec;   /* outlet proxies */
-    t_symbol *x_s;      /* name of abstraction */
-    int x_argc;         /* creation arguments for abstractions */
+    t_out **x_outvec; /* outlet proxies */
+    t_symbol *x_s;    /* name of abstraction */
+    int x_argc;       /* creation arguments for abstractions */
     t_atom *x_argv;
     int x_phase;
-    int x_startvoice;   /* number of first voice, 0 by default */
+    int x_startvoice;    /* number of first voice, 0 by default */
     int x_suppressvoice; /* suppress voice number as $1 arg */
 } t_clone;
 
 int clone_match(t_pd *z, t_symbol *name, t_symbol *dir)
 {
-    t_clone *x = (t_clone *)z;
-    if (!x->x_n)
-        return (0);
+    t_clone *x = (t_clone *) z;
+    if(!x->x_n) return (0);
     return (x->x_vec[0].c_gl->gl_name == name &&
-        canvas_getdir(x->x_vec[0].c_gl) == dir);
+            canvas_getdir(x->x_vec[0].c_gl) == dir);
 }
 
 void obj_sendinlet(t_object *x, int n, t_symbol *s, int argc, t_atom *argv);
@@ -75,38 +75,38 @@ void obj_sendinlet(t_object *x, int n, t_symbol *s, int argc, t_atom *argv);
 static void clone_in_list(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int n;
-    if (argc < 1 || argv[0].a_type != A_FLOAT)
+    if(argc < 1 || argv[0].a_type != A_FLOAT)
         pd_error(x->i_owner, "clone: no instance number in message");
-    else if ((n = argv[0].a_w.w_float - x->i_owner->x_startvoice) < 0 ||
-        n >= x->i_owner->x_n)
-            pd_error(x->i_owner, "clone: instance number %d out of range",
-                n + x->i_owner->x_startvoice);
-    else if (argc > 1 && argv[1].a_type == A_SYMBOL)
+    else if((n = argv[0].a_w.w_float - x->i_owner->x_startvoice) < 0 ||
+            n >= x->i_owner->x_n)
+        pd_error(x->i_owner, "clone: instance number %d out of range",
+            n + x->i_owner->x_startvoice);
+    else if(argc > 1 && argv[1].a_type == A_SYMBOL)
         obj_sendinlet(&x->i_owner->x_vec[n].c_gl->gl_obj, x->i_n,
-            argv[1].a_w.w_symbol, argc-2, argv+2);
-    else obj_sendinlet(&x->i_owner->x_vec[n].c_gl->gl_obj, x->i_n,
-            &s_list, argc-1, argv+1);
+            argv[1].a_w.w_symbol, argc - 2, argv + 2);
+    else
+        obj_sendinlet(&x->i_owner->x_vec[n].c_gl->gl_obj, x->i_n, &s_list,
+            argc - 1, argv + 1);
 }
 
 static void clone_in_this(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int phase = x->i_owner->x_phase;
-    if (phase < 0 || phase >= x->i_owner->x_n)
-        phase = 0;
-    if (argc <= 0)
+    if(phase < 0 || phase >= x->i_owner->x_n) phase = 0;
+    if(argc <= 0)
         return;
-    else if (argv->a_type == A_SYMBOL)
+    else if(argv->a_type == A_SYMBOL)
         obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n,
-            argv[0].a_w.w_symbol, argc-1, argv+1);
-    else obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n,
-            &s_list, argc, argv);
+            argv[0].a_w.w_symbol, argc - 1, argv + 1);
+    else
+        obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n, &s_list,
+            argc, argv);
 }
 
 static void clone_in_next(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int phase = x->i_owner->x_phase + 1;
-    if (phase < 0 || phase >= x->i_owner->x_n)
-        phase = 0;
+    if(phase < 0 || phase >= x->i_owner->x_n) phase = 0;
     x->i_owner->x_phase = phase;
     clone_in_this(x, s, argc, argv);
 }
@@ -114,15 +114,14 @@ static void clone_in_next(t_in *x, t_symbol *s, int argc, t_atom *argv)
 static void clone_in_set(t_in *x, t_floatarg f)
 {
     int phase = f;
-    if (phase < 0 || phase >= x->i_owner->x_n)
-        phase = 0;
+    if(phase < 0 || phase >= x->i_owner->x_n) phase = 0;
     x->i_owner->x_phase = phase;
 }
 
 static void clone_in_all(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int phasewas = x->i_owner->x_phase, i;
-    for (i = 0; i < x->i_owner->x_n; i++)
+    for(i = 0; i < x->i_owner->x_n; i++)
     {
         x->i_owner->x_phase = i;
         clone_in_this(x, s, argc, argv);
@@ -133,30 +132,29 @@ static void clone_in_all(t_in *x, t_symbol *s, int argc, t_atom *argv)
 static void clone_in_vis(t_in *x, t_floatarg fn, t_floatarg vis)
 {
     int n = fn - x->i_owner->x_startvoice;
-    if (n < 0)
+    if(n < 0)
         n = 0;
-    else if (n >= x->i_owner->x_n)
+    else if(n >= x->i_owner->x_n)
         n = x->i_owner->x_n - 1;
     canvas_vis(x->i_owner->x_vec[n].c_gl, (vis != 0));
 }
 
 static void clone_in_fwd(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 0 && argv->a_type == A_SYMBOL)
-        typedmess(&x->i_pd, argv->a_w.w_symbol, argc-1, argv+1);
+    if(argc > 0 && argv->a_type == A_SYMBOL)
+        typedmess(&x->i_pd, argv->a_w.w_symbol, argc - 1, argv + 1);
 }
 
 static void clone_out_anything(t_out *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    int first =
-        1 + (s != &s_list && s != &s_float && s != &s_symbol && s != &s_bang),
-            outc = argc + first;
+    int first = 1 + (s != &s_list && s != &s_float && s != &s_symbol &&
+                        s != &s_bang),
+        outc = argc + first;
     ATOMS_ALLOCA(outv, outc);
     SETFLOAT(outv, x->o_n);
-    if (first == 2)
-        SETSYMBOL(outv + 1, s);
-    memcpy(outv+first, argv, sizeof(t_atom) * argc);
+    if(first == 2) SETSYMBOL(outv + 1, s);
+    memcpy(outv + first, argv, sizeof(t_atom) * argc);
     outlet_list(x->o_outlet, 0, outc, outv);
     ATOMS_FREEA(outv, outc);
 }
@@ -165,21 +163,20 @@ static PERTHREAD int clone_voicetovis = -1;
 
 static void clone_free(t_clone *x)
 {
-    if (x->x_vec)
+    if(x->x_vec)
     {
         int i, voicetovis = -1;
-        if (THISGUI->i_reloadingabstraction)
+        if(THISGUI->i_reloadingabstraction)
         {
-            for (i = 0; i < x->x_n; i++)
-                if (x->x_vec[i].c_gl == THISGUI->i_reloadingabstraction)
+            for(i = 0; i < x->x_n; i++)
+                if(x->x_vec[i].c_gl == THISGUI->i_reloadingabstraction)
                     voicetovis = i;
         }
-        for (i = 0; i < x->x_n; i++)
+        for(i = 0; i < x->x_n; i++)
         {
             canvas_closebang(x->x_vec[i].c_gl);
             pd_free(&x->x_vec[i].c_gl->gl_pd);
-            t_freebytes(x->x_outvec[i],
-                x->x_nout * sizeof(*x->x_outvec[i]));
+            t_freebytes(x->x_outvec[i], x->x_nout * sizeof(*x->x_outvec[i]));
         }
         t_freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
         t_freebytes(x->x_argv, x->x_argc * sizeof(*x->x_argv));
@@ -194,13 +191,12 @@ static t_canvas *clone_makeone(t_symbol *s, int argc, t_atom *argv)
     t_canvas *retval;
     pd_this->pd_newest = 0;
     typedmess(&pd_objectmaker, s, argc, argv);
-    if (pd_this->pd_newest == 0)
+    if(pd_this->pd_newest == 0)
     {
-        pd_error(0, "clone: can't create subpatch '%s'",
-            s->s_name);
+        pd_error(0, "clone: can't create subpatch '%s'", s->s_name);
         return (0);
     }
-    if (*pd_this->pd_newest != canvas_class)
+    if(*pd_this->pd_newest != canvas_class)
     {
         pd_error(0, "clone: can't clone '%s' because it's not an abstraction",
             s->s_name);
@@ -208,7 +204,7 @@ static t_canvas *clone_makeone(t_symbol *s, int argc, t_atom *argv)
         pd_this->pd_newest = 0;
         return (0);
     }
-    retval = (t_canvas *)pd_this->pd_newest;
+    retval = (t_canvas *) pd_this->pd_newest;
     pd_this->pd_newest = 0;
     retval->gl_isclone = 1;
     return (retval);
@@ -218,53 +214,52 @@ void clone_setn(t_clone *x, t_floatarg f)
 {
     int dspstate = canvas_suspend_dsp();
     int nwas = x->x_n, wantn = f, i, j;
-    if (wantn < 1)
+    if(wantn < 1)
     {
         pd_error(x, "can't resize to zero or negative number; setting to 1");
         wantn = 1;
     }
-    if (wantn > nwas)
-        for (i = nwas; i < wantn; i++)
-    {
-        t_canvas *c;
-        t_out *outvec;
-        SETFLOAT(x->x_argv, x->x_startvoice + i);
-        if (!(c = clone_makeone(x->x_s, x->x_argc - x->x_suppressvoice,
-            x->x_argv + x->x_suppressvoice)))
+    if(wantn > nwas)
+        for(i = nwas; i < wantn; i++)
         {
-            pd_error(x, "clone: couldn't create '%s'", x->x_s->s_name);
-            goto done;
+            t_canvas *c;
+            t_out *outvec;
+            SETFLOAT(x->x_argv, x->x_startvoice + i);
+            if(!(c = clone_makeone(x->x_s, x->x_argc - x->x_suppressvoice,
+                     x->x_argv + x->x_suppressvoice)))
+            {
+                pd_error(x, "clone: couldn't create '%s'", x->x_s->s_name);
+                goto done;
+            }
+            x->x_vec = (t_copy *) t_resizebytes(
+                x->x_vec, i * sizeof(t_copy), (i + 1) * sizeof(t_copy));
+            x->x_vec[i].c_gl = c;
+            x->x_vec[i].c_on = 0;
+            x->x_outvec = (t_out **) t_resizebytes(x->x_outvec,
+                i * sizeof(*x->x_outvec), (i + 1) * sizeof(*x->x_outvec));
+            x->x_outvec[i] = outvec =
+                (t_out *) getbytes(x->x_nout * sizeof(*outvec));
+            for(j = 0; j < x->x_nout; j++)
+            {
+                outvec[j].o_pd = clone_out_class;
+                outvec[j].o_signal =
+                    obj_issignaloutlet(&x->x_vec[0].c_gl->gl_obj, i);
+                outvec[j].o_n = x->x_startvoice + i;
+                outvec[j].o_outlet = x->x_outvec[0][j].o_outlet;
+                obj_connect(
+                    &x->x_vec[i].c_gl->gl_obj, j, (t_object *) (&outvec[j]), 0);
+            }
+            x->x_n++;
         }
-        x->x_vec = (t_copy *)t_resizebytes(x->x_vec, i * sizeof(t_copy),
-            (i+1) * sizeof(t_copy));
-        x->x_vec[i].c_gl = c;
-        x->x_vec[i].c_on = 0;
-        x->x_outvec = (t_out **)t_resizebytes(x->x_outvec,
-            i * sizeof(*x->x_outvec), (i+1) * sizeof(*x->x_outvec));
-        x->x_outvec[i] = outvec =
-            (t_out *)getbytes(x->x_nout * sizeof(*outvec));
-        for (j = 0; j < x->x_nout; j++)
-        {
-            outvec[j].o_pd = clone_out_class;
-            outvec[j].o_signal =
-                obj_issignaloutlet(&x->x_vec[0].c_gl->gl_obj, i);
-            outvec[j].o_n = x->x_startvoice + i;
-            outvec[j].o_outlet =
-                x->x_outvec[0][j].o_outlet;
-            obj_connect(&x->x_vec[i].c_gl->gl_obj, j,
-                (t_object *)(&outvec[j]), 0);
-        }
-        x->x_n++;
-    }
-    if (wantn < nwas)
+    if(wantn < nwas)
     {
-        for (i = wantn; i < nwas; i++)
+        for(i = wantn; i < nwas; i++)
         {
             canvas_closebang(x->x_vec[i].c_gl);
             pd_free(&x->x_vec[i].c_gl->gl_pd);
         }
-        x->x_vec = (t_copy *)t_resizebytes(x->x_vec, nwas * sizeof(t_copy),
-            wantn * sizeof(*x->x_vec));
+        x->x_vec = (t_copy *) t_resizebytes(
+            x->x_vec, nwas * sizeof(t_copy), wantn * sizeof(*x->x_vec));
         x->x_n = wantn;
     }
 done:
@@ -274,19 +269,18 @@ done:
 static void clone_click(t_clone *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
-    if (!x->x_n)
-        return;
+    if(!x->x_n) return;
     canvas_vis(x->x_vec[0].c_gl, 1);
 }
 
 static void clone_loadbang(t_clone *x, t_floatarg f)
 {
     int i;
-    if (f == LB_LOAD)
-        for (i = 0; i < x->x_n; i++)
+    if(f == LB_LOAD)
+        for(i = 0; i < x->x_n; i++)
             canvas_loadbang(x->x_vec[i].c_gl);
-    else if (f == LB_CLOSE)
-        for (i = 0; i < x->x_n; i++)
+    else if(f == LB_CLOSE)
+        for(i = 0; i < x->x_n; i++)
             canvas_closebang(x->x_vec[i].c_gl);
 }
 
@@ -298,67 +292,65 @@ static void clone_dsp(t_clone *x, t_signal **sp)
 {
     int i, j, nin, nout;
     t_signal **tempsigs, **tempio;
-    if (!x->x_n)
-        return;
-    for (i = nin = 0; i < x->x_nin; i++)
-        if (x->x_invec[i].i_signal)
-            nin++;
-    for (i = nout = 0; i < x->x_nout; i++)
-        if (x->x_outvec[0][i].o_signal)
-            nout++;
-    for (j = 0; j < x->x_n; j++)
+    if(!x->x_n) return;
+    for(i = nin = 0; i < x->x_nin; i++)
+        if(x->x_invec[i].i_signal) nin++;
+    for(i = nout = 0; i < x->x_nout; i++)
+        if(x->x_outvec[0][i].o_signal) nout++;
+    for(j = 0; j < x->x_n; j++)
     {
-        if (obj_ninlets(&x->x_vec[j].c_gl->gl_obj) != x->x_nin ||
+        if(obj_ninlets(&x->x_vec[j].c_gl->gl_obj) != x->x_nin ||
             obj_noutlets(&x->x_vec[j].c_gl->gl_obj) != x->x_nout ||
-                obj_nsiginlets(&x->x_vec[j].c_gl->gl_obj) != nin ||
-                    obj_nsigoutlets(&x->x_vec[j].c_gl->gl_obj) != nout)
+            obj_nsiginlets(&x->x_vec[j].c_gl->gl_obj) != nin ||
+            obj_nsigoutlets(&x->x_vec[j].c_gl->gl_obj) != nout)
         {
             pd_error(x, "clone: can't do DSP until edited copy is saved");
-            for (i = 0; i < nout; i++)
-                dsp_add_zero(sp[nin+i]->s_vec, sp[nin+i]->s_n);
+            for(i = 0; i < nout; i++)
+                dsp_add_zero(sp[nin + i]->s_vec, sp[nin + i]->s_n);
             return;
         }
     }
-    tempsigs = (t_signal **)alloca((nin + 2 * nout) * sizeof(*tempsigs));
+    tempsigs = (t_signal **) alloca((nin + 2 * nout) * sizeof(*tempsigs));
     tempio = tempsigs + nout;
-        /* load input signals into signal vector to send subpatches */
-    for (i = 0; i < nin; i++)
+    /* load input signals into signal vector to send subpatches */
+    for(i = 0; i < nin; i++)
     {
-            /* we already have one reference "counted" for our presumed
-            use of this input signal but add one for each additional copy. */
-        sp[i]->s_refcount += x->x_n-1;
+        /* we already have one reference "counted" for our presumed
+        use of this input signal but add one for each additional copy. */
+        sp[i]->s_refcount += x->x_n - 1;
         tempio[i] = sp[i];
     }
-        /* for first copy, write output to first nout temp sigs */
-    for (i = 0; i < nout; i++)
+    /* for first copy, write output to first nout temp sigs */
+    for(i = 0; i < nout; i++)
         tempsigs[i] = signal_newfromcontext(0);
 
-    for (j = 0; j < x->x_n; j++)
+    for(j = 0; j < x->x_n; j++)
     {
-        for (i = 0; i < nout; i++)
+        for(i = 0; i < nout; i++)
             tempio[nin + i] = signal_newfromcontext(1);
         canvas_dodsp(x->x_vec[j].c_gl, 0, tempio);
-        for (i = 0; i < nout; i++)
+        for(i = 0; i < nout; i++)
         {
-            if (j == 0)
+            if(j == 0)
                 dsp_add_copy(tempio[nin + i]->s_vec, tempsigs[i]->s_vec,
                     tempsigs[i]->s_n);
-            else dsp_add_plus(tempio[nin + i]->s_vec, tempsigs[i]->s_vec,
+            else
+                dsp_add_plus(tempio[nin + i]->s_vec, tempsigs[i]->s_vec,
                     tempsigs[i]->s_vec, tempsigs[i]->s_n);
             signal_makereusable(tempio[nin + i]);
         }
     }
-        /* copy to output signsls */
-    for (i = 0; i < nout; i++)
+    /* copy to output signsls */
+    for(i = 0; i < nout; i++)
     {
-        dsp_add_copy(tempsigs[i]->s_vec, sp[nin+i]->s_vec, tempsigs[i]->s_n);
+        dsp_add_copy(tempsigs[i]->s_vec, sp[nin + i]->s_vec, tempsigs[i]->s_n);
         signal_makereusable(tempsigs[i]);
     }
 }
 
 static void *clone_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_clone *x = (t_clone *)pd_new(clone_class);
+    t_clone *x = (t_clone *) pd_new(clone_class);
     t_canvas *c;
     int wantn, dspstate, i, voicetovis = clone_voicetovis;
     t_out *outvec;
@@ -367,82 +359,83 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
     x->x_startvoice = 0;
     x->x_suppressvoice = 0;
     clone_voicetovis = -1;
-    if (argc == 0)
+    if(argc == 0)
     {
         x->x_vec = 0;
         x->x_n = 0;
         return (x);
     }
     dspstate = canvas_suspend_dsp();
-    while (argc > 0 && argv[0].a_type == A_SYMBOL &&
-        argv[0].a_w.w_symbol->s_name[0] == '-')
+    while(argc > 0 && argv[0].a_type == A_SYMBOL &&
+          argv[0].a_w.w_symbol->s_name[0] == '-')
     {
-        if (!strcmp(argv[0].a_w.w_symbol->s_name, "-s") && argc > 1 &&
+        if(!strcmp(argv[0].a_w.w_symbol->s_name, "-s") && argc > 1 &&
             argv[1].a_type == A_FLOAT)
         {
             x->x_startvoice = argv[1].a_w.w_float;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(argv[0].a_w.w_symbol->s_name, "-x"))
+        else if(!strcmp(argv[0].a_w.w_symbol->s_name, "-x"))
             x->x_suppressvoice = 1, argc--, argv++;
-        else goto usage;
+        else
+            goto usage;
     }
-    if (argc >= 2 && (wantn = atom_getfloatarg(0, argc, argv)) >= 0
-        && argv[1].a_type == A_SYMBOL)
-            x->x_s = argv[1].a_w.w_symbol;
-    else if (argc >= 2 && (wantn = atom_getfloatarg(1, argc, argv)) >= 0
-        && argv[0].a_type == A_SYMBOL)
-            x->x_s = argv[0].a_w.w_symbol;
-    else goto usage;
-        /* store a copy of the argmuents with an extra space (argc+1) for
-        supplying an instance number, which we'll bash as we go. */
+    if(argc >= 2 && (wantn = atom_getfloatarg(0, argc, argv)) >= 0 &&
+        argv[1].a_type == A_SYMBOL)
+        x->x_s = argv[1].a_w.w_symbol;
+    else if(argc >= 2 && (wantn = atom_getfloatarg(1, argc, argv)) >= 0 &&
+            argv[0].a_type == A_SYMBOL)
+        x->x_s = argv[0].a_w.w_symbol;
+    else
+        goto usage;
+    /* store a copy of the argmuents with an extra space (argc+1) for
+    supplying an instance number, which we'll bash as we go. */
     x->x_argc = argc - 1;
     x->x_argv = getbytes(x->x_argc * sizeof(*x->x_argv));
-    memcpy(x->x_argv, argv+1, x->x_argc * sizeof(*x->x_argv));
+    memcpy(x->x_argv, argv + 1, x->x_argc * sizeof(*x->x_argv));
     SETFLOAT(x->x_argv, x->x_startvoice);
-    if (!(c = clone_makeone(x->x_s, x->x_argc - x->x_suppressvoice,
-        x->x_argv + x->x_suppressvoice)))
-            goto fail;
-    x->x_vec = (t_copy *)getbytes(sizeof(*x->x_vec));
+    if(!(c = clone_makeone(x->x_s, x->x_argc - x->x_suppressvoice,
+             x->x_argv + x->x_suppressvoice)))
+        goto fail;
+    x->x_vec = (t_copy *) getbytes(sizeof(*x->x_vec));
     x->x_vec[0].c_gl = c;
     x->x_n = 1;
     x->x_nin = obj_ninlets(&x->x_vec[0].c_gl->gl_obj);
-    x->x_invec = (t_in *)getbytes(x->x_nin * sizeof(*x->x_invec));
-    for (i = 0; i < x->x_nin; i++)
+    x->x_invec = (t_in *) getbytes(x->x_nin * sizeof(*x->x_invec));
+    for(i = 0; i < x->x_nin; i++)
     {
         x->x_invec[i].i_pd = clone_in_class;
         x->x_invec[i].i_owner = x;
         x->x_invec[i].i_signal =
             obj_issignalinlet(&x->x_vec[0].c_gl->gl_obj, i);
         x->x_invec[i].i_n = i;
-        if (x->x_invec[i].i_signal)
-            inlet_new(&x->x_obj, &x->x_invec[i].i_pd,
-                &s_signal, &s_signal);
-        else inlet_new(&x->x_obj, &x->x_invec[i].i_pd, 0, 0);
+        if(x->x_invec[i].i_signal)
+            inlet_new(&x->x_obj, &x->x_invec[i].i_pd, &s_signal, &s_signal);
+        else
+            inlet_new(&x->x_obj, &x->x_invec[i].i_pd, 0, 0);
     }
     x->x_nout = obj_noutlets(&x->x_vec[0].c_gl->gl_obj);
-    x->x_outvec = (t_out **)getbytes(sizeof(*x->x_outvec));
-    x->x_outvec[0] = outvec =
-        (t_out *)getbytes(x->x_nout * sizeof(*outvec));
-    for (i = 0; i < x->x_nout; i++)
+    x->x_outvec = (t_out **) getbytes(sizeof(*x->x_outvec));
+    x->x_outvec[0] = outvec = (t_out *) getbytes(x->x_nout * sizeof(*outvec));
+    for(i = 0; i < x->x_nout; i++)
     {
         outvec[i].o_pd = clone_out_class;
-        outvec[i].o_signal =
-            obj_issignaloutlet(&x->x_vec[0].c_gl->gl_obj, i);
+        outvec[i].o_signal = obj_issignaloutlet(&x->x_vec[0].c_gl->gl_obj, i);
         outvec[i].o_n = x->x_startvoice;
         outvec[i].o_outlet =
             outlet_new(&x->x_obj, (outvec[i].o_signal ? &s_signal : 0));
-        obj_connect(&x->x_vec[0].c_gl->gl_obj, i,
-            (t_object *)(&outvec[i]), 0);
+        obj_connect(&x->x_vec[0].c_gl->gl_obj, i, (t_object *) (&outvec[i]), 0);
     }
-    clone_setn(x, (t_floatarg)(wantn));
-    x->x_phase = wantn-1;
+    clone_setn(x, (t_floatarg) (wantn));
+    x->x_phase = wantn - 1;
     canvas_resume_dsp(dspstate);
-    if (voicetovis >= 0 && voicetovis < x->x_n)
+    if(voicetovis >= 0 && voicetovis < x->x_n)
         canvas_vis(x->x_vec[voicetovis].c_gl, 1);
     return (x);
 usage:
-    pd_error(0, "usage: clone [-s starting-number] <number> <name> [arguments]");
+    pd_error(
+        0, "usage: clone [-s starting-number] <number> <name> [arguments]");
 fail:
     freebytes(x, sizeof(t_clone));
     canvas_resume_dsp(dspstate);
@@ -451,56 +444,57 @@ fail:
 
 void clone_setup(void)
 {
-    clone_class = class_new(gensym("clone"), (t_newmethod)clone_new,
-        (t_method)clone_free, sizeof(t_clone), CLASS_NOINLET, A_GIMME, 0);
-    class_addmethod(clone_class, (t_method)clone_click, gensym("click"),
+    clone_class = class_new(gensym("clone"), (t_newmethod) clone_new,
+        (t_method) clone_free, sizeof(t_clone), CLASS_NOINLET, A_GIMME, 0);
+    class_addmethod(clone_class, (t_method) clone_click, gensym("click"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(clone_class, (t_method)clone_loadbang, gensym("loadbang"),
-        A_FLOAT, 0);
-    class_addmethod(clone_class, (t_method)clone_dsp,
-        gensym("dsp"), A_CANT, 0);
+    class_addmethod(
+        clone_class, (t_method) clone_loadbang, gensym("loadbang"), A_FLOAT, 0);
+    class_addmethod(
+        clone_class, (t_method) clone_dsp, gensym("dsp"), A_CANT, 0);
 
-    clone_in_class = class_new(gensym("clone-inlet"), 0, 0,
-        sizeof(t_in), CLASS_PD, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_next, gensym("next"),
-        A_GIMME, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_this, gensym("this"),
-        A_GIMME, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_set, gensym("set"),
-        A_FLOAT, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_all, gensym("all"),
-        A_GIMME, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_vis, gensym("vis"),
+    clone_in_class =
+        class_new(gensym("clone-inlet"), 0, 0, sizeof(t_in), CLASS_PD, 0);
+    class_addmethod(
+        clone_in_class, (t_method) clone_in_next, gensym("next"), A_GIMME, 0);
+    class_addmethod(
+        clone_in_class, (t_method) clone_in_this, gensym("this"), A_GIMME, 0);
+    class_addmethod(
+        clone_in_class, (t_method) clone_in_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        clone_in_class, (t_method) clone_in_all, gensym("all"), A_GIMME, 0);
+    class_addmethod(clone_in_class, (t_method) clone_in_vis, gensym("vis"),
         A_FLOAT, A_FLOAT, 0);
-    class_addmethod(clone_in_class, (t_method)clone_in_fwd, gensym("fwd"),
-        A_GIMME, 0);
-    class_addlist(clone_in_class, (t_method)clone_in_list);
+    class_addmethod(
+        clone_in_class, (t_method) clone_in_fwd, gensym("fwd"), A_GIMME, 0);
+    class_addlist(clone_in_class, (t_method) clone_in_list);
 
-    clone_out_class = class_new(gensym("clone-outlet"), 0, 0,
-        sizeof(t_in), CLASS_PD, 0);
-    class_addanything(clone_out_class, (t_method)clone_out_anything);
+    clone_out_class =
+        class_new(gensym("clone-outlet"), 0, 0, sizeof(t_in), CLASS_PD, 0);
+    class_addanything(clone_out_class, (t_method) clone_out_anything);
 }
 
-    /* for the needs of g_editor::glist_dofinderror(): */
+/* for the needs of g_editor::glist_dofinderror(): */
 
 int clone_get_n(t_gobj *x)
 {
-    if (pd_class(&x->g_pd) != clone_class) return 0;
-    else return ((t_clone *)x)->x_n;
+    if(pd_class(&x->g_pd) != clone_class)
+        return 0;
+    else
+        return ((t_clone *) x)->x_n;
 }
 
 t_glist *clone_get_instance(t_gobj *x, int n)
 {
     t_clone *c;
-    
-    if (pd_class(&x->g_pd) != clone_class) return NULL;
 
-    c = (t_clone *)x;
+    if(pd_class(&x->g_pd) != clone_class) return NULL;
+
+    c = (t_clone *) x;
     n -= c->x_startvoice;
-    if (n < 0)
+    if(n < 0)
         n = 0;
-    else if (n >= c->x_n)
+    else if(n >= c->x_n)
         n = c->x_n - 1;
-    return  c->x_vec[n].c_gl;
+    return c->x_vec[n].c_gl;
 }
-

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -76,17 +76,25 @@ static void clone_in_list(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
     int n;
     if(argc < 1 || argv[0].a_type != A_FLOAT)
+    {
         pd_error(x->i_owner, "clone: no instance number in message");
+    }
     else if((n = argv[0].a_w.w_float - x->i_owner->x_startvoice) < 0 ||
             n >= x->i_owner->x_n)
+    {
         pd_error(x->i_owner, "clone: instance number %d out of range",
             n + x->i_owner->x_startvoice);
+    }
     else if(argc > 1 && argv[1].a_type == A_SYMBOL)
+    {
         obj_sendinlet(&x->i_owner->x_vec[n].c_gl->gl_obj, x->i_n,
             argv[1].a_w.w_symbol, argc - 2, argv + 2);
+    }
     else
+    {
         obj_sendinlet(&x->i_owner->x_vec[n].c_gl->gl_obj, x->i_n, &s_list,
             argc - 1, argv + 1);
+    }
 }
 
 static void clone_in_this(t_in *x, t_symbol *s, int argc, t_atom *argv)
@@ -96,11 +104,15 @@ static void clone_in_this(t_in *x, t_symbol *s, int argc, t_atom *argv)
     if(argc <= 0)
         return;
     if(argv->a_type == A_SYMBOL)
+    {
         obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n,
             argv[0].a_w.w_symbol, argc - 1, argv + 1);
+    }
     else
+    {
         obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n, &s_list,
             argc, argv);
+    }
 }
 
 static void clone_in_next(t_in *x, t_symbol *s, int argc, t_atom *argv)
@@ -134,9 +146,13 @@ static void clone_in_vis(t_in *x, t_floatarg fn, t_floatarg vis)
 {
     int n = fn - x->i_owner->x_startvoice;
     if(n < 0)
+    {
         n = 0;
+    }
     else if(n >= x->i_owner->x_n)
+    {
         n = x->i_owner->x_n - 1;
+    }
     canvas_vis(x->i_owner->x_vec[n].c_gl, (vis != 0));
 }
 
@@ -171,8 +187,10 @@ static void clone_free(t_clone *x)
         if(THISGUI->i_reloadingabstraction)
         {
             for(i = 0; i < x->x_n; i++)
+            {
                 if(x->x_vec[i].c_gl == THISGUI->i_reloadingabstraction)
                     voicetovis = i;
+            }
         }
         for(i = 0; i < x->x_n; i++)
         {
@@ -225,6 +243,7 @@ void clone_setn(t_clone *x, t_floatarg f)
         wantn = 1;
     }
     if(wantn > nwas)
+    {
         for(i = nwas; i < wantn; i++)
         {
             t_canvas *c;
@@ -256,6 +275,7 @@ void clone_setn(t_clone *x, t_floatarg f)
             }
             x->x_n++;
         }
+    }
     if(wantn < nwas)
     {
         for(i = wantn; i < nwas; i++)
@@ -282,11 +302,15 @@ static void clone_loadbang(t_clone *x, t_floatarg f)
 {
     int i;
     if(f == LB_LOAD)
+    {
         for(i = 0; i < x->x_n; i++)
             canvas_loadbang(x->x_vec[i].c_gl);
+    }
     else if(f == LB_CLOSE)
+    {
         for(i = 0; i < x->x_n; i++)
             canvas_closebang(x->x_vec[i].c_gl);
+    }
 }
 
 void canvas_dodsp(t_canvas *x, int toplevel, t_signal **sp);
@@ -341,11 +365,15 @@ static void clone_dsp(t_clone *x, t_signal **sp)
         for(i = 0; i < nout; i++)
         {
             if(j == 0)
+            {
                 dsp_add_copy(tempio[nin + i]->s_vec, tempsigs[i]->s_vec,
                     tempsigs[i]->s_n);
+            }
             else
+            {
                 dsp_add_plus(tempio[nin + i]->s_vec, tempsigs[i]->s_vec,
                     tempsigs[i]->s_vec, tempsigs[i]->s_n);
+            }
             signal_makereusable(tempio[nin + i]);
         }
     }
@@ -389,18 +417,28 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
             argv += 2;
         }
         else if(!strcmp(argv[0].a_w.w_symbol->s_name, "-x"))
+        {
             x->x_suppressvoice = 1, argc--, argv++;
+        }
         else
+        {
             goto usage;
+        }
     }
     if(argc >= 2 && (wantn = atom_getfloatarg(0, argc, argv)) >= 0 &&
         argv[1].a_type == A_SYMBOL)
+    {
         x->x_s = argv[1].a_w.w_symbol;
+    }
     else if(argc >= 2 && (wantn = atom_getfloatarg(1, argc, argv)) >= 0 &&
             argv[0].a_type == A_SYMBOL)
+    {
         x->x_s = argv[0].a_w.w_symbol;
+    }
     else
+    {
         goto usage;
+    }
     /* store a copy of the argmuents with an extra space (argc+1) for
     supplying an instance number, which we'll bash as we go. */
     x->x_argc = argc - 1;
@@ -423,9 +461,13 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
             obj_issignalinlet(&x->x_vec[0].c_gl->gl_obj, i);
         x->x_invec[i].i_n = i;
         if(x->x_invec[i].i_signal)
+        {
             inlet_new(&x->x_obj, &x->x_invec[i].i_pd, &s_signal, &s_signal);
+        }
         else
+        {
             inlet_new(&x->x_obj, &x->x_invec[i].i_pd, 0, 0);
+        }
     }
     x->x_nout = obj_noutlets(&x->x_vec[0].c_gl->gl_obj);
     x->x_outvec = (t_out **) getbytes(sizeof(*x->x_outvec));
@@ -504,8 +546,12 @@ t_glist *clone_get_instance(t_gobj *x, int n)
     c = (t_clone *) x;
     n -= c->x_startvoice;
     if(n < 0)
+    {
         n = 0;
+    }
     else if(n >= c->x_n)
+    {
         n = c->x_n - 1;
+    }
     return c->x_vec[n].c_gl;
 }

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -95,7 +95,7 @@ static void clone_in_this(t_in *x, t_symbol *s, int argc, t_atom *argv)
     if(phase < 0 || phase >= x->i_owner->x_n) phase = 0;
     if(argc <= 0)
         return;
-    else if(argv->a_type == A_SYMBOL)
+    if(argv->a_type == A_SYMBOL)
         obj_sendinlet(&x->i_owner->x_vec[phase].c_gl->gl_obj, x->i_n,
             argv[0].a_w.w_symbol, argc - 1, argv + 1);
     else
@@ -492,8 +492,7 @@ int clone_get_n(t_gobj *x)
 {
     if(pd_class(&x->g_pd) != clone_class)
         return 0;
-    else
-        return ((t_clone *) x)->x_n;
+    return ((t_clone *) x)->x_n;
 }
 
 t_glist *clone_get_instance(t_gobj *x, int n)

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -120,7 +120,8 @@ static void clone_in_set(t_in *x, t_floatarg f)
 
 static void clone_in_all(t_in *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int phasewas = x->i_owner->x_phase, i;
+    int phasewas = x->i_owner->x_phase;
+    int i;
     for(i = 0; i < x->i_owner->x_n; i++)
     {
         x->i_owner->x_phase = i;
@@ -148,9 +149,9 @@ static void clone_in_fwd(t_in *x, t_symbol *s, int argc, t_atom *argv)
 static void clone_out_anything(t_out *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    int first = 1 + (s != &s_list && s != &s_float && s != &s_symbol &&
-                        s != &s_bang),
-        outc = argc + first;
+    int first =
+        1 + (s != &s_list && s != &s_float && s != &s_symbol && s != &s_bang);
+    int outc = argc + first;
     ATOMS_ALLOCA(outv, outc);
     SETFLOAT(outv, x->o_n);
     if(first == 2) SETSYMBOL(outv + 1, s);
@@ -165,7 +166,8 @@ static void clone_free(t_clone *x)
 {
     if(x->x_vec)
     {
-        int i, voicetovis = -1;
+        int i;
+        int voicetovis = -1;
         if(THISGUI->i_reloadingabstraction)
         {
             for(i = 0; i < x->x_n; i++)
@@ -213,7 +215,10 @@ static t_canvas *clone_makeone(t_symbol *s, int argc, t_atom *argv)
 void clone_setn(t_clone *x, t_floatarg f)
 {
     int dspstate = canvas_suspend_dsp();
-    int nwas = x->x_n, wantn = f, i, j;
+    int nwas = x->x_n;
+    int wantn = f;
+    int i;
+    int j;
     if(wantn < 1)
     {
         pd_error(x, "can't resize to zero or negative number; setting to 1");
@@ -290,8 +295,12 @@ void signal_makereusable(t_signal *sig);
 
 static void clone_dsp(t_clone *x, t_signal **sp)
 {
-    int i, j, nin, nout;
-    t_signal **tempsigs, **tempio;
+    int i;
+    int j;
+    int nin;
+    int nout;
+    t_signal **tempsigs;
+    t_signal **tempio;
     if(!x->x_n) return;
     for(i = nin = 0; i < x->x_nin; i++)
         if(x->x_invec[i].i_signal) nin++;
@@ -352,7 +361,10 @@ static void *clone_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_clone *x = (t_clone *) pd_new(clone_class);
     t_canvas *c;
-    int wantn, dspstate, i, voicetovis = clone_voicetovis;
+    int wantn;
+    int dspstate;
+    int i;
+    int voicetovis = clone_voicetovis;
     t_out *outvec;
     x->x_invec = 0;
     x->x_outvec = 0;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -315,10 +315,14 @@ void canvas_setundo(t_canvas *x, t_undofn undofn, void *buf, const char *name)
     EDITOR->canvas_undo_buf = buf;
     EDITOR->canvas_undo_whatnext = UNDO_UNDO;
     EDITOR->canvas_undo_name = name;
-    if(x && glist_isvisible(x) && glist_istoplevel(x)) /* enable undo in menu */
+    if(x && glist_isvisible(x) && glist_istoplevel(x))
+    { /* enable undo in menu */
         sys_vgui("pdtk_undomenu .x%lx %s no\n", x, name);
+    }
     else if(hadone)
+    {
         sys_vgui("pdtk_undomenu nobody no no\n");
+    }
 }
 
 /* clear undo if it happens to be for the canvas x.
@@ -332,9 +336,13 @@ static void canvas_undo(t_canvas *x)
 {
     int dspwas = canvas_suspend_dsp();
     if(x != EDITOR->canvas_undo_canvas)
+    {
         bug("canvas_undo 1");
+    }
     else if(EDITOR->canvas_undo_whatnext != UNDO_UNDO)
+    {
         bug("canvas_undo 2");
+    }
     else
     {
 #if 0
@@ -344,8 +352,10 @@ static void canvas_undo(t_canvas *x)
             EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_UNDO);
         /* enable redo in menu */
         if(glist_isvisible(x) && glist_istoplevel(x))
+        {
             sys_vgui(
                 "pdtk_undomenu .x%lx no %s\n", x, EDITOR->canvas_undo_name);
+        }
         EDITOR->canvas_undo_whatnext = UNDO_REDO;
     }
     canvas_resume_dsp(dspwas);
@@ -355,9 +365,13 @@ static void canvas_redo(t_canvas *x)
 {
     int dspwas = canvas_suspend_dsp();
     if(x != EDITOR->canvas_undo_canvas)
+    {
         bug("canvas_undo 1");
+    }
     else if(EDITOR->canvas_undo_whatnext != UNDO_REDO)
+    {
         bug("canvas_undo 2");
+    }
     else
     {
 #if 0
@@ -367,8 +381,10 @@ static void canvas_redo(t_canvas *x)
             EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_REDO);
         /* enable undo in menu */
         if(glist_isvisible(x) && glist_istoplevel(x))
+        {
             sys_vgui(
                 "pdtk_undomenu .x%lx %s no\n", x, EDITOR->canvas_undo_name);
+        }
         EDITOR->canvas_undo_whatnext = UNDO_UNDO;
     }
     canvas_resume_dsp(dspwas);
@@ -397,11 +413,17 @@ int canvas_undo_connect(t_canvas *x, void *z, int action)
 {
     int myaction;
     if(action == UNDO_UNDO)
+    {
         myaction = UNDO_REDO;
+    }
     else if(action == UNDO_REDO)
+    {
         myaction = UNDO_UNDO;
+    }
     else
+    {
         myaction = action;
+    }
     canvas_undo_disconnect(x, z, myaction);
     return 1;
 }
@@ -692,6 +714,7 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         }
     }
     else if(action == UNDO_FREE)
+    {
         if(buf)
         {
             if(buf->u_objectbuf) binbuf_free(buf->u_objectbuf);
@@ -700,6 +723,7 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
             t_freebytes(
                 buf, sizeof(*buf) + sizeof(buf->p_a[0]) * (buf->n_obj - 1));
         }
+    }
     return 1;
 }
 
@@ -735,6 +759,7 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
     {
         int i;
         for(y = x->gl_list, i = indx = 0; y; y = y->g_next, indx++)
+        {
             if(glist_isselected(x, y))
             {
                 gobj_getrect(y, x, &x1, &y1, &x2, &y2);
@@ -743,6 +768,7 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
                 buf->u_vec[i].e_ypix = y1 / x->gl_zoom;
                 i++;
             }
+        }
     }
     else
     {
@@ -789,9 +815,13 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
                 buf->u_vec[i].e_xpix = x1 / x->gl_zoom;
                 buf->u_vec[i].e_ypix = y1 / x->gl_zoom;
                 if(cl == vinlet_class)
+                {
                     resortin = 1;
+                }
                 else if(cl == voutlet_class)
+                {
                     resortout = 1;
+                }
             }
         }
         glist_noselect(x);
@@ -1055,9 +1085,13 @@ void *canvas_undo_set_arrange(t_canvas *x, t_gobj *obj, int newindex)
 
     /* set the u_newindex appropriately */
     if(newindex == 0)
+    {
         buf->u_newindex = 0;
+    }
     else
+    {
         buf->u_newindex = glist_getindex(x, 0) - 1;
+    }
 
     /* store index of the currently selected object */
     buf->u_previndex = glist_getindex(x, obj);
@@ -1084,10 +1118,14 @@ static void canvas_doarrange(t_canvas *x, t_float which, t_gobj *oldy,
              * oldy (we know there is oldy_next as y_end != oldy in
              * canvas_done_popup)
              */
-            if(oldy_prev) /* there is indeed more before the oldy position */
+            if(oldy_prev)
+            { /* there is indeed more before the oldy position */
                 oldy_prev->g_next = oldy_next;
+            }
             else
+            {
                 x->gl_list = oldy_next;
+            }
 
 #if 0
             /* and finally redraw */
@@ -1105,10 +1143,14 @@ static void canvas_doarrange(t_canvas *x, t_float which, t_gobj *oldy,
              */
             if(oldy_prev)
             {
-                if(oldy_next) /* there is indeed more after oldy position */
+                if(oldy_next)
+                { /* there is indeed more after oldy position */
                     oldy_prev->g_next = oldy_next;
+                }
                 else
+                {
                     oldy_prev->g_next = NULL; /* oldy was the last in the cue */
+                }
             }
 
 #if 0
@@ -1213,9 +1255,13 @@ int canvas_undo_arrange(t_canvas *x, void *z, int action)
             glist_select(x, y);
 
             if(!buf->u_newindex)
+            {
                 arrangeaction = 4;
+            }
             else
+            {
                 arrangeaction = 3;
+            }
 
             /* if there is an object before ours (in other words our index is >
              * 0) */
@@ -1501,9 +1547,13 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
     t_undo_create *buf = z;
     t_gobj *y = NULL;
     if(action == UNDO_UNDO)
+    {
         y = glist_nth(x, glist_getindex(x, 0) - 1);
+    }
     else if(action == UNDO_REDO)
+    {
         y = glist_nth(x, buf->u_index);
+    }
 
     /* check if we are undoing the creation of a dirty abstraction;
      * if so, bail out */
@@ -1545,9 +1595,11 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 
         /* reposition object to its original place */
         if(action == UNDO_UNDO)
+        {
             if(canvas_apply_restore_original_position(x, buf->u_index) &&
                 x->gl_havewindow)
                 canvas_redraw(x);
+        }
 
         /* send a loadbang */
         if(pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
@@ -1555,9 +1607,13 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 
         /* select */
         if(action == UNDO_REDO)
+        {
             y = glist_nth(x, glist_getindex(x, 0) - 1);
+        }
         else
+        {
             y = glist_nth(x, buf->u_index);
+        }
         glist_select(x, y);
     }
     else if(action == UNDO_FREE)
@@ -1777,9 +1833,13 @@ static t_gobj *canvas_findhitbox(
     {
         t_selection *sel;
         for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+        {
             if(canvas_hitbox(x, sel->sel_what, xpos, ypos, &x1, &y1, &x2, &y2))
+            {
                 *x1p = x1, *y1p = y1, *x2p = x2, *y2p = y2,
                 rval = sel->sel_what;
+            }
+        }
     }
     return (rval);
 }
@@ -1997,22 +2057,28 @@ void canvas_properties(t_gobj *z, t_glist *unused)
     t_gobj *y;
     char graphbuf[200];
     if(glist_isgraph(x) != 0)
+    {
         sprintf(graphbuf,
             "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n", 0., 0.,
             glist_isgraph(x), x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
             (int) x->gl_pixwidth, (int) x->gl_pixheight, (int) x->gl_xmargin,
             (int) x->gl_ymargin);
+    }
     else
+    {
         sprintf(graphbuf,
             "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n",
             glist_dpixtodx(x, 1), -glist_dpixtody(x, 1), 0, 0., -1., 1., 1.,
             (int) x->gl_pixwidth, (int) x->gl_pixheight, (int) x->gl_xmargin,
             (int) x->gl_ymargin);
+    }
     gfxstub_new(&x->gl_pd, x, graphbuf);
     /* if any arrays are in the graph, put out their dialogs too */
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == garray_class)
             garray_properties((t_garray *) y);
+    }
 }
 
 /* called from the gui when "OK" is selected on the canvas properties
@@ -2069,13 +2135,21 @@ static void canvas_donecanvasdialog(
     if(graphme)
     {
         if(x1 != x2)
+        {
             x->gl_x1 = x1, x->gl_x2 = x2;
+        }
         else
+        {
             x->gl_x1 = 0, x->gl_x2 = 1;
+        }
         if(y1 != y2)
+        {
             x->gl_y1 = y1, x->gl_y2 = y2;
+        }
         else
+        {
             x->gl_y1 = 0, x->gl_y2 = 1;
+        }
     }
     else
     {
@@ -2106,7 +2180,9 @@ static void canvas_donecanvasdialog(
     canvas_setgraph(x, graphme, 0);
     canvas_dirty(x, 1);
     if(x->gl_havewindow)
+    {
         canvas_redraw(x);
+    }
     else if(!x->gl_isclone && glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
@@ -2160,9 +2236,13 @@ static void canvas_done_popup(
                     if(!basenamep) basenamep = strrchr(namebuf, '\\');
 #endif
                     if(!basenamep)
+                    {
                         basenamep = namebuf;
+                    }
                     else
+                    {
                         basenamep++; /* strip last '/' */
+                    }
 
                     dir = canvas_getdir((t_canvas *) y)->s_name;
                 }
@@ -2183,9 +2263,13 @@ static void canvas_done_popup(
         }
     }
     if(which == 0)
+    {
         canvas_properties(&x->gl_gobj, 0);
+    }
     else if(which == 2)
+    {
         open_via_helppath("intro.pd", canvas_getdir((t_canvas *) x)->s_name);
+    }
 }
 
 #define NOMOD 0
@@ -2285,9 +2369,13 @@ static void canvas_doclick(
         if(!doit)
         {
             if(hitbox)
+            {
                 canvas_setcursor(x, clickreturned);
+            }
             else
+            {
                 canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
+            }
         }
         return;
     }
@@ -2307,7 +2395,9 @@ static void canvas_doclick(
     {
         /* we're in a rectangle */
         if(rightclick)
+        {
             canvas_rightclick(x, xpos, ypos, hitbox);
+        }
         else if(shiftmod)
         {
             if(doit)
@@ -2324,9 +2414,13 @@ static void canvas_doclick(
                 else
                 {
                     if(glist_isselected(x, hitbox))
+                    {
                         glist_deselect(x, hitbox);
+                    }
                     else
+                    {
                         glist_select(x, hitbox);
+                    }
                 }
             }
         }
@@ -2387,9 +2481,13 @@ static void canvas_doclick(
                         canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
                 }
                 else if(doit)
+                {
                     goto nooutletafterall;
+                }
                 else
+                {
                     canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
+                }
             }
             /* not in an outlet; select and move */
             else if(doit)
@@ -2557,9 +2655,11 @@ int canvas_isconnected(t_canvas *x, t_text *ob1, int n1, t_text *ob2, int n2)
     t_outconnect *oc;
     linetraverser_start(&t, x);
     while((oc = linetraverser_next(&t)))
+    {
         if(t.tr_ob == ob1 && t.tr_outno == n1 && t.tr_ob2 == ob2 &&
             t.tr_inno == n2)
             return (1);
+    }
     return (0);
 }
 
@@ -2656,8 +2756,10 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
         sys_vgui(".x%lx.c delete x\n", x);
     }
     else
+    {
         sys_vgui(".x%lx.c coords x %d %d %d %d\n", x, x->gl_editor->e_xwas,
             x->gl_editor->e_ywas, xpos, ypos);
+    }
 
     if((y1 = canvas_findhitbox(x, xwas, ywas, &x11, &y11, &x12, &y12)) &&
         (y2 = canvas_findhitbox(x, xpos, ypos, &x21, &y21, &x22, &y22)))
@@ -2705,8 +2807,10 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                 !obj_issignalinlet(ob2, closest2))
             {
                 if(doit)
+                {
                     pd_error(0,
                         "can't connect audio signal outlet to nonsignal inlet");
+                }
                 canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
                 return;
             }
@@ -2719,10 +2823,12 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                 canvas_dirty(x, 1);
                 /* now find out if either ob1 xor ob2 are part of the selection,
                  * and if so, connect the rest of the selection as well */
-                if(mod & SHIFTMOD) /* intelligent patching needs to be activated
-                                      by modifier key */
+                if(mod & SHIFTMOD)
+                { /* intelligent patching needs to be activated
+                   by modifier key */
                     selmode = glist_isselected(x, &ob1->ob_g) +
                               2 * glist_isselected(x, &ob2->ob_g);
+                }
                 switch(selmode)
                 {
                     case 3: /* both source and sink are selected */
@@ -2796,17 +2902,25 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                                         {
                                             sob->sel_next = s;
                                             if(slast)
+                                            {
                                                 slast->sel_next = sob;
+                                            }
                                             else
+                                            {
                                                 sortedsel = sob;
+                                            }
                                             break;
                                         }
                                         slast = s;
                                     }
                                     if(slast)
+                                    {
                                         slast->sel_next = sob;
+                                    }
                                     else
+                                    {
                                         sortedsel = sob;
+                                    }
                                 }
                             }
                             /* try to maximize connections */
@@ -2824,6 +2938,7 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                             sinks = 0;
                             sources = 0;
                             if(mode)
+                            {
                                 for(sel = sortedsel;
                                     ((closest1 + 1 + sinks) < noutlet1) && sel;
                                     sel = sel->sel_next)
@@ -2833,7 +2948,9 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                                         pd_checkobject(&sel->sel_what->g_pd),
                                         closest2);
                                 }
+                            }
                             else
+                            {
                                 for(sel = sortedsel;
                                     ((closest2 + 1 + sources) < ninlet2) && sel;
                                     sel = sel->sel_next)
@@ -2842,6 +2959,7 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                                         pd_checkobject(&sel->sel_what->g_pd),
                                         closest1, ob2, closest2 + 1 + sources);
                                 }
+                            }
 
                             /* free the sorted list of selections */
                             for(sel = sortedsel; sel;)
@@ -2910,20 +3028,30 @@ static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
         int hix;
         int hiy;
         if(x->gl_editor->e_xwas < xpos)
+        {
             lox = x->gl_editor->e_xwas, hix = xpos;
+        }
         else
+        {
             hix = x->gl_editor->e_xwas, lox = xpos;
+        }
         if(x->gl_editor->e_ywas < ypos)
+        {
             loy = x->gl_editor->e_ywas, hiy = ypos;
+        }
         else
+        {
             hiy = x->gl_editor->e_ywas, loy = ypos;
+        }
         canvas_selectinrect(x, lox, loy, hix, hiy);
         sys_vgui(".x%lx.c delete x\n", x);
         x->gl_editor->e_onmotion = MA_NONE;
     }
     else
+    {
         sys_vgui(".x%lx.c coords x %d %d %d %d\n", x, x->gl_editor->e_xwas,
             x->gl_editor->e_ywas, xpos, ypos);
+    }
 }
 
 void canvas_mouseup(t_canvas *x, t_floatarg fxpos, t_floatarg fypos,
@@ -2947,9 +3075,13 @@ void canvas_mouseup(t_canvas *x, t_floatarg fxpos, t_floatarg fypos,
     EDITOR->canvas_upy = ypos;
 
     if(x->gl_editor->e_onmotion == MA_CONNECT)
+    {
         canvas_doconnect(x, xpos, ypos, mod, 1);
+    }
     else if(x->gl_editor->e_onmotion == MA_REGION)
+    {
         canvas_doregion(x, xpos, ypos, 1);
+    }
     else if((x->gl_editor->e_onmotion == MA_MOVE ||
                 x->gl_editor->e_onmotion == MA_RESIZE))
     {
@@ -3006,9 +3138,13 @@ static void canvas_displaceselection(t_canvas *x, int dx, int dy)
         t_class *cl = pd_class(&y->sel_what->g_pd);
         gobj_displace(y->sel_what, x, dx, dy);
         if(cl == vinlet_class)
+        {
             resortin = 1;
+        }
         else if(cl == voutlet_class)
+        {
             resortout = 1;
+        }
     }
     if(resortin) canvas_resortinlets(x);
     if(resortout) canvas_resortoutlets(x);
@@ -3035,7 +3171,9 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
     down = (atom_getfloat(av) != 0);      /* nonzero if it's a key down */
     shift = (atom_getfloat(av + 2) != 0); /* nonzero if shift-ed */
     if(av[1].a_type == A_SYMBOL)
+    {
         gotkeysym = av[1].a_w.w_symbol;
+    }
     else if(av[1].a_type == A_FLOAT)
     {
         char buf[UTF8_MAXBYTES1];
@@ -3085,45 +3223,85 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
     /* alias Apple key numbers to symbols.  This is done unconditionally,
        not just if we're on an Apple, just in case the GUI is remote. */
     if(keynum == 30 || keynum == 63232)
+    {
         keynum = 0, gotkeysym = gensym("Up");
+    }
     else if(keynum == 31 || keynum == 63233)
+    {
         keynum = 0, gotkeysym = gensym("Down");
+    }
     else if(keynum == 28 || keynum == 63234)
+    {
         keynum = 0, gotkeysym = gensym("Left");
+    }
     else if(keynum == 29 || keynum == 63235)
+    {
         keynum = 0, gotkeysym = gensym("Right");
+    }
     else if(keynum == 63273)
+    {
         keynum = 0, gotkeysym = gensym("Home");
+    }
     else if(keynum == 63275)
+    {
         keynum = 0, gotkeysym = gensym("End");
+    }
     else if(keynum == 63276)
+    {
         keynum = 0, gotkeysym = gensym("Prior");
+    }
     else if(keynum == 63277)
+    {
         keynum = 0, gotkeysym = gensym("Next");
+    }
     else if(keynum == 63236)
+    {
         keynum = 0, gotkeysym = gensym("F1");
+    }
     else if(keynum == 63237)
+    {
         keynum = 0, gotkeysym = gensym("F2");
+    }
     else if(keynum == 63238)
+    {
         keynum = 0, gotkeysym = gensym("F3");
+    }
     else if(keynum == 63239)
+    {
         keynum = 0, gotkeysym = gensym("F4");
+    }
     else if(keynum == 63240)
+    {
         keynum = 0, gotkeysym = gensym("F5");
+    }
     else if(keynum == 63241)
+    {
         keynum = 0, gotkeysym = gensym("F6");
+    }
     else if(keynum == 63242)
+    {
         keynum = 0, gotkeysym = gensym("F7");
+    }
     else if(keynum == 63243)
+    {
         keynum = 0, gotkeysym = gensym("F8");
+    }
     else if(keynum == 63244)
+    {
         keynum = 0, gotkeysym = gensym("F9");
+    }
     else if(keynum == 63245)
+    {
         keynum = 0, gotkeysym = gensym("F10");
+    }
     else if(keynum == 63246)
+    {
         keynum = 0, gotkeysym = gensym("F11");
+    }
     else if(keynum == 63247)
+    {
         keynum = 0, gotkeysym = gensym("F12");
+    }
     if(gensym("#key")->s_thing && down)
         pd_float(gensym("#key")->s_thing, (t_float) keynum);
     if(gensym("#keyup")->s_thing && !down)
@@ -3145,10 +3323,12 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
             x->gl_editor->e_onmotion = MA_NONE;
         /* if an object has "grabbed" keys just send them on */
         if(x->gl_editor->e_grab && x->gl_editor->e_keyfn && keynum)
+        {
             (*x->gl_editor->e_keyfn)(
                 x->gl_editor->e_grab, gotkeysym, (t_float) keynum);
         /* if a text editor is open send the key on, as long as
            it is either "real" (has a key number) or else is an arrow key. */
+        }
         else if(x->gl_editor->e_textedfor &&
                 (keynum || !strcmp(gotkeysym->s_name, "Home") ||
                     !strcmp(gotkeysym->s_name, "End") ||
@@ -3182,13 +3362,21 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
         }
         /* check for arrow keys */
         else if(!strcmp(gotkeysym->s_name, "Up"))
+        {
             canvas_displaceselection(x, 0, shift ? -10 : -1);
+        }
         else if(!strcmp(gotkeysym->s_name, "Down"))
+        {
             canvas_displaceselection(x, 0, shift ? 10 : 1);
+        }
         else if(!strcmp(gotkeysym->s_name, "Left"))
+        {
             canvas_displaceselection(x, shift ? -10 : -1, 0);
+        }
         else if(!strcmp(gotkeysym->s_name, "Right"))
+        {
             canvas_displaceselection(x, shift ? 10 : 1, 0);
+        }
         else if((MA_CONNECT == x->gl_editor->e_onmotion) &&
                 (CURSOR_EDITMODE_CONNECT == EDITOR->canvas_cursorwas) &&
                 !strncmp(gotkeysym->s_name, "Shift", 5))
@@ -3205,8 +3393,10 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
        cursor to indicate how the click action changes */
     if(x && keynum == 0 && x->gl_edit &&
         !strncmp(gotkeysym->s_name, "Control", 7))
+    {
         canvas_setcursor(
             x, down ? CURSOR_RUNMODE_NOTHING : CURSOR_EDITMODE_NOTHING);
+    }
 }
 
 static void delay_move(t_canvas *x)
@@ -3245,7 +3435,9 @@ void canvas_motion(
         x->gl_editor->e_ynew = ypos;
     }
     else if(x->gl_editor->e_onmotion == MA_REGION)
+    {
         canvas_doregion(x, xpos, ypos, 0);
+    }
     else if(x->gl_editor->e_onmotion == MA_CONNECT)
     {
         canvas_doconnect(x, xpos, ypos, mod, 0);
@@ -3264,8 +3456,10 @@ void canvas_motion(
     {
         t_rtext *rt = x->gl_editor->e_textedfor;
         if(rt)
+        {
             rtext_mouse(rt, xpos - x->gl_editor->e_xwas,
                 ypos - x->gl_editor->e_ywas, RTEXT_DRAG);
+        }
     }
     else if(x->gl_editor->e_onmotion == MA_RESIZE)
     {
@@ -3333,9 +3527,13 @@ extern int sys_perf;
 void canvas_print(t_canvas *x, t_symbol *s)
 {
     if(*s->s_name)
+    {
         sys_vgui(".x%lx.c postscript -file %s\n", x, s->s_name);
+    }
     else
+    {
         sys_vgui(".x%lx.c postscript -file x.ps\n", x);
+    }
 }
 
 /* find the innermost dirty sub-glist, if any, of this one (including itself) */
@@ -3344,9 +3542,11 @@ static t_glist *glist_finddirty(t_glist *x)
     t_gobj *g;
     t_glist *g2;
     for(g = x->gl_list; g; g = g->g_next)
+    {
         if(pd_class(&g->g_pd) == canvas_class &&
             (g2 = glist_finddirty((t_glist *) g)))
             return (g2);
+    }
 
     if(x->gl_env && x->gl_dirty)
         return (x);
@@ -3360,6 +3560,7 @@ void glob_verifyquit(void *dummy, t_floatarg f)
     t_glist *g, *g2;
     /* find all root canvases */
     for(g = pd_getcanvaslist(); g; g = g->gl_next)
+    {
         if((g2 = glist_finddirty(g)))
         {
             canvas_vis(g2, 1);
@@ -3367,10 +3568,15 @@ void glob_verifyquit(void *dummy, t_floatarg f)
                 canvas_getrootfor(g2), g2);
             return;
         }
+    }
     if(f == 0 && sys_perf)
+    {
         sys_vgui("pdtk_check .pdwindow {really quit?} {pd quit} yes\n");
+    }
     else
+    {
         glob_quit(0);
+    }
 }
 
 /* close a window (or possibly quit Pd), checking for dirty flags.
@@ -3385,7 +3591,9 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
     int force = fforce;
     t_glist *g;
     if(x->gl_owner && (force == 0 || force == 1))
+    {
         canvas_vis(x, 0); /* if subpatch, just invis it */
+    }
     else if(force == 0)
     {
         g = glist_finddirty(x);
@@ -3406,7 +3614,9 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
             pd_free(&x->gl_pd);
     }
     else if(force == 1)
+    {
         pd_free(&x->gl_pd);
+    }
     else if(force == 2)
     {
         canvas_dirty(x, 0);
@@ -3449,6 +3659,7 @@ static void canvas_zoom(t_canvas *x, t_floatarg zoom)
         t_gobj *g;
         t_object *obj;
         for(g = x->gl_list; g; g = g->g_next)
+        {
             if((obj = pd_checkobject(&g->g_pd)))
             {
                 /* pass zoom message on to all objects, except canvases
@@ -3459,6 +3670,7 @@ static void canvas_zoom(t_canvas *x, t_floatarg zoom)
                         (((t_glist *) obj)->gl_isgraph)))
                     (*(t_zoomfn) zoommethod)(&obj->te_pd, zoom);
             }
+        }
         x->gl_zoom = zoom;
         if(x->gl_havewindow)
         {
@@ -3558,8 +3770,10 @@ static int canvas_dofind(t_canvas *x, int *myindexp)
         }
     }
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class)
             didit |= canvas_dofind((t_canvas *) y, myindexp);
+    }
     return (didit);
 }
 
@@ -3689,9 +3903,13 @@ void canvas_stowconnections(t_canvas *x)
     }
     /* move the selected part to the end */
     if(!nonhead)
+    {
         x->gl_list = selhead;
+    }
     else
+    {
         x->gl_list = nonhead, nontail->g_next = selhead;
+    }
 
     /* add connections to binbuf */
     binbuf_clear(x->gl_editor->e_connectbuf);
@@ -3701,9 +3919,11 @@ void canvas_stowconnections(t_canvas *x)
         int s1 = glist_isselected(x, &t.tr_ob->ob_g);
         int s2 = glist_isselected(x, &t.tr_ob2->ob_g);
         if(s1 != s2)
+        {
             binbuf_addv(x->gl_editor->e_connectbuf, "ssiiii;", gensym("#X"),
                 gensym("connect"), glist_getindex(x, &t.tr_ob->ob_g),
                 t.tr_outno, glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
+        }
     }
 }
 
@@ -3820,8 +4040,10 @@ static void canvas_cut(t_canvas *x)
 {
     if(!x->gl_editor) /* ignore if invisible */
         return;
-    if(x->gl_editor->e_selectedline) /* delete line */
+    if(x->gl_editor->e_selectedline)
+    { /* delete line */
         canvas_clearline(x);
+    }
     else if(x->gl_editor->e_textedfor) /* delete selected text in a box */
     {
         char *buf;
@@ -3856,10 +4078,16 @@ static void glist_donewloadbangs(t_glist *x)
     {
         t_selection *sel;
         for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+        {
             if(pd_class(&sel->sel_what->g_pd) == canvas_class)
+            {
                 canvas_loadbang((t_canvas *) (&sel->sel_what->g_pd));
+            }
             else if(zgetfn(&sel->sel_what->g_pd, gensym("loadbang")))
+            {
                 vmess(&sel->sel_what->g_pd, gensym("loadbang"), "f", LB_LOAD);
+            }
+        }
     }
 }
 
@@ -4226,12 +4454,16 @@ static void canvas_selectall(t_canvas *x)
     if(!x->gl_edit) canvas_editmode(x, 1);
     /* if everyone is already selected deselect everyone */
     if(!glist_selectionindex(x, 0, 0))
+    {
         glist_noselect(x);
+    }
     else
+    {
         for(y = x->gl_list; y; y = y->g_next)
         {
             if(!glist_isselected(x, y)) glist_select(x, y);
         }
+    }
 }
 
 static void canvas_deselectall(t_canvas *x)
@@ -4264,9 +4496,11 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
         int snkX2 = 0;
         int snkY2 = 0;
         if(EDITOR->canvas_last_glist != x)
+        {
             /* we don't know the current mouse coordinates in this canvas, so
              * return... */
             return;
+        }
         gobj = canvas_findhitbox(x, xwas, ywas, &srcX1, &srcY1, &srcX2, &srcY2);
         src = gobj ? pd_checkobject(&gobj->g_pd) : 0;
         gobj = canvas_findhitbox(x, xpos, ypos, &snkX1, &snkY1, &snkX2, &snkY2);
@@ -4374,8 +4608,10 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
             }
         }
         if(oc)
+        {
             glist_selectline(x, oc, glist_getindex(x, &t.tr_ob->ob_g),
                 t.tr_outno, glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
+        }
         return;
     }
 }
@@ -4396,11 +4632,13 @@ static void canvas_reselect(t_canvas *x)
             int indx = canvas_getindex(x, x->gl_editor->e_selection->sel_what);
             glist_noselect(x);
             for(g = x->gl_list; g; g = g->g_next)
+            {
                 if(g == gwas)
                 {
                     glist_select(x, g);
                     return;
                 }
+            }
             /* "gwas" must have disappeared; just search to the last
                object and select it */
             for(g = x->gl_list; g; g = g->g_next)
@@ -4408,8 +4646,10 @@ static void canvas_reselect(t_canvas *x)
         }
     }
     else if(x->gl_editor->e_selection && !x->gl_editor->e_selection->sel_next)
+    {
         /* otherwise activate first item in selection */
         gobj_activate(x->gl_editor->e_selection->sel_what, x, 1);
+    }
 }
 
 extern t_class *text_class;
@@ -4431,19 +4671,23 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     if(EDITOR->paste_canvas == x)
         whoout += EDITOR->paste_onset, whoin += EDITOR->paste_onset;
     for(src = x->gl_list; whoout; src = src->g_next, whoout--)
+    {
         if(!src->g_next)
         {
             src = NULL;
             logpost(sink, 3, "cannot connect non-existing object");
             goto bad; /* bug fix thanks to Hannes */
         }
+    }
     for(sink = x->gl_list; whoin; sink = sink->g_next, whoin--)
+    {
         if(!sink->g_next)
         {
             sink = NULL;
             logpost(src, 3, "cannot connect to non-existing object");
             goto bad;
         }
+    }
 
     /* check they're both patchable objects */
     if(!(objsrc = pd_checkobject(&src->g_pd)) ||
@@ -4463,11 +4707,15 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     /* if object creation failed, make dummy inlets or outlets
        as needed */
     if(pd_class(&src->g_pd) == text_class && objsrc->te_type == T_OBJECT)
+    {
         while(outno >= obj_noutlets(objsrc))
             outlet_new(objsrc, 0);
+    }
     if(pd_class(&sink->g_pd) == text_class && objsink->te_type == T_OBJECT)
+    {
         while(inno >= obj_ninlets(objsink))
             inlet_new(objsink, &objsink->ob_pd, 0, 0);
+    }
 
     if(!(oc = obj_connect(objsrc, outno, objsink, inno))) goto bad;
     if(glist_isvisible(x) && x->gl_havewindow)
@@ -4516,11 +4764,13 @@ static void canvas_tidy(t_canvas *x)
 
     /* tidy horizontally */
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(all || glist_isselected(x, y))
         {
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
 
             for(y2 = x->gl_list; y2; y2 = y2->g_next)
+            {
                 if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
@@ -4528,8 +4778,10 @@ static void canvas_tidy(t_canvas *x)
                         bx1 < ax1)
                         goto nothorizhead;
                 }
+            }
 
             for(y2 = x->gl_list; y2; y2 = y2->g_next)
+            {
                 if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
@@ -4537,16 +4789,20 @@ static void canvas_tidy(t_canvas *x)
                         by1 != ay1)
                         gobj_displace(y2, x, 0, ay1 - by1);
                 }
+            }
         nothorizhead:;
         }
+    }
     /* tidy vertically.  First guess the user's favorite vertical spacing */
     for(i = NHIST, ip = histogram; i--; ip++)
         *ip = 0;
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(all || glist_isselected(x, y))
         {
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
             for(y2 = x->gl_list; y2; y2 = y2->g_next)
+            {
                 if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
@@ -4557,7 +4813,9 @@ static void canvas_tidy(t_canvas *x)
                             histogram[distance]++;
                     }
                 }
+            }
         }
+    }
     for(i = 2, besthist = 0, bestdist = 4, ip = histogram + 2; i < (NHIST - 2);
         i++, ip++)
     {
@@ -4570,11 +4828,13 @@ static void canvas_tidy(t_canvas *x)
     }
     logpost(NULL, 3, "tidy: best vertical distance %d", bestdist);
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(all || glist_isselected(x, y))
         {
             int keep = 1;
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
             for(y2 = x->gl_list; y2; y2 = y2->g_next)
+            {
                 if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
@@ -4582,10 +4842,12 @@ static void canvas_tidy(t_canvas *x)
                         ay1 >= by2 - 10 && ay1 < by2 + NHIST)
                         goto nothead;
                 }
+            }
             while(keep)
             {
                 keep = 0;
                 for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                {
                     if(all || glist_isselected(x, y2))
                     {
                         gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
@@ -4600,9 +4862,11 @@ static void canvas_tidy(t_canvas *x)
                             break;
                         }
                     }
+                }
             }
         nothead:;
         }
+    }
     canvas_dirty(x, 1);
 }
 
@@ -4719,13 +4983,21 @@ static void canvas_connect_selection(t_canvas *x)
     for(; sel; sel = sel->sel_next)
     {
         if(!a)
+        {
             a = sel->sel_what;
+        }
         else if(!b)
+        {
             b = sel->sel_what;
+        }
         else if(!c)
+        {
             c = sel->sel_what;
+        }
         else
+        {
             return;
+        }
     }
 
     if(!a) return;
@@ -4869,9 +5141,13 @@ static void canvas_texteditor(t_canvas *x)
     char *buf;
     int bufsize;
     if((foo = x->gl_editor->e_textedfor))
+    {
         rtext_gettext(foo, &buf, &bufsize);
+    }
     else
+    {
         buf = "", bufsize = 0;
+    }
     sys_vgui("pdtk_pd_texteditor {%.*s}\n", bufsize, buf);
 }
 
@@ -4891,12 +5167,14 @@ void canvas_editmode(t_canvas *x, t_floatarg state)
         t_object *ob;
         canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
         for(g = x->gl_list; g; g = g->g_next)
+        {
             if((ob = pd_checkobject(&g->g_pd)) && ob->te_type == T_TEXT)
             {
                 t_rtext *y = glist_findrtext(x, ob);
                 text_drawborder(
                     ob, x, rtext_gettag(y), rtext_width(y), rtext_height(y), 1);
             }
+        }
     }
     else
     {
@@ -4941,8 +5219,10 @@ static void canvas_dofont(
         }
     }
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_checkglist(&y->g_pd) && !canvas_isabstraction((t_canvas *) y))
             canvas_dofont((t_canvas *) y, font, xresize, yresize);
+    }
     if(x->gl_havewindow) canvas_redraw(x);
 }
 
@@ -4956,7 +5236,9 @@ static void canvas_font(
     t_canvas *x2 = canvas_getrootfor(x);
     int oldfont = x2->gl_font;
     if(!resize)
+    {
         realresize = 1;
+    }
     else
     {
         if(resize < 20) resize = 20;
@@ -4975,10 +5257,14 @@ static void canvas_font(
 void glist_getnextxy(t_glist *gl, int *xpix, int *ypix)
 {
     if(EDITOR->canvas_last_glist == gl)
+    {
         *xpix = EDITOR->canvas_last_glist_x,
         *ypix = EDITOR->canvas_last_glist_y;
+    }
     else
+    {
         *xpix = *ypix = 40;
+    }
 }
 
 static void glist_setlastxy(t_glist *gl, int xval, int yval)
@@ -5090,10 +5376,14 @@ void g_editor_freepdinstance(void)
     if(EDITOR->canvas_undo_buf)
     {
         if(!EDITOR->canvas_undo_fn)
+        {
             bug("g_editor_freepdinstance");
+        }
         else
+        {
             (*EDITOR->canvas_undo_fn)(
                 EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_FREE);
+        }
     }
     if(EDITOR->canvas_findbuf) binbuf_free(EDITOR->canvas_findbuf);
     freebytes(EDITOR, sizeof(*EDITOR));

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -624,14 +624,13 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         /* now reposition objects to their original locations */
         if(mode == UCUT_CUT || mode == UCUT_CLEAR)
         {
-            int i = 0;
 
             /* location of the first newly pasted object */
             int paste_pos = glist_getindex(x, 0) - buf->n_obj;
             t_gobj *y_prev;
             t_gobj *y;
             t_gobj *y_next;
-            for(i = 0; i < buf->n_obj; i++)
+            for(int i = 0; i < buf->n_obj; i++)
             {
                 /* first check if we are in the same position already */
                 if(paste_pos + i != buf->p_a[i])
@@ -691,14 +690,12 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
     {
         if(mode == UCUT_CUT || mode == UCUT_CLEAR)
         {
-            int i;
             /* we can't just blindly do clear here when the user may have
              * unselected things between undo and redo, so first let's select
              * the right stuff
              */
             glist_noselect(x);
-            i = 0;
-            for(i = 0; i < buf->n_obj; i++)
+            for(int i = 0; i < buf->n_obj; i++)
                 glist_select(x, glist_nth(x, buf->p_a[i]));
             canvas_doclear(x);
         }
@@ -791,8 +788,7 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
     {
         int resortin = 0;
         int resortout = 0;
-        int i;
-        for(i = 0; i < buf->u_n; i++)
+        for(int i = 0; i < buf->u_n; i++)
         {
             float newx = (buf->u_vec[i].e_xpix) * x->gl_zoom;
             float newy = (buf->u_vec[i].e_ypix) * x->gl_zoom;
@@ -825,7 +821,7 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
             }
         }
         glist_noselect(x);
-        for(i = 0; i < buf->u_n; i++)
+        for(int i = 0; i < buf->u_n; i++)
         {
             t_gobj *y = glist_nth(x, buf->u_vec[i].e_index);
             if(y) glist_select(x, y);
@@ -3835,8 +3831,7 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
         }
         else if((n = clone_get_n(g)) != 0)
         {
-            int i;
-            for(i = 0; i < n; i++)
+            for(int i = 0; i < n; i++)
             {
                 if(glist_dofinderror(clone_get_instance(g, i), error_object))
                     return 1;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -131,7 +131,8 @@ static void glist_checkanddeselectall(t_glist *gl, t_gobj *g)
 void glist_deselect(t_glist *x, t_gobj *y)
 {
     int fixdsp = 0;
-    t_selection *sel, *sel2;
+    t_selection *sel;
+    t_selection *sel2;
     t_rtext *z = 0;
 
     if(!x->gl_editor) return;
@@ -262,8 +263,9 @@ static t_gobj *glist_nth(t_glist *x, int n)
 static void canvas_applybinbuf(t_canvas *x, t_binbuf *b)
 {
     t_symbol *asym = gensym("#A");
-    t_pd *boundx = s__X.s_thing, *bounda = asym->s_thing,
-         *boundn = s__N.s_thing;
+    t_pd *boundx = s__X.s_thing;
+    t_pd *bounda = asym->s_thing;
+    t_pd *boundn = s__N.s_thing;
 
     asym->s_thing = 0;
     s__X.s_thing = &x->gl_pd;
@@ -543,7 +545,8 @@ void *canvas_undo_set_cut(t_canvas *x, int mode)
     {
         if(x->gl_list)
         {
-            int i = 0, j = 0;
+            int i = 0;
+            int j = 0;
             t_gobj *y;
             for(y = x->gl_list; y; y = y->g_next)
             {
@@ -576,7 +579,8 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         }
         else if(mode == UCUT_TEXT)
         {
-            t_gobj *y1, *y2;
+            t_gobj *y1;
+            t_gobj *y2;
             glist_noselect(x);
             for(y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
@@ -602,7 +606,9 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
 
             /* location of the first newly pasted object */
             int paste_pos = glist_getindex(x, 0) - buf->n_obj;
-            t_gobj *y_prev, *y, *y_next;
+            t_gobj *y_prev;
+            t_gobj *y;
+            t_gobj *y_next;
             for(i = 0; i < buf->n_obj; i++)
             {
                 /* first check if we are in the same position already */
@@ -676,7 +682,8 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
         }
         else if(mode == UCUT_TEXT)
         {
-            t_gobj *y1, *y2;
+            t_gobj *y1;
+            t_gobj *y2;
             for(y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
             if(y1) glist_delete(x, y1);
@@ -713,7 +720,11 @@ typedef struct _undo_move
 
 void *canvas_undo_set_move(t_canvas *x, int selected)
 {
-    int x1, y1, x2, y2, indx;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
+    int indx;
     t_gobj *y;
     t_undo_move *buf = (t_undo_move *) getbytes(sizeof(*buf));
     buf->u_n = selected ? glist_selectionindex(x, 0, 1) : glist_getindex(x, 0);
@@ -752,7 +763,8 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
     t_undo_move *buf = z;
     if(action == UNDO_UNDO || action == UNDO_REDO)
     {
-        int resortin = 0, resortout = 0;
+        int resortin = 0;
+        int resortout = 0;
         int i;
         for(i = 0; i < buf->u_n; i++)
         {
@@ -761,7 +773,10 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
             t_gobj *y = glist_nth(x, buf->u_vec[i].e_index);
             if(y)
             {
-                int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+                int x1 = 0;
+                int y1 = 0;
+                int x2 = 0;
+                int y2 = 0;
                 int doing = EDITOR->canvas_undo_already_set_move;
                 t_class *cl = pd_class(&y->g_pd);
                 glist_noselect(x);
@@ -988,7 +1003,9 @@ int canvas_undo_apply(t_canvas *x, void *z, int action)
 
 int canvas_apply_restore_original_position(t_canvas *x, int orig_pos)
 {
-    t_gobj *y, *y_prev, *y_next;
+    t_gobj *y;
+    t_gobj *y_prev;
+    t_gobj *y_next;
     /* get the last object */
     y = glist_nth(x, glist_getindex(x, 0) - 1);
     if(glist_getindex(x, y) != orig_pos)
@@ -1109,7 +1126,9 @@ static void canvas_doarrange(t_canvas *x, t_float which, t_gobj *oldy,
 int canvas_undo_arrange(t_canvas *x, void *z, int action)
 {
     t_undo_arrange *buf = z;
-    t_gobj *y = NULL, *prev = NULL, *next = NULL;
+    t_gobj *y = NULL;
+    t_gobj *prev = NULL;
+    t_gobj *next = NULL;
 
     if(!x->gl_edit) canvas_editmode(x, 1);
 
@@ -1181,7 +1200,8 @@ int canvas_undo_arrange(t_canvas *x, void *z, int action)
             break;
         case UNDO_REDO:
         {
-            t_gobj *oldy_prev = NULL, *oldy_next = NULL;
+            t_gobj *oldy_prev = NULL;
+            t_gobj *oldy_next = NULL;
             int arrangeaction;
 
             if(buf->u_newindex == buf->u_previndex) return 1;
@@ -1386,7 +1406,8 @@ void *canvas_undo_set_create(t_canvas *x)
         linetraverser_start(&t, x);
         while((oc = linetraverser_next(&t)))
         {
-            int issel1, issel2;
+            int issel1;
+            int issel2;
             issel1 = (&t.tr_ob->ob_g == y ? 1 : 0);
             issel2 = (&t.tr_ob2->ob_g == y ? 1 : 0);
             if(issel1 != issel2)
@@ -1456,7 +1477,8 @@ void *canvas_undo_set_recreate(t_canvas *x, t_gobj *y, int pos)
     linetraverser_start(&t, x);
     while((oc = linetraverser_next(&t)))
     {
-        int issel1, issel2;
+        int issel1;
+        int issel2;
         issel1 = (&t.tr_ob->ob_g == y ? 1 : 0);
         issel2 = (&t.tr_ob2->ob_g == y ? 1 : 0);
         if(issel1 != issel2)
@@ -1578,7 +1600,8 @@ int canvas_undo_font(t_canvas *x, void *z, int action)
 
         int whichresize = u_f->which;
         t_float realresize = 1. / u_f->resize;
-        t_float realresx = 1, realresy = 1;
+        t_float realresx = 1;
+        t_float realresy = 1;
         if(whichresize != 3) realresx = realresize;
         if(whichresize != 2) realresy = realresize;
         canvas_dofont(x2, u_f->font, realresx, realresy);
@@ -1714,7 +1737,10 @@ void canvas_setcursor(t_canvas *x, unsigned int cursornum)
 int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos, int *x1p,
     int *y1p, int *x2p, int *y2p)
 {
-    int x1, y1, x2, y2;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
     if(!gobj_shouldvis(y, x)) return (0);
     gobj_getrect(y, x, &x1, &y1, &x2, &y2);
     if(xpos >= x1 && xpos <= x2 && ypos >= y1 && ypos <= y2)
@@ -1733,8 +1759,12 @@ int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos, int *x1p,
 static t_gobj *canvas_findhitbox(
     t_canvas *x, int xpos, int ypos, int *x1p, int *y1p, int *x2p, int *y2p)
 {
-    t_gobj *y, *rval = 0;
-    int x1, y1, x2, y2;
+    t_gobj *y;
+    t_gobj *rval = 0;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
     *x1p = -0x7fffffff;
     for(y = x->gl_list; y; y = y->g_next)
     {
@@ -1758,7 +1788,8 @@ static t_gobj *canvas_findhitbox(
 /* right-clicking on a canvas object pops up a menu. */
 static void canvas_rightclick(t_canvas *x, int xpos, int ypos, t_gobj *y)
 {
-    int canprop, canopen;
+    int canprop;
+    int canopen;
     canprop = (!y || class_getpropertiesfn(pd_class(&y->g_pd)));
     canopen = (y && zgetfn(&y->g_pd, gensym("menu-open")));
     sys_vgui("pdtk_canvas_popup .x%lx %d %d %d %d\n", x, xpos, ypos, canprop,
@@ -1990,8 +2021,19 @@ void canvas_properties(t_gobj *z, t_glist *unused)
 static void canvas_donecanvasdialog(
     t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_float xperpix, yperpix, x1, y1, x2, y2, xpix, ypix, xmargin, ymargin;
-    int graphme, redraw = 0, fromgui;
+    t_float xperpix;
+    t_float yperpix;
+    t_float x1;
+    t_float y1;
+    t_float x2;
+    t_float y2;
+    t_float xpix;
+    t_float ypix;
+    t_float xmargin;
+    t_float ymargin;
+    int graphme;
+    int redraw = 0;
+    int fromgui;
 
     xperpix = atom_getfloatarg(0, argc, argv);
     yperpix = atom_getfloatarg(1, argc, argv);
@@ -2078,11 +2120,15 @@ static void canvas_donecanvasdialog(
 static void canvas_done_popup(
     t_canvas *x, t_float which, t_float xpos, t_float ypos)
 {
-    char namebuf[MAXPDSTRING], *basenamep;
+    char namebuf[MAXPDSTRING];
+    char *basenamep;
     t_gobj *y;
     for(y = x->gl_list; y; y = y->g_next)
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         if(canvas_hitbox(x, y, xpos, ypos, &x1, &y1, &x2, &y2))
         {
             if(which == 0) /* properties */
@@ -2156,8 +2202,16 @@ static void canvas_doclick(
     t_canvas *x, int xpos, int ypos, int which, int mod, int doit)
 {
     t_gobj *hitbox;
-    int shiftmod, runmode, altmod, doublemod = 0, rightclick;
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0, clickreturned = 0;
+    int shiftmod;
+    int runmode;
+    int altmod;
+    int doublemod = 0;
+    int rightclick;
+    int x1 = 0;
+    int y1 = 0;
+    int x2 = 0;
+    int y2 = 0;
+    int clickreturned = 0;
     t_text *hitobj;
 
     if(!x->gl_editor)
@@ -2385,14 +2439,18 @@ static void canvas_doclick(
     {
         t_linetraverser t;
         t_outconnect *oc;
-        t_float fx = xpos, fy = ypos;
+        t_float fx = xpos;
+        t_float fy = ypos;
         t_glist *glist2 = glist_getcanvas(x);
         linetraverser_start(&t, glist2);
         while((oc = linetraverser_next(&t)))
         {
-            int outindex, inindex;
-            t_float lx1 = t.tr_lx1, ly1 = t.tr_ly1, lx2 = t.tr_lx2,
-                    ly2 = t.tr_ly2;
+            int outindex;
+            int inindex;
+            t_float lx1 = t.tr_lx1;
+            t_float ly1 = t.tr_ly1;
+            t_float lx2 = t.tr_lx2;
+            t_float ly2 = t.tr_ly2;
             t_float area = (lx2 - lx1) * (fy - ly1) - (ly2 - ly1) * (fx - lx1);
             t_float dsquare =
                 (lx2 - lx1) * (lx2 - lx1) + (ly2 - ly1) * (ly2 - ly1);
@@ -2405,7 +2463,10 @@ static void canvas_doclick(
             inindex = canvas_getindex(glist2, &t.tr_ob2->ob_g);
             if(shiftmod)
             {
-                int soutindex, sinindex, soutno, sinno;
+                int soutindex;
+                int sinindex;
+                int soutno;
+                int sinno;
                 /* if no line is selected, just add this line to the selection
                  */
                 if(!x->gl_editor->e_selectedline)
@@ -2529,9 +2590,20 @@ static int tryconnect(
         {
             int iow = IOWIDTH * x->gl_zoom;
             int iom = IOMIDDLE * x->gl_zoom;
-            int x11 = 0, x12 = 0, x21 = 0, x22 = 0;
-            int y11 = 0, y12 = 0, y21 = 0, y22 = 0;
-            int noutlets1, ninlets, lx1, ly1, lx2, ly2;
+            int x11 = 0;
+            int x12 = 0;
+            int x21 = 0;
+            int x22 = 0;
+            int y11 = 0;
+            int y12 = 0;
+            int y21 = 0;
+            int y22 = 0;
+            int noutlets1;
+            int ninlets;
+            int lx1;
+            int ly1;
+            int lx2;
+            int ly2;
             gobj_getrect(&src->ob_g, x, &x11, &y11, &x12, &y12);
             gobj_getrect(&sink->ob_g, x, &x21, &y21, &x22, &y22);
 
@@ -2564,11 +2636,18 @@ static int tryconnect(
 
 static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 {
-    int x11 = 0, y11 = 0, x12 = 0, y12 = 0;
+    int x11 = 0;
+    int y11 = 0;
+    int x12 = 0;
+    int y12 = 0;
     t_gobj *y1;
-    int x21 = 0, y21 = 0, x22 = 0, y22 = 0;
+    int x21 = 0;
+    int y21 = 0;
+    int x22 = 0;
+    int y22 = 0;
     t_gobj *y2;
-    int xwas = x->gl_editor->e_xwas, ywas = x->gl_editor->e_ywas;
+    int xwas = x->gl_editor->e_xwas;
+    int ywas = x->gl_editor->e_ywas;
 #if 0
     post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, mod, doit);
 #endif
@@ -2586,12 +2665,17 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
     {
         t_object *ob1 = pd_checkobject(&y1->g_pd);
         t_object *ob2 = pd_checkobject(&y2->g_pd);
-        int noutlet1, ninlet2;
+        int noutlet1;
+        int ninlet2;
         if(ob1 && ob2 && ob1 != ob2 && (noutlet1 = obj_noutlets(ob1)) &&
             (ninlet2 = obj_ninlets(ob2)))
         {
-            int width1 = x12 - x11, closest1, hotspot1;
-            int width2 = x22 - x21, closest2, hotspot2;
+            int width1 = x12 - x11;
+            int closest1;
+            int hotspot1;
+            int width2 = x22 - x21;
+            int closest2;
+            int hotspot2;
 
             if(noutlet1 > 1)
             {
@@ -2647,7 +2731,8 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                          * connecting them */
                         if(0 == x->gl_editor->e_selection->sel_next->sel_next)
                         {
-                            int i, j;
+                            int i;
+                            int j;
                             for(i = closest1, j = closest2;
                                 (i < noutlet1) && (j < ninlet2); i++, j++)
                                 tryconnect(x, ob1, i, ob2, j);
@@ -2664,8 +2749,10 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                              */
                             int mode = 0;
                             int i;
-                            int sinks = 0, sources = 0;
-                            t_float ysinks = 0., ysources = 0.;
+                            int sinks = 0;
+                            int sources = 0;
+                            t_float ysinks = 0.;
+                            t_float ysources = 0.;
                             int msgout = !obj_issignaloutlet(ob1, closest1);
                             int sigin = obj_issignalinlet(ob2, closest2);
                             t_selection *sortedsel = 0;
@@ -2696,7 +2783,8 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
                                 /* insert the object into the sortedsel list */
                                 if((sob = getbytes(sizeof(*sob))))
                                 {
-                                    t_selection *s, *slast = 0;
+                                    t_selection *s;
+                                    t_selection *slast = 0;
                                     sob->sel_what = &ob->te_g;
                                     for(s = sortedsel; s; s = s->sel_next)
                                     {
@@ -2803,7 +2891,10 @@ void canvas_selectinrect(t_canvas *x, int lox, int loy, int hix, int hiy)
     t_gobj *y;
     for(y = x->gl_list; y; y = y->g_next)
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         gobj_getrect(y, x, &x1, &y1, &x2, &y2);
         if(hix >= x1 && lox <= x2 && hiy >= y1 && loy <= y2 &&
             !glist_isselected(x, y))
@@ -2815,7 +2906,10 @@ static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
 {
     if(doit)
     {
-        int lox, loy, hix, hiy;
+        int lox;
+        int loy;
+        int hix;
+        int hiy;
         if(x->gl_editor->e_xwas < xpos)
             lox = x->gl_editor->e_xwas, hix = xpos;
         else
@@ -2836,7 +2930,9 @@ static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
 void canvas_mouseup(t_canvas *x, t_floatarg fxpos, t_floatarg fypos,
     t_floatarg fwhich, t_floatarg fmod)
 {
-    int xpos = fxpos, ypos = fypos, which = fwhich;
+    int xpos = fxpos;
+    int ypos = fypos;
+    int which = fwhich;
     int mod = fmod;
 #if 0
     post("mouseup %d %d %d %d", xpos, ypos, which, mod);
@@ -2899,7 +2995,8 @@ void canvas_mouseup(t_canvas *x, t_floatarg fxpos, t_floatarg fypos,
 static void canvas_displaceselection(t_canvas *x, int dx, int dy)
 {
     t_selection *y;
-    int resortin = 0, resortout = 0;
+    int resortin = 0;
+    int resortout = 0;
     if(!EDITOR->canvas_undo_already_set_move)
     {
         canvas_undo_add(x, UNDO_MOTION, "motion", canvas_undo_set_move(x, 1));
@@ -2926,10 +3023,12 @@ static void canvas_displaceselection(t_canvas *x, int dx, int dy)
    "Right" or an Ascii key number.  The third is the shift key. */
 void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
-    int keynum, fflag;
+    int keynum;
+    int fflag;
     t_symbol *gotkeysym;
 
-    int down, shift;
+    int down;
+    int shift;
 
     if(ac < 3) return;
 
@@ -3113,8 +3212,8 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 
 static void delay_move(t_canvas *x)
 {
-    int incx = (x->gl_editor->e_xnew - x->gl_editor->e_xwas) / x->gl_zoom,
-        incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas) / x->gl_zoom;
+    int incx = (x->gl_editor->e_xnew - x->gl_editor->e_xwas) / x->gl_zoom;
+    int incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas) / x->gl_zoom;
     if(incx || incy) canvas_displaceselection(x, incx, incy);
     x->gl_editor->e_xwas += incx * x->gl_zoom;
     x->gl_editor->e_ywas += incy * x->gl_zoom;
@@ -3171,7 +3270,10 @@ void canvas_motion(
     }
     else if(x->gl_editor->e_onmotion == MA_RESIZE)
     {
-        int x11 = 0, y11 = 0, x12 = 0, y12 = 0;
+        int x11 = 0;
+        int y11 = 0;
+        int x12 = 0;
+        int y12 = 0;
         t_gobj *y1;
         if((y1 = canvas_findhitbox(x, x->gl_editor->e_xwas,
                 x->gl_editor->e_ywas, &x11, &y11, &x12, &y12)))
@@ -3183,7 +3285,9 @@ void canvas_motion(
                          (pd_checkglist(&ob->te_pd) &&
                              !((t_canvas *) ob)->gl_isgraph)))
             {
-                int fwidth, fheight, guifsize;
+                int fwidth;
+                int fheight;
+                int guifsize;
                 text_getfont(ob, x, &fwidth, &fheight, &guifsize);
                 wantwidth = wantwidth / fwidth;
                 if(wantwidth < 1) wantwidth = 1;
@@ -3214,7 +3318,8 @@ void canvas_motion(
 
 void canvas_startmotion(t_canvas *x)
 {
-    int xval, yval;
+    int xval;
+    int yval;
     if(!x->gl_editor) return;
     glist_getnextxy(x, &xval, &yval);
     if(xval == 0 && yval == 0) return;
@@ -3378,13 +3483,14 @@ static void canvas_zoom(t_canvas *x, t_floatarg zoom)
 static int atoms_match(int inargc, t_atom *inargv, int searchargc,
     t_atom *searchargv, int wholeword)
 {
-    int indexin, nmatched;
+    int indexin;
+    int nmatched;
     for(indexin = 0; indexin <= inargc - searchargc; indexin++)
     {
         for(nmatched = 0; nmatched < searchargc; nmatched++)
         {
-            t_atom *a1 = &inargv[indexin + nmatched],
-                   *a2 = &searchargv[nmatched];
+            t_atom *a1 = &inargv[indexin + nmatched];
+            t_atom *a2 = &searchargv[nmatched];
             if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
             {
                 if(a2->a_type != a1->a_type) goto nomatch;
@@ -3417,7 +3523,8 @@ extern t_glist *clone_get_instance(t_gobj *x, int n);
 static int canvas_dofind(t_canvas *x, int *myindexp)
 {
     t_gobj *y;
-    int findargc = binbuf_getnatom(EDITOR->canvas_findbuf), didit = 0;
+    int findargc = binbuf_getnatom(EDITOR->canvas_findbuf);
+    int didit = 0;
     t_atom *findargv = binbuf_getvec(EDITOR->canvas_findbuf);
     for(y = x->gl_list; y; y = y->g_next)
     {
@@ -3461,7 +3568,8 @@ static int canvas_dofind(t_canvas *x, int *myindexp)
 
 static void canvas_find(t_canvas *x, t_symbol *s, t_floatarg wholeword)
 {
-    int myindex = 0, found;
+    int myindex = 0;
+    int found;
     t_symbol *decodedsym = sys_decodedialog(s);
     if(!EDITOR->canvas_findbuf) EDITOR->canvas_findbuf = binbuf_new();
     binbuf_text(
@@ -3477,7 +3585,8 @@ static void canvas_find(t_canvas *x, t_symbol *s, t_floatarg wholeword)
 
 static void canvas_find_again(t_canvas *x)
 {
-    int myindex = 0, found;
+    int myindex = 0;
+    int found;
     if(!EDITOR->canvas_findbuf || !canvas_whichfind) return;
     found = canvas_dofind(canvas_whichfind, &myindex);
     sys_vgui("pdtk_showfindresult .x%lx %d %d %d\n", x, found,
@@ -3539,7 +3648,12 @@ void canvas_finderror(const void *error_object)
 
 void canvas_stowconnections(t_canvas *x)
 {
-    t_gobj *selhead = 0, *seltail = 0, *nonhead = 0, *nontail = 0, *y, *y2;
+    t_gobj *selhead = 0;
+    t_gobj *seltail = 0;
+    t_gobj *nonhead = 0;
+    t_gobj *nontail = 0;
+    t_gobj *y;
+    t_gobj *y2;
     t_linetraverser t;
     t_outconnect *oc;
     if(!x->gl_editor) return;
@@ -3660,7 +3774,8 @@ static void canvas_clearline(t_canvas *x)
 
 static void canvas_doclear(t_canvas *x)
 {
-    t_gobj *y, *y2;
+    t_gobj *y;
+    t_gobj *y2;
     int dspstate;
 
     dspstate = canvas_suspend_dsp();
@@ -3846,11 +3961,14 @@ static int binbuf_getpos(t_binbuf *b, int *x0, int *y0, t_symbol **type)
 static void canvas_dopaste(t_canvas *x, t_binbuf *b)
 {
     t_gobj *g2;
-    int dspstate = canvas_suspend_dsp(), nbox, count;
+    int dspstate = canvas_suspend_dsp();
+    int nbox;
+    int count;
     t_symbol *asym = gensym("#A");
     /* save and clear bindings to symbols #A, #N, #X; restore when done */
-    t_pd *boundx = s__X.s_thing, *bounda = asym->s_thing,
-         *boundn = s__N.s_thing;
+    t_pd *boundx = s__X.s_thing;
+    t_pd *bounda = asym->s_thing;
+    t_pd *boundn = s__N.s_thing;
     asym->s_thing = 0;
     s__X.s_thing = &x->gl_pd;
     s__N.s_thing = &pd_canvasmaker;
@@ -3902,14 +4020,16 @@ static t_symbol *get_object_type(t_object *obj)
 
 static void canvas_paste_replace(t_canvas *x)
 {
-    int x0 = 0, y0 = 0;
+    int x0 = 0;
+    int y0 = 0;
     t_symbol *typ0 = 0;
     if(!x->gl_editor) return;
     if(x->gl_editor->e_selection &&
         1 == binbuf_getpos(EDITOR->copy_binbuf, &x0, &y0, &typ0))
     {
         t_canvas *canvas = glist_getcanvas(x);
-        t_selection *mysel = 0, *y;
+        t_selection *mysel = 0;
+        t_selection *y;
         t_symbol *seltype = 0;
 
         /* check whether all the selected objects have the same type */
@@ -4003,7 +4123,8 @@ static void canvas_paste(t_canvas *x)
     else
     {
         int offset = 0;
-        int x0 = 0, y0 = 0;
+        int x0 = 0;
+        int y0 = 0;
         int foundplace = 0;
         binbuf_getpos(EDITOR->copy_binbuf, &x0, &y0, 0);
         do
@@ -4052,8 +4173,10 @@ static void canvas_duplicate(t_canvas *x)
         int inindex = x->gl_editor->e_selectline_index2;
         int outno = x->gl_editor->e_selectline_outno + 1;
         int inno = x->gl_editor->e_selectline_inno + 1;
-        t_gobj *outgobj = 0, *ingobj = 0;
-        t_object *outobj = 0, *inobj = 0;
+        t_gobj *outgobj = 0;
+        t_gobj *ingobj = 0;
+        t_object *outobj = 0;
+        t_object *inobj = 0;
         int whoout = outindex;
         int whoin = inindex;
 
@@ -4128,13 +4251,21 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
     if(x->gl_editor->e_onmotion == MA_CONNECT)
     {
         /* during connection, cycle through inlets/outlets */
-        int xwas = x->gl_editor->e_xwas, ywas = x->gl_editor->e_ywas;
-        int xpos = EDITOR->canvas_last_glist_x,
-            ypos = EDITOR->canvas_last_glist_y;
-        t_object *src, *snk;
+        int xwas = x->gl_editor->e_xwas;
+        int ywas = x->gl_editor->e_ywas;
+        int xpos = EDITOR->canvas_last_glist_x;
+        int ypos = EDITOR->canvas_last_glist_y;
+        t_object *src;
+        t_object *snk;
         t_gobj *gobj;
-        int srcX1 = 0, srcY1 = 0, srcX2 = 0, srcY2 = 0;
-        int snkX1 = 0, snkY1 = 0, snkX2 = 0, snkY2 = 0;
+        int srcX1 = 0;
+        int srcY1 = 0;
+        int srcX2 = 0;
+        int srcY2 = 0;
+        int snkX1 = 0;
+        int snkY1 = 0;
+        int snkX2 = 0;
+        int snkY2 = 0;
         if(EDITOR->canvas_last_glist != x)
             /* we don't know the current mouse coordinates in this canvas, so
              * return... */
@@ -4154,7 +4285,9 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
         if(snk && snk != src)
         {
             /* cycle inlets */
-            int width = snkX2 - snkX1, hotspot, closest;
+            int width = snkX2 - snkX1;
+            int hotspot;
+            int closest;
             int nios = obj_ninlets(snk);
             if(nios <= 1) /* no use cycling */
                 return;
@@ -4168,7 +4301,9 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
         else
         {
             /* cycle outlets */
-            int width = srcX2 - srcX1, hotspot, closest;
+            int width = srcX2 - srcX1;
+            int hotspot;
+            int closest;
             int nios = obj_noutlets(src);
             if(nios <= 1) /* no use cycling */
                 return;
@@ -4250,7 +4385,8 @@ static void canvas_cycleselect(t_canvas *x, t_float foffset)
 
 static void canvas_reselect(t_canvas *x)
 {
-    t_gobj *g, *gwas;
+    t_gobj *g;
+    t_gobj *gwas;
     /* if someone is text editing, and if only one object is
        selected,  deselect everyone and reselect.  */
     if(x->gl_editor->e_textedfor)
@@ -4259,8 +4395,8 @@ static void canvas_reselect(t_canvas *x)
         if((gwas = x->gl_editor->e_selection->sel_what) &&
             !x->gl_editor->e_selection->sel_next)
         {
-            int nobjwas = glist_getindex(x, 0),
-                indx = canvas_getindex(x, x->gl_editor->e_selection->sel_what);
+            int nobjwas = glist_getindex(x, 0);
+            int indx = canvas_getindex(x, x->gl_editor->e_selection->sel_what);
             glist_noselect(x);
             for(g = x->gl_list; g; g = g->g_next)
                 if(g == gwas)
@@ -4284,11 +4420,17 @@ extern t_class *text_class;
 void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     t_floatarg fwhoin, t_floatarg finno)
 {
-    int whoout = fwhoout, outno = foutno, whoin = fwhoin, inno = finno;
-    t_gobj *src = 0, *sink = 0;
-    t_object *objsrc, *objsink;
+    int whoout = fwhoout;
+    int outno = foutno;
+    int whoin = fwhoin;
+    int inno = finno;
+    t_gobj *src = 0;
+    t_gobj *sink = 0;
+    t_object *objsrc;
+    t_object *objsink;
     t_outconnect *oc;
-    int nin = whoin, nout = whoout;
+    int nin = whoin;
+    int nout = whoout;
     if(EDITOR->paste_canvas == x)
         whoout += EDITOR->paste_onset, whoin += EDITOR->paste_onset;
     for(src = x->gl_list; whoout; src = src->g_next, whoout--)
@@ -4354,9 +4496,21 @@ bad:
 /* LATER might have to speed this up */
 static void canvas_tidy(t_canvas *x)
 {
-    t_gobj *y, *y2;
-    int ax1, ay1, ax2, ay2, bx1, by1, bx2, by2;
-    int histogram[NHIST], *ip, i, besthist, bestdist;
+    t_gobj *y;
+    t_gobj *y2;
+    int ax1;
+    int ay1;
+    int ax2;
+    int ay2;
+    int bx1;
+    int by1;
+    int bx2;
+    int by2;
+    int histogram[NHIST];
+    int *ip;
+    int i;
+    int besthist;
+    int bestdist;
     /* if nobody is selected, this means do it to all boxes;
        otherwise just the selection */
     int all = (x->gl_editor ? (x->gl_editor->e_selection == 0) : 1);
@@ -4490,7 +4644,9 @@ static int canvas_try_bypassobj1(t_canvas *x, t_object *obj0, int in0, int out0,
      */
     /* this is doing an awful lot of iterating over the same things again and
      * again LATER speed this up */
-    int A, B, C;
+    int A;
+    int B;
+    int C;
     /* check connections (obj0->obj1->obj2, but not obj2->obj0) */
     /*
        valid:   out0, in1, out1, in2
@@ -4519,8 +4675,11 @@ static int canvas_try_insert(
     t_object *obj22, int in22, int out22 /* insert */
 )
 {
-    int out21 = 0, in02 = 0; /* iolets of the insert-objects */
-    int A, B, C;
+    int out21 = 0;
+    int in02 = 0; /* iolets of the insert-objects */
+    int A;
+    int B;
+    int C;
 
     /* check connections (obj00->obj11, but not obj22) */
     if(out00 < 0 || out22 >= 0 || out11 >= 0 || in00 >= 0 || in22 >= 0 ||
@@ -4551,9 +4710,12 @@ static int canvas_try_insert(
    a compatible type in the lower one. */
 static void canvas_connect_selection(t_canvas *x)
 {
-    t_gobj *a, *b, *c;
+    t_gobj *a;
+    t_gobj *b;
+    t_gobj *c;
     t_selection *sel;
-    t_object *objsrc, *objsink;
+    t_object *objsrc;
+    t_object *objsink;
 
     a = b = c = NULL;
     sel = x->gl_editor ? x->gl_editor->e_selection : NULL;
@@ -4641,7 +4803,8 @@ static void canvas_connect_selection(t_canvas *x)
             int noutlets = obj_noutlets(objsrc);
             int ninlets = obj_ninlets(objsink);
             int fanout = (noutlets == 1) && obj_issignaloutlet(objsrc, 0);
-            int out = 0, in = 0;
+            int out = 0;
+            int in = 0;
             while(!tryconnect(x, objsrc, out, objsink, in))
             {
                 if(noutlets <= out) return;
@@ -4660,10 +4823,21 @@ static void canvas_connect_selection(t_canvas *x)
     if((objsrc = pd_checkobject(&a->g_pd)) &&
         (objsink = pd_checkobject(&b->g_pd)))
     {
-        t_object *obj0 = objsrc, *obj2 = objsink;
+        t_object *obj0 = objsrc;
+        t_object *obj2 = objsink;
         t_object *obj1 = pd_checkobject(&c->g_pd);
-        int out01, out02, out10, out12, out20, out21;
-        int in01, in02, in10, in12, in20, in21;
+        int out01;
+        int out02;
+        int out10;
+        int out12;
+        int out20;
+        int out21;
+        int in01;
+        int in02;
+        int in10;
+        int in12;
+        int in20;
+        int in21;
         if(!obj1 || (obj0 == obj1) || (obj2 == obj1) || (obj0 == obj2)) return;
 #define GET1CONN(a, b)                                              \
     if(1 != canvas_getconns(obj##a, &out##a##b, obj##b, &in##b##a)) \
@@ -4757,7 +4931,12 @@ static void canvas_dofont(
             x, canvas_undo_move, canvas_undo_set_move(x, 0), "motion");
         for(y = x->gl_list; y; y = y->g_next)
         {
-            int x1, x2, y1, y2, nx1, ny1;
+            int x1;
+            int x2;
+            int y1;
+            int y2;
+            int nx1;
+            int ny1;
             gobj_getrect(y, x, &x1, &y1, &x2, &y2);
             nx1 = x1 * xresize + 0.5;
             ny1 = y1 * yresize + 0.5;
@@ -4774,7 +4953,9 @@ static void canvas_dofont(
 static void canvas_font(
     t_canvas *x, t_floatarg font, t_floatarg resize, t_floatarg whichresize)
 {
-    t_float realresize, realresx = 1, realresy = 1;
+    t_float realresize;
+    t_float realresx = 1;
+    t_float realresy = 1;
     t_canvas *x2 = canvas_getrootfor(x);
     int oldfont = x2->gl_font;
     if(!resize)

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -11,7 +11,7 @@
 #include "g_undo.h"
 #include "s_utf8.h" /*-- moo --*/
 #include <string.h>
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
+#ifdef _MSC_VER /* This is only for Microsoft's compiler, not cygwin, e.g. */
 #define snprintf _snprintf
 #endif
 
@@ -20,10 +20,10 @@ struct _instanceeditor
     t_binbuf *copy_binbuf;
     char *canvas_textcopybuf;
     int canvas_textcopybufsize;
-    t_undofn canvas_undo_fn;         /* current undo function if any */
-    int canvas_undo_whatnext;        /* whether we can now UNDO or REDO */
-    void *canvas_undo_buf;           /* data private to the undo function */
-    t_canvas *canvas_undo_canvas;    /* which canvas we can undo on */
+    t_undofn canvas_undo_fn;      /* current undo function if any */
+    int canvas_undo_whatnext;     /* whether we can now UNDO or REDO */
+    void *canvas_undo_buf;        /* data private to the undo function */
+    t_canvas *canvas_undo_canvas; /* which canvas we can undo on */
     const char *canvas_undo_name;
     int canvas_undo_already_set_move;
     double canvas_upclicktime;
@@ -41,8 +41,8 @@ struct _instanceeditor
 /* positional offset for duplicated items */
 #define PASTE_OFFSET 10
 
-void glist_readfrombinbuf(t_glist *x, const t_binbuf *b, const char *filename,
-    int selectem);
+void glist_readfrombinbuf(
+    t_glist *x, const t_binbuf *b, const char *filename, int selectem);
 
 /* ------------------ forward declarations --------------- */
 static void canvas_doclear(t_canvas *x);
@@ -59,10 +59,11 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
 /* ------------------------ managing the selection ----------------- */
 void glist_deselectline(t_glist *x);
-void glist_selectline(t_glist *x, t_outconnect *oc, int index1,
-    int outno, int index2, int inno)
+
+void glist_selectline(
+    t_glist *x, t_outconnect *oc, int index1, int outno, int index2, int inno)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         glist_deselectline(x);
 
@@ -72,40 +73,40 @@ void glist_selectline(t_glist *x, t_outconnect *oc, int index1,
         x->gl_editor->e_selectline_index2 = index2;
         x->gl_editor->e_selectline_inno = inno;
         x->gl_editor->e_selectline_tag = oc;
-        sys_vgui(".x%lx.c itemconfigure l%lx -fill blue\n",
-            x, x->gl_editor->e_selectline_tag);
+        sys_vgui(".x%lx.c itemconfigure l%lx -fill blue\n", x,
+            x->gl_editor->e_selectline_tag);
     }
 }
 
 void glist_deselectline(t_glist *x)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         x->gl_editor->e_selectedline = 0;
-        sys_vgui(".x%lx.c itemconfigure l%lx -fill black\n",
-            x, x->gl_editor->e_selectline_tag);
+        sys_vgui(".x%lx.c itemconfigure l%lx -fill black\n", x,
+            x->gl_editor->e_selectline_tag);
     }
 }
 
 int glist_isselected(t_glist *x, t_gobj *y)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         t_selection *sel;
-        for (sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-            if (sel->sel_what == y) return (1);
+        for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+            if(sel->sel_what == y) return (1);
     }
     return (0);
 }
 
-    /* call this for unselected objects only */
+/* call this for unselected objects only */
 void glist_select(t_glist *x, t_gobj *y)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
-        t_selection *sel = (t_selection *)getbytes(sizeof(*sel));
-            /* LATER #ifdef out the following check */
-        if (glist_isselected(x, y)) bug("glist_select");
+        t_selection *sel = (t_selection *) getbytes(sizeof(*sel));
+        /* LATER #ifdef out the following check */
+        if(glist_isselected(x, y)) bug("glist_select");
         sel->sel_next = x->gl_editor->e_selection;
         sel->sel_what = y;
         x->gl_editor->e_selection = sel;
@@ -113,37 +114,35 @@ void glist_select(t_glist *x, t_gobj *y)
     }
 }
 
-    /* recursively deselect everything in a gobj "g", if it happens to be
-       a glist, in preparation for deselecting g itself in glist_dselect() */
+/* recursively deselect everything in a gobj "g", if it happens to be
+   a glist, in preparation for deselecting g itself in glist_dselect() */
 static void glist_checkanddeselectall(t_glist *gl, t_gobj *g)
 {
     t_glist *gl2;
     t_gobj *g2;
-    if (pd_class(&g->g_pd) != canvas_class)
-        return;
-    gl2 = (t_glist *)g;
-    for (g2 = gl2->gl_list; g2; g2 = g2->g_next)
+    if(pd_class(&g->g_pd) != canvas_class) return;
+    gl2 = (t_glist *) g;
+    for(g2 = gl2->gl_list; g2; g2 = g2->g_next)
         glist_checkanddeselectall(gl2, g2);
     glist_noselect(gl2);
 }
 
-    /* call this for selected objects only */
+/* call this for selected objects only */
 void glist_deselect(t_glist *x, t_gobj *y)
 {
     int fixdsp = 0;
     t_selection *sel, *sel2;
     t_rtext *z = 0;
 
-    if (!x->gl_editor)
-        return;
+    if(!x->gl_editor) return;
 
-    if (!glist_isselected(x, y)) bug("glist_deselect");
-    if (x->gl_editor->e_textedfor)
+    if(!glist_isselected(x, y)) bug("glist_deselect");
+    if(x->gl_editor->e_textedfor)
     {
-        t_rtext *fuddy = glist_findrtext(x, (t_text *)y);
-        if (x->gl_editor->e_textedfor == fuddy)
+        t_rtext *fuddy = glist_findrtext(x, (t_text *) y);
+        if(x->gl_editor->e_textedfor == fuddy)
         {
-            if (x->gl_editor->e_textdirty)
+            if(x->gl_editor->e_textdirty)
             {
                 z = fuddy;
                 canvas_undo_add(x, UNDO_SEQUENCE_START, "typing", 0);
@@ -154,10 +153,9 @@ void glist_deselect(t_glist *x, t_gobj *y)
             }
             gobj_activate(y, x, 0);
         }
-        if (zgetfn(&y->g_pd, gensym("dsp")))
-            fixdsp = canvas_suspend_dsp();
+        if(zgetfn(&y->g_pd, gensym("dsp"))) fixdsp = canvas_suspend_dsp();
     }
-    if ((sel = x->gl_editor->e_selection)->sel_what == y)
+    if((sel = x->gl_editor->e_selection)->sel_what == y)
     {
         x->gl_editor->e_selection = x->gl_editor->e_selection->sel_next;
         gobj_select(sel->sel_what, x, 0);
@@ -165,10 +163,9 @@ void glist_deselect(t_glist *x, t_gobj *y)
     }
     else
     {
-        for (sel = x->gl_editor->e_selection; (sel2 = sel->sel_next);
-             sel = sel2)
+        for(sel = x->gl_editor->e_selection; (sel2 = sel->sel_next); sel = sel2)
         {
-            if (sel2->sel_what == y)
+            if(sel2->sel_what == y)
             {
                 sel->sel_next = sel2->sel_next;
                 gobj_select(sel2->sel_what, x, 0);
@@ -177,47 +174,45 @@ void glist_deselect(t_glist *x, t_gobj *y)
             }
         }
     }
-    if (z)
+    if(z)
     {
         char *buf;
         int bufsize;
 
         rtext_gettext(z, &buf, &bufsize);
-        text_setto((t_text *)y, x, buf, bufsize);
-        canvas_fixlinesfor(x, (t_text *)y);
+        text_setto((t_text *) y, x, buf, bufsize);
+        canvas_fixlinesfor(x, (t_text *) y);
         x->gl_editor->e_textedfor = 0;
         canvas_undo_add(x, UNDO_SEQUENCE_END, "typing", 0);
     }
-    if (fixdsp)
-        canvas_resume_dsp(1);
+    if(fixdsp) canvas_resume_dsp(1);
 }
 
 void glist_noselect(t_glist *x)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
-        while (x->gl_editor->e_selection)
+        while(x->gl_editor->e_selection)
             glist_deselect(x, x->gl_editor->e_selection->sel_what);
-        if (x->gl_editor->e_selectedline)
-            glist_deselectline(x);
+        if(x->gl_editor->e_selectedline) glist_deselectline(x);
     }
 }
 
 void glist_selectall(t_glist *x)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         glist_noselect(x);
-        if (x->gl_list)
+        if(x->gl_list)
         {
-            t_selection *sel = (t_selection *)getbytes(sizeof(*sel));
+            t_selection *sel = (t_selection *) getbytes(sizeof(*sel));
             t_gobj *y = x->gl_list;
             x->gl_editor->e_selection = sel;
             sel->sel_what = y;
             gobj_select(y, x, 1);
-            while ((y = y->g_next))
+            while((y = y->g_next))
             {
-                t_selection *sel2 = (t_selection *)getbytes(sizeof(*sel2));
+                t_selection *sel2 = (t_selection *) getbytes(sizeof(*sel2));
                 sel->sel_next = sel2;
                 sel = sel2;
                 sel->sel_what = y;
@@ -228,29 +223,28 @@ void glist_selectall(t_glist *x)
     }
 }
 
-    /* get the index of a gobj in a glist.  If y is zero, return the
-       total number of objects. */
+/* get the index of a gobj in a glist.  If y is zero, return the
+   total number of objects. */
 int glist_getindex(t_glist *x, t_gobj *y)
 {
     t_gobj *y2;
     int indx;
 
-    for (y2 = x->gl_list, indx = 0; y2 && y2 != y; y2 = y2->g_next)
+    for(y2 = x->gl_list, indx = 0; y2 && y2 != y; y2 = y2->g_next)
         indx++;
     return (indx);
 }
 
-    /* get the index of the object, among selected items, if "selected"
-       is set; otherwise, among unselected ones.  If y is zero, just
-       counts the selected or unselected objects. */
+/* get the index of the object, among selected items, if "selected"
+   is set; otherwise, among unselected ones.  If y is zero, just
+   counts the selected or unselected objects. */
 int glist_selectionindex(t_glist *x, t_gobj *y, int selected)
 {
     t_gobj *y2;
     int indx;
 
-    for (y2 = x->gl_list, indx = 0; y2 && y2 != y; y2 = y2->g_next)
-        if (selected == glist_isselected(x, y2))
-            indx++;
+    for(y2 = x->gl_list, indx = 0; y2 && y2 != y; y2 = y2->g_next)
+        if(selected == glist_isselected(x, y2)) indx++;
     return (indx);
 }
 
@@ -258,9 +252,8 @@ static t_gobj *glist_nth(t_glist *x, int n)
 {
     t_gobj *y;
     int indx;
-    for (y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
-        if (indx == n)
-            return (y);
+    for(y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
+        if(indx == n) return (y);
     return (0);
 }
 
@@ -268,10 +261,9 @@ static t_gobj *glist_nth(t_glist *x, int n)
 
 static void canvas_applybinbuf(t_canvas *x, t_binbuf *b)
 {
-    t_symbol*asym = gensym("#A");
-    t_pd *boundx = s__X.s_thing,
-        *bounda = asym->s_thing,
-        *boundn = s__N.s_thing;
+    t_symbol *asym = gensym("#A");
+    t_pd *boundx = s__X.s_thing, *bounda = asym->s_thing,
+         *boundn = s__N.s_thing;
 
     asym->s_thing = 0;
     s__X.s_thing = &x->gl_pd;
@@ -284,39 +276,36 @@ static void canvas_applybinbuf(t_canvas *x, t_binbuf *b)
     s__N.s_thing = boundn;
 }
 
-
 static int canvas_undo_confirmdiscard(t_gobj *g)
 {
     t_glist *gl2;
 
-    if (pd_class(&g->g_pd) == canvas_class &&
-        canvas_isabstraction((t_glist *)g) &&
-        (gl2 = glist_finddirty((t_glist *)g)))
+    if(pd_class(&g->g_pd) == canvas_class &&
+        canvas_isabstraction((t_glist *) g) &&
+        (gl2 = glist_finddirty((t_glist *) g)))
     {
         vmess(&gl2->gl_pd, gensym("menu-open"), "");
-        sys_vgui(
-            "pdtk_check .x%lx [format [_ \"Discard changes to '%%s'?\"] %s] {.x%lx dirty 0;\n} no\n",
-            canvas_getrootfor(gl2),
-            canvas_getrootfor(gl2)->gl_name->s_name, gl2);
+        sys_vgui("pdtk_check .x%lx [format [_ \"Discard changes to '%%s'?\"] "
+                 "%s] {.x%lx dirty 0;\n} no\n",
+            canvas_getrootfor(gl2), canvas_getrootfor(gl2)->gl_name->s_name,
+            gl2);
         return 1;
     }
     return 0;
 }
 
-void canvas_undo_set_name(const char*name)
-{
-    EDITOR->canvas_undo_name = name;
-}
+void canvas_undo_set_name(const char *name) { EDITOR->canvas_undo_name = name; }
 
-void canvas_setundo(t_canvas *x, t_undofn undofn, void *buf,
-    const char *name)
+void canvas_setundo(t_canvas *x, t_undofn undofn, void *buf, const char *name)
 {
     int hadone = 0;
-        /* blow away the old undo information.  In one special case the
-           old undo info is re-used; if so we shouldn't free it here. */
-    if (EDITOR->canvas_undo_fn && EDITOR->canvas_undo_buf && (buf != EDITOR->canvas_undo_buf))
+    /* blow away the old undo information.  In one special case the
+       old undo info is re-used; if so we shouldn't free it here. */
+    if(EDITOR->canvas_undo_fn && EDITOR->canvas_undo_buf &&
+        (buf != EDITOR->canvas_undo_buf))
     {
-        (*EDITOR->canvas_undo_fn)(EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_FREE);
+        (*EDITOR->canvas_undo_fn)(
+            EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_FREE);
         hadone = 1;
     }
     EDITOR->canvas_undo_canvas = x;
@@ -324,39 +313,37 @@ void canvas_setundo(t_canvas *x, t_undofn undofn, void *buf,
     EDITOR->canvas_undo_buf = buf;
     EDITOR->canvas_undo_whatnext = UNDO_UNDO;
     EDITOR->canvas_undo_name = name;
-    if (x && glist_isvisible(x) && glist_istoplevel(x))
-            /* enable undo in menu */
+    if(x && glist_isvisible(x) && glist_istoplevel(x)) /* enable undo in menu */
         sys_vgui("pdtk_undomenu .x%lx %s no\n", x, name);
-    else if (hadone)
+    else if(hadone)
         sys_vgui("pdtk_undomenu nobody no no\n");
 }
 
-    /* clear undo if it happens to be for the canvas x.
-       (but if x is 0, clear it regardless of who owns it.) */
+/* clear undo if it happens to be for the canvas x.
+   (but if x is 0, clear it regardless of who owns it.) */
 void canvas_noundo(t_canvas *x)
 {
-    if (!x || (x == EDITOR->canvas_undo_canvas))
-        canvas_setundo(0, 0, 0, "foo");
+    if(!x || (x == EDITOR->canvas_undo_canvas)) canvas_setundo(0, 0, 0, "foo");
 }
 
 static void canvas_undo(t_canvas *x)
 {
     int dspwas = canvas_suspend_dsp();
-    if (x != EDITOR->canvas_undo_canvas)
+    if(x != EDITOR->canvas_undo_canvas)
         bug("canvas_undo 1");
-    else if (EDITOR->canvas_undo_whatnext != UNDO_UNDO)
+    else if(EDITOR->canvas_undo_whatnext != UNDO_UNDO)
         bug("canvas_undo 2");
     else
     {
 #if 0
         post("undo");
 #endif
-        (*EDITOR->canvas_undo_fn)(EDITOR->canvas_undo_canvas,
-            EDITOR->canvas_undo_buf, UNDO_UNDO);
-            /* enable redo in menu */
-        if (glist_isvisible(x) && glist_istoplevel(x))
-            sys_vgui("pdtk_undomenu .x%lx no %s\n", x,
-                EDITOR->canvas_undo_name);
+        (*EDITOR->canvas_undo_fn)(
+            EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_UNDO);
+        /* enable redo in menu */
+        if(glist_isvisible(x) && glist_istoplevel(x))
+            sys_vgui(
+                "pdtk_undomenu .x%lx no %s\n", x, EDITOR->canvas_undo_name);
         EDITOR->canvas_undo_whatnext = UNDO_REDO;
     }
     canvas_resume_dsp(dspwas);
@@ -365,21 +352,21 @@ static void canvas_undo(t_canvas *x)
 static void canvas_redo(t_canvas *x)
 {
     int dspwas = canvas_suspend_dsp();
-    if (x != EDITOR->canvas_undo_canvas)
+    if(x != EDITOR->canvas_undo_canvas)
         bug("canvas_undo 1");
-    else if (EDITOR->canvas_undo_whatnext != UNDO_REDO)
+    else if(EDITOR->canvas_undo_whatnext != UNDO_REDO)
         bug("canvas_undo 2");
     else
     {
 #if 0
         post("redo");
 #endif
-        (*EDITOR->canvas_undo_fn)(EDITOR->canvas_undo_canvas,
-            EDITOR->canvas_undo_buf, UNDO_REDO);
-            /* enable undo in menu */
-        if (glist_isvisible(x) && glist_istoplevel(x))
-            sys_vgui("pdtk_undomenu .x%lx %s no\n", x,
-                EDITOR->canvas_undo_name);
+        (*EDITOR->canvas_undo_fn)(
+            EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_REDO);
+        /* enable undo in menu */
+        if(glist_isvisible(x) && glist_istoplevel(x))
+            sys_vgui(
+                "pdtk_undomenu .x%lx %s no\n", x, EDITOR->canvas_undo_name);
         EDITOR->canvas_undo_whatnext = UNDO_UNDO;
     }
     canvas_resume_dsp(dspwas);
@@ -394,12 +381,12 @@ typedef struct _undo_connect
     int u_inletno;
 } t_undo_connect;
 
-void *canvas_undo_set_disconnect(t_canvas *x,
-    int index1, int outno, int index2, int inno);
+void *canvas_undo_set_disconnect(
+    t_canvas *x, int index1, int outno, int index2, int inno);
 
 /* connect just calls disconnect actions backward... (see below) */
-void *canvas_undo_set_connect(t_canvas *x,
-    int index1, int outno, int index2, int inno)
+void *canvas_undo_set_connect(
+    t_canvas *x, int index1, int outno, int index2, int inno)
 {
     return (canvas_undo_set_disconnect(x, index1, outno, index2, inno));
 }
@@ -407,29 +394,30 @@ void *canvas_undo_set_connect(t_canvas *x,
 int canvas_undo_connect(t_canvas *x, void *z, int action)
 {
     int myaction;
-    if (action == UNDO_UNDO)
+    if(action == UNDO_UNDO)
         myaction = UNDO_REDO;
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
         myaction = UNDO_UNDO;
-    else myaction = action;
+    else
+        myaction = action;
     canvas_undo_disconnect(x, z, myaction);
     return 1;
 }
 
-static void canvas_connect_with_undo(t_canvas *x,
-    t_float index1, t_float outno, t_float index2, t_float inno)
+static void canvas_connect_with_undo(
+    t_canvas *x, t_float index1, t_float outno, t_float index2, t_float inno)
 {
     canvas_connect(x, index1, outno, index2, inno);
-    canvas_undo_add(x, UNDO_CONNECT, "connect", canvas_undo_set_connect(x,
-        index1, outno, index2, inno));
+    canvas_undo_add(x, UNDO_CONNECT, "connect",
+        canvas_undo_set_connect(x, index1, outno, index2, inno));
 }
 
 /* ------- specific undo methods: 2. disconnect -------- */
 
-void *canvas_undo_set_disconnect(t_canvas *x,
-    int index1, int outno, int index2, int inno)
+void *canvas_undo_set_disconnect(
+    t_canvas *x, int index1, int outno, int index2, int inno)
 {
-    t_undo_connect *buf = (t_undo_connect *)getbytes(sizeof(*buf));
+    t_undo_connect *buf = (t_undo_connect *) getbytes(sizeof(*buf));
     buf->u_index1 = index1;
     buf->u_outletno = outno;
     buf->u_index2 = index2;
@@ -437,18 +425,18 @@ void *canvas_undo_set_disconnect(t_canvas *x,
     return (buf);
 }
 
-void canvas_disconnect(t_canvas *x,
-    t_float index1, t_float outno, t_float index2, t_float inno)
+void canvas_disconnect(
+    t_canvas *x, t_float index1, t_float outno, t_float index2, t_float inno)
 {
     t_linetraverser t;
     t_outconnect *oc;
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int srcno = canvas_getindex(x, &t.tr_ob->ob_g);
         int sinkno = canvas_getindex(x, &t.tr_ob2->ob_g);
-        if (srcno == index1 && t.tr_outno == outno &&
-            sinkno == index2 && t.tr_inno == inno)
+        if(srcno == index1 && t.tr_outno == outno && sinkno == index2 &&
+            t.tr_inno == inno)
         {
             sys_vgui(".x%lx.c delete l%lx\n", x, oc);
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
@@ -460,49 +448,49 @@ void canvas_disconnect(t_canvas *x,
 int canvas_undo_disconnect(t_canvas *x, void *z, int action)
 {
     t_undo_connect *buf = z;
-    if (action == UNDO_UNDO)
+    if(action == UNDO_UNDO)
     {
-        canvas_connect(x, buf->u_index1, buf->u_outletno,
-            buf->u_index2, buf->u_inletno);
+        canvas_connect(
+            x, buf->u_index1, buf->u_outletno, buf->u_index2, buf->u_inletno);
     }
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
     {
-        canvas_disconnect(x, buf->u_index1, buf->u_outletno,
-            buf->u_index2, buf->u_inletno);
+        canvas_disconnect(
+            x, buf->u_index1, buf->u_outletno, buf->u_index2, buf->u_inletno);
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
         t_freebytes(buf, sizeof(*buf));
     return 1;
 }
 
-static void canvas_disconnect_with_undo(t_canvas *x,
-    t_float index1, t_float outno, t_float index2, t_float inno)
+static void canvas_disconnect_with_undo(
+    t_canvas *x, t_float index1, t_float outno, t_float index2, t_float inno)
 {
     canvas_disconnect(x, index1, outno, index2, inno);
-    canvas_undo_add(x, UNDO_DISCONNECT, "disconnect", canvas_undo_set_disconnect(x,
-        index1, outno, index2, inno));
+    canvas_undo_add(x, UNDO_DISCONNECT, "disconnect",
+        canvas_undo_set_disconnect(x, index1, outno, index2, inno));
 }
 
 /* ---------- ... 3. cut, clear, and typing into objects: -------- */
 
-#define UCUT_CUT 1          /* operation was a cut */
-#define UCUT_CLEAR 2        /* .. a clear */
+#define UCUT_CUT 1   /* operation was a cut */
+#define UCUT_CLEAR 2 /* .. a clear */
 
 /* following action is not needed any more LATER remove any signs of UCUT_TEXT
  * since recreate takes care of this in a more elegant way
  */
-#define UCUT_TEXT 3         /* text typed into a box */
+#define UCUT_TEXT 3 /* text typed into a box */
 
 typedef struct _undo_cut
 {
-    t_binbuf *u_objectbuf;      /* the object cleared or typed into */
-    t_binbuf *u_reconnectbuf;   /* connections into and out of object */
-    t_binbuf *u_redotextbuf;    /* buffer to paste back for redo if TEXT */
-    int u_mode;                 /* from flags above */
-    int n_obj;                  /* number of selected objects to be cut */
-    int p_a[1];    /* array of original glist positions of selected objects.
-                      At least one object is selected, we dynamically resize
-                      it later */
+    t_binbuf *u_objectbuf;    /* the object cleared or typed into */
+    t_binbuf *u_reconnectbuf; /* connections into and out of object */
+    t_binbuf *u_redotextbuf;  /* buffer to paste back for redo if TEXT */
+    int u_mode;               /* from flags above */
+    int n_obj;                /* number of selected objects to be cut */
+    int p_a[1]; /* array of original glist positions of selected objects.
+                   At least one object is selected, we dynamically resize
+                   it later */
 } t_undo_cut;
 
 void *canvas_undo_set_cut(t_canvas *x, int mode)
@@ -510,56 +498,56 @@ void *canvas_undo_set_cut(t_canvas *x, int mode)
     t_undo_cut *buf;
     t_linetraverser t;
     t_outconnect *oc;
-    int nnotsel= glist_selectionindex(x, 0, 0);
+    int nnotsel = glist_selectionindex(x, 0, 0);
     int nsel = glist_selectionindex(x, 0, 1);
-    buf = (t_undo_cut *)getbytes(sizeof(*buf) +
-        sizeof(buf->p_a[0]) * (nsel - 1));
+    buf = (t_undo_cut *) getbytes(
+        sizeof(*buf) + sizeof(buf->p_a[0]) * (nsel - 1));
     buf->n_obj = nsel;
     buf->u_mode = mode;
     buf->u_redotextbuf = 0;
 
-        /* store connections into/out of the selection */
+    /* store connections into/out of the selection */
     buf->u_reconnectbuf = binbuf_new();
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int issel1 = glist_isselected(x, &t.tr_ob->ob_g);
         int issel2 = glist_isselected(x, &t.tr_ob2->ob_g);
-        if (issel1 != issel2)
+        if(issel1 != issel2)
         {
-            binbuf_addv(buf->u_reconnectbuf, "ssiiii;",
-                gensym("#X"), gensym("connect"),
-                (issel1 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
+            binbuf_addv(buf->u_reconnectbuf, "ssiiii;", gensym("#X"),
+                gensym("connect"),
+                (issel1 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
                 t.tr_outno,
-                (issel2 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
+                (issel2 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
                 t.tr_inno);
         }
     }
-    if (mode == UCUT_TEXT)
+    if(mode == UCUT_TEXT)
     {
         buf->u_objectbuf = canvas_docopy(x);
     }
-    else if (mode == UCUT_CUT)
+    else if(mode == UCUT_CUT)
     {
         buf->u_objectbuf = canvas_docopy(x);
     }
-    else if (mode == UCUT_CLEAR)
+    else if(mode == UCUT_CLEAR)
     {
         buf->u_objectbuf = canvas_docopy(x);
     }
 
-        /* instantiate num_obj and fill array of positions of selected objects */
-    if (mode == UCUT_CUT || mode == UCUT_CLEAR)
+    /* instantiate num_obj and fill array of positions of selected objects */
+    if(mode == UCUT_CUT || mode == UCUT_CLEAR)
     {
-        if (x->gl_list)
+        if(x->gl_list)
         {
             int i = 0, j = 0;
             t_gobj *y;
-            for (y = x->gl_list; y; y = y->g_next)
+            for(y = x->gl_list; y; y = y->g_next)
             {
-                if (glist_isselected(x, y))
+                if(glist_isselected(x, y))
                 {
                     buf->p_a[i] = j;
                     i++;
@@ -575,26 +563,26 @@ void *canvas_undo_set_cut(t_canvas *x, int mode)
 int canvas_undo_cut(t_canvas *x, void *z, int action)
 {
     t_undo_cut *buf = z;
-    int mode = buf?(buf->u_mode):0;
-    if (action == UNDO_UNDO)
+    int mode = buf ? (buf->u_mode) : 0;
+    if(action == UNDO_UNDO)
     {
-        if (mode == UCUT_CUT)
+        if(mode == UCUT_CUT)
         {
             canvas_dopaste(x, buf->u_objectbuf);
         }
-        else if (mode == UCUT_CLEAR)
+        else if(mode == UCUT_CLEAR)
         {
             canvas_dopaste(x, buf->u_objectbuf);
         }
-        else if (mode == UCUT_TEXT)
+        else if(mode == UCUT_TEXT)
         {
             t_gobj *y1, *y2;
             glist_noselect(x);
-            for (y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
+            for(y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
-            if (y1)
+            if(y1)
             {
-                if (!buf->u_redotextbuf)
+                if(!buf->u_redotextbuf)
                 {
                     glist_noselect(x);
                     glist_select(x, y1);
@@ -605,106 +593,105 @@ int canvas_undo_cut(t_canvas *x, void *z, int action)
             }
             canvas_dopaste(x, buf->u_objectbuf);
         }
-        if (buf)
-            canvas_applybinbuf(x, buf->u_reconnectbuf);
+        if(buf) canvas_applybinbuf(x, buf->u_reconnectbuf);
 
-            /* now reposition objects to their original locations */
-        if (mode == UCUT_CUT || mode == UCUT_CLEAR)
+        /* now reposition objects to their original locations */
+        if(mode == UCUT_CUT || mode == UCUT_CLEAR)
         {
             int i = 0;
 
-                /* location of the first newly pasted object */
-            int paste_pos = glist_getindex(x,0) - buf->n_obj;
+            /* location of the first newly pasted object */
+            int paste_pos = glist_getindex(x, 0) - buf->n_obj;
             t_gobj *y_prev, *y, *y_next;
-            for (i = 0; i < buf->n_obj; i++)
+            for(i = 0; i < buf->n_obj; i++)
             {
-                    /* first check if we are in the same position already */
-                if (paste_pos+i != buf->p_a[i])
+                /* first check if we are in the same position already */
+                if(paste_pos + i != buf->p_a[i])
                 {
-                    y_prev = glist_nth(x, paste_pos-1+i);
-                    y = glist_nth(x, paste_pos+i);
-                    y_next = glist_nth(x, paste_pos+1+i);
-                        /* if the object is supposed to be first in the gl_list */
-                    if (buf->p_a[i] == 0)
+                    y_prev = glist_nth(x, paste_pos - 1 + i);
+                    y = glist_nth(x, paste_pos + i);
+                    y_next = glist_nth(x, paste_pos + 1 + i);
+                    /* if the object is supposed to be first in the gl_list */
+                    if(buf->p_a[i] == 0)
                     {
-                        if (y_prev && y_next)
+                        if(y_prev && y_next)
                         {
                             y_prev->g_next = y_next;
                         }
-                        else if (y_prev && !y_next)
+                        else if(y_prev && !y_next)
                             y_prev->g_next = NULL;
-                            /* now put the moved object at the beginning of the cue */
+                        /* now put the moved object at the beginning of the cue
+                         */
                         y->g_next = glist_nth(x, 0);
                         x->gl_list = y;
-                            /* LATER when objects are properly tagged lower y here */
+                        /* LATER when objects are properly tagged lower y here
+                         */
                     }
-                        /* if the object is supposed to be in the middle of gl_list */
-                    else {
-                        if (y_prev && y_next)
+                    /* if the object is supposed to be in the middle of gl_list
+                     */
+                    else
+                    {
+                        if(y_prev && y_next)
                         {
                             y_prev->g_next = y_next;
                         }
-                        else if (y_prev && !y_next)
+                        else if(y_prev && !y_next)
                         {
                             y_prev->g_next = NULL;
                         }
-                            /* now put the moved object in its right place */
-                        y_prev = glist_nth(x, buf->p_a[i]-1);
+                        /* now put the moved object in its right place */
+                        y_prev = glist_nth(x, buf->p_a[i] - 1);
                         y_next = glist_nth(x, buf->p_a[i]);
 
                         y_prev->g_next = y;
                         y->g_next = y_next;
-                            /* LATER when objects are properly tagged lower y here */
+                        /* LATER when objects are properly tagged lower y here
+                         */
                     }
                 }
             }
-                /* LATER disable redrawing here */
-            if (x->gl_havewindow)
-                canvas_redraw(x);
-            if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+            /* LATER disable redrawing here */
+            if(x->gl_havewindow) canvas_redraw(x);
+            if(x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
             {
-                gobj_vis((t_gobj *)x, x->gl_owner, 0);
-                gobj_vis((t_gobj *)x, x->gl_owner, 1);
+                gobj_vis((t_gobj *) x, x->gl_owner, 0);
+                gobj_vis((t_gobj *) x, x->gl_owner, 1);
             }
         }
     }
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
     {
-        if (mode == UCUT_CUT || mode == UCUT_CLEAR)
+        if(mode == UCUT_CUT || mode == UCUT_CLEAR)
         {
             int i;
-                /* we can't just blindly do clear here when the user may have
-                 * unselected things between undo and redo, so first let's select
-                 * the right stuff
-                 */
+            /* we can't just blindly do clear here when the user may have
+             * unselected things between undo and redo, so first let's select
+             * the right stuff
+             */
             glist_noselect(x);
             i = 0;
-            for (i = 0; i < buf->n_obj; i++)
+            for(i = 0; i < buf->n_obj; i++)
                 glist_select(x, glist_nth(x, buf->p_a[i]));
             canvas_doclear(x);
         }
-        else if (mode == UCUT_TEXT)
+        else if(mode == UCUT_TEXT)
         {
             t_gobj *y1, *y2;
-            for (y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
+            for(y1 = x->gl_list; (y2 = y1->g_next); y1 = y2)
                 ;
-            if (y1)
-                glist_delete(x, y1);
+            if(y1) glist_delete(x, y1);
             canvas_dopaste(x, buf->u_redotextbuf);
             canvas_applybinbuf(x, buf->u_reconnectbuf);
         }
     }
-    else if (action == UNDO_FREE)
-        if (buf)
+    else if(action == UNDO_FREE)
+        if(buf)
         {
-            if (buf->u_objectbuf)
-                binbuf_free(buf->u_objectbuf);
-            if (buf->u_reconnectbuf)
-                binbuf_free(buf->u_reconnectbuf);
-            if (buf->u_redotextbuf)
-                binbuf_free(buf->u_redotextbuf);
-            t_freebytes(buf, sizeof(*buf) +
-                sizeof(buf->p_a[0]) * (buf->n_obj-1));
+            if(buf->u_objectbuf) binbuf_free(buf->u_objectbuf);
+            if(buf->u_reconnectbuf) binbuf_free(buf->u_reconnectbuf);
+            if(buf->u_redotextbuf) binbuf_free(buf->u_redotextbuf);
+            t_freebytes(
+                buf, sizeof(*buf) + sizeof(buf->p_a[0]) * (buf->n_obj - 1));
         }
     return 1;
 }
@@ -728,15 +715,16 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
 {
     int x1, y1, x2, y2, indx;
     t_gobj *y;
-    t_undo_move *buf =  (t_undo_move *)getbytes(sizeof(*buf));
+    t_undo_move *buf = (t_undo_move *) getbytes(sizeof(*buf));
     buf->u_n = selected ? glist_selectionindex(x, 0, 1) : glist_getindex(x, 0);
-    buf->u_vec = (t_undo_move_elem *)getbytes(sizeof(*buf->u_vec) *
+    buf->u_vec = (t_undo_move_elem *) getbytes(
+        sizeof(*buf->u_vec) *
         (selected ? glist_selectionindex(x, 0, 1) : glist_getindex(x, 0)));
-    if (selected)
+    if(selected)
     {
         int i;
-        for (y = x->gl_list, i = indx = 0; y; y = y->g_next, indx++)
-            if (glist_isselected(x, y))
+        for(y = x->gl_list, i = indx = 0; y; y = y->g_next, indx++)
+            if(glist_isselected(x, y))
             {
                 gobj_getrect(y, x, &x1, &y1, &x2, &y2);
                 buf->u_vec[i].e_index = indx;
@@ -747,7 +735,7 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
     }
     else
     {
-        for (y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
+        for(y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
         {
             gobj_getrect(y, x, &x1, &y1, &x2, &y2);
             buf->u_vec[indx].e_index = indx;
@@ -762,42 +750,45 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
 int canvas_undo_move(t_canvas *x, void *z, int action)
 {
     t_undo_move *buf = z;
-    if (action == UNDO_UNDO || action == UNDO_REDO)
+    if(action == UNDO_UNDO || action == UNDO_REDO)
     {
         int resortin = 0, resortout = 0;
         int i;
-        for (i = 0; i < buf->u_n; i++)
+        for(i = 0; i < buf->u_n; i++)
         {
-            float newx = (buf->u_vec[i].e_xpix)*x->gl_zoom;
-            float newy = (buf->u_vec[i].e_ypix)*x->gl_zoom;
-            t_gobj*y = glist_nth(x, buf->u_vec[i].e_index);
-            if (y)
+            float newx = (buf->u_vec[i].e_xpix) * x->gl_zoom;
+            float newy = (buf->u_vec[i].e_ypix) * x->gl_zoom;
+            t_gobj *y = glist_nth(x, buf->u_vec[i].e_index);
+            if(y)
             {
-                int x1=0, y1=0, x2=0, y2=0;
+                int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
                 int doing = EDITOR->canvas_undo_already_set_move;
                 t_class *cl = pd_class(&y->g_pd);
                 glist_noselect(x);
                 glist_select(x, y);
                 gobj_getrect(y, x, &x1, &y1, &x2, &y2);
                 EDITOR->canvas_undo_already_set_move = 1;
-                canvas_displaceselection(x, (newx - x1)/(x->gl_zoom), (newy - y1)/(x->gl_zoom));
+                canvas_displaceselection(
+                    x, (newx - x1) / (x->gl_zoom), (newy - y1) / (x->gl_zoom));
                 EDITOR->canvas_undo_already_set_move = doing;
-                buf->u_vec[i].e_xpix = x1/x->gl_zoom;
-                buf->u_vec[i].e_ypix = y1/x->gl_zoom;
-                if (cl == vinlet_class) resortin = 1;
-                else if (cl == voutlet_class) resortout = 1;
+                buf->u_vec[i].e_xpix = x1 / x->gl_zoom;
+                buf->u_vec[i].e_ypix = y1 / x->gl_zoom;
+                if(cl == vinlet_class)
+                    resortin = 1;
+                else if(cl == voutlet_class)
+                    resortout = 1;
             }
         }
         glist_noselect(x);
-        for (i = 0; i < buf->u_n; i++)
+        for(i = 0; i < buf->u_n; i++)
         {
-            t_gobj* y = glist_nth(x, buf->u_vec[i].e_index);
-            if (y) glist_select(x, y);
+            t_gobj *y = glist_nth(x, buf->u_vec[i].e_index);
+            if(y) glist_select(x, y);
         }
-        if (resortin) canvas_resortinlets(x);
-        if (resortout) canvas_resortoutlets(x);
+        if(resortin) canvas_resortinlets(x);
+        if(resortout) canvas_resortoutlets(x);
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
         t_freebytes(buf->u_vec, buf->u_n * sizeof(*buf->u_vec));
         t_freebytes(buf, sizeof(*buf));
@@ -809,25 +800,26 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
 
 typedef struct _undo_paste
 {
-    int u_index;            /* index of first object pasted */
-    int u_sel_index;        /* index of object selected at the time the other
-                               object was pasted (for autopatching) */
-    int u_offset;           /* xy-offset for duplicated items (since it differs
-                               when duplicated into same or different canvas */
-    t_binbuf *u_objectbuf;  /* here we store actual copied data */
+    int u_index;           /* index of first object pasted */
+    int u_sel_index;       /* index of object selected at the time the other
+                              object was pasted (for autopatching) */
+    int u_offset;          /* xy-offset for duplicated items (since it differs
+                              when duplicated into same or different canvas */
+    t_binbuf *u_objectbuf; /* here we store actual copied data */
 } t_undo_paste;
 
-void *canvas_undo_set_paste(t_canvas *x, int numpasted, int duplicate,
-    int d_offset)
+void *canvas_undo_set_paste(
+    t_canvas *x, int numpasted, int duplicate, int d_offset)
 {
-    t_undo_paste *buf =  (t_undo_paste *)getbytes(sizeof(*buf));
-    buf->u_index = glist_getindex(x, 0) - numpasted; /* do we need numpasted at all? */
-    if (!duplicate && x->gl_editor->e_selection &&
+    t_undo_paste *buf = (t_undo_paste *) getbytes(sizeof(*buf));
+    buf->u_index =
+        glist_getindex(x, 0) - numpasted; /* do we need numpasted at all? */
+    if(!duplicate && x->gl_editor->e_selection &&
         !x->gl_editor->e_selection->sel_next)
     {
-            /* if only one object is selected which will warrant autopatching */
-        buf->u_sel_index = glist_getindex(x,
-            x->gl_editor->e_selection->sel_what);
+        /* if only one object is selected which will warrant autopatching */
+        buf->u_sel_index =
+            glist_getindex(x, x->gl_editor->e_selection->sel_what);
     }
     else
     {
@@ -837,60 +829,57 @@ void *canvas_undo_set_paste(t_canvas *x, int numpasted, int duplicate,
     buf->u_objectbuf = binbuf_duplicate(EDITOR->copy_binbuf);
     return (buf);
 }
-void *canvas_undo_set_pastebinbuf(t_canvas *x, t_binbuf *b,
-    int numpasted, int duplicate, int d_offset)
+
+void *canvas_undo_set_pastebinbuf(
+    t_canvas *x, t_binbuf *b, int numpasted, int duplicate, int d_offset)
 {
-    t_binbuf*tmpbuf = EDITOR->copy_binbuf;
-    void*ret=0;
+    t_binbuf *tmpbuf = EDITOR->copy_binbuf;
+    void *ret = 0;
     EDITOR->copy_binbuf = b;
     ret = canvas_undo_set_paste(x, numpasted, duplicate, d_offset);
     EDITOR->copy_binbuf = tmpbuf;
     return ret;
 }
 
-
 int canvas_undo_paste(t_canvas *x, void *z, int action)
 {
     t_undo_paste *buf = z;
-    if (action == UNDO_UNDO)
+    if(action == UNDO_UNDO)
     {
         t_gobj *y;
-            /* check if the paste/duplicate we are undoing contains any
-             * dirty abstractions; and if so, bail out */
-        for (y = glist_nth(x, buf->u_index); y; y = y->g_next)
-            if (canvas_undo_confirmdiscard(y))
-                return 0;
+        /* check if the paste/duplicate we are undoing contains any
+         * dirty abstractions; and if so, bail out */
+        for(y = glist_nth(x, buf->u_index); y; y = y->g_next)
+            if(canvas_undo_confirmdiscard(y)) return 0;
 
         glist_noselect(x);
-        for (y = glist_nth(x, buf->u_index); y; y = y->g_next)
+        for(y = glist_nth(x, buf->u_index); y; y = y->g_next)
             glist_select(x, y);
         canvas_doclear(x);
     }
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
     {
         glist_noselect(x);
-            /* if the pasted object is supposed to be autopatched
-             * then select the object it should be autopatched to
-             */
-        if (buf->u_sel_index > -1)
+        /* if the pasted object is supposed to be autopatched
+         * then select the object it should be autopatched to
+         */
+        if(buf->u_sel_index > -1)
         {
             glist_select(x, glist_nth(x, buf->u_sel_index));
         }
         canvas_dopaste(x, buf->u_objectbuf);
 
-            /* if it was "duplicate" have to re-enact the displacement. */
-        if (buf->u_offset)
+        /* if it was "duplicate" have to re-enact the displacement. */
+        if(buf->u_offset)
         {
             t_selection *y;
-            for (y = x->gl_editor->e_selection; y; y = y->sel_next)
-                gobj_displace(y->sel_what, x,
-                    buf->u_offset, buf->u_offset);
+            for(y = x->gl_editor->e_selection; y; y = y->sel_next)
+                gobj_displace(y->sel_what, x, buf->u_offset, buf->u_offset);
         }
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
-        if (buf->u_objectbuf)
-            binbuf_free(buf->u_objectbuf);
+        if(buf->u_objectbuf) binbuf_free(buf->u_objectbuf);
         t_freebytes(buf, sizeof(*buf));
     }
     return 1;
@@ -900,9 +889,9 @@ int canvas_undo_paste(t_canvas *x, void *z, int action)
 
 typedef struct _undo_apply
 {
-    t_binbuf *u_objectbuf;      /* the object cleared or typed into */
-    t_binbuf *u_reconnectbuf;   /* connections into and out of object */
-    int u_index;                /* index of the previous object */
+    t_binbuf *u_objectbuf;    /* the object cleared or typed into */
+    t_binbuf *u_reconnectbuf; /* connections into and out of object */
+    int u_index;              /* index of the previous object */
 } t_undo_apply;
 
 void *canvas_undo_set_apply(t_canvas *x, int n)
@@ -912,88 +901,86 @@ void *canvas_undo_set_apply(t_canvas *x, int n)
     t_linetraverser t;
     t_outconnect *oc;
     int nnotsel;
-        /* enable editor (in case it is disabled) and select the object
-           we are working on */
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
+    /* enable editor (in case it is disabled) and select the object
+       we are working on */
+    if(!x->gl_edit) canvas_editmode(x, 1);
 
-        /* deselect all objects (if we are editing one while multiple are
-         * selected, upon undoing this will recreate other selected objects,
-         * effectively resulting in unwanted duplicates)
-         * LATER: consider allowing concurrent editing of multiple objects
-         */
+    /* deselect all objects (if we are editing one while multiple are
+     * selected, upon undoing this will recreate other selected objects,
+     * effectively resulting in unwanted duplicates)
+     * LATER: consider allowing concurrent editing of multiple objects
+     */
     glist_noselect(x);
 
     obj = glist_nth(x, n);
-    if (obj && !glist_isselected(x, obj))
-        glist_select(x, obj);
-        /* get number of all items for the offset below */
-    nnotsel= glist_selectionindex(x, 0, 0);
-    buf = (t_undo_apply *)getbytes(sizeof(*buf));
+    if(obj && !glist_isselected(x, obj)) glist_select(x, obj);
+    /* get number of all items for the offset below */
+    nnotsel = glist_selectionindex(x, 0, 0);
+    buf = (t_undo_apply *) getbytes(sizeof(*buf));
 
-        /* store connections into/out of the selection */
+    /* store connections into/out of the selection */
     buf->u_reconnectbuf = binbuf_new();
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int issel1 = glist_isselected(x, &t.tr_ob->ob_g);
         int issel2 = glist_isselected(x, &t.tr_ob2->ob_g);
-        if (issel1 != issel2)
+        if(issel1 != issel2)
         {
-            binbuf_addv(buf->u_reconnectbuf, "ssiiii;",
-                gensym("#X"), gensym("connect"),
-                (issel1 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
+            binbuf_addv(buf->u_reconnectbuf, "ssiiii;", gensym("#X"),
+                gensym("connect"),
+                (issel1 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
                 t.tr_outno,
-                (issel2 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
+                (issel2 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
                 t.tr_inno);
         }
     }
-        /* copy object in its current state */
+    /* copy object in its current state */
     buf->u_objectbuf = canvas_docopy(x);
 
-        /* store index of the currently selected object */
+    /* store index of the currently selected object */
     buf->u_index = n;
 
     return (buf);
 }
 
 static int canvas_apply_restore_original_position(t_canvas *x, int orig_pos);
+
 int canvas_undo_apply(t_canvas *x, void *z, int action)
 {
     t_undo_apply *buf = z;
-    if (action == UNDO_UNDO || action == UNDO_REDO)
+    if(action == UNDO_UNDO || action == UNDO_REDO)
     {
-            /* find current instance */
+        /* find current instance */
         t_binbuf *tmp;
         glist_noselect(x);
         glist_select(x, glist_nth(x, buf->u_index));
 
-            /* copy it for the new undo/redo */
+        /* copy it for the new undo/redo */
         tmp = canvas_docopy(x);
 
-            /* delete current instance */
+        /* delete current instance */
         canvas_doclear(x);
 
-            /* replace it with previous instance */
+        /* replace it with previous instance */
         canvas_dopaste(x, buf->u_objectbuf);
 
-            /* change previous instance with current one */
+        /* change previous instance with current one */
         buf->u_objectbuf = tmp;
 
-            /* connections should stay the same */
+        /* connections should stay the same */
         canvas_applybinbuf(x, buf->u_reconnectbuf);
-            /* now we need to reposition the object to its original place */
-        if (canvas_apply_restore_original_position(x, buf->u_index) && x->gl_havewindow)
+        /* now we need to reposition the object to its original place */
+        if(canvas_apply_restore_original_position(x, buf->u_index) &&
+            x->gl_havewindow)
             canvas_redraw(x);
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
-        if (buf->u_objectbuf)
-            binbuf_free(buf->u_objectbuf);
-        if (buf->u_reconnectbuf)
-            binbuf_free(buf->u_reconnectbuf);
+        if(buf->u_objectbuf) binbuf_free(buf->u_objectbuf);
+        if(buf->u_reconnectbuf) binbuf_free(buf->u_reconnectbuf);
         t_freebytes(buf, sizeof(*buf));
     }
     return 1;
@@ -1002,60 +989,60 @@ int canvas_undo_apply(t_canvas *x, void *z, int action)
 int canvas_apply_restore_original_position(t_canvas *x, int orig_pos)
 {
     t_gobj *y, *y_prev, *y_next;
-        /* get the last object */
+    /* get the last object */
     y = glist_nth(x, glist_getindex(x, 0) - 1);
-    if (glist_getindex(x, y) != orig_pos)
+    if(glist_getindex(x, y) != orig_pos)
     {
-            /* first make the object prior to the pasted one the end of the list */
+        /* first make the object prior to the pasted one the end of the list */
         y_prev = glist_nth(x, glist_getindex(x, 0) - 2);
-        if (y_prev)
-            y_prev->g_next = NULL;
-            /* if the object is supposed to be first in the gl_list */
-        if (orig_pos == 0)
+        if(y_prev) y_prev->g_next = NULL;
+        /* if the object is supposed to be first in the gl_list */
+        if(orig_pos == 0)
         {
             y->g_next = glist_nth(x, 0);
             x->gl_list = y;
         }
-            /* if the object is supposed to be in the middle of the gl_list */
-        else {
-            y_prev = glist_nth(x, orig_pos-1);
+        /* if the object is supposed to be in the middle of the gl_list */
+        else
+        {
+            y_prev = glist_nth(x, orig_pos - 1);
             y_next = y_prev->g_next;
             y_prev->g_next = y;
             y->g_next = y_next;
         }
-        return(1);
+        return (1);
     }
-    return(0);
+    return (0);
 }
 
 /* --------- 7. arrange (to front/back)  ----------- */
 typedef struct _undo_arrange
 {
-    int u_previndex;            /* old index */
-    int u_newindex;                /* new index */
+    int u_previndex; /* old index */
+    int u_newindex;  /* new index */
 } t_undo_arrange;
 
 void *canvas_undo_set_arrange(t_canvas *x, t_gobj *obj, int newindex)
 {
-        /* newindex tells us is the new index at the beginning (0) or the end (1) */
+    /* newindex tells us is the new index at the beginning (0) or the end (1) */
 
     t_undo_arrange *buf;
-        /* enable editor (in case it is disabled) and select the object
-           we are working on */
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
+    /* enable editor (in case it is disabled) and select the object
+       we are working on */
+    if(!x->gl_edit) canvas_editmode(x, 1);
 
-        /* select the object*/
-    if (!glist_isselected(x, obj))
-        glist_select(x, obj);
+    /* select the object*/
+    if(!glist_isselected(x, obj)) glist_select(x, obj);
 
-    buf = (t_undo_arrange *)getbytes(sizeof(*buf));
+    buf = (t_undo_arrange *) getbytes(sizeof(*buf));
 
-        /* set the u_newindex appropriately */
-    if (newindex == 0) buf->u_newindex = 0;
-    else buf->u_newindex = glist_getindex(x, 0) - 1;
+    /* set the u_newindex appropriately */
+    if(newindex == 0)
+        buf->u_newindex = 0;
+    else
+        buf->u_newindex = glist_getindex(x, 0) - 1;
 
-        /* store index of the currently selected object */
+    /* store index of the currently selected object */
     buf->u_previndex = glist_getindex(x, obj);
 
     return (buf);
@@ -1067,50 +1054,54 @@ static void canvas_doarrange(t_canvas *x, t_float which, t_gobj *oldy,
     t_gobj *oldy_prev, t_gobj *oldy_next)
 {
     t_gobj *y_begin = x->gl_list;
-    t_gobj *y_end = glist_nth(x, glist_getindex(x,0) - 1);
+    t_gobj *y_end = glist_nth(x, glist_getindex(x, 0) - 1);
 
-    switch((int)which)
+    switch((int) which)
     {
-    case 3: /* to front */
+        case 3: /* to front */
             /* put the object at the end of the cue */
-        y_end->g_next = oldy;
-        oldy->g_next = NULL;
+            y_end->g_next = oldy;
+            oldy->g_next = NULL;
 
-            /* now fix links in the hole made in the list due to moving of the oldy
-             * (we know there is oldy_next as y_end != oldy in canvas_done_popup)
+            /* now fix links in the hole made in the list due to moving of the
+             * oldy (we know there is oldy_next as y_end != oldy in
+             * canvas_done_popup)
              */
-        if (oldy_prev) /* there is indeed more before the oldy position */
-            oldy_prev->g_next = oldy_next;
-        else x->gl_list = oldy_next;
+            if(oldy_prev) /* there is indeed more before the oldy position */
+                oldy_prev->g_next = oldy_next;
+            else
+                x->gl_list = oldy_next;
 
 #if 0
             /* and finally redraw */
         gui_vmess("gui_raise", "xs", x, "selected");
 #endif
-        break;
+            break;
 
-    case 4: /* to back */
-        x->gl_list = oldy; /* put it to the beginning of the cue */
-        oldy->g_next = y_begin; /* make it point to the old beginning */
+        case 4:                     /* to back */
+            x->gl_list = oldy;      /* put it to the beginning of the cue */
+            oldy->g_next = y_begin; /* make it point to the old beginning */
 
-            /* now fix links in the hole made in the list due to moving of the oldy
-             * (we know there is oldy_prev as y_begin != oldy in canvas_done_popup)
+            /* now fix links in the hole made in the list due to moving of the
+             * oldy (we know there is oldy_prev as y_begin != oldy in
+             * canvas_done_popup)
              */
-        if (oldy_prev)
-        {
-            if (oldy_next) /* there is indeed more after oldy position */
-                oldy_prev->g_next = oldy_next;
-            else oldy_prev->g_next = NULL; /* oldy was the last in the cue */
-        }
+            if(oldy_prev)
+            {
+                if(oldy_next) /* there is indeed more after oldy position */
+                    oldy_prev->g_next = oldy_next;
+                else
+                    oldy_prev->g_next = NULL; /* oldy was the last in the cue */
+            }
 
 #if 0
             /* and finally redraw */
         gui_vmess("gui_lower", "xs", x, "selected");
 #endif
-        break;
-    default:
-        bug("canvas_arrange");
-        return;
+            break;
+        default:
+            bug("canvas_arrange");
+            return;
     }
     canvas_dirty(x, 1);
 }
@@ -1118,106 +1109,107 @@ static void canvas_doarrange(t_canvas *x, t_float which, t_gobj *oldy,
 int canvas_undo_arrange(t_canvas *x, void *z, int action)
 {
     t_undo_arrange *buf = z;
-    t_gobj *y=NULL, *prev=NULL, *next=NULL;
+    t_gobj *y = NULL, *prev = NULL, *next = NULL;
 
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
+    if(!x->gl_edit) canvas_editmode(x, 1);
 
     switch(action)
     {
 
-    case UNDO_UNDO:
-        if(buf->u_newindex == buf->u_previndex) return 1;
+        case UNDO_UNDO:
+            if(buf->u_newindex == buf->u_previndex) return 1;
             /* this is our object */
-        y = glist_nth(x, buf->u_newindex);
+            y = glist_nth(x, buf->u_newindex);
 
             /* select object */
-        glist_noselect(x);
-        glist_select(x, y);
+            glist_noselect(x);
+            glist_select(x, y);
 
-        if (buf->u_newindex)
-        {
+            if(buf->u_newindex)
+            {
                 /* if it is the last object */
 
                 /* first previous object should point to nothing */
-            prev = glist_nth(x, buf->u_newindex - 1);
-            prev->g_next = NULL;
+                prev = glist_nth(x, buf->u_newindex - 1);
+                prev->g_next = NULL;
 
                 /* now we reuse vars for the following:
                    old index should be right before the object previndex
                    is pointing to as the object was moved to the end */
 
                 /* old position is not first */
-            if (buf->u_previndex)
-            {
-                prev = glist_nth(x, buf->u_previndex - 1);
-                next = prev->g_next;
+                if(buf->u_previndex)
+                {
+                    prev = glist_nth(x, buf->u_previndex - 1);
+                    next = prev->g_next;
 
                     /* now readjust pointers */
-                prev->g_next = y;
-                y->g_next = next;
-            }
+                    prev->g_next = y;
+                    y->g_next = next;
+                }
                 /* old position is first */
-            else {
-                prev = NULL;
-                next = x->gl_list;
+                else
+                {
+                    prev = NULL;
+                    next = x->gl_list;
 
                     /* now readjust pointers */
-                y->g_next = next;
-                x->gl_list = y;
+                    y->g_next = next;
+                    x->gl_list = y;
+                }
             }
-        }
-        else {
+            else
+            {
                 /* if it is the first object */
 
                 /* old index should be right after the object previndex
                    is pointing to as the object was moved to the end */
-            prev = glist_nth(x, buf->u_previndex);
+                prev = glist_nth(x, buf->u_previndex);
 
                 /* next may be NULL and that is ok */
-            next = prev->g_next;
+                next = prev->g_next;
 
                 /* first glist pointer needs to point to the second object */
-            x->gl_list = y->g_next;
+                x->gl_list = y->g_next;
 
                 /* now readjust pointers */
-            prev->g_next = y;
-            y->g_next = next;
-        }
+                prev->g_next = y;
+                y->g_next = next;
+            }
             /* and finally redraw canvas */
-        if (x->gl_havewindow)
-            canvas_redraw(x);
-        break;
-    case UNDO_REDO:
-    {
-        t_gobj *oldy_prev=NULL, *oldy_next=NULL;
-        int arrangeaction;
+            if(x->gl_havewindow) canvas_redraw(x);
+            break;
+        case UNDO_REDO:
+        {
+            t_gobj *oldy_prev = NULL, *oldy_next = NULL;
+            int arrangeaction;
 
-        if(buf->u_newindex == buf->u_previndex) return 1;
+            if(buf->u_newindex == buf->u_previndex) return 1;
             /* find our object */
-        y = glist_nth(x, buf->u_previndex);
+            y = glist_nth(x, buf->u_previndex);
 
             /* select object */
-        glist_noselect(x);
-        glist_select(x, y);
+            glist_noselect(x);
+            glist_select(x, y);
 
-        if (!buf->u_newindex) arrangeaction = 4;
-        else arrangeaction = 3;
+            if(!buf->u_newindex)
+                arrangeaction = 4;
+            else
+                arrangeaction = 3;
 
-
-            /* if there is an object before ours (in other words our index is > 0) */
-        if (glist_getindex(x,y))
-            oldy_prev = glist_nth(x, buf->u_previndex - 1);
+            /* if there is an object before ours (in other words our index is >
+             * 0) */
+            if(glist_getindex(x, y))
+                oldy_prev = glist_nth(x, buf->u_previndex - 1);
 
             /* if there is an object after ours */
-        if (y->g_next)
-            oldy_next = y->g_next;
+            if(y->g_next) oldy_next = y->g_next;
 
-        canvas_doarrange(x, arrangeaction, y, oldy_prev, oldy_next);
-    }
+            canvas_doarrange(x, arrangeaction, y, oldy_prev, oldy_next);
+        }
         break;
-    case UNDO_FREE:
-        t_freebytes(buf, sizeof(*buf));
+        case UNDO_FREE:
+            t_freebytes(buf, sizeof(*buf));
     }
     return 1;
 }
@@ -1225,30 +1217,30 @@ int canvas_undo_arrange(t_canvas *x, void *z, int action)
 /* --------- 8. apply on canvas ----------- */
 typedef struct _undo_canvas_properties
 {
-    int gl_pixwidth;            /* width in pixels (on parent, if a graph) */
+    int gl_pixwidth; /* width in pixels (on parent, if a graph) */
     int gl_pixheight;
-    t_float gl_x1;              /* bounding rectangle in our own coordinates */
+    t_float gl_x1; /* bounding rectangle in our own coordinates */
     t_float gl_y1;
     t_float gl_x2;
     t_float gl_y2;
-    int gl_screenx1;            /* screen coordinates when toplevel */
+    int gl_screenx1; /* screen coordinates when toplevel */
     int gl_screeny1;
     int gl_screenx2;
     int gl_screeny2;
-    int gl_xmargin;             /* origin for GOP rectangle */
+    int gl_xmargin; /* origin for GOP rectangle */
     int gl_ymargin;
 
-    unsigned int gl_goprect:1;  /* draw rectangle for graph-on-parent */
-    unsigned int gl_isgraph:1;  /* show as graph on parent */
-    unsigned int gl_hidetext:1; /* hide object-name + args when doing
-                                   graph on parent */
+    unsigned int gl_goprect : 1;  /* draw rectangle for graph-on-parent */
+    unsigned int gl_isgraph : 1;  /* show as graph on parent */
+    unsigned int gl_hidetext : 1; /* hide object-name + args when doing
+                                     graph on parent */
 } t_undo_canvas_properties;
 
 void *canvas_undo_set_canvas(t_canvas *x)
 {
-        /* enable editor (in case it is disabled) */
+    /* enable editor (in case it is disabled) */
     t_undo_canvas_properties *buf =
-        (t_undo_canvas_properties *)getbytes(sizeof(*buf));
+        (t_undo_canvas_properties *) getbytes(sizeof(*buf));
 
     buf->gl_pixwidth = x->gl_pixwidth;
     buf->gl_pixheight = x->gl_pixheight;
@@ -1271,13 +1263,12 @@ void *canvas_undo_set_canvas(t_canvas *x)
 
 int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
 {
-    t_undo_canvas_properties *buf = (t_undo_canvas_properties *)z;
+    t_undo_canvas_properties *buf = (t_undo_canvas_properties *) z;
     t_undo_canvas_properties tmp;
 
-    if (action == UNDO_UNDO || action == UNDO_REDO)
+    if(action == UNDO_UNDO || action == UNDO_REDO)
     {
-        if (!x->gl_edit)
-            canvas_editmode(x, 1);
+        if(!x->gl_edit) canvas_editmode(x, 1);
 #if 0
             /* close properties window first */
         t_int properties = gfxstub_haveproperties((void *)x);
@@ -1286,7 +1277,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
             gfxstub_deleteforkey(x);
         }
 #endif
-            /* store current canvas values into temporary data holder */
+        /* store current canvas values into temporary data holder */
         tmp.gl_pixwidth = x->gl_pixwidth;
         tmp.gl_pixheight = x->gl_pixheight;
         tmp.gl_x1 = x->gl_x1;
@@ -1303,7 +1294,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         tmp.gl_isgraph = x->gl_isgraph;
         tmp.gl_hidetext = x->gl_hidetext;
 
-            /* change canvas values with the ones from the undo buffer */
+        /* change canvas values with the ones from the undo buffer */
         x->gl_pixwidth = buf->gl_pixwidth;
         x->gl_pixheight = buf->gl_pixheight;
         x->gl_x1 = buf->gl_x1;
@@ -1320,7 +1311,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         x->gl_isgraph = buf->gl_isgraph;
         x->gl_hidetext = buf->gl_hidetext;
 
-            /* copy data values from the temporary data to the undo buffer */
+        /* copy data values from the temporary data to the undo buffer */
         buf->gl_pixwidth = tmp.gl_pixwidth;
         buf->gl_pixheight = tmp.gl_pixheight;
         buf->gl_x1 = tmp.gl_x1;
@@ -1337,38 +1328,37 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         buf->gl_isgraph = tmp.gl_isgraph;
         buf->gl_hidetext = tmp.gl_hidetext;
 
-            /* redraw */
-        canvas_setgraph(x, x->gl_isgraph + 2*x->gl_hidetext, 0);
+        /* redraw */
+        canvas_setgraph(x, x->gl_isgraph + 2 * x->gl_hidetext, 0);
         canvas_dirty(x, 1);
 
-        if (x->gl_havewindow)
+        if(x->gl_havewindow)
         {
             canvas_redraw(x);
         }
-        if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+        if(x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         {
             glist_noselect(x);
             gobj_vis(&x->gl_gobj, x->gl_owner, 0);
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
-            if (x->gl_owner->gl_havewindow)
-                canvas_redraw(x->gl_owner);
+            if(x->gl_owner->gl_havewindow) canvas_redraw(x->gl_owner);
         }
     }
 
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
-        if (buf)
-            t_freebytes(buf, sizeof(*buf));
+        if(buf) t_freebytes(buf, sizeof(*buf));
     }
     return 1;
 }
+
 /* --------- 9. create ----------- */
 
 typedef struct _undo_create
 {
-    int u_index;                /* index of the created object object */
-    t_binbuf *u_objectbuf;      /* the object cleared or typed into */
-    t_binbuf *u_reconnectbuf;   /* connections into and out of object */
+    int u_index;              /* index of the created object object */
+    t_binbuf *u_objectbuf;    /* the object cleared or typed into */
+    t_binbuf *u_reconnectbuf; /* connections into and out of object */
 } t_undo_create;
 
 void *canvas_undo_set_create(t_canvas *x)
@@ -1376,17 +1366,17 @@ void *canvas_undo_set_create(t_canvas *x)
     t_gobj *y;
     t_linetraverser t;
     int nnotsel;
-    t_undo_create *buf = (t_undo_create *)getbytes(sizeof(*buf));
+    t_undo_create *buf = (t_undo_create *) getbytes(sizeof(*buf));
     buf->u_index = glist_getindex(x, 0) - 1;
-    nnotsel= glist_selectionindex(x, 0, 0);
+    nnotsel = glist_selectionindex(x, 0, 0);
 
     buf->u_objectbuf = binbuf_new();
-    if (x->gl_list)
+    if(x->gl_list)
     {
         t_outconnect *oc;
-        for (y = x->gl_list; y; y = y->g_next)
+        for(y = x->gl_list; y; y = y->g_next)
         {
-            if (!y->g_next)
+            if(!y->g_next)
             {
                 gobj_save(y, buf->u_objectbuf);
                 break;
@@ -1394,20 +1384,20 @@ void *canvas_undo_set_create(t_canvas *x)
         }
         buf->u_reconnectbuf = binbuf_new();
         linetraverser_start(&t, x);
-        while ((oc = linetraverser_next(&t)))
+        while((oc = linetraverser_next(&t)))
         {
             int issel1, issel2;
-            issel1 = ( &t.tr_ob->ob_g == y ? 1 : 0);
-            issel2 = ( &t.tr_ob2->ob_g == y ? 1 : 0);
-            if (issel1 != issel2)
+            issel1 = (&t.tr_ob->ob_g == y ? 1 : 0);
+            issel2 = (&t.tr_ob2->ob_g == y ? 1 : 0);
+            if(issel1 != issel2)
             {
-                binbuf_addv(buf->u_reconnectbuf, "ssiiii;",
-                    gensym("#X"), gensym("connect"),
-                    (issel1 ? nnotsel : 0)
-                        + glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
+                binbuf_addv(buf->u_reconnectbuf, "ssiiii;", gensym("#X"),
+                    gensym("connect"),
+                    (issel1 ? nnotsel : 0) +
+                        glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
                     t.tr_outno,
-                    (issel2 ? nnotsel : 0)
-                        + glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
+                    (issel2 ? nnotsel : 0) +
+                        glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
                     t.tr_inno);
             }
         }
@@ -1420,23 +1410,23 @@ int canvas_undo_create(t_canvas *x, void *z, int action)
     t_undo_create *buf = z;
     t_gobj *y;
 
-    if (action == UNDO_UNDO)
+    if(action == UNDO_UNDO)
     {
         glist_noselect(x);
         y = glist_nth(x, buf->u_index);
         glist_select(x, y);
         canvas_doclear(x);
     }
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
     {
         canvas_applybinbuf(x, buf->u_objectbuf);
         canvas_applybinbuf(x, buf->u_reconnectbuf);
-        if (pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
-            canvas_loadbang((t_canvas *)pd_this->pd_newest);
+        if(pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
+            canvas_loadbang((t_canvas *) pd_this->pd_newest);
         y = glist_nth(x, buf->u_index);
         glist_select(x, y);
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
         binbuf_free(buf->u_objectbuf);
         binbuf_free(buf->u_reconnectbuf);
@@ -1455,28 +1445,29 @@ void *canvas_undo_set_recreate(t_canvas *x, t_gobj *y, int pos)
     t_outconnect *oc;
     int nnotsel;
 
-    t_undo_create *buf = (t_undo_create *)getbytes(sizeof(*buf));
+    t_undo_create *buf = (t_undo_create *) getbytes(sizeof(*buf));
     buf->u_index = pos;
-    nnotsel= glist_selectionindex(x, 0, 0) - 1; /* - 1 is a critical difference from the create */
+    nnotsel = glist_selectionindex(x, 0, 0) -
+              1; /* - 1 is a critical difference from the create */
     buf->u_objectbuf = binbuf_new();
     gobj_save(y, buf->u_objectbuf);
 
     buf->u_reconnectbuf = binbuf_new();
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int issel1, issel2;
-        issel1 = ( &t.tr_ob->ob_g == y ? 1 : 0);
-        issel2 = ( &t.tr_ob2->ob_g == y ? 1 : 0);
-        if (issel1 != issel2)
+        issel1 = (&t.tr_ob->ob_g == y ? 1 : 0);
+        issel2 = (&t.tr_ob2->ob_g == y ? 1 : 0);
+        if(issel1 != issel2)
         {
-            binbuf_addv(buf->u_reconnectbuf, "ssiiii;",
-                gensym("#X"), gensym("connect"),
-                (issel1 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
+            binbuf_addv(buf->u_reconnectbuf, "ssiiii;", gensym("#X"),
+                gensym("connect"),
+                (issel1 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob->ob_g, issel1),
                 t.tr_outno,
-                (issel2 ? nnotsel : 0)
-                    + glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
+                (issel2 ? nnotsel : 0) +
+                    glist_selectionindex(x, &t.tr_ob2->ob_g, issel2),
                 t.tr_inno);
         }
     }
@@ -1487,21 +1478,19 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 {
     t_undo_create *buf = z;
     t_gobj *y = NULL;
-    if (action == UNDO_UNDO)
+    if(action == UNDO_UNDO)
         y = glist_nth(x, glist_getindex(x, 0) - 1);
-    else if (action == UNDO_REDO)
+    else if(action == UNDO_REDO)
         y = glist_nth(x, buf->u_index);
 
-        /* check if we are undoing the creation of a dirty abstraction;
-         * if so, bail out */
-    if ((action == UNDO_UNDO)
-        && canvas_undo_confirmdiscard(y))
-            return 0;
+    /* check if we are undoing the creation of a dirty abstraction;
+     * if so, bail out */
+    if((action == UNDO_UNDO) && canvas_undo_confirmdiscard(y)) return 0;
 
-    if (action == UNDO_UNDO || action == UNDO_REDO)
+    if(action == UNDO_UNDO || action == UNDO_REDO)
     {
-            /* first copy new state of the current object */
-        t_undo_create *buf2 = (t_undo_create *)getbytes(sizeof(*buf));
+        /* first copy new state of the current object */
+        t_undo_create *buf2 = (t_undo_create *) getbytes(sizeof(*buf));
         buf2->u_index = buf->u_index;
 
         buf2->u_objectbuf = binbuf_new();
@@ -1509,46 +1498,47 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 
         buf2->u_reconnectbuf = binbuf_duplicate(buf->u_reconnectbuf);
 
-            /* now cut the existing object */
+        /* now cut the existing object */
         glist_noselect(x);
         glist_select(x, y);
         canvas_doclear(x);
 
-            /* then paste the old object */
+        /* then paste the old object */
 
-            /* save and clear bindings to symbols #A, #N, #X; restore when done */
+        /* save and clear bindings to symbols #A, #N, #X; restore when done */
         canvas_applybinbuf(x, buf->u_objectbuf);
         canvas_applybinbuf(x, buf->u_reconnectbuf);
 
-            /* free the old data */
+        /* free the old data */
         binbuf_free(buf->u_objectbuf);
         binbuf_free(buf->u_reconnectbuf);
         t_freebytes(buf, sizeof(*buf));
 
-            /* re-adjust pointer
-             * (this should probably belong into g_undo.c, but since it is
-             * a unique case, we'll let it be for the time being)
-             */
-        canvas_undo_get(x)->u_last->data = (void *)buf2;
+        /* re-adjust pointer
+         * (this should probably belong into g_undo.c, but since it is
+         * a unique case, we'll let it be for the time being)
+         */
+        canvas_undo_get(x)->u_last->data = (void *) buf2;
         buf = buf2;
 
-            /* reposition object to its original place */
-        if (action == UNDO_UNDO)
-            if (canvas_apply_restore_original_position(x, buf->u_index) && x->gl_havewindow)
+        /* reposition object to its original place */
+        if(action == UNDO_UNDO)
+            if(canvas_apply_restore_original_position(x, buf->u_index) &&
+                x->gl_havewindow)
                 canvas_redraw(x);
 
-            /* send a loadbang */
-        if (pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
-            canvas_loadbang((t_canvas *)pd_this->pd_newest);
+        /* send a loadbang */
+        if(pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
+            canvas_loadbang((t_canvas *) pd_this->pd_newest);
 
-            /* select */
-        if (action == UNDO_REDO)
+        /* select */
+        if(action == UNDO_REDO)
             y = glist_nth(x, glist_getindex(x, 0) - 1);
         else
             y = glist_nth(x, buf->u_index);
         glist_select(x, y);
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
         binbuf_free(buf->u_objectbuf);
         binbuf_free(buf->u_reconnectbuf);
@@ -1558,7 +1548,8 @@ int canvas_undo_recreate(t_canvas *x, void *z, int action)
 }
 
 /* ----------- 11. font -------------- */
-static void canvas_dofont(t_canvas *x, t_floatarg font, t_floatarg xresize, t_floatarg yresize);
+static void canvas_dofont(
+    t_canvas *x, t_floatarg font, t_floatarg xresize, t_floatarg yresize);
 
 typedef struct _undo_font
 {
@@ -1569,7 +1560,7 @@ typedef struct _undo_font
 
 void *canvas_undo_set_font(t_canvas *x, int font, t_float resize, int which)
 {
-    t_undo_font *u_f = (t_undo_font *)getbytes(sizeof(*u_f));
+    t_undo_font *u_f = (t_undo_font *) getbytes(sizeof(*u_f));
     u_f->font = font;
     u_f->resize = resize;
     u_f->which = which;
@@ -1580,25 +1571,24 @@ int canvas_undo_font(t_canvas *x, void *z, int action)
 {
     t_undo_font *u_f = z;
 
-    if (action == UNDO_UNDO || action == UNDO_REDO)
+    if(action == UNDO_UNDO || action == UNDO_REDO)
     {
         t_canvas *x2 = canvas_getrootfor(x);
         int tmp_font = x2->gl_font;
 
         int whichresize = u_f->which;
-        t_float realresize = 1./u_f->resize;
+        t_float realresize = 1. / u_f->resize;
         t_float realresx = 1, realresy = 1;
-        if (whichresize != 3) realresx = realresize;
-        if (whichresize != 2) realresy = realresize;
+        if(whichresize != 3) realresx = realresize;
+        if(whichresize != 2) realresy = realresize;
         canvas_dofont(x2, u_f->font, realresx, realresy);
 
         u_f->resize = realresize;
         u_f->font = tmp_font;
     }
-    else if (action == UNDO_FREE)
+    else if(action == UNDO_FREE)
     {
-        if (u_f)
-            freebytes(u_f, sizeof(*u_f));
+        if(u_f) freebytes(u_f, sizeof(*u_f));
     }
     return 1;
 }
@@ -1606,47 +1596,47 @@ int canvas_undo_font(t_canvas *x, void *z, int action)
 int clone_match(t_pd *z, t_symbol *name, t_symbol *dir);
 static void canvas_cut(t_canvas *x);
 
-    /* recursively check for abstractions to reload as result of a save.
-       Don't reload the one we just saved ("except") though. */
-    /* LATER try to do the same trick for externs. */
-static void glist_doreload(t_glist *gl, t_symbol *name, t_symbol *dir,
-    t_gobj *except)
+/* recursively check for abstractions to reload as result of a save.
+   Don't reload the one we just saved ("except") though. */
+/* LATER try to do the same trick for externs. */
+static void glist_doreload(
+    t_glist *gl, t_symbol *name, t_symbol *dir, t_gobj *except)
 {
     t_gobj *g;
     int hadwindow = gl->gl_havewindow;
     int found = 0;
-        /* to optimize redrawing we select all objects that need to be updated
-           and redraw (cut+undo) them together. Then we look for sub-patches that may have
-           more of the same... */
-    for (g = gl->gl_list; g; g = g->g_next)
+    /* to optimize redrawing we select all objects that need to be updated
+       and redraw (cut+undo) them together. Then we look for sub-patches that
+       may have more of the same... */
+    for(g = gl->gl_list; g; g = g->g_next)
     {
-            /* remake the object if it's an abstraction that appears to have
-               been loaded from the file we just saved */
+        /* remake the object if it's an abstraction that appears to have
+           been loaded from the file we just saved */
         int remakeit = (g != except && pd_class(&g->g_pd) == canvas_class &&
-            canvas_isabstraction((t_canvas *)g) &&
-                ((t_canvas *)g)->gl_name == name &&
-                    canvas_getdir((t_canvas *)g) == dir);
-            /* also remake it if it's a "clone" with that name */
-        if (pd_class(&g->g_pd) == clone_class &&
+                        canvas_isabstraction((t_canvas *) g) &&
+                        ((t_canvas *) g)->gl_name == name &&
+                        canvas_getdir((t_canvas *) g) == dir);
+        /* also remake it if it's a "clone" with that name */
+        if(pd_class(&g->g_pd) == clone_class &&
             clone_match(&g->g_pd, name, dir))
         {
-                /* LATER try not to remake the one that equals "except" */
+            /* LATER try not to remake the one that equals "except" */
             remakeit = 1;
         }
-        if (remakeit)
+        if(remakeit)
         {
-                /* Bugfix for cases where canvas_vis doesn't actually create a
-                   new editor. We need to fix canvas_vis so that the bug
-                   doesn't get triggered. But since we know this fixes a
-                   regression we'll keep this as a point in the history as we
-                   fix canvas_vis. Once that's done we can remove this call. */
+            /* Bugfix for cases where canvas_vis doesn't actually create a
+               new editor. We need to fix canvas_vis so that the bug
+               doesn't get triggered. But since we know this fixes a
+               regression we'll keep this as a point in the history as we
+               fix canvas_vis. Once that's done we can remove this call. */
             canvas_create_editor(gl);
 
-            if (!gl->gl_havewindow)
+            if(!gl->gl_havewindow)
             {
                 canvas_vis(glist_getcanvas(gl), 1);
             }
-            if (!found)
+            if(!found)
             {
                 glist_noselect(gl);
                 found = 1;
@@ -1654,8 +1644,8 @@ static void glist_doreload(t_glist *gl, t_symbol *name, t_symbol *dir,
             glist_select(gl, g);
         }
     }
-        /* cut all selected (matched) objects and undo, to reinstantiate them */
-    if (found)
+    /* cut all selected (matched) objects and undo, to reinstantiate them */
+    if(found)
     {
         canvas_cut(gl);
         canvas_undo_undo(gl);
@@ -1663,38 +1653,34 @@ static void glist_doreload(t_glist *gl, t_symbol *name, t_symbol *dir,
         glist_noselect(gl);
     }
 
-        /* now iterate over all the sub-patches... */
-    for (g = gl->gl_list; g; g = g->g_next)
+    /* now iterate over all the sub-patches... */
+    for(g = gl->gl_list; g; g = g->g_next)
     {
-        if (g != except && pd_class(&g->g_pd) == canvas_class &&
-            (!canvas_isabstraction((t_canvas *)g) ||
-                 ((t_canvas *)g)->gl_name != name ||
-                 canvas_getdir((t_canvas *)g) != dir)
-           )
-                glist_doreload((t_canvas *)g, name, dir, except);
+        if(g != except && pd_class(&g->g_pd) == canvas_class &&
+            (!canvas_isabstraction((t_canvas *) g) ||
+                ((t_canvas *) g)->gl_name != name ||
+                canvas_getdir((t_canvas *) g) != dir))
+            glist_doreload((t_canvas *) g, name, dir, except);
     }
-    if (!hadwindow && gl->gl_havewindow)
-        canvas_vis(glist_getcanvas(gl), 0);
+    if(!hadwindow && gl->gl_havewindow) canvas_vis(glist_getcanvas(gl), 0);
 }
 
-    /* call canvas_doreload on everyone */
+/* call canvas_doreload on everyone */
 void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except)
 {
     t_canvas *x;
     int dspwas = canvas_suspend_dsp();
-    t_binbuf*b = 0;
-    if(EDITOR->copy_binbuf)
-        b = binbuf_duplicate(EDITOR->copy_binbuf);
+    t_binbuf *b = 0;
+    if(EDITOR->copy_binbuf) b = binbuf_duplicate(EDITOR->copy_binbuf);
 
     THISGUI->i_reloadingabstraction = except;
-        /* find all root canvases */
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    /* find all root canvases */
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
         glist_doreload(x, name, dir, &except->gl_gobj);
     THISGUI->i_reloadingabstraction = 0;
     if(b)
     {
-        if(EDITOR->copy_binbuf)
-            binbuf_free(EDITOR->copy_binbuf);
+        if(EDITOR->copy_binbuf) binbuf_free(EDITOR->copy_binbuf);
         EDITOR->copy_binbuf = b;
     }
     canvas_resume_dsp(dspwas);
@@ -1702,25 +1688,20 @@ void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except)
 
 /* ------------------------ event handling ------------------------ */
 
-static const char *cursorlist[] = {
-    "$cursor_runmode_nothing",
-    "$cursor_runmode_clickme",
-    "$cursor_runmode_thicken",
-    "$cursor_runmode_addpoint",
-    "$cursor_editmode_nothing",
-    "$cursor_editmode_connect",
-    "$cursor_editmode_disconnect",
-    "$cursor_editmode_resize"
-};
+static const char *cursorlist[] = {"$cursor_runmode_nothing",
+    "$cursor_runmode_clickme", "$cursor_runmode_thicken",
+    "$cursor_runmode_addpoint", "$cursor_editmode_nothing",
+    "$cursor_editmode_connect", "$cursor_editmode_disconnect",
+    "$cursor_editmode_resize"};
 
 void canvas_setcursor(t_canvas *x, unsigned int cursornum)
 {
-    if (cursornum >= sizeof(cursorlist)/sizeof *cursorlist)
+    if(cursornum >= sizeof(cursorlist) / sizeof *cursorlist)
     {
         bug("canvas_setcursor");
         return;
     }
-    if (EDITOR->canvas_cursorcanvaswas != x ||
+    if(EDITOR->canvas_cursorcanvaswas != x ||
         EDITOR->canvas_cursorwas != cursornum)
     {
         sys_vgui(".x%lx configure -cursor %s\n", x, cursorlist[cursornum]);
@@ -1729,15 +1710,14 @@ void canvas_setcursor(t_canvas *x, unsigned int cursornum)
     }
 }
 
-    /* check if a point lies in a gobj.  */
-int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos,
-    int *x1p, int *y1p, int *x2p, int *y2p)
+/* check if a point lies in a gobj.  */
+int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos, int *x1p,
+    int *y1p, int *x2p, int *y2p)
 {
     int x1, y1, x2, y2;
-    if (!gobj_shouldvis(y, x))
-        return (0);
+    if(!gobj_shouldvis(y, x)) return (0);
     gobj_getrect(y, x, &x1, &y1, &x2, &y2);
-    if (xpos >= x1 && xpos <= x2 && ypos >= y1 && ypos <= y2)
+    if(xpos >= x1 && xpos <= x2 && ypos >= y1 && ypos <= y2)
     {
         *x1p = x1;
         *y1p = y1;
@@ -1745,44 +1725,44 @@ int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos,
         *y2p = y2;
         return (1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
-    /* find the last gobj, if any, containing the point. */
-static t_gobj *canvas_findhitbox(t_canvas *x, int xpos, int ypos,
-    int *x1p, int *y1p, int *x2p, int *y2p)
+/* find the last gobj, if any, containing the point. */
+static t_gobj *canvas_findhitbox(
+    t_canvas *x, int xpos, int ypos, int *x1p, int *y1p, int *x2p, int *y2p)
 {
     t_gobj *y, *rval = 0;
     int x1, y1, x2, y2;
     *x1p = -0x7fffffff;
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if (canvas_hitbox(x, y, xpos, ypos, &x1, &y1, &x2, &y2)
-            && (x1 > *x1p))
-                *x1p = x1, *y1p = y1, *x2p = x2, *y2p = y2, rval = y;
+        if(canvas_hitbox(x, y, xpos, ypos, &x1, &y1, &x2, &y2) && (x1 > *x1p))
+            *x1p = x1, *y1p = y1, *x2p = x2, *y2p = y2, rval = y;
     }
-        /* if there are at least two selected objects, we'd prefer
-           to find a selected one (never mind which) to the one we got. */
-    if (x->gl_editor && x->gl_editor->e_selection &&
+    /* if there are at least two selected objects, we'd prefer
+       to find a selected one (never mind which) to the one we got. */
+    if(x->gl_editor && x->gl_editor->e_selection &&
         x->gl_editor->e_selection->sel_next && !glist_isselected(x, y))
     {
         t_selection *sel;
-        for (sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-            if (canvas_hitbox(x, sel->sel_what, xpos, ypos, &x1, &y1, &x2, &y2))
+        for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+            if(canvas_hitbox(x, sel->sel_what, xpos, ypos, &x1, &y1, &x2, &y2))
                 *x1p = x1, *y1p = y1, *x2p = x2, *y2p = y2,
-                    rval = sel->sel_what;
+                rval = sel->sel_what;
     }
     return (rval);
 }
 
-    /* right-clicking on a canvas object pops up a menu. */
+/* right-clicking on a canvas object pops up a menu. */
 static void canvas_rightclick(t_canvas *x, int xpos, int ypos, t_gobj *y)
 {
     int canprop, canopen;
     canprop = (!y || class_getpropertiesfn(pd_class(&y->g_pd)));
     canopen = (y && zgetfn(&y->g_pd, gensym("menu-open")));
-    sys_vgui("pdtk_canvas_popup .x%lx %d %d %d %d\n",
-        x, xpos, ypos, canprop, canopen);
+    sys_vgui("pdtk_canvas_popup .x%lx %d %d %d %d\n", x, xpos, ypos, canprop,
+        canopen);
 }
 
 /* ----  editors -- perhaps this and "vis" should go to g_editor.c ------- */
@@ -1790,11 +1770,11 @@ static void canvas_rightclick(t_canvas *x, int xpos, int ypos, t_gobj *y)
 static t_editor *editor_new(t_glist *owner)
 {
     char buf[40];
-    t_editor *x = (t_editor *)getbytes(sizeof(*x));
+    t_editor *x = (t_editor *) getbytes(sizeof(*x));
     x->e_connectbuf = binbuf_new();
     x->e_deleted = binbuf_new();
     x->e_glist = owner;
-    sprintf(buf, ".x%lx", (t_int)owner);
+    sprintf(buf, ".x%lx", (t_int) owner);
     x->e_guiconnect = guiconnect_new(&owner->gl_pd, gensym(buf));
     x->e_clock = 0;
     return (x);
@@ -1806,36 +1786,34 @@ static void editor_free(t_editor *x, t_glist *y)
     guiconnect_notarget(x->e_guiconnect, 1000);
     binbuf_free(x->e_connectbuf);
     binbuf_free(x->e_deleted);
-    if (x->e_clock)
-        clock_free(x->e_clock);
-    freebytes((void *)x, sizeof(*x));
+    if(x->e_clock) clock_free(x->e_clock);
+    freebytes((void *) x, sizeof(*x));
 }
 
-    /* recursively create or destroy all editors of a glist and its
-       sub-glists, as long as they aren't toplevels. */
+/* recursively create or destroy all editors of a glist and its
+   sub-glists, as long as they aren't toplevels. */
 void canvas_create_editor(t_glist *x)
 {
     t_gobj *y;
     t_object *ob;
-    if (!x->gl_editor)
+    if(!x->gl_editor)
     {
         x->gl_editor = editor_new(x);
-        for (y = x->gl_list; y; y = y->g_next)
-            if ((ob = pd_checkobject(&y->g_pd)))
-                rtext_new(x, ob);
+        for(y = x->gl_list; y; y = y->g_next)
+            if((ob = pd_checkobject(&y->g_pd))) rtext_new(x, ob);
     }
 }
 
 void canvas_destroy_editor(t_glist *x)
 {
     glist_noselect(x);
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         t_rtext *rtext;
-            /* this happens if we had activated an atom box in run mode: */
-        if (x->gl_editor->e_textedfor)
+        /* this happens if we had activated an atom box in run mode: */
+        if(x->gl_editor->e_textedfor)
             rtext_activate(x->gl_editor->e_textedfor, 0);
-        while ((rtext = x->gl_editor->e_rtext))
+        while((rtext = x->gl_editor->e_rtext))
             rtext_free(rtext);
         editor_free(x->gl_editor, x);
         x->gl_editor = 0;
@@ -1845,20 +1823,20 @@ void canvas_destroy_editor(t_glist *x)
 void canvas_reflecttitle(t_canvas *x);
 void canvas_map(t_canvas *x, t_floatarg f);
 
-    /* we call this when we want the window to become visible, mapped, and
-       in front of all windows; or with "f" zero, when we want to get rid of
-       the window. */
+/* we call this when we want the window to become visible, mapped, and
+   in front of all windows; or with "f" zero, when we want to get rid of
+   the window. */
 void canvas_vis(t_canvas *x, t_floatarg f)
 {
     int flag = (f != 0);
-    if (flag)
+    if(flag)
     {
-            /* If a subpatch/abstraction has GOP/gl_isgraph set, then it will have
-             * a gl_editor already, if its not, it will not have a gl_editor.
-             * canvas_create_editor(x) checks if a gl_editor is already created,
-             * so its ok to run it on a canvas that already has a gl_editor. */
-        if (x->gl_editor && x->gl_havewindow)
-        {           /* just put us in front */
+        /* If a subpatch/abstraction has GOP/gl_isgraph set, then it will have
+         * a gl_editor already, if its not, it will not have a gl_editor.
+         * canvas_create_editor(x) checks if a gl_editor is already created,
+         * so its ok to run it on a canvas that already has a gl_editor. */
+        if(x->gl_editor && x->gl_havewindow)
+        { /* just put us in front */
             sys_vgui("pdtk_canvas_raise .x%lx\n", x);
         }
         else
@@ -1868,26 +1846,29 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             t_undo *undo = canvas_undo_get(x);
             t_undo_action *udo = undo ? undo->u_last : 0;
             canvas_create_editor(x);
-            if ((GLIST_DEFCANVASXLOC == x->gl_screenx1) && (GLIST_DEFCANVASYLOC == x->gl_screeny1)) /* initial values for new windows */
+            if((GLIST_DEFCANVASXLOC == x->gl_screenx1) &&
+                (GLIST_DEFCANVASYLOC ==
+                    x->gl_screeny1)) /* initial values for new windows */
             {
                 sys_vgui("pdtk_canvas_new .x%lx %d %d {} %d\n", x,
-                    (int)(x->gl_screenx2 - x->gl_screenx1),
-                    (int)(x->gl_screeny2 - x->gl_screeny1),
-                    x->gl_edit);
-            } else {
+                    (int) (x->gl_screenx2 - x->gl_screenx1),
+                    (int) (x->gl_screeny2 - x->gl_screeny1), x->gl_edit);
+            }
+            else
+            {
                 sys_vgui("pdtk_canvas_new .x%lx %d %d +%d+%d %d\n", x,
-                    (int)(x->gl_screenx2 - x->gl_screenx1),
-                    (int)(x->gl_screeny2 - x->gl_screeny1),
-                    (int)(x->gl_screenx1), (int)(x->gl_screeny1),
-                    x->gl_edit);
+                    (int) (x->gl_screenx2 - x->gl_screenx1),
+                    (int) (x->gl_screeny2 - x->gl_screeny1),
+                    (int) (x->gl_screenx1), (int) (x->gl_screeny1), x->gl_edit);
             }
             snprintf(cbuf, MAXPDSTRING - 2, "pdtk_canvas_setparents .x%lx", c);
-            while (c->gl_owner && !c->gl_isclone) {
+            while(c->gl_owner && !c->gl_isclone)
+            {
                 int cbuflen;
                 c = c->gl_owner;
-                cbuflen = (int)strlen(cbuf);
+                cbuflen = (int) strlen(cbuf);
                 snprintf(cbuf + cbuflen,
-                    MAXPDSTRING - cbuflen - 2,/* leave 2 for "\n\0" */
+                    MAXPDSTRING - cbuflen - 2, /* leave 2 for "\n\0" */
                     " .x%lx", c);
             }
             strcat(cbuf, "\n");
@@ -1895,86 +1876,79 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             x->gl_havewindow = 1;
             canvas_reflecttitle(x);
             canvas_updatewindowlist();
-            sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, udo?(udo->name):"no", (udo && udo->next)?(udo->next->name):"no");
+            sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, udo ? (udo->name) : "no",
+                (udo && udo->next) ? (udo->next->name) : "no");
         }
     }
-    else    /* make invisible */
+    else /* make invisible */
     {
         int i;
         t_canvas *x2;
-        if (!x->gl_havewindow)
+        if(!x->gl_havewindow)
         {
-                /* bug workaround -- a graph in a visible patch gets "invised"
-                   when the patch is closed, and must lose the editor here.  It's
-                   probably not the natural place to do this.  Other cases like
-                   subpatches fall here too but don'd need the editor freed, so
-                   we check if it exists. */
-            if (x->gl_editor)
-                canvas_destroy_editor(x);
+            /* bug workaround -- a graph in a visible patch gets "invised"
+               when the patch is closed, and must lose the editor here.  It's
+               probably not the natural place to do this.  Other cases like
+               subpatches fall here too but don'd need the editor freed, so
+               we check if it exists. */
+            if(x->gl_editor) canvas_destroy_editor(x);
             return;
         }
         glist_noselect(x);
-        if (glist_isvisible(x))
-            canvas_map(x, 0);
+        if(glist_isvisible(x)) canvas_map(x, 0);
         canvas_destroy_editor(x);
         sys_vgui("destroy .x%lx\n", x);
-        for (i = 1, x2 = x; x2; x2 = x2->gl_next, i++)
+        for(i = 1, x2 = x; x2; x2 = x2->gl_next, i++)
             ;
-            /* if we're a graph on our parent, and if the parent exists
-               and is visible, show ourselves on parent. */
-        if (glist_isgraph(x) && x->gl_owner && !x->gl_isclone)
+        /* if we're a graph on our parent, and if the parent exists
+           and is visible, show ourselves on parent. */
+        if(glist_isgraph(x) && x->gl_owner && !x->gl_isclone)
         {
             t_glist *gl2 = x->gl_owner;
-            if (glist_isvisible(gl2))
-                gobj_vis(&x->gl_gobj, gl2, 0);
+            if(glist_isvisible(gl2)) gobj_vis(&x->gl_gobj, gl2, 0);
             x->gl_havewindow = 0;
-            if (glist_isvisible(gl2) && !gl2->gl_isdeleting)
+            if(glist_isvisible(gl2) && !gl2->gl_isdeleting)
             {
-                    /* make sure zoom level matches parent, ie. after an open
-                       subpatch's zoom level was changed before being closed */
-                if(x->gl_zoom != gl2->gl_zoom)
-                    canvas_zoom(x, gl2->gl_zoom);
+                /* make sure zoom level matches parent, ie. after an open
+                   subpatch's zoom level was changed before being closed */
+                if(x->gl_zoom != gl2->gl_zoom) canvas_zoom(x, gl2->gl_zoom);
                 gobj_vis(&x->gl_gobj, gl2, 1);
             }
         }
-        else x->gl_havewindow = 0;
+        else
+            x->gl_havewindow = 0;
         canvas_updatewindowlist();
     }
 }
 
-    /* set a canvas up as a graph-on-parent.  Set reasonable defaults for
-       any missing parameters and redraw things if necessary. */
+/* set a canvas up as a graph-on-parent.  Set reasonable defaults for
+   any missing parameters and redraw things if necessary. */
 void canvas_setgraph(t_glist *x, int flag, int nogoprect)
 {
-    int can_graph_on_parent = x->gl_owner && !x->gl_isclone && !x->gl_loading
-        && glist_isvisible(x->gl_owner);
-    if (!flag && glist_isgraph(x))
+    int can_graph_on_parent = x->gl_owner && !x->gl_isclone && !x->gl_loading &&
+                              glist_isvisible(x->gl_owner);
+    if(!flag && glist_isgraph(x))
     {
-        if (can_graph_on_parent)
-            gobj_vis(&x->gl_gobj, x->gl_owner, 0);
+        if(can_graph_on_parent) gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         x->gl_isgraph = x->gl_hidetext = 0;
-        if (can_graph_on_parent)
+        if(can_graph_on_parent)
         {
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
             canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
         }
     }
-    else if (flag)
+    else if(flag)
     {
-        if (x->gl_pixwidth <= 0)
-            x->gl_pixwidth = GLIST_DEFGRAPHWIDTH;
+        if(x->gl_pixwidth <= 0) x->gl_pixwidth = GLIST_DEFGRAPHWIDTH;
 
-        if (x->gl_pixheight <= 0)
-            x->gl_pixheight = GLIST_DEFGRAPHHEIGHT;
+        if(x->gl_pixheight <= 0) x->gl_pixheight = GLIST_DEFGRAPHHEIGHT;
 
-        if (can_graph_on_parent)
-            gobj_vis(&x->gl_gobj, x->gl_owner, 0);
+        if(can_graph_on_parent) gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         x->gl_isgraph = 1;
-        x->gl_hidetext = !(!(flag&2));
+        x->gl_hidetext = !(!(flag & 2));
         x->gl_goprect = !nogoprect;
-        if (glist_isvisible(x) && x->gl_goprect)
-            glist_redraw(x);
-        if (can_graph_on_parent)
+        if(glist_isvisible(x) && x->gl_goprect) glist_redraw(x);
+        if(can_graph_on_parent)
         {
             gobj_vis(&x->gl_gobj, x->gl_owner, 1);
             canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
@@ -1984,47 +1958,44 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect)
 
 void garray_properties(t_garray *x);
 
-    /* tell GUI to create a properties dialog on the canvas.  We tell
-       the user the negative of the "pixel" y scale to make it appear to grow
-       naturally upward, whereas pixels grow downward. */
-void canvas_properties(t_gobj*z, t_glist*unused)
+/* tell GUI to create a properties dialog on the canvas.  We tell
+   the user the negative of the "pixel" y scale to make it appear to grow
+   naturally upward, whereas pixels grow downward. */
+void canvas_properties(t_gobj *z, t_glist *unused)
 {
-    t_glist *x = (t_glist*)z;
+    t_glist *x = (t_glist *) z;
     t_gobj *y;
     char graphbuf[200];
-    if (glist_isgraph(x) != 0)
+    if(glist_isgraph(x) != 0)
+        sprintf(graphbuf,
+            "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n", 0., 0.,
+            glist_isgraph(x), x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
+            (int) x->gl_pixwidth, (int) x->gl_pixheight, (int) x->gl_xmargin,
+            (int) x->gl_ymargin);
+    else
         sprintf(graphbuf,
             "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n",
-                0., 0.,
-                glist_isgraph(x) ,
-                x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
-                (int)x->gl_pixwidth, (int)x->gl_pixheight,
-                (int)x->gl_xmargin, (int)x->gl_ymargin);
-    else sprintf(graphbuf,
-            "pdtk_canvas_dialog %%s %g %g %d %g %g %g %g %d %d %d %d\n",
-                glist_dpixtodx(x, 1), -glist_dpixtody(x, 1),
-                0,
-                0., -1., 1., 1.,
-                (int)x->gl_pixwidth, (int)x->gl_pixheight,
-                (int)x->gl_xmargin, (int)x->gl_ymargin);
+            glist_dpixtodx(x, 1), -glist_dpixtody(x, 1), 0, 0., -1., 1., 1.,
+            (int) x->gl_pixwidth, (int) x->gl_pixheight, (int) x->gl_xmargin,
+            (int) x->gl_ymargin);
     gfxstub_new(&x->gl_pd, x, graphbuf);
-        /* if any arrays are in the graph, put out their dialogs too */
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == garray_class)
-            garray_properties((t_garray *)y);
+    /* if any arrays are in the graph, put out their dialogs too */
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == garray_class)
+            garray_properties((t_garray *) y);
 }
 
-    /* called from the gui when "OK" is selected on the canvas properties
-       dialog.  Again we negate "y" scale. */
-static void canvas_donecanvasdialog(t_glist *x,
-    t_symbol *s, int argc, t_atom *argv)
+/* called from the gui when "OK" is selected on the canvas properties
+   dialog.  Again we negate "y" scale. */
+static void canvas_donecanvasdialog(
+    t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float xperpix, yperpix, x1, y1, x2, y2, xpix, ypix, xmargin, ymargin;
     int graphme, redraw = 0, fromgui;
 
     xperpix = atom_getfloatarg(0, argc, argv);
     yperpix = atom_getfloatarg(1, argc, argv);
-    graphme = (int)(atom_getfloatarg(2, argc, argv));
+    graphme = (int) (atom_getfloatarg(2, argc, argv));
     x1 = atom_getfloatarg(3, argc, argv);
     y1 = atom_getfloatarg(4, argc, argv);
     x2 = atom_getfloatarg(5, argc, argv);
@@ -2034,16 +2005,15 @@ static void canvas_donecanvasdialog(t_glist *x,
     xmargin = atom_getfloatarg(9, argc, argv);
     ymargin = atom_getfloatarg(10, argc, argv);
     fromgui = atom_getfloatarg(11, argc, argv);
-        /* hack - if graphme is 2 (meaning, not GOP but hide the text anyhow),
-           perhaps we're happier with 0.  This is only checked if this is really
-           being called, as intended, from the GUI.  For compatibility with old
-           patches that reverse-engineered donecanvasdialog to modify patch
-           parameters, we leave the buggy behavior in when there's no "fromgui"
-           argument supplied. */
-    if (fromgui && (!(graphme & 1)))
-        graphme = 0;
-        /* parent windows are treated the same as
-           applies to individual objects */
+    /* hack - if graphme is 2 (meaning, not GOP but hide the text anyhow),
+       perhaps we're happier with 0.  This is only checked if this is really
+       being called, as intended, from the GUI.  For compatibility with old
+       patches that reverse-engineered donecanvasdialog to modify patch
+       parameters, we leave the buggy behavior in when there's no "fromgui"
+       argument supplied. */
+    if(fromgui && (!(graphme & 1))) graphme = 0;
+    /* parent windows are treated the same as
+       applies to individual objects */
     canvas_undo_add(x, UNDO_CANVAS_APPLY, "apply", canvas_undo_set_canvas(x));
 
     x->gl_pixwidth = xpix;
@@ -2052,25 +2022,25 @@ static void canvas_donecanvasdialog(t_glist *x,
     x->gl_ymargin = ymargin;
 
     yperpix = -yperpix;
-    if (xperpix == 0)
-        xperpix = 1;
-    if (yperpix == 0)
-        yperpix = 1;
+    if(xperpix == 0) xperpix = 1;
+    if(yperpix == 0) yperpix = 1;
 
-    if (graphme)
+    if(graphme)
     {
-        if (x1 != x2)
+        if(x1 != x2)
             x->gl_x1 = x1, x->gl_x2 = x2;
-        else x->gl_x1 = 0, x->gl_x2 = 1;
-        if (y1 != y2)
+        else
+            x->gl_x1 = 0, x->gl_x2 = 1;
+        if(y1 != y2)
             x->gl_y1 = y1, x->gl_y2 = y2;
-        else x->gl_y1 = 0, x->gl_y2 = 1;
+        else
+            x->gl_y1 = 0, x->gl_y2 = 1;
     }
     else
     {
-        if (xperpix != glist_dpixtodx(x, 1) || yperpix != glist_dpixtody(x, 1))
+        if(xperpix != glist_dpixtodx(x, 1) || yperpix != glist_dpixtody(x, 1))
             redraw = 1;
-        if (xperpix > 0)
+        if(xperpix > 0)
         {
             x->gl_x1 = 0;
             x->gl_x2 = xperpix;
@@ -2080,7 +2050,7 @@ static void canvas_donecanvasdialog(t_glist *x,
             x->gl_x1 = -xperpix * (x->gl_screenx2 - x->gl_screenx1);
             x->gl_x2 = x->gl_x1 + xperpix;
         }
-        if (yperpix > 0)
+        if(yperpix > 0)
         {
             x->gl_y1 = 0;
             x->gl_y2 = yperpix;
@@ -2091,89 +2061,86 @@ static void canvas_donecanvasdialog(t_glist *x,
             x->gl_y2 = x->gl_y1 + yperpix;
         }
     }
-        /* LATER avoid doing 2 redraws here (possibly one inside setgraph) */
+    /* LATER avoid doing 2 redraws here (possibly one inside setgraph) */
     canvas_setgraph(x, graphme, 0);
     canvas_dirty(x, 1);
-    if (x->gl_havewindow)
+    if(x->gl_havewindow)
         canvas_redraw(x);
-    else if (!x->gl_isclone && glist_isvisible(x->gl_owner))
+    else if(!x->gl_isclone && glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
     }
 }
 
-    /* called from the gui when a popup menu comes back with "properties,"
-       "open," or "help." */
-static void canvas_done_popup(t_canvas *x, t_float which,
-    t_float xpos, t_float ypos)
+/* called from the gui when a popup menu comes back with "properties,"
+   "open," or "help." */
+static void canvas_done_popup(
+    t_canvas *x, t_float which, t_float xpos, t_float ypos)
 {
     char namebuf[MAXPDSTRING], *basenamep;
     t_gobj *y;
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
         int x1, y1, x2, y2;
-        if (canvas_hitbox(x, y, xpos, ypos, &x1, &y1, &x2, &y2))
+        if(canvas_hitbox(x, y, xpos, ypos, &x1, &y1, &x2, &y2))
         {
-            if (which == 0)     /* properties */
+            if(which == 0) /* properties */
             {
-                if (!class_getpropertiesfn(pd_class(&y->g_pd)))
-                    continue;
+                if(!class_getpropertiesfn(pd_class(&y->g_pd))) continue;
                 (*class_getpropertiesfn(pd_class(&y->g_pd)))(y, x);
                 return;
             }
-            else if (which == 1)    /* open */
+            else if(which == 1) /* open */
             {
-                if (!zgetfn(&y->g_pd, gensym("menu-open")))
-                    continue;
+                if(!zgetfn(&y->g_pd, gensym("menu-open"))) continue;
                 vmess(&y->g_pd, gensym("menu-open"), "");
                 return;
             }
-            else    /* help */
+            else /* help */
             {
                 const char *dir;
-                if (pd_class(&y->g_pd) == canvas_class &&
-                    canvas_isabstraction((t_canvas *)y))
+                if(pd_class(&y->g_pd) == canvas_class &&
+                    canvas_isabstraction((t_canvas *) y))
                 {
-                    t_object *ob = (t_object *)y;
+                    t_object *ob = (t_object *) y;
                     int ac = binbuf_getnatom(ob->te_binbuf);
                     t_atom *av = binbuf_getvec(ob->te_binbuf);
-                    if (ac < 1)
-                        return;
+                    if(ac < 1) return;
                     atom_string(av, namebuf, MAXPDSTRING);
 
-                        /* strip dir from name : */
+                    /* strip dir from name : */
                     basenamep = strrchr(namebuf, '/');
 #ifdef _WIN32
-                    if (!basenamep)
-                        basenamep = strrchr(namebuf, '\\');
+                    if(!basenamep) basenamep = strrchr(namebuf, '\\');
 #endif
-                    if (!basenamep)
+                    if(!basenamep)
                         basenamep = namebuf;
-                    else basenamep++;   /* strip last '/' */
+                    else
+                        basenamep++; /* strip last '/' */
 
-                    dir = canvas_getdir((t_canvas *)y)->s_name;
+                    dir = canvas_getdir((t_canvas *) y)->s_name;
                 }
                 else
                 {
                     strncpy(namebuf, class_gethelpname(pd_class(&y->g_pd)),
-                        MAXPDSTRING-1);
-                    namebuf[MAXPDSTRING-1] = 0;
+                        MAXPDSTRING - 1);
+                    namebuf[MAXPDSTRING - 1] = 0;
                     dir = class_gethelpdir(pd_class(&y->g_pd));
                     basenamep = namebuf;
                 }
-                if (strlen(namebuf) < 4 ||
+                if(strlen(namebuf) < 4 ||
                     strcmp(namebuf + strlen(namebuf) - 3, ".pd"))
-                        strcat(namebuf, ".pd");
+                    strcat(namebuf, ".pd");
                 open_via_helppath(basenamep, dir);
                 return;
             }
         }
     }
-    if (which == 0)
+    if(which == 0)
         canvas_properties(&x->gl_gobj, 0);
-    else if (which == 2)
-        open_via_helppath("intro.pd", canvas_getdir((t_canvas *)x)->s_name);
+    else if(which == 2)
+        open_via_helppath("intro.pd", canvas_getdir((t_canvas *) x)->s_name);
 }
 
 #define NOMOD 0
@@ -2184,16 +2151,16 @@ static void canvas_done_popup(t_canvas *x, t_float which,
 
 #define DCLICKINTERVAL 0.25
 
-    /* mouse click */
-static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
-    int mod, int doit)
+/* mouse click */
+static void canvas_doclick(
+    t_canvas *x, int xpos, int ypos, int which, int mod, int doit)
 {
     t_gobj *hitbox;
     int shiftmod, runmode, altmod, doublemod = 0, rightclick;
-    int x1=0, y1=0, x2=0, y2=0, clickreturned = 0;
+    int x1 = 0, y1 = 0, x2 = 0, y2 = 0, clickreturned = 0;
     t_text *hitobj;
 
-    if (!x->gl_editor)
+    if(!x->gl_editor)
     {
         bug("editor");
         return;
@@ -2206,19 +2173,18 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
 
     EDITOR->canvas_undo_already_set_move = 0;
 
-        /* if keyboard was grabbed, notify grabber and cancel the grab */
-    if (doit && x->gl_editor->e_grab && x->gl_editor->e_keyfn)
+    /* if keyboard was grabbed, notify grabber and cancel the grab */
+    if(doit && x->gl_editor->e_grab && x->gl_editor->e_keyfn)
     {
-        (* x->gl_editor->e_keyfn) (x->gl_editor->e_grab, &s_, 0);
+        (*x->gl_editor->e_keyfn)(x->gl_editor->e_grab, &s_, 0);
         glist_grab(x, 0, 0, 0, 0, 0);
     }
 
-    if (doit && xpos == EDITOR->canvas_upx &&
-        ypos == EDITOR->canvas_upy &&
+    if(doit && xpos == EDITOR->canvas_upx && ypos == EDITOR->canvas_upy &&
         sys_getrealtime() - EDITOR->canvas_upclicktime < DCLICKINTERVAL)
-            doublemod = 1;
+        doublemod = 1;
     x->gl_editor->e_lastmoved = 0;
-    if (doit)
+    if(doit)
     {
         x->gl_editor->e_grab = 0;
         x->gl_editor->e_onmotion = MA_NONE;
@@ -2227,27 +2193,25 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
     post("click %d %d %d %d", xpos, ypos, which, mod);
 #endif
 
-    if (x->gl_editor->e_onmotion != MA_NONE)
-        return;
+    if(x->gl_editor->e_onmotion != MA_NONE) return;
 
     x->gl_editor->e_xwas = xpos;
     x->gl_editor->e_ywas = ypos;
 
-    if (runmode && !rightclick)
+    if(runmode && !rightclick)
     {
-            /* is a text activated ? */
-        if (x->gl_editor->e_textedfor  && doit)
+        /* is a text activated ? */
+        if(x->gl_editor->e_textedfor && doit)
         {
             hitobj = rtext_getowner(x->gl_editor->e_textedfor);
-            if (canvas_hitbox(x, &hitobj->te_g,
-                xpos, ypos, &x1, &y1, &x2, &y2))
+            if(canvas_hitbox(x, &hitobj->te_g, xpos, ypos, &x1, &y1, &x2, &y2))
             {
                 rtext_mouse(x->gl_editor->e_textedfor, xpos - x1, ypos - y1,
-                    (shiftmod? RTEXT_SHIFT :
-                        (doublemod ? RTEXT_DBL : RTEXT_DOWN)));
-                    x->gl_editor->e_onmotion = MA_DRAGTEXT;
-                    x->gl_editor->e_xwas = x1;
-                    x->gl_editor->e_ywas = y1;
+                    (shiftmod ? RTEXT_SHIFT
+                              : (doublemod ? RTEXT_DBL : RTEXT_DOWN)));
+                x->gl_editor->e_onmotion = MA_DRAGTEXT;
+                x->gl_editor->e_xwas = x1;
+                x->gl_editor->e_ywas = y1;
             }
             else
             {
@@ -2256,46 +2220,47 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
             }
             return;
         }
-        for (hitbox = x->gl_list; hitbox; hitbox = hitbox->g_next)
+        for(hitbox = x->gl_list; hitbox; hitbox = hitbox->g_next)
         {
-                /* check if the object wants to be clicked */
-            if (canvas_hitbox(x, hitbox, xpos, ypos, &x1, &y1, &x2, &y2)
-                && (clickreturned = gobj_click(hitbox, x, xpos, ypos,
-                    shiftmod, ((mod & CTRLMOD) && (!x->gl_edit)) || altmod,
-                        doublemod, doit)))
-                            break;
+            /* check if the object wants to be clicked */
+            if(canvas_hitbox(x, hitbox, xpos, ypos, &x1, &y1, &x2, &y2) &&
+                (clickreturned = gobj_click(hitbox, x, xpos, ypos, shiftmod,
+                     ((mod & CTRLMOD) && (!x->gl_edit)) || altmod, doublemod,
+                     doit)))
+                break;
         }
-        if (!doit)
+        if(!doit)
         {
-            if (hitbox)
+            if(hitbox)
                 canvas_setcursor(x, clickreturned);
-            else canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
+            else
+                canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
         }
         return;
     }
-        /* if not a runmode left click, fall here. */
+    /* if not a runmode left click, fall here. */
     hitbox = canvas_findhitbox(x, xpos, ypos, &x1, &y1, &x2, &y2);
     hitobj = (hitbox ? pd_checkobject(&hitbox->g_pd) : 0);
-        /* if text is activated while we're in locked state, this must
-        be a number box - so if we clicked outside the box, deactivate it.
-        This is a different situation from the "deselect" action below
-        when we're unlocked.  */
+    /* if text is activated while we're in locked state, this must
+    be a number box - so if we clicked outside the box, deactivate it.
+    This is a different situation from the "deselect" action below
+    when we're unlocked.  */
     /* if (doit) post("%d %x %x %x", x->gl_edit, x->gl_editor->e_textedfor,
         hitobj, (hitobj ? glist_findrtext(x, hitobj) : 0));
     if (doit && (!x->gl_edit) && x->gl_editor->e_textedfor &&
         (!hitobj || (glist_findrtext(x, hitobj) != x->gl_editor->e_textedfor)))
             rtext_activate(x->gl_editor->e_textedfor, 0);   */
-    if (hitbox)
+    if(hitbox)
     {
-            /* we're in a rectangle */
-        if (rightclick)
+        /* we're in a rectangle */
+        if(rightclick)
             canvas_rightclick(x, xpos, ypos, hitbox);
-        else if (shiftmod)
+        else if(shiftmod)
         {
-            if (doit)
+            if(doit)
             {
                 t_rtext *rt;
-                if (hitobj && (rt = x->gl_editor->e_textedfor) &&
+                if(hitobj && (rt = x->gl_editor->e_textedfor) &&
                     rt == glist_findrtext(x, hitobj))
                 {
                     rtext_mouse(rt, xpos - x1, ypos - y1, RTEXT_SHIFT);
@@ -2305,24 +2270,24 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                 }
                 else
                 {
-                    if (glist_isselected(x, hitbox))
+                    if(glist_isselected(x, hitbox))
                         glist_deselect(x, hitbox);
-                    else glist_select(x, hitbox);
+                    else
+                        glist_select(x, hitbox);
                 }
             }
         }
         else
         {
             int noutlet;
-                /* resize? only for "true" text boxes or canvases */
-            if (xpos >= x2-4 && ypos < y2-4 && hitobj &&
-                    (hitobj->te_pd->c_wb == &text_widgetbehavior ||
-                    hitobj->te_type == T_ATOM ||
-                    pd_checkglist(&hitobj->te_pd)))
+            /* resize? only for "true" text boxes or canvases */
+            if(xpos >= x2 - 4 && ypos < y2 - 4 && hitobj &&
+                (hitobj->te_pd->c_wb == &text_widgetbehavior ||
+                    hitobj->te_type == T_ATOM || pd_checkglist(&hitobj->te_pd)))
             {
-                if (doit)
+                if(doit)
                 {
-                    if (!glist_isselected(x, hitbox))
+                    if(!glist_isselected(x, hitbox))
                     {
                         glist_noselect(x);
                         glist_select(x, hitbox);
@@ -2335,48 +2300,51 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                     canvas_undo_add(x, UNDO_APPLY, "resize",
                         canvas_undo_set_apply(x, glist_getindex(x, hitbox)));
                 }
-                else canvas_setcursor(x, CURSOR_EDITMODE_RESIZE);
+                else
+                    canvas_setcursor(x, CURSOR_EDITMODE_RESIZE);
             }
-                /* look for an outlet */
-            else if (hitobj && (noutlet = obj_noutlets(hitobj)) &&
-                ypos >= y2 - (OHEIGHT*x->gl_zoom) + x->gl_zoom)
+            /* look for an outlet */
+            else if(hitobj && (noutlet = obj_noutlets(hitobj)) &&
+                    ypos >= y2 - (OHEIGHT * x->gl_zoom) + x->gl_zoom)
             {
                 int width = x2 - x1;
                 int iow = IOWIDTH * x->gl_zoom;
                 int nout1 = (noutlet > 1 ? noutlet - 1 : 1);
-                int closest = ((xpos-x1) * (nout1) + width/2)/width;
-                int hotspot = x1 +
-                    (width - iow) * closest / (nout1);
-                if (closest < noutlet &&
-                    xpos >= (hotspot - x->gl_zoom) &&
+                int closest = ((xpos - x1) * (nout1) + width / 2) / width;
+                int hotspot = x1 + (width - iow) * closest / (nout1);
+                if(closest < noutlet && xpos >= (hotspot - x->gl_zoom) &&
                     xpos <= hotspot + (iow + x->gl_zoom))
                 {
-                    if (doit)
+                    if(doit)
                     {
                         int issignal = obj_issignaloutlet(hitobj, closest);
                         x->gl_editor->e_onmotion = MA_CONNECT;
                         x->gl_editor->e_xwas = xpos;
                         x->gl_editor->e_ywas = ypos;
 
-                        sys_vgui("::pdtk_canvas::cords_to_foreground .x%lx.c 0\n", x);
                         sys_vgui(
-                            ".x%lx.c create line %d %d %d %d -width %d -tags x\n",
+                            "::pdtk_canvas::cords_to_foreground .x%lx.c 0\n",
+                            x);
+                        sys_vgui(".x%lx.c create line %d %d %d %d -width %d "
+                                 "-tags x\n",
                             x, xpos, ypos, xpos, ypos,
                             (issignal ? 2 : 1) * x->gl_zoom);
                     }
-                    else canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
+                    else
+                        canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
                 }
-                else if (doit)
+                else if(doit)
                     goto nooutletafterall;
-                else canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
+                else
+                    canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
             }
-                /* not in an outlet; select and move */
-            else if (doit)
+            /* not in an outlet; select and move */
+            else if(doit)
             {
                 t_rtext *rt;
-                    /* check if the box is being text edited */
+                /* check if the box is being text edited */
             nooutletafterall:
-                if (hitobj && (rt = x->gl_editor->e_textedfor) &&
+                if(hitobj && (rt = x->gl_editor->e_textedfor) &&
                     rt == glist_findrtext(x, hitobj))
                 {
                     rtext_mouse(rt, xpos - x1, ypos - y1,
@@ -2387,8 +2355,8 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                 }
                 else
                 {
-                        /* otherwise select and drag to displace */
-                    if (!glist_isselected(x, hitbox))
+                    /* otherwise select and drag to displace */
+                    if(!glist_isselected(x, hitbox))
                     {
                         glist_noselect(x);
                         glist_select(x, hitbox);
@@ -2396,53 +2364,55 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                     x->gl_editor->e_onmotion = MA_MOVE;
                 }
             }
-            else canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
+            else
+                canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
         }
         return;
     }
-        /* if right click doesn't hit any boxes, call rightclick
-           routine anyway */
-    if (rightclick)
-        canvas_rightclick(x, xpos, ypos, 0);
+    /* if right click doesn't hit any boxes, call rightclick
+       routine anyway */
+    if(rightclick) canvas_rightclick(x, xpos, ypos, 0);
 
-        /* if not an editing action, and if we didn't hit a
-           box, set cursor and return */
-    if (runmode || rightclick)
+    /* if not an editing action, and if we didn't hit a
+       box, set cursor and return */
+    if(runmode || rightclick)
     {
         canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
         return;
     }
-        /* having failed to find a box, we try lines now. */
-    if (!runmode && !altmod)
+    /* having failed to find a box, we try lines now. */
+    if(!runmode && !altmod)
     {
         t_linetraverser t;
         t_outconnect *oc;
         t_float fx = xpos, fy = ypos;
         t_glist *glist2 = glist_getcanvas(x);
         linetraverser_start(&t, glist2);
-        while ((oc = linetraverser_next(&t)))
+        while((oc = linetraverser_next(&t)))
         {
             int outindex, inindex;
-            t_float lx1 = t.tr_lx1, ly1 = t.tr_ly1,
-                lx2 = t.tr_lx2, ly2 = t.tr_ly2;
-            t_float area = (lx2 - lx1) * (fy - ly1) -
-                (ly2 - ly1) * (fx - lx1);
-            t_float dsquare = (lx2-lx1) * (lx2-lx1) + (ly2-ly1) * (ly2-ly1);
-            if (area * area >= 50 * dsquare) continue;
-            if ((lx2-lx1) * (fx-lx1) + (ly2-ly1) * (fy-ly1) < 0) continue;
-            if ((lx2-lx1) * (lx2-fx) + (ly2-ly1) * (ly2-fy) < 0) continue;
+            t_float lx1 = t.tr_lx1, ly1 = t.tr_ly1, lx2 = t.tr_lx2,
+                    ly2 = t.tr_ly2;
+            t_float area = (lx2 - lx1) * (fy - ly1) - (ly2 - ly1) * (fx - lx1);
+            t_float dsquare =
+                (lx2 - lx1) * (lx2 - lx1) + (ly2 - ly1) * (ly2 - ly1);
+            if(area * area >= 50 * dsquare) continue;
+            if((lx2 - lx1) * (fx - lx1) + (ly2 - ly1) * (fy - ly1) < 0)
+                continue;
+            if((lx2 - lx1) * (lx2 - fx) + (ly2 - ly1) * (ly2 - fy) < 0)
+                continue;
             outindex = canvas_getindex(glist2, &t.tr_ob->ob_g);
             inindex = canvas_getindex(glist2, &t.tr_ob2->ob_g);
-            if (shiftmod)
+            if(shiftmod)
             {
                 int soutindex, sinindex, soutno, sinno;
-                    /* if no line is selected, just add this line to the selection */
+                /* if no line is selected, just add this line to the selection
+                 */
                 if(!x->gl_editor->e_selectedline)
                 {
-                    if (doit)
+                    if(doit)
                     {
-                        glist_selectline(glist2, oc,
-                            outindex, t.tr_outno,
+                        glist_selectline(glist2, oc, outindex, t.tr_outno,
                             inindex, t.tr_inno);
                     }
                     canvas_setcursor(x, CURSOR_EDITMODE_DISCONNECT);
@@ -2452,27 +2422,30 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                 sinindex = x->gl_editor->e_selectline_index2;
                 soutno = x->gl_editor->e_selectline_outno;
                 sinno = x->gl_editor->e_selectline_inno;
-                        /* if the hovered line is already selected, deselect it */
-                if ((outindex == soutindex) && (inindex == sinindex)
-                    && (soutno == t.tr_outno) && (sinno == t.tr_inno))
+                /* if the hovered line is already selected, deselect it */
+                if((outindex == soutindex) && (inindex == sinindex) &&
+                    (soutno == t.tr_outno) && (sinno == t.tr_inno))
                 {
-                    if(doit)
-                        glist_deselectline(x);
+                    if(doit) glist_deselectline(x);
                     canvas_setcursor(x, CURSOR_EDITMODE_DISCONNECT);
                     return;
                 }
 
-                    /* swap selected and hovered connection */
-                if ((!x->gl_editor->e_selection)
-                    && ((outindex == soutindex) || (inindex == sinindex)))
+                /* swap selected and hovered connection */
+                if((!x->gl_editor->e_selection) &&
+                    ((outindex == soutindex) || (inindex == sinindex)))
                 {
                     if(doit)
                     {
                         canvas_undo_add(x, UNDO_SEQUENCE_START, "reconnect", 0);
-                        canvas_disconnect_with_undo(x, soutindex, soutno, sinindex, sinno);
-                        canvas_disconnect_with_undo(x, outindex, t.tr_outno, inindex, t.tr_inno);
-                        canvas_connect_with_undo(x, outindex, t.tr_outno, sinindex, sinno);
-                        canvas_connect_with_undo(x, soutindex, soutno, inindex, t.tr_inno);
+                        canvas_disconnect_with_undo(
+                            x, soutindex, soutno, sinindex, sinno);
+                        canvas_disconnect_with_undo(
+                            x, outindex, t.tr_outno, inindex, t.tr_inno);
+                        canvas_connect_with_undo(
+                            x, outindex, t.tr_outno, sinindex, sinno);
+                        canvas_connect_with_undo(
+                            x, soutindex, soutno, inindex, t.tr_inno);
                         canvas_undo_add(x, UNDO_SEQUENCE_END, "reconnect", 0);
 
                         x->gl_editor->e_selectline_index1 = soutindex;
@@ -2486,15 +2459,14 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                     return;
                 }
             }
-            if (!shiftmod)
+            if(!shiftmod)
             {
-                    /* !shiftmode: clear selection before selecting line */
-                if (doit)
+                /* !shiftmode: clear selection before selecting line */
+                if(doit)
                 {
                     glist_noselect(x);
-                    glist_selectline(glist2, oc,
-                        outindex, t.tr_outno,
-                        inindex, t.tr_inno);
+                    glist_selectline(
+                        glist2, oc, outindex, t.tr_outno, inindex, t.tr_inno);
                 }
                 canvas_setcursor(x, CURSOR_EDITMODE_DISCONNECT);
                 return;
@@ -2502,11 +2474,11 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
         }
     }
     canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
-    if (doit)
+    if(doit)
     {
-        if (!shiftmod) glist_noselect(x);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -tags x\n",
-            x, xpos, ypos, xpos, ypos);
+        if(!shiftmod) glist_noselect(x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -tags x\n", x, xpos,
+            ypos, xpos, ypos);
         x->gl_editor->e_xwas = xpos;
         x->gl_editor->e_ywas = ypos;
         x->gl_editor->e_onmotion = MA_REGION;
@@ -2519,32 +2491,36 @@ void canvas_mouse(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
     canvas_doclick(x, xpos, ypos, which, mod, 1);
 }
 
-int canvas_isconnected (t_canvas *x, t_text *ob1, int n1,
-    t_text *ob2, int n2)
+int canvas_isconnected(t_canvas *x, t_text *ob1, int n1, t_text *ob2, int n2)
 {
     t_linetraverser t;
     t_outconnect *oc;
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
-        if (t.tr_ob == ob1 && t.tr_outno == n1 &&
-            t.tr_ob2 == ob2 && t.tr_inno == n2)
-                return (1);
+    while((oc = linetraverser_next(&t)))
+        if(t.tr_ob == ob1 && t.tr_outno == n1 && t.tr_ob2 == ob2 &&
+            t.tr_inno == n2)
+            return (1);
     return (0);
 }
 
-static int canconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin)
+static int canconnect(
+    t_canvas *x, t_object *src, int nout, t_object *sink, int nin)
 {
-    if (!src || !sink || sink == src) /* do source and sink exist (and are not the same)?*/
+    if(!src || !sink ||
+        sink == src) /* do source and sink exist (and are not the same)?*/
         return 0;
-    if (nin >= obj_ninlets(sink) || (nout >= obj_noutlets(src))) /* do the requested iolets exist? */
+    if(nin >= obj_ninlets(sink) ||
+        (nout >= obj_noutlets(src))) /* do the requested iolets exist? */
         return 0;
-    if (canvas_isconnected(x, src, nout, sink, nin)) /* are the objects already connected? */
+    if(canvas_isconnected(
+           x, src, nout, sink, nin)) /* are the objects already connected? */
         return 0;
     return (!obj_issignaloutlet(src, nout) || /* are the iolets compatible? */
             obj_issignalinlet(sink, nin));
 }
 
-static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin)
+static int tryconnect(
+    t_canvas *x, t_object *src, int nout, t_object *sink, int nin)
 {
     if(canconnect(x, src, nout, sink, nin))
     {
@@ -2553,8 +2529,8 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
         {
             int iow = IOWIDTH * x->gl_zoom;
             int iom = IOMIDDLE * x->gl_zoom;
-            int x11=0, x12=0, x21=0, x22=0;
-            int y11=0, y12=0, y21=0, y22=0;
+            int x11 = 0, x12 = 0, x21 = 0, x22 = 0;
+            int y11 = 0, y12 = 0, y21 = 0, y22 = 0;
             int noutlets1, ninlets, lx1, ly1, lx2, ly2;
             gobj_getrect(&src->ob_g, x, &x11, &y11, &x12, &y12);
             gobj_getrect(&sink->ob_g, x, &x21, &y21, &x22, &y22);
@@ -2562,23 +2538,22 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
             noutlets1 = obj_noutlets(src);
             ninlets = obj_ninlets(sink);
 
-            lx1 = x11 + (noutlets1 > 1 ?
-                             ((x12-x11-iow) * nout)/(noutlets1-1) : 0)
-                + iom;
+            lx1 = x11 +
+                  (noutlets1 > 1 ? ((x12 - x11 - iow) * nout) / (noutlets1 - 1)
+                                 : 0) +
+                  iom;
             ly1 = y12;
-            lx2 = x21 + (ninlets > 1 ?
-                             ((x22-x21-iow) * nin)/(ninlets-1) : 0)
-                + iom;
+            lx2 =
+                x21 +
+                (ninlets > 1 ? ((x22 - x21 - iow) * nin) / (ninlets - 1) : 0) +
+                iom;
             ly2 = y21;
-            sys_vgui(
-                ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
-                glist_getcanvas(x),
-                lx1, ly1, lx2, ly2,
-                (obj_issignaloutlet(src, nout) ? 2 : 1) *
-                x->gl_zoom,
-                oc);
-            canvas_undo_add(x, UNDO_CONNECT, "connect", canvas_undo_set_connect(x,
-                    canvas_getindex(x, &src->ob_g), nout,
+            sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list "
+                     "l%lx cord]\n",
+                glist_getcanvas(x), lx1, ly1, lx2, ly2,
+                (obj_issignaloutlet(src, nout) ? 2 : 1) * x->gl_zoom, oc);
+            canvas_undo_add(x, UNDO_CONNECT, "connect",
+                canvas_undo_set_connect(x, canvas_getindex(x, &src->ob_g), nout,
                     canvas_getindex(x, &sink->ob_g), nin));
             canvas_dirty(x, 1);
             return 1;
@@ -2589,208 +2564,234 @@ static int tryconnect(t_canvas*x, t_object*src, int nout, t_object*sink, int nin
 
 static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 {
-    int x11=0, y11=0, x12=0, y12=0;
+    int x11 = 0, y11 = 0, x12 = 0, y12 = 0;
     t_gobj *y1;
-    int x21=0, y21=0, x22=0, y22=0;
+    int x21 = 0, y21 = 0, x22 = 0, y22 = 0;
     t_gobj *y2;
-    int xwas = x->gl_editor->e_xwas,
-        ywas = x->gl_editor->e_ywas;
+    int xwas = x->gl_editor->e_xwas, ywas = x->gl_editor->e_ywas;
 #if 0
     post("canvas_doconnect(%p, %d, %d, %d, %d)", x, xpos, ypos, mod, doit);
 #endif
-    if (doit) {
+    if(doit)
+    {
         sys_vgui("::pdtk_canvas::cords_to_foreground .x%lx.c 1\n", x);
         sys_vgui(".x%lx.c delete x\n", x);
     }
-    else sys_vgui(".x%lx.c coords x %d %d %d %d\n",
-                  x, x->gl_editor->e_xwas,
-                  x->gl_editor->e_ywas, xpos, ypos);
+    else
+        sys_vgui(".x%lx.c coords x %d %d %d %d\n", x, x->gl_editor->e_xwas,
+            x->gl_editor->e_ywas, xpos, ypos);
 
-    if ((y1 = canvas_findhitbox(x, xwas, ywas, &x11, &y11, &x12, &y12))
-        && (y2 = canvas_findhitbox(x, xpos, ypos, &x21, &y21, &x22, &y22)))
+    if((y1 = canvas_findhitbox(x, xwas, ywas, &x11, &y11, &x12, &y12)) &&
+        (y2 = canvas_findhitbox(x, xpos, ypos, &x21, &y21, &x22, &y22)))
     {
         t_object *ob1 = pd_checkobject(&y1->g_pd);
         t_object *ob2 = pd_checkobject(&y2->g_pd);
         int noutlet1, ninlet2;
-        if (ob1 && ob2 && ob1 != ob2 &&
-            (noutlet1 = obj_noutlets(ob1))
-            && (ninlet2 = obj_ninlets(ob2)))
+        if(ob1 && ob2 && ob1 != ob2 && (noutlet1 = obj_noutlets(ob1)) &&
+            (ninlet2 = obj_ninlets(ob2)))
         {
             int width1 = x12 - x11, closest1, hotspot1;
             int width2 = x22 - x21, closest2, hotspot2;
 
-            if (noutlet1 > 1)
+            if(noutlet1 > 1)
             {
-                closest1 = ((xwas-x11) * (noutlet1-1) + width1/2)/width1;
-                hotspot1 = x11 +
-                    (width1 - IOWIDTH) * closest1 / (noutlet1-1);
+                closest1 =
+                    ((xwas - x11) * (noutlet1 - 1) + width1 / 2) / width1;
+                hotspot1 = x11 + (width1 - IOWIDTH) * closest1 / (noutlet1 - 1);
             }
-            else closest1 = 0, hotspot1 = x11;
+            else
+                closest1 = 0, hotspot1 = x11;
 
-            if (ninlet2 > 1)
+            if(ninlet2 > 1)
             {
-                closest2 = ((xpos-x21) * (ninlet2-1) + width2/2)/width2;
-                hotspot2 = x21 +
-                    (width2 - IOWIDTH) * closest2 / (ninlet2-1);
+                closest2 = ((xpos - x21) * (ninlet2 - 1) + width2 / 2) / width2;
+                hotspot2 = x21 + (width2 - IOWIDTH) * closest2 / (ninlet2 - 1);
             }
-            else closest2 = 0, hotspot2 = x21;
+            else
+                closest2 = 0, hotspot2 = x21;
 
-            if (closest1 >= noutlet1)
-                closest1 = noutlet1 - 1;
-            if (closest2 >= ninlet2)
-                closest2 = ninlet2 - 1;
+            if(closest1 >= noutlet1) closest1 = noutlet1 - 1;
+            if(closest2 >= ninlet2) closest2 = ninlet2 - 1;
 
-            if (canvas_isconnected (x, ob1, closest1, ob2, closest2))
+            if(canvas_isconnected(x, ob1, closest1, ob2, closest2))
             {
                 canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
                 return;
             }
-            if (obj_issignaloutlet(ob1, closest1) &&
+            if(obj_issignaloutlet(ob1, closest1) &&
                 !obj_issignalinlet(ob2, closest2))
             {
-                if (doit)
-                    pd_error(0, "can't connect audio signal outlet to nonsignal inlet");
+                if(doit)
+                    pd_error(0,
+                        "can't connect audio signal outlet to nonsignal inlet");
                 canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
                 return;
             }
-            if (doit)
+            if(doit)
             {
                 t_selection *sel;
                 int selmode = 0;
                 canvas_undo_add(x, UNDO_SEQUENCE_START, "connect", 0);
                 tryconnect(x, ob1, closest1, ob2, closest2);
                 canvas_dirty(x, 1);
-                    /* now find out if either ob1 xor ob2 are part of the selection,
-                     * and if so, connect the rest of the selection as well */
-                if(mod & SHIFTMOD) /* intelligent patching needs to be activated by modifier key */
-                    selmode = glist_isselected(x, &ob1->ob_g) + 2 * glist_isselected(x, &ob2->ob_g);
-                switch(selmode) {
-                case 3: /* both source and sink are selected */
-                        /* if only the source & sink are selected, keep connecting them */
-                    if(0 == x->gl_editor->e_selection->sel_next->sel_next)
-                    {
-                        int i, j;
-                        for(i=closest1, j=closest2; (i < noutlet1) && (j < ninlet2); i++, j++ )
-                            tryconnect(x, ob1, i, ob2, j);
-                    }
-                    else
-                            /* if other objects are selected as well, connect those either as
-                             * sources or sinks, whichever allows for more connections
-                             */
-                    {
-                            /* get a left-right sorted list of all selected objects
-                             * (but the already connected ones)
-                             * count the possibles sinks and sources
-                             */
-                        int mode = 0;
-                        int i;
-                        int sinks = 0, sources = 0;
-                        t_float ysinks = 0., ysources = 0.;
-                        int msgout = !obj_issignaloutlet(ob1, closest1);
-                        int sigin = obj_issignalinlet(ob2, closest2);
-                        t_selection*sortedsel = 0;
-                            /* sort the selected objects from left-right */
-                        for(sel = x->gl_editor->e_selection, i=1; sel; sel = sel->sel_next, i++)
+                /* now find out if either ob1 xor ob2 are part of the selection,
+                 * and if so, connect the rest of the selection as well */
+                if(mod & SHIFTMOD) /* intelligent patching needs to be activated
+                                      by modifier key */
+                    selmode = glist_isselected(x, &ob1->ob_g) +
+                              2 * glist_isselected(x, &ob2->ob_g);
+                switch(selmode)
+                {
+                    case 3: /* both source and sink are selected */
+                        /* if only the source & sink are selected, keep
+                         * connecting them */
+                        if(0 == x->gl_editor->e_selection->sel_next->sel_next)
                         {
-                            t_object*ob = pd_checkobject(&sel->sel_what->g_pd);
-                            t_selection*sob = 0;
-                                /* skip illegal objects and the reference source&sink */
-                            if (!ob || (ob1 == ob) || (ob2 == ob))
-                                continue;
+                            int i, j;
+                            for(i = closest1, j = closest2;
+                                (i < noutlet1) && (j < ninlet2); i++, j++)
+                                tryconnect(x, ob1, i, ob2, j);
+                        }
+                        else
+                        /* if other objects are selected as well, connect those
+                         * either as sources or sinks, whichever allows for more
+                         * connections
+                         */
+                        {
+                            /* get a left-right sorted list of all selected
+                             * objects (but the already connected ones) count
+                             * the possibles sinks and sources
+                             */
+                            int mode = 0;
+                            int i;
+                            int sinks = 0, sources = 0;
+                            t_float ysinks = 0., ysources = 0.;
+                            int msgout = !obj_issignaloutlet(ob1, closest1);
+                            int sigin = obj_issignalinlet(ob2, closest2);
+                            t_selection *sortedsel = 0;
+                            /* sort the selected objects from left-right */
+                            for(sel = x->gl_editor->e_selection, i = 1; sel;
+                                sel = sel->sel_next, i++)
+                            {
+                                t_object *ob =
+                                    pd_checkobject(&sel->sel_what->g_pd);
+                                t_selection *sob = 0;
+                                /* skip illegal objects and the reference
+                                 * source&sink */
+                                if(!ob || (ob1 == ob) || (ob2 == ob)) continue;
 
-                            if (canconnect(x, ob1, closest1 + 1 + sinks, ob, closest2))
-                            {
-                                sinks += 1;
-                                ysinks += ob->te_ypix;
-                            }
-                            if (canconnect(x, ob, closest1, ob2, closest2 + 1 + sources))
-                            {
-                                sources += 1;
-                                ysources += ob->te_ypix;
-                            }
+                                if(canconnect(x, ob1, closest1 + 1 + sinks, ob,
+                                       closest2))
+                                {
+                                    sinks += 1;
+                                    ysinks += ob->te_ypix;
+                                }
+                                if(canconnect(x, ob, closest1, ob2,
+                                       closest2 + 1 + sources))
+                                {
+                                    sources += 1;
+                                    ysources += ob->te_ypix;
+                                }
 
                                 /* insert the object into the sortedsel list */
-                            if((sob = getbytes(sizeof(*sob)))) {
-                                t_selection*s, *slast=0;
-                                sob->sel_what = &ob->te_g;
-                                for(s=sortedsel; s; s=s->sel_next)
+                                if((sob = getbytes(sizeof(*sob))))
                                 {
-                                    t_object*o = pd_checkobject(&s->sel_what->g_pd);
-                                    if(!o) continue;
-                                    if((ob->te_xpix < o->te_xpix) || ((ob->te_xpix == o->te_xpix) && (ob->te_ypix < o->te_ypix)))
+                                    t_selection *s, *slast = 0;
+                                    sob->sel_what = &ob->te_g;
+                                    for(s = sortedsel; s; s = s->sel_next)
                                     {
-                                        sob->sel_next = s;
-                                        if(slast)
-                                            slast->sel_next = sob;
-                                        else
-                                            sortedsel = sob;
-                                        break;
+                                        t_object *o =
+                                            pd_checkobject(&s->sel_what->g_pd);
+                                        if(!o) continue;
+                                        if((ob->te_xpix < o->te_xpix) ||
+                                            ((ob->te_xpix == o->te_xpix) &&
+                                                (ob->te_ypix < o->te_ypix)))
+                                        {
+                                            sob->sel_next = s;
+                                            if(slast)
+                                                slast->sel_next = sob;
+                                            else
+                                                sortedsel = sob;
+                                            break;
+                                        }
+                                        slast = s;
                                     }
-                                    slast=s;
+                                    if(slast)
+                                        slast->sel_next = sob;
+                                    else
+                                        sortedsel = sob;
                                 }
-                                if(slast)
-                                    slast->sel_next = sob;
-                                else
-                                    sortedsel = sob;
                             }
-                        }
                             /* try to maximize connections */
-                        mode = (sinks > sources);
+                            mode = (sinks > sources);
 
-                            /* maximizing failed, so prefer to connect from top to bottom */
-                        if (sinks && (sinks == sources)) {
-                            mode = ((ysinks - ob1->te_ypix) / sinks) > ((ysources - ob2->te_ypix) / sources) * -1.;
-                        }
+                            /* maximizing failed, so prefer to connect from top
+                             * to bottom */
+                            if(sinks && (sinks == sources))
+                            {
+                                mode =
+                                    ((ysinks - ob1->te_ypix) / sinks) >
+                                    ((ysources - ob2->te_ypix) / sources) * -1.;
+                            }
 
-                        sinks = 0;
-                        sources = 0;
-                        if (mode)
-                            for(sel=sortedsel; ((closest1 + 1 + sinks) < noutlet1) && sel; sel=sel->sel_next)
-                            {
-                                sinks += tryconnect(x,
-                                                    ob1, closest1 + 1 + sinks,
-                                                    pd_checkobject(&sel->sel_what->g_pd), closest2);
-                            }
-                        else
-                            for(sel=sortedsel; ((closest2 + 1 + sources) < ninlet2) && sel; sel=sel->sel_next)
-                            {
-                                sources += tryconnect(x,
-                                                      pd_checkobject(&sel->sel_what->g_pd), closest1,
-                                                      ob2, closest2 + 1 + sources);
-                            }
+                            sinks = 0;
+                            sources = 0;
+                            if(mode)
+                                for(sel = sortedsel;
+                                    ((closest1 + 1 + sinks) < noutlet1) && sel;
+                                    sel = sel->sel_next)
+                                {
+                                    sinks += tryconnect(x, ob1,
+                                        closest1 + 1 + sinks,
+                                        pd_checkobject(&sel->sel_what->g_pd),
+                                        closest2);
+                                }
+                            else
+                                for(sel = sortedsel;
+                                    ((closest2 + 1 + sources) < ninlet2) && sel;
+                                    sel = sel->sel_next)
+                                {
+                                    sources += tryconnect(x,
+                                        pd_checkobject(&sel->sel_what->g_pd),
+                                        closest1, ob2, closest2 + 1 + sources);
+                                }
 
                             /* free the sorted list of selections */
-                        for(sel=sortedsel; sel; )
-                        {
-                            t_selection*s = sel->sel_next;
-                            freebytes(sel, sizeof(*sel));
-                            sel = s;
+                            for(sel = sortedsel; sel;)
+                            {
+                                t_selection *s = sel->sel_next;
+                                freebytes(sel, sizeof(*sel));
+                                sel = s;
+                            }
                         }
-                    }
-                    break;
-                case 1: /* source(s) selected */
-                    for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-                    {
-                        t_object*selo = pd_checkobject(&sel->sel_what->g_pd);
-                        if (!selo || selo == ob1)
-                            continue;
-                        tryconnect(x, selo, closest1, ob2, closest2);
-                    }
-                    break;
-                case 2: /* sink(s) selected */
-                    for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-                    {
-                        t_object*selo = pd_checkobject(&sel->sel_what->g_pd);
-                        if (!selo || selo == ob2)
-                            continue;
-                        tryconnect(x, ob1, closest1, selo, closest2);
-                    }
-                    break;
-                default: break;
+                        break;
+                    case 1: /* source(s) selected */
+                        for(sel = x->gl_editor->e_selection; sel;
+                            sel = sel->sel_next)
+                        {
+                            t_object *selo =
+                                pd_checkobject(&sel->sel_what->g_pd);
+                            if(!selo || selo == ob1) continue;
+                            tryconnect(x, selo, closest1, ob2, closest2);
+                        }
+                        break;
+                    case 2: /* sink(s) selected */
+                        for(sel = x->gl_editor->e_selection; sel;
+                            sel = sel->sel_next)
+                        {
+                            t_object *selo =
+                                pd_checkobject(&sel->sel_what->g_pd);
+                            if(!selo || selo == ob2) continue;
+                            tryconnect(x, ob1, closest1, selo, closest2);
+                        }
+                        break;
+                    default:
+                        break;
                 }
                 canvas_undo_add(x, UNDO_SEQUENCE_END, "connect", 0);
             }
-            else canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
+            else
+                canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
             return;
         }
     }
@@ -2800,46 +2801,47 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 void canvas_selectinrect(t_canvas *x, int lox, int loy, int hix, int hiy)
 {
     t_gobj *y;
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
         int x1, y1, x2, y2;
         gobj_getrect(y, x, &x1, &y1, &x2, &y2);
-        if (hix >= x1 && lox <= x2 && hiy >= y1 && loy <= y2
-            && !glist_isselected(x, y))
-                glist_select(x, y);
+        if(hix >= x1 && lox <= x2 && hiy >= y1 && loy <= y2 &&
+            !glist_isselected(x, y))
+            glist_select(x, y);
     }
 }
 
 static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
 {
-    if (doit)
+    if(doit)
     {
         int lox, loy, hix, hiy;
-        if (x->gl_editor->e_xwas < xpos)
+        if(x->gl_editor->e_xwas < xpos)
             lox = x->gl_editor->e_xwas, hix = xpos;
-        else hix = x->gl_editor->e_xwas, lox = xpos;
-        if (x->gl_editor->e_ywas < ypos)
+        else
+            hix = x->gl_editor->e_xwas, lox = xpos;
+        if(x->gl_editor->e_ywas < ypos)
             loy = x->gl_editor->e_ywas, hiy = ypos;
-        else hiy = x->gl_editor->e_ywas, loy = ypos;
+        else
+            hiy = x->gl_editor->e_ywas, loy = ypos;
         canvas_selectinrect(x, lox, loy, hix, hiy);
         sys_vgui(".x%lx.c delete x\n", x);
         x->gl_editor->e_onmotion = MA_NONE;
     }
-    else sys_vgui(".x%lx.c coords x %d %d %d %d\n",
-                  x, x->gl_editor->e_xwas,
-                  x->gl_editor->e_ywas, xpos, ypos);
+    else
+        sys_vgui(".x%lx.c coords x %d %d %d %d\n", x, x->gl_editor->e_xwas,
+            x->gl_editor->e_ywas, xpos, ypos);
 }
 
-void canvas_mouseup(t_canvas *x,
-    t_floatarg fxpos, t_floatarg fypos, t_floatarg fwhich,
-    t_floatarg fmod)
+void canvas_mouseup(t_canvas *x, t_floatarg fxpos, t_floatarg fypos,
+    t_floatarg fwhich, t_floatarg fmod)
 {
     int xpos = fxpos, ypos = fypos, which = fwhich;
     int mod = fmod;
 #if 0
     post("mouseup %d %d %d %d", xpos, ypos, which, mod);
 #endif
-    if (!x->gl_editor)
+    if(!x->gl_editor)
     {
         bug("editor");
         return;
@@ -2849,80 +2851,79 @@ void canvas_mouseup(t_canvas *x,
     EDITOR->canvas_upx = xpos;
     EDITOR->canvas_upy = ypos;
 
-    if (x->gl_editor->e_onmotion == MA_CONNECT)
+    if(x->gl_editor->e_onmotion == MA_CONNECT)
         canvas_doconnect(x, xpos, ypos, mod, 1);
-    else if (x->gl_editor->e_onmotion == MA_REGION)
+    else if(x->gl_editor->e_onmotion == MA_REGION)
         canvas_doregion(x, xpos, ypos, 1);
-    else if ((x->gl_editor->e_onmotion == MA_MOVE ||
-              x->gl_editor->e_onmotion == MA_RESIZE))
+    else if((x->gl_editor->e_onmotion == MA_MOVE ||
+                x->gl_editor->e_onmotion == MA_RESIZE))
     {
-            /* if there's only one text item selected activate the text.
-            LATER consider under sme conditions not activating it, for instance
-            if it appears to have been desired only to move the object.  Maybe
-            shift-click could allow dragging without activating text?  A
-            different solution (only activating if the object wasn't moved
-            (commit f0df4e586) turned out to flout ctrlD+move+retype. */
-        if (x->gl_editor->e_selection &&
-            !(x->gl_editor->e_selection->sel_next))
+        /* if there's only one text item selected activate the text.
+        LATER consider under sme conditions not activating it, for instance
+        if it appears to have been desired only to move the object.  Maybe
+        shift-click could allow dragging without activating text?  A
+        different solution (only activating if the object wasn't moved
+        (commit f0df4e586) turned out to flout ctrlD+move+retype. */
+        if(x->gl_editor->e_selection && !(x->gl_editor->e_selection->sel_next))
         {
             t_gobj *g = x->gl_editor->e_selection->sel_what;
             t_glist *gl2;
-                /* first though, check we aren't an abstraction with a
-                   dirty sub-patch that would be discarded if we edit this. */
-            if (pd_class(&g->g_pd) == canvas_class &&
-                canvas_isabstraction((t_glist *)g) &&
-                (gl2 = glist_finddirty((t_glist *)g)))
+            /* first though, check we aren't an abstraction with a
+               dirty sub-patch that would be discarded if we edit this. */
+            if(pd_class(&g->g_pd) == canvas_class &&
+                canvas_isabstraction((t_glist *) g) &&
+                (gl2 = glist_finddirty((t_glist *) g)))
             {
                 vmess(&gl2->gl_pd, gensym("menu-open"), "");
                 x->gl_editor->e_onmotion = MA_NONE;
-                sys_vgui(
-                    "pdtk_check .x%lx [format [_ \"Discard changes to '%%s'?\"] %s] {.x%lx dirty 0;\n} no\n",
+                sys_vgui("pdtk_check .x%lx [format [_ \"Discard changes to "
+                         "'%%s'?\"] %s] {.x%lx dirty 0;\n} no\n",
                     canvas_getrootfor(gl2),
                     canvas_getrootfor(gl2)->gl_name->s_name, gl2);
                 return;
             }
-                /* OK, activate it */
+            /* OK, activate it */
             gobj_activate(x->gl_editor->e_selection->sel_what, x, 1);
         }
     }
-    else if (x->gl_editor->e_onmotion == MA_PASSOUT)
+    else if(x->gl_editor->e_onmotion == MA_PASSOUT)
     {
-        if (!x->gl_editor->e_motionfn)
-            bug("e_motionfn");
+        if(!x->gl_editor->e_motionfn) bug("e_motionfn");
         (*x->gl_editor->e_motionfn)(&x->gl_editor->e_grab->g_pd,
             xpos - x->gl_editor->e_xwas, ypos - x->gl_editor->e_ywas, 1);
     }
     x->gl_editor->e_onmotion = MA_NONE;
 }
 
-    /* displace the selection by (dx, dy) pixels */
+/* displace the selection by (dx, dy) pixels */
 static void canvas_displaceselection(t_canvas *x, int dx, int dy)
 {
     t_selection *y;
     int resortin = 0, resortout = 0;
-    if (!EDITOR->canvas_undo_already_set_move)
+    if(!EDITOR->canvas_undo_already_set_move)
     {
         canvas_undo_add(x, UNDO_MOTION, "motion", canvas_undo_set_move(x, 1));
         EDITOR->canvas_undo_already_set_move = 1;
     }
-    for (y = x->gl_editor->e_selection; y; y = y->sel_next)
+    for(y = x->gl_editor->e_selection; y; y = y->sel_next)
     {
         t_class *cl = pd_class(&y->sel_what->g_pd);
         gobj_displace(y->sel_what, x, dx, dy);
-        if (cl == vinlet_class) resortin = 1;
-        else if (cl == voutlet_class) resortout = 1;
+        if(cl == vinlet_class)
+            resortin = 1;
+        else if(cl == voutlet_class)
+            resortout = 1;
     }
-    if (resortin) canvas_resortinlets(x);
-    if (resortout) canvas_resortoutlets(x);
+    if(resortin) canvas_resortinlets(x);
+    if(resortout) canvas_resortoutlets(x);
     sys_vgui("pdtk_canvas_getscroll .x%lx.c\n", x);
-    if (x->gl_editor->e_selection)
-        canvas_dirty(x, 1);
+    if(x->gl_editor->e_selection) canvas_dirty(x, 1);
 }
 
-    /* this routine is called whenever a key is pressed or released.  "x"
-       may be zero if there's no current canvas.  The first argument is true or
-       false for down/up; the second one is either a symbolic key name (e.g.,
-       "Right" or an Ascii key number.  The third is the shift key. */
+/* this routine is called whenever a key is pressed or released.  "x"
+   may be zero if there's no current canvas.  The first argument is true or
+   false for down/up; the second one is either a symbolic key name (e.g.,
+   "Right" or an Ascii key number.  The third is the shift key. */
 void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
     int keynum, fflag;
@@ -2930,275 +2931,283 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
 
     int down, shift;
 
-    if (ac < 3)
-        return;
+    if(ac < 3) return;
 
     EDITOR->canvas_undo_already_set_move = 0;
-    down = (atom_getfloat(av) != 0);  /* nonzero if it's a key down */
-    shift = (atom_getfloat(av+2) != 0);  /* nonzero if shift-ed */
-    if (av[1].a_type == A_SYMBOL)
+    down = (atom_getfloat(av) != 0);      /* nonzero if it's a key down */
+    shift = (atom_getfloat(av + 2) != 0); /* nonzero if shift-ed */
+    if(av[1].a_type == A_SYMBOL)
         gotkeysym = av[1].a_w.w_symbol;
-    else if (av[1].a_type == A_FLOAT)
+    else if(av[1].a_type == A_FLOAT)
     {
         char buf[UTF8_MAXBYTES1];
-        switch((int)(av[1].a_w.w_float))
+        switch((int) (av[1].a_w.w_float))
         {
-        case 8:  gotkeysym = gensym("BackSpace"); break;
-        case 9:  gotkeysym = gensym("Tab"); break;
-        case 10: gotkeysym = gensym("Return"); break;
-        case 27: gotkeysym = gensym("Escape"); break;
-        case 32: gotkeysym = gensym("Space"); break;
-        case 127:gotkeysym = gensym("Delete"); break;
-        default:
-                /*-- moo: assume keynum is a Unicode codepoint; encode as UTF-8 --*/
-            u8_wc_toutf8_nul(buf, (UCS4)(av[1].a_w.w_float));
-            gotkeysym = gensym(buf);
+            case 8:
+                gotkeysym = gensym("BackSpace");
+                break;
+            case 9:
+                gotkeysym = gensym("Tab");
+                break;
+            case 10:
+                gotkeysym = gensym("Return");
+                break;
+            case 27:
+                gotkeysym = gensym("Escape");
+                break;
+            case 32:
+                gotkeysym = gensym("Space");
+                break;
+            case 127:
+                gotkeysym = gensym("Delete");
+                break;
+            default:
+                /*-- moo: assume keynum is a Unicode codepoint; encode as UTF-8
+                 * --*/
+                u8_wc_toutf8_nul(buf, (UCS4) (av[1].a_w.w_float));
+                gotkeysym = gensym(buf);
         }
     }
-    else gotkeysym = gensym("?");
+    else
+        gotkeysym = gensym("?");
     fflag = (av[0].a_type == A_FLOAT ? av[0].a_w.w_float : 0);
     keynum = (av[1].a_type == A_FLOAT ? av[1].a_w.w_float : 0);
-    if (keynum == '{' || keynum == '}')
+    if(keynum == '{' || keynum == '}')
     {
-        post("keycode %d: dropped", (int)keynum);
+        post("keycode %d: dropped", (int) keynum);
         return;
     }
 #if 0
     post("keynum %d, down %d", (int)keynum, down);
 #endif
-    if (keynum == '\r') keynum = '\n';
-    if (av[1].a_type == A_SYMBOL &&
+    if(keynum == '\r') keynum = '\n';
+    if(av[1].a_type == A_SYMBOL &&
         !strcmp(av[1].a_w.w_symbol->s_name, "Return"))
-            keynum = '\n';
-        /* alias Apple key numbers to symbols.  This is done unconditionally,
-           not just if we're on an Apple, just in case the GUI is remote. */
-    if (keynum == 30 || keynum == 63232)
+        keynum = '\n';
+    /* alias Apple key numbers to symbols.  This is done unconditionally,
+       not just if we're on an Apple, just in case the GUI is remote. */
+    if(keynum == 30 || keynum == 63232)
         keynum = 0, gotkeysym = gensym("Up");
-    else if (keynum == 31 || keynum == 63233)
+    else if(keynum == 31 || keynum == 63233)
         keynum = 0, gotkeysym = gensym("Down");
-    else if (keynum == 28 || keynum == 63234)
+    else if(keynum == 28 || keynum == 63234)
         keynum = 0, gotkeysym = gensym("Left");
-    else if (keynum == 29 || keynum == 63235)
+    else if(keynum == 29 || keynum == 63235)
         keynum = 0, gotkeysym = gensym("Right");
-    else if (keynum == 63273)
+    else if(keynum == 63273)
         keynum = 0, gotkeysym = gensym("Home");
-    else if (keynum == 63275)
+    else if(keynum == 63275)
         keynum = 0, gotkeysym = gensym("End");
-    else if (keynum == 63276)
+    else if(keynum == 63276)
         keynum = 0, gotkeysym = gensym("Prior");
-    else if (keynum == 63277)
+    else if(keynum == 63277)
         keynum = 0, gotkeysym = gensym("Next");
-    else if (keynum == 63236)
+    else if(keynum == 63236)
         keynum = 0, gotkeysym = gensym("F1");
-    else if (keynum == 63237)
+    else if(keynum == 63237)
         keynum = 0, gotkeysym = gensym("F2");
-    else if (keynum == 63238)
+    else if(keynum == 63238)
         keynum = 0, gotkeysym = gensym("F3");
-    else if (keynum == 63239)
+    else if(keynum == 63239)
         keynum = 0, gotkeysym = gensym("F4");
-    else if (keynum == 63240)
+    else if(keynum == 63240)
         keynum = 0, gotkeysym = gensym("F5");
-    else if (keynum == 63241)
+    else if(keynum == 63241)
         keynum = 0, gotkeysym = gensym("F6");
-    else if (keynum == 63242)
+    else if(keynum == 63242)
         keynum = 0, gotkeysym = gensym("F7");
-    else if (keynum == 63243)
+    else if(keynum == 63243)
         keynum = 0, gotkeysym = gensym("F8");
-    else if (keynum == 63244)
+    else if(keynum == 63244)
         keynum = 0, gotkeysym = gensym("F9");
-    else if (keynum == 63245)
+    else if(keynum == 63245)
         keynum = 0, gotkeysym = gensym("F10");
-    else if (keynum == 63246)
+    else if(keynum == 63246)
         keynum = 0, gotkeysym = gensym("F11");
-    else if (keynum == 63247)
+    else if(keynum == 63247)
         keynum = 0, gotkeysym = gensym("F12");
-    if (gensym("#key")->s_thing && down)
-        pd_float(gensym("#key")->s_thing, (t_float)keynum);
-    if (gensym("#keyup")->s_thing && !down)
-        pd_float(gensym("#keyup")->s_thing, (t_float)keynum);
-    if (gensym("#keyname")->s_thing)
+    if(gensym("#key")->s_thing && down)
+        pd_float(gensym("#key")->s_thing, (t_float) keynum);
+    if(gensym("#keyup")->s_thing && !down)
+        pd_float(gensym("#keyup")->s_thing, (t_float) keynum);
+    if(gensym("#keyname")->s_thing)
     {
         t_atom at[2];
         at[0] = av[0];
         SETFLOAT(at, down);
-        SETSYMBOL(at+1, gotkeysym);
+        SETSYMBOL(at + 1, gotkeysym);
         pd_list(gensym("#keyname")->s_thing, 0, 2, at);
     }
-    if (!x || !x->gl_editor)  /* if that 'invis'ed the window,  stop. */
+    if(!x || !x->gl_editor) /* if that 'invis'ed the window,  stop. */
         return;
-    if (x && down)
+    if(x && down)
     {
-            /* cancel any dragging action */
-        if (x->gl_editor->e_onmotion == MA_MOVE)
+        /* cancel any dragging action */
+        if(x->gl_editor->e_onmotion == MA_MOVE)
             x->gl_editor->e_onmotion = MA_NONE;
-            /* if an object has "grabbed" keys just send them on */
-        if (x->gl_editor->e_grab
-            && x->gl_editor->e_keyfn && keynum)
-                (* x->gl_editor->e_keyfn)
-                    (x->gl_editor->e_grab, gotkeysym, (t_float)keynum);
-            /* if a text editor is open send the key on, as long as
-               it is either "real" (has a key number) or else is an arrow key. */
-        else if (x->gl_editor->e_textedfor && (keynum
-            || !strcmp(gotkeysym->s_name, "Home")
-            || !strcmp(gotkeysym->s_name, "End")
-            || !strcmp(gotkeysym->s_name, "Up")
-            || !strcmp(gotkeysym->s_name, "Down")
-            || !strcmp(gotkeysym->s_name, "Left")
-            || !strcmp(gotkeysym->s_name, "Right")))
+        /* if an object has "grabbed" keys just send them on */
+        if(x->gl_editor->e_grab && x->gl_editor->e_keyfn && keynum)
+            (*x->gl_editor->e_keyfn)(
+                x->gl_editor->e_grab, gotkeysym, (t_float) keynum);
+        /* if a text editor is open send the key on, as long as
+           it is either "real" (has a key number) or else is an arrow key. */
+        else if(x->gl_editor->e_textedfor &&
+                (keynum || !strcmp(gotkeysym->s_name, "Home") ||
+                    !strcmp(gotkeysym->s_name, "End") ||
+                    !strcmp(gotkeysym->s_name, "Up") ||
+                    !strcmp(gotkeysym->s_name, "Down") ||
+                    !strcmp(gotkeysym->s_name, "Left") ||
+                    !strcmp(gotkeysym->s_name, "Right")))
         {
-                /* send the key to the box's editor */
-            if (!x->gl_editor->e_textdirty)
+            /* send the key to the box's editor */
+            if(!x->gl_editor->e_textdirty)
             {
                 canvas_setundo(x, canvas_undo_cut,
                     canvas_undo_set_cut(x, UCUT_TEXT), "typing");
             }
-            rtext_key(x->gl_editor->e_textedfor,
-                (int)keynum, gotkeysym);
-            if (x->gl_editor->e_textdirty)
-                canvas_dirty(x, 1);
+            rtext_key(x->gl_editor->e_textedfor, (int) keynum, gotkeysym);
+            if(x->gl_editor->e_textdirty) canvas_dirty(x, 1);
         }
-            /* check for backspace or clear */
-        else if (keynum == 8 || keynum == 127)
+        /* check for backspace or clear */
+        else if(keynum == 8 || keynum == 127)
         {
-            if (x->gl_editor->e_selection)
+            if(x->gl_editor->e_selection)
                 canvas_undo_add(x, UNDO_SEQUENCE_START, "clear", 0);
-            if (x->gl_editor->e_selectedline)
-                canvas_clearline(x);
-            if (x->gl_editor->e_selection)
+            if(x->gl_editor->e_selectedline) canvas_clearline(x);
+            if(x->gl_editor->e_selection)
             {
-                canvas_undo_add(x, UNDO_CUT, "clear",
-                    canvas_undo_set_cut(x, UCUT_CLEAR));
+                canvas_undo_add(
+                    x, UNDO_CUT, "clear", canvas_undo_set_cut(x, UCUT_CLEAR));
                 canvas_doclear(x);
                 canvas_undo_add(x, UNDO_SEQUENCE_END, "clear", 0);
             }
         }
-            /* check for arrow keys */
-        else if (!strcmp(gotkeysym->s_name, "Up"))
+        /* check for arrow keys */
+        else if(!strcmp(gotkeysym->s_name, "Up"))
             canvas_displaceselection(x, 0, shift ? -10 : -1);
-        else if (!strcmp(gotkeysym->s_name, "Down"))
+        else if(!strcmp(gotkeysym->s_name, "Down"))
             canvas_displaceselection(x, 0, shift ? 10 : 1);
-        else if (!strcmp(gotkeysym->s_name, "Left"))
+        else if(!strcmp(gotkeysym->s_name, "Left"))
             canvas_displaceselection(x, shift ? -10 : -1, 0);
-        else if (!strcmp(gotkeysym->s_name, "Right"))
+        else if(!strcmp(gotkeysym->s_name, "Right"))
             canvas_displaceselection(x, shift ? 10 : 1, 0);
-        else if ((MA_CONNECT == x->gl_editor->e_onmotion)
-            && (CURSOR_EDITMODE_CONNECT == EDITOR->canvas_cursorwas)
-                 && !strncmp(gotkeysym->s_name, "Shift", 5))
+        else if((MA_CONNECT == x->gl_editor->e_onmotion) &&
+                (CURSOR_EDITMODE_CONNECT == EDITOR->canvas_cursorwas) &&
+                !strncmp(gotkeysym->s_name, "Shift", 5))
         {
-                /* <Shift> while in connect-mode: create connection... */
-            canvas_doconnect(x, x->gl_editor->e_xnew, x->gl_editor->e_ynew, 1, 1);
-                /* ... and continue in connect-mode */
-            canvas_doclick(x, x->gl_editor->e_xwas, x->gl_editor->e_ywas, 0, 0, 1);
-
+            /* <Shift> while in connect-mode: create connection... */
+            canvas_doconnect(
+                x, x->gl_editor->e_xnew, x->gl_editor->e_ynew, 1, 1);
+            /* ... and continue in connect-mode */
+            canvas_doclick(
+                x, x->gl_editor->e_xwas, x->gl_editor->e_ywas, 0, 0, 1);
         }
     }
-        /* if control key goes up or down, and if we're in edit mode, change
-           cursor to indicate how the click action changes */
-    if (x && keynum == 0 && x->gl_edit &&
+    /* if control key goes up or down, and if we're in edit mode, change
+       cursor to indicate how the click action changes */
+    if(x && keynum == 0 && x->gl_edit &&
         !strncmp(gotkeysym->s_name, "Control", 7))
-            canvas_setcursor(x, down ?
-                CURSOR_RUNMODE_NOTHING :CURSOR_EDITMODE_NOTHING);
+        canvas_setcursor(
+            x, down ? CURSOR_RUNMODE_NOTHING : CURSOR_EDITMODE_NOTHING);
 }
 
 static void delay_move(t_canvas *x)
 {
-    int incx = (x->gl_editor->e_xnew - x->gl_editor->e_xwas)/x->gl_zoom,
-        incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas)/x->gl_zoom;
-    if (incx || incy)
-        canvas_displaceselection(x, incx, incy);
+    int incx = (x->gl_editor->e_xnew - x->gl_editor->e_xwas) / x->gl_zoom,
+        incy = (x->gl_editor->e_ynew - x->gl_editor->e_ywas) / x->gl_zoom;
+    if(incx || incy) canvas_displaceselection(x, incx, incy);
     x->gl_editor->e_xwas += incx * x->gl_zoom;
     x->gl_editor->e_ywas += incy * x->gl_zoom;
 }
 
-    /* defined in g_text.c: */
-extern void text_getfont(t_text *x, t_glist *thisglist,
-    int *fwidthp, int *fheightp, int *guifsize);
+/* defined in g_text.c: */
+extern void text_getfont(
+    t_text *x, t_glist *thisglist, int *fwidthp, int *fheightp, int *guifsize);
 
-void canvas_motion(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
-    t_floatarg fmod)
+void canvas_motion(
+    t_canvas *x, t_floatarg xpos, t_floatarg ypos, t_floatarg fmod)
 {
 #if 0
     post("motion %g %g %g", xpos, ypos, fmod);
 #endif
     int mod = fmod;
-    if (!x->gl_editor)
+    if(!x->gl_editor)
     {
         bug("editor");
         return;
     }
     glist_setlastxy(x, xpos, ypos);
-    if (x->gl_editor->e_onmotion == MA_MOVE)
+    if(x->gl_editor->e_onmotion == MA_MOVE)
     {
-        if (!x->gl_editor->e_clock)
-            x->gl_editor->e_clock = clock_new(x, (t_method)delay_move);
+        if(!x->gl_editor->e_clock)
+            x->gl_editor->e_clock = clock_new(x, (t_method) delay_move);
         clock_unset(x->gl_editor->e_clock);
         clock_delay(x->gl_editor->e_clock, 5);
         x->gl_editor->e_xnew = xpos;
         x->gl_editor->e_ynew = ypos;
     }
-    else if (x->gl_editor->e_onmotion == MA_REGION)
+    else if(x->gl_editor->e_onmotion == MA_REGION)
         canvas_doregion(x, xpos, ypos, 0);
-    else if (x->gl_editor->e_onmotion == MA_CONNECT)
+    else if(x->gl_editor->e_onmotion == MA_CONNECT)
     {
         canvas_doconnect(x, xpos, ypos, mod, 0);
         x->gl_editor->e_xnew = xpos;
         x->gl_editor->e_ynew = ypos;
     }
-    else if (x->gl_editor->e_onmotion == MA_PASSOUT)
+    else if(x->gl_editor->e_onmotion == MA_PASSOUT)
     {
-        if (!x->gl_editor->e_motionfn)
-            bug("e_motionfn");
+        if(!x->gl_editor->e_motionfn) bug("e_motionfn");
         (*x->gl_editor->e_motionfn)(&x->gl_editor->e_grab->g_pd,
             xpos - x->gl_editor->e_xwas, ypos - x->gl_editor->e_ywas, 0);
         x->gl_editor->e_xwas = xpos;
         x->gl_editor->e_ywas = ypos;
     }
-    else if (x->gl_editor->e_onmotion == MA_DRAGTEXT)
+    else if(x->gl_editor->e_onmotion == MA_DRAGTEXT)
     {
         t_rtext *rt = x->gl_editor->e_textedfor;
-        if (rt)
+        if(rt)
             rtext_mouse(rt, xpos - x->gl_editor->e_xwas,
                 ypos - x->gl_editor->e_ywas, RTEXT_DRAG);
     }
-    else if (x->gl_editor->e_onmotion == MA_RESIZE)
+    else if(x->gl_editor->e_onmotion == MA_RESIZE)
     {
-        int x11=0, y11=0, x12=0, y12=0;
+        int x11 = 0, y11 = 0, x12 = 0, y12 = 0;
         t_gobj *y1;
-        if ((y1 = canvas_findhitbox(x,
-            x->gl_editor->e_xwas, x->gl_editor->e_ywas,
-                &x11, &y11, &x12, &y12)))
+        if((y1 = canvas_findhitbox(x, x->gl_editor->e_xwas,
+                x->gl_editor->e_ywas, &x11, &y11, &x12, &y12)))
         {
             int wantwidth = xpos - x11;
             t_object *ob = pd_checkobject(&y1->g_pd);
-            if (ob && ((ob->te_pd->c_wb == &text_widgetbehavior) ||
-                ob->te_type == T_ATOM ||
-                    (pd_checkglist(&ob->te_pd) &&
-                     !((t_canvas *)ob)->gl_isgraph)))
+            if(ob && ((ob->te_pd->c_wb == &text_widgetbehavior) ||
+                         ob->te_type == T_ATOM ||
+                         (pd_checkglist(&ob->te_pd) &&
+                             !((t_canvas *) ob)->gl_isgraph)))
             {
                 int fwidth, fheight, guifsize;
                 text_getfont(ob, x, &fwidth, &fheight, &guifsize);
                 wantwidth = wantwidth / fwidth;
-                if (wantwidth < 1)
-                    wantwidth = 1;
+                if(wantwidth < 1) wantwidth = 1;
                 ob->te_width = wantwidth;
                 gobj_vis(y1, x, 0);
                 canvas_fixlinesfor(x, ob);
                 gobj_vis(y1, x, 1);
             }
-            else if (ob && ob->ob_pd == canvas_class)
+            else if(ob && ob->ob_pd == canvas_class)
             {
                 gobj_vis(y1, x, 0);
-                ((t_canvas *)ob)->gl_pixwidth += xpos - x->gl_editor->e_xnew;
-                ((t_canvas *)ob)->gl_pixheight += ypos - x->gl_editor->e_ynew;
+                ((t_canvas *) ob)->gl_pixwidth += xpos - x->gl_editor->e_xnew;
+                ((t_canvas *) ob)->gl_pixheight += ypos - x->gl_editor->e_ynew;
                 x->gl_editor->e_xnew = xpos;
                 x->gl_editor->e_ynew = ypos;
                 canvas_fixlinesfor(x, ob);
                 gobj_vis(y1, x, 1);
             }
-            else post("not resizable");
+            else
+                post("not resizable");
         }
     }
-    else canvas_doclick(x, xpos, ypos, 0, mod, 0);
+    else
+        canvas_doclick(x, xpos, ypos, 0, mod, 0);
 
     x->gl_editor->e_lastmoved = 1;
 }
@@ -3206,9 +3215,9 @@ void canvas_motion(t_canvas *x, t_floatarg xpos, t_floatarg ypos,
 void canvas_startmotion(t_canvas *x)
 {
     int xval, yval;
-    if (!x->gl_editor) return;
+    if(!x->gl_editor) return;
     glist_getnextxy(x, &xval, &yval);
-    if (xval == 0 && yval == 0) return;
+    if(xval == 0 && yval == 0) return;
     x->gl_editor->e_onmotion = MA_MOVE;
     x->gl_editor->e_xwas = xval;
     x->gl_editor->e_ywas = yval;
@@ -3219,101 +3228,106 @@ extern int sys_perf;
 
 void canvas_print(t_canvas *x, t_symbol *s)
 {
-    if (*s->s_name) sys_vgui(".x%lx.c postscript -file %s\n", x, s->s_name);
-    else sys_vgui(".x%lx.c postscript -file x.ps\n", x);
+    if(*s->s_name)
+        sys_vgui(".x%lx.c postscript -file %s\n", x, s->s_name);
+    else
+        sys_vgui(".x%lx.c postscript -file x.ps\n", x);
 }
 
-    /* find the innermost dirty sub-glist, if any, of this one (including itself) */
+/* find the innermost dirty sub-glist, if any, of this one (including itself) */
 static t_glist *glist_finddirty(t_glist *x)
 {
     t_gobj *g;
     t_glist *g2;
-    for (g = x->gl_list; g; g = g->g_next)
-        if (pd_class(&g->g_pd) == canvas_class &&
-            (g2 = glist_finddirty((t_glist *)g)))
-                return (g2);
+    for(g = x->gl_list; g; g = g->g_next)
+        if(pd_class(&g->g_pd) == canvas_class &&
+            (g2 = glist_finddirty((t_glist *) g)))
+            return (g2);
 
-    if (x->gl_env && x->gl_dirty)
+    if(x->gl_env && x->gl_dirty)
         return (x);
     else
         return (0);
 }
 
-    /* quit, after calling glist_finddirty() on all toplevels and verifying
-       the user really wants to discard changes  */
+/* quit, after calling glist_finddirty() on all toplevels and verifying
+   the user really wants to discard changes  */
 void glob_verifyquit(void *dummy, t_floatarg f)
 {
     t_glist *g, *g2;
-        /* find all root canvases */
-    for (g = pd_getcanvaslist(); g; g = g->gl_next)
-        if ((g2 = glist_finddirty(g)))
+    /* find all root canvases */
+    for(g = pd_getcanvaslist(); g; g = g->gl_next)
+        if((g2 = glist_finddirty(g)))
         {
             canvas_vis(g2, 1);
             sys_vgui("pdtk_canvas_menuclose .x%lx {.x%lx menuclose 3;\n}\n",
-                     canvas_getrootfor(g2), g2);
+                canvas_getrootfor(g2), g2);
             return;
         }
-    if (f == 0 && sys_perf)
+    if(f == 0 && sys_perf)
         sys_vgui("pdtk_check .pdwindow {really quit?} {pd quit} yes\n");
-    else glob_quit(0);
+    else
+        glob_quit(0);
 }
 
-    /* close a window (or possibly quit Pd), checking for dirty flags.
-       The "force" parameter is interpreted as follows:
-       0 - request from GUI to close, verifying whether clean or dirty
-       1 - request from GUI to close, no verification
-       2 - verified - mark this one clean, then continue as in 1
-       3 - verified - mark this one clean, then verify-and-quit
-    */
+/* close a window (or possibly quit Pd), checking for dirty flags.
+   The "force" parameter is interpreted as follows:
+   0 - request from GUI to close, verifying whether clean or dirty
+   1 - request from GUI to close, no verification
+   2 - verified - mark this one clean, then continue as in 1
+   3 - verified - mark this one clean, then verify-and-quit
+*/
 void canvas_menuclose(t_canvas *x, t_floatarg fforce)
 {
     int force = fforce;
     t_glist *g;
-    if (x->gl_owner && (force == 0 || force == 1))
-        canvas_vis(x, 0);   /* if subpatch, just invis it */
-    else if (force == 0)
+    if(x->gl_owner && (force == 0 || force == 1))
+        canvas_vis(x, 0); /* if subpatch, just invis it */
+    else if(force == 0)
     {
         g = glist_finddirty(x);
-        if (g)
+        if(g)
         {
             vmess(&g->gl_pd, gensym("menu-open"), "");
             sys_vgui("pdtk_canvas_menuclose .x%lx {.x%lx menuclose 2;\n}\n",
-                     canvas_getrootfor(g), g);
+                canvas_getrootfor(g), g);
             return;
         }
-        else if (sys_perf)
+        else if(sys_perf)
         {
-            sys_vgui(
-                "pdtk_check .x%lx {Close this window?} {.x%lx menuclose 1;\n} yes\n",
+            sys_vgui("pdtk_check .x%lx {Close this window?} {.x%lx menuclose "
+                     "1;\n} yes\n",
                 canvas_getrootfor(x), x);
         }
-        else pd_free(&x->gl_pd);
+        else
+            pd_free(&x->gl_pd);
     }
-    else if (force == 1)
+    else if(force == 1)
         pd_free(&x->gl_pd);
-    else if (force == 2)
+    else if(force == 2)
     {
         canvas_dirty(x, 0);
-        while (x->gl_owner && !x->gl_isclone)
+        while(x->gl_owner && !x->gl_isclone)
             x = x->gl_owner;
         g = glist_finddirty(x);
-        if (g)
+        if(g)
         {
             vmess(&g->gl_pd, gensym("menu-open"), "");
             sys_vgui("pdtk_canvas_menuclose .x%lx {.x%lx menuclose 2;\n}\n",
-                     canvas_getrootfor(g), g);
+                canvas_getrootfor(g), g);
             return;
         }
-        else pd_free(&x->gl_pd);
+        else
+            pd_free(&x->gl_pd);
     }
-    else if (force == 3)
+    else if(force == 3)
     {
         canvas_dirty(x, 0);
         glob_verifyquit(0, 1);
     }
 }
 
-    /* put up a dialog which may call canvas_font back to do the work */
+/* put up a dialog which may call canvas_font back to do the work */
 static void canvas_menufont(t_canvas *x)
 {
     char buf[80];
@@ -3328,30 +3342,31 @@ typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
 /* LATER, if canvas is flipped, re-scroll to preserve bottom left corner */
 static void canvas_zoom(t_canvas *x, t_floatarg zoom)
 {
-    if (zoom != x->gl_zoom && (zoom == 1 || zoom == 2))
+    if(zoom != x->gl_zoom && (zoom == 1 || zoom == 2))
     {
         t_gobj *g;
         t_object *obj;
-        for (g = x->gl_list; g; g = g->g_next)
-            if ((obj = pd_checkobject(&g->g_pd)))
-        {
+        for(g = x->gl_list; g; g = g->g_next)
+            if((obj = pd_checkobject(&g->g_pd)))
+            {
                 /* pass zoom message on to all objects, except canvases
                    that aren't GOP */
-            t_gotfn zoommethod;
-            if ((zoommethod = zgetfn(&obj->te_pd, gensym("zoom"))) &&
-                (!(pd_class(&obj->te_pd) == canvas_class) ||
-                 (((t_glist *)obj)->gl_isgraph)))
-                    (*(t_zoomfn)zoommethod)(&obj->te_pd, zoom);
-        }
+                t_gotfn zoommethod;
+                if((zoommethod = zgetfn(&obj->te_pd, gensym("zoom"))) &&
+                    (!(pd_class(&obj->te_pd) == canvas_class) ||
+                        (((t_glist *) obj)->gl_isgraph)))
+                    (*(t_zoomfn) zoommethod)(&obj->te_pd, zoom);
+            }
         x->gl_zoom = zoom;
-        if (x->gl_havewindow)
+        if(x->gl_havewindow)
         {
-            if (!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
+            if(!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
             {
                 /* if it's flipped so that y grows upward,
                 fix so that zero is bottom edge as in canvas_dosetbounds() */
                 t_float diff = x->gl_y1 - x->gl_y2;
-                x->gl_y1 = (x->gl_screeny2 - x->gl_screeny1) * diff/x->gl_zoom;
+                x->gl_y1 =
+                    (x->gl_screeny2 - x->gl_screeny1) * diff / x->gl_zoom;
                 x->gl_y2 = x->gl_y1 - diff;
             }
             canvas_redraw(x);
@@ -3359,39 +3374,38 @@ static void canvas_zoom(t_canvas *x, t_floatarg zoom)
     }
 }
 
-    /* function to support searching */
+/* function to support searching */
 static int atoms_match(int inargc, t_atom *inargv, int searchargc,
     t_atom *searchargv, int wholeword)
 {
     int indexin, nmatched;
-    for (indexin = 0; indexin <= inargc - searchargc; indexin++)
+    for(indexin = 0; indexin <= inargc - searchargc; indexin++)
     {
-        for (nmatched = 0; nmatched < searchargc; nmatched++)
+        for(nmatched = 0; nmatched < searchargc; nmatched++)
         {
             t_atom *a1 = &inargv[indexin + nmatched],
-                *a2 = &searchargv[nmatched];
-            if (a1->a_type == A_SEMI || a1->a_type == A_COMMA)
+                   *a2 = &searchargv[nmatched];
+            if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
             {
-                if (a2->a_type != a1->a_type)
+                if(a2->a_type != a1->a_type) goto nomatch;
+            }
+            else if(a1->a_type == A_FLOAT || a1->a_type == A_DOLLAR)
+            {
+                if(a2->a_type != a1->a_type ||
+                    a1->a_w.w_float != a2->a_w.w_float)
                     goto nomatch;
             }
-            else if (a1->a_type == A_FLOAT || a1->a_type == A_DOLLAR)
+            else if(a1->a_type == A_SYMBOL || a1->a_type == A_DOLLSYM)
             {
-                if (a2->a_type != a1->a_type ||
-                    a1->a_w.w_float != a2->a_w.w_float)
-                        goto nomatch;
-            }
-            else if (a1->a_type == A_SYMBOL || a1->a_type == A_DOLLSYM)
-            {
-                if ((a2->a_type != A_SYMBOL && a2->a_type != A_DOLLSYM)
-                    || (wholeword && a1->a_w.w_symbol != a2->a_w.w_symbol)
-                    || (!wholeword &&  !strstr(a1->a_w.w_symbol->s_name,
-                                        a2->a_w.w_symbol->s_name)))
-                        goto nomatch;
+                if((a2->a_type != A_SYMBOL && a2->a_type != A_DOLLSYM) ||
+                    (wholeword && a1->a_w.w_symbol != a2->a_w.w_symbol) ||
+                    (!wholeword && !strstr(a1->a_w.w_symbol->s_name,
+                                       a2->a_w.w_symbol->s_name)))
+                    goto nomatch;
             }
         }
         return (1);
-    nomatch: ;
+    nomatch:;
     }
     return (0);
 }
@@ -3399,23 +3413,23 @@ static int atoms_match(int inargc, t_atom *inargv, int searchargc,
 extern int clone_get_n(t_gobj *x);
 extern t_glist *clone_get_instance(t_gobj *x, int n);
 
-    /* find an atom or string of atoms */
+/* find an atom or string of atoms */
 static int canvas_dofind(t_canvas *x, int *myindexp)
 {
     t_gobj *y;
     int findargc = binbuf_getnatom(EDITOR->canvas_findbuf), didit = 0;
     t_atom *findargv = binbuf_getvec(EDITOR->canvas_findbuf);
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
         t_object *ob = 0;
-        if ((ob = pd_checkobject(&y->g_pd)))
+        if((ob = pd_checkobject(&y->g_pd)))
         {
             int n;
-            if (atoms_match(binbuf_getnatom(ob->ob_binbuf),
-                binbuf_getvec(ob->ob_binbuf), findargc, findargv,
-                    EDITOR->canvas_find_wholeword))
+            if(atoms_match(binbuf_getnatom(ob->ob_binbuf),
+                   binbuf_getvec(ob->ob_binbuf), findargc, findargv,
+                   EDITOR->canvas_find_wholeword))
             {
-                if (*myindexp == EDITOR->canvas_find_index)
+                if(*myindexp == EDITOR->canvas_find_index)
                 {
                     glist_noselect(x);
                     vmess(&x->gl_pd, gensym("menu-open"), "");
@@ -3425,20 +3439,23 @@ static int canvas_dofind(t_canvas *x, int *myindexp)
                 }
                 (*myindexp)++;
             }
-            if ((n = clone_get_n((t_gobj *)ob)) != 0)
+            if((n = clone_get_n((t_gobj *) ob)) != 0)
             {
                 int i = 0;
-                    /* should we search in every clone instance, or only the first one? */
+                /* should we search in every clone instance, or only the first
+                 * one? */
                 /*for(i = 0; i < n; i++)
                 {*/
-                    didit |= canvas_dofind((t_canvas *)clone_get_instance((t_gobj *)ob, i), myindexp);
+                didit |= canvas_dofind(
+                    (t_canvas *) clone_get_instance((t_gobj *) ob, i),
+                    myindexp);
                 /*}*/
             }
         }
     }
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class)
-            didit |= canvas_dofind((t_canvas *)y, myindexp);
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class)
+            didit |= canvas_dofind((t_canvas *) y, myindexp);
     return (didit);
 }
 
@@ -3446,16 +3463,14 @@ static void canvas_find(t_canvas *x, t_symbol *s, t_floatarg wholeword)
 {
     int myindex = 0, found;
     t_symbol *decodedsym = sys_decodedialog(s);
-    if (!EDITOR->canvas_findbuf)
-        EDITOR->canvas_findbuf = binbuf_new();
-    binbuf_text(EDITOR->canvas_findbuf, decodedsym->s_name,
-        strlen(decodedsym->s_name));
+    if(!EDITOR->canvas_findbuf) EDITOR->canvas_findbuf = binbuf_new();
+    binbuf_text(
+        EDITOR->canvas_findbuf, decodedsym->s_name, strlen(decodedsym->s_name));
     EDITOR->canvas_find_index = 0;
     EDITOR->canvas_find_wholeword = wholeword;
     canvas_whichfind = x;
     found = canvas_dofind(x, &myindex);
-    if (found)
-        EDITOR->canvas_find_index = 1;
+    if(found) EDITOR->canvas_find_index = 1;
     sys_vgui("pdtk_showfindresult .x%lx %d %d %d\n", x, found,
         EDITOR->canvas_find_index, myindex);
 }
@@ -3463,19 +3478,16 @@ static void canvas_find(t_canvas *x, t_symbol *s, t_floatarg wholeword)
 static void canvas_find_again(t_canvas *x)
 {
     int myindex = 0, found;
-    if (!EDITOR->canvas_findbuf || !canvas_whichfind)
-        return;
+    if(!EDITOR->canvas_findbuf || !canvas_whichfind) return;
     found = canvas_dofind(canvas_whichfind, &myindex);
     sys_vgui("pdtk_showfindresult .x%lx %d %d %d\n", x, found,
         ++EDITOR->canvas_find_index, myindex);
-    if (!found)
-        EDITOR->canvas_find_index = 0;
+    if(!found) EDITOR->canvas_find_index = 0;
 }
 
 static void canvas_find_parent(t_canvas *x)
 {
-    if (x->gl_owner)
-        canvas_vis(x->gl_owner, 1);
+    if(x->gl_owner) canvas_vis(x->gl_owner, 1);
 }
 
 extern t_pd *message_get_responder(t_gobj *x);
@@ -3485,28 +3497,28 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
     t_gobj *g;
     int n;
 
-    for (g = gl->gl_list; g; g = g->g_next)
+    for(g = gl->gl_list; g; g = g->g_next)
     {
-        if (((const void *)g == error_object) || (message_get_responder(g) == error_object))
+        if(((const void *) g == error_object) ||
+            (message_get_responder(g) == error_object))
         {
-                /* got it... now show it. */
+            /* got it... now show it. */
             glist_noselect(gl);
-            canvas_vis((t_canvas *)gl, 1);
-            canvas_editmode((t_canvas *)gl, 1.);
+            canvas_vis((t_canvas *) gl, 1);
+            canvas_editmode((t_canvas *) gl, 1.);
             glist_select(gl, g);
             return (1);
         }
-        else if (g->g_pd == canvas_class)
+        else if(g->g_pd == canvas_class)
         {
-            if (glist_dofinderror((t_canvas *)g, error_object))
-                return (1);
+            if(glist_dofinderror((t_canvas *) g, error_object)) return (1);
         }
-        else if ((n = clone_get_n(g)) != 0)
+        else if((n = clone_get_n(g)) != 0)
         {
             int i;
             for(i = 0; i < n; i++)
             {
-                if (glist_dofinderror(clone_get_instance(g, i), error_object))
+                if(glist_dofinderror(clone_get_instance(g, i), error_object))
                     return 1;
             }
         }
@@ -3517,11 +3529,10 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
 void canvas_finderror(const void *error_object)
 {
     t_canvas *x;
-        /* find all root canvases */
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    /* find all root canvases */
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
     {
-        if (glist_dofinderror(x, error_object))
-            return;
+        if(glist_dofinderror(x, error_object)) return;
     }
     pd_error(0, "... sorry, I couldn't find the source of that error.");
 }
@@ -3531,14 +3542,14 @@ void canvas_stowconnections(t_canvas *x)
     t_gobj *selhead = 0, *seltail = 0, *nonhead = 0, *nontail = 0, *y, *y2;
     t_linetraverser t;
     t_outconnect *oc;
-    if (!x->gl_editor) return;
-        /* split list to "selected" and "unselected" parts */
-    for (y = x->gl_list; y; y = y2)
+    if(!x->gl_editor) return;
+    /* split list to "selected" and "unselected" parts */
+    for(y = x->gl_list; y; y = y2)
     {
         y2 = y->g_next;
-        if (glist_isselected(x, y))
+        if(glist_isselected(x, y))
         {
-            if (seltail)
+            if(seltail)
             {
                 seltail->g_next = y;
                 seltail = y;
@@ -3552,7 +3563,7 @@ void canvas_stowconnections(t_canvas *x)
         }
         else
         {
-            if (nontail)
+            if(nontail)
             {
                 nontail->g_next = y;
                 nontail = y;
@@ -3565,22 +3576,23 @@ void canvas_stowconnections(t_canvas *x)
             }
         }
     }
-        /* move the selected part to the end */
-    if (!nonhead) x->gl_list = selhead;
-    else x->gl_list = nonhead, nontail->g_next = selhead;
+    /* move the selected part to the end */
+    if(!nonhead)
+        x->gl_list = selhead;
+    else
+        x->gl_list = nonhead, nontail->g_next = selhead;
 
-        /* add connections to binbuf */
+    /* add connections to binbuf */
     binbuf_clear(x->gl_editor->e_connectbuf);
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int s1 = glist_isselected(x, &t.tr_ob->ob_g);
         int s2 = glist_isselected(x, &t.tr_ob2->ob_g);
-        if (s1 != s2)
-            binbuf_addv(x->gl_editor->e_connectbuf, "ssiiii;",
-                gensym("#X"), gensym("connect"),
-                glist_getindex(x, &t.tr_ob->ob_g), t.tr_outno,
-                glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
+        if(s1 != s2)
+            binbuf_addv(x->gl_editor->e_connectbuf, "ssiiii;", gensym("#X"),
+                gensym("connect"), glist_getindex(x, &t.tr_ob->ob_g),
+                t.tr_outno, glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
     }
 }
 
@@ -3598,16 +3610,15 @@ static t_binbuf *canvas_docopy(t_canvas *x)
     t_linetraverser t;
     t_outconnect *oc;
     t_binbuf *b = binbuf_new();
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if (glist_isselected(x, y))
-            gobj_save(y, b);
+        if(glist_isselected(x, y)) gobj_save(y, b);
     }
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
-        if (glist_isselected(x, &t.tr_ob->ob_g)
-            && glist_isselected(x, &t.tr_ob2->ob_g))
+        if(glist_isselected(x, &t.tr_ob->ob_g) &&
+            glist_isselected(x, &t.tr_ob2->ob_g))
         {
             binbuf_addv(b, "ssiiii;", gensym("#X"), gensym("connect"),
                 glist_selectionindex(x, &t.tr_ob->ob_g, 1), t.tr_outno,
@@ -3619,14 +3630,13 @@ static t_binbuf *canvas_docopy(t_canvas *x)
 
 static void canvas_copy(t_canvas *x)
 {
-    if (!x->gl_editor)
-        return;
-    if (x->gl_editor->e_selection)
+    if(!x->gl_editor) return;
+    if(x->gl_editor->e_selection)
     {
         binbuf_free(EDITOR->copy_binbuf);
         EDITOR->copy_binbuf = canvas_docopy(x);
     }
-    if (x->gl_editor->e_textedfor)
+    if(x->gl_editor->e_textedfor)
     {
         char *buf;
         int bufsize;
@@ -3638,12 +3648,10 @@ static void canvas_copy(t_canvas *x)
 
 static void canvas_clearline(t_canvas *x)
 {
-    if (x->gl_editor->e_selectedline)
+    if(x->gl_editor->e_selectedline)
     {
-        canvas_disconnect_with_undo(x,
-            x->gl_editor->e_selectline_index1,
-            x->gl_editor->e_selectline_outno,
-            x->gl_editor->e_selectline_index2,
+        canvas_disconnect_with_undo(x, x->gl_editor->e_selectline_index1,
+            x->gl_editor->e_selectline_outno, x->gl_editor->e_selectline_index2,
             x->gl_editor->e_selectline_inno);
         x->gl_editor->e_selectedline = 0;
         canvas_dirty(x, 1);
@@ -3656,42 +3664,40 @@ static void canvas_doclear(t_canvas *x)
     int dspstate;
 
     dspstate = canvas_suspend_dsp();
-    if (x->gl_editor->e_selectedline)
+    if(x->gl_editor->e_selectedline)
     {
-        canvas_disconnect_with_undo(x,
-            x->gl_editor->e_selectline_index1,
-            x->gl_editor->e_selectline_outno,
-            x->gl_editor->e_selectline_index2,
+        canvas_disconnect_with_undo(x, x->gl_editor->e_selectline_index1,
+            x->gl_editor->e_selectline_outno, x->gl_editor->e_selectline_index2,
             x->gl_editor->e_selectline_inno);
-        x->gl_editor->e_selectedline=0;
+        x->gl_editor->e_selectedline = 0;
     }
-        /* if text is selected, deselecting it might remake the
-           object. So we deselect it and hunt for a "new" object on
-           the glist to reselect. */
-    if (x->gl_editor->e_textedfor)
+    /* if text is selected, deselecting it might remake the
+       object. So we deselect it and hunt for a "new" object on
+       the glist to reselect. */
+    if(x->gl_editor->e_textedfor)
     {
         t_gobj *selwas = x->gl_editor->e_selection->sel_what;
         pd_this->pd_newest = 0;
         glist_noselect(x);
-        if (pd_this->pd_newest)
+        if(pd_this->pd_newest)
         {
-            for (y = x->gl_list; y; y = y->g_next)
-                if (&y->g_pd == pd_this->pd_newest) glist_select(x, y);
+            for(y = x->gl_list; y; y = y->g_next)
+                if(&y->g_pd == pd_this->pd_newest) glist_select(x, y);
         }
     }
-    while (1)   /* this is pretty weird...  should rewrite it */
+    while(1) /* this is pretty weird...  should rewrite it */
     {
-        for (y = x->gl_list; y; y = y2)
+        for(y = x->gl_list; y; y = y2)
         {
             y2 = y->g_next;
-            if (glist_isselected(x, y))
+            if(glist_isselected(x, y))
             {
                 glist_delete(x, y);
                 goto next;
             }
         }
         goto restore;
-    next: ;
+    next:;
     }
 restore:
     canvas_resume_dsp(dspstate);
@@ -3700,21 +3706,21 @@ restore:
 
 static void canvas_cut(t_canvas *x)
 {
-    if (!x->gl_editor)  /* ignore if invisible */
+    if(!x->gl_editor) /* ignore if invisible */
         return;
-    if (x->gl_editor->e_selectedline)   /* delete line */
+    if(x->gl_editor->e_selectedline) /* delete line */
         canvas_clearline(x);
-    else if (x->gl_editor->e_textedfor) /* delete selected text in a box */
+    else if(x->gl_editor->e_textedfor) /* delete selected text in a box */
     {
         char *buf;
         int bufsize;
         rtext_getseltext(x->gl_editor->e_textedfor, &buf, &bufsize);
-        if (!bufsize && x->gl_editor->e_selection &&
+        if(!bufsize && x->gl_editor->e_selection &&
             !x->gl_editor->e_selection->sel_next)
         {
-                /* if the text is already empty, delete the box.  We
-                   first clear 'textedfor' so that canvas_doclear later will
-                   think the whole box was selected, not the text */
+            /* if the text is already empty, delete the box.  We
+               first clear 'textedfor' so that canvas_doclear later will
+               think the whole box was selected, not the text */
             x->gl_editor->e_textedfor = 0;
             goto deleteobj;
         }
@@ -3722,9 +3728,9 @@ static void canvas_cut(t_canvas *x)
         rtext_key(x->gl_editor->e_textedfor, 127, &s_);
         canvas_dirty(x, 1);
     }
-    else if (x->gl_editor->e_selection)
+    else if(x->gl_editor->e_selection)
     {
-    deleteobj:      /* delete one or more objects */
+    deleteobj: /* delete one or more objects */
         canvas_undo_add(x, UNDO_CUT, "cut", canvas_undo_set_cut(x, UCUT_CUT));
         canvas_copy(x);
         canvas_doclear(x);
@@ -3734,112 +3740,107 @@ static void canvas_cut(t_canvas *x)
 
 static void glist_donewloadbangs(t_glist *x)
 {
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
         t_selection *sel;
-        for (sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-            if (pd_class(&sel->sel_what->g_pd) == canvas_class)
-                canvas_loadbang((t_canvas *)(&sel->sel_what->g_pd));
-            else if (zgetfn(&sel->sel_what->g_pd, gensym("loadbang")))
+        for(sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
+            if(pd_class(&sel->sel_what->g_pd) == canvas_class)
+                canvas_loadbang((t_canvas *) (&sel->sel_what->g_pd));
+            else if(zgetfn(&sel->sel_what->g_pd, gensym("loadbang")))
                 vmess(&sel->sel_what->g_pd, gensym("loadbang"), "f", LB_LOAD);
     }
 }
 
 static int binbuf_nextmess(int argc, const t_atom *argv)
 {
-    int i=0;
+    int i = 0;
     while(argc--)
     {
         argv++;
         i++;
-        if (A_SEMI == argv->a_type) {
-            return i+1;
+        if(A_SEMI == argv->a_type)
+        {
+            return i + 1;
         }
     }
     return i;
 }
-static int binbuf_getpos(t_binbuf*b, int *x0, int *y0, t_symbol**type)
+
+static int binbuf_getpos(t_binbuf *b, int *x0, int *y0, t_symbol **type)
 {
-        /*
-         * checks how many objects the binbuf contains and where they are located
-         * for simplicity, we stop after the first object...
-         * "objects" are any patchable things
-         * returns: 0: no objects/...
-         *          1: single object in binbuf
-         *          2: more than one object in binbuf
-         * (x0,y0) are the coordinates of the first object
-         * (type) is the type of the first object ("obj", "msg",...)
-         */
-    t_atom*argv = binbuf_getvec(b);
+    /*
+     * checks how many objects the binbuf contains and where they are located
+     * for simplicity, we stop after the first object...
+     * "objects" are any patchable things
+     * returns: 0: no objects/...
+     *          1: single object in binbuf
+     *          2: more than one object in binbuf
+     * (x0,y0) are the coordinates of the first object
+     * (type) is the type of the first object ("obj", "msg",...)
+     */
+    t_atom *argv = binbuf_getvec(b);
     int argc = binbuf_getnatom(b);
     const int argc0 = argc;
     int count = 0;
-    t_symbol*s;
-        /* get the position of the first object in the argv binbuf */
-    if(argc > 2
-       && atom_getsymbol(argv+0) == &s__N
-       && atom_getsymbol(argv+1) == gensym("canvas"))
+    t_symbol *s;
+    /* get the position of the first object in the argv binbuf */
+    if(argc > 2 && atom_getsymbol(argv + 0) == &s__N &&
+        atom_getsymbol(argv + 1) == gensym("canvas"))
     {
         int ac = argc;
-        t_atom*ap = argv;
+        t_atom *ap = argv;
         int stack = 0;
-        do {
+        do
+        {
             int off = binbuf_nextmess(argc, argv);
-            if(!off)
-                break;
+            if(!off) break;
             ac = argc;
             ap = argv;
-            argc-=off;
-            argv+=off;
-            count+=off;
+            argc -= off;
+            argv += off;
+            count += off;
             if(off >= 2)
             {
-                if (atom_getsymbol(ap+1) == gensym("restore")
-                    && atom_getsymbol(ap) == &s__X)
-                    {
-                        stack--;
-                    }
-                if (atom_getsymbol(ap+1) == gensym("canvas")
-                    && atom_getsymbol(ap) == &s__N)
-                    {
-                        stack++;
-                    }
+                if(atom_getsymbol(ap + 1) == gensym("restore") &&
+                    atom_getsymbol(ap) == &s__X)
+                {
+                    stack--;
+                }
+                if(atom_getsymbol(ap + 1) == gensym("canvas") &&
+                    atom_getsymbol(ap) == &s__N)
+                {
+                    stack++;
+                }
             }
-            if(argc<0)
-                return 0;
-        } while (stack>0);
+            if(argc < 0) return 0;
+        } while(stack > 0);
         argc = ac;
         argv = ap;
     }
-    if(argc < 4 || atom_getsymbol(argv) != &s__X)
-        return 0;
-        /* #X obj|msg|text|floatatom|symbolatom <x> <y> ...
-         * TODO: subpatches #N canvas + #X restore <x> <y>
-         */
-    s = atom_getsymbol(argv+1);
-    if(gensym("restore") == s
-       || gensym("obj") == s
-       || gensym("msg") == s
-       || gensym("text") == s
-       || gensym("floatatom") == s
-       || gensym("listbox") == s
-       || gensym("symbolatom") == s)
+    if(argc < 4 || atom_getsymbol(argv) != &s__X) return 0;
+    /* #X obj|msg|text|floatatom|symbolatom <x> <y> ...
+     * TODO: subpatches #N canvas + #X restore <x> <y>
+     */
+    s = atom_getsymbol(argv + 1);
+    if(gensym("restore") == s || gensym("obj") == s || gensym("msg") == s ||
+        gensym("text") == s || gensym("floatatom") == s ||
+        gensym("listbox") == s || gensym("symbolatom") == s)
     {
-        if(x0)*x0=atom_getfloat(argv+2);
-        if(y0)*y0=atom_getfloat(argv+3);
-        if(type)*type=s;
-    } else
+        if(x0) *x0 = atom_getfloat(argv + 2);
+        if(y0) *y0 = atom_getfloat(argv + 3);
+        if(type) *type = s;
+    }
+    else
         return 0;
 
-        /* no wind the binbuf to the next message */
+    /* no wind the binbuf to the next message */
     while(argc--)
     {
         count++;
-        if (A_SEMI == argv->a_type)
-            break;
+        if(A_SEMI == argv->a_type) break;
         argv++;
     }
-    return 1+(argc0 > count);
+    return 1 + (argc0 > count);
 }
 
 static void canvas_dopaste(t_canvas *x, t_binbuf *b)
@@ -3847,78 +3848,75 @@ static void canvas_dopaste(t_canvas *x, t_binbuf *b)
     t_gobj *g2;
     int dspstate = canvas_suspend_dsp(), nbox, count;
     t_symbol *asym = gensym("#A");
-        /* save and clear bindings to symbols #A, #N, #X; restore when done */
+    /* save and clear bindings to symbols #A, #N, #X; restore when done */
     t_pd *boundx = s__X.s_thing, *bounda = asym->s_thing,
-        *boundn = s__N.s_thing;
+         *boundn = s__N.s_thing;
     asym->s_thing = 0;
     s__X.s_thing = &x->gl_pd;
     s__N.s_thing = &pd_canvasmaker;
 
     canvas_editmode(x, 1.);
     glist_noselect(x);
-    for (g2 = x->gl_list, nbox = 0; g2; g2 = g2->g_next) nbox++;
+    for(g2 = x->gl_list, nbox = 0; g2; g2 = g2->g_next)
+        nbox++;
 
     EDITOR->paste_onset = nbox;
     EDITOR->paste_canvas = x;
 
     binbuf_eval(b, 0, 0, 0);
-    for (g2 = x->gl_list, count = 0; g2; g2 = g2->g_next, count++)
-        if (count >= nbox)
-            glist_select(x, g2);
+    for(g2 = x->gl_list, count = 0; g2; g2 = g2->g_next, count++)
+        if(count >= nbox) glist_select(x, g2);
     EDITOR->paste_canvas = 0;
     canvas_resume_dsp(dspstate);
     canvas_dirty(x, 1);
-    if (x->gl_mapped)
-        sys_vgui("pdtk_canvas_getscroll .x%lx.c\n", x);
-    if (!sys_noloadbang)
-        glist_donewloadbangs(x);
+    if(x->gl_mapped) sys_vgui("pdtk_canvas_getscroll .x%lx.c\n", x);
+    if(!sys_noloadbang) glist_donewloadbangs(x);
     asym->s_thing = bounda;
     s__X.s_thing = boundx;
     s__N.s_thing = boundn;
 }
 
-static t_symbol*get_object_type(t_object *obj)
+static t_symbol *get_object_type(t_object *obj)
 {
-    t_symbol *s=0;
-    t_binbuf *bb=0;
-    if(!obj)
-        return 0;
-    switch(obj->te_type) {
-    case T_OBJECT:
-        return gensym("obj");
-    case T_MESSAGE:
-        return gensym("msg");
-    case T_TEXT:
-        return gensym("text");
-    default:
+    t_symbol *s = 0;
+    t_binbuf *bb = 0;
+    if(!obj) return 0;
+    switch(obj->te_type)
+    {
+        case T_OBJECT:
+            return gensym("obj");
+        case T_MESSAGE:
+            return gensym("msg");
+        case T_TEXT:
+            return gensym("text");
+        default:
             /* detecting the type of a gatom by using it's save function */
-        bb=binbuf_new();
-        gobj_save(&obj->te_g, bb);
-        binbuf_getpos(bb, 0, 0, &s);
-        binbuf_free(bb);
-        return s;
+            bb = binbuf_new();
+            gobj_save(&obj->te_g, bb);
+            binbuf_getpos(bb, 0, 0, &s);
+            binbuf_free(bb);
+            return s;
     }
     return 0;
 }
 
 static void canvas_paste_replace(t_canvas *x)
 {
-    int x0=0, y0=0;
+    int x0 = 0, y0 = 0;
     t_symbol *typ0 = 0;
-    if (!x->gl_editor)
-        return;
-    if(x->gl_editor->e_selection && 1==binbuf_getpos(EDITOR->copy_binbuf, &x0, &y0, &typ0))
+    if(!x->gl_editor) return;
+    if(x->gl_editor->e_selection &&
+        1 == binbuf_getpos(EDITOR->copy_binbuf, &x0, &y0, &typ0))
     {
         t_canvas *canvas = glist_getcanvas(x);
         t_selection *mysel = 0, *y;
         t_symbol *seltype = 0;
 
-            /* check whether all the selected objects have the same type */
-        for (y = x->gl_editor->e_selection; y; y = y->sel_next)
+        /* check whether all the selected objects have the same type */
+        for(y = x->gl_editor->e_selection; y; y = y->sel_next)
         {
-            t_symbol *s=get_object_type(pd_checkobject(&y->sel_what->g_pd));
-            if (!s)
-                continue;
+            t_symbol *s = get_object_type(pd_checkobject(&y->sel_what->g_pd));
+            if(!s) continue;
             if(seltype && seltype != s)
             {
                 seltype = 0;
@@ -3927,20 +3925,19 @@ static void canvas_paste_replace(t_canvas *x)
             seltype = s;
         }
 
-            /* we will do a lot of reslecting; so copy the selection */
-        for (y = x->gl_editor->e_selection; y; y = y->sel_next)
+        /* we will do a lot of reslecting; so copy the selection */
+        for(y = x->gl_editor->e_selection; y; y = y->sel_next)
         {
             t_selection *sel = 0;
-            t_object *obj=pd_checkobject(&y->sel_what->g_pd);
-            if(!obj)
-               continue;
-                    /* if the selection mixes obj, msg,... we only want to
-                     * replace the same type;
-                     * if the selection is homogeneous (seltype==NULL), we also allow typechanges
-                     */
-            if (!seltype && get_object_type(obj) != typ0)
-                continue;
-            sel = (t_selection *)getbytes(sizeof(*sel));
+            t_object *obj = pd_checkobject(&y->sel_what->g_pd);
+            if(!obj) continue;
+            /* if the selection mixes obj, msg,... we only want to
+             * replace the same type;
+             * if the selection is homogeneous (seltype==NULL), we also allow
+             * typechanges
+             */
+            if(!seltype && get_object_type(obj) != typ0) continue;
+            sel = (t_selection *) getbytes(sizeof(*sel));
             sel->sel_what = y->sel_what;
             sel->sel_next = mysel;
             mysel = sel;
@@ -3948,61 +3945,59 @@ static void canvas_paste_replace(t_canvas *x)
 
         canvas_undo_add(x, UNDO_SEQUENCE_START, "paste/replace", 0);
 
-        for (y = mysel; y; y = y->sel_next)
+        for(y = mysel; y; y = y->sel_next)
         {
-            t_object *o = (t_object *)(&y->sel_what->g_pd);
+            t_object *o = (t_object *) (&y->sel_what->g_pd);
             int dx = o->te_xpix - x0;
             int dy = o->te_ypix - y0;
             glist_noselect(x);
             EDITOR->canvas_undo_already_set_move = 0;
-                /* save connections and move object to the end */
-                /* note: the undo sequence selects the object as a side-effect */
+            /* save connections and move object to the end */
+            /* note: the undo sequence selects the object as a side-effect */
             canvas_undo_add(x, UNDO_ARRANGE, "arrange",
                 canvas_undo_set_arrange(x, y->sel_what, 1));
             canvas_stowconnections(canvas);
-                /* recreate object */
-                /* remove the old object */
-            canvas_undo_add(x, UNDO_CUT, "clear",
-                canvas_undo_set_cut(x, UCUT_CLEAR));
+            /* recreate object */
+            /* remove the old object */
+            canvas_undo_add(
+                x, UNDO_CUT, "clear", canvas_undo_set_cut(x, UCUT_CLEAR));
             canvas_doclear(x);
 
-                /* create the new object (and loadbang if needed) */
+            /* create the new object (and loadbang if needed) */
             canvas_applybinbuf(x, EDITOR->copy_binbuf);
 
             glist_noselect(x);
             glist_select(x, glist_nth(x, glist_getindex(x, 0) - 1));
-                /* displace object (includes UNDO) */
+            /* displace object (includes UNDO) */
             canvas_displaceselection(x, dx, dy);
-                /* restore connections */
+            /* restore connections */
             canvas_restoreconnections(canvas);
 
-            canvas_undo_add(x, UNDO_CREATE, "create",
-                (void *)canvas_undo_set_create(x));
+            canvas_undo_add(
+                x, UNDO_CREATE, "create", (void *) canvas_undo_set_create(x));
 
-            if (pd_this->pd_newest && pd_class(pd_this->pd_newest) == canvas_class)
-                canvas_loadbang((t_canvas *)pd_this->pd_newest);
+            if(pd_this->pd_newest &&
+                pd_class(pd_this->pd_newest) == canvas_class)
+                canvas_loadbang((t_canvas *) pd_this->pd_newest);
         }
         canvas_undo_add(x, UNDO_SEQUENCE_END, "paste/replace", 0);
 
-            /* free the selection copy */
-        for (y = mysel; y; )
+        /* free the selection copy */
+        for(y = mysel; y;)
         {
-            t_selection*next = y->sel_next;
+            t_selection *next = y->sel_next;
             freebytes(y, sizeof(*y));
             y = next;
         }
-
     }
 }
 
-
 static void canvas_paste(t_canvas *x)
 {
-    if (!x->gl_editor)
-        return;
-    if (x->gl_editor->e_textedfor)
+    if(!x->gl_editor) return;
+    if(x->gl_editor->e_textedfor)
     {
-            /* simulate keystrokes as if the copy buffer were typed in. */
+        /* simulate keystrokes as if the copy buffer were typed in. */
         sys_vgui("pdtk_pastetext .x%lx\n", x);
     }
     else
@@ -4011,16 +4006,19 @@ static void canvas_paste(t_canvas *x)
         int x0 = 0, y0 = 0;
         int foundplace = 0;
         binbuf_getpos(EDITOR->copy_binbuf, &x0, &y0, 0);
-        do {
-                /* iterate over all existing objects
-                 * to see whether one occupies the space we want.
-                 * if so, move along
-                 */
+        do
+        {
+            /* iterate over all existing objects
+             * to see whether one occupies the space we want.
+             * if so, move along
+             */
             t_gobj *y;
             foundplace = 1;
-            for (y = x->gl_list; y; y = y->g_next) {
-                t_text *txt = (t_text *)y;
-                if((x0 + offset) == txt->te_xpix && (y0 + offset) == txt->te_ypix)
+            for(y = x->gl_list; y; y = y->g_next)
+            {
+                t_text *txt = (t_text *) y;
+                if((x0 + offset) == txt->te_xpix &&
+                    (y0 + offset) == txt->te_ypix)
                 {
                     foundplace = 0;
                     offset += PASTE_OFFSET;
@@ -4029,51 +4027,47 @@ static void canvas_paste(t_canvas *x)
             }
         } while(!foundplace);
         canvas_undo_add(x, UNDO_PASTE, "paste",
-            (void *)canvas_undo_set_paste(x, 0, 0, offset));
+            (void *) canvas_undo_set_paste(x, 0, 0, offset));
         canvas_dopaste(x, EDITOR->copy_binbuf);
         if(offset)
         {
             t_selection *y;
-            for (y = x->gl_editor->e_selection; y; y = y->sel_next)
-                gobj_displace(y->sel_what, x,
-                    offset, offset);
+            for(y = x->gl_editor->e_selection; y; y = y->sel_next)
+                gobj_displace(y->sel_what, x, offset, offset);
         }
     }
 }
 
 static void canvas_duplicate(t_canvas *x)
 {
-    if (!x->gl_editor)
-        return;
+    if(!x->gl_editor) return;
 
-    if (x->gl_editor->e_selection && x->gl_editor->e_selectedline)
+    if(x->gl_editor->e_selection && x->gl_editor->e_selectedline)
         glist_deselectline(x);
 
-        /* if a connection is selected, we extend it to the right (if possible) */
-    if (x->gl_editor->e_selectedline)
+    /* if a connection is selected, we extend it to the right (if possible) */
+    if(x->gl_editor->e_selectedline)
     {
         int outindex = x->gl_editor->e_selectline_index1;
-        int inindex  = x->gl_editor->e_selectline_index2;
+        int inindex = x->gl_editor->e_selectline_index2;
         int outno = x->gl_editor->e_selectline_outno + 1;
-        int inno  = x->gl_editor->e_selectline_inno + 1;
+        int inno = x->gl_editor->e_selectline_inno + 1;
         t_gobj *outgobj = 0, *ingobj = 0;
         t_object *outobj = 0, *inobj = 0;
         int whoout = outindex;
         int whoin = inindex;
 
-        for (outgobj = x->gl_list; whoout; outgobj = outgobj->g_next, whoout--)
-            if (!outgobj->g_next) return;
-        for (ingobj = x->gl_list; whoin; ingobj = ingobj->g_next, whoin--)
-            if (!ingobj->g_next) return;
-        outobj = (t_object*)outgobj;
-        inobj = (t_object*)ingobj;
+        for(outgobj = x->gl_list; whoout; outgobj = outgobj->g_next, whoout--)
+            if(!outgobj->g_next) return;
+        for(ingobj = x->gl_list; whoin; ingobj = ingobj->g_next, whoin--)
+            if(!ingobj->g_next) return;
+        outobj = (t_object *) outgobj;
+        inobj = (t_object *) ingobj;
 
         while(!canconnect(x, outobj, outno, inobj, inno))
         {
-            if (!outobj || obj_noutlets(outobj) <= outno)
-                return;
-            if (!inobj  || obj_ninlets (inobj ) <= inno )
-                return;
+            if(!outobj || obj_noutlets(outobj) <= outno) return;
+            if(!inobj || obj_ninlets(inobj) <= inno) return;
             outno++;
             inno++;
         }
@@ -4085,23 +4079,20 @@ static void canvas_duplicate(t_canvas *x)
         }
         return;
     }
-    if (x->gl_editor->e_onmotion == MA_NONE && x->gl_editor->e_selection)
+    if(x->gl_editor->e_onmotion == MA_NONE && x->gl_editor->e_selection)
     {
         t_selection *y;
-        t_binbuf*b = 0;
-        if(EDITOR->copy_binbuf)
-            b = binbuf_duplicate(EDITOR->copy_binbuf);
+        t_binbuf *b = 0;
+        if(EDITOR->copy_binbuf) b = binbuf_duplicate(EDITOR->copy_binbuf);
         canvas_copy(x);
         canvas_undo_add(x, UNDO_PASTE, "duplicate",
-            (void *)canvas_undo_set_paste(x, 0, 1, PASTE_OFFSET));
+            (void *) canvas_undo_set_paste(x, 0, 1, PASTE_OFFSET));
         canvas_dopaste(x, EDITOR->copy_binbuf);
-        for (y = x->gl_editor->e_selection; y; y = y->sel_next)
-            gobj_displace(y->sel_what, x,
-                PASTE_OFFSET, PASTE_OFFSET);
+        for(y = x->gl_editor->e_selection; y; y = y->sel_next)
+            gobj_displace(y->sel_what, x, PASTE_OFFSET, PASTE_OFFSET);
         if(b)
         {
-            if(EDITOR->copy_binbuf)
-                binbuf_free(EDITOR->copy_binbuf);
+            if(EDITOR->copy_binbuf) binbuf_free(EDITOR->copy_binbuf);
             EDITOR->copy_binbuf = b;
         }
         canvas_dirty(x, 1);
@@ -4111,177 +4102,180 @@ static void canvas_duplicate(t_canvas *x)
 static void canvas_selectall(t_canvas *x)
 {
     t_gobj *y;
-    if (!x->gl_editor)
-        return;
-    if (!x->gl_edit)
-        canvas_editmode(x, 1);
-        /* if everyone is already selected deselect everyone */
-    if (!glist_selectionindex(x, 0, 0))
+    if(!x->gl_editor) return;
+    if(!x->gl_edit) canvas_editmode(x, 1);
+    /* if everyone is already selected deselect everyone */
+    if(!glist_selectionindex(x, 0, 0))
         glist_noselect(x);
-    else for (y = x->gl_list; y; y = y->g_next)
-         {
-             if (!glist_isselected(x, y))
-                 glist_select(x, y);
-         }
+    else
+        for(y = x->gl_list; y; y = y->g_next)
+        {
+            if(!glist_isselected(x, y)) glist_select(x, y);
+        }
 }
 
 static void canvas_deselectall(t_canvas *x)
 {
-    if(x)glist_noselect(x);
+    if(x) glist_noselect(x);
 }
-static void canvas_cycleselect(t_canvas*x, t_float foffset)
-{
-        /* select (currentselection+offset)%objectcount */
-    int offset = (int)foffset;
-    if (!x->gl_editor)
-        return;
 
-    if (x->gl_editor->e_onmotion == MA_CONNECT)
+static void canvas_cycleselect(t_canvas *x, t_float foffset)
+{
+    /* select (currentselection+offset)%objectcount */
+    int offset = (int) foffset;
+    if(!x->gl_editor) return;
+
+    if(x->gl_editor->e_onmotion == MA_CONNECT)
     {
-            /* during connection, cycle through inlets/outlets */
-        int xwas = x->gl_editor->e_xwas,
-            ywas = x->gl_editor->e_ywas;
+        /* during connection, cycle through inlets/outlets */
+        int xwas = x->gl_editor->e_xwas, ywas = x->gl_editor->e_ywas;
         int xpos = EDITOR->canvas_last_glist_x,
             ypos = EDITOR->canvas_last_glist_y;
         t_object *src, *snk;
-        t_gobj*gobj;
-        int srcX1=0, srcY1=0, srcX2=0, srcY2=0;
-        int snkX1=0, snkY1=0, snkX2=0, snkY2=0;
+        t_gobj *gobj;
+        int srcX1 = 0, srcY1 = 0, srcX2 = 0, srcY2 = 0;
+        int snkX1 = 0, snkY1 = 0, snkX2 = 0, snkY2 = 0;
         if(EDITOR->canvas_last_glist != x)
-                /* we don't know the current mouse coordinates in this canvas, so return... */
+            /* we don't know the current mouse coordinates in this canvas, so
+             * return... */
             return;
         gobj = canvas_findhitbox(x, xwas, ywas, &srcX1, &srcY1, &srcX2, &srcY2);
-        src = gobj?pd_checkobject(&gobj->g_pd):0;
+        src = gobj ? pd_checkobject(&gobj->g_pd) : 0;
         gobj = canvas_findhitbox(x, xpos, ypos, &snkX1, &snkY1, &snkX2, &snkY2);
-        snk = gobj?pd_checkobject(&gobj->g_pd):0;
+        snk = gobj ? pd_checkobject(&gobj->g_pd) : 0;
 
         if(!src) /* this should never happen */
             return;
 
-            /* are we hovering over an object?
-             * - if so, cycle through inlets
-             * - else, cycle through outlets
-             */
-        if(snk && snk != src) {
-                /* cycle inlets */
+        /* are we hovering over an object?
+         * - if so, cycle through inlets
+         * - else, cycle through outlets
+         */
+        if(snk && snk != src)
+        {
+            /* cycle inlets */
             int width = snkX2 - snkX1, hotspot, closest;
             int nios = obj_ninlets(snk);
-            if (nios <= 1) /* no use cycling */
+            if(nios <= 1) /* no use cycling */
                 return;
-            closest = ((xpos-snkX1) * (nios-1) + width/2)/width;
+            closest = ((xpos - snkX1) * (nios - 1) + width / 2) / width;
             closest = ((closest + offset) % nios + nios) % nios;
-            hotspot = snkX1 + (width - IOWIDTH) * closest / (nios-1.0) + IOWIDTH*0.5;
+            hotspot = snkX1 + (width - IOWIDTH) * closest / (nios - 1.0) +
+                      IOWIDTH * 0.5;
             sys_vgui("::pdtk_canvas::setmouse .x%lx.c %d %d\n",
                 glist_getcanvas(x), hotspot, ypos);
-        } else {
-                /* cycle outlets */
+        }
+        else
+        {
+            /* cycle outlets */
             int width = srcX2 - srcX1, hotspot, closest;
             int nios = obj_noutlets(src);
-            if (nios <= 1) /* no use cycling */
+            if(nios <= 1) /* no use cycling */
                 return;
-            closest = ((xwas-srcX1) * (nios-1) + width/2)/width;
+            closest = ((xwas - srcX1) * (nios - 1) + width / 2) / width;
             closest = ((closest + offset) % nios + nios) % nios;
-            hotspot = srcX1 + (width - IOWIDTH) * closest / (nios-1.0) + IOWIDTH*0.5;
+            hotspot = srcX1 + (width - IOWIDTH) * closest / (nios - 1.0) +
+                      IOWIDTH * 0.5;
             x->gl_editor->e_xwas = hotspot;
             canvas_doconnect(x, xpos, ypos, 0, 0);
         }
         return;
     }
-    if (x->gl_editor->e_selection)
+    if(x->gl_editor->e_selection)
     {
-            /* cycle the selection to the next object */
+        /* cycle the selection to the next object */
         int newindex;
         int objectcount = glist_getindex(x, 0);
-            /* only cycle selection if the current selection contains exactly 1 item */
-        t_gobj* y = x->gl_editor->e_selection->sel_next ? 0 : x->gl_editor->e_selection->sel_what;
-        if (!y || !objectcount)
-            return;
+        /* only cycle selection if the current selection contains exactly 1 item
+         */
+        t_gobj *y = x->gl_editor->e_selection->sel_next
+                        ? 0
+                        : x->gl_editor->e_selection->sel_what;
+        if(!y || !objectcount) return;
         newindex = (glist_getindex(x, y) + offset) % objectcount;
-        if (newindex < 0) newindex += objectcount;
+        if(newindex < 0) newindex += objectcount;
         glist_deselect(x, y);
         glist_select(x, glist_nth(x, newindex));
         return;
     }
-    if (x->gl_editor->e_selectedline)
+    if(x->gl_editor->e_selectedline)
     {
-            /* if (only) a line is selected, cycle to next line */
+        /* if (only) a line is selected, cycle to next line */
         int connectioncount = 0;
         int foundit = 0;
         t_linetraverser t;
         t_outconnect *oc = 0;
 
         linetraverser_start(&t, x);
-        while (offset && (oc = linetraverser_next(&t)))
+        while(offset && (oc = linetraverser_next(&t)))
         {
             connectioncount++;
-            if(!foundit) {
+            if(!foundit)
+            {
                 int srcno = glist_getindex(x, &t.tr_ob->ob_g);
                 int sinkno = glist_getindex(x, &t.tr_ob2->ob_g);
-                if((srcno      == x->gl_editor->e_selectline_index1) &&
+                if((srcno == x->gl_editor->e_selectline_index1) &&
                     (t.tr_outno == x->gl_editor->e_selectline_outno) &&
-                    (sinkno     == x->gl_editor->e_selectline_index2) &&
-                    (t.tr_inno  == x->gl_editor->e_selectline_inno)) {
+                    (sinkno == x->gl_editor->e_selectline_index2) &&
+                    (t.tr_inno == x->gl_editor->e_selectline_inno))
+                {
                     foundit = connectioncount;
                 }
-            } else
+            }
+            else
                 offset--;
         }
 
-        if (!connectioncount)
-            offset = 0;
+        if(!connectioncount) offset = 0;
 
-            /* if the offset is non-0, wrap it... */
-        if (offset)
+        /* if the offset is non-0, wrap it... */
+        if(offset)
         {
-            offset = (((offset - 1) % connectioncount) + connectioncount)
-                % connectioncount;
+            offset = (((offset - 1) % connectioncount) + connectioncount) %
+                     connectioncount;
             /* ... and start from the beginning */
             linetraverser_start(&t, x);
-            while ((oc = linetraverser_next(&t)))
+            while((oc = linetraverser_next(&t)))
             {
-                if(!offset)break;
+                if(!offset) break;
                 offset--;
             }
         }
-        if (oc)
-            glist_selectline(x, oc,
-                glist_getindex(x, &t.tr_ob->ob_g), t.tr_outno,
-                glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
+        if(oc)
+            glist_selectline(x, oc, glist_getindex(x, &t.tr_ob->ob_g),
+                t.tr_outno, glist_getindex(x, &t.tr_ob2->ob_g), t.tr_inno);
         return;
     }
 }
 
-
 static void canvas_reselect(t_canvas *x)
 {
     t_gobj *g, *gwas;
-        /* if someone is text editing, and if only one object is
-           selected,  deselect everyone and reselect.  */
-    if (x->gl_editor->e_textedfor)
+    /* if someone is text editing, and if only one object is
+       selected,  deselect everyone and reselect.  */
+    if(x->gl_editor->e_textedfor)
     {
-            /* only do this if exactly one item is selected. */
-        if ((gwas = x->gl_editor->e_selection->sel_what) &&
+        /* only do this if exactly one item is selected. */
+        if((gwas = x->gl_editor->e_selection->sel_what) &&
             !x->gl_editor->e_selection->sel_next)
         {
             int nobjwas = glist_getindex(x, 0),
                 indx = canvas_getindex(x, x->gl_editor->e_selection->sel_what);
             glist_noselect(x);
-            for (g = x->gl_list; g; g = g->g_next)
-                if (g == gwas)
+            for(g = x->gl_list; g; g = g->g_next)
+                if(g == gwas)
                 {
                     glist_select(x, g);
                     return;
                 }
-                /* "gwas" must have disappeared; just search to the last
-                   object and select it */
-            for (g = x->gl_list; g; g = g->g_next)
-                if (!g->g_next)
-                    glist_select(x, g);
+            /* "gwas" must have disappeared; just search to the last
+               object and select it */
+            for(g = x->gl_list; g; g = g->g_next)
+                if(!g->g_next) glist_select(x, g);
         }
     }
-    else if (x->gl_editor->e_selection &&
-             !x->gl_editor->e_selection->sel_next)
-            /* otherwise activate first item in selection */
+    else if(x->gl_editor->e_selection && !x->gl_editor->e_selection->sel_next)
+        /* otherwise activate first item in selection */
         gobj_activate(x->gl_editor->e_selection->sel_what, x, 1);
 }
 
@@ -4295,48 +4289,52 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     t_object *objsrc, *objsink;
     t_outconnect *oc;
     int nin = whoin, nout = whoout;
-    if (EDITOR->paste_canvas == x) whoout += EDITOR->paste_onset,
-        whoin += EDITOR->paste_onset;
-    for (src = x->gl_list; whoout; src = src->g_next, whoout--)
-        if (!src->g_next) {
+    if(EDITOR->paste_canvas == x)
+        whoout += EDITOR->paste_onset, whoin += EDITOR->paste_onset;
+    for(src = x->gl_list; whoout; src = src->g_next, whoout--)
+        if(!src->g_next)
+        {
             src = NULL;
             logpost(sink, 3, "cannot connect non-existing object");
             goto bad; /* bug fix thanks to Hannes */
         }
-    for (sink = x->gl_list; whoin; sink = sink->g_next, whoin--)
-        if (!sink->g_next) {
+    for(sink = x->gl_list; whoin; sink = sink->g_next, whoin--)
+        if(!sink->g_next)
+        {
             sink = NULL;
             logpost(src, 3, "cannot connect to non-existing object");
             goto bad;
         }
 
-        /* check they're both patchable objects */
-    if (!(objsrc = pd_checkobject(&src->g_pd)) ||
-        !(objsink = pd_checkobject(&sink->g_pd))) {
-        logpost(src?src:sink, 3, "cannot connect unpatchable object");
+    /* check they're both patchable objects */
+    if(!(objsrc = pd_checkobject(&src->g_pd)) ||
+        !(objsink = pd_checkobject(&sink->g_pd)))
+    {
+        logpost(src ? src : sink, 3, "cannot connect unpatchable object");
         goto bad;
     }
 
-        /* check if objects are already connected */
-    if (canvas_isconnected(x, objsrc, outno, objsink, inno)) {
+    /* check if objects are already connected */
+    if(canvas_isconnected(x, objsrc, outno, objsink, inno))
+    {
         logpost(src, 3, "io pair already connected");
         goto bad;
     }
 
-        /* if object creation failed, make dummy inlets or outlets
-           as needed */
-    if (pd_class(&src->g_pd) == text_class && objsrc->te_type == T_OBJECT)
-        while (outno >= obj_noutlets(objsrc))
+    /* if object creation failed, make dummy inlets or outlets
+       as needed */
+    if(pd_class(&src->g_pd) == text_class && objsrc->te_type == T_OBJECT)
+        while(outno >= obj_noutlets(objsrc))
             outlet_new(objsrc, 0);
-    if (pd_class(&sink->g_pd) == text_class && objsink->te_type == T_OBJECT)
-        while (inno >= obj_ninlets(objsink))
+    if(pd_class(&sink->g_pd) == text_class && objsink->te_type == T_OBJECT)
+        while(inno >= obj_ninlets(objsink))
             inlet_new(objsink, &objsink->ob_pd, 0, 0);
 
-    if (!(oc = obj_connect(objsrc, outno, objsink, inno))) goto bad;
-    if (glist_isvisible(x) && x->gl_havewindow)
+    if(!(oc = obj_connect(objsrc, outno, objsink, inno))) goto bad;
+    if(glist_isvisible(x) && x->gl_havewindow)
     {
-        sys_vgui(
-            ".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx cord]\n",
+        sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list l%lx "
+                 "cord]\n",
             glist_getcanvas(x), 0, 0, 0, 0,
             (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom, oc);
         canvas_fixlinesfor(x, objsrc);
@@ -4344,107 +4342,107 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     return;
 
 bad:
-    post("%s %d %d %d %d (%s->%s) connection failed",
-        x->gl_name->s_name, nout, outno, nin, inno,
-            (src? class_getname(pd_class(&src->g_pd)) : "???"),
-            (sink? class_getname(pd_class(&sink->g_pd)) : "???"));
+    post("%s %d %d %d %d (%s->%s) connection failed", x->gl_name->s_name, nout,
+        outno, nin, inno, (src ? class_getname(pd_class(&src->g_pd)) : "???"),
+        (sink ? class_getname(pd_class(&sink->g_pd)) : "???"));
 }
 
 #define XTOLERANCE 18
 #define YTOLERANCE 17
 #define NHIST 35
 
-    /* LATER might have to speed this up */
+/* LATER might have to speed this up */
 static void canvas_tidy(t_canvas *x)
 {
     t_gobj *y, *y2;
     int ax1, ay1, ax2, ay2, bx1, by1, bx2, by2;
     int histogram[NHIST], *ip, i, besthist, bestdist;
-        /* if nobody is selected, this means do it to all boxes;
-           otherwise just the selection */
+    /* if nobody is selected, this means do it to all boxes;
+       otherwise just the selection */
     int all = (x->gl_editor ? (x->gl_editor->e_selection == 0) : 1);
 
     canvas_undo_add(x, UNDO_MOTION, "{tidy up}", canvas_undo_set_move(x, !all));
 
-        /* tidy horizontally */
-    for (y = x->gl_list; y; y = y->g_next)
-        if (all || glist_isselected(x, y))
+    /* tidy horizontally */
+    for(y = x->gl_list; y; y = y->g_next)
+        if(all || glist_isselected(x, y))
         {
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
 
-            for (y2 = x->gl_list; y2; y2 = y2->g_next)
-                if (all || glist_isselected(x, y2))
+            for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
-                    if (by1 <= ay1 + YTOLERANCE && by1 >= ay1 - YTOLERANCE &&
+                    if(by1 <= ay1 + YTOLERANCE && by1 >= ay1 - YTOLERANCE &&
                         bx1 < ax1)
                         goto nothorizhead;
                 }
 
-            for (y2 = x->gl_list; y2; y2 = y2->g_next)
-                if (all || glist_isselected(x, y2))
+            for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
-                    if (by1 <= ay1 + YTOLERANCE && by1 >= ay1 - YTOLERANCE
-                        && by1 != ay1)
-                        gobj_displace(y2, x, 0, ay1-by1);
+                    if(by1 <= ay1 + YTOLERANCE && by1 >= ay1 - YTOLERANCE &&
+                        by1 != ay1)
+                        gobj_displace(y2, x, 0, ay1 - by1);
                 }
-        nothorizhead: ;
+        nothorizhead:;
         }
-        /* tidy vertically.  First guess the user's favorite vertical spacing */
-    for (i = NHIST, ip = histogram; i--; ip++) *ip = 0;
-    for (y = x->gl_list; y; y = y->g_next)
-        if (all || glist_isselected(x, y))
+    /* tidy vertically.  First guess the user's favorite vertical spacing */
+    for(i = NHIST, ip = histogram; i--; ip++)
+        *ip = 0;
+    for(y = x->gl_list; y; y = y->g_next)
+        if(all || glist_isselected(x, y))
         {
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
-            for (y2 = x->gl_list; y2; y2 = y2->g_next)
-                if (all || glist_isselected(x, y2))
+            for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
-                    if (bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE)
+                    if(bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE)
                     {
-                        int distance = by1-ay2;
-                        if (distance >= 0 && distance < NHIST)
+                        int distance = by1 - ay2;
+                        if(distance >= 0 && distance < NHIST)
                             histogram[distance]++;
                     }
                 }
         }
-    for (i = 2, besthist = 0, bestdist = 4, ip = histogram + 2;
-         i < (NHIST-2); i++, ip++)
+    for(i = 2, besthist = 0, bestdist = 4, ip = histogram + 2; i < (NHIST - 2);
+        i++, ip++)
     {
-        int hit = ip[-2] + 2 * ip[-1] + 3 * ip[0] + 2* ip[1] + ip[2];
-        if (hit > besthist)
+        int hit = ip[-2] + 2 * ip[-1] + 3 * ip[0] + 2 * ip[1] + ip[2];
+        if(hit > besthist)
         {
             besthist = hit;
             bestdist = i;
         }
     }
     logpost(NULL, 3, "tidy: best vertical distance %d", bestdist);
-    for (y = x->gl_list; y; y = y->g_next)
-        if (all || glist_isselected(x, y))
+    for(y = x->gl_list; y; y = y->g_next)
+        if(all || glist_isselected(x, y))
         {
             int keep = 1;
             gobj_getrect(y, x, &ax1, &ay1, &ax2, &ay2);
-            for (y2 = x->gl_list; y2; y2 = y2->g_next)
-                if (all || glist_isselected(x, y2))
+            for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                if(all || glist_isselected(x, y2))
                 {
                     gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
-                    if (bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE &&
+                    if(bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE &&
                         ay1 >= by2 - 10 && ay1 < by2 + NHIST)
                         goto nothead;
                 }
-            while (keep)
+            while(keep)
             {
                 keep = 0;
-                for (y2 = x->gl_list; y2; y2 = y2->g_next)
-                    if (all || glist_isselected(x, y2))
+                for(y2 = x->gl_list; y2; y2 = y2->g_next)
+                    if(all || glist_isselected(x, y2))
                     {
                         gobj_getrect(y2, x, &bx1, &by1, &bx2, &by2);
-                        if (bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE &&
+                        if(bx1 <= ax1 + XTOLERANCE && bx1 >= ax1 - XTOLERANCE &&
                             by1 > ay1 && by1 < ay2 + NHIST)
                         {
                             int vmove = ay2 + bestdist - by1;
-                            gobj_displace(y2, x, ax1-bx1, vmove);
+                            gobj_displace(y2, x, ax1 - bx1, vmove);
                             ay1 = by1 + vmove;
                             ay2 = by2 + vmove;
                             keep = 1;
@@ -4452,7 +4450,7 @@ static void canvas_tidy(t_canvas *x)
                         }
                     }
             }
-        nothead: ;
+        nothead:;
         }
     canvas_dirty(x, 1);
 }
@@ -4460,48 +4458,47 @@ static void canvas_tidy(t_canvas *x)
 /* returns the total number of connections between two objects
  * outno/inno are set to the last connection indices
  */
-static int canvas_getconns(t_object*objsrc, int *outno, t_object*objsink, int *inno)
+static int canvas_getconns(
+    t_object *objsrc, int *outno, t_object *objsink, int *inno)
 {
     int count = 0;
     int n;
-    for(n=0; n<obj_noutlets(objsrc); n++)
+    for(n = 0; n < obj_noutlets(objsrc); n++)
     {
-        t_outlet*out = 0;
+        t_outlet *out = 0;
         t_outconnect *oc = obj_starttraverseoutlet(objsrc, &out, n);
         while(oc)
         {
-            t_object*o;
-            t_inlet*in;
+            t_object *o;
+            t_inlet *in;
             int which;
             oc = obj_nexttraverseoutlet(oc, &o, &in, &which);
-            if(o == objsink)
-                *outno = n, *inno = which, count++;
+            if(o == objsink) *outno = n, *inno = which, count++;
         }
     }
     return count;
 }
-static int canvas_try_bypassobj1(t_canvas* x,
-    t_object* obj0, int in0, int out0,
-    t_object* obj1, int in1, int out1,
-    t_object* obj2, int in2, int out2)
+
+static int canvas_try_bypassobj1(t_canvas *x, t_object *obj0, int in0, int out0,
+    t_object *obj1, int in1, int out1, t_object *obj2, int in2, int out2)
 {
-        /* tries to bypass 'obj1' so 'obj0->obj1->obj2' becomes
-         * 'obj0->obj2' (+ 'obj1'); only bypass if there's exactly one
-         * connection between both obj0->obj1 and obj1->obj2 and the two
-         * connections are of the same type
-         * skip connection, if it's already there
-         */
-        /* this is doing an awful lot of iterating over the same things again and again
-         * LATER speed this up */
+    /* tries to bypass 'obj1' so 'obj0->obj1->obj2' becomes
+     * 'obj0->obj2' (+ 'obj1'); only bypass if there's exactly one
+     * connection between both obj0->obj1 and obj1->obj2 and the two
+     * connections are of the same type
+     * skip connection, if it's already there
+     */
+    /* this is doing an awful lot of iterating over the same things again and
+     * again LATER speed this up */
     int A, B, C;
-        /* check connections (obj0->obj1->obj2, but not obj2->obj0) */
-        /*
-           valid:   out0, in1, out1, in2
-           invalid: in0, out2
-        */
-    if(out0<0 || out1<0 || out2>=0 || in0>=0 || in1<0 || in2<0)
+    /* check connections (obj0->obj1->obj2, but not obj2->obj0) */
+    /*
+       valid:   out0, in1, out1, in2
+       invalid: in0, out2
+    */
+    if(out0 < 0 || out1 < 0 || out2 >= 0 || in0 >= 0 || in1 < 0 || in2 < 0)
         return 0;
-        /* check whether the connection types match */
+    /* check whether the connection types match */
     if(obj_issignaloutlet(obj0, out0) ^ obj_issignaloutlet(obj1, out1))
         return 0;
     A = glist_getindex(x, &obj0->te_g);
@@ -4509,44 +4506,49 @@ static int canvas_try_bypassobj1(t_canvas* x,
     C = glist_getindex(x, &obj2->te_g);
     canvas_disconnect_with_undo(x, A, out0, B, in1);
     canvas_disconnect_with_undo(x, B, out1, C, in2);
-    if (!canvas_isconnected(x, obj0, out0, obj2, in2))
+    if(!canvas_isconnected(x, obj0, out0, obj2, in2))
         canvas_connect_with_undo(x, A, out0, C, in2);
     return 1;
 }
-static int canvas_try_insert(t_canvas *x
-    , t_object* obj00, int in00, int out00 /* source */
-    , t_object* obj11, int in11, int out11 /* sink   */
-    , t_object* obj22, int in22, int out22 /* insert */
-    )
+
+static int canvas_try_insert(
+    t_canvas *x, t_object *obj00, int in00, int out00 /* source */
+    ,
+    t_object *obj11, int in11, int out11 /* sink   */
+    ,
+    t_object *obj22, int in22, int out22 /* insert */
+)
 {
     int out21 = 0, in02 = 0; /* iolets of the insert-objects */
     int A, B, C;
 
-        /* check connections (obj00->obj11, but not obj22) */
-    if(out00<0 || out22>=0 || out11>=0 || in00>=0 || in22>=0 || in11<0)
+    /* check connections (obj00->obj11, but not obj22) */
+    if(out00 < 0 || out22 >= 0 || out11 >= 0 || in00 >= 0 || in22 >= 0 ||
+        in11 < 0)
         return 0;
 
-        /* check whether the connection types match */
+    /* check whether the connection types match */
     if((obj_issignaloutlet(obj00, out00) && !obj_issignalinlet(obj22, in02)))
         return 0;
     if((obj_issignaloutlet(obj22, out21) && !obj_issignalinlet(obj11, in11)))
         return 0;
 
-        /* then connect them */
+    /* then connect them */
     A = glist_getindex(x, &obj00->te_g);
     B = glist_getindex(x, &obj11->te_g);
     C = glist_getindex(x, &obj22->te_g);
 
     canvas_disconnect_with_undo(x, A, out00, B, in11);
-    if (!canvas_isconnected     (x, obj00, out00, obj22, in02))
-        canvas_connect_with_undo(x, A,     out00, C,     in02);
-    if (!canvas_isconnected     (x, obj22, out21, obj11, in11))
-        canvas_connect_with_undo(x, C,     out21, B,     in11);
+    if(!canvas_isconnected(x, obj00, out00, obj22, in02))
+        canvas_connect_with_undo(x, A, out00, C, in02);
+    if(!canvas_isconnected(x, obj22, out21, obj11, in11))
+        canvas_connect_with_undo(x, C, out21, B, in11);
     return 1;
 }
-    /* If we have two selected objects on the canvas, try to connect
-       the first outlet of the upper object to the first inlet with
-       a compatible type in the lower one. */
+
+/* If we have two selected objects on the canvas, try to connect
+   the first outlet of the upper object to the first inlet with
+   a compatible type in the lower one. */
 static void canvas_connect_selection(t_canvas *x)
 {
     t_gobj *a, *b, *c;
@@ -4555,39 +4557,38 @@ static void canvas_connect_selection(t_canvas *x)
 
     a = b = c = NULL;
     sel = x->gl_editor ? x->gl_editor->e_selection : NULL;
-    for (; sel; sel = sel->sel_next)
+    for(; sel; sel = sel->sel_next)
     {
-        if (!a)
+        if(!a)
             a = sel->sel_what;
-        else if (!b)
+        else if(!b)
             b = sel->sel_what;
-        else if (!c)
+        else if(!c)
             c = sel->sel_what;
         else
             return;
     }
 
-    if(!a)
-        return;
+    if(!a) return;
 
     if(!b)
     {
-            /* only a single object is selected.
-             * if a connection is selected, insert the object
-             * if no connection is selected, disconnect the object
-             */
-        t_object*obj = pd_checkobject(&a->g_pd);
-        if(!obj)
-            return;
+        /* only a single object is selected.
+         * if a connection is selected, insert the object
+         * if no connection is selected, disconnect the object
+         */
+        t_object *obj = pd_checkobject(&a->g_pd);
+        if(!obj) return;
         if(x->gl_editor->e_selectedline)
         {
             b = glist_nth(x, x->gl_editor->e_selectline_index1);
-            objsrc = b?pd_checkobject(&b->g_pd):0;
+            objsrc = b ? pd_checkobject(&b->g_pd) : 0;
             b = glist_nth(x, x->gl_editor->e_selectline_index2);
-            objsink = b?pd_checkobject(&b->g_pd):0;
+            objsink = b ? pd_checkobject(&b->g_pd) : 0;
 
-            if(canconnect(x, objsrc, x->gl_editor->e_selectline_outno, obj, 0)
-               && canconnect(x, obj, 0, objsink, x->gl_editor->e_selectline_inno))
+            if(canconnect(
+                   x, objsrc, x->gl_editor->e_selectline_outno, obj, 0) &&
+                canconnect(x, obj, 0, objsink, x->gl_editor->e_selectline_inno))
             {
                 canvas_undo_add(x, UNDO_SEQUENCE_START, "reconnect", 0);
                 tryconnect(x, objsrc, x->gl_editor->e_selectline_outno, obj, 0);
@@ -4598,44 +4599,44 @@ static void canvas_connect_selection(t_canvas *x)
         }
         else
         {
-                /* disconnect the entire object */
+            /* disconnect the entire object */
             t_linetraverser t;
             t_outconnect *oc;
             canvas_undo_add(x, UNDO_SEQUENCE_START, "disconnect", 0);
             linetraverser_start(&t, x);
-            while ((oc = linetraverser_next(&t)))
+            while((oc = linetraverser_next(&t)))
             {
-                if ((obj == t.tr_ob) || (obj == t.tr_ob2))
+                if((obj == t.tr_ob) || (obj == t.tr_ob2))
                 {
                     int srcno = glist_getindex(x, &t.tr_ob->ob_g);
                     int sinkno = glist_getindex(x, &t.tr_ob2->ob_g);
-                    canvas_disconnect_with_undo(x, srcno, t.tr_outno, sinkno, t.tr_inno);
+                    canvas_disconnect_with_undo(
+                        x, srcno, t.tr_outno, sinkno, t.tr_inno);
                 }
             }
             canvas_undo_add(x, UNDO_SEQUENCE_END, "disconnect", 0);
         }
-            /* need to return since we have touched 'b' */
+        /* need to return since we have touched 'b' */
         return;
     }
 
     if(!c)
     {
-            /* exactly two objects are selected
-             * connect them (top to bottom) if they are patchable
-             */
-        if (!(objsrc = pd_checkobject(&a->g_pd)) ||
+        /* exactly two objects are selected
+         * connect them (top to bottom) if they are patchable
+         */
+        if(!(objsrc = pd_checkobject(&a->g_pd)) ||
             !(objsink = pd_checkobject(&b->g_pd)))
             return;
 
         if(objsink->te_ypix < objsrc->te_ypix)
         {
-            t_object*obj = objsink;
+            t_object *obj = objsink;
             objsink = objsrc;
             objsrc = obj;
         }
-        if (!objsrc || !objsink)
-            return;
-        if (obj_noutlets(objsrc))
+        if(!objsrc || !objsink) return;
+        if(obj_noutlets(objsrc))
         {
             int noutlets = obj_noutlets(objsrc);
             int ninlets = obj_ninlets(objsink);
@@ -4643,61 +4644,50 @@ static void canvas_connect_selection(t_canvas *x)
             int out = 0, in = 0;
             while(!tryconnect(x, objsrc, out, objsink, in))
             {
-                if (noutlets <= out)
-                    return;
-                if (ninlets <= in )
-                    return;
+                if(noutlets <= out) return;
+                if(ninlets <= in) return;
                 in++;
-                if(!fanout)
-                    out++;
+                if(!fanout) out++;
             }
         }
         return;
     }
 
-        /* exactly three objects are selected
-         * if they are chained up, unconnect the middle object, and connect the source to the sink
-         * if only two of them are connected, insert the third
-         */
-    if ((objsrc = pd_checkobject(&a->g_pd)) &&
+    /* exactly three objects are selected
+     * if they are chained up, unconnect the middle object, and connect the
+     * source to the sink if only two of them are connected, insert the third
+     */
+    if((objsrc = pd_checkobject(&a->g_pd)) &&
         (objsink = pd_checkobject(&b->g_pd)))
     {
         t_object *obj0 = objsrc, *obj2 = objsink;
         t_object *obj1 = pd_checkobject(&c->g_pd);
         int out01, out02, out10, out12, out20, out21;
         int in01, in02, in10, in12, in20, in21;
-        if(!obj1
-           || (obj0 == obj1)
-           || (obj2 == obj1)
-           || (obj0 == obj2))
-            return;
-#define GET1CONN(a, b) \
-        if (1 != canvas_getconns(obj##a, &out##a##b, obj##b, &in##b##a)) \
-            out##a##b = in##b##a = -1
+        if(!obj1 || (obj0 == obj1) || (obj2 == obj1) || (obj0 == obj2)) return;
+#define GET1CONN(a, b)                                              \
+    if(1 != canvas_getconns(obj##a, &out##a##b, obj##b, &in##b##a)) \
+    out##a##b = in##b##a = -1
         GET1CONN(0, 1);
         GET1CONN(0, 2);
         GET1CONN(1, 0);
         GET1CONN(1, 2);
         GET1CONN(2, 0);
         GET1CONN(2, 1);
-#define TRYCONNCHANGE(fun, a, b, c)                                      \
-        canvas_try_##fun(x, obj##a, in##a##c, out##a##b, obj##b, in##b##a, out##b##c, obj##c, in##c##b, out##c##a)
+#define TRYCONNCHANGE(fun, a, b, c)                                    \
+    canvas_try_##fun(x, obj##a, in##a##c, out##a##b, obj##b, in##b##a, \
+        out##b##c, obj##c, in##c##b, out##c##a)
 
         canvas_undo_add(x, UNDO_SEQUENCE_START, "reconnect", 0);
-        0
-            || TRYCONNCHANGE(bypassobj1, 0, 1, 2)
-            || TRYCONNCHANGE(bypassobj1, 0, 2, 1)
-            || TRYCONNCHANGE(bypassobj1, 1, 0, 2)
-            || TRYCONNCHANGE(bypassobj1, 1, 2, 0)
-            || TRYCONNCHANGE(bypassobj1, 2, 0, 1)
-            || TRYCONNCHANGE(bypassobj1, 2, 1, 0)
-            || TRYCONNCHANGE(insert,     0, 1, 2)
-            || TRYCONNCHANGE(insert,     0, 2, 1)
-            || TRYCONNCHANGE(insert,     1, 0, 2)
-            || TRYCONNCHANGE(insert,     1, 2, 0)
-            || TRYCONNCHANGE(insert,     2, 0, 1)
-            || TRYCONNCHANGE(insert,     2, 1, 0)
-            ;
+        0 || TRYCONNCHANGE(bypassobj1, 0, 1, 2) ||
+            TRYCONNCHANGE(bypassobj1, 0, 2, 1) ||
+            TRYCONNCHANGE(bypassobj1, 1, 0, 2) ||
+            TRYCONNCHANGE(bypassobj1, 1, 2, 0) ||
+            TRYCONNCHANGE(bypassobj1, 2, 0, 1) ||
+            TRYCONNCHANGE(bypassobj1, 2, 1, 0) ||
+            TRYCONNCHANGE(insert, 0, 1, 2) || TRYCONNCHANGE(insert, 0, 2, 1) ||
+            TRYCONNCHANGE(insert, 1, 0, 2) || TRYCONNCHANGE(insert, 1, 2, 0) ||
+            TRYCONNCHANGE(insert, 2, 0, 1) || TRYCONNCHANGE(insert, 2, 1, 0);
         canvas_undo_add(x, UNDO_SEQUENCE_END, "reconnect", 0);
     }
 }
@@ -4707,96 +4697,96 @@ static void canvas_texteditor(t_canvas *x)
     t_rtext *foo;
     char *buf;
     int bufsize;
-    if ((foo = x->gl_editor->e_textedfor))
+    if((foo = x->gl_editor->e_textedfor))
         rtext_gettext(foo, &buf, &bufsize);
-    else buf = "", bufsize = 0;
+    else
+        buf = "", bufsize = 0;
     sys_vgui("pdtk_pd_texteditor {%.*s}\n", bufsize, buf);
-
 }
 
 void glob_key(void *dummy, t_symbol *s, int ac, t_atom *av)
 {
-        /* canvas_key checks for zero */
+    /* canvas_key checks for zero */
     canvas_key(0, s, ac, av);
 }
 
 void canvas_editmode(t_canvas *x, t_floatarg state)
 {
-    if (x->gl_edit == (unsigned int) state)
-        return;
+    if(x->gl_edit == (unsigned int) state) return;
     x->gl_edit = (unsigned int) state;
-    if (x->gl_edit && glist_isvisible(x) && glist_istoplevel(x))
+    if(x->gl_edit && glist_isvisible(x) && glist_istoplevel(x))
     {
         t_gobj *g;
         t_object *ob;
         canvas_setcursor(x, CURSOR_EDITMODE_NOTHING);
-        for (g = x->gl_list; g; g = g->g_next)
-            if ((ob = pd_checkobject(&g->g_pd)) && ob->te_type == T_TEXT)
+        for(g = x->gl_list; g; g = g->g_next)
+            if((ob = pd_checkobject(&g->g_pd)) && ob->te_type == T_TEXT)
             {
                 t_rtext *y = glist_findrtext(x, ob);
-                text_drawborder(ob, x,
-                                rtext_gettag(y), rtext_width(y), rtext_height(y), 1);
+                text_drawborder(
+                    ob, x, rtext_gettag(y), rtext_width(y), rtext_height(y), 1);
             }
     }
     else
     {
-        glist_noselect(x);  /* this can knock us back into edit mode so : */
+        glist_noselect(x); /* this can knock us back into edit mode so : */
         x->gl_edit = (unsigned int) state;
-        if (glist_isvisible(x) && glist_istoplevel(x))
+        if(glist_isvisible(x) && glist_istoplevel(x))
         {
             canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
             sys_vgui(".x%lx.c delete commentbar\n", glist_getcanvas(x));
         }
     }
-    if (glist_isvisible(x) && x->gl_havewindow)
+    if(glist_isvisible(x) && x->gl_havewindow)
     {
-        sys_vgui("pdtk_canvas_editmode .x%lx %d\n",
-            glist_getcanvas(x), x->gl_edit);
+        sys_vgui(
+            "pdtk_canvas_editmode .x%lx %d\n", glist_getcanvas(x), x->gl_edit);
         canvas_reflecttitle(x);
     }
 }
 
-    /* called by canvas_font below */
-static void canvas_dofont(t_canvas *x, t_floatarg font, t_floatarg xresize,
-    t_floatarg yresize)
+/* called by canvas_font below */
+static void canvas_dofont(
+    t_canvas *x, t_floatarg font, t_floatarg xresize, t_floatarg yresize)
 {
     t_gobj *y;
     x->gl_font = font;
-    if (xresize != 1 || yresize != 1)
+    if(xresize != 1 || yresize != 1)
     {
-        canvas_setundo(x, canvas_undo_move, canvas_undo_set_move(x, 0),
-            "motion");
-        for (y = x->gl_list; y; y = y->g_next)
+        canvas_setundo(
+            x, canvas_undo_move, canvas_undo_set_move(x, 0), "motion");
+        for(y = x->gl_list; y; y = y->g_next)
         {
             int x1, x2, y1, y2, nx1, ny1;
             gobj_getrect(y, x, &x1, &y1, &x2, &y2);
             nx1 = x1 * xresize + 0.5;
             ny1 = y1 * yresize + 0.5;
-            gobj_displace(y, x, nx1-x1, ny1-y1);
+            gobj_displace(y, x, nx1 - x1, ny1 - y1);
         }
     }
-    for (y = x->gl_list; y; y = y->g_next)
-        if (pd_checkglist(&y->g_pd)  && !canvas_isabstraction((t_canvas *)y))
-            canvas_dofont((t_canvas *)y, font, xresize, yresize);
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_checkglist(&y->g_pd) && !canvas_isabstraction((t_canvas *) y))
+            canvas_dofont((t_canvas *) y, font, xresize, yresize);
     if(x->gl_havewindow) canvas_redraw(x);
 }
 
-    /* canvas_menufont calls up a TK dialog which calls this back */
-static void canvas_font(t_canvas *x, t_floatarg font, t_floatarg resize,
-    t_floatarg whichresize)
+/* canvas_menufont calls up a TK dialog which calls this back */
+static void canvas_font(
+    t_canvas *x, t_floatarg font, t_floatarg resize, t_floatarg whichresize)
 {
     t_float realresize, realresx = 1, realresy = 1;
     t_canvas *x2 = canvas_getrootfor(x);
     int oldfont = x2->gl_font;
-    if (!resize) realresize = 1;
+    if(!resize)
+        realresize = 1;
     else
     {
-        if (resize < 20) resize = 20;
-        if (resize > 500) resize = 500;
+        if(resize < 20) resize = 20;
+        if(resize > 500) resize = 500;
         realresize = resize * 0.01;
     }
-    if (whichresize != 3) realresx = realresize;
-    if (whichresize != 2) realresy = realresize;
+    if(whichresize != 3) realresx = realresize;
+    if(whichresize != 2) realresy = realresize;
     canvas_dofont(x2, font, realresx, realresy);
     canvas_undo_add(x2, UNDO_FONT, "font",
         canvas_undo_set_font(x2, oldfont, realresize, whichresize));
@@ -4806,10 +4796,11 @@ static void canvas_font(t_canvas *x, t_floatarg font, t_floatarg resize,
 
 void glist_getnextxy(t_glist *gl, int *xpix, int *ypix)
 {
-    if (EDITOR->canvas_last_glist == gl)
+    if(EDITOR->canvas_last_glist == gl)
         *xpix = EDITOR->canvas_last_glist_x,
         *ypix = EDITOR->canvas_last_glist_y;
-    else *xpix = *ypix = 40;
+    else
+        *xpix = *ypix = 40;
 }
 
 static void glist_setlastxy(t_glist *gl, int xval, int yval)
@@ -4819,117 +4810,113 @@ static void glist_setlastxy(t_glist *gl, int xval, int yval)
     EDITOR->canvas_last_glist_y = yval;
 }
 
-
-void canvas_triggerize(t_glist*cnv);
+void canvas_triggerize(t_glist *cnv);
 
 void g_editor_setup(void)
 {
-/* ------------------------ events ---------------------------------- */
-    class_addmethod(canvas_class, (t_method)canvas_mouse, gensym("mouse"),
+    /* ------------------------ events ---------------------------------- */
+    class_addmethod(canvas_class, (t_method) canvas_mouse, gensym("mouse"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_mouseup, gensym("mouseup"),
+    class_addmethod(canvas_class, (t_method) canvas_mouseup, gensym("mouseup"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_DEFFLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_key, gensym("key"),
-        A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_motion, gensym("motion"),
+    class_addmethod(
+        canvas_class, (t_method) canvas_key, gensym("key"), A_GIMME, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_motion, gensym("motion"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
 
-/* ------------------------ menu actions ---------------------------- */
-    class_addmethod(canvas_class, (t_method)canvas_menuclose,
+    /* ------------------------ menu actions ---------------------------- */
+    class_addmethod(canvas_class, (t_method) canvas_menuclose,
         gensym("menuclose"), A_DEFFLOAT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_cut,
-        gensym("cut"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_copy,
-        gensym("copy"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_paste,
-        gensym("paste"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_paste_replace,
+    class_addmethod(canvas_class, (t_method) canvas_cut, gensym("cut"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_copy, gensym("copy"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_paste, gensym("paste"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_paste_replace,
         gensym("paste-replace"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_duplicate,
-        gensym("duplicate"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_selectall,
-        gensym("selectall"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_deselectall,
+    class_addmethod(
+        canvas_class, (t_method) canvas_duplicate, gensym("duplicate"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_selectall, gensym("selectall"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_deselectall,
         gensym("deselectall"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_reselect,
-        gensym("reselect"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_cycleselect,
+    class_addmethod(
+        canvas_class, (t_method) canvas_reselect, gensym("reselect"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_cycleselect,
         gensym("cycleselect"), A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_undo_undo,
-        gensym("undo"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_undo_redo,
-        gensym("redo"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_tidy,
-        gensym("tidy"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_connect_selection,
+    class_addmethod(
+        canvas_class, (t_method) canvas_undo_undo, gensym("undo"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_undo_redo, gensym("redo"), A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_tidy, gensym("tidy"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_connect_selection,
         gensym("connect_selection"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_texteditor,
+    class_addmethod(canvas_class, (t_method) canvas_texteditor,
         gensym("texteditor"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_editmode,
+    class_addmethod(canvas_class, (t_method) canvas_editmode,
         gensym("editmode"), A_DEFFLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_print,
-        gensym("print"), A_SYMBOL, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_menufont,
-        gensym("menufont"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_font,
-        gensym("font"), A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_zoom,
-        gensym("zoom"), A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_find,
-        gensym("find"), A_SYMBOL, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_find_again,
+    class_addmethod(canvas_class, (t_method) canvas_print, gensym("print"),
+        A_SYMBOL, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_menufont, gensym("menufont"), A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_font, gensym("font"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+    class_addmethod(
+        canvas_class, (t_method) canvas_zoom, gensym("zoom"), A_FLOAT, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_find, gensym("find"),
+        A_SYMBOL, A_FLOAT, A_NULL);
+    class_addmethod(canvas_class, (t_method) canvas_find_again,
         gensym("findagain"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_find_parent,
+    class_addmethod(canvas_class, (t_method) canvas_find_parent,
         gensym("findparent"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_done_popup,
+    class_addmethod(canvas_class, (t_method) canvas_done_popup,
         gensym("done-popup"), A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_donecanvasdialog,
+    class_addmethod(canvas_class, (t_method) canvas_donecanvasdialog,
         gensym("donecanvasdialog"), A_GIMME, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_arraydialog,
+    class_addmethod(canvas_class, (t_method) glist_arraydialog,
         gensym("arraydialog"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_triggerize,
-        gensym("triggerize"), 0);
-    class_addmethod(canvas_class, (t_method)canvas_disconnect,
+    class_addmethod(
+        canvas_class, (t_method) canvas_triggerize, gensym("triggerize"), 0);
+    class_addmethod(canvas_class, (t_method) canvas_disconnect,
         gensym("disconnect"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
 }
 
 void canvas_editor_for_class(t_class *c)
 {
-    class_addmethod(c, (t_method)canvas_mouse, gensym("mouse"),
-        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(c, (t_method)canvas_mouseup, gensym("mouseup"),
+    class_addmethod(c, (t_method) canvas_mouse, gensym("mouse"), A_FLOAT,
         A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(c, (t_method)canvas_key, gensym("key"),
-        A_GIMME, A_NULL);
-    class_addmethod(c, (t_method)canvas_motion, gensym("motion"),
-        A_FLOAT, A_FLOAT, A_FLOAT, A_DEFFLOAT, A_NULL);
+    class_addmethod(c, (t_method) canvas_mouseup, gensym("mouseup"), A_FLOAT,
+        A_FLOAT, A_FLOAT, A_NULL);
+    class_addmethod(c, (t_method) canvas_key, gensym("key"), A_GIMME, A_NULL);
+    class_addmethod(c, (t_method) canvas_motion, gensym("motion"), A_FLOAT,
+        A_FLOAT, A_FLOAT, A_DEFFLOAT, A_NULL);
 
-/* ------------------------ menu actions ---------------------------- */
-    class_addmethod(c, (t_method)canvas_menuclose,
-        gensym("menuclose"), A_DEFFLOAT, 0);
-    class_addmethod(c, (t_method)canvas_find_parent,
-        gensym("findparent"), A_NULL);
+    /* ------------------------ menu actions ---------------------------- */
+    class_addmethod(
+        c, (t_method) canvas_menuclose, gensym("menuclose"), A_DEFFLOAT, 0);
+    class_addmethod(
+        c, (t_method) canvas_find_parent, gensym("findparent"), A_NULL);
 }
 
 void g_editor_newpdinstance(void)
 {
     EDITOR = getbytes(sizeof(*EDITOR));
-        /* other stuff is null-checked but this needs to exist: */
+    /* other stuff is null-checked but this needs to exist: */
     EDITOR->copy_binbuf = binbuf_new();
 }
 
 void g_editor_freepdinstance(void)
 {
-    if (EDITOR->copy_binbuf)
-        binbuf_free(EDITOR->copy_binbuf);
-    if (EDITOR->canvas_undo_buf)
+    if(EDITOR->copy_binbuf) binbuf_free(EDITOR->copy_binbuf);
+    if(EDITOR->canvas_undo_buf)
     {
-        if (!EDITOR->canvas_undo_fn)
+        if(!EDITOR->canvas_undo_fn)
             bug("g_editor_freepdinstance");
-        else (*EDITOR->canvas_undo_fn)
-            (EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_FREE);
+        else
+            (*EDITOR->canvas_undo_fn)(
+                EDITOR->canvas_undo_canvas, EDITOR->canvas_undo_buf, UNDO_FREE);
     }
-    if (EDITOR->canvas_findbuf)
-        binbuf_free(EDITOR->canvas_findbuf);
+    if(EDITOR->canvas_findbuf) binbuf_free(EDITOR->canvas_findbuf);
     freebytes(EDITOR, sizeof(*EDITOR));
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1751,8 +1751,7 @@ int canvas_hitbox(t_canvas *x, t_gobj *y, int xpos, int ypos, int *x1p,
         *y2p = y2;
         return (1);
     }
-    else
-        return (0);
+    return (0);
 }
 
 /* find the last gobj, if any, containing the point. */
@@ -2137,7 +2136,7 @@ static void canvas_done_popup(
                 (*class_getpropertiesfn(pd_class(&y->g_pd)))(y, x);
                 return;
             }
-            else if(which == 1) /* open */
+            if(which == 1) /* open */
             {
                 if(!zgetfn(&y->g_pd, gensym("menu-open"))) continue;
                 vmess(&y->g_pd, gensym("menu-open"), "");
@@ -3351,8 +3350,7 @@ static t_glist *glist_finddirty(t_glist *x)
 
     if(x->gl_env && x->gl_dirty)
         return (x);
-    else
-        return (0);
+    return (0);
 }
 
 /* quit, after calling glist_finddirty() on all toplevels and verifying
@@ -3398,7 +3396,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                 canvas_getrootfor(g), g);
             return;
         }
-        else if(sys_perf)
+        if(sys_perf)
         {
             sys_vgui("pdtk_check .x%lx {Close this window?} {.x%lx menuclose "
                      "1;\n} yes\n",
@@ -3422,8 +3420,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                 canvas_getrootfor(g), g);
             return;
         }
-        else
-            pd_free(&x->gl_pd);
+        pd_free(&x->gl_pd);
     }
     else if(force == 3)
     {
@@ -3618,7 +3615,7 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
             glist_select(gl, g);
             return (1);
         }
-        else if(g->g_pd == canvas_class)
+        if(g->g_pd == canvas_class)
         {
             if(glist_dofinderror((t_canvas *) g, error_object)) return (1);
         }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -2,86 +2,86 @@
  * For information on usage and redistribution, and for a DISCLAIMER OF ALL
  * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
-
 #include "m_pd.h"
 
 #include "g_canvas.h"
 #include "m_imp.h"
 #include "g_undo.h"
 
-
-void *canvas_undo_set_pastebinbuf(t_canvas *x, t_binbuf *b,
-    int numpasted, int duplicate, int d_offset);
+void *canvas_undo_set_pastebinbuf(
+    t_canvas *x, t_binbuf *b, int numpasted, int duplicate, int d_offset);
 
 /* ------------ utilities ---------- */
-typedef struct _triggerize_return {
-        /* data to return from triggerize */
-    t_gobj*tr_editgobj; /* if set, immediately switch this object to being edited */
+typedef struct _triggerize_return
+{
+    /* data to return from triggerize */
+    t_gobj *tr_editgobj; /* if set, immediately switch this object to being
+                            edited */
 } t_triggerize_return;
 
+static t_gobj *o2g(t_object *obj) { return &(obj->te_g); }
 
-static t_gobj*o2g(t_object*obj)
+static t_object *g2o(t_gobj *gobj) { return pd_checkobject(&gobj->g_pd); }
+
+static t_gobj *glist_getlast(t_glist *cnv)
 {
-    return &(obj->te_g);
-}
-static t_object*g2o(t_gobj*gobj)
-{
-    return pd_checkobject(&gobj->g_pd);
-}
-static t_gobj*glist_getlast(t_glist*cnv)
-{
-        /* get last object on <ncv> */
-    t_gobj*result=NULL;
-    for(result=cnv->gl_list; result->g_next;) result=result->g_next;
+    /* get last object on <ncv> */
+    t_gobj *result = NULL;
+    for(result = cnv->gl_list; result->g_next;)
+        result = result->g_next;
     return result;
 }
-static void dereconnect(t_glist*cnv, t_object*org, t_object*replace)
+
+static void dereconnect(t_glist *cnv, t_object *org, t_object *replace)
 {
-    t_gobj*gobj;
+    t_gobj *gobj;
     int replace_i = canvas_getindex(cnv, o2g(replace));
-    for(gobj=cnv->gl_list; gobj; gobj=gobj->g_next)
+    for(gobj = cnv->gl_list; gobj; gobj = gobj->g_next)
     {
-        t_object*obj=g2o(gobj);
+        t_object *obj = g2o(gobj);
         int obj_i = canvas_getindex(cnv, gobj);
-        int obj_nout=0;
+        int obj_nout = 0;
         int nout;
-        if(!obj)continue;
-        obj_nout=obj_noutlets(obj);
-        for(nout=0; nout<obj_nout; nout++)
+        if(!obj) continue;
+        obj_nout = obj_noutlets(obj);
+        for(nout = 0; nout < obj_nout; nout++)
         {
-            t_outlet*out=0;
-            t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
+            t_outlet *out = 0;
+            t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
             while(conn)
             {
                 int which;
-                t_object*dest=0;
-                t_inlet *in =0;
+                t_object *dest = 0;
+                t_inlet *in = 0;
                 int dest_i;
-                conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
-                if(dest!=org)
-                    continue;
+                conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
+                if(dest != org) continue;
                 dest_i = canvas_getindex(cnv, o2g(dest));
                 obj_disconnect(obj, nout, dest, which);
                 canvas_undo_add(cnv, UNDO_DISCONNECT, "disconnect",
-                    canvas_undo_set_disconnect(cnv, obj_i, nout, dest_i, which));
+                    canvas_undo_set_disconnect(
+                        cnv, obj_i, nout, dest_i, which));
                 obj_connect(obj, nout, replace, which);
                 canvas_undo_add(cnv, UNDO_CONNECT, "connect",
-                    canvas_undo_set_connect(cnv, obj_i, nout, replace_i, which));
+                    canvas_undo_set_connect(
+                        cnv, obj_i, nout, replace_i, which));
             }
         }
     }
 }
-static void obj_delete_undo(t_glist*x, t_object *obj)
+
+static void obj_delete_undo(t_glist *x, t_object *obj)
 {
-        /* delete an object with undo */
-    t_gobj*gobj=o2g(obj);
+    /* delete an object with undo */
+    t_gobj *gobj = o2g(obj);
     canvas_undo_add(x, UNDO_RECREATE, "recreate",
-        (void *)canvas_undo_set_recreate(x, gobj,canvas_getindex(x, gobj)));
+        (void *) canvas_undo_set_recreate(x, gobj, canvas_getindex(x, gobj)));
     glist_delete(x, gobj);
 }
-static t_object*triggerize_createobj(t_glist*x, t_binbuf*b)
+
+static t_object *triggerize_createobj(t_glist *x, t_binbuf *b)
 {
-        /* send a binbuf to a canvas */
+    /* send a binbuf to a canvas */
     t_pd *boundx = s__X.s_thing, *boundn = s__N.s_thing;
     s__X.s_thing = &x->gl_pd;
     s__N.s_thing = &pd_canvasmaker;
@@ -92,16 +92,16 @@ static t_object*triggerize_createobj(t_glist*x, t_binbuf*b)
     s__N.s_thing = boundn;
     return g2o(glist_getlast(x));
 }
-static void stack_conn(t_glist*x, t_object*new, int*newoutlet, t_object*org,
-    int orgoutlet, t_outconnect*conn)
+
+static void stack_conn(t_glist *x, t_object *new, int *newoutlet, t_object *org,
+    int orgoutlet, t_outconnect *conn)
 {
-    t_object*dest=0;
-    t_inlet *in =0;
+    t_object *dest = 0;
+    t_inlet *in = 0;
     int which;
     int new_i, org_i, dest_i;
-    if(!conn)
-        return;
-    conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+    if(!conn) return;
+    conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
     stack_conn(x, new, newoutlet, org, orgoutlet, conn);
     new_i = canvas_getindex(x, o2g(new));
     org_i = canvas_getindex(x, o2g(org));
@@ -114,41 +114,42 @@ static void stack_conn(t_glist*x, t_object*new, int*newoutlet, t_object*org,
         canvas_undo_set_connect(x, new_i, *newoutlet, dest_i, which));
     (*newoutlet)++;
 }
-static int has_fanout(t_object*obj)
+
+static int has_fanout(t_object *obj)
 {
-        /* check if we actually do have a fan out */
-    int obj_nout=obj_noutlets(obj);
+    /* check if we actually do have a fan out */
+    int obj_nout = obj_noutlets(obj);
     int nout;
-    for(nout=0; nout<obj_nout; nout++)
+    for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
-        int count=0;
-        if(obj_issignaloutlet(obj, nout))
-            continue;
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
+        int count = 0;
+        if(obj_issignaloutlet(obj, nout)) continue;
         while(conn)
         {
             int which;
-            t_object*dest=0;
-            t_inlet *in =0;
-            if(count)return 1;
-            conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+            t_object *dest = 0;
+            t_inlet *in = 0;
+            if(count) return 1;
+            conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
             count++;
         }
     }
     return 0;
 }
-static int only_triggers_selected(t_glist*cnv)
-{
-        /* check if all selected objects in <cnv> are triggers */
-    const t_symbol*s_trigger=gensym("trigger");
-    t_gobj*gobj = NULL;
 
-    for(gobj=cnv->gl_list; gobj; gobj=gobj->g_next)
+static int only_triggers_selected(t_glist *cnv)
+{
+    /* check if all selected objects in <cnv> are triggers */
+    const t_symbol *s_trigger = gensym("trigger");
+    t_gobj *gobj = NULL;
+
+    for(gobj = cnv->gl_list; gobj; gobj = gobj->g_next)
     {
-        t_object*obj=g2o(gobj);
-        if(obj && glist_isselected(cnv, gobj)
-           && (s_trigger != obj->te_g.g_pd->c_name))
+        t_object *obj = g2o(gobj);
+        if(obj && glist_isselected(cnv, gobj) &&
+            (s_trigger != obj->te_g.g_pd->c_name))
         {
             return 0;
         }
@@ -157,70 +158,71 @@ static int only_triggers_selected(t_glist*cnv)
 }
 
 /* ------------------------- triggerize ---------------------------- */
-static int triggerize_fanout_inplace(t_glist*x, t_object*obj)
+static int triggerize_fanout_inplace(t_glist *x, t_object *obj)
 {
-        /* avoid fanouts in [t] objects by adding additional outlets */
+    /* avoid fanouts in [t] objects by adding additional outlets */
 
-    int posX=obj->te_xpix;
-    int posY=obj->te_ypix;
-    t_atom*argv=binbuf_getvec(obj->te_binbuf);
-    int obj_nout=obj_noutlets(obj);
+    int posX = obj->te_xpix;
+    int posY = obj->te_ypix;
+    t_atom *argv = binbuf_getvec(obj->te_binbuf);
+    int obj_nout = obj_noutlets(obj);
     int nout, newout;
-    t_binbuf*b=0;
-    t_object*stub=0;
-        /* check if we actually do have a fan out */
-    if(!has_fanout(obj))return 0;
-        /* create a new trigger object, that has outlets for the fans */
-    b=binbuf_new();
+    t_binbuf *b = 0;
+    t_object *stub = 0;
+    /* check if we actually do have a fan out */
+    if(!has_fanout(obj)) return 0;
+    /* create a new trigger object, that has outlets for the fans */
+    b = binbuf_new();
     binbuf_addv(b, "ssii", gensym("#X"), gensym("obj"), posX, posY);
     binbuf_add(b, 1, argv);
     argv++;
-    for(nout=0; nout<obj_nout; nout++)
+    for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
         while(conn)
         {
             int which;
-            t_object*dest=0;
-            t_inlet *in =0;
-            conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+            t_object *dest = 0;
+            t_inlet *in = 0;
+            conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
             binbuf_add(b, 1, argv);
         }
         argv++;
     }
     binbuf_addsemi(b);
-    canvas_undo_add(x, UNDO_PASTE, "paste",
-        canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
-    stub=triggerize_createobj(x, b);
+    canvas_undo_add(
+        x, UNDO_PASTE, "paste", canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
+    stub = triggerize_createobj(x, b);
     binbuf_free(b);
 
-        /* connect */
-    newout=0;
+    /* connect */
+    newout = 0;
     dereconnect(x, obj, stub);
-    for(nout=0; nout<obj_nout; nout++)
+    for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
         stack_conn(x, stub, &newout, obj, nout, conn);
     }
 
-        /* free old object */
+    /* free old object */
     obj_delete_undo(x, obj);
     return 1;
 }
-static void triggerize_defanout(t_glist*x, int count, t_outconnect*conn,
-    t_object*obj, t_object*trigger, int nout)
+
+static void triggerize_defanout(t_glist *x, int count, t_outconnect *conn,
+    t_object *obj, t_object *trigger, int nout)
 {
-    t_object *dest=0;
-    t_inlet *in=0;
-    int which=0;
+    t_object *dest = 0;
+    t_inlet *in = 0;
+    int which = 0;
     int obj_i = canvas_getindex(x, o2g(obj));
     int trigger_i = canvas_getindex(x, o2g(trigger));
     int dest_i;
     if(!conn) return;
     conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
-    triggerize_defanout(x, count-1, conn, obj, trigger, nout);
+    triggerize_defanout(x, count - 1, conn, obj, trigger, nout);
 
     dest_i = canvas_getindex(x, o2g(dest));
     obj_disconnect(obj, nout, dest, which);
@@ -231,55 +233,55 @@ static void triggerize_defanout(t_glist*x, int count, t_outconnect*conn,
         canvas_undo_set_connect(x, trigger_i, count, dest_i, which));
 }
 
-static int triggerize_fanout(t_glist*x, t_object*obj)
+static int triggerize_fanout(t_glist *x, t_object *obj)
 {
-        /* replace all fanouts with [trigger]s
-         * if the fanning out object is already a trigger, just expand it */
-    const t_symbol*s_trigger=gensym("trigger");
-        /* shift trigger object slightly, to make it easier selectable in case of overlaps: */
+    /* replace all fanouts with [trigger]s
+     * if the fanning out object is already a trigger, just expand it */
+    const t_symbol *s_trigger = gensym("trigger");
+    /* shift trigger object slightly, to make it easier selectable in case of
+     * overlaps: */
     const int xoffset = -10;
     const int yoffset = 5;
-    int obj_nout=obj_noutlets(obj);
+    int obj_nout = obj_noutlets(obj);
     int nout;
     int posX = 0, posY;
-    int didit=0;
+    int didit = 0;
 
     int _x; /* dummy variable */
     gobj_getrect(o2g(obj), x, &_x, &_x, &_x, &posY);
     posY /= x->gl_zoom;
     posY += yoffset;
 
-        /* if the object is a [trigger], we just insert new outlets */
+    /* if the object is a [trigger], we just insert new outlets */
     if(s_trigger == obj->te_g.g_pd->c_name)
     {
         return triggerize_fanout_inplace(x, obj);
     }
-        /* for other objects, we create a new [trigger a a] object
-         *  and replace the fan-out with that */
-    for(nout=0; nout<obj_nout; nout++)
+    /* for other objects, we create a new [trigger a a] object
+     *  and replace the fan-out with that */
+    for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
-        int count=0;
-        if(obj_issignaloutlet(obj, nout))
-            continue;
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
+        int count = 0;
+        if(obj_issignaloutlet(obj, nout)) continue;
         while(conn)
         {
             int which;
-            t_object*dest=0;
-            t_inlet *in =0;
-            conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+            t_object *dest = 0;
+            t_inlet *in = 0;
+            conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
             count++;
         }
-        if(count>1)
+        if(count > 1)
         {
             int i, obj_i, stub_i;
             t_object *stub;
-                /* fan out: create a [t] object to resolve it */
+            /* fan out: create a [t] object to resolve it */
 
-                /* need to get the coordinates of the fanning outlet */
+            /* need to get the coordinates of the fanning outlet */
             t_linetraverser t;
-            t_binbuf*b=binbuf_new();
+            t_binbuf *b = binbuf_new();
             linetraverser_start(&t, x);
             while((conn = linetraverser_next(&t)))
             {
@@ -291,21 +293,22 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
             }
 
             obj_i = canvas_getindex(x, o2g(obj));
-            stub=0;
+            stub = 0;
             binbuf_clear(b);
-            binbuf_addv(b, "ssiis", gensym("#X"), gensym("obj"), posX, posY, gensym("t"));
-            for(i=0; i<count; i++)
+            binbuf_addv(b, "ssiis", gensym("#X"), gensym("obj"), posX, posY,
+                gensym("t"));
+            for(i = 0; i < count; i++)
             {
                 binbuf_addv(b, "s", gensym("a"));
             }
             binbuf_addsemi(b);
             canvas_undo_add(x, UNDO_PASTE, "paste",
                 canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
-            stub=triggerize_createobj(x, b);
+            stub = triggerize_createobj(x, b);
             binbuf_free(b);
             stub_i = canvas_getindex(x, o2g(stub));
-            conn=obj_starttraverseoutlet(obj, &out, nout);
-            triggerize_defanout(x, count-1, conn, obj, stub, nout);
+            conn = obj_starttraverseoutlet(obj, &out, nout);
+            triggerize_defanout(x, count - 1, conn, obj, stub, nout);
             obj_connect(obj, nout, stub, 0);
             canvas_undo_add(x, UNDO_CONNECT, "connect",
                 canvas_undo_set_connect(x, obj_i, nout, stub_i, 0));
@@ -315,16 +318,17 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
     }
     return didit;
 }
-static int triggerize_fanouts(t_glist*cnv)
+
+static int triggerize_fanouts(t_glist *cnv)
 {
-        /* iterate over all selected objects and try to eliminate fanouts */
-    t_gobj*gobj = NULL;
-    int count=0;
+    /* iterate over all selected objects and try to eliminate fanouts */
+    t_gobj *gobj = NULL;
+    int count = 0;
     canvas_undo_add(cnv, UNDO_SEQUENCE_START, "triggerize", 0);
-    for(gobj=cnv->gl_list; gobj; )
+    for(gobj = cnv->gl_list; gobj;)
     {
-        t_gobj*next=gobj->g_next;
-        t_object*obj=g2o(gobj);
+        t_gobj *next = gobj->g_next;
+        t_object *obj = g2o(gobj);
         if(obj && glist_isselected(cnv, gobj) && triggerize_fanout(cnv, obj))
             count++;
         gobj = next;
@@ -333,63 +337,65 @@ static int triggerize_fanouts(t_glist*cnv)
     return count;
 }
 
-static int triggerize_line(t_glist*x, t_triggerize_return*tr)
+static int triggerize_line(t_glist *x, t_triggerize_return *tr)
 {
-        /* triggerize a single selected line, by inserting a [t a] object
-         * (or it's signal equivalent) */
-    t_editor*ed=x->gl_editor;
+    /* triggerize a single selected line, by inserting a [t a] object
+     * (or it's signal equivalent) */
+    t_editor *ed = x->gl_editor;
     int src_obj, src_out, dst_obj, dst_in, new_obj;
     t_gobj *src = 0, *dst = 0;
-    t_binbuf*b=0;
-    int posx=100, posy=100;
-    t_object*stub=0;
+    t_binbuf *b = 0;
+    int posx = 100, posy = 100;
+    t_object *stub = 0;
     int sigline = 0;
     int dspstate = 0;
 
-    if(!ed->e_selectedline)
-        return 0;
-    src_obj=ed->e_selectline_index1;
-    src_out=ed->e_selectline_outno;
-    dst_obj=ed->e_selectline_index2;
-    dst_in =ed->e_selectline_inno;
-    for (src = x->gl_list; src_obj; src = src->g_next, src_obj--)
-        if (!src->g_next) goto bad;
-    for (dst = x->gl_list; dst_obj; dst = dst->g_next, dst_obj--)
-        if (!dst->g_next) goto bad;
-    src_obj=ed->e_selectline_index1;
-    dst_obj=ed->e_selectline_index2;
+    if(!ed->e_selectedline) return 0;
+    src_obj = ed->e_selectline_index1;
+    src_out = ed->e_selectline_outno;
+    dst_obj = ed->e_selectline_index2;
+    dst_in = ed->e_selectline_inno;
+    for(src = x->gl_list; src_obj; src = src->g_next, src_obj--)
+        if(!src->g_next) goto bad;
+    for(dst = x->gl_list; dst_obj; dst = dst->g_next, dst_obj--)
+        if(!dst->g_next) goto bad;
+    src_obj = ed->e_selectline_index1;
+    dst_obj = ed->e_selectline_index2;
 
     if(1)
     {
-        t_object*obj1=g2o(src);
-        t_object*obj2=g2o(dst);
+        t_object *obj1 = g2o(src);
+        t_object *obj2 = g2o(dst);
         if(obj1 && obj2)
         {
             float posSource, posSink;
             int nio;
             int _x; /* dummy variable */
             int posSourceY, posSinkY;
-            int boxHeight;  /* height of inserted box */
+            int boxHeight; /* height of inserted box */
             int posLeft, posRight;
 
-                /* get real x-position of the outlet */
+            /* get real x-position of the outlet */
             gobj_getrect(src, x, &posLeft, &_x, &posRight, &posSourceY);
             posLeft /= x->gl_zoom;
             posRight /= x->gl_zoom;
             posSourceY /= x->gl_zoom;
             nio = obj_noutlets(obj1);
-            posSource = posLeft + (posRight - posLeft - IOWIDTH) * src_out / ((nio==1)?1.:(nio-1.));
+            posSource = posLeft + (posRight - posLeft - IOWIDTH) * src_out /
+                                      ((nio == 1) ? 1. : (nio - 1.));
 
-                /* get real x-position of the inlet */
+            /* get real x-position of the inlet */
             gobj_getrect(dst, x, &posLeft, &posSinkY, &posRight, &_x);
             posLeft /= x->gl_zoom;
             posRight /= x->gl_zoom;
             posSinkY /= x->gl_zoom;
             nio = obj_ninlets(obj2);
-            posSink = posLeft + (posRight - posLeft - IOWIDTH) * dst_in / ((nio==1)?1.:(nio-1.));
+            posSink = posLeft + (posRight - posLeft - IOWIDTH) * dst_in /
+                                    ((nio == 1) ? 1. : (nio - 1.));
 
-		/* get height of the box that will be inserted */
-            boxHeight = glist_fontheight(x) / x->gl_zoom + 4; /* ATOM_BMARGIN = 4 */
+            /* get height of the box that will be inserted */
+            boxHeight =
+                glist_fontheight(x) / x->gl_zoom + 4; /* ATOM_BMARGIN = 4 */
 
             posx = (posSource + posSink) * 0.5;
             posy = (posSourceY + posSinkY - boxHeight) >> 1;
@@ -397,34 +403,35 @@ static int triggerize_line(t_glist*x, t_triggerize_return*tr)
     }
 
     sigline = obj_issignaloutlet(g2o(src), src_out);
-    if(sigline)
-        dspstate = canvas_suspend_dsp();
+    if(sigline) dspstate = canvas_suspend_dsp();
 
     canvas_undo_add(x, UNDO_SEQUENCE_START, "{insert object}", 0);
-    b=binbuf_new();
+    b = binbuf_new();
     if(sigline)
     {
-        binbuf_addv(b, "ssiiiisi;", gensym("#N"),
-            gensym("canvas"), 200, 100, 190, 200, gensym("nop~"), 0);
-        binbuf_addv(b, "ssiis;", gensym("#X"),
-            gensym("obj"), 50, 70, gensym("inlet~"));
-        binbuf_addv(b, "ssiis;", gensym("#X"),
-            gensym("obj"), 50,140, gensym("outlet~"));
-        binbuf_addv(b, "ssiiii;", gensym("#X"),
-            gensym("connect"), 0,0,1,0);
-        binbuf_addv(b, "ssiiss", gensym("#X"),
-            gensym("restore"), posx, posy, gensym("pd"), gensym("nop~"));
-    } else {
-        binbuf_addv(b,"ssii", gensym("#X"), gensym("obj"), posx, posy);
-        binbuf_addv(b,"ss", gensym("t"), gensym("a"));
+        binbuf_addv(b, "ssiiiisi;", gensym("#N"), gensym("canvas"), 200, 100,
+            190, 200, gensym("nop~"), 0);
+        binbuf_addv(
+            b, "ssiis;", gensym("#X"), gensym("obj"), 50, 70, gensym("inlet~"));
+        binbuf_addv(b, "ssiis;", gensym("#X"), gensym("obj"), 50, 140,
+            gensym("outlet~"));
+        binbuf_addv(b, "ssiiii;", gensym("#X"), gensym("connect"), 0, 0, 1, 0);
+        binbuf_addv(b, "ssiiss", gensym("#X"), gensym("restore"), posx, posy,
+            gensym("pd"), gensym("nop~"));
+    }
+    else
+    {
+        binbuf_addv(b, "ssii", gensym("#X"), gensym("obj"), posx, posy);
+        binbuf_addv(b, "ss", gensym("t"), gensym("a"));
     }
     binbuf_addsemi(b);
-    canvas_undo_add(x, UNDO_PASTE, "paste",
-        canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
+    canvas_undo_add(
+        x, UNDO_PASTE, "paste", canvas_undo_set_pastebinbuf(x, b, 0, 0, 0));
 
-    stub=triggerize_createobj(x, b);
+    stub = triggerize_createobj(x, b);
     new_obj = canvas_getindex(x, &stub->ob_g);
-    binbuf_free(b);b=0;
+    binbuf_free(b);
+    b = 0;
 
     obj_disconnect(g2o(src), src_out, g2o(dst), dst_in);
     canvas_undo_add(x, UNDO_DISCONNECT, "disconnect",
@@ -441,70 +448,71 @@ static int triggerize_line(t_glist*x, t_triggerize_return*tr)
     glist_select(x, o2g(stub));
 
     canvas_undo_add(x, UNDO_SEQUENCE_END, "{insert object}", 0);
-        /* remember the inserted object, so we can select/edit it later */
-    if(tr)
-        tr->tr_editgobj = o2g(stub);
-    if(sigline)
-        canvas_resume_dsp(dspstate);
+    /* remember the inserted object, so we can select/edit it later */
+    if(tr) tr->tr_editgobj = o2g(stub);
+    if(sigline) canvas_resume_dsp(dspstate);
     return 1;
 bad:
     return 0;
 }
-static int minimize_trigger(t_glist*cnv, t_object*obj)
+
+static int minimize_trigger(t_glist *cnv, t_object *obj)
 {
-        /* remove all unused outlets from [trigger] */
-    t_binbuf*b=binbuf_new();
-    t_atom*argv=binbuf_getvec(obj->te_binbuf);
-    t_object*stub=0;
-    int obj_nout=obj_noutlets(obj);
+    /* remove all unused outlets from [trigger] */
+    t_binbuf *b = binbuf_new();
+    t_atom *argv = binbuf_getvec(obj->te_binbuf);
+    t_object *stub = 0;
+    int obj_nout = obj_noutlets(obj);
     int nout, stub_i, obj_i = canvas_getindex(cnv, o2g(obj));
 
     int count = 0;
 
-    binbuf_addv(b, "ssii", gensym("#X"),
-        gensym("obj"), obj->te_xpix, obj->te_ypix);
+    binbuf_addv(
+        b, "ssii", gensym("#X"), gensym("obj"), obj->te_xpix, obj->te_ypix);
     binbuf_add(b, 1, argv);
-        /* go through all the outlets, and add those that have connections */
+    /* go through all the outlets, and add those that have connections */
     for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn = obj_starttraverseoutlet(obj, &out, nout);
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
         if(conn)
         {
             binbuf_add(b, 1, argv + 1 + nout);
-        } else {
+        }
+        else
+        {
             count++;
         }
     }
     if(!count || count == obj_nout)
     {
-            /* either no outlet to delete or all: skip this object */
+        /* either no outlet to delete or all: skip this object */
         binbuf_free(b);
         return 0;
     }
-        /* create the replacement object (which only has outlets that
-         * are going to be connected) */
-    canvas_undo_add(cnv, UNDO_PASTE, "paste",
-        canvas_undo_set_pastebinbuf(cnv, b, 0, 0, 0));
-    stub=triggerize_createobj(cnv, b);
+    /* create the replacement object (which only has outlets that
+     * are going to be connected) */
+    canvas_undo_add(
+        cnv, UNDO_PASTE, "paste", canvas_undo_set_pastebinbuf(cnv, b, 0, 0, 0));
+    stub = triggerize_createobj(cnv, b);
     stub_i = canvas_getindex(cnv, o2g(stub));
 
-        /* no go through the original object's outlets, and duplicate the
-         * connection of each to the new object */
-    for(nout=0, count=0; nout<obj_nout; nout++)
+    /* no go through the original object's outlets, and duplicate the
+     * connection of each to the new object */
+    for(nout = 0, count = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
         if(!conn) /* nothing connected here; skip it */
             continue;
 
-            /* repeat all connections of this outlet (should only be one) */
+        /* repeat all connections of this outlet (should only be one) */
         while(conn)
         {
             int which, dest_i;
-            t_object*dest=0;
-            t_inlet *in =0;
-            conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+            t_object *dest = 0;
+            t_inlet *in = 0;
+            conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
             dest_i = canvas_getindex(cnv, o2g(dest));
             obj_disconnect(obj, nout, dest, which);
             canvas_undo_add(cnv, UNDO_DISCONNECT, "disconnect",
@@ -520,44 +528,45 @@ static int minimize_trigger(t_glist*cnv, t_object*obj)
     obj_delete_undo(cnv, obj);
     return 1;
 }
-static int expand_trigger(t_glist*cnv, t_object*obj)
+
+static int expand_trigger(t_glist *cnv, t_object *obj)
 {
-        /* expand the trigger to the left, by inserting a first "a" outlet */
-    t_binbuf*b=binbuf_new();
-    int argc=binbuf_getnatom(obj->te_binbuf);
-    t_atom*argv=binbuf_getvec(obj->te_binbuf);
-    t_object*stub=0;
-    int obj_nout=obj_noutlets(obj);
+    /* expand the trigger to the left, by inserting a first "a" outlet */
+    t_binbuf *b = binbuf_new();
+    int argc = binbuf_getnatom(obj->te_binbuf);
+    t_atom *argv = binbuf_getvec(obj->te_binbuf);
+    t_object *stub = 0;
+    int obj_nout = obj_noutlets(obj);
     int stub_i, obj_i = canvas_getindex(cnv, o2g(obj));
     int nout;
 
-    binbuf_addv(b, "ssii", gensym("#X"),
-        gensym("obj"), obj->te_xpix, obj->te_ypix);
+    binbuf_addv(
+        b, "ssii", gensym("#X"), gensym("obj"), obj->te_xpix, obj->te_ypix);
     binbuf_add(b, 1, argv);
     binbuf_addv(b, "s", gensym("a"));
-    binbuf_add(b, argc-1, argv+1);
-    canvas_undo_add(cnv, UNDO_PASTE, "paste",
-        canvas_undo_set_pastebinbuf(cnv, b, 0, 0, 0));
-    stub=triggerize_createobj(cnv, b);
+    binbuf_add(b, argc - 1, argv + 1);
+    canvas_undo_add(
+        cnv, UNDO_PASTE, "paste", canvas_undo_set_pastebinbuf(cnv, b, 0, 0, 0));
+    stub = triggerize_createobj(cnv, b);
     stub_i = canvas_getindex(cnv, o2g(stub));
-    for(nout=0; nout<obj_nout; nout++)
+    for(nout = 0; nout < obj_nout; nout++)
     {
-        t_outlet*out=0;
-        t_outconnect*conn=obj_starttraverseoutlet(obj, &out, nout);
+        t_outlet *out = 0;
+        t_outconnect *conn = obj_starttraverseoutlet(obj, &out, nout);
         while(conn)
         {
             int which;
-            t_object*dest=0;
-            t_inlet *in =0;
+            t_object *dest = 0;
+            t_inlet *in = 0;
             int dest_i;
-            conn=obj_nexttraverseoutlet(conn, &dest, &in, &which);
+            conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
             dest_i = canvas_getindex(cnv, o2g(dest));
             obj_disconnect(obj, nout, dest, which);
             canvas_undo_add(cnv, UNDO_DISCONNECT, "disconnect",
                 canvas_undo_set_disconnect(cnv, obj_i, nout, dest_i, which));
-            obj_connect(stub, nout+1, dest, which);
+            obj_connect(stub, nout + 1, dest, which);
             canvas_undo_add(cnv, UNDO_CONNECT, "connect",
-                canvas_undo_set_connect(cnv, stub_i, nout+1, dest_i, which));
+                canvas_undo_set_connect(cnv, stub_i, nout + 1, dest_i, which));
         }
     }
     binbuf_free(b);
@@ -565,88 +574,86 @@ static int expand_trigger(t_glist*cnv, t_object*obj)
     obj_delete_undo(cnv, obj);
     return 1;
 }
-typedef int (*t_fun_withobject)(t_glist*, t_object*);
-static int with_triggers(t_glist*cnv, t_fun_withobject fun)
+
+typedef int (*t_fun_withobject)(t_glist *, t_object *);
+
+static int with_triggers(t_glist *cnv, t_fun_withobject fun)
 {
-        /* run <fun> on all selected [trigger] objects */
-    const t_symbol*s_trigger=gensym("trigger");
-    int count=0;
-    t_gobj*gobj = NULL;
-    for(gobj=cnv->gl_list; gobj;)
+    /* run <fun> on all selected [trigger] objects */
+    const t_symbol *s_trigger = gensym("trigger");
+    int count = 0;
+    t_gobj *gobj = NULL;
+    for(gobj = cnv->gl_list; gobj;)
     {
-        t_gobj*next=gobj->g_next;
-        t_object*obj=g2o(gobj);
+        t_gobj *next = gobj->g_next;
+        t_object *obj = g2o(gobj);
         if(obj && glist_isselected(cnv, gobj))
         {
-            const t_symbol*c_name=obj->te_g.g_pd->c_name;
-            if((s_trigger == c_name) && fun(cnv, obj))
-                count++;
+            const t_symbol *c_name = obj->te_g.g_pd->c_name;
+            if((s_trigger == c_name) && fun(cnv, obj)) count++;
         }
-        gobj=next;
+        gobj = next;
     }
     return count;
 }
-static int triggerize_triggers(t_glist*cnv)
+
+static int triggerize_triggers(t_glist *cnv)
 {
-        /* cleanup [trigger] objects */
-    int count=0;
+    /* cleanup [trigger] objects */
+    int count = 0;
 
-        /* nothing to do, if the selection is not exclusively [trigger] objects */
-    if(!only_triggers_selected(cnv))
-        return 0;
+    /* nothing to do, if the selection is not exclusively [trigger] objects */
+    if(!only_triggers_selected(cnv)) return 0;
 
-        /* TODO: here's the place to merge multiple connected triggers */
+    /* TODO: here's the place to merge multiple connected triggers */
 
-        /* remove all unused outlets from (selected) triggers */
+    /* remove all unused outlets from (selected) triggers */
     canvas_undo_add(cnv, UNDO_SEQUENCE_START, "{minimize triggers}", 0);
     count = with_triggers(cnv, minimize_trigger);
     canvas_undo_add(cnv, UNDO_SEQUENCE_END, "{minimize triggers}", 0);
-    if(count)
-        return count;
+    if(count) return count;
 
-        /* expand each (selected) trigger to the left */
+    /* expand each (selected) trigger to the left */
     canvas_undo_add(cnv, UNDO_SEQUENCE_START, "{expand triggers}", 0);
     count = with_triggers(cnv, expand_trigger);
     canvas_undo_add(cnv, UNDO_SEQUENCE_END, "{expand triggers}", 0);
-    if(count)
-        return count;
+    if(count) return count;
 
-        /* nothing more to do */
+    /* nothing more to do */
     return 0;
 }
 
-static int canvas_do_triggerize(t_glist*cnv, t_triggerize_return*tr)
+static int canvas_do_triggerize(t_glist *cnv, t_triggerize_return *tr)
 {
-        /*
-         * selected msg-connection: insert [t a] (->triggerize_line)
-         * selected sig-connection: insert [pd nop~] (->triggerize_line)
-         * selected [trigger]s with fan-outs: remove them (by inserting new outlets of the correct type) (->triggerize_fanouts)
-         * selected objects with fan-outs: remove fan-outs (->triggerize_fanouts)
-         * selected [trigger]: remove unused outlets (->triggerize_triggers)
-         * selected [trigger]: else, add left-most "a" outlet (->triggerize_triggers)
-         */
+    /*
+     * selected msg-connection: insert [t a] (->triggerize_line)
+     * selected sig-connection: insert [pd nop~] (->triggerize_line)
+     * selected [trigger]s with fan-outs: remove them (by inserting new outlets
+     * of the correct type) (->triggerize_fanouts) selected objects with
+     * fan-outs: remove fan-outs (->triggerize_fanouts) selected [trigger]:
+     * remove unused outlets (->triggerize_triggers) selected [trigger]: else,
+     * add left-most "a" outlet (->triggerize_triggers)
+     */
 
-    return(triggerize_line(cnv, tr)
-        || triggerize_fanouts(cnv)
-        || triggerize_triggers(cnv));
+    return (triggerize_line(cnv, tr) || triggerize_fanouts(cnv) ||
+            triggerize_triggers(cnv));
 }
-void canvas_triggerize(t_glist*cnv)
+
+void canvas_triggerize(t_glist *cnv)
 {
     int count = 0;
-    t_triggerize_return*tr;
-    if(!cnv || !cnv->gl_editor)
-        return;
-    if(!cnv->gl_editor->e_selection && !cnv->gl_editor->e_selectedline)
-        return;
+    t_triggerize_return *tr;
+    if(!cnv || !cnv->gl_editor) return;
+    if(!cnv->gl_editor->e_selection && !cnv->gl_editor->e_selectedline) return;
     tr = getbytes(sizeof(*tr));
-    if((count = canvas_do_triggerize(cnv, tr))) {
+    if((count = canvas_do_triggerize(cnv, tr)))
+    {
         canvas_dirty(cnv, 1);
-            /* fix display of connections, objects,... */
+        /* fix display of connections, objects,... */
         canvas_redraw(cnv);
         glist_redraw(cnv);
-            /* if we inserted an object, allow the user to change it now */
-        if(tr->tr_editgobj)
-            gobj_activate(tr->tr_editgobj, cnv, 1);
+        /* if we inserted an object, allow the user to change it now */
+        if(tr->tr_editgobj) gobj_activate(tr->tr_editgobj, cnv, 1);
     }
     freebytes(tr, sizeof(*tr));
 }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -280,7 +280,6 @@ static int triggerize_fanout(t_glist *x, t_object *obj)
         }
         if(count > 1)
         {
-            int i;
             int obj_i;
             int stub_i;
             t_object *stub;
@@ -304,7 +303,7 @@ static int triggerize_fanout(t_glist *x, t_object *obj)
             binbuf_clear(b);
             binbuf_addv(b, "ssiis", gensym("#X"), gensym("obj"), posX, posY,
                 gensym("t"));
-            for(i = 0; i < count; i++)
+            for(int i = 0; i < count; i++)
             {
                 binbuf_addv(b, "s", gensym("a"));
             }

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -82,7 +82,8 @@ static void obj_delete_undo(t_glist *x, t_object *obj)
 static t_object *triggerize_createobj(t_glist *x, t_binbuf *b)
 {
     /* send a binbuf to a canvas */
-    t_pd *boundx = s__X.s_thing, *boundn = s__N.s_thing;
+    t_pd *boundx = s__X.s_thing;
+    t_pd *boundn = s__N.s_thing;
     s__X.s_thing = &x->gl_pd;
     s__N.s_thing = &pd_canvasmaker;
 
@@ -99,7 +100,9 @@ static void stack_conn(t_glist *x, t_object *new, int *newoutlet, t_object *org,
     t_object *dest = 0;
     t_inlet *in = 0;
     int which;
-    int new_i, org_i, dest_i;
+    int new_i;
+    int org_i;
+    int dest_i;
     if(!conn) return;
     conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
     stack_conn(x, new, newoutlet, org, orgoutlet, conn);
@@ -166,7 +169,8 @@ static int triggerize_fanout_inplace(t_glist *x, t_object *obj)
     int posY = obj->te_ypix;
     t_atom *argv = binbuf_getvec(obj->te_binbuf);
     int obj_nout = obj_noutlets(obj);
-    int nout, newout;
+    int nout;
+    int newout;
     t_binbuf *b = 0;
     t_object *stub = 0;
     /* check if we actually do have a fan out */
@@ -244,7 +248,8 @@ static int triggerize_fanout(t_glist *x, t_object *obj)
     const int yoffset = 5;
     int obj_nout = obj_noutlets(obj);
     int nout;
-    int posX = 0, posY;
+    int posX = 0;
+    int posY;
     int didit = 0;
 
     int _x; /* dummy variable */
@@ -275,7 +280,9 @@ static int triggerize_fanout(t_glist *x, t_object *obj)
         }
         if(count > 1)
         {
-            int i, obj_i, stub_i;
+            int i;
+            int obj_i;
+            int stub_i;
             t_object *stub;
             /* fan out: create a [t] object to resolve it */
 
@@ -342,10 +349,16 @@ static int triggerize_line(t_glist *x, t_triggerize_return *tr)
     /* triggerize a single selected line, by inserting a [t a] object
      * (or it's signal equivalent) */
     t_editor *ed = x->gl_editor;
-    int src_obj, src_out, dst_obj, dst_in, new_obj;
-    t_gobj *src = 0, *dst = 0;
+    int src_obj;
+    int src_out;
+    int dst_obj;
+    int dst_in;
+    int new_obj;
+    t_gobj *src = 0;
+    t_gobj *dst = 0;
     t_binbuf *b = 0;
-    int posx = 100, posy = 100;
+    int posx = 100;
+    int posy = 100;
     t_object *stub = 0;
     int sigline = 0;
     int dspstate = 0;
@@ -368,12 +381,15 @@ static int triggerize_line(t_glist *x, t_triggerize_return *tr)
         t_object *obj2 = g2o(dst);
         if(obj1 && obj2)
         {
-            float posSource, posSink;
+            float posSource;
+            float posSink;
             int nio;
             int _x; /* dummy variable */
-            int posSourceY, posSinkY;
+            int posSourceY;
+            int posSinkY;
             int boxHeight; /* height of inserted box */
-            int posLeft, posRight;
+            int posLeft;
+            int posRight;
 
             /* get real x-position of the outlet */
             gobj_getrect(src, x, &posLeft, &_x, &posRight, &posSourceY);
@@ -463,7 +479,9 @@ static int minimize_trigger(t_glist *cnv, t_object *obj)
     t_atom *argv = binbuf_getvec(obj->te_binbuf);
     t_object *stub = 0;
     int obj_nout = obj_noutlets(obj);
-    int nout, stub_i, obj_i = canvas_getindex(cnv, o2g(obj));
+    int nout;
+    int stub_i;
+    int obj_i = canvas_getindex(cnv, o2g(obj));
 
     int count = 0;
 
@@ -509,7 +527,8 @@ static int minimize_trigger(t_glist *cnv, t_object *obj)
         /* repeat all connections of this outlet (should only be one) */
         while(conn)
         {
-            int which, dest_i;
+            int which;
+            int dest_i;
             t_object *dest = 0;
             t_inlet *in = 0;
             conn = obj_nexttraverseoutlet(conn, &dest, &in, &which);
@@ -537,7 +556,8 @@ static int expand_trigger(t_glist *cnv, t_object *obj)
     t_atom *argv = binbuf_getvec(obj->te_binbuf);
     t_object *stub = 0;
     int obj_nout = obj_noutlets(obj);
-    int stub_i, obj_i = canvas_getindex(cnv, o2g(obj));
+    int stub_i;
+    int obj_i = canvas_getindex(cnv, o2g(obj));
     int nout;
 
     binbuf_addv(

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -30,7 +30,9 @@ void glist_add(t_glist *x, t_gobj *y)
     t_object *ob;
     y->g_next = 0;
     if(!x->gl_list)
+    {
         x->gl_list = y;
+    }
     else
     {
         t_gobj *y2;
@@ -47,9 +49,11 @@ void glist_add(t_glist *x, t_gobj *y)
     }
     if(glist_isvisible(x)) gobj_vis(y, x, 1);
     if(class_isdrawcommand(y->g_pd))
+    {
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
                                         glist_getcanvas(x)->gl_name)),
             0);
+    }
 }
 
 /* this is to protect against a hairy problem in which deleting
@@ -111,17 +115,21 @@ void glist_delete(t_glist *x, t_gobj *y)
             else
             {
                 if(glist_isvisible(x))
+                {
                     text_eraseborder(&gl->gl_obj, x,
                         rtext_gettag(glist_findrtext(x, &gl->gl_obj)));
+                }
             }
         }
     }
     /* if we're a drawing command, erase all scalars now, before deleting
     it; we'll redraw them once it's deleted below. */
     if(drawcommand)
+    {
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
                                         glist_getcanvas(x)->gl_name)),
             2);
+    }
     gobj_delete(y, x);
     if(glist_isvisible(canvas))
     {
@@ -131,22 +139,30 @@ void glist_delete(t_glist *x, t_gobj *y)
         !(rtext = glist_findrtext(x, ob)))
         rtext = rtext_new(x, ob);
     if(x->gl_list == y)
+    {
         x->gl_list = y->g_next;
+    }
     else
+    {
         for(g = x->gl_list; g; g = g->g_next)
+        {
             if(g->g_next == y)
             {
                 g->g_next = y->g_next;
                 break;
             }
+        }
+    }
     if(y->g_pd == scalar_class) x->gl_valid = ++glist_valid;
     pd_free(&y->g_pd);
     if(rtext) rtext_free(rtext);
     if(chkdsp) canvas_update_dsp();
     if(drawcommand)
+    {
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
                                         glist_getcanvas(x)->gl_name)),
             1);
+    }
     canvas_setdeleting(canvas, wasdeleting);
 }
 
@@ -188,9 +204,13 @@ void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
 {
     t_glist *x2 = glist_getcanvas(x);
     if(motionfn)
+    {
         x2->gl_editor->e_onmotion = MA_PASSOUT;
+    }
     else
+    {
         x2->gl_editor->e_onmotion = 0;
+    }
     x2->gl_editor->e_grab = y;
     x2->gl_editor->e_motionfn = motionfn;
     x2->gl_editor->e_keyfn = keyfn;
@@ -232,30 +252,46 @@ static t_gobj *glist_merge(t_glist *x, t_gobj *g1, t_gobj *g2)
             if(g2)
             {
                 if(f1 <= f2)
+                {
                     goto put1;
+                }
                 else
+                {
                     goto put2;
+                }
             }
             else
                 goto put1;
         }
         else if(g2)
+        {
             goto put2;
+        }
         else
+        {
             break;
+        }
     put1:
         if(g9)
+        {
             g9->g_next = g1, g9 = g1;
+        }
         else
+        {
             g9 = g = g1;
+        }
         if((g1 = g1->g_next)) f1 = gobj_getxforsort(g1);
         g9->g_next = 0;
         continue;
     put2:
         if(g9)
+        {
             g9->g_next = g2, g9 = g2;
+        }
         else
+        {
             g9 = g = g2;
+        }
         if((g2 = g2->g_next)) f2 = gobj_getxforsort(g2);
         g9->g_next = 0;
     }
@@ -500,7 +536,9 @@ static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     if(argc < 1)
+    {
         pd_error(0, "graph_xlabel: no y value given");
+    }
     else
     {
         x->gl_xlabely = atom_getfloat(argv);
@@ -519,7 +557,9 @@ static void graph_ylabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     if(argc < 1)
+    {
         pd_error(0, "graph_ylabel: no x value given");
+    }
     else
     {
         x->gl_ylabelx = atom_getfloat(argv);
@@ -549,11 +589,13 @@ t_float glist_pixelstox(t_glist *x, t_float xpix)
     window right now, our range in our coordinates (x1, etc.) is spread
     over the visible window size, given by screenx1, etc. */
     if(x->gl_isgraph && x->gl_havewindow)
+    {
         return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * (xpix) /
                                (x->gl_screenx2 - x->gl_screenx1));
 
     /* otherwise, we appear in a graph within a parent glist,
      so get our screen rectangle on parent and transform. */
+    }
     else
     {
         int x1;
@@ -571,8 +613,10 @@ t_float glist_pixelstoy(t_glist *x, t_float ypix)
     if(!x->gl_isgraph)
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * ypix / x->gl_zoom);
     if(x->gl_isgraph && x->gl_havewindow)
+    {
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * (ypix) /
                                (x->gl_screeny2 - x->gl_screeny1));
+    }
     else
     {
         int x1;
@@ -591,8 +635,10 @@ t_float glist_xtopixels(t_glist *x, t_float xval)
     if(!x->gl_isgraph)
         return (((xval - x->gl_x1) * x->gl_zoom) / (x->gl_x2 - x->gl_x1));
     if(x->gl_isgraph && x->gl_havewindow)
+    {
         return (x->gl_screenx2 - x->gl_screenx1) * (xval - x->gl_x1) /
                (x->gl_x2 - x->gl_x1);
+    }
     else
     {
         int x1;
@@ -610,8 +656,10 @@ t_float glist_ytopixels(t_glist *x, t_float yval)
     if(!x->gl_isgraph)
         return (((yval - x->gl_y1) * x->gl_zoom) / (x->gl_y2 - x->gl_y1));
     if(x->gl_isgraph && x->gl_havewindow)
+    {
         return (x->gl_screeny2 - x->gl_screeny1) * (yval - x->gl_y1) /
                (x->gl_y2 - x->gl_y1);
+    }
     else
     {
         int x1;
@@ -648,12 +696,16 @@ int text_xpix(t_text *x, t_glist *glist)
     if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_xpix * glist->gl_zoom);
     if(glist->gl_goprect)
+    {
         return (glist_xtopixels(glist, glist->gl_x1) +
                 glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));
+    }
     else
+    {
         return (glist_xtopixels(glist,
             glist->gl_x1 + (glist->gl_x2 - glist->gl_x1) * x->te_xpix /
                                (glist->gl_screenx2 - glist->gl_screenx1)));
+    }
 }
 
 int text_ypix(t_text *x, t_glist *glist)
@@ -661,12 +713,16 @@ int text_ypix(t_text *x, t_glist *glist)
     if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_ypix * glist->gl_zoom);
     if(glist->gl_goprect)
+    {
         return (glist_ytopixels(glist, glist->gl_y1) +
                 glist->gl_zoom * (x->te_ypix - glist->gl_ymargin));
+    }
     else
+    {
         return (glist_ytopixels(glist,
             glist->gl_y1 + (glist->gl_y2 - glist->gl_y1) * x->te_ypix /
                                (glist->gl_screeny2 - glist->gl_screeny1)));
+    }
 }
 
 /* redraw all the items in a glist.  We construe this to mean
@@ -691,9 +747,11 @@ void glist_redraw(t_glist *x)
             /* redraw all the lines */
             linetraverser_start(&t, x);
             while((oc = linetraverser_next(&t)))
+            {
                 sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
                     glist_getcanvas(x), oc, t.tr_lx1, t.tr_ly1, t.tr_lx2,
                     t.tr_ly2);
+            }
             canvas_drawredrect(x, 0);
             if(x->gl_goprect)
             {
@@ -737,9 +795,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
 
     sprintf(tag, "graph%lx", (t_int) x);
     if(vis)
+    {
         glist_drawiofor(parent_glist, &x->gl_obj, 1, tag, x1, y1, x2, y2);
+    }
     else
+    {
         glist_eraseiofor(parent_glist, &x->gl_obj, tag);
+    }
     /* if we look like a graph but have been moved to a toplevel,
     just show the bounding rectangle */
     if(x->gl_havewindow)
@@ -780,6 +842,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         /* if there's just one "garray" in the graph, write its name
             along the top */
         for(i = (y1 < y2 ? y1 : y2) - 1, g = x->gl_list; g; g = g->g_next)
+        {
             if(g->g_pd == garray_class &&
                 !garray_getname((t_garray *) g, &arrayname))
             {
@@ -789,6 +852,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                     glist_getcanvas(x), x1, i, arrayname->s_name, sys_font, fs,
                     sys_fontweight, tag);
             }
+        }
 
         /* draw ticks on horizontal borders.  If lperb field is
         zero, this is disabled. */
@@ -797,9 +861,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             t_float upix;
             t_float lpix;
             if(y2 < y1)
+            {
                 upix = y1, lpix = y2;
+            }
             else
+            {
                 upix = y2, lpix = y1;
+            }
             for(i = 0, f = x->gl_xtick.k_point;
                 f < 0.99 * x->gl_x2 + 0.01 * x->gl_x1;
                 i++, f += x->gl_xtick.k_inc)
@@ -840,9 +908,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             t_float ubound;
             t_float lbound;
             if(x->gl_y2 < x->gl_y1)
+            {
                 ubound = x->gl_y1, lbound = x->gl_y2;
+            }
             else
+            {
                 ubound = x->gl_y2, lbound = x->gl_y1;
+            }
             for(i = 0, f = x->gl_ytick.k_point;
                 f < 0.99 * ubound + 0.01 * lbound; i++, f += x->gl_ytick.k_inc)
             {
@@ -876,6 +948,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         }
         /* draw x labels */
         for(i = 0; i < x->gl_nxlabels; i++)
+        {
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
                      "-anchor %s -tags [list %s label graph]\n",
                 glist_getcanvas(x),
@@ -883,15 +956,18 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                 (int) glist_ytopixels(x, x->gl_xlabely),
                 x->gl_xlabel[i]->s_name, sys_font, fs, sys_fontweight,
                 xlabelanchor, tag);
+        }
 
         /* draw y labels */
         for(i = 0; i < x->gl_nylabels; i++)
+        {
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
                      "-anchor %s -tags [list %s label graph]\n",
                 glist_getcanvas(x), (int) glist_xtopixels(x, x->gl_ylabelx),
                 (int) glist_ytopixels(x, atof(x->gl_ylabel[i]->s_name)),
                 x->gl_ylabel[i]->s_name, sys_font, fs, sys_fontweight,
                 ylabelanchor, tag);
+        }
 
         /* draw contents of graph as glist */
         for(g = x->gl_list; g; g = g->g_next)
@@ -986,7 +1062,9 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
     t_glist *x = (t_glist *) z;
     if(!x->gl_isgraph)
+    {
         text_widgetbehavior.w_displacefn(z, glist, dx, dy);
+    }
     else
     {
         x->gl_obj.te_xpix += dx;
@@ -1003,7 +1081,9 @@ static void graph_select(t_gobj *z, t_glist *glist, int state)
 {
     t_glist *x = (t_glist *) z;
     if(!x->gl_isgraph)
+    {
         text_widgetbehavior.w_selectfn(z, glist, state);
+    }
     else
     {
         t_rtext *y = glist_findrtext(glist, &x->gl_obj);
@@ -1060,14 +1140,18 @@ static void graph_motion(void *z, t_floatarg dx, t_floatarg dy)
     if(oldx < newx - 1)
     {
         for(i = oldx + 1; i <= newx; i++)
+        {
             vec[i].w_float = newy + (oldy - newy) * ((t_float) (newx - i)) /
                                         (t_float) (newx - oldx);
+        }
     }
     else if(oldx > newx + 1)
     {
         for(i = oldx - 1; i >= newx; i--)
+        {
             vec[i].w_float = newy + (oldy - newy) * ((t_float) (newx - i)) /
                                         (t_float) (newx - oldx);
+        }
     }
     else
         vec[newx].w_float = newy;
@@ -1081,10 +1165,14 @@ static int graph_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     t_gobj *y;
     int clickreturned = 0;
     if(!x->gl_isgraph)
+    {
         return (text_widgetbehavior.w_clickfn(
             z, glist, xpix, ypix, shift, alt, dbl, doit));
+    }
     if(x->gl_havewindow)
+    {
         return (0);
+    }
     else
     {
         for(y = x->gl_list; y; y = y->g_next)
@@ -1102,9 +1190,13 @@ static int graph_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
         if(!doit)
         {
             if(y)
+            {
                 canvas_setcursor(glist_getcanvas(x), clickreturned);
+            }
             else
+            {
                 canvas_setcursor(glist_getcanvas(x), CURSOR_RUNMODE_NOTHING);
+            }
         }
         return (clickreturned);
     }
@@ -1128,8 +1220,10 @@ t_glist *glist_findgraph(t_glist *x)
     t_gobj *y = 0;
     t_gobj *z;
     for(z = x->gl_list; z; z = z->g_next)
+    {
         if(pd_class(&z->g_pd) == canvas_class && ((t_glist *) z)->gl_isgraph)
             y = z;
+    }
     return ((t_glist *) y);
 }
 

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -534,7 +534,6 @@ static void graph_yticks(
 
 static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     if(argc < 1)
     {
         pd_error(0, "graph_xlabel: no y value given");
@@ -547,7 +546,7 @@ static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
         x->gl_xlabel = (t_symbol **) t_resizebytes(x->gl_xlabel,
             x->gl_nxlabels * sizeof(t_symbol *), argc * sizeof(t_symbol *));
         x->gl_nxlabels = argc;
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
             x->gl_xlabel[i] = atom_gensym(&argv[i]);
     }
     glist_redraw(x);
@@ -555,7 +554,6 @@ static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 
 static void graph_ylabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     if(argc < 1)
     {
         pd_error(0, "graph_ylabel: no x value given");
@@ -568,7 +566,7 @@ static void graph_ylabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
         x->gl_ylabel = (t_symbol **) t_resizebytes(x->gl_ylabel,
             x->gl_nylabels * sizeof(t_symbol *), argc * sizeof(t_symbol *));
         x->gl_nylabels = argc;
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
             x->gl_ylabel[i] = atom_gensym(&argv[i]);
     }
     glist_redraw(x);
@@ -776,7 +774,6 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
 {
     t_glist *x = (t_glist *) gr;
     char tag[50];
-    t_gobj *g;
     int x1;
     int y1;
     int x2;
@@ -823,9 +820,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
     /* otherwise draw (or erase) us as a graph inside another glist. */
     if(vis)
     {
-        int i;
         t_float f;
-        t_gobj *g;
         t_symbol *arrayname;
         char *ylabelanchor =
             (x->gl_ylabelx > 0.5 * (x->gl_x1 + x->gl_x2) ? "w" : "e");
@@ -841,6 +836,8 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
 
         /* if there's just one "garray" in the graph, write its name
             along the top */
+        int i;
+        t_gobj *g;
         for(i = (y1 < y2 ? y1 : y2) - 1, g = x->gl_list; g; g = g->g_next)
         {
             if(g->g_pd == garray_class &&
@@ -947,7 +944,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             }
         }
         /* draw x labels */
-        for(i = 0; i < x->gl_nxlabels; i++)
+        for(int i = 0; i < x->gl_nxlabels; i++)
         {
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
                      "-anchor %s -tags [list %s label graph]\n",
@@ -959,7 +956,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         }
 
         /* draw y labels */
-        for(i = 0; i < x->gl_nylabels; i++)
+        for(int i = 0; i < x->gl_nylabels; i++)
         {
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
                      "-anchor %s -tags [list %s label graph]\n",
@@ -970,13 +967,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         }
 
         /* draw contents of graph as glist */
-        for(g = x->gl_list; g; g = g->g_next)
+        for(t_gobj *g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 1);
     }
     else
     {
         sys_vgui(".x%lx.c delete %s\n", glist_getcanvas(x->gl_owner), tag);
-        for(g = x->gl_list; g; g = g->g_next)
+        for(t_gobj *g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 0);
     }
 }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -258,7 +258,6 @@ static t_gobj *glist_merge(t_glist *x, t_gobj *g1, t_gobj *g2)
             g9 = g = g2;
         if((g2 = g2->g_next)) f2 = gobj_getxforsort(g2);
         g9->g_next = 0;
-        continue;
     }
     return (g);
 }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -214,8 +214,7 @@ static t_float gobj_getxforsort(t_gobj *g)
         scalar_getbasexy((t_scalar *) g, &x1, &y1);
         return (x1);
     }
-    else
-        return (0);
+    return (0);
 }
 
 static t_gobj *glist_merge(t_glist *x, t_gobj *g1, t_gobj *g2)
@@ -268,21 +267,19 @@ static t_gobj *glist_dosort(t_glist *x, t_gobj *g, int nitems)
 {
     if(nitems < 2)
         return (g);
-    else
-    {
-        int n1 = nitems / 2;
-        int n2 = nitems - n1;
-        int i;
-        t_gobj *g2;
-        t_gobj *g3;
-        for(g2 = g, i = n1 - 1; i--; g2 = g2->g_next)
-            ;
-        g3 = g2->g_next;
-        g2->g_next = 0;
-        g = glist_dosort(x, g, n1);
-        g3 = glist_dosort(x, g3, n2);
-        return (glist_merge(x, g, g3));
-    }
+
+    int n1 = nitems / 2;
+    int n2 = nitems - n1;
+    int i;
+    t_gobj *g2;
+    t_gobj *g3;
+    for(g2 = g, i = n1 - 1; i--; g2 = g2->g_next)
+        ;
+    g3 = g2->g_next;
+    g2->g_next = 0;
+    g = glist_dosort(x, g, n1);
+    g3 = glist_dosort(x, g3, n2);
+    return (glist_merge(x, g, g3));
 }
 
 void glist_sort(t_glist *x)
@@ -552,7 +549,7 @@ t_float glist_pixelstox(t_glist *x, t_float xpix)
     /* if we're a graph when shown on parent, but own our own
     window right now, our range in our coordinates (x1, etc.) is spread
     over the visible window size, given by screenx1, etc. */
-    else if(x->gl_isgraph && x->gl_havewindow)
+    if(x->gl_isgraph && x->gl_havewindow)
         return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * (xpix) /
                                (x->gl_screenx2 - x->gl_screenx1));
 
@@ -574,7 +571,7 @@ t_float glist_pixelstoy(t_glist *x, t_float ypix)
 {
     if(!x->gl_isgraph)
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * ypix / x->gl_zoom);
-    else if(x->gl_isgraph && x->gl_havewindow)
+    if(x->gl_isgraph && x->gl_havewindow)
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * (ypix) /
                                (x->gl_screeny2 - x->gl_screeny1));
     else
@@ -594,7 +591,7 @@ t_float glist_xtopixels(t_glist *x, t_float xval)
 {
     if(!x->gl_isgraph)
         return (((xval - x->gl_x1) * x->gl_zoom) / (x->gl_x2 - x->gl_x1));
-    else if(x->gl_isgraph && x->gl_havewindow)
+    if(x->gl_isgraph && x->gl_havewindow)
         return (x->gl_screenx2 - x->gl_screenx1) * (xval - x->gl_x1) /
                (x->gl_x2 - x->gl_x1);
     else
@@ -613,7 +610,7 @@ t_float glist_ytopixels(t_glist *x, t_float yval)
 {
     if(!x->gl_isgraph)
         return (((yval - x->gl_y1) * x->gl_zoom) / (x->gl_y2 - x->gl_y1));
-    else if(x->gl_isgraph && x->gl_havewindow)
+    if(x->gl_isgraph && x->gl_havewindow)
         return (x->gl_screeny2 - x->gl_screeny1) * (yval - x->gl_y1) /
                (x->gl_y2 - x->gl_y1);
     else
@@ -651,7 +648,7 @@ int text_xpix(t_text *x, t_glist *glist)
 {
     if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_xpix * glist->gl_zoom);
-    else if(glist->gl_goprect)
+    if(glist->gl_goprect)
         return (glist_xtopixels(glist, glist->gl_x1) +
                 glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));
     else
@@ -664,7 +661,7 @@ int text_ypix(t_text *x, t_glist *glist)
 {
     if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_ypix * glist->gl_zoom);
-    else if(glist->gl_goprect)
+    if(glist->gl_goprect)
         return (glist_ytopixels(glist, glist->gl_y1) +
                 glist->gl_zoom * (x->te_ypix - glist->gl_ymargin));
     else
@@ -1087,7 +1084,7 @@ static int graph_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     if(!x->gl_isgraph)
         return (text_widgetbehavior.w_clickfn(
             z, glist, xpix, ypix, shift, alt, dbl, doit));
-    else if(x->gl_havewindow)
+    if(x->gl_havewindow)
         return (0);
     else
     {

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2001 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* This file deals with the behavior of glists as either "text objects" or
 "graphs" inside another glist.  LATER move the inlet/outlet code of g_canvas.c
@@ -16,10 +16,10 @@ to this file... */
 /* ---------------------- forward definitions ----------------- */
 
 static void graph_vis(t_gobj *gr, t_glist *unused_glist, int vis);
-static void graph_graphrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2);
-static void graph_getrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2);
+static void graph_graphrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2);
+static void graph_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2);
 
 /* -------------------- maintaining the list -------------------- */
 
@@ -29,31 +29,32 @@ void glist_add(t_glist *x, t_gobj *y)
 {
     t_object *ob;
     y->g_next = 0;
-    if (!x->gl_list) x->gl_list = y;
+    if(!x->gl_list)
+        x->gl_list = y;
     else
     {
         t_gobj *y2;
-        for (y2 = x->gl_list; y2->g_next; y2 = y2->g_next);
+        for(y2 = x->gl_list; y2->g_next; y2 = y2->g_next)
+            ;
         y2->g_next = y;
     }
-    if (x->gl_editor && (ob = pd_checkobject(&y->g_pd)))
-        rtext_new(x, ob);
-    if (x->gl_editor && x->gl_isgraph && !x->gl_goprect
-        && pd_checkobject(&y->g_pd))
+    if(x->gl_editor && (ob = pd_checkobject(&y->g_pd))) rtext_new(x, ob);
+    if(x->gl_editor && x->gl_isgraph && !x->gl_goprect &&
+        pd_checkobject(&y->g_pd))
     {
         x->gl_goprect = 1;
         canvas_drawredrect(x, 1);
     }
-    if (glist_isvisible(x))
-        gobj_vis(y, x, 1);
-    if (class_isdrawcommand(y->g_pd))
+    if(glist_isvisible(x)) gobj_vis(y, x, 1);
+    if(class_isdrawcommand(y->g_pd))
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
-            glist_getcanvas(x)->gl_name)), 0);
+                                        glist_getcanvas(x)->gl_name)),
+            0);
 }
 
-    /* this is to protect against a hairy problem in which deleting
-    a sub-canvas might delete an inlet on a box, after the box had
-    been invisible-ized, so that we have to protect against redrawing it! */
+/* this is to protect against a hairy problem in which deleting
+a sub-canvas might delete an inlet on a box, after the box had
+been invisible-ized, so that we have to protect against redrawing it! */
 int canvas_setdeleting(t_canvas *x, int flag)
 {
     int ret = x->gl_isdeleting;
@@ -61,10 +62,10 @@ int canvas_setdeleting(t_canvas *x, int flag)
     return (ret);
 }
 
-    /* JMZ: emit a closebang message */
+/* JMZ: emit a closebang message */
 void rtext_freefortext(t_glist *gl, t_text *who);
 
-    /* delete an object from a glist and free it */
+/* delete an object from a glist and free it */
 void glist_delete(t_glist *x, t_gobj *y)
 {
     t_gobj *g;
@@ -75,109 +76,109 @@ void glist_delete(t_glist *x, t_gobj *y)
     int drawcommand = class_isdrawcommand(y->g_pd);
     int wasdeleting;
 
-    if (pd_class(&y->g_pd) == canvas_class) {
-            /* JMZ: send a closebang to the canvas */
-        canvas_closebang((t_canvas *)y);
+    if(pd_class(&y->g_pd) == canvas_class)
+    {
+        /* JMZ: send a closebang to the canvas */
+        canvas_closebang((t_canvas *) y);
     }
 
     wasdeleting = canvas_setdeleting(canvas, 1);
-    if (x->gl_editor)
+    if(x->gl_editor)
     {
-            /* if we've grabbed events from canvas release them */
-        if (canvas->gl_editor && canvas->gl_editor->e_grab == y)
+        /* if we've grabbed events from canvas release them */
+        if(canvas->gl_editor && canvas->gl_editor->e_grab == y)
             canvas->gl_editor->e_grab = 0;
-                /* perhaps we grabbed our own glist instead? don't know if
-                this ever happens: */
-        if (x->gl_editor->e_grab == y)
-            x->gl_editor->e_grab = 0;
-        if (glist_isselected(x, y)) glist_deselect(x, y);
+        /* perhaps we grabbed our own glist instead? don't know if
+        this ever happens: */
+        if(x->gl_editor->e_grab == y) x->gl_editor->e_grab = 0;
+        if(glist_isselected(x, y)) glist_deselect(x, y);
 
-            /* HACK -- we had phantom outlets not getting erased on the
-            screen because the canvas_setdeleting() mechanism is too
-            crude.  LATER carefully set up rules for when the rtexts
-            should exist, so that they stay around until all the
-            steps of becoming invisible are done.  In the meantime, just
-            zap the inlets and outlets here... */
-        if (pd_class(&y->g_pd) == canvas_class)
+        /* HACK -- we had phantom outlets not getting erased on the
+        screen because the canvas_setdeleting() mechanism is too
+        crude.  LATER carefully set up rules for when the rtexts
+        should exist, so that they stay around until all the
+        steps of becoming invisible are done.  In the meantime, just
+        zap the inlets and outlets here... */
+        if(pd_class(&y->g_pd) == canvas_class)
         {
-            t_glist *gl = (t_glist *)y;
-            if (gl->gl_isgraph && glist_isvisible(x))
+            t_glist *gl = (t_glist *) y;
+            if(gl->gl_isgraph && glist_isvisible(x))
             {
                 char tag[80];
-                sprintf(tag, "graph%lx", (t_int)gl);
+                sprintf(tag, "graph%lx", (t_int) gl);
                 glist_eraseiofor(x, &gl->gl_obj, tag);
             }
             else
             {
-                if (glist_isvisible(x))
+                if(glist_isvisible(x))
                     text_eraseborder(&gl->gl_obj, x,
                         rtext_gettag(glist_findrtext(x, &gl->gl_obj)));
             }
         }
     }
-        /* if we're a drawing command, erase all scalars now, before deleting
-        it; we'll redraw them once it's deleted below. */
-    if (drawcommand)
+    /* if we're a drawing command, erase all scalars now, before deleting
+    it; we'll redraw them once it's deleted below. */
+    if(drawcommand)
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
-            glist_getcanvas(x)->gl_name)), 2);
+                                        glist_getcanvas(x)->gl_name)),
+            2);
     gobj_delete(y, x);
-    if (glist_isvisible(canvas))
+    if(glist_isvisible(canvas))
     {
         gobj_vis(y, x, 0);
     }
-    if (x->gl_editor && (ob = pd_checkobject(&y->g_pd)) &&
+    if(x->gl_editor && (ob = pd_checkobject(&y->g_pd)) &&
         !(rtext = glist_findrtext(x, ob)))
-            rtext = rtext_new(x, ob);
-    if (x->gl_list == y) x->gl_list = y->g_next;
-    else for (g = x->gl_list; g; g = g->g_next)
-        if (g->g_next == y)
-    {
-        g->g_next = y->g_next;
-        break;
-    }
-    if (y->g_pd == scalar_class)
-        x->gl_valid = ++glist_valid;
+        rtext = rtext_new(x, ob);
+    if(x->gl_list == y)
+        x->gl_list = y->g_next;
+    else
+        for(g = x->gl_list; g; g = g->g_next)
+            if(g->g_next == y)
+            {
+                g->g_next = y->g_next;
+                break;
+            }
+    if(y->g_pd == scalar_class) x->gl_valid = ++glist_valid;
     pd_free(&y->g_pd);
-    if (rtext)
-        rtext_free(rtext);
-    if (chkdsp) canvas_update_dsp();
-    if (drawcommand)
+    if(rtext) rtext_free(rtext);
+    if(chkdsp) canvas_update_dsp();
+    if(drawcommand)
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
-            glist_getcanvas(x)->gl_name)), 1);
+                                        glist_getcanvas(x)->gl_name)),
+            1);
     canvas_setdeleting(canvas, wasdeleting);
 }
 
-    /* remove every object from a glist.  Experimental. */
+/* remove every object from a glist.  Experimental. */
 void glist_clear(t_glist *x)
 {
     t_gobj *y;
     int dspstate = 0, suspended = 0;
     t_symbol *dspsym = gensym("dsp");
-    while ((y = x->gl_list))
+    while((y = x->gl_list))
     {
-            /* to avoid unnecessary DSP resorting, we suspend DSP
-            only if we hit a patchable object. */
-        if (!suspended && pd_checkobject(&y->g_pd) && zgetfn(&y->g_pd, dspsym))
+        /* to avoid unnecessary DSP resorting, we suspend DSP
+        only if we hit a patchable object. */
+        if(!suspended && pd_checkobject(&y->g_pd) && zgetfn(&y->g_pd, dspsym))
         {
             dspstate = canvas_suspend_dsp();
             suspended = 1;
         }
-            /* here's the real deletion. */
+        /* here's the real deletion. */
         glist_delete(x, y);
     }
-    if (suspended)
-        canvas_resume_dsp(dspstate);
+    if(suspended) canvas_resume_dsp(dspstate);
 }
 
 void glist_retext(t_glist *glist, t_text *y)
 {
     t_canvas *c = glist_getcanvas(glist);
-        /* check that we have built rtexts yet.  LATER need a better test. */
-    if (glist->gl_editor && glist->gl_editor->e_rtext)
+    /* check that we have built rtexts yet.  LATER need a better test. */
+    if(glist->gl_editor && glist->gl_editor->e_rtext)
     {
         t_rtext *rt = glist_findrtext(glist, y);
-        if (rt)
-            rtext_retext(rt);
+        if(rt) rtext_retext(rt);
     }
 }
 
@@ -185,9 +186,10 @@ void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
     t_glistkeyfn keyfn, int xpos, int ypos)
 {
     t_glist *x2 = glist_getcanvas(x);
-    if (motionfn)
+    if(motionfn)
         x2->gl_editor->e_onmotion = MA_PASSOUT;
-    else x2->gl_editor->e_onmotion = 0;
+    else
+        x2->gl_editor->e_onmotion = 0;
     x2->gl_editor->e_grab = y;
     x2->gl_editor->e_motionfn = motionfn;
     x2->gl_editor->e_keyfn = keyfn;
@@ -197,75 +199,76 @@ void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
 
 t_canvas *glist_getcanvas(t_glist *x)
 {
-    while (x->gl_owner && !x->gl_isclone && !x->gl_havewindow && x->gl_isgraph)
-            x = x->gl_owner;
-    return((t_canvas *)x);
+    while(x->gl_owner && !x->gl_isclone && !x->gl_havewindow && x->gl_isgraph)
+        x = x->gl_owner;
+    return ((t_canvas *) x);
 }
 
 static t_float gobj_getxforsort(t_gobj *g)
 {
-    if (pd_class(&g->g_pd) == scalar_class)
+    if(pd_class(&g->g_pd) == scalar_class)
     {
         t_float x1, y1;
-        scalar_getbasexy((t_scalar *)g, &x1, &y1);
-        return(x1);
+        scalar_getbasexy((t_scalar *) g, &x1, &y1);
+        return (x1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
 static t_gobj *glist_merge(t_glist *x, t_gobj *g1, t_gobj *g2)
 {
     t_gobj *g = 0, *g9 = 0;
     t_float f1 = 0, f2 = 0;
-    if (g1)
-        f1 = gobj_getxforsort(g1);
-    if (g2)
-        f2 = gobj_getxforsort(g2);
-    while (1)
+    if(g1) f1 = gobj_getxforsort(g1);
+    if(g2) f2 = gobj_getxforsort(g2);
+    while(1)
     {
-        if (g1)
+        if(g1)
         {
-            if (g2)
+            if(g2)
             {
-                if (f1 <= f2)
+                if(f1 <= f2)
                     goto put1;
-                else goto put2;
+                else
+                    goto put2;
             }
-            else goto put1;
+            else
+                goto put1;
         }
-        else if (g2)
+        else if(g2)
             goto put2;
-        else break;
+        else
+            break;
     put1:
-        if (g9)
+        if(g9)
             g9->g_next = g1, g9 = g1;
-        else g9 = g = g1;
-        if ((g1 = g1->g_next))
-            f1 = gobj_getxforsort(g1);
+        else
+            g9 = g = g1;
+        if((g1 = g1->g_next)) f1 = gobj_getxforsort(g1);
         g9->g_next = 0;
         continue;
     put2:
-        if (g9)
+        if(g9)
             g9->g_next = g2, g9 = g2;
-        else g9 = g = g2;
-        if ((g2 = g2->g_next))
-            f2 = gobj_getxforsort(g2);
+        else
+            g9 = g = g2;
+        if((g2 = g2->g_next)) f2 = gobj_getxforsort(g2);
         g9->g_next = 0;
         continue;
     }
     return (g);
 }
 
-static t_gobj *glist_dosort(t_glist *x,
-    t_gobj *g, int nitems)
+static t_gobj *glist_dosort(t_glist *x, t_gobj *g, int nitems)
 {
-    if (nitems < 2)
+    if(nitems < 2)
         return (g);
     else
     {
-        int n1 = nitems/2, n2 = nitems - n1, i;
+        int n1 = nitems / 2, n2 = nitems - n1, i;
         t_gobj *g2, *g3;
-        for (g2 = g, i = n1-1; i--; g2 = g2->g_next)
+        for(g2 = g, i = n1 - 1; i--; g2 = g2->g_next)
             ;
         g3 = g2->g_next;
         g2->g_next = 0;
@@ -280,45 +283,42 @@ void glist_sort(t_glist *x)
     int nitems = 0, foo = 0;
     t_float lastx = -1e37;
     t_gobj *g;
-    for (g = x->gl_list; g; g = g->g_next)
+    for(g = x->gl_list; g; g = g->g_next)
     {
         t_float x1 = gobj_getxforsort(g);
-        if (x1 < lastx)
-            foo = 1;
+        if(x1 < lastx) foo = 1;
         lastx = x1;
         nitems++;
     }
-    if (foo)
-        x->gl_list = glist_dosort(x, x->gl_list, nitems);
+    if(foo) x->gl_list = glist_dosort(x, x->gl_list, nitems);
 }
 
 /* --------------- inlets and outlets  ----------- */
 
-
 t_inlet *canvas_addinlet(t_canvas *x, t_pd *who, t_symbol *s)
 {
     t_inlet *ip = inlet_new(&x->gl_obj, who, s, 0);
-    if (!x->gl_loading && x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+    if(!x->gl_loading && x->gl_owner && !x->gl_isclone &&
+        glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
     }
-    if (!x->gl_loading) canvas_resortinlets(x);
+    if(!x->gl_loading) canvas_resortinlets(x);
     return (ip);
 }
 
 void canvas_rminlet(t_canvas *x, t_inlet *ip)
 {
     t_canvas *owner = x->gl_isclone ? NULL : x->gl_owner;
-    int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting)
-        && glist_istoplevel(owner));
+    int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting) &&
+                  glist_istoplevel(owner));
 
-    if (owner) canvas_deletelinesforio(owner, &x->gl_obj, ip, 0);
-    if (redraw)
-        gobj_vis(&x->gl_gobj, x->gl_owner, 0);
+    if(owner) canvas_deletelinesforio(owner, &x->gl_obj, ip, 0);
+    if(redraw) gobj_vis(&x->gl_gobj, x->gl_owner, 0);
     inlet_free(ip);
-    if (redraw)
+    if(redraw)
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
@@ -333,29 +333,28 @@ void canvas_resortinlets(t_canvas *x)
     int ninlets = 0, i, j, xmax;
     t_gobj *y, **vec, **vp, **maxp;
 
-    for (ninlets = 0, y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == vinlet_class) ninlets++;
+    for(ninlets = 0, y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == vinlet_class) ninlets++;
 
-    if (ninlets < 2) return;
+    if(ninlets < 2) return;
 
-    vec = (t_gobj **)getbytes(ninlets * sizeof(*vec));
+    vec = (t_gobj **) getbytes(ninlets * sizeof(*vec));
 
-    for (y = x->gl_list, vp = vec; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == vinlet_class) *vp++ = y;
+    for(y = x->gl_list, vp = vec; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == vinlet_class) *vp++ = y;
 
-    for (i = ninlets; i--;)
+    for(i = ninlets; i--;)
     {
         t_inlet *ip;
-        for (vp = vec, xmax = -0x7fffffff, maxp = 0, j = ninlets;
-            j--; vp++)
+        for(vp = vec, xmax = -0x7fffffff, maxp = 0, j = ninlets; j--; vp++)
         {
             int x1, y1, x2, y2;
             t_gobj *g = *vp;
-            if (!g) continue;
+            if(!g) continue;
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
-            if (x1 > xmax) xmax = x1, maxp = vp;
+            if(x1 > xmax) xmax = x1, maxp = vp;
         }
-        if (!maxp) break;
+        if(!maxp) break;
         y = *maxp;
         *maxp = 0;
         ip = vinlet_getit(&y->g_pd);
@@ -363,35 +362,35 @@ void canvas_resortinlets(t_canvas *x)
         obj_moveinletfirst(&x->gl_obj, ip);
     }
     freebytes(vec, ninlets * sizeof(*vec));
-    if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+    if(x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
 }
 
 t_outlet *canvas_addoutlet(t_canvas *x, t_pd *who, t_symbol *s)
 {
     t_outlet *op = outlet_new(&x->gl_obj, s);
-    if (!x->gl_loading && !x->gl_isclone && x->gl_owner && glist_isvisible(x->gl_owner))
+    if(!x->gl_loading && !x->gl_isclone && x->gl_owner &&
+        glist_isvisible(x->gl_owner))
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 0);
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
     }
-    if (!x->gl_loading) canvas_resortoutlets(x);
+    if(!x->gl_loading) canvas_resortoutlets(x);
     return (op);
 }
 
 void canvas_rmoutlet(t_canvas *x, t_outlet *op)
 {
     t_canvas *owner = x->gl_isclone ? NULL : x->gl_owner;
-    int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting)
-        && glist_istoplevel(owner));
+    int redraw = (owner && glist_isvisible(owner) && (!owner->gl_isdeleting) &&
+                  glist_istoplevel(owner));
 
-    if (owner) canvas_deletelinesforio(owner, &x->gl_obj, 0, op);
-    if (redraw)
-        gobj_vis(&x->gl_gobj, x->gl_owner, 0);
+    if(owner) canvas_deletelinesforio(owner, &x->gl_obj, 0, op);
+    if(redraw) gobj_vis(&x->gl_gobj, x->gl_owner, 0);
 
     outlet_free(op);
-    if (redraw)
+    if(redraw)
     {
         gobj_vis(&x->gl_gobj, x->gl_owner, 1);
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
@@ -406,29 +405,28 @@ void canvas_resortoutlets(t_canvas *x)
     int noutlets = 0, i, j, xmax;
     t_gobj *y, **vec, **vp, **maxp;
 
-    for (noutlets = 0, y = x->gl_list; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == voutlet_class) noutlets++;
+    for(noutlets = 0, y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == voutlet_class) noutlets++;
 
-    if (noutlets < 2) return;
+    if(noutlets < 2) return;
 
-    vec = (t_gobj **)getbytes(noutlets * sizeof(*vec));
+    vec = (t_gobj **) getbytes(noutlets * sizeof(*vec));
 
-    for (y = x->gl_list, vp = vec; y; y = y->g_next)
-        if (pd_class(&y->g_pd) == voutlet_class) *vp++ = y;
+    for(y = x->gl_list, vp = vec; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == voutlet_class) *vp++ = y;
 
-    for (i = noutlets; i--;)
+    for(i = noutlets; i--;)
     {
         t_outlet *ip;
-        for (vp = vec, xmax = -0x7fffffff, maxp = 0, j = noutlets;
-            j--; vp++)
+        for(vp = vec, xmax = -0x7fffffff, maxp = 0, j = noutlets; j--; vp++)
         {
             int x1, y1, x2, y2;
             t_gobj *g = *vp;
-            if (!g) continue;
+            if(!g) continue;
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
-            if (x1 > xmax) xmax = x1, maxp = vp;
+            if(x1 > xmax) xmax = x1, maxp = vp;
         }
-        if (!maxp) break;
+        if(!maxp) break;
         y = *maxp;
         *maxp = 0;
         ip = voutlet_getit(&y->g_pd);
@@ -436,22 +434,20 @@ void canvas_resortoutlets(t_canvas *x)
         obj_moveoutletfirst(&x->gl_obj, ip);
     }
     freebytes(vec, noutlets * sizeof(*vec));
-    if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+    if(x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         canvas_fixlinesfor(x->gl_owner, &x->gl_obj);
 }
 
 /* ----------calculating coordinates and controlling appearance --------- */
 
-
-static void graph_bounds(t_glist *x, t_floatarg x1, t_floatarg y1,
-    t_floatarg x2, t_floatarg y2)
+static void graph_bounds(
+    t_glist *x, t_floatarg x1, t_floatarg y1, t_floatarg x2, t_floatarg y2)
 {
     x->gl_x1 = x1;
     x->gl_x2 = x2;
     x->gl_y1 = y1;
     x->gl_y2 = y2;
-    if (x->gl_x2 == x->gl_x1 ||
-        x->gl_y2 == x->gl_y1)
+    if(x->gl_x2 == x->gl_x1 || x->gl_y2 == x->gl_y1)
     {
         pd_error(0, "graph: empty bounds rectangle");
         x1 = y1 = 0;
@@ -460,8 +456,8 @@ static void graph_bounds(t_glist *x, t_floatarg x1, t_floatarg y1,
     glist_redraw(x);
 }
 
-static void graph_xticks(t_glist *x,
-    t_floatarg point, t_floatarg inc, t_floatarg f)
+static void graph_xticks(
+    t_glist *x, t_floatarg point, t_floatarg inc, t_floatarg f)
 {
     x->gl_xtick.k_point = point;
     x->gl_xtick.k_inc = inc;
@@ -469,8 +465,8 @@ static void graph_xticks(t_glist *x,
     glist_redraw(x);
 }
 
-static void graph_yticks(t_glist *x,
-    t_floatarg point, t_floatarg inc, t_floatarg f)
+static void graph_yticks(
+    t_glist *x, t_floatarg point, t_floatarg inc, t_floatarg f)
 {
     x->gl_ytick.k_point = point;
     x->gl_ytick.k_inc = inc;
@@ -481,15 +477,18 @@ static void graph_yticks(t_glist *x,
 static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    if (argc < 1) pd_error(0, "graph_xlabel: no y value given");
+    if(argc < 1)
+        pd_error(0, "graph_xlabel: no y value given");
     else
     {
         x->gl_xlabely = atom_getfloat(argv);
-        argv++; argc--;
-        x->gl_xlabel = (t_symbol **)t_resizebytes(x->gl_xlabel,
-            x->gl_nxlabels * sizeof (t_symbol *), argc * sizeof (t_symbol *));
+        argv++;
+        argc--;
+        x->gl_xlabel = (t_symbol **) t_resizebytes(x->gl_xlabel,
+            x->gl_nxlabels * sizeof(t_symbol *), argc * sizeof(t_symbol *));
         x->gl_nxlabels = argc;
-        for (i = 0; i < argc; i++) x->gl_xlabel[i] = atom_gensym(&argv[i]);
+        for(i = 0; i < argc; i++)
+            x->gl_xlabel[i] = atom_gensym(&argv[i]);
     }
     glist_redraw(x);
 }
@@ -497,81 +496,79 @@ static void graph_xlabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 static void graph_ylabel(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    if (argc < 1) pd_error(0, "graph_ylabel: no x value given");
+    if(argc < 1)
+        pd_error(0, "graph_ylabel: no x value given");
     else
     {
         x->gl_ylabelx = atom_getfloat(argv);
-        argv++; argc--;
-        x->gl_ylabel = (t_symbol **)t_resizebytes(x->gl_ylabel,
-            x->gl_nylabels * sizeof (t_symbol *), argc * sizeof (t_symbol *));
+        argv++;
+        argc--;
+        x->gl_ylabel = (t_symbol **) t_resizebytes(x->gl_ylabel,
+            x->gl_nylabels * sizeof(t_symbol *), argc * sizeof(t_symbol *));
         x->gl_nylabels = argc;
-        for (i = 0; i < argc; i++) x->gl_ylabel[i] = atom_gensym(&argv[i]);
+        for(i = 0; i < argc; i++)
+            x->gl_ylabel[i] = atom_gensym(&argv[i]);
     }
     glist_redraw(x);
 }
 
 /****** routines to convert pixels to X or Y value and vice versa ******/
 
-    /* convert an x pixel value to an x coordinate value */
+/* convert an x pixel value to an x coordinate value */
 t_float glist_pixelstox(t_glist *x, t_float xpix)
 {
-        /* if we appear as a text box on parent, our range in our
-        coordinates (x1, etc.) specifies the coordinate range
-        of a one-pixel square at top left of the window. */
-    if (!x->gl_isgraph)
+    /* if we appear as a text box on parent, our range in our
+    coordinates (x1, etc.) specifies the coordinate range
+    of a one-pixel square at top left of the window. */
+    if(!x->gl_isgraph)
         return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * xpix / x->gl_zoom);
 
-        /* if we're a graph when shown on parent, but own our own
-        window right now, our range in our coordinates (x1, etc.) is spread
-        over the visible window size, given by screenx1, etc. */
-    else if (x->gl_isgraph && x->gl_havewindow)
-        return (x->gl_x1 + (x->gl_x2 - x->gl_x1) *
-            (xpix) / (x->gl_screenx2 - x->gl_screenx1));
+    /* if we're a graph when shown on parent, but own our own
+    window right now, our range in our coordinates (x1, etc.) is spread
+    over the visible window size, given by screenx1, etc. */
+    else if(x->gl_isgraph && x->gl_havewindow)
+        return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * (xpix) /
+                               (x->gl_screenx2 - x->gl_screenx1));
 
-        /* otherwise, we appear in a graph within a parent glist,
-         so get our screen rectangle on parent and transform. */
+    /* otherwise, we appear in a graph within a parent glist,
+     so get our screen rectangle on parent and transform. */
     else
     {
         int x1, y1, x2, y2;
-        if (!x->gl_owner)
-            bug("glist_pixelstox");
+        if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
-        return (x->gl_x1 + (x->gl_x2 - x->gl_x1) *
-            (xpix - x1) / (x2 - x1));
+        return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * (xpix - x1) / (x2 - x1));
     }
 }
 
 t_float glist_pixelstoy(t_glist *x, t_float ypix)
 {
-    if (!x->gl_isgraph)
+    if(!x->gl_isgraph)
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * ypix / x->gl_zoom);
-    else if (x->gl_isgraph && x->gl_havewindow)
-        return (x->gl_y1 + (x->gl_y2 - x->gl_y1) *
-                (ypix) / (x->gl_screeny2 - x->gl_screeny1));
+    else if(x->gl_isgraph && x->gl_havewindow)
+        return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * (ypix) /
+                               (x->gl_screeny2 - x->gl_screeny1));
     else
     {
         int x1, y1, x2, y2;
-        if (!x->gl_owner)
-            bug("glist_pixelstox");
+        if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
-        return (x->gl_y1 + (x->gl_y2 - x->gl_y1) *
-            (ypix - y1) / (y2 - y1));
+        return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * (ypix - y1) / (y2 - y1));
     }
 }
 
-    /* convert an x coordinate value to an x pixel location in window */
+/* convert an x coordinate value to an x pixel location in window */
 t_float glist_xtopixels(t_glist *x, t_float xval)
 {
-    if (!x->gl_isgraph)
+    if(!x->gl_isgraph)
         return (((xval - x->gl_x1) * x->gl_zoom) / (x->gl_x2 - x->gl_x1));
-    else if (x->gl_isgraph && x->gl_havewindow)
-        return (x->gl_screenx2 - x->gl_screenx1) *
-            (xval - x->gl_x1) / (x->gl_x2 - x->gl_x1);
+    else if(x->gl_isgraph && x->gl_havewindow)
+        return (x->gl_screenx2 - x->gl_screenx1) * (xval - x->gl_x1) /
+               (x->gl_x2 - x->gl_x1);
     else
     {
         int x1, y1, x2, y2;
-        if (!x->gl_owner)
-            bug("glist_pixelstox");
+        if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (x1 + (x2 - x1) * (xval - x->gl_x1) / (x->gl_x2 - x->gl_x1));
     }
@@ -579,24 +576,23 @@ t_float glist_xtopixels(t_glist *x, t_float xval)
 
 t_float glist_ytopixels(t_glist *x, t_float yval)
 {
-    if (!x->gl_isgraph)
+    if(!x->gl_isgraph)
         return (((yval - x->gl_y1) * x->gl_zoom) / (x->gl_y2 - x->gl_y1));
-    else if (x->gl_isgraph && x->gl_havewindow)
-        return (x->gl_screeny2 - x->gl_screeny1) *
-                (yval - x->gl_y1) / (x->gl_y2 - x->gl_y1);
+    else if(x->gl_isgraph && x->gl_havewindow)
+        return (x->gl_screeny2 - x->gl_screeny1) * (yval - x->gl_y1) /
+               (x->gl_y2 - x->gl_y1);
     else
     {
         int x1, y1, x2, y2;
-        if (!x->gl_owner)
-            bug("glist_pixelstox");
+        if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (y1 + (y2 - y1) * (yval - x->gl_y1) / (x->gl_y2 - x->gl_y1));
     }
 }
 
-    /* convert an X screen distance to an X coordinate increment.
-      This is terribly inefficient;
-      but probably not a big enough CPU hog to warrant optimizing. */
+/* convert an X screen distance to an X coordinate increment.
+  This is terribly inefficient;
+  but probably not a big enough CPU hog to warrant optimizing. */
 t_float glist_dpixtodx(t_glist *x, t_float dxpix)
 {
     return (dxpix * (glist_pixelstox(x, 1) - glist_pixelstox(x, 0)));
@@ -607,68 +603,70 @@ t_float glist_dpixtody(t_glist *x, t_float dypix)
     return (dypix * (glist_pixelstoy(x, 1) - glist_pixelstoy(x, 0)));
 }
 
-    /* get the window location in pixels of a "text" object.  The
-    object's x and y positions are in pixels when the glist they're
-    in is toplevel.  Otherwise, if it's a new-style graph-on-parent
-    (so gl_goprect is set) we use the offset into the framing subrectangle
-    as an offset into the parent rectangle.  Finally, it might be an old,
-    proportional-style GOP.  In this case we do a coordinate transformation. */
+/* get the window location in pixels of a "text" object.  The
+object's x and y positions are in pixels when the glist they're
+in is toplevel.  Otherwise, if it's a new-style graph-on-parent
+(so gl_goprect is set) we use the offset into the framing subrectangle
+as an offset into the parent rectangle.  Finally, it might be an old,
+proportional-style GOP.  In this case we do a coordinate transformation. */
 int text_xpix(t_text *x, t_glist *glist)
 {
-    if (glist->gl_havewindow || !glist->gl_isgraph)
+    if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_xpix * glist->gl_zoom);
-    else if (glist->gl_goprect)
+    else if(glist->gl_goprect)
         return (glist_xtopixels(glist, glist->gl_x1) +
-            glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));
-    else return (glist_xtopixels(glist,
-            glist->gl_x1 + (glist->gl_x2 - glist->gl_x1) *
-                x->te_xpix / (glist->gl_screenx2 - glist->gl_screenx1)));
+                glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));
+    else
+        return (glist_xtopixels(glist,
+            glist->gl_x1 + (glist->gl_x2 - glist->gl_x1) * x->te_xpix /
+                               (glist->gl_screenx2 - glist->gl_screenx1)));
 }
 
 int text_ypix(t_text *x, t_glist *glist)
 {
-    if (glist->gl_havewindow || !glist->gl_isgraph)
+    if(glist->gl_havewindow || !glist->gl_isgraph)
         return (x->te_ypix * glist->gl_zoom);
-    else if (glist->gl_goprect)
+    else if(glist->gl_goprect)
         return (glist_ytopixels(glist, glist->gl_y1) +
-            glist->gl_zoom * (x->te_ypix - glist->gl_ymargin));
-    else return (glist_ytopixels(glist,
-            glist->gl_y1 + (glist->gl_y2 - glist->gl_y1) *
-                x->te_ypix / (glist->gl_screeny2 - glist->gl_screeny1)));
+                glist->gl_zoom * (x->te_ypix - glist->gl_ymargin));
+    else
+        return (glist_ytopixels(glist,
+            glist->gl_y1 + (glist->gl_y2 - glist->gl_y1) * x->te_ypix /
+                               (glist->gl_screeny2 - glist->gl_screeny1)));
 }
 
-    /* redraw all the items in a glist.  We construe this to mean
-    redrawing in its own window and on parent, as needed in each case.
-    This is too conservative -- for instance, when you draw an "open"
-    rectangle on the parent, you shouldn't have to redraw the window!  */
+/* redraw all the items in a glist.  We construe this to mean
+redrawing in its own window and on parent, as needed in each case.
+This is too conservative -- for instance, when you draw an "open"
+rectangle on the parent, you shouldn't have to redraw the window!  */
 void glist_redraw(t_glist *x)
 {
-    if (glist_isvisible(x))
+    if(glist_isvisible(x))
     {
-            /* LATER fix the graph_vis() code to handle both cases */
-        if (glist_istoplevel(x))
+        /* LATER fix the graph_vis() code to handle both cases */
+        if(glist_istoplevel(x))
         {
             t_gobj *g;
             t_linetraverser t;
             t_outconnect *oc;
-            for (g = x->gl_list; g; g = g->g_next)
+            for(g = x->gl_list; g; g = g->g_next)
             {
                 gobj_vis(g, x, 0);
                 gobj_vis(g, x, 1);
             }
-                /* redraw all the lines */
+            /* redraw all the lines */
             linetraverser_start(&t, x);
-            while ((oc = linetraverser_next(&t)))
+            while((oc = linetraverser_next(&t)))
                 sys_vgui(".x%lx.c coords l%lx %d %d %d %d\n",
-                    glist_getcanvas(x), oc,
-                        t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
+                    glist_getcanvas(x), oc, t.tr_lx1, t.tr_ly1, t.tr_lx2,
+                    t.tr_ly2);
             canvas_drawredrect(x, 0);
-            if (x->gl_goprect)
+            if(x->gl_goprect)
             {
                 canvas_drawredrect(x, 1);
             }
         }
-        if (x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
+        if(x->gl_owner && !x->gl_isclone && glist_isvisible(x->gl_owner))
         {
             graph_vis(&x->gl_gobj, x->gl_owner, 0);
             graph_vis(&x->gl_gobj, x->gl_owner, 1);
@@ -680,198 +678,201 @@ void glist_redraw(t_glist *x)
 
 int garray_getname(t_garray *x, t_symbol **namep);
 
-
-    /* Note that some code in here would also be useful for drawing
-    graph decorations in toplevels... */
+/* Note that some code in here would also be useful for drawing
+graph decorations in toplevels... */
 static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
 {
-    t_glist *x = (t_glist *)gr;
+    t_glist *x = (t_glist *) gr;
     char tag[50];
     t_gobj *g;
     int x1, y1, x2, y2;
-        /* ordinary subpatches: just act like a text object */
-    if (!x->gl_isgraph)
+    /* ordinary subpatches: just act like a text object */
+    if(!x->gl_isgraph)
     {
         text_widgetbehavior.w_visfn(gr, parent_glist, vis);
         return;
     }
 
-    if (vis && canvas_showtext(x))
+    if(vis && canvas_showtext(x))
         rtext_draw(glist_findrtext(parent_glist, &x->gl_obj));
     graph_getrect(gr, parent_glist, &x1, &y1, &x2, &y2);
-    if (!vis)
-        rtext_erase(glist_findrtext(parent_glist, &x->gl_obj));
+    if(!vis) rtext_erase(glist_findrtext(parent_glist, &x->gl_obj));
 
-    sprintf(tag, "graph%lx", (t_int)x);
-    if (vis)
-        glist_drawiofor(parent_glist, &x->gl_obj, 1,
-            tag, x1, y1, x2, y2);
-    else glist_eraseiofor(parent_glist, &x->gl_obj, tag);
-        /* if we look like a graph but have been moved to a toplevel,
-        just show the bounding rectangle */
-    if (x->gl_havewindow)
+    sprintf(tag, "graph%lx", (t_int) x);
+    if(vis)
+        glist_drawiofor(parent_glist, &x->gl_obj, 1, tag, x1, y1, x2, y2);
+    else
+        glist_eraseiofor(parent_glist, &x->gl_obj, tag);
+    /* if we look like a graph but have been moved to a toplevel,
+    just show the bounding rectangle */
+    if(x->gl_havewindow)
     {
-        if (vis)
+        if(vis)
         {
             sys_vgui(".x%lx.c create polygon %d %d %d %d %d %d %d %d %d %d "
-                "-width %d -fill #c0c0c0 -joinstyle miter -tags [list %s graph]\n",
-                glist_getcanvas(x->gl_owner),
-                x1, y1, x1, y2, x2, y2, x2, y1, x1, y1, glist_getzoom(x), tag);
+                     "-width %d -fill #c0c0c0 -joinstyle miter -tags [list %s "
+                     "graph]\n",
+                glist_getcanvas(x->gl_owner), x1, y1, x1, y2, x2, y2, x2, y1,
+                x1, y1, glist_getzoom(x), tag);
         }
         else
         {
-            sys_vgui(".x%lx.c delete %s\n",
-                glist_getcanvas(x->gl_owner), tag);
+            sys_vgui(".x%lx.c delete %s\n", glist_getcanvas(x->gl_owner), tag);
         }
         return;
     }
-        /* otherwise draw (or erase) us as a graph inside another glist. */
-    if (vis)
+    /* otherwise draw (or erase) us as a graph inside another glist. */
+    if(vis)
     {
         int i;
         t_float f;
         t_gobj *g;
         t_symbol *arrayname;
         char *ylabelanchor =
-            (x->gl_ylabelx > 0.5*(x->gl_x1 + x->gl_x2) ? "w" : "e");
+            (x->gl_ylabelx > 0.5 * (x->gl_x1 + x->gl_x2) ? "w" : "e");
         char *xlabelanchor =
-            (x->gl_xlabely > 0.5*(x->gl_y1 + x->gl_y2) ? "s" : "n");
+            (x->gl_xlabely > 0.5 * (x->gl_y1 + x->gl_y2) ? "s" : "n");
         int fs = sys_hostfontsize(glist_getfont(x), glist_getzoom(x));
 
-            /* draw a rectangle around the graph */
+        /* draw a rectangle around the graph */
         sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
-            "-width %d -capstyle projecting -tags [list %s graph]\n",
-            glist_getcanvas(x->gl_owner),
-            x1, y1, x1, y2, x2, y2, x2, y1, x1, y1, glist_getzoom(x), tag);
+                 "-width %d -capstyle projecting -tags [list %s graph]\n",
+            glist_getcanvas(x->gl_owner), x1, y1, x1, y2, x2, y2, x2, y1, x1,
+            y1, glist_getzoom(x), tag);
 
-            /* if there's just one "garray" in the graph, write its name
-                along the top */
-        for (i = (y1 < y2 ? y1 : y2)-1, g = x->gl_list; g; g = g->g_next)
-            if (g->g_pd == garray_class &&
-                !garray_getname((t_garray *)g, &arrayname))
-        {
-            i -= glist_fontheight(x);
-            sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor nw "
-                "-font {{%s} -%d %s} -tags [list %s label graph]\n",
-                glist_getcanvas(x),  x1, i,
-                arrayname->s_name, sys_font,
-                fs, sys_fontweight, tag);
-        }
+        /* if there's just one "garray" in the graph, write its name
+            along the top */
+        for(i = (y1 < y2 ? y1 : y2) - 1, g = x->gl_list; g; g = g->g_next)
+            if(g->g_pd == garray_class &&
+                !garray_getname((t_garray *) g, &arrayname))
+            {
+                i -= glist_fontheight(x);
+                sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor nw "
+                         "-font {{%s} -%d %s} -tags [list %s label graph]\n",
+                    glist_getcanvas(x), x1, i, arrayname->s_name, sys_font, fs,
+                    sys_fontweight, tag);
+            }
 
-            /* draw ticks on horizontal borders.  If lperb field is
-            zero, this is disabled. */
-        if (x->gl_xtick.k_lperb)
+        /* draw ticks on horizontal borders.  If lperb field is
+        zero, this is disabled. */
+        if(x->gl_xtick.k_lperb)
         {
             t_float upix, lpix;
-            if (y2 < y1)
+            if(y2 < y1)
                 upix = y1, lpix = y2;
-            else upix = y2, lpix = y1;
-            for (i = 0, f = x->gl_xtick.k_point;
-                f < 0.99 * x->gl_x2 + 0.01*x->gl_x1; i++,
-                    f += x->gl_xtick.k_inc)
+            else
+                upix = y2, lpix = y1;
+            for(i = 0, f = x->gl_xtick.k_point;
+                f < 0.99 * x->gl_x2 + 0.01 * x->gl_x1;
+                i++, f += x->gl_xtick.k_inc)
             {
                 int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix, glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix, glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), (int) glist_xtopixels(x, f),
+                    (int) upix, (int) glist_xtopixels(x, f),
+                    (int) upix - tickpix, glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), (int) glist_xtopixels(x, f),
+                    (int) lpix, (int) glist_xtopixels(x, f),
+                    (int) lpix + tickpix, glist_getzoom(x), tag);
             }
-            for (i = 1, f = x->gl_xtick.k_point - x->gl_xtick.k_inc;
-                f > 0.99 * x->gl_x1 + 0.01*x->gl_x2;
-                    i++, f -= x->gl_xtick.k_inc)
+            for(i = 1, f = x->gl_xtick.k_point - x->gl_xtick.k_inc;
+                f > 0.99 * x->gl_x1 + 0.01 * x->gl_x2;
+                i++, f -= x->gl_xtick.k_inc)
             {
                 int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix, glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix, glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), (int) glist_xtopixels(x, f),
+                    (int) upix, (int) glist_xtopixels(x, f),
+                    (int) upix - tickpix, glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), (int) glist_xtopixels(x, f),
+                    (int) lpix, (int) glist_xtopixels(x, f),
+                    (int) lpix + tickpix, glist_getzoom(x), tag);
             }
         }
 
-            /* draw ticks in vertical borders*/
-        if (x->gl_ytick.k_lperb)
+        /* draw ticks in vertical borders*/
+        if(x->gl_ytick.k_lperb)
         {
             t_float ubound, lbound;
-            if (x->gl_y2 < x->gl_y1)
+            if(x->gl_y2 < x->gl_y1)
                 ubound = x->gl_y1, lbound = x->gl_y2;
-            else ubound = x->gl_y2, lbound = x->gl_y1;
-            for (i = 0, f = x->gl_ytick.k_point;
-                f < 0.99 * ubound + 0.01 * lbound;
-                    i++, f += x->gl_ytick.k_inc)
+            else
+                ubound = x->gl_y2, lbound = x->gl_y1;
+            for(i = 0, f = x->gl_ytick.k_point;
+                f < 0.99 * ubound + 0.01 * lbound; i++, f += x->gl_ytick.k_inc)
             {
                 int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), x1,
+                    (int) glist_ytopixels(x, f), x1 + tickpix,
+                    (int) glist_ytopixels(x, f), glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), x2,
+                    (int) glist_ytopixels(x, f), x2 - tickpix,
+                    (int) glist_ytopixels(x, f), glist_getzoom(x), tag);
             }
-            for (i = 1, f = x->gl_ytick.k_point - x->gl_ytick.k_inc;
-                f > 0.99 * lbound + 0.01 * ubound;
-                    i++, f -= x->gl_ytick.k_inc)
+            for(i = 1, f = x->gl_ytick.k_point - x->gl_ytick.k_inc;
+                f > 0.99 * lbound + 0.01 * ubound; i++, f -= x->gl_ytick.k_inc)
             {
                 int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
-                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags [list %s graph]\n",
-                    glist_getcanvas(x->gl_owner),
-                    x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f), glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), x1,
+                    (int) glist_ytopixels(x, f), x1 + tickpix,
+                    (int) glist_ytopixels(x, f), glist_getzoom(x), tag);
+                sys_vgui(".x%lx.c create line %d %d %d %d -width %d -tags "
+                         "[list %s graph]\n",
+                    glist_getcanvas(x->gl_owner), x2,
+                    (int) glist_ytopixels(x, f), x2 - tickpix,
+                    (int) glist_ytopixels(x, f), glist_getzoom(x), tag);
             }
         }
-            /* draw x labels */
-        for (i = 0; i < x->gl_nxlabels; i++)
+        /* draw x labels */
+        for(i = 0; i < x->gl_nxlabels; i++)
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
-                "-anchor %s -tags [list %s label graph]\n",
+                     "-anchor %s -tags [list %s label graph]\n",
                 glist_getcanvas(x),
-                (int)glist_xtopixels(x, atof(x->gl_xlabel[i]->s_name)),
-                (int)glist_ytopixels(x, x->gl_xlabely),
-                x->gl_xlabel[i]->s_name, sys_font,
-                fs, sys_fontweight, xlabelanchor, tag);
+                (int) glist_xtopixels(x, atof(x->gl_xlabel[i]->s_name)),
+                (int) glist_ytopixels(x, x->gl_xlabely),
+                x->gl_xlabel[i]->s_name, sys_font, fs, sys_fontweight,
+                xlabelanchor, tag);
 
-            /* draw y labels */
-        for (i = 0; i < x->gl_nylabels; i++)
+        /* draw y labels */
+        for(i = 0; i < x->gl_nylabels; i++)
             sys_vgui(".x%lx.c create text %d %d -text {%s} -font {{%s} -%d %s} "
-                "-anchor %s -tags [list %s label graph]\n",
-                glist_getcanvas(x),
-                (int)glist_xtopixels(x, x->gl_ylabelx),
-                (int)glist_ytopixels(x, atof(x->gl_ylabel[i]->s_name)),
-                x->gl_ylabel[i]->s_name, sys_font,
-                fs, sys_fontweight, ylabelanchor, tag);
+                     "-anchor %s -tags [list %s label graph]\n",
+                glist_getcanvas(x), (int) glist_xtopixels(x, x->gl_ylabelx),
+                (int) glist_ytopixels(x, atof(x->gl_ylabel[i]->s_name)),
+                x->gl_ylabel[i]->s_name, sys_font, fs, sys_fontweight,
+                ylabelanchor, tag);
 
-            /* draw contents of graph as glist */
-        for (g = x->gl_list; g; g = g->g_next)
+        /* draw contents of graph as glist */
+        for(g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 1);
     }
     else
     {
-        sys_vgui(".x%lx.c delete %s\n",
-            glist_getcanvas(x->gl_owner), tag);
-        for (g = x->gl_list; g; g = g->g_next)
+        sys_vgui(".x%lx.c delete %s\n", glist_getcanvas(x->gl_owner), tag);
+        for(g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 0);
     }
 }
 
-    /* get the graph's rectangle, not counting extra swelling for controls
-    to keep them inside the graph.  This is the "logical" pixel size. */
+/* get the graph's rectangle, not counting extra swelling for controls
+to keep them inside the graph.  This is the "logical" pixel size. */
 
-static void graph_graphrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void graph_graphrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_glist *x = (t_glist *)z;
+    t_glist *x = (t_glist *) z;
     int x1 = text_xpix(&x->gl_obj, glist);
     int y1 = text_ypix(&x->gl_obj, glist);
     int x2, y2;
@@ -884,29 +885,27 @@ static void graph_graphrect(t_gobj *z, t_glist *glist,
     *yp2 = y2;
 }
 
-    /* get the rectangle, enlarged to contain all the "contents" --
-    meaning their formal bounds rectangles. */
-static void graph_getrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+/* get the rectangle, enlarged to contain all the "contents" --
+meaning their formal bounds rectangles. */
+static void graph_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
     int x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff, y2 = -0x7fffffff;
-    t_glist *x = (t_glist *)z;
-    if (x->gl_isgraph)
+    t_glist *x = (t_glist *) z;
+    if(x->gl_isgraph)
     {
         int hadwindow;
         t_gobj *g;
         int x21, y21, x22, y22;
 
         graph_graphrect(z, glist, &x1, &y1, &x2, &y2);
-        if (canvas_showtext(x))
+        if(canvas_showtext(x))
         {
             text_widgetbehavior.w_getrectfn(z, glist, &x21, &y21, &x22, &y22);
-            if (x22 > x2)
-                x2 = x22;
-            if (y22 > y2)
-                y2 = y22;
+            if(x22 > x2) x2 = x22;
+            if(y22 > y2) y2 = y22;
         }
-        if (!x->gl_goprect)
+        if(!x->gl_goprect)
         {
             /* expand the rectangle to fit in text objects; this applies only
             to the old (0.37) graph-on-parent behavior. */
@@ -914,24 +913,23 @@ static void graph_getrect(t_gobj *z, t_glist *glist,
             calls below.  */
             hadwindow = x->gl_havewindow;
             x->gl_havewindow = 0;
-            for (g = x->gl_list; g; g = g->g_next)
+            for(g = x->gl_list; g; g = g->g_next)
             {
-                    /* don't do this for arrays, just let them hang outside the
-                    box.  And ignore "text" objects which aren't shown on
-                    parent */
-                if (pd_class(&g->g_pd) == garray_class ||
+                /* don't do this for arrays, just let them hang outside the
+                box.  And ignore "text" objects which aren't shown on
+                parent */
+                if(pd_class(&g->g_pd) == garray_class ||
                     pd_checkobject(&g->g_pd))
-                        continue;
+                    continue;
                 gobj_getrect(g, x, &x21, &y21, &x22, &y22);
-                if (x22 > x2)
-                    x2 = x22;
-                if (y22 > y2)
-                    y2 = y22;
+                if(x22 > x2) x2 = x22;
+                if(y22 > y2) y2 = y22;
             }
             x->gl_havewindow = hadwindow;
         }
     }
-    else text_widgetbehavior.w_getrectfn(z, glist, &x1, &y1, &x2, &y2);
+    else
+        text_widgetbehavior.w_getrectfn(z, glist, &x1, &y1, &x2, &y2);
     *xp1 = x1;
     *yp1 = y1;
     *xp2 = x2;
@@ -940,14 +938,15 @@ static void graph_getrect(t_gobj *z, t_glist *glist,
 
 static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
-    t_glist *x = (t_glist *)z;
-    if (!x->gl_isgraph)
+    t_glist *x = (t_glist *) z;
+    if(!x->gl_isgraph)
         text_widgetbehavior.w_displacefn(z, glist, dx, dy);
     else
     {
         x->gl_obj.te_xpix += dx;
         x->gl_obj.te_ypix += dy;
-        if (glist_isvisible(glist)) {
+        if(glist_isvisible(glist))
+        {
             glist_redraw(x);
             canvas_fixlinesfor(glist, &x->gl_obj);
         }
@@ -956,49 +955,46 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 
 static void graph_select(t_gobj *z, t_glist *glist, int state)
 {
-    t_glist *x = (t_glist *)z;
-    if (!x->gl_isgraph)
+    t_glist *x = (t_glist *) z;
+    if(!x->gl_isgraph)
         text_widgetbehavior.w_selectfn(z, glist, state);
     else
     {
         t_rtext *y = glist_findrtext(glist, &x->gl_obj);
-        if (canvas_showtext(x))
-            rtext_select(y, state);
-        sys_vgui(".x%lx.c itemconfigure %sR -fill %s\n", glist,
-        rtext_gettag(y), (state? "blue" : "black"));
+        if(canvas_showtext(x)) rtext_select(y, state);
+        sys_vgui(".x%lx.c itemconfigure %sR -fill %s\n", glist, rtext_gettag(y),
+            (state ? "blue" : "black"));
         sys_vgui(".x%lx.c itemconfigure graph%lx -fill %s\n",
-            glist_getcanvas(glist), z, (state? "blue" : "black"));
+            glist_getcanvas(glist), z, (state ? "blue" : "black"));
     }
 }
 
 static void graph_activate(t_gobj *z, t_glist *glist, int state)
 {
-    t_glist *x = (t_glist *)z;
-    if (canvas_showtext(x))
-        text_widgetbehavior.w_activatefn(z, glist, state);
+    t_glist *x = (t_glist *) z;
+    if(canvas_showtext(x)) text_widgetbehavior.w_activatefn(z, glist, state);
 }
 
 static void graph_delete(t_gobj *z, t_glist *glist)
 {
-    t_glist *x = (t_glist *)z;
+    t_glist *x = (t_glist *) z;
     t_gobj *y;
-    while ((y = x->gl_list))
+    while((y = x->gl_list))
         glist_delete(x, y);
-    if (glist_isvisible(x))
-        text_widgetbehavior.w_deletefn(z, glist);
-            /* if we have connections to the actual 'canvas' object, zap
-            them as well (e.g., array or scalar objects that are implemented
-            as canvases with "real" inlets).  Connections to ordinary canvas
-            in/outlets already got zapped when we cleared the contents above */
+    if(glist_isvisible(x)) text_widgetbehavior.w_deletefn(z, glist);
+    /* if we have connections to the actual 'canvas' object, zap
+    them as well (e.g., array or scalar objects that are implemented
+    as canvases with "real" inlets).  Connections to ordinary canvas
+    in/outlets already got zapped when we cleared the contents above */
     canvas_deletelinesfor(glist, &x->gl_obj);
 }
 
 static void graph_motion(void *z, t_floatarg dx, t_floatarg dy)
 {
-    t_glist *x = (t_glist *)z;
+    t_glist *x = (t_glist *) z;
     t_float newxpix = THISGUI->i_graph_lastxpix + dx,
-        newypix = THISGUI->i_graph_lastypix + dy;
-    t_garray *a = (t_garray *)(x->gl_list);
+            newypix = THISGUI->i_graph_lastypix + dy;
+    t_garray *a = (t_garray *) (x->gl_list);
     int oldx = 0.5 + glist_pixelstox(x, THISGUI->i_graph_lastxpix);
     int newx = 0.5 + glist_pixelstox(x, newxpix);
     t_word *vec;
@@ -1007,67 +1003,64 @@ static void graph_motion(void *z, t_floatarg dx, t_floatarg dy)
     t_float newy = glist_pixelstoy(x, newypix);
     THISGUI->i_graph_lastxpix = newxpix;
     THISGUI->i_graph_lastypix = newypix;
-        /* verify that the array is OK */
-    if (!a || pd_class((t_pd *)a) != garray_class)
-        return;
-    if (!garray_getfloatwords(a, &nelem, &vec))
-        return;
-    if (oldx < 0) oldx = 0;
-    if (oldx >= nelem)
-        oldx = nelem - 1;
-    if (newx < 0) newx = 0;
-    if (newx >= nelem)
-        newx = nelem - 1;
-    if (oldx < newx - 1)
+    /* verify that the array is OK */
+    if(!a || pd_class((t_pd *) a) != garray_class) return;
+    if(!garray_getfloatwords(a, &nelem, &vec)) return;
+    if(oldx < 0) oldx = 0;
+    if(oldx >= nelem) oldx = nelem - 1;
+    if(newx < 0) newx = 0;
+    if(newx >= nelem) newx = nelem - 1;
+    if(oldx < newx - 1)
     {
-        for (i = oldx + 1; i <= newx; i++)
-            vec[i].w_float = newy + (oldy - newy) *
-                ((t_float)(newx - i))/(t_float)(newx - oldx);
+        for(i = oldx + 1; i <= newx; i++)
+            vec[i].w_float = newy + (oldy - newy) * ((t_float) (newx - i)) /
+                                        (t_float) (newx - oldx);
     }
-    else if (oldx > newx + 1)
+    else if(oldx > newx + 1)
     {
-        for (i = oldx - 1; i >= newx; i--)
-            vec[i].w_float = newy + (oldy - newy) *
-                ((t_float)(newx - i))/(t_float)(newx - oldx);
+        for(i = oldx - 1; i >= newx; i--)
+            vec[i].w_float = newy + (oldy - newy) * ((t_float) (newx - i)) /
+                                        (t_float) (newx - oldx);
     }
-    else vec[newx].w_float = newy;
+    else
+        vec[newx].w_float = newy;
     garray_redraw(a);
 }
 
-static int graph_click(t_gobj *z, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int graph_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_glist *x = (t_glist *)z;
+    t_glist *x = (t_glist *) z;
     t_gobj *y;
     int clickreturned = 0;
-    if (!x->gl_isgraph)
-        return (text_widgetbehavior.w_clickfn(z, glist,
-            xpix, ypix, shift, alt, dbl, doit));
-    else if (x->gl_havewindow)
+    if(!x->gl_isgraph)
+        return (text_widgetbehavior.w_clickfn(
+            z, glist, xpix, ypix, shift, alt, dbl, doit));
+    else if(x->gl_havewindow)
         return (0);
     else
     {
-        for (y = x->gl_list; y; y = y->g_next)
+        for(y = x->gl_list; y; y = y->g_next)
         {
             int x1, y1, x2, y2;
-                /* check if the object wants to be clicked */
-            if (canvas_hitbox(x, y, xpix, ypix, &x1, &y1, &x2, &y2)
-                &&  (clickreturned = gobj_click(y, x, xpix, ypix,
-                    shift, alt, 0, doit)))
-                        break;
+            /* check if the object wants to be clicked */
+            if(canvas_hitbox(x, y, xpix, ypix, &x1, &y1, &x2, &y2) &&
+                (clickreturned =
+                        gobj_click(y, x, xpix, ypix, shift, alt, 0, doit)))
+                break;
         }
-        if (!doit)
+        if(!doit)
         {
-            if (y)
+            if(y)
                 canvas_setcursor(glist_getcanvas(x), clickreturned);
-            else canvas_setcursor(glist_getcanvas(x), CURSOR_RUNMODE_NOTHING);
+            else
+                canvas_setcursor(glist_getcanvas(x), CURSOR_RUNMODE_NOTHING);
         }
         return (clickreturned);
     }
 }
 
-const t_widgetbehavior graph_widgetbehavior =
-{
+const t_widgetbehavior graph_widgetbehavior = {
     graph_getrect,
     graph_displace,
     graph_select,
@@ -1077,16 +1070,16 @@ const t_widgetbehavior graph_widgetbehavior =
     graph_click,
 };
 
-    /* find the graph most recently added to this glist;
-        if none exists, return 0. */
+/* find the graph most recently added to this glist;
+    if none exists, return 0. */
 
 t_glist *glist_findgraph(t_glist *x)
 {
     t_gobj *y = 0, *z;
-    for (z = x->gl_list; z; z = z->g_next)
-        if (pd_class(&z->g_pd) == canvas_class && ((t_glist *)z)->gl_isgraph)
+    for(z = x->gl_list; z; z = z->g_next)
+        if(pd_class(&z->g_pd) == canvas_class && ((t_glist *) z)->gl_isgraph)
             y = z;
-    return ((t_glist *)y);
+    return ((t_glist *) y);
 }
 
 extern void canvas_menuarray(t_glist *canvas);
@@ -1094,25 +1087,19 @@ extern void canvas_menuarray(t_glist *canvas);
 void g_graph_setup_class(t_class *c)
 {
     class_setwidget(c, &graph_widgetbehavior);
-    class_addmethod(c, (t_method)graph_bounds, gensym("bounds"),
-        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(c, (t_method)graph_xticks, gensym("xticks"),
+    class_addmethod(c, (t_method) graph_bounds, gensym("bounds"), A_FLOAT,
         A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(c, (t_method)graph_xlabel, gensym("xlabel"),
-        A_GIMME, 0);
-    class_addmethod(c, (t_method)graph_yticks, gensym("yticks"),
-        A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(c, (t_method)graph_ylabel, gensym("ylabel"),
-        A_GIMME, 0);
-    class_addmethod(c, (t_method)graph_array, gensym("array"),
-        A_SYMBOL, A_FLOAT, A_SYMBOL, A_DEFFLOAT, A_NULL);
-    class_addmethod(c, (t_method)canvas_menuarray,
-        gensym("menuarray"), A_NULL);
-    class_addmethod(c, (t_method)glist_sort,
-        gensym("sort"), A_NULL);
+    class_addmethod(c, (t_method) graph_xticks, gensym("xticks"), A_FLOAT,
+        A_FLOAT, A_FLOAT, 0);
+    class_addmethod(c, (t_method) graph_xlabel, gensym("xlabel"), A_GIMME, 0);
+    class_addmethod(c, (t_method) graph_yticks, gensym("yticks"), A_FLOAT,
+        A_FLOAT, A_FLOAT, 0);
+    class_addmethod(c, (t_method) graph_ylabel, gensym("ylabel"), A_GIMME, 0);
+    class_addmethod(c, (t_method) graph_array, gensym("array"), A_SYMBOL,
+        A_FLOAT, A_SYMBOL, A_DEFFLOAT, A_NULL);
+    class_addmethod(
+        c, (t_method) canvas_menuarray, gensym("menuarray"), A_NULL);
+    class_addmethod(c, (t_method) glist_sort, gensym("sort"), A_NULL);
 }
 
-void g_graph_setup(void)
-{
-    g_graph_setup_class(canvas_class);
-}
+void g_graph_setup(void) { g_graph_setup_class(canvas_class); }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -154,7 +154,8 @@ void glist_delete(t_glist *x, t_gobj *y)
 void glist_clear(t_glist *x)
 {
     t_gobj *y;
-    int dspstate = 0, suspended = 0;
+    int dspstate = 0;
+    int suspended = 0;
     t_symbol *dspsym = gensym("dsp");
     while((y = x->gl_list))
     {
@@ -208,7 +209,8 @@ static t_float gobj_getxforsort(t_gobj *g)
 {
     if(pd_class(&g->g_pd) == scalar_class)
     {
-        t_float x1, y1;
+        t_float x1;
+        t_float y1;
         scalar_getbasexy((t_scalar *) g, &x1, &y1);
         return (x1);
     }
@@ -218,8 +220,10 @@ static t_float gobj_getxforsort(t_gobj *g)
 
 static t_gobj *glist_merge(t_glist *x, t_gobj *g1, t_gobj *g2)
 {
-    t_gobj *g = 0, *g9 = 0;
-    t_float f1 = 0, f2 = 0;
+    t_gobj *g = 0;
+    t_gobj *g9 = 0;
+    t_float f1 = 0;
+    t_float f2 = 0;
     if(g1) f1 = gobj_getxforsort(g1);
     if(g2) f2 = gobj_getxforsort(g2);
     while(1)
@@ -266,8 +270,11 @@ static t_gobj *glist_dosort(t_glist *x, t_gobj *g, int nitems)
         return (g);
     else
     {
-        int n1 = nitems / 2, n2 = nitems - n1, i;
-        t_gobj *g2, *g3;
+        int n1 = nitems / 2;
+        int n2 = nitems - n1;
+        int i;
+        t_gobj *g2;
+        t_gobj *g3;
         for(g2 = g, i = n1 - 1; i--; g2 = g2->g_next)
             ;
         g3 = g2->g_next;
@@ -280,7 +287,8 @@ static t_gobj *glist_dosort(t_glist *x, t_gobj *g, int nitems)
 
 void glist_sort(t_glist *x)
 {
-    int nitems = 0, foo = 0;
+    int nitems = 0;
+    int foo = 0;
     t_float lastx = -1e37;
     t_gobj *g;
     for(g = x->gl_list; g; g = g->g_next)
@@ -330,8 +338,14 @@ extern void obj_moveinletfirst(t_object *x, t_inlet *i);
 
 void canvas_resortinlets(t_canvas *x)
 {
-    int ninlets = 0, i, j, xmax;
-    t_gobj *y, **vec, **vp, **maxp;
+    int ninlets = 0;
+    int i;
+    int j;
+    int xmax;
+    t_gobj *y;
+    t_gobj **vec;
+    t_gobj **vp;
+    t_gobj **maxp;
 
     for(ninlets = 0, y = x->gl_list; y; y = y->g_next)
         if(pd_class(&y->g_pd) == vinlet_class) ninlets++;
@@ -348,7 +362,10 @@ void canvas_resortinlets(t_canvas *x)
         t_inlet *ip;
         for(vp = vec, xmax = -0x7fffffff, maxp = 0, j = ninlets; j--; vp++)
         {
-            int x1, y1, x2, y2;
+            int x1;
+            int y1;
+            int x2;
+            int y2;
             t_gobj *g = *vp;
             if(!g) continue;
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
@@ -402,8 +419,14 @@ extern void obj_moveoutletfirst(t_object *x, t_outlet *i);
 
 void canvas_resortoutlets(t_canvas *x)
 {
-    int noutlets = 0, i, j, xmax;
-    t_gobj *y, **vec, **vp, **maxp;
+    int noutlets = 0;
+    int i;
+    int j;
+    int xmax;
+    t_gobj *y;
+    t_gobj **vec;
+    t_gobj **vp;
+    t_gobj **maxp;
 
     for(noutlets = 0, y = x->gl_list; y; y = y->g_next)
         if(pd_class(&y->g_pd) == voutlet_class) noutlets++;
@@ -420,7 +443,10 @@ void canvas_resortoutlets(t_canvas *x)
         t_outlet *ip;
         for(vp = vec, xmax = -0x7fffffff, maxp = 0, j = noutlets; j--; vp++)
         {
-            int x1, y1, x2, y2;
+            int x1;
+            int y1;
+            int x2;
+            int y2;
             t_gobj *g = *vp;
             if(!g) continue;
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
@@ -534,7 +560,10 @@ t_float glist_pixelstox(t_glist *x, t_float xpix)
      so get our screen rectangle on parent and transform. */
     else
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * (xpix - x1) / (x2 - x1));
@@ -550,7 +579,10 @@ t_float glist_pixelstoy(t_glist *x, t_float ypix)
                                (x->gl_screeny2 - x->gl_screeny1));
     else
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * (ypix - y1) / (y2 - y1));
@@ -567,7 +599,10 @@ t_float glist_xtopixels(t_glist *x, t_float xval)
                (x->gl_x2 - x->gl_x1);
     else
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (x1 + (x2 - x1) * (xval - x->gl_x1) / (x->gl_x2 - x->gl_x1));
@@ -583,7 +618,10 @@ t_float glist_ytopixels(t_glist *x, t_float yval)
                (x->gl_y2 - x->gl_y1);
     else
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
         if(!x->gl_owner) bug("glist_pixelstox");
         graph_graphrect(&x->gl_gobj, x->gl_owner, &x1, &y1, &x2, &y2);
         return (y1 + (y2 - y1) * (yval - x->gl_y1) / (x->gl_y2 - x->gl_y1));
@@ -685,7 +723,10 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
     t_glist *x = (t_glist *) gr;
     char tag[50];
     t_gobj *g;
-    int x1, y1, x2, y2;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
     /* ordinary subpatches: just act like a text object */
     if(!x->gl_isgraph)
     {
@@ -757,7 +798,8 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         zero, this is disabled. */
         if(x->gl_xtick.k_lperb)
         {
-            t_float upix, lpix;
+            t_float upix;
+            t_float lpix;
             if(y2 < y1)
                 upix = y1, lpix = y2;
             else
@@ -799,7 +841,8 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         /* draw ticks in vertical borders*/
         if(x->gl_ytick.k_lperb)
         {
-            t_float ubound, lbound;
+            t_float ubound;
+            t_float lbound;
             if(x->gl_y2 < x->gl_y1)
                 ubound = x->gl_y1, lbound = x->gl_y2;
             else
@@ -875,7 +918,8 @@ static void graph_graphrect(
     t_glist *x = (t_glist *) z;
     int x1 = text_xpix(&x->gl_obj, glist);
     int y1 = text_ypix(&x->gl_obj, glist);
-    int x2, y2;
+    int x2;
+    int y2;
     x2 = x1 + x->gl_zoom * x->gl_pixwidth;
     y2 = y1 + x->gl_zoom * x->gl_pixheight;
 
@@ -890,13 +934,19 @@ meaning their formal bounds rectangles. */
 static void graph_getrect(
     t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    int x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff, y2 = -0x7fffffff;
+    int x1 = 0x7fffffff;
+    int y1 = 0x7fffffff;
+    int x2 = -0x7fffffff;
+    int y2 = -0x7fffffff;
     t_glist *x = (t_glist *) z;
     if(x->gl_isgraph)
     {
         int hadwindow;
         t_gobj *g;
-        int x21, y21, x22, y22;
+        int x21;
+        int y21;
+        int x22;
+        int y22;
 
         graph_graphrect(z, glist, &x1, &y1, &x2, &y2);
         if(canvas_showtext(x))
@@ -992,13 +1042,14 @@ static void graph_delete(t_gobj *z, t_glist *glist)
 static void graph_motion(void *z, t_floatarg dx, t_floatarg dy)
 {
     t_glist *x = (t_glist *) z;
-    t_float newxpix = THISGUI->i_graph_lastxpix + dx,
-            newypix = THISGUI->i_graph_lastypix + dy;
+    t_float newxpix = THISGUI->i_graph_lastxpix + dx;
+    t_float newypix = THISGUI->i_graph_lastypix + dy;
     t_garray *a = (t_garray *) (x->gl_list);
     int oldx = 0.5 + glist_pixelstox(x, THISGUI->i_graph_lastxpix);
     int newx = 0.5 + glist_pixelstox(x, newxpix);
     t_word *vec;
-    int nelem, i;
+    int nelem;
+    int i;
     t_float oldy = glist_pixelstoy(x, THISGUI->i_graph_lastypix);
     t_float newy = glist_pixelstoy(x, newypix);
     THISGUI->i_graph_lastxpix = newxpix;
@@ -1042,7 +1093,10 @@ static int graph_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     {
         for(y = x->gl_list; y; y = y->g_next)
         {
-            int x1, y1, x2, y2;
+            int x1;
+            int y1;
+            int x2;
+            int y2;
             /* check if the object wants to be clicked */
             if(canvas_hitbox(x, y, xpix, ypix, &x1, &y1, &x2, &y2) &&
                 (clickreturned =
@@ -1075,7 +1129,8 @@ const t_widgetbehavior graph_widgetbehavior = {
 
 t_glist *glist_findgraph(t_glist *x)
 {
-    t_gobj *y = 0, *z;
+    t_gobj *y = 0;
+    t_gobj *z;
     for(z = x->gl_list; z; z = z->g_next)
         if(pd_class(&z->g_pd) == canvas_class && ((t_glist *) z)->gl_isgraph)
             y = z;

--- a/src/g_guiconnect.c
+++ b/src/g_guiconnect.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2000 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  a thing to forward messages from the GUI, dealing with race conditions
 in which the "target" gets deleted while the GUI is sending it something.
@@ -24,61 +24,55 @@ static t_class *guiconnect_class;
 
 t_guiconnect *guiconnect_new(t_pd *who, t_symbol *sym)
 {
-    t_guiconnect *x = (t_guiconnect *)pd_new(guiconnect_class);
+    t_guiconnect *x = (t_guiconnect *) pd_new(guiconnect_class);
     x->x_who = who;
     x->x_sym = sym;
     pd_bind(&x->x_obj.ob_pd, sym);
     return (x);
 }
 
-    /* cleanup routine; delete any resources we have */
+/* cleanup routine; delete any resources we have */
 static void guiconnect_free(t_guiconnect *x)
 {
-    if (x->x_sym)
-        pd_unbind(&x->x_obj.ob_pd, x->x_sym);
-    if (x->x_clock)
-        clock_free(x->x_clock);
+    if(x->x_sym) pd_unbind(&x->x_obj.ob_pd, x->x_sym);
+    if(x->x_clock) clock_free(x->x_clock);
 }
 
-    /* this is called when the clock times out to indicate the GUI should
-    be gone by now. */
-static void guiconnect_tick(t_guiconnect *x)
-{
-    pd_free(&x->x_obj.ob_pd);
-}
+/* this is called when the clock times out to indicate the GUI should
+be gone by now. */
+static void guiconnect_tick(t_guiconnect *x) { pd_free(&x->x_obj.ob_pd); }
 
-    /* the target calls this to disconnect.  If the gui has "signed off"
-    we're ready to delete the object; otherwise we wait either for signoff
-    or for a timeout. */
+/* the target calls this to disconnect.  If the gui has "signed off"
+we're ready to delete the object; otherwise we wait either for signoff
+or for a timeout. */
 void guiconnect_notarget(t_guiconnect *x, double timedelay)
 {
-    if (!x->x_sym)
+    if(!x->x_sym)
         pd_free(&x->x_obj.ob_pd);
     else
     {
         x->x_who = 0;
-        if (timedelay > 0)
+        if(timedelay > 0)
         {
-            x->x_clock = clock_new(x, (t_method)guiconnect_tick);
+            x->x_clock = clock_new(x, (t_method) guiconnect_tick);
             clock_delay(x->x_clock, timedelay);
         }
     }
 }
 
-    /* the GUI calls this to send messages to the target. */
-static void guiconnect_anything(t_guiconnect *x,
-    t_symbol *s, int ac, t_atom *av)
+/* the GUI calls this to send messages to the target. */
+static void guiconnect_anything(
+    t_guiconnect *x, t_symbol *s, int ac, t_atom *av)
 {
-    if (x->x_who)
-        typedmess(x->x_who, s, ac, av);
+    if(x->x_who) typedmess(x->x_who, s, ac, av);
 }
 
-    /* the GUI calls this when it disappears.  (If there's any chance the
-    GUI will fail to do this, the "target", when it signs off, should specify
-    a timeout after which the guiconnect will disappear.) */
+/* the GUI calls this when it disappears.  (If there's any chance the
+GUI will fail to do this, the "target", when it signs off, should specify
+a timeout after which the guiconnect will disappear.) */
 static void guiconnect_signoff(t_guiconnect *x)
 {
-    if (!x->x_who)
+    if(!x->x_who)
         pd_free(&x->x_obj.ob_pd);
     else
     {
@@ -90,8 +84,8 @@ static void guiconnect_signoff(t_guiconnect *x)
 void g_guiconnect_setup(void)
 {
     guiconnect_class = class_new(gensym("guiconnect"), 0,
-        (t_method)guiconnect_free, sizeof(t_guiconnect), CLASS_PD, 0);
+        (t_method) guiconnect_free, sizeof(t_guiconnect), CLASS_PD, 0);
     class_addanything(guiconnect_class, guiconnect_anything);
-    class_addmethod(guiconnect_class, (t_method)guiconnect_signoff,
-        gensym("signoff"), 0);
+    class_addmethod(
+        guiconnect_class, (t_method) guiconnect_signoff, gensym("signoff"), 0);
 }

--- a/src/g_guiconnect.c
+++ b/src/g_guiconnect.c
@@ -48,7 +48,9 @@ or for a timeout. */
 void guiconnect_notarget(t_guiconnect *x, double timedelay)
 {
     if(!x->x_sym)
+    {
         pd_free(&x->x_obj.ob_pd);
+    }
     else
     {
         x->x_who = 0;
@@ -73,7 +75,9 @@ a timeout after which the guiconnect will disappear.) */
 static void guiconnect_signoff(t_guiconnect *x)
 {
     if(!x->x_who)
+    {
         pd_free(&x->x_obj.ob_pd);
+    }
     else
     {
         pd_unbind(&x->x_obj.ob_pd, x->x_sym);

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -81,15 +81,19 @@ void hradio_draw_new(t_hradio *x, t_glist *glist)
         x->x_drawn = x->x_on;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xx11b, yy12 + IEMGUI_ZOOM(x) - ioh, xx11b + iow, yy12, x,
             0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xx11b, yy11, xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh, x,
             0);
+    }
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
              "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
         canvas, xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -134,11 +138,15 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
         xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
         yy11 + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xx11b,
             yy12 + IEMGUI_ZOOM(x) - ioh, xx11b + iow, yy12);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xx11b,
             yy11, xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh);
+    }
 }
 
 void hradio_draw_erase(t_hradio *x, t_glist *glist)
@@ -254,19 +262,33 @@ void hradio_draw_select(t_hradio *x, t_glist *glist)
 void hradio_draw(t_hradio *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         sys_queuegui(x, glist, hradio_draw_update);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         hradio_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         hradio_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         hradio_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         hradio_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         hradio_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         hradio_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ hdl widgetbehaviour----------------------------- */
@@ -528,8 +550,10 @@ static int hradio_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     int shift, int alt, int dbl, int doit)
 {
     if(doit)
+    {
         hradio_click((t_hradio *) z, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
+    }
     return (1);
 }
 
@@ -660,9 +684,13 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;
@@ -676,9 +704,13 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     if(on < 0) on = 0;
     if(on >= x->x_number) on = x->x_number - 1;
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_on = on;
+    }
     else
+    {
         x->x_on = 0;
+    }
     x->x_on_old = x->x_on;
     x->x_change = (chg == 0) ? 0 : 1;
     if(x->x_gui.x_fsf.x_rcv_able)

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -48,13 +48,20 @@ void hradio_draw_update(t_gobj *client, t_glist *glist)
 
 void hradio_draw_new(t_hradio *x, t_glist *glist)
 {
-    int n = x->x_number, i, dx = x->x_gui.x_w, s4 = dx / 4;
-    int yy11 = text_ypix(&x->x_gui.x_obj, glist), yy12 = yy11 + dx;
-    int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b,
-        xx21 = xx11b + s4;
+    int n = x->x_number;
+    int i;
+    int dx = x->x_gui.x_w;
+    int s4 = dx / 4;
+    int yy11 = text_ypix(&x->x_gui.x_obj, glist);
+    int yy12 = yy11 + dx;
+    int yy21 = yy11 + s4;
+    int yy22 = yy12 - s4;
+    int xx11b = text_xpix(&x->x_gui.x_obj, glist);
+    int xx11 = xx11b;
+    int xx21 = xx11b + s4;
     int xx22 = xx11b + dx - s4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
@@ -94,13 +101,20 @@ void hradio_draw_new(t_hradio *x, t_glist *glist)
 
 void hradio_draw_move(t_hradio *x, t_glist *glist)
 {
-    int n = x->x_number, i, dx = x->x_gui.x_w, s4 = dx / 4;
-    int yy11 = text_ypix(&x->x_gui.x_obj, glist), yy12 = yy11 + dx;
-    int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b,
-        xx21 = xx11b + s4;
+    int n = x->x_number;
+    int i;
+    int dx = x->x_gui.x_w;
+    int s4 = dx / 4;
+    int yy11 = text_ypix(&x->x_gui.x_obj, glist);
+    int yy12 = yy11 + dx;
+    int yy21 = yy11 + s4;
+    int yy22 = yy12 - s4;
+    int xx11b = text_xpix(&x->x_gui.x_obj, glist);
+    int xx11 = xx11b;
+    int xx21 = xx11b + s4;
     int xx22 = xx11b + dx - s4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     xx11 = xx11b;
@@ -129,7 +143,8 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
 
 void hradio_draw_erase(t_hradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
@@ -146,7 +161,8 @@ void hradio_draw_erase(t_hradio *x, t_glist *glist)
 
 void hradio_draw_config(t_hradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
@@ -168,7 +184,8 @@ void hradio_draw_io(t_hradio *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -208,7 +225,8 @@ void hradio_draw_io(t_hradio *x, t_glist *glist, int old_snd_rcv_flags)
 
 void hradio_draw_select(t_hradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
@@ -597,8 +615,12 @@ static void hradio_single_change(t_hradio *x) { x->x_change = 0; }
 static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
 {
     t_hradio *x = (t_hradio *) pd_new(old ? hradio_old_class : hradio_class);
-    int a = IEM_GUI_DEFAULTSIZE, on = 0;
-    int ldx = 0, ldy = -8, chg = 1, num = 8;
+    int a = IEM_GUI_DEFAULTSIZE;
+    int on = 0;
+    int ldx = 0;
+    int ldy = -8;
+    int chg = 1;
+    int num = 8;
     int fs = 10;
     t_float fval = 0;
 

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -33,17 +33,15 @@ static t_class *hradio_class, *hradio_old_class;
 
 void hradio_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_hradio *x = (t_hradio *)client;
+    t_hradio *x = (t_hradio *) client;
     if(glist_isvisible(glist))
     {
         t_canvas *canvas = glist_getcanvas(glist);
 
         sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
-                 canvas, x, x->x_drawn,
-                 x->x_gui.x_bcol, x->x_gui.x_bcol);
+            canvas, x, x->x_drawn, x->x_gui.x_bcol, x->x_gui.x_bcol);
         sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
-                 canvas, x, x->x_on,
-                 x->x_gui.x_fcol, x->x_gui.x_fcol);
+            canvas, x, x->x_on, x->x_gui.x_fcol, x->x_gui.x_fcol);
         x->x_drawn = x->x_on;
     }
 }
@@ -53,43 +51,45 @@ void hradio_draw_new(t_hradio *x, t_glist *glist)
     int n = x->x_number, i, dx = x->x_gui.x_w, s4 = dx / 4;
     int yy11 = text_ypix(&x->x_gui.x_obj, glist), yy12 = yy11 + dx;
     int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b, xx21 = xx11b + s4;
+    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b,
+        xx21 = xx11b + s4;
     int xx22 = xx11b + dx - s4;
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE%d\n",
-                 canvas, xx11, yy11, xx11 + dx, yy12, IEMGUI_ZOOM(x),
-                 x->x_gui.x_bcol, x, i);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x -tags %lxBUT%d\n",
-                 canvas, xx21, yy21, xx22, yy22,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x, i);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x "
+                 "-tags %lxBASE%d\n",
+            canvas, xx11, yy11, xx11 + dx, yy12, IEMGUI_ZOOM(x),
+            x->x_gui.x_bcol, x, i);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline "
+                 "#%06x -tags %lxBUT%d\n",
+            canvas, xx21, yy21, xx22, yy22,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x, i);
         xx11 += dx;
         xx21 += dx;
         xx22 += dx;
         x->x_drawn = x->x_on;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xx11b, yy12 + IEMGUI_ZOOM(x) - ioh,
-             xx11b + iow, yy12,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xx11b, yy12 + IEMGUI_ZOOM(x) - ioh, xx11b + iow, yy12, x,
+            0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xx11b, yy11,
-             xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             yy11 + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xx11b, yy11, xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh, x,
+            0);
+    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
+             "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
+        canvas, xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        yy11 + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 void hradio_draw_move(t_hradio *x, t_glist *glist)
@@ -97,7 +97,8 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
     int n = x->x_number, i, dx = x->x_gui.x_w, s4 = dx / 4;
     int yy11 = text_ypix(&x->x_gui.x_obj, glist), yy12 = yy11 + dx;
     int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b, xx21 = xx11b + s4;
+    int xx11b = text_xpix(&x->x_gui.x_obj, glist), xx11 = xx11b,
+        xx21 = xx11b + s4;
     int xx22 = xx11b + dx - s4;
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
@@ -107,30 +108,26 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
     xx22 = xx11b + dx - s4;
     for(i = 0; i < n; i++)
     {
-        sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n",
-                 canvas, x, i, xx11, yy11, xx11 + dx, yy12);
-        sys_vgui(".x%lx.c coords %lxBUT%d %d %d %d %d\n",
-                 canvas, x, i, xx21, yy21, xx22, yy22);
+        sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n", canvas, x, i, xx11,
+            yy11, xx11 + dx, yy12);
+        sys_vgui(".x%lx.c coords %lxBUT%d %d %d %d %d\n", canvas, x, i, xx21,
+            yy21, xx22, yy22);
         xx11 += dx;
         xx21 += dx;
         xx22 += dx;
     }
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             yy11 + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xx11b + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        yy11 + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xx11b, yy12 + IEMGUI_ZOOM(x) - ioh,
-             xx11b + iow, yy12);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xx11b,
+            yy12 + IEMGUI_ZOOM(x) - ioh, xx11b + iow, yy12);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xx11b, yy11,
-             xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh);
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xx11b,
+            yy11, xx11b + iow, yy11 - IEMGUI_ZOOM(x) + ioh);
 }
 
-void hradio_draw_erase(t_hradio* x, t_glist* glist)
+void hradio_draw_erase(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
@@ -147,26 +144,27 @@ void hradio_draw_erase(t_hradio* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void hradio_draw_config(t_hradio* x, t_glist* glist)
+void hradio_draw_config(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize, sys_fontweight,
-             x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED:x->x_gui.x_lcol,
-             strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize, sys_fontweight,
+        x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
+        strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
     for(i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c itemconfigure %lxBASE%d -fill #%06x\n", canvas, x, i,
-                 x->x_gui.x_bcol);
-        sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n", canvas, x, i,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+            x->x_gui.x_bcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
+            canvas, x, i, (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
     }
 }
 
-void hradio_draw_io(t_hradio* x, t_glist* glist, int old_snd_rcv_flags)
+void hradio_draw_io(t_hradio *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
@@ -175,37 +173,40 @@ void hradio_draw_io(t_hradio* x, t_glist* glist, int old_snd_rcv_flags)
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-                 canvas,
-                 xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-                 xpos + iow, ypos + x->x_gui.x_h,
-                 x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep these above outlet */
-        if(x->x_on == 0) {
-            sys_vgui(".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
-            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        if(x->x_on == 0)
+        {
+            sys_vgui(
+                ".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(
+                ".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
         }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
     if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-                 canvas,
-                 xpos, ypos,
-                 xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-                 x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep these above inlet */
-        if(x->x_on == 0) {
-            sys_vgui(".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
-            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        if(x->x_on == 0)
+        {
+            sys_vgui(
+                ".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(
+                ".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
         }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void hradio_draw_select(t_hradio* x, t_glist* glist)
+void hradio_draw_select(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
@@ -214,20 +215,21 @@ void hradio_draw_select(t_hradio* x, t_glist* glist)
     {
         for(i = 0; i < n; i++)
         {
-            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas, x, i,
-                     IEM_GUI_COLOR_SELECTED);
+            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
+                x, i, IEM_GUI_COLOR_SELECTED);
         }
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
         for(i = 0; i < n; i++)
         {
-            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas, x, i,
-                     IEM_GUI_COLOR_NORMAL);
+            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
+                x, i, IEM_GUI_COLOR_NORMAL);
         }
         sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
-                 x->x_gui.x_lcol);
+            x->x_gui.x_lcol);
     }
 }
 
@@ -251,9 +253,10 @@ void hradio_draw(t_hradio *x, t_glist *glist, int mode)
 
 /* ------------------------ hdl widgetbehaviour----------------------------- */
 
-static void hradio_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
+static void hradio_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_hradio *x = (t_hradio *)z;
+    t_hradio *x = (t_hradio *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -263,28 +266,27 @@ static void hradio_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *x
 
 static void hradio_save(t_gobj *z, t_binbuf *b)
 {
-    t_hradio *x = (t_hradio *)z;
+    t_hradio *x = (t_hradio *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
-    binbuf_addv(b, "ssiisiiiisssiiiisssf", gensym("#X"),gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                (pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class ?
-                    gensym("hdl") : gensym("hradio")),
-                x->x_gui.x_w/IEMGUI_ZOOM(x),
-                x->x_change, iem_symargstoint(&x->x_gui.x_isa), x->x_number,
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_fval:0.);
+    binbuf_addv(b, "ssiisiiiisssiiiisssf", gensym("#X"), gensym("obj"),
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        (pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class
+                ? gensym("hdl")
+                : gensym("hradio")),
+        x->x_gui.x_w / IEMGUI_ZOOM(x), x->x_change,
+        iem_symargstoint(&x->x_gui.x_isa), x->x_number, srl[0], srl[1], srl[2],
+        x->x_gui.x_ldx, x->x_gui.x_ldy, iem_fstyletoint(&x->x_gui.x_fsf),
+        x->x_gui.x_fontsize, bflcol[0], bflcol[1], bflcol[2],
+        x->x_gui.x_isa.x_loadinit ? x->x_fval : 0.);
     binbuf_addv(b, ";");
 }
 
 static void hradio_properties(t_gobj *z, t_glist *owner)
 {
-    t_hradio *x = (t_hradio *)z;
+    t_hradio *x = (t_hradio *) z;
     char buf[800];
     t_symbol *srl[3];
     int hchange = -1;
@@ -300,34 +302,34 @@ static void hradio_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            0,/*no_schedule*/
-            hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number,
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, 0, /*no_schedule*/
+        hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number, srl[0]->s_name,
+        srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
 static void hradio_dialog(t_hradio *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getfloatarg(0, argc, argv);
-    int chg = (int)atom_getfloatarg(4, argc, argv);
-    int num = (int)atom_getfloatarg(6, argc, argv);
+    int a = (int) atom_getfloatarg(0, argc, argv);
+    int chg = (int) atom_getfloatarg(4, argc, argv);
+    int num = (int) atom_getfloatarg(6, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+1, 0);
-    SETFLOAT(undo+2, 0);
-    SETFLOAT(undo+3, 0);
-    SETFLOAT(undo+4, (pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)?x->x_change:-1);
-    SETFLOAT(undo+6, x->x_number);
+    SETFLOAT(undo + 1, 0);
+    SETFLOAT(undo + 2, 0);
+    SETFLOAT(undo + 3, 0);
+    SETFLOAT(undo + 4, (pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)
+                           ? x->x_change
+                           : -1);
+    SETFLOAT(undo + 6, x->x_number);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     if(chg != 0) chg = 1;
     x->x_change = chg;
@@ -348,23 +350,21 @@ static void hradio_dialog(t_hradio *x, t_symbol *s, int argc, t_atom *argv)
     else
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
-        (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
+        (*x->x_gui.x_draw)(
+            x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+        canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
     }
-
 }
 
 static void hradio_set(t_hradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
     int old = x->x_on_old;
 
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
     if(x->x_on != x->x_on_old)
     {
         old = x->x_on_old;
@@ -382,20 +382,20 @@ static void hradio_set(t_hradio *x, t_floatarg f)
 
 static void hradio_bang(t_hradio *x)
 {
-        /* compatibility with earlier "hdial" behavior */
+    /* compatibility with earlier "hdial" behavior */
     if(pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)
     {
         if((x->x_change) && (x->x_on != x->x_on_old))
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on_old);
-            SETFLOAT(x->x_at+1, 0.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on_old);
+            SETFLOAT(x->x_at + 1, 0.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
         }
         x->x_on_old = x->x_on;
-        SETFLOAT(x->x_at, (t_float)x->x_on);
-        SETFLOAT(x->x_at+1, 1.0);
+        SETFLOAT(x->x_at, (t_float) x->x_on);
+        SETFLOAT(x->x_at + 1, 1.0);
         outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
         if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
             pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -411,31 +411,28 @@ static void hradio_bang(t_hradio *x)
 
 static void hradio_fout(t_hradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
 
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
 
     if(pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)
     {
         if((x->x_change) && (i != x->x_on_old))
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on_old);
-            SETFLOAT(x->x_at+1, 0.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on_old);
+            SETFLOAT(x->x_at + 1, 0.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
         }
-        if(x->x_on != x->x_on_old)
-            x->x_on_old = x->x_on;
+        if(x->x_on != x->x_on_old) x->x_on_old = x->x_on;
         x->x_on = i;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         x->x_on_old = x->x_on;
-        SETFLOAT(x->x_at, (t_float)x->x_on);
-        SETFLOAT(x->x_at+1, 1.0);
+        SETFLOAT(x->x_at, (t_float) x->x_on);
+        SETFLOAT(x->x_at + 1, 1.0);
         outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
         if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
             pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -454,36 +451,33 @@ static void hradio_fout(t_hradio *x, t_floatarg f)
 
 static void hradio_float(t_hradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
 
     if(pd_class(&x->x_gui.x_obj.ob_pd) == hradio_old_class)
     {
-            /* compatibility with earlier "hdial" behavior */
+        /* compatibility with earlier "hdial" behavior */
         if((x->x_change) && (i != x->x_on_old))
         {
             if(x->x_gui.x_fsf.x_put_in2out)
             {
-                SETFLOAT(x->x_at, (t_float)x->x_on_old);
-                SETFLOAT(x->x_at+1, 0.0);
+                SETFLOAT(x->x_at, (t_float) x->x_on_old);
+                SETFLOAT(x->x_at + 1, 0.0);
                 outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
                 if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                     pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
             }
         }
-        if(x->x_on != x->x_on_old)
-            x->x_on_old = x->x_on;
+        if(x->x_on != x->x_on_old) x->x_on_old = x->x_on;
         x->x_on = i;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         x->x_on_old = x->x_on;
         if(x->x_gui.x_fsf.x_put_in2out)
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on);
-            SETFLOAT(x->x_at+1, 1.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on);
+            SETFLOAT(x->x_at + 1, 1.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -504,89 +498,105 @@ static void hradio_float(t_hradio *x, t_floatarg f)
     }
 }
 
-static void hradio_click(t_hradio *x, t_floatarg xpos, t_floatarg ypos, t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+static void hradio_click(t_hradio *x, t_floatarg xpos, t_floatarg ypos,
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
-    int xx = (int)xpos - (int)text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist);
+    int xx = (int) xpos - (int) text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist);
 
-    hradio_fout(x, (t_float)(xx / x->x_gui.x_w));
+    hradio_fout(x, (t_float) (xx / x->x_gui.x_w));
 }
 
-static int hradio_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int hradio_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
     if(doit)
-        hradio_click((t_hradio *)z, (t_floatarg)xpix, (t_floatarg)ypix, (t_floatarg)shift, 0, (t_floatarg)alt);
+        hradio_click((t_hradio *) z, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
     return (1);
 }
 
 static void hradio_loadbang(t_hradio *x, t_floatarg action)
 {
-    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
-        hradio_bang(x);
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit) hradio_bang(x);
 }
 
 static void hradio_number(t_hradio *x, t_floatarg num)
 {
-    int n = (int)num;
+    int n = (int) num;
 
-    if(n < 1)
-        n = 1;
-    if(n > IEM_RADIO_MAX)
-        n = IEM_RADIO_MAX;
+    if(n < 1) n = 1;
+    if(n > IEM_RADIO_MAX) n = IEM_RADIO_MAX;
     if(n != x->x_number)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_ERASE);
         x->x_number = n;
-        if(x->x_on >= x->x_number)
-            x->x_on = x->x_number - 1;
+        if(x->x_on >= x->x_number) x->x_on = x->x_number - 1;
         x->x_on_old = x->x_on;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_NEW);
-        canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+        canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
     }
 }
 
 static void hradio_size(t_hradio *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void hradio_delta(t_hradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hradio_pos(t_hradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hradio_color(t_hradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hradio_send(t_hradio *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void hradio_receive(t_hradio *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void hradio_label(t_hradio *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void hradio_label_pos(t_hradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hradio_label_font(t_hradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hradio_init(t_hradio *x, t_floatarg f)
-{x->x_gui.x_isa.x_loadinit = (f == 0.0) ? 0 : 1;}
+{
+    x->x_gui.x_isa.x_loadinit = (f == 0.0) ? 0 : 1;
+}
 
-static void hradio_double_change(t_hradio *x)
-{x->x_change = 1;}
+static void hradio_double_change(t_hradio *x) { x->x_change = 1; }
 
-static void hradio_single_change(t_hradio *x)
-{x->x_change = 0;}
+static void hradio_single_change(t_hradio *x) { x->x_change = 0; }
 
 static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
 {
-    t_hradio *x = (t_hradio *)pd_new(old ? hradio_old_class : hradio_class);
+    t_hradio *x = (t_hradio *) pd_new(old ? hradio_old_class : hradio_class);
     int a = IEM_GUI_DEFAULTSIZE, on = 0;
     int ldx = 0, ldy = -8, chg = 1, num = 8;
     int fs = 10;
@@ -599,50 +609,50 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if((argc == 15)&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2)
-       &&IS_A_FLOAT(argv,3)
-       &&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4))
-       &&(IS_A_SYMBOL(argv,5)||IS_A_FLOAT(argv,5))
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)&&IS_A_FLOAT(argv,14))
+    if((argc == 15) && IS_A_FLOAT(argv, 0) && IS_A_FLOAT(argv, 1) &&
+        IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) &&
+        (IS_A_SYMBOL(argv, 4) || IS_A_FLOAT(argv, 4)) &&
+        (IS_A_SYMBOL(argv, 5) || IS_A_FLOAT(argv, 5)) &&
+        (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) && IS_A_FLOAT(argv, 7) &&
+        IS_A_FLOAT(argv, 8) && IS_A_FLOAT(argv, 9) && IS_A_FLOAT(argv, 10) &&
+        IS_A_FLOAT(argv, 14))
     {
-        a = (int)atom_getfloatarg(0, argc, argv);
-        chg = (int)atom_getfloatarg(1, argc, argv);
+        a = (int) atom_getfloatarg(0, argc, argv);
+        chg = (int) atom_getfloatarg(1, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(2, argc, argv));
-        num = (int)atom_getfloatarg(3, argc, argv);
+        num = (int) atom_getfloatarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getfloatarg(7, argc, argv);
-        ldy = (int)atom_getfloatarg(8, argc, argv);
+        ldx = (int) atom_getfloatarg(7, argc, argv);
+        ldy = (int) atom_getfloatarg(8, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(9, argc, argv));
-        fs = (int)atom_getfloatarg(10, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
+        fs = (int) atom_getfloatarg(10, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 11, argv + 12, argv + 13);
         fval = atom_getfloatarg(14, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 4, 0);
-    x->x_gui.x_draw = (t_iemfunptr)hradio_draw;
+    else
+        iemgui_new_getnames(&x->x_gui, 4, 0);
+    x->x_gui.x_draw = (t_iemfunptr) hradio_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if(!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if(!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
-    if(num < 1)
-        num = 1;
-    if(num > IEM_RADIO_MAX)
-        num = IEM_RADIO_MAX;
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
+    if(num < 1) num = 1;
+    if(num > IEM_RADIO_MAX) num = IEM_RADIO_MAX;
     x->x_number = num;
     x->x_fval = fval;
     on = fval;
-    if(on < 0)
-        on = 0;
-    if(on >= x->x_number)
-        on = x->x_number - 1;
+    if(on < 0) on = 0;
+    if(on >= x->x_number) on = x->x_number - 1;
     if(x->x_gui.x_isa.x_loadinit)
         x->x_on = on;
     else
@@ -653,8 +663,7 @@ static void *hradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
@@ -683,42 +692,42 @@ static void hradio_ff(t_hradio *x)
 
 void g_hradio_setup(void)
 {
-    hradio_class = class_new(gensym("hradio"), (t_newmethod)hradio_new,
-        (t_method)hradio_ff, sizeof(t_hradio), 0, A_GIMME, 0);
+    hradio_class = class_new(gensym("hradio"), (t_newmethod) hradio_new,
+        (t_method) hradio_ff, sizeof(t_hradio), 0, A_GIMME, 0);
     class_addbang(hradio_class, hradio_bang);
     class_addfloat(hradio_class, hradio_float);
-    class_addmethod(hradio_class, (t_method)hradio_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(hradio_class, (t_method)hradio_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_loadbang,
+    class_addmethod(hradio_class, (t_method) hradio_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(hradio_class, (t_method) hradio_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(hradio_class, (t_method)hradio_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(hradio_class, (t_method)hradio_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(hradio_class, (t_method)hradio_receive,
-        gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(hradio_class, (t_method)hradio_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(hradio_class, (t_method)hradio_label_pos,
+    class_addmethod(
+        hradio_class, (t_method) hradio_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(hradio_class, (t_method) hradio_receive, gensym("receive"),
+        A_DEFSYM, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(hradio_class, (t_method) hradio_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_label_font,
+    class_addmethod(hradio_class, (t_method) hradio_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(hradio_class, (t_method)hradio_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(hradio_class, (t_method)hradio_number,
-        gensym("number"), A_FLOAT, 0);
-    class_addmethod(hradio_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        hradio_class, (t_method) hradio_number, gensym("number"), A_FLOAT, 0);
+    class_addmethod(
+        hradio_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     hradio_widgetbehavior.w_getrectfn = hradio_getrect;
     hradio_widgetbehavior.w_displacefn = iemgui_displace;
     hradio_widgetbehavior.w_selectfn = iemgui_select;
@@ -731,50 +740,50 @@ void g_hradio_setup(void)
     class_setsavefn(hradio_class, hradio_save);
     class_setpropertiesfn(hradio_class, hradio_properties);
 
-        /*obsolete version (0.34-0.35) */
-    hradio_old_class = class_new(gensym("hdl"), (t_newmethod)hdial_new,
-        (t_method)hradio_ff, sizeof(t_hradio), 0, A_GIMME, 0);
-    class_addcreator((t_newmethod)hradio_new, gensym("rdb"), A_GIMME, 0);
-    class_addcreator((t_newmethod)hradio_new, gensym("radiobut"), A_GIMME, 0);
-    class_addcreator((t_newmethod)hradio_new, gensym("radiobutton"),
-        A_GIMME, 0);
+    /*obsolete version (0.34-0.35) */
+    hradio_old_class = class_new(gensym("hdl"), (t_newmethod) hdial_new,
+        (t_method) hradio_ff, sizeof(t_hradio), 0, A_GIMME, 0);
+    class_addcreator((t_newmethod) hradio_new, gensym("rdb"), A_GIMME, 0);
+    class_addcreator((t_newmethod) hradio_new, gensym("radiobut"), A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) hradio_new, gensym("radiobutton"), A_GIMME, 0);
     class_addbang(hradio_old_class, hradio_bang);
     class_addfloat(hradio_old_class, hradio_float);
-    class_addmethod(hradio_old_class, (t_method)hradio_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_dialog,
+    class_addmethod(hradio_old_class, (t_method) hradio_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(hradio_old_class, (t_method) hradio_dialog,
         gensym("dialog"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_loadbang,
-        gensym("loadbang"), 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_receive,
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_loadbang, gensym("loadbang"), 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(hradio_old_class, (t_method) hradio_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_label_pos,
+    class_addmethod(hradio_old_class, (t_method) hradio_label, gensym("label"),
+        A_DEFSYM, 0);
+    class_addmethod(hradio_old_class, (t_method) hradio_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_label_font,
+    class_addmethod(hradio_old_class, (t_method) hradio_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_number,
+    class_addmethod(
+        hradio_old_class, (t_method) hradio_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(hradio_old_class, (t_method) hradio_number,
         gensym("number"), A_FLOAT, 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_single_change,
+    class_addmethod(hradio_old_class, (t_method) hradio_single_change,
         gensym("single_change"), 0);
-    class_addmethod(hradio_old_class, (t_method)hradio_double_change,
+    class_addmethod(hradio_old_class, (t_method) hradio_double_change,
         gensym("double_change"), 0);
-    class_addmethod(hradio_old_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
+    class_addmethod(
+        hradio_old_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     class_setwidget(hradio_old_class, &hradio_widgetbehavior);
 }

--- a/src/g_hdial.c
+++ b/src/g_hdial.c
@@ -49,7 +49,6 @@ void hradio_draw_update(t_gobj *client, t_glist *glist)
 void hradio_draw_new(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     int dx = x->x_gui.x_w;
     int s4 = dx / 4;
     int yy11 = text_ypix(&x->x_gui.x_obj, glist);
@@ -64,7 +63,7 @@ void hradio_draw_new(t_hradio *x, t_glist *glist)
     int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x "
                  "-tags %lxBASE%d\n",
@@ -106,7 +105,6 @@ void hradio_draw_new(t_hradio *x, t_glist *glist)
 void hradio_draw_move(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     int dx = x->x_gui.x_w;
     int s4 = dx / 4;
     int yy11 = text_ypix(&x->x_gui.x_obj, glist);
@@ -124,7 +122,7 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
     xx11 = xx11b;
     xx21 = xx11b + s4;
     xx22 = xx11b + dx - s4;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n", canvas, x, i, xx11,
             yy11, xx11 + dx, yy12);
@@ -152,10 +150,9 @@ void hradio_draw_move(t_hradio *x, t_glist *glist)
 void hradio_draw_erase(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c delete %lxBASE%d\n", canvas, x, i);
         sys_vgui(".x%lx.c delete %lxBUT%d\n", canvas, x, i);
@@ -170,7 +167,6 @@ void hradio_draw_erase(t_hradio *x, t_glist *glist)
 void hradio_draw_config(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
@@ -178,7 +174,7 @@ void hradio_draw_config(t_hradio *x, t_glist *glist)
         canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize, sys_fontweight,
         x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
         strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c itemconfigure %lxBASE%d -fill #%06x\n", canvas, x, i,
             x->x_gui.x_bcol);
@@ -234,12 +230,11 @@ void hradio_draw_io(t_hradio *x, t_glist *glist, int old_snd_rcv_flags)
 void hradio_draw_select(t_hradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
                 x, i, IEM_GUI_COLOR_SELECTED);
@@ -249,7 +244,7 @@ void hradio_draw_select(t_hradio *x, t_glist *glist)
     }
     else
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
                 x, i, IEM_GUI_COLOR_NORMAL);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -48,8 +48,10 @@ static void hslider_draw_new(t_hslider *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int lmargin = LMARGIN * IEMGUI_ZOOM(x), rmargin = RMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int lmargin = LMARGIN * IEMGUI_ZOOM(x);
+    int rmargin = RMARGIN * IEMGUI_ZOOM(x);
     int r = xpos + (x->x_val + 50) / 100;
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -85,8 +87,10 @@ static void hslider_draw_move(t_hslider *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int lmargin = LMARGIN * IEMGUI_ZOOM(x), rmargin = RMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int lmargin = LMARGIN * IEMGUI_ZOOM(x);
+    int rmargin = RMARGIN * IEMGUI_ZOOM(x);
     int r = xpos + (x->x_val + 50) / 100;
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -141,7 +145,8 @@ static void hslider_draw_io(t_hslider *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int lmargin = LMARGIN * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -569,10 +574,15 @@ static void hslider_loadbang(t_hslider *x, t_floatarg action)
 static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_hslider *x = (t_hslider *) pd_new(hslider_class);
-    int w = IEM_SL_DEFAULTSIZE, h = IEM_GUI_DEFAULTSIZE;
-    int lilo = 0, ldx = -2, ldy = -8, steady = 1;
+    int w = IEM_SL_DEFAULTSIZE;
+    int h = IEM_GUI_DEFAULTSIZE;
+    int lilo = 0;
+    int ldx = -2;
+    int ldy = -8;
+    int steady = 1;
     int fs = 10;
-    double min = 0.0, max = (double) (IEM_SL_DEFAULTSIZE - 1);
+    double min = 0.0;
+    double max = (double) (IEM_SL_DEFAULTSIZE - 1);
     t_float v = 0;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -60,15 +60,19 @@ static void hslider_draw_new(t_hslider *x, t_glist *glist)
         canvas, xpos - lmargin, ypos, xpos + x->x_gui.x_w + rmargin,
         ypos + x->x_gui.x_h, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
             xpos - lmargin + iow, ypos + x->x_gui.x_h, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xpos - lmargin, ypos, xpos - lmargin + iow,
             ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    }
     sys_vgui(
         ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
         canvas, r, ypos + IEMGUI_ZOOM(x), r,
@@ -97,13 +101,17 @@ static void hslider_draw_move(t_hslider *x, t_glist *glist)
     sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos - lmargin,
         ypos, xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0,
             xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
             xpos - lmargin + iow, ypos + x->x_gui.x_h);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0,
             xpos - lmargin, ypos, xpos - lmargin + iow,
             ypos - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", canvas, x, r,
         ypos + IEMGUI_ZOOM(x), r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
     sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
@@ -199,19 +207,33 @@ static void hslider_draw_select(t_hslider *x, t_glist *glist)
 void hslider_draw(t_hslider *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         sys_queuegui(x, glist, hslider_draw_update);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         hslider_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         hslider_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         hslider_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         hslider_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         hslider_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         hslider_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ hsl widgetbehaviour----------------------------- */
@@ -256,11 +278,15 @@ void hslider_check_width(t_hslider *x, int w)
         x->x_val = x->x_pos;
     }
     if(x->x_lin0_log1)
+    {
         x->x_k = log(x->x_max / x->x_min) /
                  (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
+    }
     else
+    {
         x->x_k = (x->x_max - x->x_min) /
                  (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
+    }
 }
 
 void hslider_check_minmax(t_hslider *x, double min, double max)
@@ -280,11 +306,15 @@ void hslider_check_minmax(t_hslider *x, double min, double max)
     x->x_min = min;
     x->x_max = max;
     if(x->x_lin0_log1)
+    {
         x->x_k = log(x->x_max / x->x_min) /
                  (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
+    }
     else
+    {
         x->x_k = (x->x_max - x->x_min) /
                  (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
+    }
 }
 
 static void hslider_properties(t_gobj *z, t_glist *owner)
@@ -331,9 +361,13 @@ static void hslider_set(t_hslider *x, t_floatarg f) /* bugfix */
         if(f < x->x_min) f = x->x_min;
     }
     if(x->x_lin0_log1)
+    {
         g = log(f / x->x_min) / x->x_k;
+    }
     else
+    {
         g = (f - x->x_min) / x->x_k;
+    }
     x->x_val = IEMGUI_ZOOM(x) * (int) (100.0 * g + 0.49999);
     x->x_pos = x->x_val;
     if(x->x_val != old)
@@ -349,9 +383,13 @@ static t_float hslider_getfval(t_hslider *x)
                       : (x->x_val / (100 * IEMGUI_ZOOM(x))) * 100;
 
     if(x->x_lin0_log1)
+    {
         fval = x->x_min * exp(x->x_k * (double) (zoomval) *0.01);
+    }
     else
+    {
         fval = (double) (zoomval) *0.01 * x->x_k + x->x_min;
+    }
     if((fval < 1.0e-10) && (fval > -1.0e-10)) fval = 0.0;
     return (fval);
 }
@@ -361,9 +399,13 @@ static void hslider_bang(t_hslider *x)
     double out;
 
     if(pd_compatibilitylevel < 46)
+    {
         out = hslider_getfval(x);
+    }
     else
+    {
         out = x->x_fval;
+    }
     outlet_float(x->x_gui.x_obj.ob_outlet, out);
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
         pd_float(x->x_gui.x_snd->s_thing, out);
@@ -392,9 +434,13 @@ static void hslider_dialog(t_hslider *x, t_symbol *s, int argc, t_atom *argv)
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
     if(steady)
+    {
         x->x_steady = 1;
+    }
     else
+    {
         x->x_steady = 0;
+    }
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_h = iemgui_clip_size(h) * IEMGUI_ZOOM(x);
     hslider_check_width(x, w);
@@ -412,9 +458,13 @@ static void hslider_motion(
     if(up != 0) return;
 
     if(x->x_gui.x_fsf.x_finemoved)
+    {
         x->x_pos += (int) dx;
+    }
     else
+    {
         x->x_pos += 100 * (int) dx;
+    }
     x->x_val = x->x_pos;
     if(x->x_val > (100 * x->x_gui.x_w - 100))
     {
@@ -440,8 +490,10 @@ static void hslider_click(t_hslider *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     if(!x->x_steady)
+    {
         x->x_val = (int) (100.0 * (xpos - text_xpix(&x->x_gui.x_obj,
                                               x->x_gui.x_glist)));
+    }
     if(x->x_val > (100 * x->x_gui.x_w - 100))
         x->x_val = 100 * x->x_gui.x_w - 100;
     if(x->x_val < 0) x->x_val = 0;
@@ -463,9 +515,13 @@ static int hslider_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
         hslider_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
+        {
             x->x_gui.x_fsf.x_finemoved = 1;
+        }
         else
+        {
             x->x_gui.x_fsf.x_finemoved = 0;
+        }
     }
     return (1);
 }
@@ -474,8 +530,10 @@ static void hslider_size(t_hslider *x, t_symbol *s, int ac, t_atom *av)
 {
     hslider_check_width(x, (int) atom_getfloatarg(0, ac, av) * IEMGUI_ZOOM(x));
     if(ac > 1)
+    {
         x->x_gui.x_h = iemgui_clip_size((int) atom_getfloatarg(1, ac, av)) *
                        IEMGUI_ZOOM(x);
+    }
     iemgui_size((void *) x, &x->x_gui);
 }
 
@@ -624,9 +682,13 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fsf.x_rcv_able = 1;
     x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_val = v;
+    }
     else
+    {
         x->x_val = 0;
+    }
     x->x_pos = x->x_val;
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
@@ -635,9 +697,13 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_hslider.c
+++ b/src/g_hslider.c
@@ -33,15 +33,14 @@ static t_class *hslider_class;
 
 static void hslider_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_hslider *x = (t_hslider *)client;
-    if (glist_isvisible(glist))
+    t_hslider *x = (t_hslider *) client;
+    if(glist_isvisible(glist))
     {
-        int r = text_xpix(&x->x_gui.x_obj, glist) + ((x->x_val + 50)/100);
+        int r = text_xpix(&x->x_gui.x_obj, glist) + ((x->x_val + 50) / 100);
         int ypos = text_ypix(&x->x_gui.x_obj, glist);
         t_canvas *canvas = glist_getcanvas(glist);
-        sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
-                 canvas, x, r, ypos + IEMGUI_ZOOM(x),
-                 r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
+        sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", canvas, x, r,
+            ypos + IEMGUI_ZOOM(x), r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
     }
 }
 
@@ -51,37 +50,35 @@ static void hslider_draw_new(t_hslider *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int lmargin = LMARGIN * IEMGUI_ZOOM(x), rmargin = RMARGIN * IEMGUI_ZOOM(x);
-    int r = xpos + (x->x_val + 50)/100;
+    int r = xpos + (x->x_val + 50) / 100;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE\n",
-             canvas, xpos - lmargin, ypos,
-             xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h,
-             IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags "
+             "%lxBASE\n",
+        canvas, xpos - lmargin, ypos, xpos + x->x_gui.x_w + rmargin,
+        ypos + x->x_gui.x_h, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos - lmargin + iow, ypos + x->x_gui.x_h,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos - lmargin + iow, ypos + x->x_gui.x_h, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos - lmargin, ypos,
-             xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
-             canvas, r, ypos + IEMGUI_ZOOM(x),
-             r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x),
-             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos - lmargin, ypos, xpos - lmargin + iow,
+            ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    sys_vgui(
+        ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
+        canvas, r, ypos + IEMGUI_ZOOM(x), r,
+        ypos + x->x_gui.x_h - IEMGUI_ZOOM(x), 1 + 2 * IEMGUI_ZOOM(x),
+        x->x_gui.x_fcol, x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 static void hslider_draw_move(t_hslider *x, t_glist *glist)
@@ -90,32 +87,27 @@ static void hslider_draw_move(t_hslider *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int lmargin = LMARGIN * IEMGUI_ZOOM(x), rmargin = RMARGIN * IEMGUI_ZOOM(x);
-    int r = xpos + (x->x_val + 50)/100;
+    int r = xpos + (x->x_val + 50) / 100;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x,
-             xpos - lmargin, ypos,
-             xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h);
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos - lmargin,
+        ypos, xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos - lmargin + iow, ypos + x->x_gui.x_h);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0,
+            xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos - lmargin + iow, ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos - lmargin, ypos,
-             xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
-             canvas, x, r, ypos + IEMGUI_ZOOM(x),
-             r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0,
+            xpos - lmargin, ypos, xpos - lmargin + iow,
+            ypos - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", canvas, x, r,
+        ypos + IEMGUI_ZOOM(x), r, ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-static void hslider_draw_erase(t_hslider* x, t_glist* glist)
+static void hslider_draw_erase(t_hslider *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -128,19 +120,24 @@ static void hslider_draw_erase(t_hslider* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-static void hslider_draw_config(t_hslider* x, t_glist* glist)
+static void hslider_draw_config(t_hslider *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
-    sys_vgui(".x%lx.c itemconfigure %lxKNOB -fill #%06x\n", canvas, x, x->x_gui.x_fcol);
-    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name
+                                                 : ""));
+    sys_vgui(".x%lx.c itemconfigure %lxKNOB -fill #%06x\n", canvas, x,
+        x->x_gui.x_fcol);
+    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x,
+        x->x_gui.x_bcol);
 }
 
-static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
+static void hslider_draw_io(t_hslider *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
@@ -150,11 +147,10 @@ static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos - lmargin + iow, ypos + x->x_gui.x_h,
-             x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos - lmargin, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos - lmargin + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep these above outlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxOUT%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
@@ -163,11 +159,10 @@ static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
     if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos - lmargin, ypos,
-             xpos - lmargin + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos - lmargin, ypos, xpos - lmargin + iow,
+            ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep these above inlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxIN%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
@@ -176,19 +171,23 @@ static void hslider_draw_io(t_hslider* x, t_glist* glist, int old_snd_rcv_flags)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-static void hslider_draw_select(t_hslider* x, t_glist* glist)
+static void hslider_draw_select(t_hslider *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            x->x_gui.x_lcol);
     }
 }
 
@@ -212,82 +211,80 @@ void hslider_draw(t_hslider *x, t_glist *glist, int mode)
 
 /* ------------------------ hsl widgetbehaviour----------------------------- */
 
-
-static void hslider_getrect(t_gobj *z, t_glist *glist,
-                            int *xp1, int *yp1, int *xp2, int *yp2)
+static void hslider_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_hslider* x = (t_hslider*)z;
+    t_hslider *x = (t_hslider *) z;
 
-    *xp1 = text_xpix(&x->x_gui.x_obj, glist) - LMARGIN*glist_getzoom(glist);
+    *xp1 = text_xpix(&x->x_gui.x_obj, glist) - LMARGIN * glist_getzoom(glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
-    *xp2 = *xp1 + x->x_gui.x_w + (LMARGIN + RMARGIN)*glist_getzoom(glist);
+    *xp2 = *xp1 + x->x_gui.x_w + (LMARGIN + RMARGIN) * glist_getzoom(glist);
     *yp2 = *yp1 + x->x_gui.x_h;
 }
 
 static void hslider_save(t_gobj *z, t_binbuf *b)
 {
-    t_hslider *x = (t_hslider *)z;
+    t_hslider *x = (t_hslider *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiiffiisssiiiisssii", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("hsl"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_gui.x_h/IEMGUI_ZOOM(x),
-                (t_float)x->x_min, (t_float)x->x_max,
-                x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_val:0, x->x_steady);
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("hsl"), x->x_gui.x_w / IEMGUI_ZOOM(x),
+        x->x_gui.x_h / IEMGUI_ZOOM(x), (t_float) x->x_min, (t_float) x->x_max,
+        x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa), srl[0], srl[1],
+        srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
+        iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize, bflcol[0],
+        bflcol[1], bflcol[2], x->x_gui.x_isa.x_loadinit ? x->x_val : 0,
+        x->x_steady);
     binbuf_addv(b, ";");
 }
 
 void hslider_check_width(t_hslider *x, int w)
 {
-    if(w < IEM_SL_MINSIZE * IEMGUI_ZOOM(x))
-        w = IEM_SL_MINSIZE * IEMGUI_ZOOM(x);
+    if(w < IEM_SL_MINSIZE * IEMGUI_ZOOM(x)) w = IEM_SL_MINSIZE * IEMGUI_ZOOM(x);
     x->x_gui.x_w = w;
-    if(x->x_val > (x->x_gui.x_w*100 - 100))
+    if(x->x_val > (x->x_gui.x_w * 100 - 100))
     {
-        x->x_pos = x->x_gui.x_w*100 - 100;
+        x->x_pos = x->x_gui.x_w * 100 - 100;
         x->x_val = x->x_pos;
     }
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max/x->x_min) / (double)(x->x_gui.x_w/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max / x->x_min) /
+                 (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_w/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) /
+                 (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
 }
 
 void hslider_check_minmax(t_hslider *x, double min, double max)
 {
     if(x->x_lin0_log1)
     {
-        if((min == 0.0) && (max == 0.0))
-            max = 1.0;
+        if((min == 0.0) && (max == 0.0)) max = 1.0;
         if(max > 0.0)
         {
-            if(min <= 0.0)
-                min = 0.01*max;
+            if(min <= 0.0) min = 0.01 * max;
         }
         else
         {
-            if(min > 0.0)
-                max = 0.01*min;
+            if(min > 0.0) max = 0.01 * min;
         }
     }
     x->x_min = min;
     x->x_max = max;
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max/x->x_min) / (double)(x->x_gui.x_w/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max / x->x_min) /
+                 (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_w/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) /
+                 (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
 }
 
 static void hslider_properties(t_gobj *z, t_glist *owner)
 {
-    t_hslider *x = (t_hslider *)z;
+    t_hslider *x = (t_hslider *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -300,58 +297,57 @@ static void hslider_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_SL_MINSIZE, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_min, x->x_max, 0.0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady, -1,/*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_SL_MINSIZE,
+        x->x_gui.x_h / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, x->x_min, x->x_max,
+        0.0, /*no_schedule*/
+        x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady,
+        -1, /*no multi, but iem-characteristic*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
-static void hslider_set(t_hslider *x, t_floatarg f)    /* bugfix */
+static void hslider_set(t_hslider *x, t_floatarg f) /* bugfix */
 {
     int old = x->x_val;
     double g;
 
     x->x_fval = f;
-    if (x->x_min > x->x_max)
+    if(x->x_min > x->x_max)
     {
-        if(f > x->x_min)
-            f = x->x_min;
-        if(f < x->x_max)
-            f = x->x_max;
+        if(f > x->x_min) f = x->x_min;
+        if(f < x->x_max) f = x->x_max;
     }
     else
     {
-        if(f > x->x_max)
-            f = x->x_max;
-        if(f < x->x_min)
-            f = x->x_min;
+        if(f > x->x_max) f = x->x_max;
+        if(f < x->x_min) f = x->x_min;
     }
     if(x->x_lin0_log1)
-        g = log(f/x->x_min) / x->x_k;
+        g = log(f / x->x_min) / x->x_k;
     else
         g = (f - x->x_min) / x->x_k;
-    x->x_val = IEMGUI_ZOOM(x) * (int)(100.0*g + 0.49999);
+    x->x_val = IEMGUI_ZOOM(x) * (int) (100.0 * g + 0.49999);
     x->x_pos = x->x_val;
     if(x->x_val != old)
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
 }
 
-    /* compute numeric value (fval) from pixel location (val) and range */
+/* compute numeric value (fval) from pixel location (val) and range */
 static t_float hslider_getfval(t_hslider *x)
 {
     t_float fval;
-    int zoomval = (x->x_gui.x_fsf.x_finemoved) ?
-        x->x_val/IEMGUI_ZOOM(x) : (x->x_val / (100*IEMGUI_ZOOM(x))) * 100;
+    int zoomval = (x->x_gui.x_fsf.x_finemoved)
+                      ? x->x_val / IEMGUI_ZOOM(x)
+                      : (x->x_val / (100 * IEMGUI_ZOOM(x))) * 100;
 
-    if (x->x_lin0_log1)
-        fval = x->x_min * exp(x->x_k * (double)(zoomval) * 0.01);
-    else fval = (double)(zoomval) * 0.01 * x->x_k + x->x_min;
-    if ((fval < 1.0e-10) && (fval > -1.0e-10))
-        fval = 0.0;
+    if(x->x_lin0_log1)
+        fval = x->x_min * exp(x->x_k * (double) (zoomval) *0.01);
+    else
+        fval = (double) (zoomval) *0.01 * x->x_k + x->x_min;
+    if((fval < 1.0e-10) && (fval > -1.0e-10)) fval = 0.0;
     return (fval);
 }
 
@@ -359,9 +355,10 @@ static void hslider_bang(t_hslider *x)
 {
     double out;
 
-    if (pd_compatibilitylevel < 46)
+    if(pd_compatibilitylevel < 46)
         out = hslider_getfval(x);
-    else out = x->x_fval;
+    else
+        out = x->x_fval;
     outlet_float(x->x_gui.x_obj.ob_outlet, out);
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
         pd_float(x->x_gui.x_snd->s_thing, out);
@@ -370,23 +367,22 @@ static void hslider_bang(t_hslider *x)
 static void hslider_dialog(t_hslider *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getfloatarg(0, argc, argv) * IEMGUI_ZOOM(x);
-    int h = (int)atom_getfloatarg(1, argc, argv);
-    double min = (double)atom_getfloatarg(2, argc, argv);
-    double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getfloatarg(4, argc, argv);
-    int steady = (int)atom_getfloatarg(17, argc, argv);
+    int w = (int) atom_getfloatarg(0, argc, argv) * IEMGUI_ZOOM(x);
+    int h = (int) atom_getfloatarg(1, argc, argv);
+    double min = (double) atom_getfloatarg(2, argc, argv);
+    double max = (double) atom_getfloatarg(3, argc, argv);
+    int lilo = (int) atom_getfloatarg(4, argc, argv);
+    int steady = (int) atom_getfloatarg(17, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+2, x->x_min);
-    SETFLOAT(undo+3, x->x_max);
-    SETFLOAT(undo+4, x->x_lin0_log1);
-    SETFLOAT(undo+17, x->x_steady);
+    SETFLOAT(undo + 2, x->x_min);
+    SETFLOAT(undo + 3, x->x_max);
+    SETFLOAT(undo + 4, x->x_lin0_log1);
+    SETFLOAT(undo + 17, x->x_steady);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
@@ -401,24 +397,23 @@ static void hslider_dialog(t_hslider *x, t_symbol *s, int argc, t_atom *argv)
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
-static void hslider_motion(t_hslider *x, t_floatarg dx, t_floatarg dy,
-    t_floatarg up)
+static void hslider_motion(
+    t_hslider *x, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
     int old = x->x_val;
-    if (up != 0)
-        return;
+    if(up != 0) return;
 
     if(x->x_gui.x_fsf.x_finemoved)
-        x->x_pos += (int)dx;
+        x->x_pos += (int) dx;
     else
-        x->x_pos += 100 * (int)dx;
+        x->x_pos += 100 * (int) dx;
     x->x_val = x->x_pos;
-    if(x->x_val > (100*x->x_gui.x_w - 100))
+    if(x->x_val > (100 * x->x_gui.x_w - 100))
     {
-        x->x_val = 100*x->x_gui.x_w - 100;
+        x->x_val = 100 * x->x_gui.x_w - 100;
         x->x_pos += 50;
         x->x_pos -= x->x_pos % 100;
     }
@@ -429,7 +424,7 @@ static void hslider_motion(t_hslider *x, t_floatarg dx, t_floatarg dy,
         x->x_pos -= x->x_pos % 100;
     }
     x->x_fval = hslider_getfval(x);
-    if (old != x->x_val)
+    if(old != x->x_val)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         hslider_bang(x);
@@ -440,29 +435,28 @@ static void hslider_click(t_hslider *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     if(!x->x_steady)
-        x->x_val = (int)(100.0 * (xpos -
-            text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist)));
-    if(x->x_val > (100*x->x_gui.x_w - 100))
-        x->x_val = 100*x->x_gui.x_w - 100;
-    if(x->x_val < 0)
-        x->x_val = 0;
+        x->x_val = (int) (100.0 * (xpos - text_xpix(&x->x_gui.x_obj,
+                                              x->x_gui.x_glist)));
+    if(x->x_val > (100 * x->x_gui.x_w - 100))
+        x->x_val = 100 * x->x_gui.x_w - 100;
+    if(x->x_val < 0) x->x_val = 0;
     x->x_fval = hslider_getfval(x);
     x->x_pos = x->x_val;
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
     hslider_bang(x);
     glist_grab(x->x_gui.x_glist, &x->x_gui.x_obj.te_g,
-        (t_glistmotionfn)hslider_motion, 0, xpos, ypos);
+        (t_glistmotionfn) hslider_motion, 0, xpos, ypos);
 }
 
-static int hslider_newclick(t_gobj *z, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int hslider_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_hslider* x = (t_hslider *)z;
+    t_hslider *x = (t_hslider *) z;
 
     if(doit)
     {
-        hslider_click(x, (t_floatarg)xpix, (t_floatarg)ypix, (t_floatarg)shift,
-                      0, (t_floatarg)alt);
+        hslider_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
             x->x_gui.x_fsf.x_finemoved = 1;
         else
@@ -473,41 +467,58 @@ static int hslider_newclick(t_gobj *z, struct _glist *glist,
 
 static void hslider_size(t_hslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    hslider_check_width(x, (int)atom_getfloatarg(0, ac, av)*IEMGUI_ZOOM(x));
+    hslider_check_width(x, (int) atom_getfloatarg(0, ac, av) * IEMGUI_ZOOM(x));
     if(ac > 1)
-        x->x_gui.x_h = iemgui_clip_size((int)atom_getfloatarg(1, ac, av))*IEMGUI_ZOOM(x);
-    iemgui_size((void *)x, &x->x_gui);
+        x->x_gui.x_h = iemgui_clip_size((int) atom_getfloatarg(1, ac, av)) *
+                       IEMGUI_ZOOM(x);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void hslider_delta(t_hslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hslider_pos(t_hslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hslider_range(t_hslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    hslider_check_minmax(x, (double)atom_getfloatarg(0, ac, av),
-                            (double)atom_getfloatarg(1, ac, av));
+    hslider_check_minmax(x, (double) atom_getfloatarg(0, ac, av),
+        (double) atom_getfloatarg(1, ac, av));
 }
 
 static void hslider_color(t_hslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hslider_send(t_hslider *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void hslider_receive(t_hslider *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void hslider_label(t_hslider *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void hslider_label_pos(t_hslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hslider_label_font(t_hslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void hslider_log(t_hslider *x)
 {
@@ -518,7 +529,8 @@ static void hslider_log(t_hslider *x)
 static void hslider_lin(t_hslider *x)
 {
     x->x_lin0_log1 = 0;
-    x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_w/IEMGUI_ZOOM(x) - 1);
+    x->x_k =
+        (x->x_max - x->x_min) / (double) (x->x_gui.x_w / IEMGUI_ZOOM(x) - 1);
 }
 
 static void hslider_init(t_hslider *x, t_floatarg f)
@@ -534,7 +546,7 @@ static void hslider_steady(t_hslider *x, t_floatarg f)
 static void hslider_zoom(t_hslider *x, t_floatarg f)
 {
     /* scale current pixel value */
-    x->x_val = (IEMGUI_ZOOM(x) == 2 ? (x->x_val)/2 : (x->x_val)*2);
+    x->x_val = (IEMGUI_ZOOM(x) == 2 ? (x->x_val) / 2 : (x->x_val) * 2);
     x->x_pos = x->x_val;
     iemgui_zoom(&x->x_gui, f);
 }
@@ -542,13 +554,12 @@ static void hslider_zoom(t_hslider *x, t_floatarg f)
 static void hslider_float(t_hslider *x, t_floatarg f)
 {
     hslider_set(x, f);
-    if(x->x_gui.x_fsf.x_put_in2out)
-        hslider_bang(x);
+    if(x->x_gui.x_fsf.x_put_in2out) hslider_bang(x);
 }
 
 static void hslider_loadbang(t_hslider *x, t_floatarg action)
 {
-    if (action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         hslider_bang(x);
@@ -557,11 +568,11 @@ static void hslider_loadbang(t_hslider *x, t_floatarg action)
 
 static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_hslider *x = (t_hslider *)pd_new(hslider_class);
+    t_hslider *x = (t_hslider *) pd_new(hslider_class);
     int w = IEM_SL_DEFAULTSIZE, h = IEM_GUI_DEFAULTSIZE;
     int lilo = 0, ldx = -2, ldy = -8, steady = 1;
     int fs = 10;
-    double min = 0.0, max = (double)(IEM_SL_DEFAULTSIZE-1);
+    double min = 0.0, max = (double) (IEM_SL_DEFAULTSIZE - 1);
     t_float v = 0;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);
@@ -571,58 +582,62 @@ static void *hslider_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if(((argc == 17)||(argc == 18))&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)
-       &&IS_A_FLOAT(argv,2)&&IS_A_FLOAT(argv,3)
-       &&IS_A_FLOAT(argv,4)&&IS_A_FLOAT(argv,5)
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&(IS_A_SYMBOL(argv,7)||IS_A_FLOAT(argv,7))
-       &&(IS_A_SYMBOL(argv,8)||IS_A_FLOAT(argv,8))
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
-       &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
+    if(((argc == 17) || (argc == 18)) && IS_A_FLOAT(argv, 0) &&
+        IS_A_FLOAT(argv, 1) && IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) &&
+        IS_A_FLOAT(argv, 4) && IS_A_FLOAT(argv, 5) &&
+        (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) &&
+        (IS_A_SYMBOL(argv, 7) || IS_A_FLOAT(argv, 7)) &&
+        (IS_A_SYMBOL(argv, 8) || IS_A_FLOAT(argv, 8)) && IS_A_FLOAT(argv, 9) &&
+        IS_A_FLOAT(argv, 10) && IS_A_FLOAT(argv, 11) && IS_A_FLOAT(argv, 12) &&
+        IS_A_FLOAT(argv, 16))
     {
-        w = (int)atom_getfloatarg(0, argc, argv);
-        h = (int)atom_getfloatarg(1, argc, argv);
-        min = (double)atom_getfloatarg(2, argc, argv);
-        max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getfloatarg(4, argc, argv);
+        w = (int) atom_getfloatarg(0, argc, argv);
+        h = (int) atom_getfloatarg(1, argc, argv);
+        min = (double) atom_getfloatarg(2, argc, argv);
+        max = (double) atom_getfloatarg(3, argc, argv);
+        lilo = (int) atom_getfloatarg(4, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getfloatarg(9, argc, argv);
-        ldy = (int)atom_getfloatarg(10, argc, argv);
+        ldx = (int) atom_getfloatarg(9, argc, argv);
+        ldy = (int) atom_getfloatarg(10, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(11, argc, argv));
-        fs = (int)atom_getfloatarg(12, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
+        fs = (int) atom_getfloatarg(12, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 13, argv + 14, argv + 15);
         v = atom_getfloatarg(16, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 6, 0);
-    if((argc == 18)&&IS_A_FLOAT(argv,17))
-        steady = (int)atom_getfloatarg(17, argc, argv);
-    x->x_gui.x_draw = (t_iemfunptr)hslider_draw;
+    else
+        iemgui_new_getnames(&x->x_gui, 6, 0);
+    if((argc == 18) && IS_A_FLOAT(argv, 17))
+        steady = (int) atom_getfloatarg(17, argc, argv);
+    x->x_gui.x_draw = (t_iemfunptr) hslider_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (x->x_gui.x_isa.x_loadinit)
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(x->x_gui.x_isa.x_loadinit)
         x->x_val = v;
-    else x->x_val = 0;
+    else
+        x->x_val = 0;
     x->x_pos = x->x_val;
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
     if(steady != 0) steady = 1;
     x->x_steady = steady;
-    if (!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if (!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
-    if (x->x_gui.x_fsf.x_rcv_able)
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
+    if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_h = iemgui_clip_size(h);
     hslider_check_width(x, w);
@@ -643,60 +658,58 @@ static void hslider_free(t_hslider *x)
 
 void g_hslider_setup(void)
 {
-    hslider_class = class_new(gensym("hsl"), (t_newmethod)hslider_new,
-        (t_method)hslider_free, sizeof(t_hslider), 0, A_GIMME, 0);
+    hslider_class = class_new(gensym("hsl"), (t_newmethod) hslider_new,
+        (t_method) hslider_free, sizeof(t_hslider), 0, A_GIMME, 0);
 #ifndef GGEE_HSLIDER_COMPATIBLE
-    class_addcreator((t_newmethod)hslider_new, gensym("hslider"), A_GIMME, 0);
+    class_addcreator((t_newmethod) hslider_new, gensym("hslider"), A_GIMME, 0);
 #endif
     class_addbang(hslider_class, hslider_bang);
     class_addfloat(hslider_class, hslider_float);
-    class_addmethod(hslider_class, (t_method)hslider_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_motion,
-        gensym("motion"), A_FLOAT, A_FLOAT, A_DEFFLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_loadbang,
+    class_addmethod(hslider_class, (t_method) hslider_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(hslider_class, (t_method) hslider_motion, gensym("motion"),
+        A_FLOAT, A_FLOAT, A_DEFFLOAT, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(hslider_class, (t_method) hslider_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_range,
-        gensym("range"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(hslider_class, (t_method)hslider_receive,
+    class_addmethod(
+        hslider_class, (t_method) hslider_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_range, gensym("range"), A_GIMME, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(hslider_class, (t_method) hslider_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(hslider_class, (t_method)hslider_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(hslider_class, (t_method)hslider_label_pos,
+    class_addmethod(
+        hslider_class, (t_method) hslider_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(hslider_class, (t_method) hslider_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_label_font,
+    class_addmethod(hslider_class, (t_method) hslider_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(hslider_class, (t_method)hslider_log,
-        gensym("log"), 0);
-    class_addmethod(hslider_class, (t_method)hslider_lin,
-        gensym("lin"), 0);
-    class_addmethod(hslider_class, (t_method)hslider_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_steady,
-        gensym("steady"), A_FLOAT, 0);
-    class_addmethod(hslider_class, (t_method)hslider_zoom,
-        gensym("zoom"), A_CANT, 0);
-    hslider_widgetbehavior.w_getrectfn =    hslider_getrect;
-    hslider_widgetbehavior.w_displacefn =   iemgui_displace;
-    hslider_widgetbehavior.w_selectfn =     iemgui_select;
-    hslider_widgetbehavior.w_activatefn =   NULL;
-    hslider_widgetbehavior.w_deletefn =     iemgui_delete;
-    hslider_widgetbehavior.w_visfn =        iemgui_vis;
-    hslider_widgetbehavior.w_clickfn =      hslider_newclick;
+    class_addmethod(hslider_class, (t_method) hslider_log, gensym("log"), 0);
+    class_addmethod(hslider_class, (t_method) hslider_lin, gensym("lin"), 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_steady, gensym("steady"), A_FLOAT, 0);
+    class_addmethod(
+        hslider_class, (t_method) hslider_zoom, gensym("zoom"), A_CANT, 0);
+    hslider_widgetbehavior.w_getrectfn = hslider_getrect;
+    hslider_widgetbehavior.w_displacefn = iemgui_displace;
+    hslider_widgetbehavior.w_selectfn = iemgui_select;
+    hslider_widgetbehavior.w_activatefn = NULL;
+    hslider_widgetbehavior.w_deletefn = iemgui_delete;
+    hslider_widgetbehavior.w_visfn = iemgui_vis;
+    hslider_widgetbehavior.w_clickfn = hslider_newclick;
     class_setwidget(hslider_class, &hslider_widgetbehavior);
     class_sethelpsymbol(hslider_class, gensym("hslider"));
     class_setsavefn(hslider_class, hslider_save);

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -97,12 +97,15 @@ t_int *vinlet_perform(t_int *w)
 {
     t_vinlet *x = (t_vinlet *) (w[1]);
     t_sample *out = (t_sample *) (w[2]);
-    int n = (int) (w[3]);
-    t_sample *in = x->x_read;
-    while(n--)
-        *out++ = *in++;
-    if(in == x->x_endbuf) in = x->x_buf;
-    x->x_read = in;
+    int num_samples = (int) (w[3]);
+
+    for(int i = 0; i < num_samples; i++)
+        out[i] = x->x_read[i];
+
+    if(x->x_read + num_samples == x->x_endbuf) 
+        x->x_read = x->x_buf;
+    else
+        x->x_read = x->x_read + num_samples;
     return (w + 4);
 }
 
@@ -422,10 +425,15 @@ static t_int *voutlet_doepilog(t_int *w)
 
     int n = (int) (w[3]);
     t_sample *in = x->x_empty;
-    if(x->x_updown.downsample != x->x_updown.upsample) out = x->x_updown.s_vec;
+    if(x->x_updown.downsample != x->x_updown.upsample) 
+        out = x->x_updown.s_vec;
     for(; n--; in++)
-        *out++ = *in, *in = 0;
-    if(in == x->x_endbuf) in = x->x_buf;
+    {
+        *out++ = *in;
+        *in = 0;
+    }
+    if(in == x->x_endbuf) 
+        in = x->x_buf;
     x->x_empty = in;
     return (w + 4);
 }
@@ -437,8 +445,12 @@ static t_int *voutlet_doepilog_resampling(t_int *w)
     t_sample *in = x->x_empty;
     t_sample *out = x->x_updown.s_vec;
     for(; n--; in++)
-        *out++ = *in, *in = 0;
-    if(in == x->x_endbuf) in = x->x_buf;
+    {
+        *out++ = *in;
+        *in = 0;
+    }
+    if(in == x->x_endbuf) 
+        in = x->x_buf;
     x->x_empty = in;
     return (w + 3);
 }

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -109,10 +109,14 @@ t_int *vinlet_perform(t_int *w)
 static void vinlet_fwd(t_vinlet *x, t_symbol *s, int argc, t_atom *argv)
 {
 
-    if(!x->x_buf) /* if we're not signal, just forward */
+    if(!x->x_buf)
+    { /* if we're not signal, just forward */
         outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
+    }
     else if(x->x_fwdout && argc > 0 && argv->a_type == A_SYMBOL)
+    {
         outlet_anything(x->x_fwdout, argv->a_w.w_symbol, argc - 1, argv + 1);
+    }
 }
 
 static void vinlet_dsp(t_vinlet *x, t_signal **sp)
@@ -219,8 +223,10 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs, int myvecsize,
                     : x->x_endbuf;
 
             if(upsample * downsample == 1)
+            {
                 dsp_add(vinlet_doprolog, 3, x, insig->s_vec,
                     (t_int) re_parentvecsize);
+            }
             else
             {
                 int method = (x->x_updown.method == 3
@@ -269,13 +275,21 @@ static void *vinlet_newsig(t_symbol *s)
      * downsampling method (no filtering !)
      */
     if(s == gensym("hold"))
+    {
         x->x_updown.method = 1; /* up: sample and hold */
+    }
     else if(s == gensym("lin") || s == gensym("linear"))
+    {
         x->x_updown.method = 2; /* up: linear interpolation */
+    }
     else if(s == gensym("pad"))
+    {
         x->x_updown.method = 0; /* up: zero-padding */
+    }
     else
+    {
         x->x_updown.method = 3; /* sample/hold unless version<0.44 */
+    }
 
     if(s == gensym("fwd")) /* turn on forwarding */
         x->x_fwdout = outlet_new(&x->x_obj, 0);
@@ -462,7 +476,9 @@ static void voutlet_dsp(t_voutlet *x, t_signal **sp)
     if(!x->x_buf) return;
     insig = sp[0];
     if(x->x_justcopyout)
+    {
         dsp_add_copy(insig->s_vec, x->x_directsignal->s_vec, insig->s_n);
+    }
     else if(x->x_directsignal)
     {
         /* if we're just going to make the signal available on the
@@ -526,9 +542,13 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs, int myvecsize,
         x->x_write = x->x_buf + re_parentvecsize * blockphase;
         if(x->x_write == x->x_endbuf) x->x_write = x->x_buf;
         if(period == 1 && frequency > 1)
+        {
             x->x_hop = re_parentvecsize / frequency;
+        }
         else
+        {
             x->x_hop = period * re_parentvecsize;
+        }
         /* post("phase %d, block %d, parent %d", phase & 63,
             parentvecsize * blockphase, parentvecsize * epilogphase); */
         if(parentsigs)
@@ -536,8 +556,10 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs, int myvecsize,
             /* set epilog pointer and schedule it */
             x->x_empty = x->x_buf + re_parentvecsize * epilogphase;
             if(upsample * downsample == 1)
+            {
                 dsp_add(voutlet_doepilog, 3, x, outsig->s_vec,
                     (t_int) re_parentvecsize);
+            }
             else
             {
                 int method = (x->x_updown.method == 3
@@ -584,16 +606,26 @@ static void *voutlet_newsig(t_symbol *s)
      * downsampling method (no filtering !)
      */
     if(s == gensym("hold"))
+    {
         x->x_updown.method = 1; /* up: sample and hold */
+    }
     else if(s == gensym("lin"))
+    {
         x->x_updown.method = 2; /* up: linear interpolation */
+    }
     else if(s == gensym("linear"))
+    {
         x->x_updown.method = 2; /* up: linear interpolation */
+    }
     else if(s == gensym("pad"))
+    {
         x->x_updown.method = 0; /* up: zero pad */
+    }
     else
+    {
         x->x_updown.method =
             3; /* up: zero-padding; down: ignore samples between */
+    }
 
     return (x);
 }

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -141,7 +141,8 @@ t_int *vinlet_doprolog(t_int *w)
     t_sample *out = x->x_fill;
     if(out == x->x_endbuf)
     {
-        t_sample *f1 = x->x_buf, *f2 = x->x_buf + x->x_hop;
+        t_sample *f1 = x->x_buf;
+        t_sample *f2 = x->x_buf + x->x_hop;
         int nshift = x->x_bufsize - x->x_hop;
         out -= x->x_hop;
         while(nshift--)
@@ -171,7 +172,10 @@ void vinlet_dspprolog(struct _vinlet *x, t_signal **parentsigs, int myvecsize,
     parent. */
     if(reblock)
     {
-        int parentvecsize, bufsize, oldbufsize, prologphase;
+        int parentvecsize;
+        int bufsize;
+        int oldbufsize;
+        int prologphase;
         int re_parentvecsize; /* resampled parentvectorsize */
         /* this should never happen: */
         if(!x->x_buf) return;
@@ -383,7 +387,8 @@ t_int *voutlet_perform(t_int *w)
     t_voutlet *x = (t_voutlet *) (w[1]);
     t_sample *in = (t_sample *) (w[2]);
     int n = (int) (w[3]);
-    t_sample *out = x->x_write, *outwas = out;
+    t_sample *out = x->x_write;
+    t_sample *outwas = out;
     while(n--)
     {
         *out++ += *in++;
@@ -482,9 +487,13 @@ void voutlet_dspepilog(struct _voutlet *x, t_signal **parentsigs, int myvecsize,
     if(reblock)
     {
         t_signal *outsig;
-        int parentvecsize, bufsize, oldbufsize;
+        int parentvecsize;
+        int bufsize;
+        int oldbufsize;
         int re_parentvecsize;
-        int bigperiod, epilogphase, blockphase;
+        int bigperiod;
+        int epilogphase;
+        int blockphase;
         if(parentsigs)
         {
             outsig = parentsigs[outlet_getsignalindex(x->x_parentoutlet)];

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -116,15 +116,25 @@ void my_canvas_draw_select(t_my_canvas *x, t_glist *glist)
 void my_canvas_draw(t_my_canvas *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         my_canvas_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         my_canvas_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         my_canvas_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         my_canvas_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         my_canvas_draw_config(x, glist);
+    }
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */
@@ -366,9 +376,13 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     if(h < 1) h = 1;
     x->x_vis_h = h;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -295,8 +295,13 @@ static void my_canvas_label_font(
 static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_my_canvas *x = (t_my_canvas *) pd_new(my_canvas_class);
-    int a = IEM_GUI_DEFAULTSIZE, w = 100, h = 60;
-    int ldx = 20, ldy = 12, f = 2, i = 0;
+    int a = IEM_GUI_DEFAULTSIZE;
+    int w = 100;
+    int h = 60;
+    int ldx = 20;
+    int ldy = 12;
+    int f = 2;
+    int i = 0;
     int fs = 14;
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -32,26 +32,27 @@ void my_canvas_draw_new(t_my_canvas *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int offset = (IEMGUI_ZOOM(x) > 1 ? IEMGUI_ZOOM(x) : 0); /* keep zoomed border inside visible area */
+    int offset =
+        (IEMGUI_ZOOM(x) > 1 ? IEMGUI_ZOOM(x)
+                            : 0); /* keep zoomed border inside visible area */
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x -tags %lxRECT\n",
-             canvas, xpos, ypos,
-             xpos + x->x_vis_w * IEMGUI_ZOOM(x),
-             ypos + x->x_vis_h * IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -outline #%06x -tags %lxBASE\n",
-             canvas, xpos + offset, ypos + offset,
-             xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h,
-             IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x "
+             "-tags %lxRECT\n",
+        canvas, xpos, ypos, xpos + x->x_vis_w * IEMGUI_ZOOM(x),
+        ypos + x->x_vis_h * IEMGUI_ZOOM(x), x->x_gui.x_bcol, x->x_gui.x_bcol,
+        x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -outline #%06x "
+             "-tags %lxBASE\n",
+        canvas, xpos + offset, ypos + offset, xpos + offset + x->x_gui.x_w,
+        ypos + offset + x->x_gui.x_h, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas,
-             xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 void my_canvas_draw_move(t_my_canvas *x, t_glist *glist)
@@ -61,19 +62,17 @@ void my_canvas_draw_move(t_my_canvas *x, t_glist *glist)
     int offset = (IEMGUI_ZOOM(x) > 1 ? IEMGUI_ZOOM(x) : 0);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c coords %lxRECT %d %d %d %d\n",
-             canvas, x, xpos, ypos,
-             xpos + x->x_vis_w * IEMGUI_ZOOM(x),
-             ypos + x->x_vis_h * IEMGUI_ZOOM(x));
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x, xpos + offset, ypos + offset,
-             xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxRECT %d %d %d %d\n", canvas, x, xpos, ypos,
+        xpos + x->x_vis_w * IEMGUI_ZOOM(x), ypos + x->x_vis_h * IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos + offset,
+        ypos + offset, xpos + offset + x->x_gui.x_w,
+        ypos + offset + x->x_gui.x_h);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-void my_canvas_draw_erase(t_my_canvas* x, t_glist* glist)
+void my_canvas_draw_erase(t_my_canvas *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -82,31 +81,35 @@ void my_canvas_draw_erase(t_my_canvas* x, t_glist* glist)
     sys_vgui(".x%lx.c delete %lxLABEL\n", canvas, x);
 }
 
-void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
+void my_canvas_draw_config(t_my_canvas *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxRECT -fill #%06x -outline #%06x\n", canvas, x,
-             x->x_gui.x_bcol, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxRECT -fill #%06x -outline #%06x\n",
+        canvas, x, x->x_gui.x_bcol, x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol,
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight, x->x_gui.x_lcol,
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name
+                                                 : ""));
 }
 
-void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
+void my_canvas_draw_select(t_my_canvas *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, x->x_gui.x_bcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            x->x_gui.x_bcol);
     }
 }
 
@@ -126,9 +129,10 @@ void my_canvas_draw(t_my_canvas *x, t_glist *glist, int mode)
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */
 
-static void my_canvas_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
+static void my_canvas_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_my_canvas *x = (t_my_canvas *)z;
+    t_my_canvas *x = (t_my_canvas *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -138,23 +142,23 @@ static void my_canvas_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int
 
 static void my_canvas_save(t_gobj *z, t_binbuf *b)
 {
-    t_my_canvas *x = (t_my_canvas *)z;
+    t_my_canvas *x = (t_my_canvas *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
-    binbuf_addv(b, "ssiisiiisssiiiissi", gensym("#X"),gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("cnv"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_vis_w, x->x_vis_h,
-                srl[0], srl[1], srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[2], iem_symargstoint(&x->x_gui.x_isa));
+    binbuf_addv(b, "ssiisiiisssiiiissi", gensym("#X"), gensym("obj"),
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("cnv"), x->x_gui.x_w / IEMGUI_ZOOM(x), x->x_vis_w, x->x_vis_h,
+        srl[0], srl[1], srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
+        iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize, bflcol[0],
+        bflcol[2], iem_symargstoint(&x->x_gui.x_isa));
     binbuf_addv(b, ";");
 }
 
 static void my_canvas_properties(t_gobj *z, t_glist *owner)
 {
-    t_my_canvas *x = (t_my_canvas *)z;
+    t_my_canvas *x = (t_my_canvas *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -167,13 +171,12 @@ static void my_canvas_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x none #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), 1,
-            x->x_vis_w, x->x_vis_h, 0,/*no_schedule*/
-            -1, -1, -1, -1,/*no linlog, no init, no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), 1, x->x_vis_w, x->x_vis_h,
+        0,              /*no_schedule*/
+        -1, -1, -1, -1, /*no linlog, no init, no multi*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
@@ -181,13 +184,16 @@ static void my_canvas_get_pos(t_my_canvas *x)
 {
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
     {
-        x->x_at[0].a_w.w_float = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist)/IEMGUI_ZOOM(x);
-        x->x_at[1].a_w.w_float = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist)/IEMGUI_ZOOM(x);
+        x->x_at[0].a_w.w_float =
+            text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist) / IEMGUI_ZOOM(x);
+        x->x_at[1].a_w.w_float =
+            text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) / IEMGUI_ZOOM(x);
         pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
     }
 }
 
-static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv)
+static void my_canvas_dialog(
+    t_my_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
     int a = atom_getfloatarg(0, argc, argv);
@@ -196,27 +202,23 @@ static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT (undo+1, 0);
-    SETFLOAT (undo+2, x->x_vis_w);
-    SETFLOAT (undo+3, x->x_vis_h);
-    SETFLOAT (undo+5, -1);
-    SETSYMBOL(undo+15, gensym("none"));
+    SETFLOAT(undo + 1, 0);
+    SETFLOAT(undo + 2, x->x_vis_w);
+    SETFLOAT(undo + 3, x->x_vis_h);
+    SETFLOAT(undo + 5, -1);
+    SETSYMBOL(undo + 15, gensym("none"));
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_isa.x_loadinit = 0;
-    if(a < 1)
-        a = 1;
+    if(a < 1) a = 1;
     x->x_gui.x_w = a * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    if(w < 1)
-        w = 1;
+    if(w < 1) w = 1;
     x->x_vis_w = w;
-    if(h < 1)
-        h = 1;
+    if(h < 1) h = 1;
     x->x_vis_h = h;
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
@@ -226,32 +228,33 @@ static void my_canvas_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
     int i = atom_getfloatarg(0, ac, av);
 
-    if(i < 1)
-        i = 1;
-    x->x_gui.x_w = i*IEMGUI_ZOOM(x);
+    if(i < 1) i = 1;
+    x->x_gui.x_w = i * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void my_canvas_delta(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_canvas_pos(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_canvas_vis_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 {
     int i;
 
     i = atom_getfloatarg(0, ac, av);
-    if(i < 1)
-        i = 1;
+    if(i < 1) i = 1;
     x->x_vis_w = i;
     if(ac > 1)
     {
         i = atom_getfloatarg(1, ac, av);
-        if(i < 1)
-            i = 1;
+        if(i < 1) i = 1;
     }
     x->x_vis_h = i;
     if(glist_isvisible(x->x_gui.x_glist))
@@ -259,26 +262,39 @@ static void my_canvas_vis_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 }
 
 static void my_canvas_color(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_canvas_send(t_my_canvas *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void my_canvas_receive(t_my_canvas *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void my_canvas_label(t_my_canvas *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void my_canvas_label_pos(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
-static void my_canvas_label_font(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+static void my_canvas_label_font(
+    t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_my_canvas *x = (t_my_canvas *)pd_new(my_canvas_class);
+    t_my_canvas *x = (t_my_canvas *) pd_new(my_canvas_class);
     int a = IEM_GUI_DEFAULTSIZE, w = 100, h = 60;
     int ldx = 20, ldy = 12, f = 2, i = 0;
     int fs = 14;
@@ -290,73 +306,74 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x404040;
 
-    if(((argc >= 10)&&(argc <= 13))
-       &&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2))
+    if(((argc >= 10) && (argc <= 13)) && IS_A_FLOAT(argv, 0) &&
+        IS_A_FLOAT(argv, 1) && IS_A_FLOAT(argv, 2))
     {
         a = atom_getfloatarg(0, argc, argv);
         w = atom_getfloatarg(1, argc, argv);
         h = atom_getfloatarg(2, argc, argv);
     }
-    if((argc >= 12)&&(IS_A_SYMBOL(argv,3)||IS_A_FLOAT(argv,3))&&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4)))
+    if((argc >= 12) && (IS_A_SYMBOL(argv, 3) || IS_A_FLOAT(argv, 3)) &&
+        (IS_A_SYMBOL(argv, 4) || IS_A_FLOAT(argv, 4)))
     {
         i = 2;
         iemgui_new_getnames(&x->x_gui, 3, argv);
     }
-    else if((argc == 11)&&(IS_A_SYMBOL(argv,3)||IS_A_FLOAT(argv,3)))
+    else if((argc == 11) && (IS_A_SYMBOL(argv, 3) || IS_A_FLOAT(argv, 3)))
     {
         i = 1;
         iemgui_new_getnames(&x->x_gui, 3, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 3, 0);
+    else
+        iemgui_new_getnames(&x->x_gui, 3, 0);
 
-    if(((argc >= 10)&&(argc <= 13))
-       &&(IS_A_SYMBOL(argv,i+3)||IS_A_FLOAT(argv,i+3))&&IS_A_FLOAT(argv,i+4)
-       &&IS_A_FLOAT(argv,i+5)&&IS_A_FLOAT(argv,i+6)
-       &&IS_A_FLOAT(argv,i+7))
+    if(((argc >= 10) && (argc <= 13)) &&
+        (IS_A_SYMBOL(argv, i + 3) || IS_A_FLOAT(argv, i + 3)) &&
+        IS_A_FLOAT(argv, i + 4) && IS_A_FLOAT(argv, i + 5) &&
+        IS_A_FLOAT(argv, i + 6) && IS_A_FLOAT(argv, i + 7))
     {
-            /* disastrously, the "label" sits in a different part of the
-            message.  So we have to track its location separately (in
-            the slot x_labelbindex) and initialize it specially here. */
-        iemgui_new_dogetname(&x->x_gui, i+3, argv);
-        x->x_gui.x_labelbindex = i+4;
-        ldx = atom_getfloatarg(i+4, argc, argv);
-        ldy = atom_getfloatarg(i+5, argc, argv);
-        iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(i+6, argc, argv));
-        fs = atom_getfloatarg(i+7, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+i+8, 0, argv+i+9);
+        /* disastrously, the "label" sits in a different part of the
+        message.  So we have to track its location separately (in
+        the slot x_labelbindex) and initialize it specially here. */
+        iemgui_new_dogetname(&x->x_gui, i + 3, argv);
+        x->x_gui.x_labelbindex = i + 4;
+        ldx = atom_getfloatarg(i + 4, argc, argv);
+        ldy = atom_getfloatarg(i + 5, argc, argv);
+        iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(i + 6, argc, argv));
+        fs = atom_getfloatarg(i + 7, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + i + 8, 0, argv + i + 9);
     }
-    if((argc == 13)&&IS_A_FLOAT(argv,i+10))
+    if((argc == 13) && IS_A_FLOAT(argv, i + 10))
     {
-        iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(i+10, argc, argv));
+        iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(i + 10, argc, argv));
     }
-    x->x_gui.x_draw = (t_iemfunptr)my_canvas_draw;
+    x->x_gui.x_draw = (t_iemfunptr) my_canvas_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if (!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(a < 1)
-        a = 1;
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(a < 1) a = 1;
     x->x_gui.x_w = a;
     x->x_gui.x_h = x->x_gui.x_w;
-    if(w < 1)
-        w = 1;
+    if(w < 1) w = 1;
     x->x_vis_w = w;
-    if(h < 1)
-        h = 1;
+    if(h < 1) h = 1;
     x->x_vis_h = h;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
-    if (x->x_gui.x_fsf.x_rcv_able)
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
+    if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_at[0].a_type = A_FLOAT;
     x->x_at[1].a_type = A_FLOAT;
@@ -374,42 +391,44 @@ static void my_canvas_ff(t_my_canvas *x)
 
 void g_mycanvas_setup(void)
 {
-    my_canvas_class = class_new(gensym("cnv"), (t_newmethod)my_canvas_new,
-        (t_method)my_canvas_ff, sizeof(t_my_canvas), CLASS_NOINLET, A_GIMME, 0);
-    class_addcreator((t_newmethod)my_canvas_new, gensym("my_canvas"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_dialog,
+    my_canvas_class = class_new(gensym("cnv"), (t_newmethod) my_canvas_new,
+        (t_method) my_canvas_ff, sizeof(t_my_canvas), CLASS_NOINLET, A_GIMME,
+        0);
+    class_addcreator(
+        (t_newmethod) my_canvas_new, gensym("my_canvas"), A_GIMME, 0);
+    class_addmethod(my_canvas_class, (t_method) my_canvas_dialog,
         gensym("dialog"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_delta,
+    class_addmethod(
+        my_canvas_class, (t_method) my_canvas_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(my_canvas_class, (t_method) my_canvas_delta,
         gensym("delta"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_vis_size,
+    class_addmethod(
+        my_canvas_class, (t_method) my_canvas_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(my_canvas_class, (t_method) my_canvas_vis_size,
         gensym("vis_size"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_color,
+    class_addmethod(my_canvas_class, (t_method) my_canvas_color,
         gensym("color"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_receive,
+    class_addmethod(my_canvas_class, (t_method) my_canvas_send, gensym("send"),
+        A_DEFSYM, 0);
+    class_addmethod(my_canvas_class, (t_method) my_canvas_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_label,
+    class_addmethod(my_canvas_class, (t_method) my_canvas_label,
         gensym("label"), A_DEFSYM, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_label_pos,
+    class_addmethod(my_canvas_class, (t_method) my_canvas_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_label_font,
+    class_addmethod(my_canvas_class, (t_method) my_canvas_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(my_canvas_class, (t_method)my_canvas_get_pos,
-        gensym("get_pos"), 0);
-    class_addmethod(my_canvas_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
-    my_canvas_widgetbehavior.w_getrectfn  = my_canvas_getrect;
+    class_addmethod(
+        my_canvas_class, (t_method) my_canvas_get_pos, gensym("get_pos"), 0);
+    class_addmethod(
+        my_canvas_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
+    my_canvas_widgetbehavior.w_getrectfn = my_canvas_getrect;
     my_canvas_widgetbehavior.w_displacefn = iemgui_displace;
-    my_canvas_widgetbehavior.w_selectfn   = iemgui_select;
+    my_canvas_widgetbehavior.w_selectfn = iemgui_select;
     my_canvas_widgetbehavior.w_activatefn = NULL;
-    my_canvas_widgetbehavior.w_deletefn   = iemgui_delete;
-    my_canvas_widgetbehavior.w_visfn      = iemgui_vis;
-    my_canvas_widgetbehavior.w_clickfn    = NULL;
+    my_canvas_widgetbehavior.w_deletefn = iemgui_delete;
+    my_canvas_widgetbehavior.w_visfn = iemgui_vis;
+    my_canvas_widgetbehavior.w_clickfn = NULL;
     class_setwidget(my_canvas_class, &my_canvas_widgetbehavior);
     class_sethelpsymbol(my_canvas_class, gensym("cnv"));
     class_setsavefn(my_canvas_class, my_canvas_save);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -61,9 +61,13 @@ void my_numbox_calc_fontwidth(t_my_numbox *x)
     int f = 31;
 
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         f = 27;
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         f = 25;
+    }
 
     w = x->x_gui.x_fontsize * f * x->x_numwidth;
     w /= 36;
@@ -195,14 +199,18 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
         ypos + x->x_gui.x_h - IEMGUI_ZOOM(x), IEMGUI_ZOOM(x), x->x_gui.x_fcol,
         x);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
             xpos + iow, ypos + x->x_gui.x_h, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    }
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
              "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
         canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -237,12 +245,16 @@ static void my_numbox_draw_move(t_my_numbox *x, t_glist *glist)
         xpos + IEMGUI_ZOOM(x), ypos + IEMGUI_ZOOM(x), xpos + half, ypos + half,
         xpos + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
             ypos + x->x_gui.x_h);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
         xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
         ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
@@ -357,19 +369,33 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
 void my_numbox_draw(t_my_numbox *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         sys_queuegui(x, glist, my_numbox_draw_update);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         my_numbox_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         my_numbox_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         my_numbox_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         my_numbox_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         my_numbox_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         my_numbox_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ nbx widgetbehaviour----------------------------- */
@@ -438,9 +464,13 @@ int my_numbox_check_minmax(t_my_numbox *x, double min, double max)
         ret = 1;
     }
     if(x->x_lin0_log1)
+    {
         x->x_k = exp(log(x->x_max / x->x_min) / (double) (x->x_log_height));
+    }
     else
+    {
         x->x_k = 1.0;
+    }
     return (ret);
 }
 
@@ -533,9 +563,13 @@ static void my_numbox_motion(
 
     if(x->x_gui.x_fsf.x_finemoved) k2 = 0.01;
     if(x->x_lin0_log1)
+    {
         x->x_val *= pow(x->x_k, -k2 * dy);
+    }
     else
+    {
         x->x_val -= k2 * dy;
+    }
     my_numbox_clip(x);
     sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     my_numbox_bang(x);
@@ -559,9 +593,13 @@ static int my_numbox_newclick(t_gobj *z, struct _glist *glist, int xpix,
         my_numbox_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
+        {
             x->x_gui.x_fsf.x_finemoved = 1;
+        }
         else
+        {
             x->x_gui.x_fsf.x_finemoved = 0;
+        }
         if(!x->x_gui.x_fsf.x_change)
         {
             clock_delay(x->x_clock_wait, 50);
@@ -599,9 +637,13 @@ static void my_numbox_log_height(t_my_numbox *x, t_floatarg lh)
     if(lh < 10.0) lh = 10.0;
     x->x_log_height = (int) lh;
     if(x->x_lin0_log1)
+    {
         x->x_k = exp(log(x->x_max / x->x_min) / (double) (x->x_log_height));
+    }
     else
+    {
         x->x_k = 1.0;
+    }
 }
 
 static void my_numbox_float(t_my_numbox *x, t_floatarg f)
@@ -822,9 +864,13 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fsf.x_rcv_able = 1;
     x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_val = v;
+    }
     else
+    {
         x->x_val = 0.0;
+    }
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
     if(log_height < 10) log_height = 10;
@@ -832,9 +878,13 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -57,7 +57,8 @@ void my_numbox_clip(t_my_numbox *x)
 
 void my_numbox_calc_fontwidth(t_my_numbox *x)
 {
-    int w, f = 31;
+    int w;
+    int f = 31;
 
     if(x->x_gui.x_fsf.x_font_style == 1)
         f = 27;
@@ -73,7 +74,10 @@ void my_numbox_calc_fontwidth(t_my_numbox *x)
 void my_numbox_ftoa(t_my_numbox *x)
 {
     double f = x->x_val;
-    int bufsize, is_exp = 0, i, idecimal;
+    int bufsize;
+    int is_exp = 0;
+    int i;
+    int idecimal;
 
     sprintf(x->x_buf, "%g", f);
     bufsize = (int) strlen(x->x_buf);
@@ -171,10 +175,12 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int w = x->x_gui.x_w, half = x->x_gui.x_h / 2;
+    int w = x->x_gui.x_w;
+    int half = x->x_gui.x_h / 2;
     int d = IEMGUI_ZOOM(x) + x->x_gui.x_h / (34 * IEMGUI_ZOOM(x));
     int corner = x->x_gui.x_h / 4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c create polygon %d %d %d %d %d %d %d %d %d %d %d %d "
@@ -216,10 +222,12 @@ static void my_numbox_draw_move(t_my_numbox *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int w = x->x_gui.x_w, half = x->x_gui.x_h / 2;
+    int w = x->x_gui.x_w;
+    int half = x->x_gui.x_h / 2;
     int d = IEMGUI_ZOOM(x) + x->x_gui.x_h / (34 * IEMGUI_ZOOM(x));
     int corner = x->x_gui.x_h / 4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c coords %lxBASE1 %d %d %d %d %d %d %d %d %d %d %d %d\n",
@@ -282,7 +290,8 @@ static void my_numbox_draw_io(
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -603,7 +612,8 @@ static void my_numbox_float(t_my_numbox *x, t_floatarg f)
 
 static void my_numbox_size(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 {
-    int h, w;
+    int h;
+    int w;
 
     w = (int) atom_getfloatarg(0, ac, av);
     if(w < MINDIGITS) w = MINDIGITS;
@@ -764,11 +774,16 @@ static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_my_numbox *x = (t_my_numbox *) pd_new(my_numbox_class);
-    int w = 5, h = 14;
-    int lilo = 0, ldx = 0, ldy = -8;
+    int w = 5;
+    int h = 14;
+    int lilo = 0;
+    int ldx = 0;
+    int ldy = -8;
     int fs = 10;
     int log_height = 256;
-    double min = -1.0e+37, max = 1.0e+37, v = 0.0;
+    double min = -1.0e+37;
+    double max = 1.0e+37;
+    double v = 0.0;
 
     x->x_gui.x_bcol = 0xFCFCFC;
     x->x_gui.x_fcol = 0x00;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -80,14 +80,13 @@ void my_numbox_ftoa(t_my_numbox *x)
     double f = x->x_val;
     int bufsize;
     int is_exp = 0;
-    int i;
     int idecimal;
 
     sprintf(x->x_buf, "%g", f);
     bufsize = (int) strlen(x->x_buf);
     if(bufsize >= 5) /* if it is in exponential mode */
     {
-        i = bufsize - 4;
+        int i = bufsize - 4;
         if((x->x_buf[i] == 'e') || (x->x_buf[i] == 'E')) is_exp = 1;
     }
     if(bufsize > x->x_numwidth) /* if to reduce */
@@ -99,7 +98,7 @@ void my_numbox_ftoa(t_my_numbox *x)
                 x->x_buf[0] = (f < 0.0 ? '-' : '+');
                 x->x_buf[1] = 0;
             }
-            i = bufsize - 4;
+            int i = bufsize - 4;
             for(idecimal = 0; idecimal < i; idecimal++)
                 if(x->x_buf[idecimal] == '.') break;
             if(idecimal > (x->x_numwidth - 4))
@@ -112,7 +111,7 @@ void my_numbox_ftoa(t_my_numbox *x)
                 int new_exp_index = x->x_numwidth - 4;
                 int old_exp_index = bufsize - 4;
 
-                for(i = 0; i < 4; i++, new_exp_index++, old_exp_index++)
+                for(int i = 0; i < 4; i++, new_exp_index++, old_exp_index++)
                     x->x_buf[new_exp_index] = x->x_buf[old_exp_index];
                 x->x_buf[x->x_numwidth] = 0;
             }

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -21,7 +21,7 @@
 #endif
 
 #define MINDIGITS 1
-#define MINFONT   4
+#define MINFONT 4
 
 /*------------------ global functions -------------------------*/
 
@@ -51,10 +51,8 @@ static void my_numbox_tick_wait(t_my_numbox *x)
 
 void my_numbox_clip(t_my_numbox *x)
 {
-    if(x->x_val < x->x_min)
-        x->x_val = x->x_min;
-    if(x->x_val > x->x_max)
-        x->x_val = x->x_max;
+    if(x->x_val < x->x_min) x->x_val = x->x_min;
+    if(x->x_val > x->x_max) x->x_val = x->x_max;
 }
 
 void my_numbox_calc_fontwidth(t_my_numbox *x)
@@ -68,7 +66,8 @@ void my_numbox_calc_fontwidth(t_my_numbox *x)
 
     w = x->x_gui.x_fontsize * f * x->x_numwidth;
     w /= 36;
-    x->x_gui.x_w = (w + (x->x_gui.x_h/2)/IEMGUI_ZOOM(x) + 4) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        (w + (x->x_gui.x_h / 2) / IEMGUI_ZOOM(x) + 4) * IEMGUI_ZOOM(x);
 }
 
 void my_numbox_ftoa(t_my_numbox *x)
@@ -77,14 +76,13 @@ void my_numbox_ftoa(t_my_numbox *x)
     int bufsize, is_exp = 0, i, idecimal;
 
     sprintf(x->x_buf, "%g", f);
-    bufsize = (int)strlen(x->x_buf);
-    if(bufsize >= 5)/* if it is in exponential mode */
+    bufsize = (int) strlen(x->x_buf);
+    if(bufsize >= 5) /* if it is in exponential mode */
     {
         i = bufsize - 4;
-        if((x->x_buf[i] == 'e') || (x->x_buf[i] == 'E'))
-            is_exp = 1;
+        if((x->x_buf[i] == 'e') || (x->x_buf[i] == 'E')) is_exp = 1;
     }
-    if(bufsize > x->x_numwidth)/* if to reduce */
+    if(bufsize > x->x_numwidth) /* if to reduce */
     {
         if(is_exp)
         {
@@ -95,8 +93,7 @@ void my_numbox_ftoa(t_my_numbox *x)
             }
             i = bufsize - 4;
             for(idecimal = 0; idecimal < i; idecimal++)
-                if(x->x_buf[idecimal] == '.')
-                    break;
+                if(x->x_buf[idecimal] == '.') break;
             if(idecimal > (x->x_numwidth - 4))
             {
                 x->x_buf[0] = (f < 0.0 ? '-' : '+');
@@ -115,8 +112,7 @@ void my_numbox_ftoa(t_my_numbox *x)
         else
         {
             for(idecimal = 0; idecimal < bufsize; idecimal++)
-                if(x->x_buf[idecimal] == '.')
-                    break;
+                if(x->x_buf[idecimal] == '.') break;
             if(idecimal > x->x_numwidth)
             {
                 x->x_buf[0] = (f < 0.0 ? '-' : '+');
@@ -130,7 +126,7 @@ void my_numbox_ftoa(t_my_numbox *x)
 
 static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_my_numbox *x = (t_my_numbox *)client;
+    t_my_numbox *x = (t_my_numbox *) client;
     if(glist_isvisible(glist))
     {
         if(x->x_gui.x_fsf.x_change)
@@ -138,33 +134,34 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
             if(x->x_buf[0])
             {
                 char *cp = x->x_buf;
-                int sl = (int)strlen(x->x_buf);
+                int sl = (int) strlen(x->x_buf);
 
                 x->x_buf[sl] = '>';
-                x->x_buf[sl+1] = 0;
-                if(sl >= x->x_numwidth)
-                    cp += sl - x->x_numwidth + 1;
-                sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
-                         glist_getcanvas(glist), x,
-                         IEM_GUI_COLOR_EDITED, cp);
+                x->x_buf[sl + 1] = 0;
+                if(sl >= x->x_numwidth) cp += sl - x->x_numwidth + 1;
+                sys_vgui(
+                    ".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
+                    glist_getcanvas(glist), x, IEM_GUI_COLOR_EDITED, cp);
                 x->x_buf[sl] = 0;
             }
             else
             {
                 my_numbox_ftoa(x);
-                sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
-                         glist_getcanvas(glist), x,
-                         IEM_GUI_COLOR_EDITED, x->x_buf);
+                sys_vgui(
+                    ".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
+                    glist_getcanvas(glist), x, IEM_GUI_COLOR_EDITED, x->x_buf);
                 x->x_buf[0] = 0;
             }
         }
         else
         {
             my_numbox_ftoa(x);
-            sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
-                     glist_getcanvas(glist), x,
-                     (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_fcol),
-                     x->x_buf);
+            sys_vgui(
+                ".x%lx.c itemconfigure %lxNUMBER -fill #%06x -text {%s} \n",
+                glist_getcanvas(glist), x,
+                (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED
+                                           : x->x_gui.x_fcol),
+                x->x_buf);
             x->x_buf[0] = 0;
         }
     }
@@ -174,95 +171,78 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int w = x->x_gui.x_w, half = x->x_gui.x_h/2;
-    int d = IEMGUI_ZOOM(x) + x->x_gui.x_h/(34*IEMGUI_ZOOM(x));
-    int corner = x->x_gui.x_h/4;
+    int w = x->x_gui.x_w, half = x->x_gui.x_h / 2;
+    int d = IEMGUI_ZOOM(x) + x->x_gui.x_h / (34 * IEMGUI_ZOOM(x));
+    int corner = x->x_gui.x_h / 4;
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c create polygon %d %d %d %d %d %d %d %d %d %d %d %d "
              "-width %d -outline #%06x -fill #%06x -tags %lxBASE1\n",
-             canvas,
-             xpos, ypos,
-             xpos + w - corner, ypos,
-             xpos + w, ypos + corner,
-             xpos + w, ypos + x->x_gui.x_h,
-             xpos, ypos + x->x_gui.x_h,
-             xpos, ypos,
-             IEMGUI_ZOOM(x), IEM_GUI_COLOR_NORMAL, x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d %d %d -width %d -fill #%06x -tags %lxBASE2\n",
-             canvas,
-             xpos + IEMGUI_ZOOM(x), ypos + IEMGUI_ZOOM(x),
-             xpos + half, ypos + half,
-             xpos + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - IEMGUI_ZOOM(x),
-             IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
+        canvas, xpos, ypos, xpos + w - corner, ypos, xpos + w, ypos + corner,
+        xpos + w, ypos + x->x_gui.x_h, xpos, ypos + x->x_gui.x_h, xpos, ypos,
+        IEMGUI_ZOOM(x), IEM_GUI_COLOR_NORMAL, x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create line %d %d %d %d %d %d -width %d -fill #%06x "
+             "-tags %lxBASE2\n",
+        canvas, xpos + IEMGUI_ZOOM(x), ypos + IEMGUI_ZOOM(x), xpos + half,
+        ypos + half, xpos + IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_h - IEMGUI_ZOOM(x), IEMGUI_ZOOM(x), x->x_gui.x_fcol,
+        x);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
+             "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
     my_numbox_ftoa(x);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags %lxNUMBER\n",
-             canvas, xpos + half + 2*IEMGUI_ZOOM(x), ypos + half + d,
-             x->x_buf, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
-             sys_fontweight, (x->x_gui.x_fsf.x_change ? IEM_GUI_COLOR_EDITED : x->x_gui.x_fcol), x);
+    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
+             "%s} -fill #%06x -tags %lxNUMBER\n",
+        canvas, xpos + half + 2 * IEMGUI_ZOOM(x), ypos + half + d, x->x_buf,
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        (x->x_gui.x_fsf.x_change ? IEM_GUI_COLOR_EDITED : x->x_gui.x_fcol), x);
 }
 
 static void my_numbox_draw_move(t_my_numbox *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int w = x->x_gui.x_w, half = x->x_gui.x_h/2;
+    int w = x->x_gui.x_w, half = x->x_gui.x_h / 2;
     int d = IEMGUI_ZOOM(x) + x->x_gui.x_h / (34 * IEMGUI_ZOOM(x));
-    int corner = x->x_gui.x_h/4;
+    int corner = x->x_gui.x_h / 4;
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c coords %lxBASE1 %d %d %d %d %d %d %d %d %d %d %d %d\n",
-             canvas, x,
-             xpos, ypos,
-             xpos + w - corner, ypos,
-             xpos + w, ypos + corner,
-             xpos + w, ypos + x->x_gui.x_h,
-             xpos, ypos + x->x_gui.x_h,
-             xpos, ypos);
-    sys_vgui(".x%lx.c coords %lxBASE2 %d %d %d %d %d %d\n",
-             canvas, x,
-             xpos + IEMGUI_ZOOM(x), ypos + IEMGUI_ZOOM(x),
-             xpos + half, ypos + half,
-             xpos + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
+        canvas, x, xpos, ypos, xpos + w - corner, ypos, xpos + w, ypos + corner,
+        xpos + w, ypos + x->x_gui.x_h, xpos, ypos + x->x_gui.x_h, xpos, ypos);
+    sys_vgui(".x%lx.c coords %lxBASE2 %d %d %d %d %d %d\n", canvas, x,
+        xpos + IEMGUI_ZOOM(x), ypos + IEMGUI_ZOOM(x), xpos + half, ypos + half,
+        xpos + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
+            ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x,
-             xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
-    sys_vgui(".x%lx.c coords %lxNUMBER %d %d\n",
-             canvas, x, xpos + half + 2*IEMGUI_ZOOM(x), ypos + half + d);
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxNUMBER %d %d\n", canvas, x,
+        xpos + half + 2 * IEMGUI_ZOOM(x), ypos + half + d);
 }
 
-static void my_numbox_draw_erase(t_my_numbox* x, t_glist* glist)
+static void my_numbox_draw_erase(t_my_numbox *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -276,48 +256,52 @@ static void my_numbox_draw_erase(t_my_numbox* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
+static void my_numbox_draw_config(t_my_numbox *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
-             strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name:"");
-    sys_vgui(".x%lx.c itemconfigure %lxNUMBER -font {{%s} -%d %s} -fill #%06x \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_fcol));
-    sys_vgui(".x%lx.c itemconfigure %lxBASE1 -fill #%06x\n", canvas,
-             x, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
+        strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
+    sys_vgui(
+        ".x%lx.c itemconfigure %lxNUMBER -font {{%s} -%d %s} -fill #%06x \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_fcol));
+    sys_vgui(".x%lx.c itemconfigure %lxBASE1 -fill #%06x\n", canvas, x,
+        x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxBASE2 -fill #%06x\n", canvas, x,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_fcol));
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_fcol));
 }
 
-static void my_numbox_draw_io(t_my_numbox* x,t_glist* glist, int old_snd_rcv_flags)
+static void my_numbox_draw_io(
+    t_my_numbox *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep these above outlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxNUMBER %lxLABEL\n", canvas, x, x);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep these above inlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxNUMBER %lxLABEL\n", canvas, x, x);
@@ -339,25 +323,25 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
             x->x_buf[0] = 0;
             sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         }
-        sys_vgui(".x%lx.c itemconfigure %lxBASE1 -outline #%06x\n",
-            canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxBASE2 -fill #%06x\n",
-            canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n",
-            canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x\n",
-            canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE1 -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE2 -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE1 -outline #%06x\n",
-            canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxBASE2 -fill #%06x\n",
-            canvas, x, x->x_gui.x_fcol);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n",
-            canvas, x, x->x_gui.x_lcol);
-        sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x\n",
-            canvas, x, x->x_gui.x_fcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE1 -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE2 -fill #%06x\n", canvas, x,
+            x->x_gui.x_fcol);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxNUMBER -fill #%06x\n", canvas, x,
+            x->x_gui.x_fcol);
     }
 }
 
@@ -381,10 +365,10 @@ void my_numbox_draw(t_my_numbox *x, t_glist *glist, int mode)
 
 /* ------------------------ nbx widgetbehaviour----------------------------- */
 
-static void my_numbox_getrect(t_gobj *z, t_glist *glist,
-                              int *xp1, int *yp1, int *xp2, int *yp2)
+static void my_numbox_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_my_numbox* x = (t_my_numbox*)z;
+    t_my_numbox *x = (t_my_numbox *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -394,7 +378,7 @@ static void my_numbox_getrect(t_gobj *z, t_glist *glist,
 
 static void my_numbox_save(t_gobj *z, t_binbuf *b)
 {
-    t_my_numbox *x = (t_my_numbox *)z;
+    t_my_numbox *x = (t_my_numbox *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
@@ -406,15 +390,13 @@ static void my_numbox_save(t_gobj *z, t_binbuf *b)
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
     binbuf_addv(b, "ssiisiiffiisssiiiisssfi", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("nbx"), x->x_numwidth, x->x_gui.x_h/IEMGUI_ZOOM(x),
-                (t_float)x->x_min, (t_float)x->x_max,
-                x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_val:0., x->x_log_height);
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("nbx"), x->x_numwidth, x->x_gui.x_h / IEMGUI_ZOOM(x),
+        (t_float) x->x_min, (t_float) x->x_max, x->x_lin0_log1,
+        iem_symargstoint(&x->x_gui.x_isa), srl[0], srl[1], srl[2],
+        x->x_gui.x_ldx, x->x_gui.x_ldy, iem_fstyletoint(&x->x_gui.x_fsf),
+        x->x_gui.x_fontsize, bflcol[0], bflcol[1], bflcol[2],
+        x->x_gui.x_isa.x_loadinit ? x->x_val : 0., x->x_log_height);
     binbuf_addv(b, ";");
 }
 
@@ -424,17 +406,14 @@ int my_numbox_check_minmax(t_my_numbox *x, double min, double max)
 
     if(x->x_lin0_log1)
     {
-        if((min == 0.0) && (max == 0.0))
-            max = 1.0;
+        if((min == 0.0) && (max == 0.0)) max = 1.0;
         if(max > 0.0)
         {
-            if(min <= 0.0)
-                min = 0.01 * max;
+            if(min <= 0.0) min = 0.01 * max;
         }
         else
         {
-            if(min > 0.0)
-                max = 0.01 * min;
+            if(min > 0.0) max = 0.01 * min;
         }
     }
     x->x_min = min;
@@ -450,15 +429,15 @@ int my_numbox_check_minmax(t_my_numbox *x, double min, double max)
         ret = 1;
     }
     if(x->x_lin0_log1)
-        x->x_k = exp(log(x->x_max/x->x_min) / (double)(x->x_log_height));
+        x->x_k = exp(log(x->x_max / x->x_min) / (double) (x->x_log_height));
     else
         x->x_k = 1.0;
-    return(ret);
+    return (ret);
 }
 
 static void my_numbox_properties(t_gobj *z, t_glist *owner)
 {
-    t_my_numbox *x = (t_my_numbox *)z;
+    t_my_numbox *x = (t_my_numbox *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -477,15 +456,14 @@ static void my_numbox_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_numwidth, MINDIGITS, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_min, x->x_max, 0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, -1,
-                x->x_log_height, /*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
-                0xffffff & x->x_gui.x_lcol);
+        x->x_numwidth, MINDIGITS, x->x_gui.x_h / IEMGUI_ZOOM(x),
+        IEM_GUI_MINSIZE, x->x_min, x->x_max, 0, /*no_schedule*/
+        x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, -1,
+        x->x_log_height, /*no multi, but iem-characteristic*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
@@ -496,40 +474,36 @@ static void my_numbox_bang(t_my_numbox *x)
         pd_float(x->x_gui.x_snd->s_thing, x->x_val);
 }
 
-static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
-    t_atom *argv)
+static void my_numbox_dialog(
+    t_my_numbox *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getfloatarg(0, argc, argv);
-    int h = (int)atom_getfloatarg(1, argc, argv);
-    double min = (double)atom_getfloatarg(2, argc, argv);
-    double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getfloatarg(4, argc, argv);
-    int log_height = (int)atom_getfloatarg(6, argc, argv);
+    int w = (int) atom_getfloatarg(0, argc, argv);
+    int h = (int) atom_getfloatarg(1, argc, argv);
+    double min = (double) atom_getfloatarg(2, argc, argv);
+    double max = (double) atom_getfloatarg(3, argc, argv);
+    int lilo = (int) atom_getfloatarg(4, argc, argv);
+    int log_height = (int) atom_getfloatarg(6, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+0, x->x_numwidth);
-    SETFLOAT(undo+2, x->x_min);
-    SETFLOAT(undo+3, x->x_max);
-    SETFLOAT(undo+4, x->x_lin0_log1);
-    SETFLOAT(undo+6, x->x_log_height);
+    SETFLOAT(undo + 0, x->x_numwidth);
+    SETFLOAT(undo + 2, x->x_min);
+    SETFLOAT(undo + 3, x->x_max);
+    SETFLOAT(undo + 4, x->x_lin0_log1);
+    SETFLOAT(undo + 6, x->x_log_height);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
-    if(w < MINDIGITS)
-        w = MINDIGITS;
+    if(w < MINDIGITS) w = MINDIGITS;
     x->x_numwidth = w;
-    if(h < IEM_GUI_MINSIZE)
-        h = IEM_GUI_MINSIZE;
+    if(h < IEM_GUI_MINSIZE) h = IEM_GUI_MINSIZE;
     x->x_gui.x_h = h * IEMGUI_ZOOM(x);
-    if(log_height < 10)
-        log_height = 10;
+    if(log_height < 10) log_height = 10;
     x->x_log_height = log_height;
     my_numbox_calc_fontwidth(x);
     /*if(my_numbox_check_minmax(x, min, max))
@@ -539,22 +513,20 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
-static void my_numbox_motion(t_my_numbox *x, t_floatarg dx, t_floatarg dy,
-    t_floatarg up)
+static void my_numbox_motion(
+    t_my_numbox *x, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
     double k2 = 1.0;
-    if (up != 0)
-        return;
+    if(up != 0) return;
 
-    if(x->x_gui.x_fsf.x_finemoved)
-        k2 = 0.01;
+    if(x->x_gui.x_fsf.x_finemoved) k2 = 0.01;
     if(x->x_lin0_log1)
-        x->x_val *= pow(x->x_k, -k2*dy);
+        x->x_val *= pow(x->x_k, -k2 * dy);
     else
-        x->x_val -= k2*dy;
+        x->x_val -= k2 * dy;
     my_numbox_clip(x);
     sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     my_numbox_bang(x);
@@ -562,21 +534,21 @@ static void my_numbox_motion(t_my_numbox *x, t_floatarg dx, t_floatarg dy,
 }
 
 static void my_numbox_click(t_my_numbox *x, t_floatarg xpos, t_floatarg ypos,
-                            t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     glist_grab(x->x_gui.x_glist, &x->x_gui.x_obj.te_g,
-        (t_glistmotionfn)my_numbox_motion, my_numbox_key, xpos, ypos);
+        (t_glistmotionfn) my_numbox_motion, my_numbox_key, xpos, ypos);
 }
 
-static int my_numbox_newclick(t_gobj *z, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int my_numbox_newclick(t_gobj *z, struct _glist *glist, int xpix,
+    int ypix, int shift, int alt, int dbl, int doit)
 {
-    t_my_numbox* x = (t_my_numbox *)z;
+    t_my_numbox *x = (t_my_numbox *) z;
 
     if(doit)
     {
-        my_numbox_click( x, (t_floatarg)xpix, (t_floatarg)ypix,
-            (t_floatarg)shift, 0, (t_floatarg)alt);
+        my_numbox_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
             x->x_gui.x_fsf.x_finemoved = 1;
         else
@@ -603,9 +575,9 @@ static int my_numbox_newclick(t_gobj *z, struct _glist *glist,
 static void my_numbox_set(t_my_numbox *x, t_floatarg f)
 {
     t_float ftocompare = f;
-        /* bitwise comparison, suggested by Dan Borstein - to make this work
-        ftocompare must be t_float type like x_val. */
-    if (memcmp(&ftocompare, &x->x_val, sizeof(ftocompare)))
+    /* bitwise comparison, suggested by Dan Borstein - to make this work
+    ftocompare must be t_float type like x_val. */
+    if(memcmp(&ftocompare, &x->x_val, sizeof(ftocompare)))
     {
         x->x_val = ftocompare;
         my_numbox_clip(x);
@@ -615,11 +587,10 @@ static void my_numbox_set(t_my_numbox *x, t_floatarg f)
 
 static void my_numbox_log_height(t_my_numbox *x, t_floatarg lh)
 {
-    if(lh < 10.0)
-        lh = 10.0;
-    x->x_log_height = (int)lh;
+    if(lh < 10.0) lh = 10.0;
+    x->x_log_height = (int) lh;
     if(x->x_lin0_log1)
-        x->x_k = exp(log(x->x_max/x->x_min)/(double)(x->x_log_height));
+        x->x_k = exp(log(x->x_max / x->x_min) / (double) (x->x_log_height));
     else
         x->x_k = 1.0;
 }
@@ -627,39 +598,40 @@ static void my_numbox_log_height(t_my_numbox *x, t_floatarg lh)
 static void my_numbox_float(t_my_numbox *x, t_floatarg f)
 {
     my_numbox_set(x, f);
-    if(x->x_gui.x_fsf.x_put_in2out)
-        my_numbox_bang(x);
+    if(x->x_gui.x_fsf.x_put_in2out) my_numbox_bang(x);
 }
 
 static void my_numbox_size(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 {
     int h, w;
 
-    w = (int)atom_getfloatarg(0, ac, av);
-    if(w < MINDIGITS)
-        w = MINDIGITS;
+    w = (int) atom_getfloatarg(0, ac, av);
+    if(w < MINDIGITS) w = MINDIGITS;
     x->x_numwidth = w;
     if(ac > 1)
     {
-        h = (int)atom_getfloatarg(1, ac, av);
-        if(h < IEM_GUI_MINSIZE)
-            h = IEM_GUI_MINSIZE;
+        h = (int) atom_getfloatarg(1, ac, av);
+        if(h < IEM_GUI_MINSIZE) h = IEM_GUI_MINSIZE;
         x->x_gui.x_h = h * IEMGUI_ZOOM(x);
     }
     my_numbox_calc_fontwidth(x);
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void my_numbox_delta(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_numbox_pos(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_numbox_range(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 {
-    if(my_numbox_check_minmax(x, (double)atom_getfloatarg(0, ac, av),
-                                 (double)atom_getfloatarg(1, ac, av)))
+    if(my_numbox_check_minmax(x, (double) atom_getfloatarg(0, ac, av),
+           (double) atom_getfloatarg(1, ac, av)))
     {
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         /*my_numbox_bang(x);*/
@@ -667,34 +639,42 @@ static void my_numbox_range(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 }
 
 static void my_numbox_color(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void my_numbox_send(t_my_numbox *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void my_numbox_receive(t_my_numbox *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void my_numbox_label(t_my_numbox *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void my_numbox_label_pos(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
-
-static void my_numbox_label_font(t_my_numbox *x,
-    t_symbol *s, int ac, t_atom *av)
 {
-    int f = (int)atom_getfloatarg(1, ac, av);
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
-    if(f < 4)
-        f = 4;
+static void my_numbox_label_font(
+    t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
+{
+    int f = (int) atom_getfloatarg(1, ac, av);
+
+    if(f < 4) f = 4;
     x->x_gui.x_fontsize = f;
-    f = (int)atom_getfloatarg(0, ac, av);
-    if((f < 0) || (f > 2))
-        f = 0;
+    f = (int) atom_getfloatarg(0, ac, av);
+    if((f < 0) || (f > 2)) f = 0;
     x->x_gui.x_fsf.x_font_style = f;
     my_numbox_calc_fontwidth(x);
-    iemgui_label_font((void *)x, &x->x_gui, s, ac, av);
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
 }
 
 static void my_numbox_log(t_my_numbox *x)
@@ -707,10 +687,7 @@ static void my_numbox_log(t_my_numbox *x)
     }
 }
 
-static void my_numbox_lin(t_my_numbox *x)
-{
-    x->x_lin0_log1 = 0;
-}
+static void my_numbox_lin(t_my_numbox *x) { x->x_lin0_log1 = 0; }
 
 static void my_numbox_init(t_my_numbox *x, t_floatarg f)
 {
@@ -740,10 +717,10 @@ static void my_numbox_key(void *z, t_symbol *keysym, t_floatarg fkey)
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         return;
     }
-    if(((c >= '0') && (c <= '9')) || (c == '.') || (c == '-') ||
-        (c == 'e') || (c == '+') || (c == 'E'))
+    if(((c >= '0') && (c <= '9')) || (c == '.') || (c == '-') || (c == 'e') ||
+        (c == '+') || (c == 'E'))
     {
-        if(strlen(x->x_buf) < (IEMGUI_MAX_NUM_LEN-2))
+        if(strlen(x->x_buf) < (IEMGUI_MAX_NUM_LEN - 2))
         {
             buf[0] = c;
             strcat(x->x_buf, buf);
@@ -752,10 +729,9 @@ static void my_numbox_key(void *z, t_symbol *keysym, t_floatarg fkey)
     }
     else if((c == '\b') || (c == 127))
     {
-        int sl = (int)strlen(x->x_buf) - 1;
+        int sl = (int) strlen(x->x_buf) - 1;
 
-        if(sl < 0)
-            sl = 0;
+        if(sl < 0) sl = 0;
         x->x_buf[sl] = 0;
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
@@ -774,7 +750,8 @@ static void my_numbox_key(void *z, t_symbol *keysym, t_floatarg fkey)
 
 static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 {
-    if(!ac) {
+    if(!ac)
+    {
         my_numbox_bang(x);
     }
     else if(IS_A_FLOAT(av, 0))
@@ -786,7 +763,7 @@ static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 
 static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_my_numbox *x = (t_my_numbox *)pd_new(my_numbox_class);
+    t_my_numbox *x = (t_my_numbox *) pd_new(my_numbox_class);
     int w = 5, h = 14;
     int lilo = 0, ldx = 0, ldy = -8;
     int fs = 10;
@@ -797,73 +774,72 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if((argc >= 17)&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)
-       &&IS_A_FLOAT(argv,2)&&IS_A_FLOAT(argv,3)
-       &&IS_A_FLOAT(argv,4)&&IS_A_FLOAT(argv,5)
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&(IS_A_SYMBOL(argv,7)||IS_A_FLOAT(argv,7))
-       &&(IS_A_SYMBOL(argv,8)||IS_A_FLOAT(argv,8))
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
-       &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
+    if((argc >= 17) && IS_A_FLOAT(argv, 0) && IS_A_FLOAT(argv, 1) &&
+        IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) && IS_A_FLOAT(argv, 4) &&
+        IS_A_FLOAT(argv, 5) && (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) &&
+        (IS_A_SYMBOL(argv, 7) || IS_A_FLOAT(argv, 7)) &&
+        (IS_A_SYMBOL(argv, 8) || IS_A_FLOAT(argv, 8)) && IS_A_FLOAT(argv, 9) &&
+        IS_A_FLOAT(argv, 10) && IS_A_FLOAT(argv, 11) && IS_A_FLOAT(argv, 12) &&
+        IS_A_FLOAT(argv, 16))
     {
-        w = (int)atom_getfloatarg(0, argc, argv);
-        h = (int)atom_getfloatarg(1, argc, argv);
-        min = (double)atom_getfloatarg(2, argc, argv);
-        max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getfloatarg(4, argc, argv);
+        w = (int) atom_getfloatarg(0, argc, argv);
+        h = (int) atom_getfloatarg(1, argc, argv);
+        min = (double) atom_getfloatarg(2, argc, argv);
+        max = (double) atom_getfloatarg(3, argc, argv);
+        lilo = (int) atom_getfloatarg(4, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getfloatarg(9, argc, argv);
-        ldy = (int)atom_getfloatarg(10, argc, argv);
+        ldx = (int) atom_getfloatarg(9, argc, argv);
+        ldy = (int) atom_getfloatarg(10, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(11, argc, argv));
-        fs = (int)atom_getfloatarg(12, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
+        fs = (int) atom_getfloatarg(12, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 13, argv + 14, argv + 15);
         v = atom_getfloatarg(16, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 6, 0);
-    if((argc == 18)&&IS_A_FLOAT(argv,17))
+    else
+        iemgui_new_getnames(&x->x_gui, 6, 0);
+    if((argc == 18) && IS_A_FLOAT(argv, 17))
     {
-        log_height = (int)atom_getfloatarg(17, argc, argv);
+        log_height = (int) atom_getfloatarg(17, argc, argv);
     }
-    x->x_gui.x_draw = (t_iemfunptr)my_numbox_draw;
+    x->x_gui.x_draw = (t_iemfunptr) my_numbox_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
     if(x->x_gui.x_isa.x_loadinit)
         x->x_val = v;
     else
         x->x_val = 0.0;
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
-    if(log_height < 10)
-        log_height = 10;
+    if(log_height < 10) log_height = 10;
     x->x_log_height = log_height;
-    if(!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if(!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < MINFONT)
-        fs = MINFONT;
+    if(fs < MINFONT) fs = MINFONT;
     x->x_gui.x_fontsize = fs;
-    if(w < MINDIGITS)
-        w = MINDIGITS;
+    if(w < MINDIGITS) w = MINDIGITS;
     x->x_numwidth = w;
-    if(h < IEM_GUI_MINSIZE)
-        h = IEM_GUI_MINSIZE;
+    if(h < IEM_GUI_MINSIZE) h = IEM_GUI_MINSIZE;
     x->x_gui.x_h = h;
     x->x_buf[0] = 0;
     my_numbox_check_minmax(x, min, max);
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    x->x_clock_reset = clock_new(x, (t_method)my_numbox_tick_reset);
-    x->x_clock_wait = clock_new(x, (t_method)my_numbox_tick_wait);
+    x->x_clock_reset = clock_new(x, (t_method) my_numbox_tick_reset);
+    x->x_clock_wait = clock_new(x, (t_method) my_numbox_tick_wait);
     x->x_gui.x_fsf.x_change = 0;
     iemgui_newzoom(&x->x_gui);
     my_numbox_calc_fontwidth(x);
@@ -882,59 +858,60 @@ static void my_numbox_free(t_my_numbox *x)
 
 void g_numbox_setup(void)
 {
-    my_numbox_class = class_new(gensym("nbx"), (t_newmethod)my_numbox_new,
-        (t_method)my_numbox_free, sizeof(t_my_numbox), 0, A_GIMME, 0);
-    class_addcreator((t_newmethod)my_numbox_new, gensym("my_numbox"), A_GIMME, 0);
+    my_numbox_class = class_new(gensym("nbx"), (t_newmethod) my_numbox_new,
+        (t_method) my_numbox_free, sizeof(t_my_numbox), 0, A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) my_numbox_new, gensym("my_numbox"), A_GIMME, 0);
     class_addbang(my_numbox_class, my_numbox_bang);
     class_addfloat(my_numbox_class, my_numbox_float);
     class_addlist(my_numbox_class, my_numbox_list);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_click,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_click,
         gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_motion,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_motion,
         gensym("motion"), A_FLOAT, A_FLOAT, A_DEFFLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_dialog,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_dialog,
         gensym("dialog"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_loadbang,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_delta,
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(my_numbox_class, (t_method) my_numbox_delta,
         gensym("delta"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_range,
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(my_numbox_class, (t_method) my_numbox_range,
         gensym("range"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_color,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_color,
         gensym("color"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_receive,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_send, gensym("send"),
+        A_DEFSYM, 0);
+    class_addmethod(my_numbox_class, (t_method) my_numbox_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_label,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_label,
         gensym("label"), A_DEFSYM, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_label_pos,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_label_font,
+    class_addmethod(my_numbox_class, (t_method) my_numbox_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_log,
-        gensym("log"), 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_lin,
-        gensym("lin"), 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)my_numbox_log_height,
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_log, gensym("log"), 0);
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_lin, gensym("lin"), 0);
+    class_addmethod(
+        my_numbox_class, (t_method) my_numbox_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(my_numbox_class, (t_method) my_numbox_log_height,
         gensym("log_height"), A_FLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
-    my_numbox_widgetbehavior.w_getrectfn =    my_numbox_getrect;
-    my_numbox_widgetbehavior.w_displacefn =   iemgui_displace;
-    my_numbox_widgetbehavior.w_selectfn =     iemgui_select;
-    my_numbox_widgetbehavior.w_activatefn =   NULL;
-    my_numbox_widgetbehavior.w_deletefn =     iemgui_delete;
-    my_numbox_widgetbehavior.w_visfn =        iemgui_vis;
-    my_numbox_widgetbehavior.w_clickfn =      my_numbox_newclick;
+    class_addmethod(
+        my_numbox_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
+    my_numbox_widgetbehavior.w_getrectfn = my_numbox_getrect;
+    my_numbox_widgetbehavior.w_displacefn = iemgui_displace;
+    my_numbox_widgetbehavior.w_selectfn = iemgui_select;
+    my_numbox_widgetbehavior.w_activatefn = NULL;
+    my_numbox_widgetbehavior.w_deletefn = iemgui_delete;
+    my_numbox_widgetbehavior.w_visfn = iemgui_vis;
+    my_numbox_widgetbehavior.w_clickfn = my_numbox_newclick;
     class_setwidget(my_numbox_class, &my_numbox_widgetbehavior);
     class_sethelpsymbol(my_numbox_class, gensym("nbx"));
     class_setsavefn(my_numbox_class, my_numbox_save);

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -130,7 +130,9 @@ static void canvas_readerror(
 static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
     t_symbol *templatesym, t_word *w, int argc, t_atom *argv)
 {
-    int message, n, i;
+    int message;
+    int n;
+    int i;
 
     t_template *template = template_findbyname(templatesym);
     if(!template)
@@ -146,7 +148,8 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
         if(template->t_vec[i].ds_type == DT_ARRAY)
         {
             t_array *a = w[i].w_array;
-            int elemsize = a->a_elemsize, nitems = 0;
+            int elemsize = a->a_elemsize;
+            int nitems = 0;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
             t_template *arraytemplate = template_findbyname(arraytemplatesym);
             if(!arraytemplate)
@@ -172,7 +175,8 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
         else if(template->t_vec[i].ds_type == DT_TEXT)
         {
             t_binbuf *z = binbuf_new();
-            int first = *p_nextmsg, last;
+            int first = *p_nextmsg;
+            int last;
             for(last = first; last < natoms && vec[last].a_type != A_SEMI;
                 last++)
                 ;
@@ -189,7 +193,8 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
 int canvas_readscalar(
     t_glist *x, int natoms, t_atom *vec, int *p_nextmsg, int selectit)
 {
-    int message, nline;
+    int message;
+    int nline;
     t_template *template;
     t_symbol *templatesym;
     t_scalar *sc;
@@ -246,7 +251,10 @@ void glist_readfrombinbuf(
     t_glist *x, const t_binbuf *b, const char *filename, int selectem)
 {
     t_canvas *canvas = glist_getcanvas(x);
-    int natoms, nline, message, nextmsg = 0;
+    int natoms;
+    int nline;
+    int message;
+    int nextmsg = 0;
     t_atom *vec;
 
     natoms = binbuf_getnatom(b);
@@ -263,10 +271,12 @@ void glist_readfrombinbuf(
     /* read in templates and check for consistency */
     while(1)
     {
-        t_template *newtemplate, *existtemplate;
+        t_template *newtemplate;
+        t_template *existtemplate;
         t_symbol *templatesym;
         t_atom *templateargs = getbytes(0);
-        int ntemplateargs = 0, newnargs;
+        int ntemplateargs = 0;
+        int newnargs;
         nline = canvas_scanbinbuf(natoms, vec, &message, &nextmsg);
         if(nline < 2)
         {
@@ -365,8 +375,13 @@ we either copy the data from the new scalar to the old one in place
 thing in its place on the list. */
 void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
 {
-    int ntotal, nnew, scindex;
-    t_gobj *y, *y2 = 0, *newone, *oldone = 0;
+    int ntotal;
+    int nnew;
+    int scindex;
+    t_gobj *y;
+    t_gobj *y2 = 0;
+    t_gobj *newone;
+    t_gobj *oldone = 0;
     t_template *template;
     glist_noselect(x);
     for(y = x->gl_list, ntotal = 0, scindex = -1; y; y = y->g_next)
@@ -447,7 +462,8 @@ didit:;
 void canvas_doaddtemplate(
     t_symbol *templatesym, int *p_ntemplates, t_symbol ***p_templatevec)
 {
-    int n = *p_ntemplates, i;
+    int n = *p_ntemplates;
+    int i;
     t_symbol **templatevec = *p_templatevec;
     for(i = 0; i < n; i++)
         if(templatevec[i] == templatesym) return;
@@ -467,7 +483,9 @@ void canvas_writescalar(
 {
     t_template *template = template_findbyname(templatesym);
     t_atom *a = (t_atom *) t_getbytes(0);
-    int i, n = template ? (template->t_n) : 0, natom = 0;
+    int i;
+    int n = template ? (template->t_n) : 0;
+    int natom = 0;
     if(!amarrayelement)
     {
         t_atom templatename;
@@ -501,7 +519,8 @@ void canvas_writescalar(
         {
             int j;
             t_array *a = w[i].w_array;
-            int elemsize = a->a_elemsize, nitems = a->a_n;
+            int elemsize = a->a_elemsize;
+            int nitems = a->a_n;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
             for(j = 0; j < nitems; j++)
                 canvas_writescalar(arraytemplatesym,
@@ -546,7 +565,8 @@ static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
             {
                 int j;
                 t_array *a = w->w_array;
-                int elemsize = a->a_elemsize, nitems = a->a_n;
+                int elemsize = a->a_elemsize;
+                int nitems = a->a_n;
                 t_symbol *arraytemplatesym = ds->ds_arraytemplate;
                 canvas_doaddtemplate(
                     arraytemplatesym, p_ntemplates, p_templatevec);
@@ -593,7 +613,8 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
     for(i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
-        int j, m = template->t_n;
+        int j;
+        int m = template->t_n;
         /* drop "pd-" prefix from template symbol to print it: */
         binbuf_addv(
             b, "ss;", gensym("template"), gensym(templatevec[i]->s_name + 3));
@@ -756,12 +777,14 @@ static void canvas_collecttemplatesfor(
 static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 {
     t_symbol **templatevec = getbytes(0);
-    int i, ntemplates = 0;
+    int i;
+    int ntemplates = 0;
     canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
     for(i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
-        int j, m;
+        int j;
+        int m;
         if(!template)
         {
             bug("canvas_savetemplatesto");

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2002 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*
 Routines to read and write canvases to files:
@@ -31,15 +31,15 @@ typedef struct _savestate
 
 static void *savestate_new(void)
 {
-    t_savestate *x = (t_savestate *)pd_new(savestate_class);
+    t_savestate *x = (t_savestate *) pd_new(savestate_class);
     x->x_stateout = outlet_new(&x->x_obj, &s_list);
     x->x_bangout = outlet_new(&x->x_obj, &s_bang);
     x->x_savetobuf = 0;
     return (x);
 }
 
-    /* call this when the owning abstraction's parent patch is saved so we
-    can add state-restoring messages to binbuf */
+/* call this when the owning abstraction's parent patch is saved so we
+can add state-restoring messages to binbuf */
 static void savestate_doit(t_savestate *x, t_binbuf *b)
 {
     x->x_savetobuf = b;
@@ -47,74 +47,77 @@ static void savestate_doit(t_savestate *x, t_binbuf *b)
     x->x_savetobuf = 0;
 }
 
-    /* called by abstraction in response to savestate_doit(); lists received
-    here are added to the parent patch's save buffer after the line that will
-    create the abstraction, addressed to "#A" which will be this patch after
-    it is recreated by reopening the parent patch, pasting, or "undo". */
+/* called by abstraction in response to savestate_doit(); lists received
+here are added to the parent patch's save buffer after the line that will
+create the abstraction, addressed to "#A" which will be this patch after
+it is recreated by reopening the parent patch, pasting, or "undo". */
 static void savestate_list(t_savestate *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_savetobuf)
+    if(x->x_savetobuf)
     {
         binbuf_addv(x->x_savetobuf, "ss", gensym("#A"), gensym("saved"));
         binbuf_add(x->x_savetobuf, argc, argv);
         binbuf_addv(x->x_savetobuf, ";");
     }
-    else pd_error(x, "savestate: ignoring message sent when not saving parent");
+    else
+        pd_error(x, "savestate: ignoring message sent when not saving parent");
 }
 
 static void savestate_setup(void)
 {
     savestate_class = class_new(gensym("savestate"),
-        (t_newmethod)savestate_new, 0, sizeof(t_savestate), 0, 0);
+        (t_newmethod) savestate_new, 0, sizeof(t_savestate), 0, 0);
     class_addlist(savestate_class, savestate_list);
 }
 
 void canvas_statesavers_doit(t_glist *x, t_binbuf *b)
 {
     t_gobj *g;
-    for (g = x->gl_list; g; g = g->g_next)
-        if (g->g_pd == savestate_class)
-            savestate_doit((t_savestate *)g, b);
-        else if (g->g_pd == canvas_class && !canvas_isabstraction((t_canvas *)g))
-            canvas_statesavers_doit((t_glist *)g, b);
+    for(g = x->gl_list; g; g = g->g_next)
+        if(g->g_pd == savestate_class)
+            savestate_doit((t_savestate *) g, b);
+        else if(g->g_pd == canvas_class &&
+                !canvas_isabstraction((t_canvas *) g))
+            canvas_statesavers_doit((t_glist *) g, b);
 }
 
 void canvas_saved(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_gobj *g;
-    for (g = x->gl_list; g; g = g->g_next)
-        if (g->g_pd == savestate_class)
-            outlet_list(((t_savestate *)g)->x_stateout, 0, argc, argv);
-        else if (g->g_pd == canvas_class && !canvas_isabstraction((t_canvas *)g))
-            canvas_saved((t_glist *)g, s, argc, argv);
+    for(g = x->gl_list; g; g = g->g_next)
+        if(g->g_pd == savestate_class)
+            outlet_list(((t_savestate *) g)->x_stateout, 0, argc, argv);
+        else if(g->g_pd == canvas_class &&
+                !canvas_isabstraction((t_canvas *) g))
+            canvas_saved((t_glist *) g, s, argc, argv);
 }
 
 static t_class *declare_class;
 void canvas_savedeclarationsto(t_canvas *x, t_binbuf *b);
 
-    /* the following routines read "scalars" from a file into a canvas. */
+/* the following routines read "scalars" from a file into a canvas. */
 
-static int canvas_scanbinbuf(int natoms, t_atom *vec, int *p_indexout,
-    int *p_next)
+static int canvas_scanbinbuf(
+    int natoms, t_atom *vec, int *p_indexout, int *p_next)
 {
     int i;
     int indexwas = *p_next;
     *p_indexout = indexwas;
-    if (indexwas >= natoms)
-        return (0);
-    for (i = indexwas; i < natoms && vec[i].a_type != A_SEMI; i++)
+    if(indexwas >= natoms) return (0);
+    for(i = indexwas; i < natoms && vec[i].a_type != A_SEMI; i++)
         ;
-    if (i >= natoms)
+    if(i >= natoms)
         *p_next = i;
-    else *p_next = i + 1;
+    else
+        *p_next = i + 1;
     return (i - indexwas);
 }
 
-int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
-    int *p_nextmsg, int selectit);
+int canvas_readscalar(
+    t_glist *x, int natoms, t_atom *vec, int *p_nextmsg, int selectit);
 
-static void canvas_readerror(int natoms, t_atom *vec, int message,
-    int nline, char *s)
+static void canvas_readerror(
+    int natoms, t_atom *vec, int message, int nline, char *s)
 {
     pd_error(0, "%s", s);
     startpost("line was:");
@@ -122,15 +125,15 @@ static void canvas_readerror(int natoms, t_atom *vec, int message,
     endpost();
 }
 
-    /* fill in the contents of the scalar into the vector w. */
+/* fill in the contents of the scalar into the vector w. */
 
-static void glist_readatoms(t_glist *x, int natoms, t_atom *vec,
-    int *p_nextmsg, t_symbol *templatesym, t_word *w, int argc, t_atom *argv)
+static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
+    t_symbol *templatesym, t_word *w, int argc, t_atom *argv)
 {
     int message, n, i;
 
     t_template *template = template_findbyname(templatesym);
-    if (!template)
+    if(!template)
     {
         pd_error(0, "%s: no such template", templatesym->s_name);
         *p_nextmsg = natoms;
@@ -138,52 +141,53 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec,
     }
     word_restore(w, template, argc, argv);
     n = template->t_n;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        if (template->t_vec[i].ds_type == DT_ARRAY)
+        if(template->t_vec[i].ds_type == DT_ARRAY)
         {
             t_array *a = w[i].w_array;
             int elemsize = a->a_elemsize, nitems = 0;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
-            t_template *arraytemplate =
-                template_findbyname(arraytemplatesym);
-            if (!arraytemplate)
+            t_template *arraytemplate = template_findbyname(arraytemplatesym);
+            if(!arraytemplate)
             {
                 pd_error(0, "%s: no such template", arraytemplatesym->s_name);
             }
-            else while (1)
-            {
-                t_word *element;
-                int nline = canvas_scanbinbuf(natoms, vec, &message, p_nextmsg);
+            else
+                while(1)
+                {
+                    t_word *element;
+                    int nline =
+                        canvas_scanbinbuf(natoms, vec, &message, p_nextmsg);
                     /* empty line terminates array */
-                if (!nline)
-                    break;
-                array_resize(a, nitems + 1);
-                element = (t_word *)(((char *)a->a_vec) +
-                    nitems * elemsize);
-                glist_readatoms(x, natoms, vec, p_nextmsg, arraytemplatesym,
-                    element, nline, vec + message);
-                nitems++;
-            }
+                    if(!nline) break;
+                    array_resize(a, nitems + 1);
+                    element =
+                        (t_word *) (((char *) a->a_vec) + nitems * elemsize);
+                    glist_readatoms(x, natoms, vec, p_nextmsg, arraytemplatesym,
+                        element, nline, vec + message);
+                    nitems++;
+                }
         }
-        else if (template->t_vec[i].ds_type == DT_TEXT)
+        else if(template->t_vec[i].ds_type == DT_TEXT)
         {
             t_binbuf *z = binbuf_new();
             int first = *p_nextmsg, last;
-            for (last = first; last < natoms && vec[last].a_type != A_SEMI;
-                last++);
-            binbuf_restore(z, last-first, vec+first);
+            for(last = first; last < natoms && vec[last].a_type != A_SEMI;
+                last++)
+                ;
+            binbuf_restore(z, last - first, vec + first);
             binbuf_add(w[i].w_binbuf, binbuf_getnatom(z), binbuf_getvec(z));
             binbuf_free(z);
             last++;
-            if (last > natoms) last = natoms;
+            if(last > natoms) last = natoms;
             *p_nextmsg = last;
         }
     }
 }
 
-int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
-    int *p_nextmsg, int selectit)
+int canvas_readscalar(
+    t_glist *x, int natoms, t_atom *vec, int *p_nextmsg, int selectit)
 {
     int message, nline;
     t_template *template;
@@ -192,9 +196,9 @@ int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
     int nextmsg = *p_nextmsg;
     int wasvis = glist_isvisible(x);
 
-    if (nextmsg >= natoms || vec[nextmsg].a_type != A_SYMBOL)
+    if(nextmsg >= natoms || vec[nextmsg].a_type != A_SYMBOL)
     {
-        if (nextmsg < natoms)
+        if(nextmsg < natoms)
             post("stopping early: type %d", vec[nextmsg].a_type);
         *p_nextmsg = natoms;
         return (0);
@@ -202,43 +206,44 @@ int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
     templatesym = canvas_makebindsym(vec[nextmsg].a_w.w_symbol);
     *p_nextmsg = nextmsg + 1;
 
-    if (!(template = template_findbyname(templatesym)))
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(0, "canvas_read: %s: no such template", templatesym->s_name);
         *p_nextmsg = natoms;
         return (0);
     }
     sc = scalar_new(x, templatesym);
-    if (!sc)
+    if(!sc)
     {
         pd_error(0, "couldn't create scalar \"%s\"", templatesym->s_name);
         *p_nextmsg = natoms;
         return (0);
     }
-    if (wasvis)
+    if(wasvis)
     {
-            /* temporarily lie about vis flag while this is built */
+        /* temporarily lie about vis flag while this is built */
         glist_getcanvas(x)->gl_mapped = 0;
     }
     glist_add(x, &sc->sc_gobj);
 
     nline = canvas_scanbinbuf(natoms, vec, &message, p_nextmsg);
-    glist_readatoms(x, natoms, vec, p_nextmsg, templatesym, sc->sc_vec,
-        nline, vec + message);
-    if (wasvis)
+    glist_readatoms(x, natoms, vec, p_nextmsg, templatesym, sc->sc_vec, nline,
+        vec + message);
+    if(wasvis)
     {
-            /* reset vis flag as before */
+        /* reset vis flag as before */
         glist_getcanvas(x)->gl_mapped = 1;
         gobj_vis(&sc->sc_gobj, x, 1);
     }
-    if (selectit)
+    if(selectit)
     {
         glist_select(x, &sc->sc_gobj);
     }
     return (1);
 }
 
-void glist_readfrombinbuf(t_glist *x, const t_binbuf *b, const char *filename, int selectem)
+void glist_readfrombinbuf(
+    t_glist *x, const t_binbuf *b, const char *filename, int selectem)
 {
     t_canvas *canvas = glist_getcanvas(x);
     int natoms, nline, message, nextmsg = 0;
@@ -247,65 +252,62 @@ void glist_readfrombinbuf(t_glist *x, const t_binbuf *b, const char *filename, i
     natoms = binbuf_getnatom(b);
     vec = binbuf_getvec(b);
 
-
-            /* check for file type */
+    /* check for file type */
     nline = canvas_scanbinbuf(natoms, vec, &message, &nextmsg);
-    if (nline != 1 && vec[message].a_type != A_SYMBOL &&
+    if(nline != 1 && vec[message].a_type != A_SYMBOL &&
         strcmp(vec[message].a_w.w_symbol->s_name, "data"))
     {
         pd_error(x, "%s: file apparently of wrong type", filename);
         return;
     }
-        /* read in templates and check for consistency */
-    while (1)
+    /* read in templates and check for consistency */
+    while(1)
     {
         t_template *newtemplate, *existtemplate;
         t_symbol *templatesym;
         t_atom *templateargs = getbytes(0);
         int ntemplateargs = 0, newnargs;
         nline = canvas_scanbinbuf(natoms, vec, &message, &nextmsg);
-        if (nline < 2)
+        if(nline < 2)
         {
-            t_freebytes(templateargs, sizeof (*templateargs) * ntemplateargs);
+            t_freebytes(templateargs, sizeof(*templateargs) * ntemplateargs);
             break;
         }
-        else if (nline > 2)
-            canvas_readerror(natoms, vec, message, nline,
-                "extra items ignored");
-        else if (vec[message].a_type != A_SYMBOL ||
-            strcmp(vec[message].a_w.w_symbol->s_name, "template") ||
-            vec[message + 1].a_type != A_SYMBOL)
+        else if(nline > 2)
+            canvas_readerror(
+                natoms, vec, message, nline, "extra items ignored");
+        else if(vec[message].a_type != A_SYMBOL ||
+                strcmp(vec[message].a_w.w_symbol->s_name, "template") ||
+                vec[message + 1].a_type != A_SYMBOL)
         {
-            canvas_readerror(natoms, vec, message, nline,
-                "bad template header");
+            canvas_readerror(
+                natoms, vec, message, nline, "bad template header");
             continue;
         }
         templatesym = canvas_makebindsym(vec[message + 1].a_w.w_symbol);
-        while (1)
+        while(1)
         {
             nline = canvas_scanbinbuf(natoms, vec, &message, &nextmsg);
-            if (nline != 2 && nline != 3)
-                break;
+            if(nline != 2 && nline != 3) break;
             newnargs = ntemplateargs + nline;
-            templateargs = (t_atom *)t_resizebytes(templateargs,
+            templateargs = (t_atom *) t_resizebytes(templateargs,
                 sizeof(*templateargs) * ntemplateargs,
                 sizeof(*templateargs) * newnargs);
             templateargs[ntemplateargs] = vec[message];
             templateargs[ntemplateargs + 1] = vec[message + 1];
-            if (nline == 3)
-                templateargs[ntemplateargs + 2] = vec[message + 2];
+            if(nline == 3) templateargs[ntemplateargs + 2] = vec[message + 2];
             ntemplateargs = newnargs;
         }
-        if (!(existtemplate = template_findbyname(templatesym)))
+        if(!(existtemplate = template_findbyname(templatesym)))
         {
             pd_error(0, "%s: template not found in current patch",
                 templatesym->s_name);
-            t_freebytes(templateargs, sizeof (*templateargs) * ntemplateargs);
+            t_freebytes(templateargs, sizeof(*templateargs) * ntemplateargs);
             return;
         }
         newtemplate = template_new(templatesym, ntemplateargs, templateargs);
-        t_freebytes(templateargs, sizeof (*templateargs) * ntemplateargs);
-        if (!template_match(existtemplate, newtemplate))
+        t_freebytes(templateargs, sizeof(*templateargs) * ntemplateargs);
+        if(!template_match(existtemplate, newtemplate))
         {
             pd_error(0, "%s: template doesn't match current one",
                 templatesym->s_name);
@@ -314,38 +316,35 @@ void glist_readfrombinbuf(t_glist *x, const t_binbuf *b, const char *filename, i
         }
         pd_free(&newtemplate->t_pdobj);
     }
-    while (nextmsg < natoms)
+    while(nextmsg < natoms)
     {
         canvas_readscalar(x, natoms, vec, &nextmsg, selectem);
     }
 }
 
-static void glist_doread(t_glist *x, t_symbol *filename, t_symbol *format,
-    int clearme)
+static void glist_doread(
+    t_glist *x, t_symbol *filename, t_symbol *format, int clearme)
 {
     t_binbuf *b = binbuf_new();
     t_canvas *canvas = glist_getcanvas(x);
     int wasvis = glist_isvisible(canvas);
     int cr = 0;
 
-    if (!strcmp(format->s_name, "cr"))
+    if(!strcmp(format->s_name, "cr"))
         cr = 1;
-    else if (*format->s_name)
+    else if(*format->s_name)
         pd_error(0, "qlist_read: unknown flag: %s", format->s_name);
 
-    if (binbuf_read_via_canvas(b, filename->s_name, canvas, cr))
+    if(binbuf_read_via_canvas(b, filename->s_name, canvas, cr))
     {
         pd_error(x, "read failed");
         binbuf_free(b);
         return;
     }
-    if (wasvis)
-        canvas_vis(canvas, 0);
-    if (clearme)
-        glist_clear(x);
+    if(wasvis) canvas_vis(canvas, 0);
+    if(clearme) glist_clear(x);
     glist_readfrombinbuf(x, b, filename->s_name, 0);
-    if (wasvis)
-        canvas_vis(canvas, 1);
+    if(wasvis) canvas_vis(canvas, 1);
     binbuf_free(b);
 }
 
@@ -359,64 +358,64 @@ void glist_mergefile(t_glist *x, t_symbol *filename, t_symbol *format)
     glist_doread(x, filename, format, 0);
 }
 
-    /* read text from a "properties" window, called from a gfxstub set
-    up in scalar_properties().  We try to restore the object; if successful
-    we either copy the data from the new scalar to the old one in place
-    (if their templates match) or else delete the old scalar and put the new
-    thing in its place on the list. */
+/* read text from a "properties" window, called from a gfxstub set
+up in scalar_properties().  We try to restore the object; if successful
+we either copy the data from the new scalar to the old one in place
+(if their templates match) or else delete the old scalar and put the new
+thing in its place on the list. */
 void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
 {
     int ntotal, nnew, scindex;
     t_gobj *y, *y2 = 0, *newone, *oldone = 0;
     t_template *template;
     glist_noselect(x);
-    for (y = x->gl_list, ntotal = 0, scindex = -1; y; y = y->g_next)
+    for(y = x->gl_list, ntotal = 0, scindex = -1; y; y = y->g_next)
     {
-        if (y == &sc->sc_gobj)
-            scindex = ntotal, oldone = y;
+        if(y == &sc->sc_gobj) scindex = ntotal, oldone = y;
         ntotal++;
     }
 
-    if (scindex == -1)
+    if(scindex == -1)
     {
         pd_error(0, "data_properties: scalar disappeared");
         return;
     }
     glist_readfrombinbuf(x, b, "properties dialog", 0);
     newone = 0;
-        /* take the new object off the list */
-    if (ntotal)
+    /* take the new object off the list */
+    if(ntotal)
     {
-        for (y = x->gl_list, nnew = 1; (y2 = y->g_next);
-            y = y2, nnew++)
-                if (nnew == ntotal)
-        {
-            newone = y2;
-            gobj_vis(newone, x, 0);
-            y->g_next = y2->g_next;
-            break;
-        }
+        for(y = x->gl_list, nnew = 1; (y2 = y->g_next); y = y2, nnew++)
+            if(nnew == ntotal)
+            {
+                newone = y2;
+                gobj_vis(newone, x, 0);
+                y->g_next = y2->g_next;
+                break;
+            }
     }
-    else gobj_vis((newone = x->gl_list), x, 0), x->gl_list = newone->g_next;
-    if (!newone)
+    else
+        gobj_vis((newone = x->gl_list), x, 0), x->gl_list = newone->g_next;
+    if(!newone)
         pd_error(0, "couldn't update properties (perhaps a format problem?)");
-    else if (!oldone)
+    else if(!oldone)
         bug("data_properties: couldn't find old element");
-    else if (newone->g_pd == scalar_class && oldone->g_pd == scalar_class
-        && ((t_scalar *)newone)->sc_template ==
-            ((t_scalar *)oldone)->sc_template
-        && (template = template_findbyname(((t_scalar *)newone)->sc_template)))
+    else if(newone->g_pd == scalar_class && oldone->g_pd == scalar_class &&
+            ((t_scalar *) newone)->sc_template ==
+                ((t_scalar *) oldone)->sc_template &&
+            (template =
+                    template_findbyname(((t_scalar *) newone)->sc_template)))
     {
-            /* swap new one with old one; then delete new one */
+        /* swap new one with old one; then delete new one */
         int i;
-        for (i = 0; i < template->t_n; i++)
+        for(i = 0; i < template->t_n; i++)
         {
-            t_word w = ((t_scalar *)newone)->sc_vec[i];
-            ((t_scalar *)newone)->sc_vec[i] = ((t_scalar *)oldone)->sc_vec[i];
-            ((t_scalar *)oldone)->sc_vec[i] = w;
+            t_word w = ((t_scalar *) newone)->sc_vec[i];
+            ((t_scalar *) newone)->sc_vec[i] = ((t_scalar *) oldone)->sc_vec[i];
+            ((t_scalar *) oldone)->sc_vec[i] = w;
         }
         pd_free(&newone->g_pd);
-        if (glist_isvisible(x))
+        if(glist_isvisible(x))
         {
             gobj_vis(oldone, x, 0);
             gobj_vis(oldone, x, 1);
@@ -424,156 +423,155 @@ void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
     }
     else
     {
-            /* delete old one; put new one where the old one was on glist */
+        /* delete old one; put new one where the old one was on glist */
         glist_delete(x, oldone);
-        if (scindex > 0)
+        if(scindex > 0)
         {
-            for (y = x->gl_list, nnew = 1; y;
-                y = y->g_next, nnew++)
-                    if (nnew == scindex || !y->g_next)
-            {
-                newone->g_next = y->g_next;
-                y->g_next = newone;
-                goto didit;
-            }
+            for(y = x->gl_list, nnew = 1; y; y = y->g_next, nnew++)
+                if(nnew == scindex || !y->g_next)
+                {
+                    newone->g_next = y->g_next;
+                    y->g_next = newone;
+                    goto didit;
+                }
             bug("data_properties: can't reinsert");
         }
-        else newone->g_next = x->gl_list, x->gl_list = newone;
+        else
+            newone->g_next = x->gl_list, x->gl_list = newone;
     }
-didit:
-    ;
+didit:;
 }
 
-    /* ----------- routines to write data to a binbuf ----------- */
+/* ----------- routines to write data to a binbuf ----------- */
 
-void canvas_doaddtemplate(t_symbol *templatesym,
-    int *p_ntemplates, t_symbol ***p_templatevec)
+void canvas_doaddtemplate(
+    t_symbol *templatesym, int *p_ntemplates, t_symbol ***p_templatevec)
 {
     int n = *p_ntemplates, i;
     t_symbol **templatevec = *p_templatevec;
-    for (i = 0; i < n; i++)
-        if (templatevec[i] == templatesym)
-            return;
-    templatevec = (t_symbol **)t_resizebytes(templatevec,
-        n * sizeof(*templatevec), (n+1) * sizeof(*templatevec));
+    for(i = 0; i < n; i++)
+        if(templatevec[i] == templatesym) return;
+    templatevec = (t_symbol **) t_resizebytes(
+        templatevec, n * sizeof(*templatevec), (n + 1) * sizeof(*templatevec));
     templatevec[n] = templatesym;
     *p_templatevec = templatevec;
-    *p_ntemplates = n+1;
+    *p_ntemplates = n + 1;
 }
 
 static void glist_writelist(t_gobj *y, t_binbuf *b);
 
 void binbuf_savetext(t_binbuf *bfrom, t_binbuf *bto);
 
-void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
-    int amarrayelement)
+void canvas_writescalar(
+    t_symbol *templatesym, t_word *w, t_binbuf *b, int amarrayelement)
 {
     t_template *template = template_findbyname(templatesym);
-    t_atom *a = (t_atom *)t_getbytes(0);
-    int i, n = template?(template->t_n):0, natom = 0;
-    if (!amarrayelement)
+    t_atom *a = (t_atom *) t_getbytes(0);
+    int i, n = template ? (template->t_n) : 0, natom = 0;
+    if(!amarrayelement)
     {
         t_atom templatename;
         SETSYMBOL(&templatename, gensym(templatesym->s_name + 3));
         binbuf_add(b, 1, &templatename);
     }
-    if (!template)
-        bug("canvas_writescalar");
-        /* write the atoms (floats and symbols) */
-    for (i = 0; i < n; i++)
+    if(!template) bug("canvas_writescalar");
+    /* write the atoms (floats and symbols) */
+    for(i = 0; i < n; i++)
     {
-        if (template->t_vec[i].ds_type == DT_FLOAT ||
+        if(template->t_vec[i].ds_type == DT_FLOAT ||
             template->t_vec[i].ds_type == DT_SYMBOL)
         {
-            a = (t_atom *)t_resizebytes(a,
-                natom * sizeof(*a), (natom + 1) * sizeof (*a));
-            if (template->t_vec[i].ds_type == DT_FLOAT)
+            a = (t_atom *) t_resizebytes(
+                a, natom * sizeof(*a), (natom + 1) * sizeof(*a));
+            if(template->t_vec[i].ds_type == DT_FLOAT)
                 SETFLOAT(a + natom, w[i].w_float);
-            else SETSYMBOL(a + natom,  w[i].w_symbol);
+            else
+                SETSYMBOL(a + natom, w[i].w_symbol);
             natom++;
         }
     }
-        /* array elements have to have at least something */
-    if (natom == 0 && amarrayelement)
-        SETSYMBOL(a + natom,  &s_bang), natom++;
+    /* array elements have to have at least something */
+    if(natom == 0 && amarrayelement) SETSYMBOL(a + natom, &s_bang), natom++;
     binbuf_add(b, natom, a);
     binbuf_addsemi(b);
     t_freebytes(a, natom * sizeof(*a));
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        if (template->t_vec[i].ds_type == DT_ARRAY)
+        if(template->t_vec[i].ds_type == DT_ARRAY)
         {
             int j;
             t_array *a = w[i].w_array;
             int elemsize = a->a_elemsize, nitems = a->a_n;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
-            for (j = 0; j < nitems; j++)
+            for(j = 0; j < nitems; j++)
                 canvas_writescalar(arraytemplatesym,
-                    (t_word *)(((char *)a->a_vec) + elemsize * j), b, 1);
+                    (t_word *) (((char *) a->a_vec) + elemsize * j), b, 1);
             binbuf_addsemi(b);
         }
-        else if (template->t_vec[i].ds_type == DT_TEXT)
+        else if(template->t_vec[i].ds_type == DT_TEXT)
             binbuf_savetext(w[i].w_binbuf, b);
     }
 }
 
 static void glist_writelist(t_gobj *y, t_binbuf *b)
 {
-    for (; y; y = y->g_next)
+    for(; y; y = y->g_next)
     {
-        if (pd_class(&y->g_pd) == scalar_class)
+        if(pd_class(&y->g_pd) == scalar_class)
         {
-            canvas_writescalar(((t_scalar *)y)->sc_template,
-                ((t_scalar *)y)->sc_vec, b, 0);
+            canvas_writescalar(
+                ((t_scalar *) y)->sc_template, ((t_scalar *) y)->sc_vec, b, 0);
         }
     }
 }
 
-    /* ------------ routines to write out templates for data ------- */
+/* ------------ routines to write out templates for data ------- */
 
-static void canvas_addtemplatesforlist(t_gobj *y,
-    int  *p_ntemplates, t_symbol ***p_templatevec);
+static void canvas_addtemplatesforlist(
+    t_gobj *y, int *p_ntemplates, t_symbol ***p_templatevec);
 
-static void canvas_addtemplatesforscalar(t_symbol *templatesym,
-    t_word *w, int *p_ntemplates, t_symbol ***p_templatevec)
+static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
+    int *p_ntemplates, t_symbol ***p_templatevec)
 {
     t_dataslot *ds;
     int i;
     t_template *template = template_findbyname(templatesym);
     canvas_doaddtemplate(templatesym, p_ntemplates, p_templatevec);
-    if (!template)
+    if(!template)
         bug("canvas_addtemplatesforscalar");
-    else for (ds = template->t_vec, i = template->t_n; i--; ds++, w++)
-    {
-        if (ds->ds_type == DT_ARRAY)
+    else
+        for(ds = template->t_vec, i = template->t_n; i--; ds++, w++)
         {
-            int j;
-            t_array *a = w->w_array;
-            int elemsize = a->a_elemsize, nitems = a->a_n;
-            t_symbol *arraytemplatesym = ds->ds_arraytemplate;
-            canvas_doaddtemplate(arraytemplatesym, p_ntemplates, p_templatevec);
-            for (j = 0; j < nitems; j++)
-                canvas_addtemplatesforscalar(arraytemplatesym,
-                    (t_word *)(((char *)a->a_vec) + elemsize * j),
+            if(ds->ds_type == DT_ARRAY)
+            {
+                int j;
+                t_array *a = w->w_array;
+                int elemsize = a->a_elemsize, nitems = a->a_n;
+                t_symbol *arraytemplatesym = ds->ds_arraytemplate;
+                canvas_doaddtemplate(
+                    arraytemplatesym, p_ntemplates, p_templatevec);
+                for(j = 0; j < nitems; j++)
+                    canvas_addtemplatesforscalar(arraytemplatesym,
+                        (t_word *) (((char *) a->a_vec) + elemsize * j),
                         p_ntemplates, p_templatevec);
+            }
         }
-    }
 }
 
-static void canvas_addtemplatesforlist(t_gobj *y,
-    int  *p_ntemplates, t_symbol ***p_templatevec)
+static void canvas_addtemplatesforlist(
+    t_gobj *y, int *p_ntemplates, t_symbol ***p_templatevec)
 {
-    for (; y; y = y->g_next)
+    for(; y; y = y->g_next)
     {
-        if (pd_class(&y->g_pd) == scalar_class)
+        if(pd_class(&y->g_pd) == scalar_class)
         {
-            canvas_addtemplatesforscalar(((t_scalar *)y)->sc_template,
-                ((t_scalar *)y)->sc_vec, p_ntemplates, p_templatevec);
+            canvas_addtemplatesforscalar(((t_scalar *) y)->sc_template,
+                ((t_scalar *) y)->sc_vec, p_ntemplates, p_templatevec);
         }
     }
 }
 
-    /* write all "scalars" in a glist to a binbuf. */
+/* write all "scalars" in a glist to a binbuf. */
 t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
 {
     int i;
@@ -582,53 +580,64 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
     t_gobj *y;
     t_binbuf *b = binbuf_new();
 
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if ((pd_class(&y->g_pd) == scalar_class) &&
+        if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
         {
-            canvas_addtemplatesforscalar(((t_scalar *)y)->sc_template,
-                ((t_scalar *)y)->sc_vec,  &ntemplates, &templatevec);
+            canvas_addtemplatesforscalar(((t_scalar *) y)->sc_template,
+                ((t_scalar *) y)->sc_vec, &ntemplates, &templatevec);
         }
     }
     binbuf_addv(b, "s;", gensym("data"));
-    for (i = 0; i < ntemplates; i++)
+    for(i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
         int j, m = template->t_n;
-            /* drop "pd-" prefix from template symbol to print it: */
-        binbuf_addv(b, "ss;", gensym("template"),
-            gensym(templatevec[i]->s_name + 3));
-        for (j = 0; j < m; j++)
+        /* drop "pd-" prefix from template symbol to print it: */
+        binbuf_addv(
+            b, "ss;", gensym("template"), gensym(templatevec[i]->s_name + 3));
+        for(j = 0; j < m; j++)
         {
             t_symbol *type;
-            switch (template->t_vec[j].ds_type)
+            switch(template->t_vec[j].ds_type)
             {
-                case DT_FLOAT: type = &s_float; break;
-                case DT_SYMBOL: type = &s_symbol; break;
-                case DT_ARRAY: type = gensym("array"); break;
-                case DT_TEXT: type = &s_list; break;
-                default: type = &s_float; bug("canvas_write");
+                case DT_FLOAT:
+                    type = &s_float;
+                    break;
+                case DT_SYMBOL:
+                    type = &s_symbol;
+                    break;
+                case DT_ARRAY:
+                    type = gensym("array");
+                    break;
+                case DT_TEXT:
+                    type = &s_list;
+                    break;
+                default:
+                    type = &s_float;
+                    bug("canvas_write");
             }
-            if (template->t_vec[j].ds_type == DT_ARRAY)
+            if(template->t_vec[j].ds_type == DT_ARRAY)
                 binbuf_addv(b, "sss;", type, template->t_vec[j].ds_name,
                     gensym(template->t_vec[j].ds_arraytemplate->s_name + 3));
-            else binbuf_addv(b, "ss;", type, template->t_vec[j].ds_name);
+            else
+                binbuf_addv(b, "ss;", type, template->t_vec[j].ds_name);
         }
         binbuf_addsemi(b);
     }
     binbuf_addsemi(b);
-        /* now write out the objects themselves */
-    for (y = x->gl_list; y; y = y->g_next)
+    /* now write out the objects themselves */
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if ((pd_class(&y->g_pd) == scalar_class) &&
+        if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
         {
-            canvas_writescalar(((t_scalar *)y)->sc_template,
-                ((t_scalar *)y)->sc_vec,  b, 0);
+            canvas_writescalar(
+                ((t_scalar *) y)->sc_template, ((t_scalar *) y)->sc_vec, b, 0);
         }
     }
-    t_freebytes(templatevec, ntemplates*sizeof(*templatevec));
+    t_freebytes(templatevec, ntemplates * sizeof(*templatevec));
     return (b);
 }
 
@@ -639,15 +648,15 @@ static void glist_write(t_glist *x, t_symbol *filename, t_symbol *format)
     char buf[MAXPDSTRING];
     t_canvas *canvas = glist_getcanvas(x);
     canvas_makefilename(canvas, filename->s_name, buf, MAXPDSTRING);
-    if (!strcmp(format->s_name, "cr"))
+    if(!strcmp(format->s_name, "cr"))
         cr = 1;
-    else if (*format->s_name)
+    else if(*format->s_name)
         pd_error(0, "qlist_read: unknown flag: %s", format->s_name);
 
     b = glist_writetobinbuf(x, 1);
-    if (b)
+    if(b)
     {
-        if (binbuf_write(b, buf, "", cr))
+        if(binbuf_write(b, buf, "", cr))
             pd_error(0, "%s: write failed", filename->s_name);
         binbuf_free(b);
     }
@@ -657,16 +666,16 @@ static void glist_write(t_glist *x, t_symbol *filename, t_symbol *format)
 
 typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
 
-    /* save to a binbuf, called recursively; cf. canvas_savetofile() which
-    saves the document, and is only called on root canvases. */
+/* save to a binbuf, called recursively; cf. canvas_savetofile() which
+saves the document, and is only called on root canvases. */
 static void canvas_saveto(t_canvas *x, t_binbuf *b)
 {
     t_gobj *y;
     t_linetraverser t;
     t_outconnect *oc;
 
-        /* subpatch */
-    if (x->gl_owner && !x->gl_env)
+    /* subpatch */
+    if(x->gl_owner && !x->gl_env)
     {
         /* have to go to original binbuf to find out how we were named. */
         t_binbuf *bz = binbuf_new();
@@ -675,113 +684,119 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
         patchsym = atom_getsymbolarg(1, binbuf_getnatom(bz), binbuf_getvec(bz));
         binbuf_free(bz);
         binbuf_addv(b, "ssiiiisi;", gensym("#N"), gensym("canvas"),
-            (int)(x->gl_screenx1),
-            (int)(x->gl_screeny1),
-            (int)(x->gl_screenx2 - x->gl_screenx1),
-            (int)(x->gl_screeny2 - x->gl_screeny1),
-            (patchsym != &s_ ? patchsym: gensym("(subpatch)")),
-            x->gl_mapped);
+            (int) (x->gl_screenx1), (int) (x->gl_screeny1),
+            (int) (x->gl_screenx2 - x->gl_screenx1),
+            (int) (x->gl_screeny2 - x->gl_screeny1),
+            (patchsym != &s_ ? patchsym : gensym("(subpatch)")), x->gl_mapped);
     }
-        /* root or abstraction */
+    /* root or abstraction */
     else
     {
         binbuf_addv(b, "ssiiiii;", gensym("#N"), gensym("canvas"),
-            (int)(x->gl_screenx1),
-            (int)(x->gl_screeny1),
-            (int)(x->gl_screenx2 - x->gl_screenx1),
-            (int)(x->gl_screeny2 - x->gl_screeny1),
-                (int)x->gl_font);
+            (int) (x->gl_screenx1), (int) (x->gl_screeny1),
+            (int) (x->gl_screenx2 - x->gl_screenx1),
+            (int) (x->gl_screeny2 - x->gl_screeny1), (int) x->gl_font);
         canvas_savedeclarationsto(x, b);
     }
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
         gobj_save(y, b);
 
     linetraverser_start(&t, x);
-    while ((oc = linetraverser_next(&t)))
+    while((oc = linetraverser_next(&t)))
     {
         int srcno = canvas_getindex(x, &t.tr_ob->ob_g);
         int sinkno = canvas_getindex(x, &t.tr_ob2->ob_g);
-        binbuf_addv(b, "ssiiii;", gensym("#X"), gensym("connect"),
-            srcno, t.tr_outno, sinkno, t.tr_inno);
+        binbuf_addv(b, "ssiiii;", gensym("#X"), gensym("connect"), srcno,
+            t.tr_outno, sinkno, t.tr_inno);
     }
-        /* unless everything is the default (as in ordinary subpatches)
-        print out a "coords" message to set up the coordinate systems */
-    if (x->gl_isgraph || x->gl_x1 || x->gl_y1 ||
-        x->gl_x2 != 1 ||  x->gl_y2 != 1 || x->gl_pixwidth || x->gl_pixheight)
+    /* unless everything is the default (as in ordinary subpatches)
+    print out a "coords" message to set up the coordinate systems */
+    if(x->gl_isgraph || x->gl_x1 || x->gl_y1 || x->gl_x2 != 1 ||
+        x->gl_y2 != 1 || x->gl_pixwidth || x->gl_pixheight)
     {
-        if (x->gl_isgraph && x->gl_goprect)
-                /* if we have a graph-on-parent rectangle, we're new style.
-                The format is arranged so
-                that old versions of Pd can at least do something with it. */
+        if(x->gl_isgraph && x->gl_goprect)
+            /* if we have a graph-on-parent rectangle, we're new style.
+            The format is arranged so
+            that old versions of Pd can at least do something with it. */
             binbuf_addv(b, "ssfffffffff;", gensym("#X"), gensym("coords"),
-                x->gl_x1, x->gl_y1,
-                x->gl_x2, x->gl_y2,
-                (t_float)x->gl_pixwidth, (t_float)x->gl_pixheight,
-                (t_float)((x->gl_hidetext)?2.:1.),
-                (t_float)x->gl_xmargin, (t_float)x->gl_ymargin);
-                    /* otherwise write in 0.38-compatible form */
-        else binbuf_addv(b, "ssfffffff;", gensym("#X"), gensym("coords"),
-                x->gl_x1, x->gl_y1,
-                x->gl_x2, x->gl_y2,
-                (t_float)x->gl_pixwidth, (t_float)x->gl_pixheight,
-                (t_float)x->gl_isgraph);
+                x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
+                (t_float) x->gl_pixwidth, (t_float) x->gl_pixheight,
+                (t_float) ((x->gl_hidetext) ? 2. : 1.), (t_float) x->gl_xmargin,
+                (t_float) x->gl_ymargin);
+        /* otherwise write in 0.38-compatible form */
+        else
+            binbuf_addv(b, "ssfffffff;", gensym("#X"), gensym("coords"),
+                x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
+                (t_float) x->gl_pixwidth, (t_float) x->gl_pixheight,
+                (t_float) x->gl_isgraph);
     }
 }
 
-    /* call this recursively to collect all the template names for
-    a canvas or for the selection. */
-static void canvas_collecttemplatesfor(t_canvas *x, int *ntemplatesp,
-    t_symbol ***templatevecp, int wholething)
+/* call this recursively to collect all the template names for
+a canvas or for the selection. */
+static void canvas_collecttemplatesfor(
+    t_canvas *x, int *ntemplatesp, t_symbol ***templatevecp, int wholething)
 {
     t_gobj *y;
 
-    for (y = x->gl_list; y; y = y->g_next)
+    for(y = x->gl_list; y; y = y->g_next)
     {
-        if ((pd_class(&y->g_pd) == scalar_class) &&
+        if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
-                canvas_addtemplatesforscalar(((t_scalar *)y)->sc_template,
-                    ((t_scalar *)y)->sc_vec,  ntemplatesp, templatevecp);
-        else if ((pd_class(&y->g_pd) == canvas_class) &&
-            (wholething || glist_isselected(x, y)))
-                canvas_collecttemplatesfor((t_canvas *)y,
-                    ntemplatesp, templatevecp, 1);
+            canvas_addtemplatesforscalar(((t_scalar *) y)->sc_template,
+                ((t_scalar *) y)->sc_vec, ntemplatesp, templatevecp);
+        else if((pd_class(&y->g_pd) == canvas_class) &&
+                (wholething || glist_isselected(x, y)))
+            canvas_collecttemplatesfor(
+                (t_canvas *) y, ntemplatesp, templatevecp, 1);
     }
 }
 
-    /* save the templates needed by a canvas to a binbuf. */
+/* save the templates needed by a canvas to a binbuf. */
 static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 {
     t_symbol **templatevec = getbytes(0);
     int i, ntemplates = 0;
     canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
-    for (i = 0; i < ntemplates; i++)
+    for(i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
         int j, m;
-        if (!template)
+        if(!template)
         {
             bug("canvas_savetemplatesto");
             continue;
         }
         m = template->t_n;
-            /* drop "pd-" prefix from template symbol to print */
+        /* drop "pd-" prefix from template symbol to print */
         binbuf_addv(b, "sss", &s__N, gensym("struct"),
             gensym(templatevec[i]->s_name + 3));
-        for (j = 0; j < m; j++)
+        for(j = 0; j < m; j++)
         {
             t_symbol *type;
-            switch (template->t_vec[j].ds_type)
+            switch(template->t_vec[j].ds_type)
             {
-                case DT_FLOAT: type = &s_float; break;
-                case DT_SYMBOL: type = &s_symbol; break;
-                case DT_ARRAY: type = gensym("array"); break;
-                case DT_TEXT: type = gensym("text"); break;
-                default: type = &s_float; bug("canvas_write");
+                case DT_FLOAT:
+                    type = &s_float;
+                    break;
+                case DT_SYMBOL:
+                    type = &s_symbol;
+                    break;
+                case DT_ARRAY:
+                    type = gensym("array");
+                    break;
+                case DT_TEXT:
+                    type = gensym("text");
+                    break;
+                default:
+                    type = &s_float;
+                    bug("canvas_write");
             }
-            if (template->t_vec[j].ds_type == DT_ARRAY)
+            if(template->t_vec[j].ds_type == DT_ARRAY)
                 binbuf_addv(b, "sss", type, template->t_vec[j].ds_name,
                     gensym(template->t_vec[j].ds_arraytemplate->s_name + 3));
-            else binbuf_addv(b, "ss", type, template->t_vec[j].ds_name);
+            else
+                binbuf_addv(b, "ss", type, template->t_vec[j].ds_name);
         }
         binbuf_addsemi(b);
     }
@@ -790,32 +805,31 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 
 void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except);
 
-    /* save a "root" canvas to a file; cf. canvas_saveto() which saves the
-    body (and which is called recursively.) */
-static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
-    float fdestroy)
+/* save a "root" canvas to a file; cf. canvas_saveto() which saves the
+body (and which is called recursively.) */
+static void canvas_savetofile(
+    t_canvas *x, t_symbol *filename, t_symbol *dir, float fdestroy)
 {
     t_binbuf *b = binbuf_new();
     canvas_savetemplatesto(x, b, 1);
     canvas_saveto(x, b);
     errno = 0;
-    if (binbuf_write(b, filename->s_name, dir->s_name, 0))
+    if(binbuf_write(b, filename->s_name, dir->s_name, 0))
         post("%s/%s: %s", dir->s_name, filename->s_name,
             (errno ? strerror(errno) : "write failed"));
     else
     {
-            /* if not an abstraction, reset title bar and directory */
-        if (!x->gl_owner)
-{
+        /* if not an abstraction, reset title bar and directory */
+        if(!x->gl_owner)
+        {
             canvas_rename(x, filename, dir);
             /* update window list in case Save As changed the window name */
             canvas_updatewindowlist();
-}
+        }
         post("saved to: %s/%s", dir->s_name, filename->s_name);
         canvas_dirty(x, 0);
         canvas_reload(filename, dir, x);
-        if (fdestroy != 0)
-            vmess(&x->gl_pd, gensym("menuclose"), "f", 1.);
+        if(fdestroy != 0) vmess(&x->gl_pd, gensym("menuclose"), "f", 1.);
     }
     binbuf_free(b);
 }
@@ -823,49 +837,50 @@ static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
 static void canvas_menusaveas(t_canvas *x, t_float fdestroy)
 {
     t_canvas *x2 = canvas_getrootfor(x);
-    sys_vgui("pdtk_canvas_saveas .x%lx {%s} {%s} %d\n", x2,
-        x2->gl_name->s_name, canvas_getdir(x2)->s_name, (fdestroy != 0));
+    sys_vgui("pdtk_canvas_saveas .x%lx {%s} {%s} %d\n", x2, x2->gl_name->s_name,
+        canvas_getdir(x2)->s_name, (fdestroy != 0));
 }
 
 static void canvas_menusave(t_canvas *x, t_float fdestroy)
 {
     t_canvas *x2 = canvas_getrootfor(x);
     const char *name = x2->gl_name->s_name;
-    if (*name && UNTITLED_STRNCMP(name)
-            && (strlen(name) < 4 || strcmp(name + strlen(name)-4, ".pat")
-                || strcmp(name + strlen(name)-4, ".mxt")))
+    if(*name && UNTITLED_STRNCMP(name) &&
+        (strlen(name) < 4 || strcmp(name + strlen(name) - 4, ".pat") ||
+            strcmp(name + strlen(name) - 4, ".mxt")))
     {
         canvas_savetofile(x2, x2->gl_name, canvas_getdir(x2), fdestroy);
     }
-    else canvas_menusaveas(x2, fdestroy);
+    else
+        canvas_menusaveas(x2, fdestroy);
 }
 
 void g_readwrite_setup(void)
 {
     savestate_setup();
-    class_addmethod(canvas_class, (t_method)glist_write,
-        gensym("write"), A_SYMBOL, A_DEFSYM, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_read,
-        gensym("read"), A_SYMBOL, A_DEFSYM, A_NULL);
-    class_addmethod(canvas_class, (t_method)glist_mergefile,
+    class_addmethod(canvas_class, (t_method) glist_write, gensym("write"),
+        A_SYMBOL, A_DEFSYM, A_NULL);
+    class_addmethod(canvas_class, (t_method) glist_read, gensym("read"),
+        A_SYMBOL, A_DEFSYM, A_NULL);
+    class_addmethod(canvas_class, (t_method) glist_mergefile,
         gensym("mergefile"), A_SYMBOL, A_DEFSYM, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_savetofile,
+    class_addmethod(canvas_class, (t_method) canvas_savetofile,
         gensym("savetofile"), A_SYMBOL, A_SYMBOL, A_DEFFLOAT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_saveto,
-        gensym("saveto"), A_CANT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_saved,
-        gensym("saved"), A_GIMME, 0);
-/* ------------------ from the menu ------------------------- */
-    class_addmethod(canvas_class, (t_method)canvas_menusave,
+    class_addmethod(
+        canvas_class, (t_method) canvas_saveto, gensym("saveto"), A_CANT, 0);
+    class_addmethod(
+        canvas_class, (t_method) canvas_saved, gensym("saved"), A_GIMME, 0);
+    /* ------------------ from the menu ------------------------- */
+    class_addmethod(canvas_class, (t_method) canvas_menusave,
         gensym("menusave"), A_DEFFLOAT, 0);
-    class_addmethod(canvas_class, (t_method)canvas_menusaveas,
+    class_addmethod(canvas_class, (t_method) canvas_menusaveas,
         gensym("menusaveas"), A_DEFFLOAT, 0);
 }
 
 void canvas_readwrite_for_class(t_class *c)
 {
-    class_addmethod(c, (t_method)canvas_menusave,
-        gensym("menusave"), A_DEFFLOAT, 0);
-    class_addmethod(c, (t_method)canvas_menusaveas,
-        gensym("menusaveas"), A_DEFFLOAT, 0);
+    class_addmethod(
+        c, (t_method) canvas_menusave, gensym("menusave"), A_DEFFLOAT, 0);
+    class_addmethod(
+        c, (t_method) canvas_menusaveas, gensym("menusaveas"), A_DEFFLOAT, 0);
 }

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -148,7 +148,6 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
 {
     int message;
     int n;
-    int i;
 
     t_template *template = template_findbyname(templatesym);
     if(!template)
@@ -159,7 +158,7 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
     }
     word_restore(w, template, argc, argv);
     n = template->t_n;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(template->t_vec[i].ds_type == DT_ARRAY)
         {
@@ -452,8 +451,7 @@ void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
                     template_findbyname(((t_scalar *) newone)->sc_template)))
     {
         /* swap new one with old one; then delete new one */
-        int i;
-        for(i = 0; i < template->t_n; i++)
+        for(int i = 0; i < template->t_n; i++)
         {
             t_word w = ((t_scalar *) newone)->sc_vec[i];
             ((t_scalar *) newone)->sc_vec[i] = ((t_scalar *) oldone)->sc_vec[i];
@@ -495,9 +493,8 @@ void canvas_doaddtemplate(
     t_symbol *templatesym, int *p_ntemplates, t_symbol ***p_templatevec)
 {
     int n = *p_ntemplates;
-    int i;
     t_symbol **templatevec = *p_templatevec;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         if(templatevec[i] == templatesym) return;
     templatevec = (t_symbol **) t_resizebytes(
         templatevec, n * sizeof(*templatevec), (n + 1) * sizeof(*templatevec));
@@ -515,7 +512,6 @@ void canvas_writescalar(
 {
     t_template *template = template_findbyname(templatesym);
     t_atom *a = (t_atom *) t_getbytes(0);
-    int i;
     int n = template ? (template->t_n) : 0;
     int natom = 0;
     if(!amarrayelement)
@@ -526,7 +522,7 @@ void canvas_writescalar(
     }
     if(!template) bug("canvas_writescalar");
     /* write the atoms (floats and symbols) */
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(template->t_vec[i].ds_type == DT_FLOAT ||
             template->t_vec[i].ds_type == DT_SYMBOL)
@@ -549,7 +545,7 @@ void canvas_writescalar(
     binbuf_add(b, natom, a);
     binbuf_addsemi(b);
     t_freebytes(a, natom * sizeof(*a));
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(template->t_vec[i].ds_type == DT_ARRAY)
         {
@@ -590,8 +586,6 @@ static void canvas_addtemplatesforlist(
 static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
     int *p_ntemplates, t_symbol ***p_templatevec)
 {
-    t_dataslot *ds;
-    int i;
     t_template *template = template_findbyname(templatesym);
     canvas_doaddtemplate(templatesym, p_ntemplates, p_templatevec);
     if(!template)
@@ -600,6 +594,8 @@ static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
     }
     else
     {
+        int i;
+        t_dataslot *ds;
         for(ds = template->t_vec, i = template->t_n; i--; ds++, w++)
         {
             if(ds->ds_type == DT_ARRAY)
@@ -638,13 +634,12 @@ static void canvas_addtemplatesforlist(
 /* write all "scalars" in a glist to a binbuf. */
 t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
 {
-    int i;
     t_symbol **templatevec = getbytes(0);
     int ntemplates = 0;
     t_gobj *y;
     t_binbuf *b = binbuf_new();
 
-    for(y = x->gl_list; y; y = y->g_next)
+    for(t_gobj *y = x->gl_list; y; y = y->g_next)
     {
         if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
@@ -654,15 +649,14 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
         }
     }
     binbuf_addv(b, "s;", gensym("data"));
-    for(i = 0; i < ntemplates; i++)
+    for(int i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
-        int j;
         int m = template->t_n;
         /* drop "pd-" prefix from template symbol to print it: */
         binbuf_addv(
             b, "ss;", gensym("template"), gensym(templatevec[i]->s_name + 3));
-        for(j = 0; j < m; j++)
+        for(int j = 0; j < m; j++)
         {
             t_symbol *type;
             switch(template->t_vec[j].ds_type)
@@ -697,7 +691,7 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
     }
     binbuf_addsemi(b);
     /* now write out the objects themselves */
-    for(y = x->gl_list; y; y = y->g_next)
+    for(t_gobj *y = x->gl_list; y; y = y->g_next)
     {
         if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
@@ -837,13 +831,11 @@ static void canvas_collecttemplatesfor(
 static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 {
     t_symbol **templatevec = getbytes(0);
-    int i;
     int ntemplates = 0;
     canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
-    for(i = 0; i < ntemplates; i++)
+    for(int i = 0; i < ntemplates; i++)
     {
         t_template *template = template_findbyname(templatevec[i]);
-        int j;
         int m;
         if(!template)
         {
@@ -854,7 +846,7 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
         /* drop "pd-" prefix from template symbol to print */
         binbuf_addv(b, "sss", &s__N, gensym("struct"),
             gensym(templatevec[i]->s_name + 3));
-        for(j = 0; j < m; j++)
+        for(int j = 0; j < m; j++)
         {
             t_symbol *type;
             switch(template->t_vec[j].ds_type)

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -283,7 +283,7 @@ void glist_readfrombinbuf(
             t_freebytes(templateargs, sizeof(*templateargs) * ntemplateargs);
             break;
         }
-        else if(nline > 2)
+        if(nline > 2)
             canvas_readerror(
                 natoms, vec, message, nline, "extra items ignored");
         else if(vec[message].a_type != A_SYMBOL ||

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -74,22 +74,34 @@ void canvas_statesavers_doit(t_glist *x, t_binbuf *b)
 {
     t_gobj *g;
     for(g = x->gl_list; g; g = g->g_next)
+    {
         if(g->g_pd == savestate_class)
+        {
             savestate_doit((t_savestate *) g, b);
+        }
         else if(g->g_pd == canvas_class &&
                 !canvas_isabstraction((t_canvas *) g))
+        {
             canvas_statesavers_doit((t_glist *) g, b);
+        }
+    }
 }
 
 void canvas_saved(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_gobj *g;
     for(g = x->gl_list; g; g = g->g_next)
+    {
         if(g->g_pd == savestate_class)
+        {
             outlet_list(((t_savestate *) g)->x_stateout, 0, argc, argv);
+        }
         else if(g->g_pd == canvas_class &&
                 !canvas_isabstraction((t_canvas *) g))
+        {
             canvas_saved((t_glist *) g, s, argc, argv);
+        }
+    }
 }
 
 static t_class *declare_class;
@@ -107,9 +119,13 @@ static int canvas_scanbinbuf(
     for(i = indexwas; i < natoms && vec[i].a_type != A_SEMI; i++)
         ;
     if(i >= natoms)
+    {
         *p_next = i;
+    }
     else
+    {
         *p_next = i + 1;
+    }
     return (i - indexwas);
 }
 
@@ -157,6 +173,7 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
                 pd_error(0, "%s: no such template", arraytemplatesym->s_name);
             }
             else
+            {
                 while(1)
                 {
                     t_word *element;
@@ -171,6 +188,7 @@ static void glist_readatoms(t_glist *x, int natoms, t_atom *vec, int *p_nextmsg,
                         element, nline, vec + message);
                     nitems++;
                 }
+            }
         }
         else if(template->t_vec[i].ds_type == DT_TEXT)
         {
@@ -284,8 +302,10 @@ void glist_readfrombinbuf(
             break;
         }
         if(nline > 2)
+        {
             canvas_readerror(
                 natoms, vec, message, nline, "extra items ignored");
+        }
         else if(vec[message].a_type != A_SYMBOL ||
                 strcmp(vec[message].a_w.w_symbol->s_name, "template") ||
                 vec[message + 1].a_type != A_SYMBOL)
@@ -341,9 +361,13 @@ static void glist_doread(
     int cr = 0;
 
     if(!strcmp(format->s_name, "cr"))
+    {
         cr = 1;
+    }
     else if(*format->s_name)
+    {
         pd_error(0, "qlist_read: unknown flag: %s", format->s_name);
+    }
 
     if(binbuf_read_via_canvas(b, filename->s_name, canvas, cr))
     {
@@ -401,6 +425,7 @@ void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
     if(ntotal)
     {
         for(y = x->gl_list, nnew = 1; (y2 = y->g_next); y = y2, nnew++)
+        {
             if(nnew == ntotal)
             {
                 newone = y2;
@@ -408,13 +433,18 @@ void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
                 y->g_next = y2->g_next;
                 break;
             }
+        }
     }
     else
         gobj_vis((newone = x->gl_list), x, 0), x->gl_list = newone->g_next;
     if(!newone)
+    {
         pd_error(0, "couldn't update properties (perhaps a format problem?)");
+    }
     else if(!oldone)
+    {
         bug("data_properties: couldn't find old element");
+    }
     else if(newone->g_pd == scalar_class && oldone->g_pd == scalar_class &&
             ((t_scalar *) newone)->sc_template ==
                 ((t_scalar *) oldone)->sc_template &&
@@ -443,12 +473,14 @@ void canvas_dataproperties(t_canvas *x, t_scalar *sc, t_binbuf *b)
         if(scindex > 0)
         {
             for(y = x->gl_list, nnew = 1; y; y = y->g_next, nnew++)
+            {
                 if(nnew == scindex || !y->g_next)
                 {
                     newone->g_next = y->g_next;
                     y->g_next = newone;
                     goto didit;
                 }
+            }
             bug("data_properties: can't reinsert");
         }
         else
@@ -502,9 +534,13 @@ void canvas_writescalar(
             a = (t_atom *) t_resizebytes(
                 a, natom * sizeof(*a), (natom + 1) * sizeof(*a));
             if(template->t_vec[i].ds_type == DT_FLOAT)
+            {
                 SETFLOAT(a + natom, w[i].w_float);
+            }
             else
+            {
                 SETSYMBOL(a + natom, w[i].w_symbol);
+            }
             natom++;
         }
     }
@@ -523,8 +559,10 @@ void canvas_writescalar(
             int nitems = a->a_n;
             t_symbol *arraytemplatesym = template->t_vec[i].ds_arraytemplate;
             for(j = 0; j < nitems; j++)
+            {
                 canvas_writescalar(arraytemplatesym,
                     (t_word *) (((char *) a->a_vec) + elemsize * j), b, 1);
+            }
             binbuf_addsemi(b);
         }
         else if(template->t_vec[i].ds_type == DT_TEXT)
@@ -557,8 +595,11 @@ static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
     t_template *template = template_findbyname(templatesym);
     canvas_doaddtemplate(templatesym, p_ntemplates, p_templatevec);
     if(!template)
+    {
         bug("canvas_addtemplatesforscalar");
+    }
     else
+    {
         for(ds = template->t_vec, i = template->t_n; i--; ds++, w++)
         {
             if(ds->ds_type == DT_ARRAY)
@@ -571,11 +612,14 @@ static void canvas_addtemplatesforscalar(t_symbol *templatesym, t_word *w,
                 canvas_doaddtemplate(
                     arraytemplatesym, p_ntemplates, p_templatevec);
                 for(j = 0; j < nitems; j++)
+                {
                     canvas_addtemplatesforscalar(arraytemplatesym,
                         (t_word *) (((char *) a->a_vec) + elemsize * j),
                         p_ntemplates, p_templatevec);
+                }
             }
         }
+    }
 }
 
 static void canvas_addtemplatesforlist(
@@ -640,10 +684,14 @@ t_binbuf *glist_writetobinbuf(t_glist *x, int wholething)
                     bug("canvas_write");
             }
             if(template->t_vec[j].ds_type == DT_ARRAY)
+            {
                 binbuf_addv(b, "sss;", type, template->t_vec[j].ds_name,
                     gensym(template->t_vec[j].ds_arraytemplate->s_name + 3));
+            }
             else
+            {
                 binbuf_addv(b, "ss;", type, template->t_vec[j].ds_name);
+            }
         }
         binbuf_addsemi(b);
     }
@@ -670,9 +718,13 @@ static void glist_write(t_glist *x, t_symbol *filename, t_symbol *format)
     t_canvas *canvas = glist_getcanvas(x);
     canvas_makefilename(canvas, filename->s_name, buf, MAXPDSTRING);
     if(!strcmp(format->s_name, "cr"))
+    {
         cr = 1;
+    }
     else if(*format->s_name)
+    {
         pd_error(0, "qlist_read: unknown flag: %s", format->s_name);
+    }
 
     b = glist_writetobinbuf(x, 1);
     if(b)
@@ -736,6 +788,7 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
         x->gl_y2 != 1 || x->gl_pixwidth || x->gl_pixheight)
     {
         if(x->gl_isgraph && x->gl_goprect)
+        {
             /* if we have a graph-on-parent rectangle, we're new style.
             The format is arranged so
             that old versions of Pd can at least do something with it. */
@@ -745,11 +798,14 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
                 (t_float) ((x->gl_hidetext) ? 2. : 1.), (t_float) x->gl_xmargin,
                 (t_float) x->gl_ymargin);
         /* otherwise write in 0.38-compatible form */
+        }
         else
+        {
             binbuf_addv(b, "ssfffffff;", gensym("#X"), gensym("coords"),
                 x->gl_x1, x->gl_y1, x->gl_x2, x->gl_y2,
                 (t_float) x->gl_pixwidth, (t_float) x->gl_pixheight,
                 (t_float) x->gl_isgraph);
+        }
     }
 }
 
@@ -764,12 +820,16 @@ static void canvas_collecttemplatesfor(
     {
         if((pd_class(&y->g_pd) == scalar_class) &&
             (wholething || glist_isselected(x, y)))
+        {
             canvas_addtemplatesforscalar(((t_scalar *) y)->sc_template,
                 ((t_scalar *) y)->sc_vec, ntemplatesp, templatevecp);
+        }
         else if((pd_class(&y->g_pd) == canvas_class) &&
                 (wholething || glist_isselected(x, y)))
+        {
             canvas_collecttemplatesfor(
                 (t_canvas *) y, ntemplatesp, templatevecp, 1);
+        }
     }
 }
 
@@ -816,10 +876,14 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
                     bug("canvas_write");
             }
             if(template->t_vec[j].ds_type == DT_ARRAY)
+            {
                 binbuf_addv(b, "sss", type, template->t_vec[j].ds_name,
                     gensym(template->t_vec[j].ds_arraytemplate->s_name + 3));
+            }
             else
+            {
                 binbuf_addv(b, "ss", type, template->t_vec[j].ds_name);
+            }
         }
         binbuf_addsemi(b);
     }
@@ -838,8 +902,10 @@ static void canvas_savetofile(
     canvas_saveto(x, b);
     errno = 0;
     if(binbuf_write(b, filename->s_name, dir->s_name, 0))
+    {
         post("%s/%s: %s", dir->s_name, filename->s_name,
             (errno ? strerror(errno) : "write failed"));
+    }
     else
     {
         /* if not an abstraction, reset title bar and directory */

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -607,12 +607,11 @@ int rtext_findatomfor(t_rtext *x, int xpos, int ypos)
     int h = ypos;
     int indx;
     int natom = 0;
-    int i;
     int gotone = 0;
     /* get byte index of character clicked on */
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
     /* search through for whitespace before that index */
-    for(i = 0; i <= indx; i++)
+    for(int i = 0; i <= indx; i++)
     {
         if(x->x_buf[i] == ';' || x->x_buf[i] == ',')
         {

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include <string.h>
@@ -22,89 +22,88 @@
 
 struct _rtext
 {
-    char *x_buf;    /*-- raw byte string, assumed UTF-8 encoded (moo) --*/
-    int x_bufsize;  /*-- byte length --*/
-    int x_selstart; /*-- byte offset --*/
-    int x_selend;   /*-- byte offset --*/
-    int x_active;       /* 1 if 'actively editing */
-    int x_dragfrom;     /* character onset we're dragging from */
-    int x_drawnwidth;   /* screen size, pixels */
+    char *x_buf;      /*-- raw byte string, assumed UTF-8 encoded (moo) --*/
+    int x_bufsize;    /*-- byte length --*/
+    int x_selstart;   /*-- byte offset --*/
+    int x_selend;     /*-- byte offset --*/
+    int x_active;     /* 1 if 'actively editing */
+    int x_dragfrom;   /* character onset we're dragging from */
+    int x_drawnwidth; /* screen size, pixels */
     int x_drawnheight;
-    t_text *x_text;     /* owner */
-    t_glist *x_glist;   /* glist owner belongs to */
-    char x_tag[50];     /* tag for gui */
-    struct _rtext *x_next;  /* next in editor list */
+    t_text *x_text;        /* owner */
+    t_glist *x_glist;      /* glist owner belongs to */
+    char x_tag[50];        /* tag for gui */
+    struct _rtext *x_next; /* next in editor list */
 };
 
 t_rtext *rtext_new(t_glist *glist, t_text *who)
 {
-    t_rtext *x = (t_rtext *)getbytes(sizeof *x);
+    t_rtext *x = (t_rtext *) getbytes(sizeof *x);
     int w = 0, h = 0, indx;
     x->x_text = who;
     x->x_glist = glist;
     x->x_next = glist->gl_editor->e_rtext;
-    x->x_selstart = x->x_selend = x->x_active =
-        x->x_drawnwidth = x->x_drawnheight = 0;
+    x->x_selstart = x->x_selend = x->x_active = x->x_drawnwidth =
+        x->x_drawnheight = 0;
     binbuf_gettext(who->te_binbuf, &x->x_buf, &x->x_bufsize);
-        /* allocate extra space for hidden null terminator */
-    x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize+1);
+    /* allocate extra space for hidden null terminator */
+    x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize + 1);
     x->x_buf[x->x_bufsize] = 0;
     glist->gl_editor->e_rtext = x;
-    sprintf(x->x_tag, ".x%lx.t%lx", (t_int)glist_getcanvas(x->x_glist),
-        (t_int)x);
+    sprintf(
+        x->x_tag, ".x%lx.t%lx", (t_int) glist_getcanvas(x->x_glist), (t_int) x);
     return (x);
 }
 
 void rtext_free(t_rtext *x)
 {
-    if (x->x_glist->gl_editor->e_textedfor == x)
+    if(x->x_glist->gl_editor->e_textedfor == x)
         x->x_glist->gl_editor->e_textedfor = 0;
-    if (x->x_glist->gl_editor->e_rtext == x)
+    if(x->x_glist->gl_editor->e_rtext == x)
         x->x_glist->gl_editor->e_rtext = x->x_next;
     else
     {
         t_rtext *e2;
-        for (e2 = x->x_glist->gl_editor->e_rtext; e2; e2 = e2->x_next)
-            if (e2->x_next == x)
-        {
-            e2->x_next = x->x_next;
-            break;
-        }
+        for(e2 = x->x_glist->gl_editor->e_rtext; e2; e2 = e2->x_next)
+            if(e2->x_next == x)
+            {
+                e2->x_next = x->x_next;
+                break;
+            }
     }
     freebytes(x->x_buf, x->x_bufsize + 1); /* extra 0 byte */
     freebytes(x, sizeof *x);
 }
 
-const char *rtext_gettag(t_rtext *x)
-{
-    return (x->x_tag);
-}
+const char *rtext_gettag(t_rtext *x) { return (x->x_tag); }
 
 void rtext_gettext(t_rtext *x, char **buf, int *bufsize)
 {
     *buf = x->x_buf;
     *bufsize = x->x_bufsize;
 }
+
 void rtext_getseltext(t_rtext *x, char **buf, int *bufsize)
 {
     *buf = x->x_buf + x->x_selstart;
     *bufsize = x->x_selend - x->x_selstart;
 }
 
-t_text *rtext_getowner(t_rtext *x)
-{
-    return (x->x_text);
-}
+t_text *rtext_getowner(t_rtext *x) { return (x->x_text); }
 
 /* convert t_text te_type symbol for use as a Tk tag */
 static t_symbol *rtext_gettype(t_rtext *x)
 {
-    switch (x->x_text->te_type)
+    switch(x->x_text->te_type)
     {
-    case T_TEXT: return gensym("text");
-    case T_OBJECT: return gensym("obj");
-    case T_MESSAGE: return gensym("msg");
-    case T_ATOM: return gensym("atom");
+        case T_TEXT:
+            return gensym("text");
+        case T_OBJECT:
+            return gensym("obj");
+        case T_MESSAGE:
+            return gensym("msg");
+        case T_ATOM:
+            return gensym("atom");
     }
     return (&s_);
 }
@@ -124,9 +123,9 @@ static int firstone(char *s, int c, int n)
 {
     char *s2 = s + n;
     int i = 0;
-    while (s != s2)
+    while(s != s2)
     {
-        if (*s == c) return (i);
+        if(*s == c) return (i);
         i++;
         s++;
     }
@@ -136,36 +135,36 @@ static int firstone(char *s, int c, int n)
 static int lastone(char *s, int c, int n)
 {
     char *s2 = s + n;
-    while (s2 != s)
+    while(s2 != s)
     {
         s2--;
         n--;
-        if (*s2 == c) return (n);
+        if(*s2 == c) return (n);
     }
     return (-1);
 }
 
-    /* break the text into lines, and compute byte index of character at
-    location (width, height).  Then reset (width, height) to report size of
-    resulting line-broken text.  Used for object, message, and comment boxes;
-    another version below is for atoms.  Also we report the onsets of
-    the beginning and end of the selection, as byte onsets into the reformatted
-    text, which we'll use to inform the GUI how to show the selection.
+/* break the text into lines, and compute byte index of character at
+location (width, height).  Then reset (width, height) to report size of
+resulting line-broken text.  Used for object, message, and comment boxes;
+another version below is for atoms.  Also we report the onsets of
+the beginning and end of the selection, as byte onsets into the reformatted
+text, which we'll use to inform the GUI how to show the selection.
 
-    The input is taken from x->buf and x->bufsize fields of the text object;
-    the wrapped text is put in "tempbuf" with byte length outchars_b_p.
+The input is taken from x->buf and x->bufsize fields of the text object;
+the wrapped text is put in "tempbuf" with byte length outchars_b_p.
 
-    x->x_buf is assumed to contain text in UTF-8 format, in which characters
-    may occupy multiple bytes. variables with a "_b" suffix are raw byte
-    strings, lengths, or offsets;  those with a "_c" suffix are logical
-    character lengths or offsets.
-    The UTF8 handling was contributed by Bryan Jurish, who says "moo." */
+x->x_buf is assumed to contain text in UTF-8 format, in which characters
+may occupy multiple bytes. variables with a "_b" suffix are raw byte
+strings, lengths, or offsets;  those with a "_c" suffix are logical
+character lengths or offsets.
+The UTF8 handling was contributed by Bryan Jurish, who says "moo." */
 
 #define DEFAULTBOXWIDTH 60
 
-static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
-    int *indexp,  char *tempbuf, int *outchars_b_p, int *selstart_b_p,
-    int *selend_b_p, int fontwidth, int fontheight)
+static void rtext_formattext(t_rtext *x, int *widthp, int *heightp, int *indexp,
+    char *tempbuf, int *outchars_b_p, int *selstart_b_p, int *selend_b_p,
+    int fontwidth, int fontheight)
 {
     int widthspec_c = x->x_text->te_width;
     int widthlimit_c = (widthspec_c ? widthspec_c : DEFAULTBOXWIDTH);
@@ -173,30 +172,30 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
     int inindex_c = 0;
     int x_bufsize_c = u8_charnum(x->x_buf, x->x_bufsize);
     int nlines = 0, ncolumns = 0, reportedindex = 0;
-    int findx = (*widthp + (fontwidth/2)) / fontwidth;
+    int findx = (*widthp + (fontwidth / 2)) / fontwidth;
     int findy = *heightp / fontheight;
 
     *selstart_b_p = *selend_b_p = 0;
 
-    while (x_bufsize_c - inindex_c > 0)
+    while(x_bufsize_c - inindex_c > 0)
     {
-        int inchars_b  = x->x_bufsize - inindex_b;
-        int inchars_c  = x_bufsize_c  - inindex_c;
+        int inchars_b = x->x_bufsize - inindex_b;
+        int inchars_c = x_bufsize_c - inindex_c;
         int maxindex_c = (inchars_c > widthlimit_c ? widthlimit_c : inchars_c);
         int maxindex_b = u8_offset(x->x_buf + inindex_b, maxindex_c);
         int eatchar = 1;
-        int foundit_b  = firstone(x->x_buf + inindex_b, '\n', maxindex_b);
+        int foundit_b = firstone(x->x_buf + inindex_b, '\n', maxindex_b);
         int foundit_c;
-        if (foundit_b < 0)
+        if(foundit_b < 0)
         {
-                /* too much text to fit in one line? */
-            if (inchars_c > widthlimit_c)
+            /* too much text to fit in one line? */
+            if(inchars_c > widthlimit_c)
             {
-                    /* is there a space to break the line at?  OK if it's even
-                    one byte past the end since in this context we know there's
-                    more text */
+                /* is there a space to break the line at?  OK if it's even
+                one byte past the end since in this context we know there's
+                more text */
                 foundit_b = lastone(x->x_buf + inindex_b, ' ', maxindex_b + 1);
-                if (foundit_b < 0)
+                if(foundit_b < 0)
                 {
                     foundit_b = maxindex_b;
                     foundit_c = maxindex_c;
@@ -215,44 +214,42 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
         else
             foundit_c = u8_charnum(x->x_buf + inindex_b, foundit_b);
 
-        if (nlines == findy)
+        if(nlines == findy)
         {
-            int actualx = (findx < 0 ? 0 :
-                (findx > foundit_c ? foundit_c : findx));
+            int actualx =
+                (findx < 0 ? 0 : (findx > foundit_c ? foundit_c : findx));
             *indexp = inindex_b + u8_offset(x->x_buf + inindex_b, actualx);
             reportedindex = 1;
         }
-        strncpy(tempbuf+ *outchars_b_p, x->x_buf + inindex_b, foundit_b);
-        if (x->x_selstart >= inindex_b &&
+        strncpy(tempbuf + *outchars_b_p, x->x_buf + inindex_b, foundit_b);
+        if(x->x_selstart >= inindex_b &&
             x->x_selstart <= inindex_b + foundit_b + eatchar)
-                *selstart_b_p = x->x_selstart + *outchars_b_p - inindex_b;
-        if (x->x_selend >= inindex_b &&
+            *selstart_b_p = x->x_selstart + *outchars_b_p - inindex_b;
+        if(x->x_selend >= inindex_b &&
             x->x_selend <= inindex_b + foundit_b + eatchar)
-                *selend_b_p = x->x_selend + *outchars_b_p - inindex_b;
+            *selend_b_p = x->x_selend + *outchars_b_p - inindex_b;
         *outchars_b_p += foundit_b;
         inindex_b += (foundit_b + eatchar);
         inindex_c += (foundit_c + eatchar);
-        if (inindex_b < x->x_bufsize)
-            tempbuf[(*outchars_b_p)++] = '\n';
-        if (foundit_c > ncolumns)
-            ncolumns = foundit_c;
+        if(inindex_b < x->x_bufsize) tempbuf[(*outchars_b_p)++] = '\n';
+        if(foundit_c > ncolumns) ncolumns = foundit_c;
         nlines++;
     }
-    if (!reportedindex)
-        *indexp = *outchars_b_p;
-    if (nlines < 1) nlines = 1;
-    if (!widthspec_c)
+    if(!reportedindex) *indexp = *outchars_b_p;
+    if(nlines < 1) nlines = 1;
+    if(!widthspec_c)
     {
-        while (ncolumns < (x->x_text->te_type == T_TEXT ? 1 : 3))
+        while(ncolumns < (x->x_text->te_type == T_TEXT ? 1 : 3))
         {
             tempbuf[(*outchars_b_p)++] = ' ';
             ncolumns++;
         }
     }
-    else ncolumns = widthspec_c;
+    else
+        ncolumns = widthspec_c;
     *widthp = ncolumns * fontwidth;
     *heightp = nlines * fontheight;
-    if (glist_getzoom(x->x_glist) > 1)
+    if(glist_getzoom(x->x_glist) > 1)
     {
         /* zoom margins */
         *widthp += (LMARGIN + RMARGIN) * glist_getzoom(x->x_glist);
@@ -263,200 +260,191 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
         *widthp += LMARGIN + RMARGIN;
         *heightp += TMARGIN + BMARGIN;
     }
-
 }
 
-    /* same as above, but for atom boxes, which are always on one line. */
-static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp,
-    int *indexp,  char *tempbuf, int *outchars_b_p, int *selstart_b_p,
-    int *selend_b_p, int fontwidth, int fontheight)
+/* same as above, but for atom boxes, which are always on one line. */
+static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp, int *indexp,
+    char *tempbuf, int *outchars_b_p, int *selstart_b_p, int *selend_b_p,
+    int fontwidth, int fontheight)
 {
-    int findx = *widthp / fontwidth;  /* character index; want byte index */
+    int findx = *widthp / fontwidth; /* character index; want byte index */
     *indexp = 0;
-        /* special case: for number boxes, try to pare the number down
-        to the specified width of the box. */
-    if (x->x_text->te_width > 0 && binbuf_getnatom(x->x_text->te_binbuf) == 1 &&
+    /* special case: for number boxes, try to pare the number down
+    to the specified width of the box. */
+    if(x->x_text->te_width > 0 && binbuf_getnatom(x->x_text->te_binbuf) == 1 &&
         binbuf_getvec(x->x_text->te_binbuf)->a_type == A_FLOAT &&
         x->x_bufsize > x->x_text->te_width)
     {
-            /* try to reduce size by dropping decimal digits */
+        /* try to reduce size by dropping decimal digits */
         int wantreduce = x->x_bufsize - x->x_text->te_width;
-        char *decimal = 0, *nextchar, *ebuf = x->x_buf + x->x_bufsize,
-            *s1, *s2;
+        char *decimal = 0, *nextchar, *ebuf = x->x_buf + x->x_bufsize, *s1, *s2;
         int ndecimals;
         strncpy(tempbuf, x->x_buf, x->x_bufsize);
         tempbuf[x->x_bufsize] = 0;
         ebuf = tempbuf + x->x_bufsize;
-        for (decimal = tempbuf; decimal < ebuf; decimal++)
-            if (*decimal == '.')
-                break;
-        if (decimal >= ebuf)
-            goto giveup;
-        for (nextchar = decimal + 1; nextchar < ebuf; nextchar++)
-            if (*nextchar < '0' || *nextchar > '9')
-                break;
-        if (nextchar - decimal - 1 < wantreduce)
-            goto giveup;
-        for (s1 = nextchar - wantreduce, s2 = s1 + wantreduce;
-            s2 < ebuf; s1++, s2++)
-                *s1 = *s2;
+        for(decimal = tempbuf; decimal < ebuf; decimal++)
+            if(*decimal == '.') break;
+        if(decimal >= ebuf) goto giveup;
+        for(nextchar = decimal + 1; nextchar < ebuf; nextchar++)
+            if(*nextchar < '0' || *nextchar > '9') break;
+        if(nextchar - decimal - 1 < wantreduce) goto giveup;
+        for(s1 = nextchar - wantreduce, s2 = s1 + wantreduce; s2 < ebuf;
+            s1++, s2++)
+            *s1 = *s2;
         *outchars_b_p = x->x_text->te_width;
         goto done;
     giveup:
-            /* give up and bash last char to '>' */
-        tempbuf[x->x_text->te_width-1] = '>';
+        /* give up and bash last char to '>' */
+        tempbuf[x->x_text->te_width - 1] = '>';
         tempbuf[x->x_text->te_width] = 0;
         *outchars_b_p = x->x_text->te_width;
-    done: ;
+    done:;
         *indexp = findx;
         *widthp = x->x_text->te_width * fontwidth;
     }
     else
     {
         int outchars_c = 0, prev_b = 0;
-        int widthlimit_c = (x->x_text->te_width > 0 ? x->x_text->te_width :
-                1000);   /* nice big fat limit since we can't wrap */
+        int widthlimit_c =
+            (x->x_text->te_width > 0
+                    ? x->x_text->te_width
+                    : 1000); /* nice big fat limit since we can't wrap */
         uint32_t thischar;
         *outchars_b_p = 0;
-        for (outchars_c = 0;
+        for(outchars_c = 0;
             *outchars_b_p < x->x_bufsize && outchars_c < widthlimit_c;
-                outchars_c++)
+            outchars_c++)
         {
             prev_b = *outchars_b_p;
             thischar = u8_nextchar(x->x_buf, outchars_b_p);
-            if (findx > outchars_c)
-                *indexp = *outchars_b_p;
-            if (thischar == '\n' || !thischar)
+            if(findx > outchars_c) *indexp = *outchars_b_p;
+            if(thischar == '\n' || !thischar)
             {
                 *(outchars_b_p) = prev_b;
                 break;
             }
             memcpy(tempbuf + prev_b, x->x_buf + prev_b, *outchars_b_p - prev_b);
-                /* if box is full and there's more, bash last char to '>' */
-            if (outchars_c == widthlimit_c-1 && x->x_bufsize > *(outchars_b_p)
-                 && (x->x_buf[*(outchars_b_p)] != ' ' ||
-                    x->x_bufsize > *(outchars_b_p)+1))
+            /* if box is full and there's more, bash last char to '>' */
+            if(outchars_c == widthlimit_c - 1 &&
+                x->x_bufsize > *(outchars_b_p) &&
+                (x->x_buf[*(outchars_b_p)] != ' ' ||
+                    x->x_bufsize > *(outchars_b_p) + 1))
             {
                 tempbuf[prev_b] = '>';
             }
         }
-        if (x->x_text->te_width > 0)
+        if(x->x_text->te_width > 0)
             *widthp = x->x_text->te_width * fontwidth;
-        else *widthp = (outchars_c > 3 ? outchars_c : 3) * fontwidth;
+        else
+            *widthp = (outchars_c > 3 ? outchars_c : 3) * fontwidth;
         tempbuf[*outchars_b_p] = 0;
     }
-    if (*indexp > *outchars_b_p)
-        *indexp = *outchars_b_p;
-    if (*indexp < 0)
-        *indexp = 0;
+    if(*indexp > *outchars_b_p) *indexp = *outchars_b_p;
+    if(*indexp < 0) *indexp = 0;
     *selstart_b_p = x->x_selstart;
     *selend_b_p = x->x_selend;
     *widthp += (LMARGIN + RMARGIN - 2) * glist_getzoom(x->x_glist);
     *heightp = fontheight + (TMARGIN + BMARGIN - 1) * glist_getzoom(x->x_glist);
 }
 
-    /* the following routine computes line breaks and carries out
-    some action which could be:
-        SEND_FIRST - draw the box  for the first time
-        SEND_UPDATE - redraw the updated box
-        otherwise - don't draw, just calculate.
-    Called with *widthp and *heightp as coordinates of
-    a test point, the routine reports the index of the character found
-    there in *indexp.  *widthp and *heightp are set to the width and height
-    of the entire text in pixels.
-    */
+/* the following routine computes line breaks and carries out
+some action which could be:
+    SEND_FIRST - draw the box  for the first time
+    SEND_UPDATE - redraw the updated box
+    otherwise - don't draw, just calculate.
+Called with *widthp and *heightp as coordinates of
+a test point, the routine reports the index of the character found
+there in *indexp.  *widthp and *heightp are set to the width and height
+of the entire text in pixels.
+*/
 
-    /* LATER get this and sys_vgui to work together properly,
-        breaking up messages as needed.  As of now, there's
-        a limit of 1950 characters, imposed by sys_vgui(). */
+/* LATER get this and sys_vgui to work together properly,
+    breaking up messages as needed.  As of now, there's
+    a limit of 1950 characters, imposed by sys_vgui(). */
 #define UPBUFSIZE 4000
 
-void text_getfont(t_text *x, t_glist *thisglist,
-    int *fheightp, int *fwidthp, int *guifsize);
+void text_getfont(
+    t_text *x, t_glist *thisglist, int *fheightp, int *fwidthp, int *guifsize);
 
-static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
-    int *indexp)
+static void rtext_senditup(
+    t_rtext *x, int action, int *widthp, int *heightp, int *indexp)
 {
     char smallbuf[200], *tempbuf;
     int outchars_b = 0, guifontsize, fontwidth, fontheight;
     t_canvas *canvas = glist_getcanvas(x->x_glist);
     char smallescbuf[400], *escbuf = 0;
     size_t escchars = 0;
-    int selstart_b, selend_b;   /* beginning and end of selection in bytes */
-        /* if we're a GOP (the new, "goprect" style) borrow the font size
-        from the inside to preserve the spacing */
+    int selstart_b, selend_b; /* beginning and end of selection in bytes */
+    /* if we're a GOP (the new, "goprect" style) borrow the font size
+    from the inside to preserve the spacing */
 
     text_getfont(x->x_text, x->x_glist, &fontwidth, &fontheight, &guifontsize);
-    if (x->x_bufsize >= 100)
-         tempbuf = (char *)t_getbytes(2 * x->x_bufsize + 1);
-    else tempbuf = smallbuf;
+    if(x->x_bufsize >= 100)
+        tempbuf = (char *) t_getbytes(2 * x->x_bufsize + 1);
+    else
+        tempbuf = smallbuf;
     tempbuf[0] = 0;
 
-    if (x->x_text->te_type == T_ATOM)
-        rtext_formatatom(x, widthp, heightp, indexp,
-            tempbuf, &outchars_b, &selstart_b,  &selend_b,
-            fontwidth, fontheight);
-    else rtext_formattext(x, widthp, heightp, indexp,
-            tempbuf, &outchars_b, &selstart_b, &selend_b,
-            fontwidth, fontheight);
+    if(x->x_text->te_type == T_ATOM)
+        rtext_formatatom(x, widthp, heightp, indexp, tempbuf, &outchars_b,
+            &selstart_b, &selend_b, fontwidth, fontheight);
+    else
+        rtext_formattext(x, widthp, heightp, indexp, tempbuf, &outchars_b,
+            &selstart_b, &selend_b, fontwidth, fontheight);
 
-    if (action && x->x_text->te_width && x->x_text->te_type != T_ATOM)
+    if(action && x->x_text->te_width && x->x_text->te_type != T_ATOM)
     {
-            /* if our width is specified but the "natural" width is the
-            same as the specified width, set specified width to zero
-            so future text editing will automatically change width.
-            Except atoms whose content changes at runtime. */
+        /* if our width is specified but the "natural" width is the
+        same as the specified width, set specified width to zero
+        so future text editing will automatically change width.
+        Except atoms whose content changes at runtime. */
         int widthwas = x->x_text->te_width, newwidth = 0, newheight = 0,
             newindex = 0;
         x->x_text->te_width = 0;
         rtext_senditup(x, 0, &newwidth, &newheight, &newindex);
-        if (newwidth != *widthp)
-            x->x_text->te_width = widthwas;
+        if(newwidth != *widthp) x->x_text->te_width = widthwas;
     }
 
-    if (action && !canvas->gl_havewindow)
-        action = 0;
+    if(action && !canvas->gl_havewindow) action = 0;
 
-    escbuf = (tempbuf == smallbuf)?smallescbuf:t_getbytes(2 * outchars_b + 1);
+    escbuf =
+        (tempbuf == smallbuf) ? smallescbuf : t_getbytes(2 * outchars_b + 1);
     pdgui_strnescape(escbuf, 2 * outchars_b + 1, tempbuf, outchars_b);
 
-    if (action == SEND_FIRST)
+    if(action == SEND_FIRST)
     {
         int lmargin = LMARGIN, tmargin = TMARGIN;
-        if (glist_getzoom(x->x_glist) > 1)
+        if(glist_getzoom(x->x_glist) > 1)
         {
             /* zoom margins */
             lmargin *= glist_getzoom(x->x_glist);
             tmargin *= glist_getzoom(x->x_glist);
         }
-            /* we add an extra space to the string just in case the last
-            character is an unescaped backslash ('\') which would have confused
-            tcl/tk by escaping the close brace otherwise.  The GUI code
-            drops the last character in the string. */
+        /* we add an extra space to the string just in case the last
+        character is an unescaped backslash ('\') which would have confused
+        tcl/tk by escaping the close brace otherwise.  The GUI code
+        drops the last character in the string. */
         sys_vgui("pdtk_text_new .x%lx.c {%s %s text} %d %d {%s } %d %s\n",
             canvas, x->x_tag, rtext_gettype(x)->s_name,
             text_xpix(x->x_text, x->x_glist) + lmargin,
-                text_ypix(x->x_text, x->x_glist) + tmargin,
-            escbuf,
-            guifontsize,
-            (glist_isselected(x->x_glist,
-                &x->x_text->te_g)? "blue" : "black"));
+            text_ypix(x->x_text, x->x_glist) + tmargin, escbuf, guifontsize,
+            (glist_isselected(x->x_glist, &x->x_text->te_g) ? "blue"
+                                                            : "black"));
     }
-    else if (action == SEND_UPDATE)
+    else if(action == SEND_UPDATE)
     {
-        sys_vgui("pdtk_text_set .x%lx.c %s {%s }\n",
-            canvas, x->x_tag, escbuf);
-        if (*widthp != x->x_drawnwidth || *heightp != x->x_drawnheight)
-            text_drawborder(x->x_text, x->x_glist, x->x_tag,
-                *widthp, *heightp, 0);
-        if (x->x_active)
+        sys_vgui("pdtk_text_set .x%lx.c %s {%s }\n", canvas, x->x_tag, escbuf);
+        if(*widthp != x->x_drawnwidth || *heightp != x->x_drawnheight)
+            text_drawborder(
+                x->x_text, x->x_glist, x->x_tag, *widthp, *heightp, 0);
+        if(x->x_active)
         {
-            if (selend_b > selstart_b)
+            if(selend_b > selstart_b)
             {
-                sys_vgui(".x%lx.c select from %s %d\n", canvas,
-                    x->x_tag, u8_charnum(x->x_buf, selstart_b));
-                sys_vgui(".x%lx.c select to %s %d\n", canvas,
-                    x->x_tag, u8_charnum(x->x_buf, selend_b) - 1);
+                sys_vgui(".x%lx.c select from %s %d\n", canvas, x->x_tag,
+                    u8_charnum(x->x_buf, selstart_b));
+                sys_vgui(".x%lx.c select to %s %d\n", canvas, x->x_tag,
+                    u8_charnum(x->x_buf, selend_b) - 1);
                 sys_vgui(".x%lx.c focus \"\"\n", canvas);
             }
             else
@@ -472,21 +460,19 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
     x->x_drawnwidth = *widthp;
     x->x_drawnheight = *heightp;
 
-    if (tempbuf != smallbuf)
-        t_freebytes(tempbuf, 2 * x->x_bufsize + 1);
-    if(escbuf != smallescbuf)
-        t_freebytes(escbuf, 2 * outchars_b + 1);
+    if(tempbuf != smallbuf) t_freebytes(tempbuf, 2 * x->x_bufsize + 1);
+    if(escbuf != smallescbuf) t_freebytes(escbuf, 2 * outchars_b + 1);
 }
 
-    /* remake text buffer from binbuf */
+/* remake text buffer from binbuf */
 void rtext_retext(t_rtext *x)
 {
     int w = 0, h = 0, indx;
     t_text *text = x->x_text;
     t_freebytes(x->x_buf, x->x_bufsize + 1); /* extra 0 byte */
     binbuf_gettext(text->te_binbuf, &x->x_buf, &x->x_bufsize);
-        /* allocate extra space for hidden null terminator */
-    x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize+1);
+    /* allocate extra space for hidden null terminator */
+    x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize + 1);
     x->x_buf[x->x_bufsize] = 0;
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
 }
@@ -495,9 +481,8 @@ void rtext_retext(t_rtext *x)
 t_rtext *glist_findrtext(t_glist *gl, t_text *who)
 {
     t_rtext *x;
-    if (!gl->gl_editor)
-        canvas_create_editor(gl);
-    for (x = gl->gl_editor->e_rtext; x && x->x_text != who; x = x->x_next)
+    if(!gl->gl_editor) canvas_create_editor(gl);
+    for(x = gl->gl_editor->e_rtext; x && x->x_text != who; x = x->x_next)
         ;
     return (x);
 }
@@ -529,16 +514,16 @@ void rtext_erase(t_rtext *x)
 
 void rtext_displace(t_rtext *x, int dx, int dy)
 {
-    sys_vgui(".x%lx.c move %s %d %d\n", glist_getcanvas(x->x_glist),
-        x->x_tag, dx, dy);
+    sys_vgui(".x%lx.c move %s %d %d\n", glist_getcanvas(x->x_glist), x->x_tag,
+        dx, dy);
 }
 
 void rtext_select(t_rtext *x, int state)
 {
     t_glist *glist = x->x_glist;
     t_canvas *canvas = glist_getcanvas(glist);
-    sys_vgui(".x%lx.c itemconfigure %s -fill %s\n", canvas,
-        x->x_tag, (state? "blue" : "black"));
+    sys_vgui(".x%lx.c itemconfigure %s -fill %s\n", canvas, x->x_tag,
+        (state ? "blue" : "black"));
 }
 
 void gatom_undarken(t_text *x);
@@ -548,7 +533,7 @@ void rtext_activate(t_rtext *x, int state)
     int w = 0, h = 0, indx;
     t_glist *glist = x->x_glist;
     t_canvas *canvas = glist_getcanvas(glist);
-    if (state)
+    if(state)
     {
         sys_vgui("pdtk_text_editing .x%lx %s 1\n", canvas, x->x_tag);
         glist->gl_editor->e_textedfor = x;
@@ -560,37 +545,35 @@ void rtext_activate(t_rtext *x, int state)
     else
     {
         sys_vgui("pdtk_text_editing .x%lx {} 0\n", canvas);
-        if (glist->gl_editor->e_textedfor == x)
+        if(glist->gl_editor->e_textedfor == x)
             glist->gl_editor->e_textedfor = 0;
         x->x_active = 0;
-        if (x->x_text->te_type == T_ATOM)
-            gatom_undarken(x->x_text);
+        if(x->x_text->te_type == T_ATOM) gatom_undarken(x->x_text);
     }
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
 }
 
-    /* figure out which atom a click falls into if any; -1 if you
-    clicked on a space or something */
+/* figure out which atom a click falls into if any; -1 if you
+clicked on a space or something */
 int rtext_findatomfor(t_rtext *x, int xpos, int ypos)
 {
     int w = xpos, h = ypos, indx, natom = 0, i, gotone = 0;
-        /* get byte index of character clicked on */
+    /* get byte index of character clicked on */
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
-        /* search through for whitespace before that index */
-    for (i = 0; i <= indx; i++)
+    /* search through for whitespace before that index */
+    for(i = 0; i <= indx; i++)
     {
-        if (x->x_buf[i] == ';' || x->x_buf[i] == ',')
+        if(x->x_buf[i] == ';' || x->x_buf[i] == ',')
             natom++, gotone = 0;
-        else if (x->x_buf[i] == ' ' || x->x_buf[i] == '\n')
+        else if(x->x_buf[i] == ' ' || x->x_buf[i] == '\n')
             gotone = 0;
         else
         {
-            if (!gotone)
-                natom++;
+            if(!gotone) natom++;
             gotone = 1;
         }
     }
-    return (natom-1);
+    return (natom - 1);
 }
 
 void gatom_key(void *z, t_symbol *keysym, t_floatarg f);
@@ -599,103 +582,103 @@ void rtext_key(t_rtext *x, int keynum, t_symbol *keysym)
 {
     int w = 0, h = 0, indx, i, newsize, ndel;
     char *s1, *s2;
-        /* CR to atom boxes sends message and resets */
-    if (keynum == '\n' && x->x_text->te_type == T_ATOM)
+    /* CR to atom boxes sends message and resets */
+    if(keynum == '\n' && x->x_text->te_type == T_ATOM)
     {
         gatom_key(x->x_text, keysym, keynum);
         return;
     }
-    if (keynum)
+    if(keynum)
     {
         int n = keynum;
-        if (n == '\r') n = '\n';
-        if (n == '\b')  /* backspace */
+        if(n == '\r') n = '\n';
+        if(n == '\b') /* backspace */
         {
-                    /* LATER delete the box if all text is selected...
-                    this causes reentrancy problems now. */
+            /* LATER delete the box if all text is selected...
+            this causes reentrancy problems now. */
             /* if ((!x->x_selstart) && (x->x_selend == x->x_bufsize))
             {
                 ....
             } */
-            if (x->x_selstart && (x->x_selstart == x->x_selend))
+            if(x->x_selstart && (x->x_selstart == x->x_selend))
                 u8_dec(x->x_buf, &x->x_selstart);
         }
-        else if (n == 127)      /* delete */
+        else if(n == 127) /* delete */
         {
-            if (x->x_selend < x->x_bufsize && (x->x_selstart == x->x_selend))
+            if(x->x_selend < x->x_bufsize && (x->x_selstart == x->x_selend))
                 u8_inc(x->x_buf, &x->x_selend);
         }
 
         ndel = x->x_selend - x->x_selstart;
-        for (i = x->x_selend; i < x->x_bufsize; i++)
-            x->x_buf[i- ndel] = x->x_buf[i];
+        for(i = x->x_selend; i < x->x_bufsize; i++)
+            x->x_buf[i - ndel] = x->x_buf[i];
         newsize = x->x_bufsize - ndel;
-            /* allocate extra space for hidden null terminator */
-        x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize+1);
+        /* allocate extra space for hidden null terminator */
+        x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize + 1);
         x->x_buf[newsize] = 0;
         x->x_bufsize = newsize;
 
-/* at Guenter's suggestion, use 'n>31' to test whether a character might
-be printable in whatever 8-bit character set we find ourselves. */
+        /* at Guenter's suggestion, use 'n>31' to test whether a character might
+        be printable in whatever 8-bit character set we find ourselves. */
 
-/*-- moo:
-  ... but test with "<" rather than "!=" in order to accommodate unicode
-  codepoints for n (which we get since Tk is sending the "%A" substitution
-  for bind <Key>), effectively reducing the coverage of this clause to 7
-  bits.  Case n>127 is covered by the next clause.
-*/
-        if (n == '\n' || (n > 31 && n < 127))
+        /*-- moo:
+          ... but test with "<" rather than "!=" in order to accommodate unicode
+          codepoints for n (which we get since Tk is sending the "%A"
+          substitution for bind <Key>), effectively reducing the coverage of
+          this clause to 7 bits.  Case n>127 is covered by the next clause.
+        */
+        if(n == '\n' || (n > 31 && n < 127))
         {
-            newsize = x->x_bufsize+1;
-                /* allocate extra space for hidden null terminator */
-            x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize+1);
-            for (i = x->x_bufsize; i > x->x_selstart; i--)
-                x->x_buf[i] = x->x_buf[i-1];
+            newsize = x->x_bufsize + 1;
+            /* allocate extra space for hidden null terminator */
+            x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize + 1);
+            for(i = x->x_bufsize; i > x->x_selstart; i--)
+                x->x_buf[i] = x->x_buf[i - 1];
             x->x_buf[x->x_selstart] = n;
             x->x_buf[newsize] = 0;
             x->x_bufsize = newsize;
             x->x_selstart = x->x_selstart + 1;
         }
         /*--moo: check for unicode codepoints beyond 7-bit ASCII --*/
-        else if (n > 127)
+        else if(n > 127)
         {
             int ch_nbytes = u8_wc_nbytes(n);
             newsize = x->x_bufsize + ch_nbytes;
-                /* allocate extra space for hidden null terminator */
-            x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize+1);
+            /* allocate extra space for hidden null terminator */
+            x->x_buf = resizebytes(x->x_buf, x->x_bufsize, newsize + 1);
 
-            for (i = newsize-1; i > x->x_selstart; i--)
-                x->x_buf[i] = x->x_buf[i-ch_nbytes];
+            for(i = newsize - 1; i > x->x_selstart; i--)
+                x->x_buf[i] = x->x_buf[i - ch_nbytes];
             x->x_buf[newsize] = 0;
             x->x_bufsize = newsize;
             /*-- moo: assume canvas_key() has encoded keysym as UTF-8 */
-            strncpy(x->x_buf+x->x_selstart, keysym->s_name, ch_nbytes);
+            strncpy(x->x_buf + x->x_selstart, keysym->s_name, ch_nbytes);
             x->x_selstart = x->x_selstart + ch_nbytes;
         }
         x->x_selend = x->x_selstart;
         x->x_glist->gl_editor->e_textdirty = 1;
     }
-    else if (!strcmp(keysym->s_name, "Home"))
+    else if(!strcmp(keysym->s_name, "Home"))
     {
-        if (x->x_selend == x->x_selstart)
+        if(x->x_selend == x->x_selstart)
         {
             x->x_selend = x->x_selstart = 0;
         }
         else
             x->x_selstart = 0;
     }
-    else if (!strcmp(keysym->s_name, "End"))
+    else if(!strcmp(keysym->s_name, "End"))
     {
-        if (x->x_selend == x->x_selstart)
+        if(x->x_selend == x->x_selstart)
         {
             x->x_selend = x->x_selstart = x->x_bufsize;
         }
         else
             x->x_selend = x->x_bufsize;
     }
-    else if (!strcmp(keysym->s_name, "Right"))
+    else if(!strcmp(keysym->s_name, "Right"))
     {
-        if (x->x_selend == x->x_selstart && x->x_selstart < x->x_bufsize)
+        if(x->x_selend == x->x_selstart && x->x_selstart < x->x_bufsize)
         {
             u8_inc(x->x_buf, &x->x_selstart);
             x->x_selend = x->x_selstart;
@@ -703,9 +686,9 @@ be printable in whatever 8-bit character set we find ourselves. */
         else
             x->x_selstart = x->x_selend;
     }
-    else if (!strcmp(keysym->s_name, "Left"))
+    else if(!strcmp(keysym->s_name, "Left"))
     {
-        if (x->x_selend == x->x_selstart && x->x_selstart > 0)
+        if(x->x_selend == x->x_selstart && x->x_selstart > 0)
         {
             u8_dec(x->x_buf, &x->x_selstart);
             x->x_selend = x->x_selstart;
@@ -713,22 +696,19 @@ be printable in whatever 8-bit character set we find ourselves. */
         else
             x->x_selend = x->x_selstart;
     }
-        /* this should be improved...  life's too short */
-    else if (!strcmp(keysym->s_name, "Up"))
+    /* this should be improved...  life's too short */
+    else if(!strcmp(keysym->s_name, "Up"))
     {
-        if (x->x_selstart)
-            u8_dec(x->x_buf, &x->x_selstart);
-        while (x->x_selstart > 0 && x->x_buf[x->x_selstart] != '\n')
+        if(x->x_selstart) u8_dec(x->x_buf, &x->x_selstart);
+        while(x->x_selstart > 0 && x->x_buf[x->x_selstart] != '\n')
             u8_dec(x->x_buf, &x->x_selstart);
         x->x_selend = x->x_selstart;
     }
-    else if (!strcmp(keysym->s_name, "Down"))
+    else if(!strcmp(keysym->s_name, "Down"))
     {
-        while (x->x_selend < x->x_bufsize &&
-            x->x_buf[x->x_selend] != '\n')
+        while(x->x_selend < x->x_bufsize && x->x_buf[x->x_selend] != '\n')
             u8_inc(x->x_buf, &x->x_selend);
-        if (x->x_selend < x->x_bufsize)
-            u8_inc(x->x_buf, &x->x_selend);
+        if(x->x_selend < x->x_bufsize) u8_inc(x->x_buf, &x->x_selend);
         x->x_selstart = x->x_selend;
     }
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
@@ -738,55 +718,54 @@ void rtext_mouse(t_rtext *x, int xval, int yval, int flag)
 {
     int w = xval, h = yval, indx;
     rtext_senditup(x, SEND_CHECK, &w, &h, &indx);
-    if (flag == RTEXT_DOWN)
+    if(flag == RTEXT_DOWN)
     {
         x->x_dragfrom = x->x_selstart = x->x_selend = indx;
     }
-    else if (flag == RTEXT_DBL)
+    else if(flag == RTEXT_DBL)
     {
         int whereseparator, newseparator;
         x->x_dragfrom = -1;
         whereseparator = 0;
-        if ((newseparator = lastone(x->x_buf, ' ', indx)) > whereseparator)
-            whereseparator = newseparator+1;
-        if ((newseparator = lastone(x->x_buf, '\n', indx)) > whereseparator)
-            whereseparator = newseparator+1;
-        if ((newseparator = lastone(x->x_buf, ';', indx)) > whereseparator)
-            whereseparator = newseparator+1;
-        if ((newseparator = lastone(x->x_buf, ',', indx)) > whereseparator)
-            whereseparator = newseparator+1;
+        if((newseparator = lastone(x->x_buf, ' ', indx)) > whereseparator)
+            whereseparator = newseparator + 1;
+        if((newseparator = lastone(x->x_buf, '\n', indx)) > whereseparator)
+            whereseparator = newseparator + 1;
+        if((newseparator = lastone(x->x_buf, ';', indx)) > whereseparator)
+            whereseparator = newseparator + 1;
+        if((newseparator = lastone(x->x_buf, ',', indx)) > whereseparator)
+            whereseparator = newseparator + 1;
         x->x_selstart = whereseparator;
 
         whereseparator = x->x_bufsize - indx;
-        if ((newseparator =
-            firstone(x->x_buf+indx, ' ', x->x_bufsize - indx)) >= 0 &&
-                newseparator < whereseparator)
-                    whereseparator = newseparator;
-        if ((newseparator =
-            firstone(x->x_buf+indx, '\n', x->x_bufsize - indx)) >= 0 &&
-                newseparator < whereseparator)
-                    whereseparator = newseparator;
-        if ((newseparator =
-            firstone(x->x_buf+indx, ';', x->x_bufsize - indx)) >= 0 &&
-                newseparator < whereseparator)
-                    whereseparator = newseparator;
-        if ((newseparator =
-            firstone(x->x_buf+indx, ',', x->x_bufsize - indx)) >= 0 &&
-                newseparator < whereseparator)
-                    whereseparator = newseparator;
+        if((newseparator =
+                   firstone(x->x_buf + indx, ' ', x->x_bufsize - indx)) >= 0 &&
+            newseparator < whereseparator)
+            whereseparator = newseparator;
+        if((newseparator =
+                   firstone(x->x_buf + indx, '\n', x->x_bufsize - indx)) >= 0 &&
+            newseparator < whereseparator)
+            whereseparator = newseparator;
+        if((newseparator =
+                   firstone(x->x_buf + indx, ';', x->x_bufsize - indx)) >= 0 &&
+            newseparator < whereseparator)
+            whereseparator = newseparator;
+        if((newseparator =
+                   firstone(x->x_buf + indx, ',', x->x_bufsize - indx)) >= 0 &&
+            newseparator < whereseparator)
+            whereseparator = newseparator;
         x->x_selend = indx + whereseparator;
     }
-    else if (flag == RTEXT_SHIFT)
+    else if(flag == RTEXT_SHIFT)
     {
-        if (indx * 2 > x->x_selstart + x->x_selend)
+        if(indx * 2 > x->x_selstart + x->x_selend)
             x->x_dragfrom = x->x_selstart, x->x_selend = indx;
         else
             x->x_dragfrom = x->x_selend, x->x_selstart = indx;
     }
-    else if (flag == RTEXT_DRAG)
+    else if(flag == RTEXT_DRAG)
     {
-        if (x->x_dragfrom < 0)
-            return;
+        if(x->x_dragfrom < 0) return;
         x->x_selstart = (x->x_dragfrom < indx ? x->x_dragfrom : indx);
         x->x_selend = (x->x_dragfrom > indx ? x->x_dragfrom : indx);
     }

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -39,7 +39,9 @@ struct _rtext
 t_rtext *rtext_new(t_glist *glist, t_text *who)
 {
     t_rtext *x = (t_rtext *) getbytes(sizeof *x);
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     x->x_text = who;
     x->x_glist = glist;
     x->x_next = glist->gl_editor->e_rtext;
@@ -171,7 +173,9 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp, int *indexp,
     int inindex_b = 0;
     int inindex_c = 0;
     int x_bufsize_c = u8_charnum(x->x_buf, x->x_bufsize);
-    int nlines = 0, ncolumns = 0, reportedindex = 0;
+    int nlines = 0;
+    int ncolumns = 0;
+    int reportedindex = 0;
     int findx = (*widthp + (fontwidth / 2)) / fontwidth;
     int findy = *heightp / fontheight;
 
@@ -277,7 +281,11 @@ static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp, int *indexp,
     {
         /* try to reduce size by dropping decimal digits */
         int wantreduce = x->x_bufsize - x->x_text->te_width;
-        char *decimal = 0, *nextchar, *ebuf = x->x_buf + x->x_bufsize, *s1, *s2;
+        char *decimal = 0;
+        char *nextchar;
+        char *ebuf = x->x_buf + x->x_bufsize;
+        char *s1;
+        char *s2;
         int ndecimals;
         strncpy(tempbuf, x->x_buf, x->x_bufsize);
         tempbuf[x->x_bufsize] = 0;
@@ -304,7 +312,8 @@ static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp, int *indexp,
     }
     else
     {
-        int outchars_c = 0, prev_b = 0;
+        int outchars_c = 0;
+        int prev_b = 0;
         int widthlimit_c =
             (x->x_text->te_width > 0
                     ? x->x_text->te_width
@@ -369,12 +378,18 @@ void text_getfont(
 static void rtext_senditup(
     t_rtext *x, int action, int *widthp, int *heightp, int *indexp)
 {
-    char smallbuf[200], *tempbuf;
-    int outchars_b = 0, guifontsize, fontwidth, fontheight;
+    char smallbuf[200];
+    char *tempbuf;
+    int outchars_b = 0;
+    int guifontsize;
+    int fontwidth;
+    int fontheight;
     t_canvas *canvas = glist_getcanvas(x->x_glist);
-    char smallescbuf[400], *escbuf = 0;
+    char smallescbuf[400];
+    char *escbuf = 0;
     size_t escchars = 0;
-    int selstart_b, selend_b; /* beginning and end of selection in bytes */
+    int selstart_b;
+    int selend_b; /* beginning and end of selection in bytes */
     /* if we're a GOP (the new, "goprect" style) borrow the font size
     from the inside to preserve the spacing */
 
@@ -398,8 +413,10 @@ static void rtext_senditup(
         same as the specified width, set specified width to zero
         so future text editing will automatically change width.
         Except atoms whose content changes at runtime. */
-        int widthwas = x->x_text->te_width, newwidth = 0, newheight = 0,
-            newindex = 0;
+        int widthwas = x->x_text->te_width;
+        int newwidth = 0;
+        int newheight = 0;
+        int newindex = 0;
         x->x_text->te_width = 0;
         rtext_senditup(x, 0, &newwidth, &newheight, &newindex);
         if(newwidth != *widthp) x->x_text->te_width = widthwas;
@@ -413,7 +430,8 @@ static void rtext_senditup(
 
     if(action == SEND_FIRST)
     {
-        int lmargin = LMARGIN, tmargin = TMARGIN;
+        int lmargin = LMARGIN;
+        int tmargin = TMARGIN;
         if(glist_getzoom(x->x_glist) > 1)
         {
             /* zoom margins */
@@ -467,7 +485,9 @@ static void rtext_senditup(
 /* remake text buffer from binbuf */
 void rtext_retext(t_rtext *x)
 {
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     t_text *text = x->x_text;
     t_freebytes(x->x_buf, x->x_bufsize + 1); /* extra 0 byte */
     binbuf_gettext(text->te_binbuf, &x->x_buf, &x->x_bufsize);
@@ -489,21 +509,27 @@ t_rtext *glist_findrtext(t_glist *gl, t_text *who)
 
 int rtext_width(t_rtext *x)
 {
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     rtext_senditup(x, SEND_CHECK, &w, &h, &indx);
     return (w);
 }
 
 int rtext_height(t_rtext *x)
 {
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     rtext_senditup(x, SEND_CHECK, &w, &h, &indx);
     return (h);
 }
 
 void rtext_draw(t_rtext *x)
 {
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     rtext_senditup(x, SEND_FIRST, &w, &h, &indx);
 }
 
@@ -530,7 +556,9 @@ void gatom_undarken(t_text *x);
 
 void rtext_activate(t_rtext *x, int state)
 {
-    int w = 0, h = 0, indx;
+    int w = 0;
+    int h = 0;
+    int indx;
     t_glist *glist = x->x_glist;
     t_canvas *canvas = glist_getcanvas(glist);
     if(state)
@@ -557,7 +585,12 @@ void rtext_activate(t_rtext *x, int state)
 clicked on a space or something */
 int rtext_findatomfor(t_rtext *x, int xpos, int ypos)
 {
-    int w = xpos, h = ypos, indx, natom = 0, i, gotone = 0;
+    int w = xpos;
+    int h = ypos;
+    int indx;
+    int natom = 0;
+    int i;
+    int gotone = 0;
     /* get byte index of character clicked on */
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
     /* search through for whitespace before that index */
@@ -580,8 +613,14 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f);
 
 void rtext_key(t_rtext *x, int keynum, t_symbol *keysym)
 {
-    int w = 0, h = 0, indx, i, newsize, ndel;
-    char *s1, *s2;
+    int w = 0;
+    int h = 0;
+    int indx;
+    int i;
+    int newsize;
+    int ndel;
+    char *s1;
+    char *s2;
     /* CR to atom boxes sends message and resets */
     if(keynum == '\n' && x->x_text->te_type == T_ATOM)
     {
@@ -716,7 +755,9 @@ void rtext_key(t_rtext *x, int keynum, t_symbol *keysym)
 
 void rtext_mouse(t_rtext *x, int xval, int yval, int flag)
 {
-    int w = xval, h = yval, indx;
+    int w = xval;
+    int h = yval;
+    int indx;
     rtext_senditup(x, SEND_CHECK, &w, &h, &indx);
     if(flag == RTEXT_DOWN)
     {
@@ -724,7 +765,8 @@ void rtext_mouse(t_rtext *x, int xval, int yval, int flag)
     }
     else if(flag == RTEXT_DBL)
     {
-        int whereseparator, newseparator;
+        int whereseparator;
+        int newseparator;
         x->x_dragfrom = -1;
         whereseparator = 0;
         if((newseparator = lastone(x->x_buf, ' ', indx)) > whereseparator)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -62,16 +62,20 @@ void rtext_free(t_rtext *x)
     if(x->x_glist->gl_editor->e_textedfor == x)
         x->x_glist->gl_editor->e_textedfor = 0;
     if(x->x_glist->gl_editor->e_rtext == x)
+    {
         x->x_glist->gl_editor->e_rtext = x->x_next;
+    }
     else
     {
         t_rtext *e2;
         for(e2 = x->x_glist->gl_editor->e_rtext; e2; e2 = e2->x_next)
+        {
             if(e2->x_next == x)
             {
                 e2->x_next = x->x_next;
                 break;
             }
+        }
     }
     freebytes(x->x_buf, x->x_bufsize + 1); /* extra 0 byte */
     freebytes(x, sizeof *x);
@@ -343,9 +347,13 @@ static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp, int *indexp,
             }
         }
         if(x->x_text->te_width > 0)
+        {
             *widthp = x->x_text->te_width * fontwidth;
+        }
         else
+        {
             *widthp = (outchars_c > 3 ? outchars_c : 3) * fontwidth;
+        }
         tempbuf[*outchars_b_p] = 0;
     }
     if(*indexp > *outchars_b_p) *indexp = *outchars_b_p;
@@ -395,17 +403,25 @@ static void rtext_senditup(
 
     text_getfont(x->x_text, x->x_glist, &fontwidth, &fontheight, &guifontsize);
     if(x->x_bufsize >= 100)
+    {
         tempbuf = (char *) t_getbytes(2 * x->x_bufsize + 1);
+    }
     else
+    {
         tempbuf = smallbuf;
+    }
     tempbuf[0] = 0;
 
     if(x->x_text->te_type == T_ATOM)
+    {
         rtext_formatatom(x, widthp, heightp, indexp, tempbuf, &outchars_b,
             &selstart_b, &selend_b, fontwidth, fontheight);
+    }
     else
+    {
         rtext_formattext(x, widthp, heightp, indexp, tempbuf, &outchars_b,
             &selstart_b, &selend_b, fontwidth, fontheight);
+    }
 
     if(action && x->x_text->te_width && x->x_text->te_type != T_ATOM)
     {
@@ -453,8 +469,10 @@ static void rtext_senditup(
     {
         sys_vgui("pdtk_text_set .x%lx.c %s {%s }\n", canvas, x->x_tag, escbuf);
         if(*widthp != x->x_drawnwidth || *heightp != x->x_drawnheight)
+        {
             text_drawborder(
                 x->x_text, x->x_glist, x->x_tag, *widthp, *heightp, 0);
+        }
         if(x->x_active)
         {
             if(selend_b > selstart_b)
@@ -597,9 +615,13 @@ int rtext_findatomfor(t_rtext *x, int xpos, int ypos)
     for(i = 0; i <= indx; i++)
     {
         if(x->x_buf[i] == ';' || x->x_buf[i] == ',')
+        {
             natom++, gotone = 0;
+        }
         else if(x->x_buf[i] == ' ' || x->x_buf[i] == '\n')
+        {
             gotone = 0;
+        }
         else
         {
             if(!gotone) natom++;
@@ -801,9 +823,13 @@ void rtext_mouse(t_rtext *x, int xval, int yval, int flag)
     else if(flag == RTEXT_SHIFT)
     {
         if(indx * 2 > x->x_selstart + x->x_selend)
+        {
             x->x_dragfrom = x->x_selstart, x->x_selend = indx;
+        }
         else
+        {
             x->x_dragfrom = x->x_selend, x->x_selstart = indx;
+        }
     }
     else if(flag == RTEXT_DRAG)
     {

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* This file defines the "scalar" object, which is not a text object, just a
 "gobj".  Scalars have templates which describe their structures, which
@@ -10,7 +10,7 @@ can contain numbers, sublists, and arrays.
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>      /* for read/write to files */
+#include <stdio.h> /* for read/write to files */
 #include "m_pd.h"
 #include "g_canvas.h"
 
@@ -21,7 +21,7 @@ can contain numbers, sublists, and arrays.
 t_gstub *gstub_new(t_glist *gl, t_array *a)
 {
     t_gstub *gs = t_getbytes(sizeof(*gs));
-    if (gl)
+    if(gl)
     {
         gs->gs_which = GP_GLIST;
         gs->gs_un.gs_glist = gl;
@@ -43,9 +43,10 @@ gone and the refcount goes to zero, we can free the gstub safely. */
 static void gstub_dis(t_gstub *gs)
 {
     int refcount = --gs->gs_refcount;
-    if ((!refcount) && gs->gs_which == GP_NONE)
-        t_freebytes(gs, sizeof (*gs));
-    else if (refcount < 0) bug("gstub_dis");
+    if((!refcount) && gs->gs_which == GP_NONE)
+        t_freebytes(gs, sizeof(*gs));
+    else if(refcount < 0)
+        bug("gstub_dis");
 }
 
 /* this routing is called by the owner to inform the gstub that it is
@@ -55,8 +56,8 @@ otherwise we wait for the last gstub_dis() to free it. */
 void gstub_cutoff(t_gstub *gs)
 {
     gs->gs_which = GP_NONE;
-    if (gs->gs_refcount < 0) bug("gstub_cutoff");
-    if (!gs->gs_refcount) t_freebytes(gs, sizeof (*gs));
+    if(gs->gs_refcount < 0) bug("gstub_cutoff");
+    if(!gs->gs_refcount) t_freebytes(gs, sizeof(*gs));
 }
 
 /* call this to verify that a pointer is fresh, i.e., that it either
@@ -67,38 +68,45 @@ Unless "headok" is set,  the routine also fails for the head of a list. */
 int gpointer_check(const t_gpointer *gp, int headok)
 {
     t_gstub *gs = gp->gp_stub;
-    if (!gs) return (0);
-    if (gs->gs_which == GP_ARRAY)
+    if(!gs) return (0);
+    if(gs->gs_which == GP_ARRAY)
     {
-        if (gs->gs_un.gs_array->a_valid != gp->gp_valid) return (0);
-        else return (1);
+        if(gs->gs_un.gs_array->a_valid != gp->gp_valid)
+            return (0);
+        else
+            return (1);
     }
-    else if (gs->gs_which == GP_GLIST)
+    else if(gs->gs_which == GP_GLIST)
     {
-        if (!headok && !gp->gp_un.gp_scalar) return (0);
-        else if (gs->gs_un.gs_glist->gl_valid != gp->gp_valid) return (0);
-        else return (1);
+        if(!headok && !gp->gp_un.gp_scalar)
+            return (0);
+        else if(gs->gs_un.gs_glist->gl_valid != gp->gp_valid)
+            return (0);
+        else
+            return (1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
-    /* copy a pointer to another, assuming the second one hasn't yet been
-    initialized.  New gpointers should be initialized either by this
-    routine or by gpointer_init below. */
+/* copy a pointer to another, assuming the second one hasn't yet been
+initialized.  New gpointers should be initialized either by this
+routine or by gpointer_init below. */
 void gpointer_copy(const t_gpointer *gpfrom, t_gpointer *gpto)
 {
     *gpto = *gpfrom;
-    if (gpto->gp_stub)
+    if(gpto->gp_stub)
         gpto->gp_stub->gs_refcount++;
-    else bug("gpointer_copy");
+    else
+        bug("gpointer_copy");
 }
 
-    /* clear a gpointer that was previously set, releasing the associated
-    gstub if this was the last reference to it. */
+/* clear a gpointer that was previously set, releasing the associated
+gstub if this was the last reference to it. */
 void gpointer_unset(t_gpointer *gp)
 {
     t_gstub *gs;
-    if ((gs = gp->gp_stub))
+    if((gs = gp->gp_stub))
     {
         gstub_dis(gs);
         gp->gp_stub = 0;
@@ -108,7 +116,7 @@ void gpointer_unset(t_gpointer *gp)
 void gpointer_setglist(t_gpointer *gp, t_glist *glist, t_scalar *x)
 {
     t_gstub *gs;
-    if ((gs = gp->gp_stub)) gstub_dis(gs);
+    if((gs = gp->gp_stub)) gstub_dis(gs);
     gp->gp_stub = gs = glist->gl_stub;
     gp->gp_valid = glist->gl_valid;
     gp->gp_un.gp_scalar = x;
@@ -118,7 +126,7 @@ void gpointer_setglist(t_gpointer *gp, t_glist *glist, t_scalar *x)
 void gpointer_setarray(t_gpointer *gp, t_array *array, t_word *w)
 {
     t_gstub *gs;
-    if ((gs = gp->gp_stub)) gstub_dis(gs);
+    if((gs = gp->gp_stub)) gstub_dis(gs);
     gp->gp_stub = gs = array->a_stub;
     gp->gp_valid = array->a_valid;
     gp->gp_un.gp_w = w;
@@ -140,12 +148,13 @@ freshness. */
 t_symbol *gpointer_gettemplatesym(const t_gpointer *gp)
 {
     t_gstub *gs = gp->gp_stub;
-    if (gs->gs_which == GP_GLIST)
+    if(gs->gs_which == GP_GLIST)
     {
         t_scalar *sc = gp->gp_un.gp_scalar;
-        if (sc)
+        if(sc)
             return (sc->sc_template);
-        else return (0);
+        else
+            return (0);
     }
     else
     {
@@ -154,8 +163,8 @@ t_symbol *gpointer_gettemplatesym(const t_gpointer *gp)
     }
 }
 
-t_binbuf *pointertobinbuf(t_pd *x, t_gpointer *gp, t_symbol *s,
-    const char *fname)
+t_binbuf *pointertobinbuf(
+    t_pd *x, t_gpointer *gp, t_symbol *s, const char *fname)
 {
     t_symbol *templatesym = gpointer_gettemplatesym(gp), *arraytype;
     t_template *template;
@@ -163,32 +172,33 @@ t_binbuf *pointertobinbuf(t_pd *x, t_gpointer *gp, t_symbol *s,
     t_binbuf *b;
     t_gstub *gs = gp->gp_stub;
     t_word *vec;
-    if (!templatesym)
+    if(!templatesym)
     {
         pd_error(x, "%s: bad pointer", fname);
         return (0);
     }
-    if (!(template = template_findbyname(templatesym)))
+    if(!(template = template_findbyname(templatesym)))
     {
-        pd_error(x, "%s: couldn't find template %s", fname,
-            templatesym->s_name);
+        pd_error(
+            x, "%s: couldn't find template %s", fname, templatesym->s_name);
         return (0);
     }
-    if (!template_find_field(template, s, &onset, &type, &arraytype))
+    if(!template_find_field(template, s, &onset, &type, &arraytype))
     {
-        pd_error(x, "%s: %s.%s: no such field", fname,
-            templatesym->s_name, s->s_name);
+        pd_error(x, "%s: %s.%s: no such field", fname, templatesym->s_name,
+            s->s_name);
         return (0);
     }
-    if (type != DT_TEXT)
+    if(type != DT_TEXT)
     {
-        pd_error(x, "%s: %s.%s: not a list", fname,
-            templatesym->s_name, s->s_name);
+        pd_error(
+            x, "%s: %s.%s: not a list", fname, templatesym->s_name, s->s_name);
         return (0);
     }
-    if (gs->gs_which == GP_ARRAY)
+    if(gs->gs_which == GP_ARRAY)
         vec = gp->gp_un.gp_w;
-    else vec = gp->gp_un.gp_scalar->sc_vec;
+    else
+        vec = gp->gp_un.gp_scalar->sc_vec;
     return (vec[onset].w_binbuf);
 }
 
@@ -196,64 +206,64 @@ void word_init(t_word *wp, t_template *template, t_gpointer *gp)
 {
     int i, nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
-    for (i = 0; i < nitems; i++, datatypes++, wp++)
+    for(i = 0; i < nitems; i++, datatypes++, wp++)
     {
         int type = datatypes->ds_type;
-        if (type == DT_FLOAT)
+        if(type == DT_FLOAT)
             wp->w_float = 0;
-        else if (type == DT_SYMBOL)
+        else if(type == DT_SYMBOL)
             wp->w_symbol = &s_symbol;
-        else if (type == DT_ARRAY)
+        else if(type == DT_ARRAY)
             wp->w_array = array_new(datatypes->ds_arraytemplate, gp);
-        else if (type == DT_TEXT)
+        else if(type == DT_TEXT)
             wp->w_binbuf = binbuf_new();
     }
 }
 
-void word_restore(t_word *wp, t_template *template,
-    int argc, t_atom *argv)
+void word_restore(t_word *wp, t_template *template, int argc, t_atom *argv)
 {
     int i, nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
-    for (i = 0; i < nitems; i++, datatypes++, wp++)
+    for(i = 0; i < nitems; i++, datatypes++, wp++)
     {
         int type = datatypes->ds_type;
-        if (type == DT_FLOAT)
+        if(type == DT_FLOAT)
         {
             t_float f;
-            if (argc)
+            if(argc)
             {
-                f =  atom_getfloat(argv);
+                f = atom_getfloat(argv);
                 argv++, argc--;
             }
-            else f = 0;
+            else
+                f = 0;
             wp->w_float = f;
         }
-        else if (type == DT_SYMBOL)
+        else if(type == DT_SYMBOL)
         {
             t_symbol *s;
-            if (argc)
+            if(argc)
             {
-                s =  atom_getsymbol(argv);
+                s = atom_getsymbol(argv);
                 argv++, argc--;
             }
-            else s = &s_;
+            else
+                s = &s_;
             wp->w_symbol = s;
         }
     }
-    if (argc)
-        post("warning: word_restore: extra arguments");
+    if(argc) post("warning: word_restore: extra arguments");
 }
 
 void word_free(t_word *wp, t_template *template)
 {
     int i;
     t_dataslot *dt;
-    for (dt = template->t_vec, i = 0; i < template->t_n; i++, dt++)
+    for(dt = template->t_vec, i = 0; i < template->t_n; i++, dt++)
     {
-        if (dt->ds_type == DT_ARRAY)
+        if(dt->ds_type == DT_ARRAY)
             array_free(wp[i].w_array);
-        else if (dt->ds_type == DT_TEXT)
+        else if(dt->ds_type == DT_TEXT)
             binbuf_free(wp[i].w_binbuf);
     }
 }
@@ -263,25 +273,28 @@ static int template_cancreate(t_template *template)
     int i, type, nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
     t_template *elemtemplate;
-    for (i = 0; i < nitems; i++, datatypes++)
-        if (datatypes->ds_type == DT_ARRAY &&
-            (!(elemtemplate = template_findbyname(datatypes->ds_arraytemplate))
-                || !template_cancreate(elemtemplate)))
-    {
-        pd_error(0, "%s: no such template", datatypes->ds_arraytemplate->s_name);
-        return (0);
-    }
+    for(i = 0; i < nitems; i++, datatypes++)
+        if(datatypes->ds_type == DT_ARRAY &&
+            (!(elemtemplate =
+                     template_findbyname(datatypes->ds_arraytemplate)) ||
+                !template_cancreate(elemtemplate)))
+        {
+            pd_error(
+                0, "%s: no such template", datatypes->ds_arraytemplate->s_name);
+            return (0);
+        }
     return (1);
 }
 
 /* ------------------- scalars ---------------------- */
 
 t_class *scalar_class;
-    /* make a new scalar and add to the glist.  We create a "gp" here which
-    will be used for array items to point back here.  This gp doesn't do
-    reference counting or "validation" updates though; the parent won't go away
-    without the contained arrays going away too.  The "gp" is copied out
-    by value in the word_init() routine so we can throw our copy away. */
+
+/* make a new scalar and add to the glist.  We create a "gp" here which
+will be used for array items to point back here.  This gp doesn't do
+reference counting or "validation" updates though; the parent won't go away
+without the contained arrays going away too.  The "gp" is copied out
+by value in the word_init() routine so we can throw our copy away. */
 
 t_scalar *scalar_new(t_glist *owner, t_symbol *templatesym)
 {
@@ -290,15 +303,14 @@ t_scalar *scalar_new(t_glist *owner, t_symbol *templatesym)
     t_gpointer gp;
     gpointer_init(&gp);
     template = template_findbyname(templatesym);
-    if (!template)
+    if(!template)
     {
         pd_error(0, "scalar: couldn't find template %s", templatesym->s_name);
         return (0);
     }
-    if (!template_cancreate(template))
-        return (0);
-    x = (t_scalar *)getbytes(sizeof(t_scalar) +
-        (template->t_n - 1) * sizeof(*x->sc_vec));
+    if(!template_cancreate(template)) return (0);
+    x = (t_scalar *) getbytes(
+        sizeof(t_scalar) + (template->t_n - 1) * sizeof(*x->sc_vec));
     x->sc_gobj.g_pd = scalar_class;
     x->sc_template = templatesym;
     gpointer_setglist(&gp, owner, x);
@@ -306,18 +318,17 @@ t_scalar *scalar_new(t_glist *owner, t_symbol *templatesym)
     return (x);
 }
 
-    /* Pd method to create a new scalar, add it to a glist, and initialize
-    it from the message arguments. */
+/* Pd method to create a new scalar, add it to a glist, and initialize
+it from the message arguments. */
 
-void glist_scalar(t_glist *glist,
-    t_symbol *classname, int argc, t_atom *argv)
+void glist_scalar(t_glist *glist, t_symbol *classname, int argc, t_atom *argv)
 {
     t_symbol *templatesym =
         canvas_makebindsym(atom_getsymbolarg(0, argc, argv));
     t_binbuf *b;
     int natoms, nextmsg = 0;
     t_atom *vec;
-    if (!template_findbyname(templatesym))
+    if(!template_findbyname(templatesym))
     {
         pd_error(glist, "%s: no such template",
             atom_getsymbolarg(0, argc, argv)->s_name);
@@ -340,18 +351,18 @@ void scalar_getbasexy(t_scalar *x, t_float *basex, t_float *basey)
     *basey = template_getfloat(template, gensym("y"), x->sc_vec, 0);
 }
 
-static void scalar_getrect(t_gobj *z, t_glist *owner,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void scalar_getrect(
+    t_gobj *z, t_glist *owner, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_template *template = template_findbyname(x->sc_template);
     t_canvas *templatecanvas = template_findcanvas(template);
     int x1 = 0x7fffffff, x2 = -0x7fffffff, y1 = 0x7fffffff, y2 = -0x7fffffff;
     t_gobj *y;
     t_float basex, basey;
     scalar_getbasexy(x, &basex, &basey);
-        /* if someone deleted the template canvas, we're just a point */
-    if (!templatecanvas)
+    /* if someone deleted the template canvas, we're just a point */
+    if(!templatecanvas)
     {
         x1 = x2 = glist_xtopixels(owner, basex);
         y1 = y2 = glist_ytopixels(owner, basey);
@@ -360,21 +371,19 @@ static void scalar_getrect(t_gobj *z, t_glist *owner,
     {
         x1 = y1 = 0x7fffffff;
         x2 = y2 = -0x7fffffff;
-        for (y = templatecanvas->gl_list; y; y = y->g_next)
+        for(y = templatecanvas->gl_list; y; y = y->g_next)
         {
             const t_parentwidgetbehavior *wb = pd_getparentwidget(&y->g_pd);
             int nx1, ny1, nx2, ny2;
-            if (!wb) continue;
-            (*wb->w_parentgetrectfn)(y, owner,
-                x->sc_vec, template, basex, basey,
-                &nx1, &ny1, &nx2, &ny2);
-            if (nx1 < x1) x1 = nx1;
-            if (ny1 < y1) y1 = ny1;
-            if (nx2 > x2) x2 = nx2;
-            if (ny2 > y2) y2 = ny2;
+            if(!wb) continue;
+            (*wb->w_parentgetrectfn)(y, owner, x->sc_vec, template, basex,
+                basey, &nx1, &ny1, &nx2, &ny2);
+            if(nx1 < x1) x1 = nx1;
+            if(ny1 < y1) y1 = ny1;
+            if(nx2 > x2) x2 = nx2;
+            if(ny2 > y2) y2 = ny2;
         }
-        if (x2 < x1 || y2 < y1)
-            x1 = y1 = x2 = y2 = 0;
+        if(x2 < x1 || y2 < y1) x1 = y1 = x2 = y2 = 0;
     }
     /* post("scalar x1 %d y1 %d x2 %d y2 %d", x1, y1, x2, y2); */
     *xp1 = x1;
@@ -385,16 +394,18 @@ static void scalar_getrect(t_gobj *z, t_glist *owner,
 
 static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
 {
-    if (state)
+    if(state)
     {
         int x1, y1, x2, y2;
 
         scalar_getrect(&x->sc_gobj, glist, &x1, &y1, &x2, &y2);
-        x1--; x2++; y1--; y2++;
+        x1--;
+        x2++;
+        y1--;
+        y2++;
         sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d \
             -width 0 -fill blue -tags select%lx\n",
-                glist_getcanvas(glist), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1,
-                x);
+            glist_getcanvas(glist), x1, y1, x1, y2, x2, y2, x2, y1, x1, y1, x);
     }
     else
     {
@@ -404,7 +415,7 @@ static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
 
 static void scalar_select(t_gobj *z, t_glist *owner, int state)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_template *tmpl;
     t_symbol *templatesym = x->sc_template;
     t_atom at;
@@ -412,44 +423,44 @@ static void scalar_select(t_gobj *z, t_glist *owner, int state)
     gpointer_init(&gp);
     gpointer_setglist(&gp, owner, x);
     SETPOINTER(&at, &gp);
-    if ((tmpl = template_findbyname(templatesym)))
-        template_notify(tmpl, (state ? gensym("select") : gensym("deselect")),
-            1, &at);
+    if((tmpl = template_findbyname(templatesym)))
+        template_notify(
+            tmpl, (state ? gensym("select") : gensym("deselect")), 1, &at);
     gpointer_unset(&gp);
     scalar_drawselectrect(x, owner, state);
 }
 
 static void scalar_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_symbol *templatesym = x->sc_template;
     t_template *template = template_findbyname(templatesym);
     t_symbol *zz;
     t_atom at[3];
     t_gpointer gp;
     int xonset, yonset, xtype, ytype, gotx, goty;
-    if (!template)
+    if(!template)
     {
         pd_error(0, "scalar: couldn't find template %s", templatesym->s_name);
         return;
     }
     gotx = template_find_field(template, gensym("x"), &xonset, &xtype, &zz);
-    if (gotx && (xtype != DT_FLOAT))
-        gotx = 0;
+    if(gotx && (xtype != DT_FLOAT)) gotx = 0;
     goty = template_find_field(template, gensym("y"), &yonset, &ytype, &zz);
-    if (goty && (ytype != DT_FLOAT))
-        goty = 0;
-    if (gotx)
-        *(t_float *)(((char *)(x->sc_vec)) + xonset) +=
-            glist->gl_zoom * dx * (glist_pixelstox(glist, 1) - glist_pixelstox(glist, 0));
-    if (goty)
-        *(t_float *)(((char *)(x->sc_vec)) + yonset) +=
-            glist->gl_zoom * dy * (glist_pixelstoy(glist, 1) - glist_pixelstoy(glist, 0));
+    if(goty && (ytype != DT_FLOAT)) goty = 0;
+    if(gotx)
+        *(t_float *) (((char *) (x->sc_vec)) + xonset) +=
+            glist->gl_zoom * dx *
+            (glist_pixelstox(glist, 1) - glist_pixelstox(glist, 0));
+    if(goty)
+        *(t_float *) (((char *) (x->sc_vec)) + yonset) +=
+            glist->gl_zoom * dy *
+            (glist_pixelstoy(glist, 1) - glist_pixelstoy(glist, 0));
     gpointer_init(&gp);
     gpointer_setglist(&gp, glist, x);
     SETPOINTER(&at[0], &gp);
-    SETFLOAT(&at[1], (t_float)dx);
-    SETFLOAT(&at[2], (t_float)dy);
+    SETFLOAT(&at[1], (t_float) dx);
+    SETFLOAT(&at[2], (t_float) dy);
     template_notify(template, gensym("displace"), 2, at);
     scalar_redraw(x, glist);
 }
@@ -461,39 +472,39 @@ static void scalar_activate(t_gobj *z, t_glist *owner, int state)
 }
 
 static void scalar_delete(t_gobj *z, t_glist *glist)
-{
-    /* nothing to do */
+{ /* nothing to do */
 }
 
 static void scalar_vis(t_gobj *z, t_glist *owner, int vis)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_template *template = template_findbyname(x->sc_template);
     t_canvas *templatecanvas = template_findcanvas(template);
     t_gobj *y;
     t_float basex, basey;
     scalar_getbasexy(x, &basex, &basey);
-        /* if we don't know how to draw it, make a small rectangle */
-    if (!templatecanvas)
+    /* if we don't know how to draw it, make a small rectangle */
+    if(!templatecanvas)
     {
-        if (vis)
+        if(vis)
         {
             int x1 = glist_xtopixels(owner, basex);
             int y1 = glist_ytopixels(owner, basey);
             sys_vgui(".x%lx.c create rectangle %d %d %d %d -tags scalar%lx\n",
-                glist_getcanvas(owner), x1-1, y1-1, x1+1, y1+1, x);
+                glist_getcanvas(owner), x1 - 1, y1 - 1, x1 + 1, y1 + 1, x);
         }
-        else sys_vgui(".x%lx.c delete scalar%lx\n", glist_getcanvas(owner), x);
+        else
+            sys_vgui(".x%lx.c delete scalar%lx\n", glist_getcanvas(owner), x);
         return;
     }
 
-    for (y = templatecanvas->gl_list; y; y = y->g_next)
+    for(y = templatecanvas->gl_list; y; y = y->g_next)
     {
         const t_parentwidgetbehavior *wb = pd_getparentwidget(&y->g_pd);
-        if (!wb) continue;
+        if(!wb) continue;
         (*wb->w_parentvisfn)(y, owner, x->sc_vec, template, basex, basey, vis);
     }
-    if (glist_isselected(owner, &x->sc_gobj))
+    if(glist_isselected(owner, &x->sc_gobj))
     {
         scalar_drawselectrect(x, owner, 0);
         scalar_drawselectrect(x, owner, 1);
@@ -503,7 +514,7 @@ static void scalar_vis(t_gobj *z, t_glist *owner, int vis)
 
 static void scalar_doredraw(t_gobj *client, t_glist *glist)
 {
-    if (glist_isvisible(glist))
+    if(glist_isvisible(glist))
     {
         scalar_vis(client, glist, 0);
         scalar_vis(client, glist, 1);
@@ -512,17 +523,15 @@ static void scalar_doredraw(t_gobj *client, t_glist *glist)
 
 void scalar_redraw(t_scalar *x, t_glist *glist)
 {
-    if (glist_isvisible(glist))
-        sys_queuegui(x, glist, scalar_doredraw);
+    if(glist_isvisible(glist)) sys_queuegui(x, glist, scalar_doredraw);
 }
 
 extern void template_notifyforscalar(t_template *template, t_glist *owner,
     t_scalar *sc, t_symbol *s, int argc, t_atom *argv);
 
 int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
-    t_array *ap, struct _glist *owner,
-    t_float xloc, t_float yloc, int xpix, int ypix,
-    int shift, int alt, int dbl, int doit)
+    t_array *ap, struct _glist *owner, t_float xloc, t_float yloc, int xpix,
+    int ypix, int shift, int alt, int dbl, int doit)
 {
     int hit = 0;
     t_canvas *templatecanvas = template_findcanvas(template);
@@ -531,35 +540,33 @@ int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
     t_float basex = template_getfloat(template, gensym("x"), data, 0);
     t_float basey = template_getfloat(template, gensym("y"), data, 0);
     SETFLOAT(at, 0); /* unused - this is later bashed to the gpointer */
-    SETFLOAT(at+1, basex + xloc);
-    SETFLOAT(at+2, basey + yloc);
-    if (doit)
-        template_notifyforscalar(template, owner,
-            sc, gensym("click"), 3, at);
-    for (y = templatecanvas->gl_list; y; y = y->g_next)
+    SETFLOAT(at + 1, basex + xloc);
+    SETFLOAT(at + 2, basey + yloc);
+    if(doit)
+        template_notifyforscalar(template, owner, sc, gensym("click"), 3, at);
+    for(y = templatecanvas->gl_list; y; y = y->g_next)
     {
         const t_parentwidgetbehavior *wb = pd_getparentwidget(&y->g_pd);
-        if (!wb) continue;
-        if ((hit = (*wb->w_parentclickfn)(y, owner,
-            data, template, sc, ap, basex + xloc, basey + yloc,
-            xpix, ypix, shift, alt, dbl, doit)))
-                return (hit);
+        if(!wb) continue;
+        if((hit = (*wb->w_parentclickfn)(y, owner, data, template, sc, ap,
+                basex + xloc, basey + yloc, xpix, ypix, shift, alt, dbl, doit)))
+            return (hit);
     }
     return (0);
 }
 
-static int scalar_click(t_gobj *z, struct _glist *owner,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int scalar_click(t_gobj *z, struct _glist *owner, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_template *template = template_findbyname(x->sc_template);
-    return (scalar_doclick(x->sc_vec, template, x, 0,
-        owner, 0, 0, xpix, ypix, shift, alt, dbl, doit));
+    return (scalar_doclick(x->sc_vec, template, x, 0, owner, 0, 0, xpix, ypix,
+        shift, alt, dbl, doit));
 }
 
 static void scalar_save(t_gobj *z, t_binbuf *b)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     t_binbuf *b2 = binbuf_new();
     t_atom a, *argv;
     int i, argc;
@@ -572,7 +579,7 @@ static void scalar_save(t_gobj *z, t_binbuf *b)
 
 static void scalar_properties(t_gobj *z, struct _glist *owner)
 {
-    t_scalar *x = (t_scalar *)z;
+    t_scalar *x = (t_scalar *) z;
     char *buf, buf2[80];
     int bufsize;
     t_binbuf *b;
@@ -581,17 +588,16 @@ static void scalar_properties(t_gobj *z, struct _glist *owner)
     b = glist_writetobinbuf(owner, 0);
     binbuf_gettext(b, &buf, &bufsize);
     binbuf_free(b);
-    buf = t_resizebytes(buf, bufsize, bufsize+1);
+    buf = t_resizebytes(buf, bufsize, bufsize + 1);
     buf[bufsize] = 0;
     sprintf(buf2, "pdtk_data_dialog %%s {");
-    gfxstub_new((t_pd *)owner, x, buf2);
+    gfxstub_new((t_pd *) owner, x, buf2);
     sys_gui(buf);
     sys_gui("}\n");
-    t_freebytes(buf, bufsize+1);
+    t_freebytes(buf, bufsize + 1);
 }
 
-static const t_widgetbehavior scalar_widgetbehavior =
-{
+static const t_widgetbehavior scalar_widgetbehavior = {
     scalar_getrect,
     scalar_displace,
     scalar_select,
@@ -608,15 +614,15 @@ static void scalar_free(t_scalar *x)
     t_symbol *templatesym = x->sc_template;
     t_template *template = template_findbyname(templatesym);
     sys_unqueuegui(x);
-    if (!template)
+    if(!template)
     {
         pd_error(0, "scalar: couldn't find template %s", templatesym->s_name);
         return;
     }
     word_free(x->sc_vec, template);
     gfxstub_deleteforkey(x);
-        /* the "size" field in the class is zero, so Pd doesn't try to free
-        us automatically (see pd_free()) */
+    /* the "size" field in the class is zero, so Pd doesn't try to free
+    us automatically (see pd_free()) */
     freebytes(x, sizeof(t_scalar) + (template->t_n - 1) * sizeof(*x->sc_vec));
 }
 
@@ -624,8 +630,8 @@ static void scalar_free(t_scalar *x)
 
 void g_scalar_setup(void)
 {
-    scalar_class = class_new(gensym("scalar"), 0, (t_method)scalar_free, 0,
-        CLASS_GOBJ, 0);
+    scalar_class = class_new(
+        gensym("scalar"), 0, (t_method) scalar_free, 0, CLASS_GOBJ, 0);
     class_setwidget(scalar_class, &scalar_widgetbehavior);
     class_setsavefn(scalar_class, scalar_save);
     class_setpropertiesfn(scalar_class, scalar_properties);

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -220,10 +220,9 @@ t_binbuf *pointertobinbuf(
 
 void word_init(t_word *wp, t_template *template, t_gpointer *gp)
 {
-    int i;
     int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
-    for(i = 0; i < nitems; i++, datatypes++, wp++)
+    for(int i = 0; i < nitems; i++, datatypes++, wp++)
     {
         int type = datatypes->ds_type;
         if(type == DT_FLOAT)
@@ -247,10 +246,9 @@ void word_init(t_word *wp, t_template *template, t_gpointer *gp)
 
 void word_restore(t_word *wp, t_template *template, int argc, t_atom *argv)
 {
-    int i;
     int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
-    for(i = 0; i < nitems; i++, datatypes++, wp++)
+    for(int i = 0; i < nitems; i++, datatypes++, wp++)
     {
         int type = datatypes->ds_type;
         if(type == DT_FLOAT)
@@ -300,12 +298,11 @@ void word_free(t_word *wp, t_template *template)
 
 static int template_cancreate(t_template *template)
 {
-    int i;
     int type;
     int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
     t_template *elemtemplate;
-    for(i = 0; i < nitems; i++, datatypes++)
+    for(int i = 0; i < nitems; i++, datatypes++)
     {
         if(datatypes->ds_type == DT_ARRAY &&
             (!(elemtemplate =

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -73,14 +73,13 @@ int gpointer_check(const t_gpointer *gp, int headok)
     {
         if(gs->gs_un.gs_array->a_valid != gp->gp_valid)
             return (0);
-        else
-            return (1);
+        return (1);
     }
     else if(gs->gs_which == GP_GLIST)
     {
         if(!headok && !gp->gp_un.gp_scalar)
             return (0);
-        else if(gs->gs_un.gs_glist->gl_valid != gp->gp_valid)
+        if(gs->gs_un.gs_glist->gl_valid != gp->gp_valid)
             return (0);
         else
             return (1);
@@ -153,8 +152,7 @@ t_symbol *gpointer_gettemplatesym(const t_gpointer *gp)
         t_scalar *sc = gp->gp_un.gp_scalar;
         if(sc)
             return (sc->sc_template);
-        else
-            return (0);
+        return (0);
     }
     else
     {

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -166,9 +166,11 @@ t_symbol *gpointer_gettemplatesym(const t_gpointer *gp)
 t_binbuf *pointertobinbuf(
     t_pd *x, t_gpointer *gp, t_symbol *s, const char *fname)
 {
-    t_symbol *templatesym = gpointer_gettemplatesym(gp), *arraytype;
+    t_symbol *templatesym = gpointer_gettemplatesym(gp);
+    t_symbol *arraytype;
     t_template *template;
-    int onset, type;
+    int onset;
+    int type;
     t_binbuf *b;
     t_gstub *gs = gp->gp_stub;
     t_word *vec;
@@ -204,7 +206,8 @@ t_binbuf *pointertobinbuf(
 
 void word_init(t_word *wp, t_template *template, t_gpointer *gp)
 {
-    int i, nitems = template->t_n;
+    int i;
+    int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
     for(i = 0; i < nitems; i++, datatypes++, wp++)
     {
@@ -222,7 +225,8 @@ void word_init(t_word *wp, t_template *template, t_gpointer *gp)
 
 void word_restore(t_word *wp, t_template *template, int argc, t_atom *argv)
 {
-    int i, nitems = template->t_n;
+    int i;
+    int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
     for(i = 0; i < nitems; i++, datatypes++, wp++)
     {
@@ -270,7 +274,9 @@ void word_free(t_word *wp, t_template *template)
 
 static int template_cancreate(t_template *template)
 {
-    int i, type, nitems = template->t_n;
+    int i;
+    int type;
+    int nitems = template->t_n;
     t_dataslot *datatypes = template->t_vec;
     t_template *elemtemplate;
     for(i = 0; i < nitems; i++, datatypes++)
@@ -326,7 +332,8 @@ void glist_scalar(t_glist *glist, t_symbol *classname, int argc, t_atom *argv)
     t_symbol *templatesym =
         canvas_makebindsym(atom_getsymbolarg(0, argc, argv));
     t_binbuf *b;
-    int natoms, nextmsg = 0;
+    int natoms;
+    int nextmsg = 0;
     t_atom *vec;
     if(!template_findbyname(templatesym))
     {
@@ -357,9 +364,13 @@ static void scalar_getrect(
     t_scalar *x = (t_scalar *) z;
     t_template *template = template_findbyname(x->sc_template);
     t_canvas *templatecanvas = template_findcanvas(template);
-    int x1 = 0x7fffffff, x2 = -0x7fffffff, y1 = 0x7fffffff, y2 = -0x7fffffff;
+    int x1 = 0x7fffffff;
+    int x2 = -0x7fffffff;
+    int y1 = 0x7fffffff;
+    int y2 = -0x7fffffff;
     t_gobj *y;
-    t_float basex, basey;
+    t_float basex;
+    t_float basey;
     scalar_getbasexy(x, &basex, &basey);
     /* if someone deleted the template canvas, we're just a point */
     if(!templatecanvas)
@@ -374,7 +385,10 @@ static void scalar_getrect(
         for(y = templatecanvas->gl_list; y; y = y->g_next)
         {
             const t_parentwidgetbehavior *wb = pd_getparentwidget(&y->g_pd);
-            int nx1, ny1, nx2, ny2;
+            int nx1;
+            int ny1;
+            int nx2;
+            int ny2;
             if(!wb) continue;
             (*wb->w_parentgetrectfn)(y, owner, x->sc_vec, template, basex,
                 basey, &nx1, &ny1, &nx2, &ny2);
@@ -396,7 +410,10 @@ static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
 {
     if(state)
     {
-        int x1, y1, x2, y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
 
         scalar_getrect(&x->sc_gobj, glist, &x1, &y1, &x2, &y2);
         x1--;
@@ -438,7 +455,12 @@ static void scalar_displace(t_gobj *z, t_glist *glist, int dx, int dy)
     t_symbol *zz;
     t_atom at[3];
     t_gpointer gp;
-    int xonset, yonset, xtype, ytype, gotx, goty;
+    int xonset;
+    int yonset;
+    int xtype;
+    int ytype;
+    int gotx;
+    int goty;
     if(!template)
     {
         pd_error(0, "scalar: couldn't find template %s", templatesym->s_name);
@@ -481,7 +503,8 @@ static void scalar_vis(t_gobj *z, t_glist *owner, int vis)
     t_template *template = template_findbyname(x->sc_template);
     t_canvas *templatecanvas = template_findcanvas(template);
     t_gobj *y;
-    t_float basex, basey;
+    t_float basex;
+    t_float basey;
     scalar_getbasexy(x, &basex, &basey);
     /* if we don't know how to draw it, make a small rectangle */
     if(!templatecanvas)
@@ -568,8 +591,10 @@ static void scalar_save(t_gobj *z, t_binbuf *b)
 {
     t_scalar *x = (t_scalar *) z;
     t_binbuf *b2 = binbuf_new();
-    t_atom a, *argv;
-    int i, argc;
+    t_atom a;
+    t_atom *argv;
+    int i;
+    int argc;
     canvas_writescalar(x->sc_template, x->sc_vec, b2, 0);
     binbuf_addv(b, "ss", &s__X, gensym("scalar"));
     binbuf_addbinbuf(b, b2);
@@ -580,7 +605,8 @@ static void scalar_save(t_gobj *z, t_binbuf *b)
 static void scalar_properties(t_gobj *z, struct _glist *owner)
 {
     t_scalar *x = (t_scalar *) z;
-    char *buf, buf2[80];
+    char *buf;
+    char buf2[80];
     int bufsize;
     t_binbuf *b;
     glist_noselect(owner);
@@ -610,7 +636,8 @@ static const t_widgetbehavior scalar_widgetbehavior = {
 static void scalar_free(t_scalar *x)
 {
     int i;
-    t_dataslot *datatypes, *dt;
+    t_dataslot *datatypes;
+    t_dataslot *dt;
     t_symbol *templatesym = x->sc_template;
     t_template *template = template_findbyname(templatesym);
     sys_unqueuegui(x);

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -44,9 +44,13 @@ static void gstub_dis(t_gstub *gs)
 {
     int refcount = --gs->gs_refcount;
     if((!refcount) && gs->gs_which == GP_NONE)
+    {
         t_freebytes(gs, sizeof(*gs));
+    }
     else if(refcount < 0)
+    {
         bug("gstub_dis");
+    }
 }
 
 /* this routing is called by the owner to inform the gstub that it is
@@ -80,9 +84,13 @@ int gpointer_check(const t_gpointer *gp, int headok)
         if(!headok && !gp->gp_un.gp_scalar)
             return (0);
         if(gs->gs_un.gs_glist->gl_valid != gp->gp_valid)
+        {
             return (0);
+        }
         else
+        {
             return (1);
+        }
     }
     else
         return (0);
@@ -95,9 +103,13 @@ void gpointer_copy(const t_gpointer *gpfrom, t_gpointer *gpto)
 {
     *gpto = *gpfrom;
     if(gpto->gp_stub)
+    {
         gpto->gp_stub->gs_refcount++;
+    }
     else
+    {
         bug("gpointer_copy");
+    }
 }
 
 /* clear a gpointer that was previously set, releasing the associated
@@ -196,9 +208,13 @@ t_binbuf *pointertobinbuf(
         return (0);
     }
     if(gs->gs_which == GP_ARRAY)
+    {
         vec = gp->gp_un.gp_w;
+    }
     else
+    {
         vec = gp->gp_un.gp_scalar->sc_vec;
+    }
     return (vec[onset].w_binbuf);
 }
 
@@ -211,13 +227,21 @@ void word_init(t_word *wp, t_template *template, t_gpointer *gp)
     {
         int type = datatypes->ds_type;
         if(type == DT_FLOAT)
+        {
             wp->w_float = 0;
+        }
         else if(type == DT_SYMBOL)
+        {
             wp->w_symbol = &s_symbol;
+        }
         else if(type == DT_ARRAY)
+        {
             wp->w_array = array_new(datatypes->ds_arraytemplate, gp);
+        }
         else if(type == DT_TEXT)
+        {
             wp->w_binbuf = binbuf_new();
+        }
     }
 }
 
@@ -264,9 +288,13 @@ void word_free(t_word *wp, t_template *template)
     for(dt = template->t_vec, i = 0; i < template->t_n; i++, dt++)
     {
         if(dt->ds_type == DT_ARRAY)
+        {
             array_free(wp[i].w_array);
+        }
         else if(dt->ds_type == DT_TEXT)
+        {
             binbuf_free(wp[i].w_binbuf);
+        }
     }
 }
 
@@ -278,6 +306,7 @@ static int template_cancreate(t_template *template)
     t_dataslot *datatypes = template->t_vec;
     t_template *elemtemplate;
     for(i = 0; i < nitems; i++, datatypes++)
+    {
         if(datatypes->ds_type == DT_ARRAY &&
             (!(elemtemplate =
                      template_findbyname(datatypes->ds_arraytemplate)) ||
@@ -287,6 +316,7 @@ static int template_cancreate(t_template *template)
                 0, "%s: no such template", datatypes->ds_arraytemplate->s_name);
             return (0);
         }
+    }
     return (1);
 }
 
@@ -439,8 +469,10 @@ static void scalar_select(t_gobj *z, t_glist *owner, int state)
     gpointer_setglist(&gp, owner, x);
     SETPOINTER(&at, &gp);
     if((tmpl = template_findbyname(templatesym)))
+    {
         template_notify(
             tmpl, (state ? gensym("select") : gensym("deselect")), 1, &at);
+    }
     gpointer_unset(&gp);
     scalar_drawselectrect(x, owner, state);
 }
@@ -469,13 +501,17 @@ static void scalar_displace(t_gobj *z, t_glist *glist, int dx, int dy)
     goty = template_find_field(template, gensym("y"), &yonset, &ytype, &zz);
     if(goty && (ytype != DT_FLOAT)) goty = 0;
     if(gotx)
+    {
         *(t_float *) (((char *) (x->sc_vec)) + xonset) +=
             glist->gl_zoom * dx *
             (glist_pixelstox(glist, 1) - glist_pixelstox(glist, 0));
+    }
     if(goty)
+    {
         *(t_float *) (((char *) (x->sc_vec)) + yonset) +=
             glist->gl_zoom * dy *
             (glist_pixelstoy(glist, 1) - glist_pixelstoy(glist, 0));
+    }
     gpointer_init(&gp);
     gpointer_setglist(&gp, glist, x);
     SETPOINTER(&at[0], &gp);

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -197,7 +197,6 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
     int *p_type, t_symbol **p_arraytype)
 {
     t_template *t;
-    int i;
     int n;
     if(!x)
     {
@@ -205,7 +204,7 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
         return (0);
     }
     n = x->t_n;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(x->t_vec[i].ds_name == name)
         {
@@ -327,14 +326,13 @@ void template_setsymbol(
     arrays.  This is used for reading in "data files". */
 int template_match(t_template *x1, t_template *x2)
 {
-    int i;
     if(x1->t_n < x2->t_n) return (0);
-    for(i = x2->t_n; i < x1->t_n; i++)
+    for(int i = x2->t_n; i < x1->t_n; i++)
     {
         if(x1->t_vec[i].ds_type == DT_ARRAY) return (0);
     }
     if(x2->t_n > x1->t_n) post("add elements...");
-    for(i = 0; i < x2->t_n; i++)
+    for(int i = 0; i < x2->t_n; i++)
         if(!dataslot_matches(&x1->t_vec[i], &x2->t_vec[i], 1)) return (0);
     return (1);
 }
@@ -354,8 +352,7 @@ static void template_conformwords(t_template *tfrom, t_template *tto,
 {
     int nfrom = tfrom->t_n;
     int nto = tto->t_n;
-    int i;
-    for(i = 0; i < nto; i++)
+    for(int i = 0; i < nto; i++)
     {
         if(conformaction[i] >= 0)
         {
@@ -376,7 +373,6 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
     t_gpointer gp;
     int nto = tto->t_n;
     int nfrom = tfrom->t_n;
-    int i;
     t_template *scalartemplate;
     /* post("conform scalar"); */
     /* possibly replace the scalar */
@@ -428,7 +424,7 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
         scalartemplate = template_findbyname(x->sc_template);
     }
     /* convert all array elements */
-    for(i = 0; i < scalartemplate->t_n; i++)
+    for(int i = 0; i < scalartemplate->t_n; i++)
     {
         t_dataslot *ds = scalartemplate->t_vec + i;
         if(ds->ds_type == DT_ARRAY)
@@ -444,8 +440,6 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
 static void template_conformarray(
     t_template *tfrom, t_template *tto, int *conformaction, t_array *a)
 {
-    int i;
-    int j;
     t_template *scalartemplate = 0;
     if(a->a_templatesym == tfrom->t_sym)
     {
@@ -455,7 +449,7 @@ static void template_conformarray(
         char *newarray = getbytes(newelemsize * a->a_n);
         char *oldarray = a->a_vec;
         if(a->a_elemsize != oldelemsize) bug("template_conformarray");
-        for(i = 0; i < a->a_n; i++)
+        for(int i = 0; i < a->a_n; i++)
         {
             t_word *wp = (t_word *) (newarray + newelemsize * i);
             word_init(wp, tto, &a->a_gp);
@@ -470,10 +464,10 @@ static void template_conformarray(
     else
         scalartemplate = template_findbyname(a->a_templatesym);
     /* convert all arrays and sublist fields in each element of the array */
-    for(i = 0; i < a->a_n; i++)
+    for(int i = 0; i < a->a_n; i++)
     {
         t_word *wp = (t_word *) (a->a_vec + sizeof(t_word) * a->a_n * i);
-        for(j = 0; j < scalartemplate->t_n; j++)
+        for(int j = 0; j < scalartemplate->t_n; j++)
         {
             t_dataslot *ds = scalartemplate->t_vec + j;
             if(ds->ds_type == DT_ARRAY)
@@ -521,19 +515,17 @@ void template_conform(t_template *tfrom, t_template *tto)
 {
     int nto = tto->t_n;
     int nfrom = tfrom->t_n;
-    int i;
-    int j;
     int *conformaction = (int *) getbytes(sizeof(int) * nto);
     int *conformedfrom = (int *) getbytes(sizeof(int) * nfrom);
     int doit = 0;
-    for(i = 0; i < nto; i++)
+    for(int i = 0; i < nto; i++)
         conformaction[i] = -1;
-    for(i = 0; i < nfrom; i++)
+    for(int i = 0; i < nfrom; i++)
         conformedfrom[i] = 0;
-    for(i = 0; i < nto; i++)
+    for(int i = 0; i < nto; i++)
     {
         t_dataslot *dataslot = &tto->t_vec[i];
-        for(j = 0; j < nfrom; j++)
+        for(int j = 0; j < nfrom; j++)
         {
             t_dataslot *dataslot2 = &tfrom->t_vec[j];
             if(dataslot_matches(dataslot, dataslot2, 1))
@@ -543,12 +535,12 @@ void template_conform(t_template *tfrom, t_template *tto)
             }
         }
     }
-    for(i = 0; i < nto; i++)
+    for(int i = 0; i < nto; i++)
     {
         if(conformaction[i] < 0)
         {
             t_dataslot *dataslot = &tto->t_vec[i];
-            for(j = 0; j < nfrom; j++)
+            for(int j = 0; j < nfrom; j++)
             {
                 if(!conformedfrom[j] &&
                     dataslot_matches(dataslot, &tfrom->t_vec[j], 0))
@@ -565,14 +557,13 @@ void template_conform(t_template *tfrom, t_template *tto)
     }
     else
     {
-        for(i = 0; i < nto; i++)
+        for(int i = 0; i < nto; i++)
             if(conformaction[i] != i) doit = 1;
     }
 
     if(doit)
     {
-        t_glist *gl;
-        for(gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
+        for(t_glist *gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
             template_conformglist(tfrom, tto, gl, conformaction);
     }
     freebytes(conformaction, sizeof(int) * nto);
@@ -692,14 +683,13 @@ static void *gtemplate_donew(t_symbol *sym, int argc, t_atom *argv)
 {
     t_gtemplate *x = (t_gtemplate *) pd_new(gtemplate_class);
     t_template *t = template_findbyname(sym);
-    int i;
     t_symbol *sx = gensym("x");
     x->x_owner = canvas_getcurrent();
     x->x_next = 0;
     x->x_sym = sym;
     x->x_argc = argc;
     x->x_argv = (t_atom *) getbytes(argc * sizeof(t_atom));
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         x->x_argv[i] = argv[i];
 
     /* already have a template by this name? */
@@ -1366,7 +1356,7 @@ static void curve_vis(t_gobj *z, t_glist *glist, t_word *data,
             }
             else
                 sys_vgui(".x%lx.c create line\\\n", glist_getcanvas(glist));
-            for(i = 0; i < n; i++)
+            for(int i = 0; i < n; i++)
                 sys_vgui("%d %d\\\n", pix[2 * i], pix[2 * i + 1]);
             sys_vgui("-width %f\\\n", width);
             if(flags & CLOSED)
@@ -2312,8 +2302,7 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
         /* un-draw the individual points */
         if(scalarvis != 0)
         {
-            int i;
-            for(i = 0; i < nelem; i++)
+            for(int i = 0; i < nelem; i++)
             {
                 t_gobj *y;
                 for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
@@ -2343,8 +2332,7 @@ static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
     if(TEMPLATE->array_motion_xfield)
     {
         /* it's an x, y plot */
-        int i;
-        for(i = 0; i < TEMPLATE->array_motion_npoints; i++)
+        for(int i = 0; i < TEMPLATE->array_motion_npoints; i++)
         {
             t_word *thisword =
                 (t_word *) (((char *) TEMPLATE->array_motion_wp) +
@@ -2511,7 +2499,6 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
     int yonset;
     int wonset;
     int xonset;
-    int i;
 
     if(!array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
            &elemsize, xfield, yfield, wfield, &xonset, &yonset, &wonset))
@@ -2570,7 +2557,7 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
         else
         {
             /* First we get the closest distance to any element */
-            for(i = 0; i < array->a_n; i += incr)
+            for(int i = 0; i < array->a_n; i += incr)
             {
                 t_float pxpix;
                 t_float pypix;
@@ -2616,7 +2603,7 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
             best += 0.001; /* add truncation error margin */
                            /* otherwise we try to grab a vertex */
             if(!edit) return (0);
-            for(i = 0; i < array->a_n; i += incr)
+            for(int i = 0; i < array->a_n; i += incr)
             {
                 t_float pxpix;
                 t_float pypix;

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -111,7 +111,9 @@ static void template_takeofflist(t_template *x)
 {
     /* take it off the template list */
     if(x == pd_this->pd_templatelist)
+    {
         pd_this->pd_templatelist = x->t_next;
+    }
     else
     {
         t_template *z;
@@ -141,12 +143,18 @@ t_template *template_new(t_symbol *templatesym, int argc, t_atom *argv)
         newtypesym = argv[0].a_w.w_symbol;
         newname = argv[1].a_w.w_symbol;
         if(newtypesym == &s_float)
+        {
             newtype = DT_FLOAT;
+        }
         else if(newtypesym == &s_symbol)
+        {
             newtype = DT_SYMBOL;
         /* "list" is old name.. accepted here but never saved as such */
+        }
         else if(newtypesym == gensym("text") || newtypesym == &s_list)
+        {
             newtype = DT_TEXT;
+        }
         else if(newtypesym == gensym("array"))
         {
             if(argc < 3 || argv[2].a_type != A_SYMBOL)
@@ -198,6 +206,7 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
     }
     n = x->t_n;
     for(i = 0; i < n; i++)
+    {
         if(x->t_vec[i].ds_name == name)
         {
             *p_onset = i * sizeof(t_word);
@@ -205,6 +214,7 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
             *p_arraytype = x->t_vec[i].ds_arraytemplate;
             return (1);
         }
+    }
     return (0);
 }
 
@@ -218,14 +228,20 @@ t_float template_getfloat(
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
         if(type == DT_FLOAT)
+        {
             val = *(t_float *) (((char *) wp) + onset);
+        }
         else if(loud)
+        {
             pd_error(
                 0, "%s.%s: not a number", x->t_sym->s_name, fieldname->s_name);
+        }
     }
     else if(loud)
+    {
         pd_error(
             0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
+    }
     return (val);
 }
 
@@ -238,14 +254,20 @@ void template_setfloat(
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
         if(type == DT_FLOAT)
+        {
             *(t_float *) (((char *) wp) + onset) = f;
+        }
         else if(loud)
+        {
             pd_error(
                 0, "%s.%s: not a number", x->t_sym->s_name, fieldname->s_name);
+        }
     }
     else if(loud)
+    {
         pd_error(
             0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
+    }
 }
 
 t_symbol *template_getsymbol(
@@ -258,14 +280,20 @@ t_symbol *template_getsymbol(
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
         if(type == DT_SYMBOL)
+        {
             val = *(t_symbol **) (((char *) wp) + onset);
+        }
         else if(loud)
+        {
             pd_error(
                 0, "%s.%s: not a symbol", x->t_sym->s_name, fieldname->s_name);
+        }
     }
     else if(loud)
+    {
         pd_error(
             0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
+    }
     return (val);
 }
 
@@ -278,14 +306,20 @@ void template_setsymbol(
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
         if(type == DT_SYMBOL)
+        {
             *(t_symbol **) (((char *) wp) + onset) = s;
+        }
         else if(loud)
+        {
             pd_error(
                 0, "%s.%s: not a symbol", x->t_sym->s_name, fieldname->s_name);
+        }
     }
     else if(loud)
+    {
         pd_error(
             0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
+    }
 }
 
 /* stringent check to see if a "saved" template, x2, matches the current
@@ -373,12 +407,14 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
             t_gobj *y;
             t_gobj *y2;
             for(y = glist->gl_list; (y2 = y->g_next); y = y2)
+            {
                 if(y2 == &scfrom->sc_gobj)
                 {
                     x->sc_gobj.g_next = y2->g_next;
                     y->g_next = &x->sc_gobj;
                     goto nobug;
                 }
+            }
             bug("template_conformscalar");
         nobug:;
         }
@@ -463,14 +499,20 @@ static void template_conformglist(
     for(g = glist->gl_list; g; g = g->g_next)
     {
         if(pd_class(&g->g_pd) == scalar_class)
+        {
             g = &template_conformscalar(
                 tfrom, tto, conformaction, glist, (t_scalar *) g)
                      ->sc_gobj;
+        }
         else if(pd_class(&g->g_pd) == canvas_class)
+        {
             template_conformglist(tfrom, tto, (t_glist *) g, conformaction);
+        }
         else if(pd_class(&g->g_pd) == garray_class)
+        {
             template_conformarray(
                 tfrom, tto, conformaction, garray_getarray((t_garray *) g));
+        }
     }
 }
 
@@ -502,22 +544,30 @@ void template_conform(t_template *tfrom, t_template *tto)
         }
     }
     for(i = 0; i < nto; i++)
+    {
         if(conformaction[i] < 0)
         {
             t_dataslot *dataslot = &tto->t_vec[i];
             for(j = 0; j < nfrom; j++)
+            {
                 if(!conformedfrom[j] &&
                     dataslot_matches(dataslot, &tfrom->t_vec[j], 0))
                 {
                     conformaction[i] = j;
                     conformedfrom[j] = 1;
                 }
+            }
         }
+    }
     if(nto != nfrom)
+    {
         doit = 1;
+    }
     else
+    {
         for(i = 0; i < nto; i++)
             if(conformaction[i] != i) doit = 1;
+    }
 
     if(doit)
     {
@@ -702,8 +752,10 @@ static void *gtemplate_new(t_symbol *s, int argc, t_atom *argv)
     t_symbol *sym = atom_getsymbolarg(0, argc, argv);
     if(argc >= 1) argc--, argv++;
     if(sym->s_name[0] == '-')
+    {
         post("warning: struct '%s' initial '-' may confuse get/set, etc.",
             sym->s_name);
+    }
     return (gtemplate_donew(canvas_makebindsym(sym), argc, argv));
 }
 
@@ -859,7 +911,9 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
         if(got == 3 || (got < 4 && strchr(s2, '('))) goto fail;
         if(got < 5 && (s3 = strchr(s2, '(')) && strchr(s3 + 1, '(')) goto fail;
         if(got == 4)
+        {
             fd->fd_quantum = 0;
+        }
         else if(got == 2)
         {
             fd->fd_quantum = 0;
@@ -884,17 +938,25 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
 static void fielddesc_setfloatarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
     if(argc <= 0)
+    {
         fielddesc_setfloat_const(fd, 0);
+    }
     else if(argv->a_type == A_SYMBOL)
+    {
         fielddesc_setfloat_var(fd, argv->a_w.w_symbol);
+    }
     else
+    {
         fielddesc_setfloat_const(fd, argv->a_w.w_float);
+    }
 }
 
 static void fielddesc_setsymbolarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
     if(argc <= 0)
+    {
         fielddesc_setsymbol_const(fd, &s_);
+    }
     else if(argv->a_type == A_SYMBOL)
     {
         fd->fd_type = A_SYMBOL;
@@ -910,7 +972,9 @@ static void fielddesc_setsymbolarg(t_fielddesc *fd, int argc, t_atom *argv)
 static void fielddesc_setarrayarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
     if(argc <= 0)
+    {
         fielddesc_setfloat_const(fd, 0);
+    }
     else if(argv->a_type == A_SYMBOL)
     {
         fd->fd_type = A_ARRAY;
@@ -998,7 +1062,9 @@ t_float fielddesc_cvtfromcoord(t_fielddesc *f, t_float coord)
 {
     t_float val;
     if(f->fd_screen2 == f->fd_screen1)
+    {
         val = coord;
+    }
     else
     {
         t_float div = (f->fd_v2 - f->fd_v1) / (f->fd_screen2 - f->fd_screen1);
@@ -1025,8 +1091,10 @@ void fielddesc_setcoord(
     else
     {
         if(loud)
+        {
             pd_error(0,
                 "attempt to set constant or symbolic data field to a number");
+        }
     }
 }
 
@@ -1114,17 +1182,29 @@ static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
     }
     x->x_flags = flags;
     if((flags & CLOSED) && argc)
+    {
         fielddesc_setfloatarg(&x->x_fillcolor, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_fillcolor, 0);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_outlinecolor, 0);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_width, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_width, 1);
+    }
     if(argc < 0) argc = 0;
     nxy = (argc + (argc & 1));
     x->x_npoints = (nxy >> 1);
@@ -1290,15 +1370,21 @@ static void curve_vis(t_gobj *z, t_glist *glist, t_word *data,
                 sys_vgui("%d %d\\\n", pix[2 * i], pix[2 * i + 1]);
             sys_vgui("-width %f\\\n", width);
             if(flags & CLOSED)
+            {
                 sys_vgui("-fill %s -outline %s\\\n", fill, outline);
+            }
             else
+            {
                 sys_vgui("-fill %s\\\n", outline);
+            }
             if(flags & BEZ) sys_vgui("-smooth 1\\\n");
             sys_vgui("-tags curve%lx\n", data);
         }
         else
+        {
             post("warning: drawing shapes need at least two points to be "
                  "graphed");
+        }
     }
     else
     {
@@ -1341,15 +1427,21 @@ static void curve_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
     }
     /* LATER figure out what to do to notify for an array? */
     if(TEMPLATE->curve_motion_scalar)
+    {
         template_notifyforscalar(TEMPLATE->curve_motion_template,
             TEMPLATE->curve_motion_glist, TEMPLATE->curve_motion_scalar,
             gensym("change"), 1, &at);
+    }
     if(TEMPLATE->curve_motion_scalar)
+    {
         scalar_redraw(
             TEMPLATE->curve_motion_scalar, TEMPLATE->curve_motion_glist);
+    }
     if(TEMPLATE->curve_motion_array)
+    {
         array_redraw(
             TEMPLATE->curve_motion_array, TEMPLATE->curve_motion_glist);
+    }
 }
 
 static int curve_click(t_gobj *z, t_glist *glist, t_word *data,
@@ -1401,11 +1493,15 @@ static int curve_click(t_gobj *z, t_glist *glist, t_word *data,
         TEMPLATE->curve_motion_field = 2 * bestn;
         TEMPLATE->curve_motion_template = template;
         if(TEMPLATE->curve_motion_scalar)
+        {
             gpointer_setglist(&TEMPLATE->curve_motion_gpointer,
                 TEMPLATE->curve_motion_glist, TEMPLATE->curve_motion_scalar);
+        }
         else
+        {
             gpointer_setarray(&TEMPLATE->curve_motion_gpointer,
                 TEMPLATE->curve_motion_array, TEMPLATE->curve_motion_wp);
+        }
         glist_grab(glist, z, curve_motionfn, 0, xpix, ypix);
     }
     return (1);
@@ -1532,33 +1628,61 @@ static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
             break;
     }
     if(argc)
+    {
         fielddesc_setarrayarg(&x->x_data, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_data, 1);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_outlinecolor, 0);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_width, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_width, 1);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_xloc, 1);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_yloc, 1);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_xinc, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_xinc, 1);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_style, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_style, defstyle);
+    }
     return (x);
 }
 
@@ -1665,23 +1789,35 @@ int array_getfields(t_symbol *elemtemplatesym, t_canvas **elemtemplatecanvasp,
     }
     elemsize = elemtemplate->t_n * sizeof(t_word);
     if(yfielddesc && yfielddesc->fd_var)
+    {
         varname = yfielddesc->fd_un.fd_varsym;
+    }
     else
+    {
         varname = gensym("y");
+    }
     if(!template_find_field(elemtemplate, varname, &yonset, &type, &dummy) ||
         type != DT_FLOAT)
         yonset = -1;
     if(xfielddesc && xfielddesc->fd_var)
+    {
         varname = xfielddesc->fd_un.fd_varsym;
+    }
     else
+    {
         varname = gensym("x");
+    }
     if(!template_find_field(elemtemplate, varname, &xonset, &type, &dummy) ||
         type != DT_FLOAT)
         xonset = -1;
     if(wfielddesc && wfielddesc->fd_var)
+    {
         varname = wfielddesc->fd_un.fd_varsym;
+    }
     else
+    {
         varname = gensym("w");
+    }
     if(!template_find_field(elemtemplate, varname, &wonset, &type, &dummy) ||
         type != DT_FLOAT)
         wonset = -1;
@@ -1763,19 +1899,27 @@ static void plot_getrect(t_gobj *z, t_glist *glist, t_word *data,
             {
                 /* check also the drawing instructions for the scalar */
                 if(xonset >= 0)
+                {
                     usexloc = basex + xloc +
                               fielddesc_cvttocoord(xfielddesc,
                                   *(t_float *) (((char *) (array->a_vec) +
                                                     elemsize * i) +
                                                 xonset));
+                }
                 else
+                {
                     usexloc = basex + xsum, xsum += xinc;
+                }
                 if(yonset >= 0)
+                {
                     yval =
                         *(t_float *) (((char *) (array->a_vec) + elemsize * i) +
                                       yonset);
+                }
                 else
+                {
                     yval = 0;
+                }
                 useyloc = basey + yloc + fielddesc_cvttocoord(yfielddesc, yval);
                 for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
@@ -1912,9 +2056,13 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 }
 
                 if(yonset >= 0)
+                {
                     yval = yloc + *(t_float *) ((elem + elemsize * i) + yonset);
+                }
                 else
+                {
                     yval = 0;
+                }
                 yval = CLIP(yval);
                 if(yval < minyval) minyval = yval;
                 if(yval > maxyval) maxyval = yval;
@@ -1960,14 +2108,22 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 for(i = 0, xsum = xloc; i < nelem; i++)
                 {
                     if(xonset >= 0)
+                    {
                         usexloc = xloc +
                                   *(t_float *) ((elem + elemsize * i) + xonset);
+                    }
                     else
+                    {
                         usexloc = xsum, xsum += xinc;
+                    }
                     if(yonset >= 0)
+                    {
                         yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    }
                     else
+                    {
                         yval = 0;
+                    }
                     yval = CLIP(yval);
                     wval = *(t_float *) ((elem + elemsize * i) + wonset);
                     wval = CLIP(wval);
@@ -1992,14 +2148,22 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 {
                     t_float usexloc;
                     if(xonset >= 0)
+                    {
                         usexloc = xloc +
                                   *(t_float *) ((elem + elemsize * i) + xonset);
+                    }
                     else
+                    {
                         xsum -= xinc, usexloc = xsum;
+                    }
                     if(yonset >= 0)
+                    {
                         yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    }
                     else
+                    {
                         yval = 0;
+                    }
                     yval = CLIP(yval);
                     wval = *(t_float *) ((elem + elemsize * i) + wonset);
                     wval = CLIP(wval);
@@ -2052,14 +2216,22 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 {
                     t_float usexloc;
                     if(xonset >= 0)
+                    {
                         usexloc = xloc +
                                   *(t_float *) ((elem + elemsize * i) + xonset);
+                    }
                     else
+                    {
                         usexloc = xsum, xsum += xinc;
+                    }
                     if(yonset >= 0)
+                    {
                         yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    }
                     else
+                    {
                         yval = 0;
+                    }
                     yval = CLIP(yval);
                     xpix = glist_xtopixels(glist,
                         basex + fielddesc_cvttocoord(xfielddesc, usexloc));
@@ -2077,12 +2249,16 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 }
                 /* TK will complain if there aren't at least 2 points... */
                 if(ndrawn == 0)
+                {
                     sys_vgui("0 0 0 0 \\\n");
+                }
                 else if(ndrawn == 1)
+                {
                     sys_vgui("%d %f \\\n", ixpix + 10,
                         glist_ytopixels(
                             glist, basey + yloc +
                                        fielddesc_cvttocoord(yfielddesc, yval)));
+                }
 
                 sys_vgui("-width %f\\\n", linewidth);
                 sys_vgui("-fill %s\\\n", outline);
@@ -2102,14 +2278,22 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 t_float useyloc;
                 t_gobj *y;
                 if(xonset >= 0)
+                {
                     usexloc = basex + xloc +
                               *(t_float *) ((elem + elemsize * i) + xonset);
+                }
                 else
+                {
                     usexloc = basex + xsum, xsum += xinc;
+                }
                 if(yonset >= 0)
+                {
                     yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                }
                 else
+                {
                     yval = 0;
+                }
                 useyloc = basey + yloc + fielddesc_cvttocoord(yfielddesc, yval);
                 for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
@@ -2215,9 +2399,13 @@ static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
             1);
         t_float ydiff = newy - oldy;
         if(thisx < 0)
+        {
             thisx = 0;
+        }
         else if(thisx >= TEMPLATE->array_motion_npoints)
+        {
             thisx = TEMPLATE->array_motion_npoints - 1;
+        }
         increment = (thisx > TEMPLATE->array_motion_lastx ? -1 : 1);
         nchange = 1 + increment * (TEMPLATE->array_motion_lastx - thisx);
 
@@ -2233,11 +2421,15 @@ static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
         TEMPLATE->array_motion_lastx = thisx;
     }
     if(TEMPLATE->array_motion_scalar)
+    {
         scalar_redraw(
             TEMPLATE->array_motion_scalar, TEMPLATE->array_motion_glist);
+    }
     if(TEMPLATE->array_motion_array)
+    {
         array_redraw(
             TEMPLATE->array_motion_array, TEMPLATE->array_motion_glist);
+    }
 }
 
 int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
@@ -2268,21 +2460,29 @@ static int array_doclick_element(t_array *array, t_glist *glist,
         return (0);
     /* if it has more than 2000 points, just check 300 of them. */
     if(array->a_n < 2000)
+    {
         incr = 1;
+    }
     else
+    {
         incr = array->a_n / 300;
+    }
     for(i = 0, xsum = 0; i < array->a_n; i += incr)
     {
         t_float usexloc;
         t_float useyloc;
         if(xonset >= 0)
+        {
             usexloc =
                 xloc +
                 fielddesc_cvttocoord(xfield,
                     *(t_float *) (((char *) (array->a_vec) + elemsize * i) +
                                   xonset));
+        }
         else
+        {
             usexloc = xloc + xsum, xsum += xinc;
+        }
         useyloc =
             yloc + (yonset >= 0 ? fielddesc_cvttocoord(yfield,
                                       *(t_float *) (((char *) (array->a_vec) +
@@ -2334,9 +2534,13 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
         {
             int xval = glist_pixelstox(glist, xpix);
             if(xval < 0)
+            {
                 xval = 0;
+            }
             else if(xval >= array->a_n)
+            {
                 xval = array->a_n - 1;
+            }
             TEMPLATE->array_motion_yfield = yfield;
             TEMPLATE->array_motion_ycumulative = glist_pixelstoy(glist, ypix);
             TEMPLATE->array_motion_fatten = 0;
@@ -2352,11 +2556,15 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                     glist_pixelstoy(glist, ypix), 1);
                 glist_grab(glist, 0, array_motionfn, 0, xpix, ypix);
                 if(TEMPLATE->array_motion_scalar)
+                {
                     scalar_redraw(TEMPLATE->array_motion_scalar,
                         TEMPLATE->array_motion_glist);
+                }
                 if(TEMPLATE->array_motion_array)
+                {
                     array_redraw(TEMPLATE->array_motion_array,
                         TEMPLATE->array_motion_glist);
+                }
             }
         }
         else
@@ -2439,11 +2647,17 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                 if(dx + dy <= best || dx + dy2 <= best || dx + dy3 <= best)
                 {
                     if(dy < dy2 && dy < dy3)
+                    {
                         TEMPLATE->array_motion_fatten = 0;
+                    }
                     else if(dy2 < dy3)
+                    {
                         TEMPLATE->array_motion_fatten = -1;
+                    }
                     else
+                    {
                         TEMPLATE->array_motion_fatten = 1;
+                    }
                     if(doit)
                     {
                         char *elem = (char *) array->a_vec;
@@ -2478,9 +2692,13 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                             TEMPLATE->array_motion_wp =
                                 (t_word *) (elem + i * elemsize);
                             if(shift)
+                            {
                                 TEMPLATE->array_motion_npoints = array->a_n - i;
+                            }
                             else
+                            {
                                 TEMPLATE->array_motion_npoints = 1;
+                            }
                         }
                         else
                         {
@@ -2528,9 +2746,11 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                         return (CURSOR_RUNMODE_ADDPOINT);
                     }
                     else
+                    {
                         return (TEMPLATE->array_motion_fatten
                                     ? CURSOR_RUNMODE_THICKEN
                                     : CURSOR_RUNMODE_CLICKME);
+                    }
                 }
             }
         }
@@ -2631,21 +2851,37 @@ static void *drawnumber_new(t_symbol *classsym, int argc, t_atom *argv)
     x->x_fieldname = atom_getsymbolarg(0, argc, argv);
     if(argc) argc--, argv++;
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_xloc, 0);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_yloc, 0);
+    }
     if(argc)
+    {
         fielddesc_setfloatarg(&x->x_color, argc--, argv++);
+    }
     else
+    {
         fielddesc_setfloat_const(&x->x_color, 1);
+    }
     if(argc)
+    {
         x->x_label = atom_getsymbolarg(0, argc, argv);
+    }
     else
+    {
         x->x_label = &s_;
+    }
 
     return (x);
 }
@@ -2689,7 +2925,9 @@ static void drawnumber_getbuf(
     int onset;
     int type = drawnumber_gettype(x, data, template, &onset);
     if(type < 0)
+    {
         buf[0] = 0;
+    }
     else
     {
         strncpy(buf, x->x_label->s_name, DRAWNUMBER_BUFSIZE);
@@ -2715,9 +2953,13 @@ static void drawnumber_getbuf(
         {
             t_atom at;
             if(type == DT_FLOAT)
+            {
                 SETFLOAT(&at, ((t_word *) ((char *) data + onset))->w_float);
+            }
             else
+            {
                 SETSYMBOL(&at, ((t_word *) ((char *) data + onset))->w_symbol);
+            }
             atom_string(&at, buf + nchars, DRAWNUMBER_BUFSIZE - nchars);
         }
     }
@@ -2814,8 +3056,10 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist, t_word *data,
         sys_vgui(" -tags [list drawnumber%lx label]\n", data);
     }
     else
+    {
         sys_vgui(
             ".x%lx.c delete drawnumber%lx\n", glist_getcanvas(glist), data);
+    }
 }
 
 static void drawnumber_motionfn(
@@ -2835,16 +3079,22 @@ static void drawnumber_motionfn(
         TEMPLATE->drawnumber_motion_wp, TEMPLATE->drawnumber_motion_ycumulative,
         1);
     if(TEMPLATE->drawnumber_motion_scalar)
+    {
         template_notifyforscalar(TEMPLATE->drawnumber_motion_template,
             TEMPLATE->drawnumber_motion_glist,
             TEMPLATE->drawnumber_motion_scalar, gensym("change"), 1, &at);
+    }
 
     if(TEMPLATE->drawnumber_motion_scalar)
+    {
         scalar_redraw(TEMPLATE->drawnumber_motion_scalar,
             TEMPLATE->drawnumber_motion_glist);
+    }
     if(TEMPLATE->drawnumber_motion_array)
+    {
         array_redraw(TEMPLATE->drawnumber_motion_array,
             TEMPLATE->drawnumber_motion_glist);
+    }
 }
 
 static void drawnumber_key(void *z, t_symbol *keysym, t_floatarg fkey)
@@ -2863,13 +3113,17 @@ static void drawnumber_key(void *z, t_symbol *keysym, t_floatarg fkey)
     {
         /* key entry for a symbol field */
         if(TEMPLATE->drawnumber_motion_firstkey)
+        {
             sbuf[0] = 0;
+        }
         else
+        {
             strncpy(sbuf,
                 template_getsymbol(TEMPLATE->drawnumber_motion_template,
                     x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1)
                     ->s_name,
                 MAXPDSTRING);
+        }
         sbuf[MAXPDSTRING - 1] = 0;
         if(key == '\b')
         {
@@ -2886,11 +3140,15 @@ static void drawnumber_key(void *z, t_symbol *keysym, t_floatarg fkey)
         /* key entry for a numeric field.  This is just a stopgap. */
         double newf;
         if(TEMPLATE->drawnumber_motion_firstkey)
+        {
             sbuf[0] = 0;
+        }
         else
+        {
             sprintf(sbuf, "%g",
                 template_getfloat(TEMPLATE->drawnumber_motion_template,
                     x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1));
+        }
         TEMPLATE->drawnumber_motion_firstkey = (key == '\n');
         if(key == '\b')
         {
@@ -2905,15 +3163,21 @@ static void drawnumber_key(void *z, t_symbol *keysym, t_floatarg fkey)
         template_setfloat(TEMPLATE->drawnumber_motion_template, x->x_fieldname,
             TEMPLATE->drawnumber_motion_wp, (t_float) newf, 1);
         if(TEMPLATE->drawnumber_motion_scalar)
+        {
             template_notifyforscalar(TEMPLATE->drawnumber_motion_template,
                 TEMPLATE->drawnumber_motion_glist,
                 TEMPLATE->drawnumber_motion_scalar, gensym("change"), 1, &at);
+        }
         if(TEMPLATE->drawnumber_motion_scalar)
+        {
             scalar_redraw(TEMPLATE->drawnumber_motion_scalar,
                 TEMPLATE->drawnumber_motion_glist);
+        }
         if(TEMPLATE->drawnumber_motion_array)
+        {
             array_redraw(TEMPLATE->drawnumber_motion_array,
                 TEMPLATE->drawnumber_motion_glist);
+        }
     }
     else
         post("typing at text fields not yet implemented");
@@ -2948,13 +3212,17 @@ static int drawnumber_click(t_gobj *z, t_glist *glist, t_word *data,
                 template_getfloat(template, x->x_fieldname, data, 0);
             TEMPLATE->drawnumber_motion_type = type;
             if(TEMPLATE->drawnumber_motion_scalar)
+            {
                 gpointer_setglist(&TEMPLATE->drawnumber_motion_gpointer,
                     TEMPLATE->drawnumber_motion_glist,
                     TEMPLATE->drawnumber_motion_scalar);
+            }
             else
+            {
                 gpointer_setarray(&TEMPLATE->drawnumber_motion_gpointer,
                     TEMPLATE->drawnumber_motion_array,
                     TEMPLATE->drawnumber_motion_wp);
+            }
             glist_grab(
                 glist, z, drawnumber_motionfn, drawnumber_key, xpix, ypix);
         }

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -930,8 +930,7 @@ static t_float fielddesc_getfloat(
     {
         if(f->fd_var)
             return (template_getfloat(template, f->fd_un.fd_varsym, wp, loud));
-        else
-            return (f->fd_un.fd_float);
+        return (f->fd_un.fd_float);
     }
     else
     {
@@ -969,8 +968,7 @@ t_float fielddesc_getcoord(
                 template_getfloat(template, f->fd_un.fd_varsym, wp, loud);
             return (fielddesc_cvttocoord(f, val));
         }
-        else
-            return (f->fd_un.fd_float);
+        return (f->fd_un.fd_float);
     }
     else
     {
@@ -986,8 +984,7 @@ static t_symbol *fielddesc_getsymbol(
     {
         if(f->fd_var)
             return (template_getsymbol(template, f->fd_un.fd_varsym, wp, loud));
-        else
-            return (f->fd_un.fd_symbol);
+        return (f->fd_un.fd_symbol);
     }
     else
     {
@@ -2403,8 +2400,7 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                         xloc, xinc, yloc, xfield, yfield, wfield, xpix, ypix,
                         shift, alt, dbl, doit));
                 }
-                else
-                    return (0);
+                return (0);
             }
             /* Now we walk over the array again and decide whether we
             a) grab an element, b) change the line width,
@@ -2461,7 +2457,7 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                                 array, glist, array->a_n - 1);
                             return (0);
                         }
-                        else if(alt)
+                        if(alt)
                         {
                             /* add a point (after the clicked-on one) */
                             array_resize_and_redraw(
@@ -2529,8 +2525,7 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                     {
                         if(xpix < pxpix)
                             return (CURSOR_EDITMODE_DISCONNECT);
-                        else
-                            return (CURSOR_RUNMODE_ADDPOINT);
+                        return (CURSOR_RUNMODE_ADDPOINT);
                     }
                     else
                         return (TEMPLATE->array_motion_fatten
@@ -2569,8 +2564,7 @@ static int plot_click(t_gobj *z, t_glist *glist, t_word *data,
             basex + xloc, xinc, basey + yloc, scalarvis, edit, xfielddesc,
             yfielddesc, wfielddesc, xpix, ypix, shift, alt, dbl, doit));
     }
-    else
-        return (0);
+    return (0);
 }
 
 const t_parentwidgetbehavior plot_widgetbehavior = {
@@ -2683,8 +2677,7 @@ static int drawnumber_gettype(
            template, x->x_fieldname, onsetp, &type, &arraytype) &&
         type != DT_ARRAY)
         return (type);
-    else
-        return (-1);
+    return (-1);
 }
 
 #define DRAWNUMBER_BUFSIZE 1024
@@ -2967,8 +2960,7 @@ static int drawnumber_click(t_gobj *z, t_glist *glist, t_word *data,
         }
         return (1);
     }
-    else
-        return (0);
+    return (0);
 }
 
 const t_parentwidgetbehavior drawnumber_widgetbehavior = {

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include <string.h>
@@ -15,8 +15,8 @@ template.  Templates describe objects of type "array" (g_array.c) and
 "scalar" (g_scalar.c).
 */
 
-    /* the structure of a "struct" object (also the obsolete "gtemplate"
-    you get when using the name "template" in a box.) */
+/* the structure of a "struct" object (also the obsolete "gtemplate"
+you get when using the name "template" in a box.) */
 
 struct _gtemplate
 {
@@ -72,15 +72,14 @@ struct _instancetemplate
     int drawnumber_motion_firstkey;
 };
 
-
 /* ---------------- forward definitions ---------------- */
 
 static void template_addtolist(t_template *x);
 static void template_takeofflist(t_template *x);
-static void template_conformarray(t_template *tfrom, t_template *tto,
-    int *conformaction, t_array *a);
-static void template_conformglist(t_template *tfrom, t_template *tto,
-    t_glist *glist,  int *conformaction);
+static void template_conformarray(
+    t_template *tfrom, t_template *tto, int *conformaction, t_array *a);
+static void template_conformglist(
+    t_template *tfrom, t_template *tto, t_glist *glist, int *conformaction);
 
 /* ---------------------- storage ------------------------- */
 
@@ -90,19 +89,18 @@ static t_class *template_class;
 /* there's a pre-defined "float" template.  LATER should we bind this
 to a symbol such as "pd-float"??? */
 
-    /* return true if two dataslot definitions match */
-static int dataslot_matches(t_dataslot *ds1, t_dataslot *ds2,
-    int nametoo)
+/* return true if two dataslot definitions match */
+static int dataslot_matches(t_dataslot *ds1, t_dataslot *ds2, int nametoo)
 {
     return ((!nametoo || ds1->ds_name == ds2->ds_name) &&
-        ds1->ds_type == ds2->ds_type &&
+            ds1->ds_type == ds2->ds_type &&
             (ds1->ds_type != DT_ARRAY ||
                 ds1->ds_arraytemplate == ds2->ds_arraytemplate));
 }
 
 /* -- templates, the active ingredient in gtemplates defined below. ------- */
 
-    /* add a template to the list */
+/* add a template to the list */
 static void template_addtolist(t_template *x)
 {
     x->t_next = pd_this->pd_templatelist;
@@ -111,43 +109,43 @@ static void template_addtolist(t_template *x)
 
 static void template_takeofflist(t_template *x)
 {
-        /* take it off the template list */
-    if (x == pd_this->pd_templatelist) pd_this->pd_templatelist = x->t_next;
+    /* take it off the template list */
+    if(x == pd_this->pd_templatelist)
+        pd_this->pd_templatelist = x->t_next;
     else
     {
         t_template *z;
-        for (z = pd_this->pd_templatelist; z->t_next != x; z = z->t_next)
-            if (!z->t_next) return;
+        for(z = pd_this->pd_templatelist; z->t_next != x; z = z->t_next)
+            if(!z->t_next) return;
         z->t_next = x->t_next;
     }
 }
 
 t_template *template_new(t_symbol *templatesym, int argc, t_atom *argv)
 {
-    t_template *x = (t_template *)pd_new(template_class);
+    t_template *x = (t_template *) pd_new(template_class);
     x->t_n = 0;
-    x->t_vec = (t_dataslot *)t_getbytes(0);
+    x->t_vec = (t_dataslot *) t_getbytes(0);
     x->t_next = 0;
     template_addtolist(x);
-    while (argc > 0)
+    while(argc > 0)
     {
         int newtype, oldn, newn;
         t_symbol *newname, *newarraytemplate = &s_, *newtypesym;
-        if (argc < 2 || argv[0].a_type != A_SYMBOL ||
-            argv[1].a_type != A_SYMBOL)
-                goto bad;
+        if(argc < 2 || argv[0].a_type != A_SYMBOL || argv[1].a_type != A_SYMBOL)
+            goto bad;
         newtypesym = argv[0].a_w.w_symbol;
         newname = argv[1].a_w.w_symbol;
-        if (newtypesym == &s_float)
+        if(newtypesym == &s_float)
             newtype = DT_FLOAT;
-        else if (newtypesym == &s_symbol)
+        else if(newtypesym == &s_symbol)
             newtype = DT_SYMBOL;
-                /* "list" is old name.. accepted here but never saved as such */
-        else if (newtypesym == gensym("text") || newtypesym == &s_list)
+        /* "list" is old name.. accepted here but never saved as such */
+        else if(newtypesym == gensym("text") || newtypesym == &s_list)
             newtype = DT_TEXT;
-        else if (newtypesym == gensym("array"))
+        else if(newtypesym == gensym("array"))
         {
-            if (argc < 3 || argv[2].a_type != A_SYMBOL)
+            if(argc < 3 || argv[2].a_type != A_SYMBOL)
             {
                 pd_error(x, "array lacks element template or name");
                 goto bad;
@@ -163,21 +161,23 @@ t_template *template_new(t_symbol *templatesym, int argc, t_atom *argv)
             goto bad;
         }
         newn = (oldn = x->t_n) + 1;
-        x->t_vec = (t_dataslot *)t_resizebytes(x->t_vec,
-            oldn * sizeof(*x->t_vec), newn * sizeof(*x->t_vec));
+        x->t_vec = (t_dataslot *) t_resizebytes(
+            x->t_vec, oldn * sizeof(*x->t_vec), newn * sizeof(*x->t_vec));
         x->t_n = newn;
         x->t_vec[oldn].ds_type = newtype;
         x->t_vec[oldn].ds_name = newname;
         x->t_vec[oldn].ds_arraytemplate = newarraytemplate;
     bad:
-        argc -= 2; argv += 2;
+        argc -= 2;
+        argv += 2;
     }
-    if (*templatesym->s_name)
+    if(*templatesym->s_name)
     {
         x->t_sym = templatesym;
         pd_bind(&x->t_pdobj, x->t_sym);
     }
-    else x->t_sym = templatesym;
+    else
+        x->t_sym = templatesym;
     return (x);
 }
 
@@ -186,109 +186,113 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
 {
     t_template *t;
     int i, n;
-    if (!x)
+    if(!x)
     {
         bug("template_find_field");
         return (0);
     }
     n = x->t_n;
-    for (i = 0; i < n; i++)
-        if (x->t_vec[i].ds_name == name)
-    {
-        *p_onset = i * sizeof(t_word);
-        *p_type = x->t_vec[i].ds_type;
-        *p_arraytype = x->t_vec[i].ds_arraytemplate;
-        return (1);
-    }
+    for(i = 0; i < n; i++)
+        if(x->t_vec[i].ds_name == name)
+        {
+            *p_onset = i * sizeof(t_word);
+            *p_type = x->t_vec[i].ds_type;
+            *p_arraytype = x->t_vec[i].ds_arraytemplate;
+            return (1);
+        }
     return (0);
 }
 
-t_float template_getfloat(t_template *x, t_symbol *fieldname, t_word *wp,
-    int loud)
+t_float template_getfloat(
+    t_template *x, t_symbol *fieldname, t_word *wp, int loud)
 {
     int onset, type;
     t_symbol *arraytype;
     t_float val = 0;
-    if (template_find_field(x, fieldname, &onset, &type, &arraytype))
+    if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
-        if (type == DT_FLOAT)
-            val = *(t_float *)(((char *)wp) + onset);
-        else if (loud) pd_error(0, "%s.%s: not a number",
-            x->t_sym->s_name, fieldname->s_name);
+        if(type == DT_FLOAT)
+            val = *(t_float *) (((char *) wp) + onset);
+        else if(loud)
+            pd_error(
+                0, "%s.%s: not a number", x->t_sym->s_name, fieldname->s_name);
     }
-    else if (loud) pd_error(0, "%s.%s: no such field",
-        x->t_sym->s_name, fieldname->s_name);
+    else if(loud)
+        pd_error(
+            0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
     return (val);
 }
 
-void template_setfloat(t_template *x, t_symbol *fieldname, t_word *wp,
-    t_float f, int loud)
+void template_setfloat(
+    t_template *x, t_symbol *fieldname, t_word *wp, t_float f, int loud)
 {
     int onset, type;
     t_symbol *arraytype;
-    if (template_find_field(x, fieldname, &onset, &type, &arraytype))
-     {
-        if (type == DT_FLOAT)
-            *(t_float *)(((char *)wp) + onset) = f;
-        else if (loud) pd_error(0, "%s.%s: not a number",
-            x->t_sym->s_name, fieldname->s_name);
+    if(template_find_field(x, fieldname, &onset, &type, &arraytype))
+    {
+        if(type == DT_FLOAT)
+            *(t_float *) (((char *) wp) + onset) = f;
+        else if(loud)
+            pd_error(
+                0, "%s.%s: not a number", x->t_sym->s_name, fieldname->s_name);
     }
-    else if (loud) pd_error(0, "%s.%s: no such field",
-        x->t_sym->s_name, fieldname->s_name);
+    else if(loud)
+        pd_error(
+            0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
 }
 
-t_symbol *template_getsymbol(t_template *x, t_symbol *fieldname, t_word *wp,
-    int loud)
+t_symbol *template_getsymbol(
+    t_template *x, t_symbol *fieldname, t_word *wp, int loud)
 {
     int onset, type;
     t_symbol *arraytype;
     t_symbol *val = &s_;
-    if (template_find_field(x, fieldname, &onset, &type, &arraytype))
+    if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
-        if (type == DT_SYMBOL)
-            val = *(t_symbol **)(((char *)wp) + onset);
-        else if (loud) pd_error(0, "%s.%s: not a symbol",
-            x->t_sym->s_name, fieldname->s_name);
+        if(type == DT_SYMBOL)
+            val = *(t_symbol **) (((char *) wp) + onset);
+        else if(loud)
+            pd_error(
+                0, "%s.%s: not a symbol", x->t_sym->s_name, fieldname->s_name);
     }
-    else if (loud) pd_error(0, "%s.%s: no such field",
-        x->t_sym->s_name, fieldname->s_name);
+    else if(loud)
+        pd_error(
+            0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
     return (val);
 }
 
-void template_setsymbol(t_template *x, t_symbol *fieldname, t_word *wp,
-    t_symbol *s, int loud)
+void template_setsymbol(
+    t_template *x, t_symbol *fieldname, t_word *wp, t_symbol *s, int loud)
 {
     int onset, type;
     t_symbol *arraytype;
-    if (template_find_field(x, fieldname, &onset, &type, &arraytype))
-     {
-        if (type == DT_SYMBOL)
-            *(t_symbol **)(((char *)wp) + onset) = s;
-        else if (loud) pd_error(0, "%s.%s: not a symbol",
-            x->t_sym->s_name, fieldname->s_name);
+    if(template_find_field(x, fieldname, &onset, &type, &arraytype))
+    {
+        if(type == DT_SYMBOL)
+            *(t_symbol **) (((char *) wp) + onset) = s;
+        else if(loud)
+            pd_error(
+                0, "%s.%s: not a symbol", x->t_sym->s_name, fieldname->s_name);
     }
-    else if (loud) pd_error(0, "%s.%s: no such field",
-        x->t_sym->s_name, fieldname->s_name);
+    else if(loud)
+        pd_error(
+            0, "%s.%s: no such field", x->t_sym->s_name, fieldname->s_name);
 }
 
-    /* stringent check to see if a "saved" template, x2, matches the current
-        one (x1).  It's OK if x1 has additional scalar elements but not (yet)
-        arrays.  This is used for reading in "data files". */
+/* stringent check to see if a "saved" template, x2, matches the current
+    one (x1).  It's OK if x1 has additional scalar elements but not (yet)
+    arrays.  This is used for reading in "data files". */
 int template_match(t_template *x1, t_template *x2)
 {
     int i;
-    if (x1->t_n < x2->t_n)
-        return (0);
-    for (i = x2->t_n; i < x1->t_n; i++)
+    if(x1->t_n < x2->t_n) return (0);
+    for(i = x2->t_n; i < x1->t_n; i++)
     {
-        if (x1->t_vec[i].ds_type == DT_ARRAY)
-                return (0);
+        if(x1->t_vec[i].ds_type == DT_ARRAY) return (0);
     }
-    if (x2->t_n > x1->t_n)
-        post("add elements...");
-    for (i = 0; i < x2->t_n; i++)
-        if (!dataslot_matches(&x1->t_vec[i], &x2->t_vec[i], 1))
-            return (0);
+    if(x2->t_n > x1->t_n) post("add elements...");
+    for(i = 0; i < x2->t_n; i++)
+        if(!dataslot_matches(&x1->t_vec[i], &x2->t_vec[i], 1)) return (0);
     return (1);
 }
 
@@ -301,17 +305,17 @@ which would make an old one whereas we will want a new one (but whose array
 elements might still be old ones.)
     LATER deal with graphics updates too... */
 
-    /* conform the word vector of a scalar to the new template */
+/* conform the word vector of a scalar to the new template */
 static void template_conformwords(t_template *tfrom, t_template *tto,
     int *conformaction, t_word *wfrom, t_word *wto)
 {
     int nfrom = tfrom->t_n, nto = tto->t_n, i;
-    for (i = 0; i < nto; i++)
+    for(i = 0; i < nto; i++)
     {
-        if (conformaction[i] >= 0)
+        if(conformaction[i] >= 0)
         {
-                /* we swap the two, in case it's an array or list, so that
-                when "wfrom" is deleted the old one gets cleaned up. */
+            /* we swap the two, in case it's an array or list, so that
+            when "wfrom" is deleted the old one gets cleaned up. */
             t_word wwas = wto[i];
             wto[i] = wfrom[conformaction[i]];
             wfrom[conformaction[i]] = wwas;
@@ -319,7 +323,7 @@ static void template_conformwords(t_template *tfrom, t_template *tto,
     }
 }
 
-    /* conform a scalar, recursively conforming arrays  */
+/* conform a scalar, recursively conforming arrays  */
 static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
     int *conformaction, t_glist *glist, t_scalar *scfrom)
 {
@@ -328,25 +332,25 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
     int nto = tto->t_n, nfrom = tfrom->t_n, i;
     t_template *scalartemplate;
     /* post("conform scalar"); */
-        /* possibly replace the scalar */
-    if (scfrom->sc_template == tfrom->t_sym)
+    /* possibly replace the scalar */
+    if(scfrom->sc_template == tfrom->t_sym)
     {
-            /* see scalar_new() for comment about the gpointer. */
+        /* see scalar_new() for comment about the gpointer. */
         gpointer_init(&gp);
-        x = (t_scalar *)getbytes(sizeof(t_scalar) +
-            (tto->t_n - 1) * sizeof(*x->sc_vec));
+        x = (t_scalar *) getbytes(
+            sizeof(t_scalar) + (tto->t_n - 1) * sizeof(*x->sc_vec));
         x->sc_gobj.g_pd = scalar_class;
         x->sc_template = tfrom->t_sym;
         gpointer_setglist(&gp, glist, x);
-            /* Here we initialize to the new template, but array and list
-            elements will still belong to old template. */
+        /* Here we initialize to the new template, but array and list
+        elements will still belong to old template. */
         word_init(x->sc_vec, tto, &gp);
 
-        template_conformwords(tfrom, tto, conformaction,
-            scfrom->sc_vec, x->sc_vec);
+        template_conformwords(
+            tfrom, tto, conformaction, scfrom->sc_vec, x->sc_vec);
 
-            /* replace the old one with the new one in the list */
-        if (glist->gl_list == &scfrom->sc_gobj)
+        /* replace the old one with the new one in the list */
+        if(glist->gl_list == &scfrom->sc_gobj)
         {
             glist->gl_list = &x->sc_gobj;
             x->sc_gobj.g_next = scfrom->sc_gobj.g_next;
@@ -354,17 +358,17 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
         else
         {
             t_gobj *y, *y2;
-            for (y = glist->gl_list; (y2 = y->g_next); y = y2)
-                if (y2 == &scfrom->sc_gobj)
-            {
-                x->sc_gobj.g_next = y2->g_next;
-                y->g_next = &x->sc_gobj;
-                goto nobug;
-            }
+            for(y = glist->gl_list; (y2 = y->g_next); y = y2)
+                if(y2 == &scfrom->sc_gobj)
+                {
+                    x->sc_gobj.g_next = y2->g_next;
+                    y->g_next = &x->sc_gobj;
+                    goto nobug;
+                }
             bug("template_conformscalar");
-        nobug: ;
+        nobug:;
         }
-            /* burn the old one */
+        /* burn the old one */
         pd_free(&scfrom->sc_gobj.g_pd);
         scalartemplate = tto;
     }
@@ -373,133 +377,133 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
         x = scfrom;
         scalartemplate = template_findbyname(x->sc_template);
     }
-        /* convert all array elements */
-    for (i = 0; i < scalartemplate->t_n; i++)
+    /* convert all array elements */
+    for(i = 0; i < scalartemplate->t_n; i++)
     {
         t_dataslot *ds = scalartemplate->t_vec + i;
-        if (ds->ds_type == DT_ARRAY)
+        if(ds->ds_type == DT_ARRAY)
         {
-            template_conformarray(tfrom, tto, conformaction,
-                x->sc_vec[i].w_array);
+            template_conformarray(
+                tfrom, tto, conformaction, x->sc_vec[i].w_array);
         }
     }
     return (x);
 }
 
-    /* conform an array, recursively conforming sublists and arrays  */
-static void template_conformarray(t_template *tfrom, t_template *tto,
-    int *conformaction, t_array *a)
+/* conform an array, recursively conforming sublists and arrays  */
+static void template_conformarray(
+    t_template *tfrom, t_template *tto, int *conformaction, t_array *a)
 {
     int i, j;
     t_template *scalartemplate = 0;
-    if (a->a_templatesym == tfrom->t_sym)
+    if(a->a_templatesym == tfrom->t_sym)
     {
         /* the array elements must all be conformed */
         int oldelemsize = sizeof(t_word) * tfrom->t_n,
             newelemsize = sizeof(t_word) * tto->t_n;
         char *newarray = getbytes(newelemsize * a->a_n);
         char *oldarray = a->a_vec;
-        if (a->a_elemsize != oldelemsize)
-            bug("template_conformarray");
-        for (i = 0; i < a->a_n; i++)
+        if(a->a_elemsize != oldelemsize) bug("template_conformarray");
+        for(i = 0; i < a->a_n; i++)
         {
-            t_word *wp = (t_word *)(newarray + newelemsize * i);
+            t_word *wp = (t_word *) (newarray + newelemsize * i);
             word_init(wp, tto, &a->a_gp);
             template_conformwords(tfrom, tto, conformaction,
-                (t_word *)(oldarray + oldelemsize * i), wp);
-            word_free((t_word *)(oldarray + oldelemsize * i), tfrom);
+                (t_word *) (oldarray + oldelemsize * i), wp);
+            word_free((t_word *) (oldarray + oldelemsize * i), tfrom);
         }
         scalartemplate = tto;
         a->a_vec = newarray;
         freebytes(oldarray, oldelemsize * a->a_n);
     }
-    else scalartemplate = template_findbyname(a->a_templatesym);
-        /* convert all arrays and sublist fields in each element of the array */
-    for (i = 0; i < a->a_n; i++)
+    else
+        scalartemplate = template_findbyname(a->a_templatesym);
+    /* convert all arrays and sublist fields in each element of the array */
+    for(i = 0; i < a->a_n; i++)
     {
-        t_word *wp = (t_word *)(a->a_vec + sizeof(t_word) * a->a_n * i);
-        for (j = 0; j < scalartemplate->t_n; j++)
+        t_word *wp = (t_word *) (a->a_vec + sizeof(t_word) * a->a_n * i);
+        for(j = 0; j < scalartemplate->t_n; j++)
         {
             t_dataslot *ds = scalartemplate->t_vec + j;
-            if (ds->ds_type == DT_ARRAY)
+            if(ds->ds_type == DT_ARRAY)
             {
-                template_conformarray(tfrom, tto, conformaction,
-                    wp[j].w_array);
+                template_conformarray(tfrom, tto, conformaction, wp[j].w_array);
             }
         }
     }
 }
 
-    /* this routine searches for every scalar in the glist that belongs
-    to the "from" template and makes it belong to the "to" template.  Descend
-    glists recursively.
-    We don't handle redrawing here; this is to be filled in LATER... */
+/* this routine searches for every scalar in the glist that belongs
+to the "from" template and makes it belong to the "to" template.  Descend
+glists recursively.
+We don't handle redrawing here; this is to be filled in LATER... */
 
 t_array *garray_getarray(t_garray *x);
 
-static void template_conformglist(t_template *tfrom, t_template *tto,
-    t_glist *glist,  int *conformaction)
+static void template_conformglist(
+    t_template *tfrom, t_template *tto, t_glist *glist, int *conformaction)
 {
     t_gobj *g;
     /* post("conform glist %s", glist->gl_name->s_name); */
-    for (g = glist->gl_list; g; g = g->g_next)
+    for(g = glist->gl_list; g; g = g->g_next)
     {
-        if (pd_class(&g->g_pd) == scalar_class)
-            g = &template_conformscalar(tfrom, tto, conformaction,
-                glist, (t_scalar *)g)->sc_gobj;
-        else if (pd_class(&g->g_pd) == canvas_class)
-            template_conformglist(tfrom, tto, (t_glist *)g, conformaction);
-        else if (pd_class(&g->g_pd) == garray_class)
-            template_conformarray(tfrom, tto, conformaction,
-                garray_getarray((t_garray *)g));
+        if(pd_class(&g->g_pd) == scalar_class)
+            g = &template_conformscalar(
+                tfrom, tto, conformaction, glist, (t_scalar *) g)
+                     ->sc_gobj;
+        else if(pd_class(&g->g_pd) == canvas_class)
+            template_conformglist(tfrom, tto, (t_glist *) g, conformaction);
+        else if(pd_class(&g->g_pd) == garray_class)
+            template_conformarray(
+                tfrom, tto, conformaction, garray_getarray((t_garray *) g));
     }
 }
 
-    /* globally conform all scalars from one template to another */
+/* globally conform all scalars from one template to another */
 void template_conform(t_template *tfrom, t_template *tto)
 {
     int nto = tto->t_n, nfrom = tfrom->t_n, i, j,
-        *conformaction = (int *)getbytes(sizeof(int) * nto),
-        *conformedfrom = (int *)getbytes(sizeof(int) * nfrom), doit = 0;
-    for (i = 0; i < nto; i++)
+        *conformaction = (int *) getbytes(sizeof(int) * nto),
+        *conformedfrom = (int *) getbytes(sizeof(int) * nfrom), doit = 0;
+    for(i = 0; i < nto; i++)
         conformaction[i] = -1;
-    for (i = 0; i < nfrom; i++)
+    for(i = 0; i < nfrom; i++)
         conformedfrom[i] = 0;
-    for (i = 0; i < nto; i++)
+    for(i = 0; i < nto; i++)
     {
         t_dataslot *dataslot = &tto->t_vec[i];
-        for (j = 0; j < nfrom; j++)
+        for(j = 0; j < nfrom; j++)
         {
             t_dataslot *dataslot2 = &tfrom->t_vec[j];
-            if (dataslot_matches(dataslot, dataslot2, 1))
+            if(dataslot_matches(dataslot, dataslot2, 1))
             {
                 conformaction[i] = j;
                 conformedfrom[j] = 1;
             }
         }
     }
-    for (i = 0; i < nto; i++)
-        if (conformaction[i] < 0)
-    {
-        t_dataslot *dataslot = &tto->t_vec[i];
-        for (j = 0; j < nfrom; j++)
-            if (!conformedfrom[j] &&
-                dataslot_matches(dataslot, &tfrom->t_vec[j], 0))
+    for(i = 0; i < nto; i++)
+        if(conformaction[i] < 0)
         {
-            conformaction[i] = j;
-            conformedfrom[j] = 1;
+            t_dataslot *dataslot = &tto->t_vec[i];
+            for(j = 0; j < nfrom; j++)
+                if(!conformedfrom[j] &&
+                    dataslot_matches(dataslot, &tfrom->t_vec[j], 0))
+                {
+                    conformaction[i] = j;
+                    conformedfrom[j] = 1;
+                }
         }
-    }
-    if (nto != nfrom)
+    if(nto != nfrom)
         doit = 1;
-    else for (i = 0; i < nto; i++)
-        if (conformaction[i] != i)
-            doit = 1;
+    else
+        for(i = 0; i < nto; i++)
+            if(conformaction[i] != i) doit = 1;
 
-    if (doit)
+    if(doit)
     {
         t_glist *gl;
-        for (gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
+        for(gl = pd_getcanvaslist(); gl; gl = gl->gl_next)
             template_conformglist(tfrom, tto, gl, conformaction);
     }
     freebytes(conformaction, sizeof(int) * nto);
@@ -508,31 +512,30 @@ void template_conform(t_template *tfrom, t_template *tto)
 
 t_template *template_findbyname(t_symbol *s)
 {
-    return ((t_template *)pd_findbyclass(s, template_class));
+    return ((t_template *) pd_findbyclass(s, template_class));
 }
 
 t_canvas *template_findcanvas(t_template *template)
 {
     t_gtemplate *gt;
-    if (!template)
+    if(!template)
     {
         bug("template_findcanvas");
         return (0);
     }
-    if (!(gt = template->t_list))
-        return (0);
+    if(!(gt = template->t_list)) return (0);
     return (gt->x_owner);
     /* return ((t_canvas *)pd_findbyclass(template->t_sym, canvas_class)); */
 }
 
 void template_notify(t_template *template, t_symbol *s, int argc, t_atom *argv)
 {
-    if (template->t_list)
+    if(template->t_list)
         outlet_anything(template->t_list->x_obj.ob_outlet, s, argc, argv);
 }
 
-    /* bash the first of (argv) with a pointer to a scalar, and send on
-    to template as a notification message */
+/* bash the first of (argv) with a pointer to a scalar, and send on
+to template as a notification message */
 void template_notifyforscalar(t_template *template, t_glist *owner,
     t_scalar *sc, t_symbol *s, int argc, t_atom *argv)
 {
@@ -544,40 +547,39 @@ void template_notifyforscalar(t_template *template, t_glist *owner,
     gpointer_unset(&gp);
 }
 
-    /* call this when reading a patch from a file to declare what templates
-    we'll need.  If there's already a template, check if it matches.
-    If it doesn't it's still OK as long as there are no "struct" (gtemplate)
-    objects hanging from it; we just conform everyone to the new template.
-    If there are still struct objects belonging to the other template, we're
-    in trouble.  LATER we'll figure out how to conform the new patch's objects
-    to the pre-existing struct. */
-static void *template_usetemplate(void *dummy, t_symbol *s,
-    int argc, t_atom *argv)
+/* call this when reading a patch from a file to declare what templates
+we'll need.  If there's already a template, check if it matches.
+If it doesn't it's still OK as long as there are no "struct" (gtemplate)
+objects hanging from it; we just conform everyone to the new template.
+If there are still struct objects belonging to the other template, we're
+in trouble.  LATER we'll figure out how to conform the new patch's objects
+to the pre-existing struct. */
+static void *template_usetemplate(
+    void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     t_template *x;
     t_symbol *templatesym =
         canvas_makebindsym(atom_getsymbolarg(0, argc, argv));
-    if (!argc)
-        return (0);
-    argc--; argv++;
-            /* check if there's already a template by this name. */
-    if ((x = (t_template *)pd_findbyclass(templatesym, template_class)))
+    if(!argc) return (0);
+    argc--;
+    argv++;
+    /* check if there's already a template by this name. */
+    if((x = (t_template *) pd_findbyclass(templatesym, template_class)))
     {
         t_template *y = template_new(&s_, argc, argv), *y2;
-            /* If the new template is the same as the old one,
-            there's nothing to do.  */
-        if (!template_match(x, y))
+        /* If the new template is the same as the old one,
+        there's nothing to do.  */
+        if(!template_match(x, y))
         {
-                /* Are there "struct" objects upholding this template? */
-            if (x->t_list)
+            /* Are there "struct" objects upholding this template? */
+            if(x->t_list)
             {
-                    /* don't know what to do here! */
-                pd_error(0, "%s: template mismatch",
-                    templatesym->s_name);
+                /* don't know what to do here! */
+                pd_error(0, "%s: template mismatch", templatesym->s_name);
             }
             else
             {
-                    /* conform everyone to the new template */
+                /* conform everyone to the new template */
                 template_conform(x, y);
                 pd_free(&x->t_pdobj);
                 y2 = template_new(templatesym, argc, argv);
@@ -586,27 +588,26 @@ static void *template_usetemplate(void *dummy, t_symbol *s,
         }
         pd_free(&y->t_pdobj);
     }
-        /* otherwise, just make one. */
-    else template_new(templatesym, argc, argv);
+    /* otherwise, just make one. */
+    else
+        template_new(templatesym, argc, argv);
     return (0);
 }
 
-    /* here we assume someone has already cleaned up all instances of this. */
+/* here we assume someone has already cleaned up all instances of this. */
 void template_free(t_template *x)
 {
-    if (*x->t_sym->s_name)
-        pd_unbind(&x->t_pdobj, x->t_sym);
+    if(*x->t_sym->s_name) pd_unbind(&x->t_pdobj, x->t_sym);
     t_freebytes(x->t_vec, x->t_n * sizeof(*x->t_vec));
     template_takeofflist(x);
 }
 
 static void template_setup(void)
 {
-    template_class = class_new(gensym("template"), 0, (t_method)template_free,
+    template_class = class_new(gensym("template"), 0, (t_method) template_free,
         sizeof(t_template), CLASS_PD, 0);
-    class_addmethod(pd_canvasmaker, (t_method)template_usetemplate,
+    class_addmethod(pd_canvasmaker, (t_method) template_usetemplate,
         gensym("struct"), A_GIMME, 0);
-
 }
 
 /* ---------------- gtemplates.  One per canvas. ----------- */
@@ -619,7 +620,7 @@ another one to add new fields, for example. */
 
 static void *gtemplate_donew(t_symbol *sym, int argc, t_atom *argv)
 {
-    t_gtemplate *x = (t_gtemplate *)pd_new(gtemplate_class);
+    t_gtemplate *x = (t_gtemplate *) pd_new(gtemplate_class);
     t_template *t = template_findbyname(sym);
     int i;
     t_symbol *sx = gensym("x");
@@ -627,36 +628,36 @@ static void *gtemplate_donew(t_symbol *sym, int argc, t_atom *argv)
     x->x_next = 0;
     x->x_sym = sym;
     x->x_argc = argc;
-    x->x_argv = (t_atom *)getbytes(argc * sizeof(t_atom));
-    for (i = 0; i < argc; i++)
+    x->x_argv = (t_atom *) getbytes(argc * sizeof(t_atom));
+    for(i = 0; i < argc; i++)
         x->x_argv[i] = argv[i];
 
-        /* already have a template by this name? */
-    if (t)
+    /* already have a template by this name? */
+    if(t)
     {
         x->x_template = t;
-            /* if it's already got a "struct" object we
-            just tack this one to the end of the list and leave it
-            there. */
-        if (t->t_list)
+        /* if it's already got a "struct" object we
+        just tack this one to the end of the list and leave it
+        there. */
+        if(t->t_list)
         {
             t_gtemplate *x2, *x3;
-            for (x2 = x->x_template->t_list; (x3 = x2->x_next); x2 = x3)
+            for(x2 = x->x_template->t_list; (x3 = x2->x_next); x2 = x3)
                 ;
             x2->x_next = x;
             post("template %s: warning: already exists.", sym->s_name);
         }
         else
         {
-                /* if there's none, we just replace the template with
-                our own and conform it. */
+            /* if there's none, we just replace the template with
+            our own and conform it. */
             t_template *y = template_new(&s_, argc, argv);
             canvas_redrawallfortemplate(t, 2);
-                /* Unless the new template is different from the old one,
-                there's nothing to do.  */
-            if (!template_match(t, y))
+            /* Unless the new template is different from the old one,
+            there's nothing to do.  */
+            if(!template_match(t, y))
             {
-                    /* conform everyone to the new template */
+                /* conform everyone to the new template */
                 template_conform(t, y);
                 pd_free(&t->t_pdobj);
                 x->x_template = t = template_new(sym, argc, argv);
@@ -668,7 +669,7 @@ static void *gtemplate_donew(t_symbol *sym, int argc, t_atom *argv)
     }
     else
     {
-            /* otherwise make a new one and we're the only struct on it. */
+        /* otherwise make a new one and we're the only struct on it. */
         x->x_template = t = template_new(sym, argc, argv);
         t->t_list = x;
     }
@@ -679,20 +680,19 @@ static void *gtemplate_donew(t_symbol *sym, int argc, t_atom *argv)
 static void *gtemplate_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sym = atom_getsymbolarg(0, argc, argv);
-    if (argc >= 1)
-        argc--, argv++;
-    if (sym->s_name[0] == '-')
+    if(argc >= 1) argc--, argv++;
+    if(sym->s_name[0] == '-')
         post("warning: struct '%s' initial '-' may confuse get/set, etc.",
             sym->s_name);
     return (gtemplate_donew(canvas_makebindsym(sym), argc, argv));
 }
 
-    /* old version (0.34) -- delete 2003 or so */
+/* old version (0.34) -- delete 2003 or so */
 static void *gtemplate_new_old(t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sym = canvas_makebindsym(canvas_getcurrent()->gl_name);
     static int warned;
-    if (!warned)
+    if(!warned)
     {
         post("warning -- 'template' (%s) is obsolete; replace with 'struct'",
             sym->s_name);
@@ -701,43 +701,41 @@ static void *gtemplate_new_old(t_symbol *s, int argc, t_atom *argv)
     return (gtemplate_donew(sym, argc, argv));
 }
 
-t_template *gtemplate_get(t_gtemplate *x)
-{
-    return (x->x_template);
-}
+t_template *gtemplate_get(t_gtemplate *x) { return (x->x_template); }
 
 static void gtemplate_free(t_gtemplate *x)
 {
-        /* get off the template's list */
+    /* get off the template's list */
     t_template *t = x->x_template;
     t_gtemplate *y;
-    if (x == t->t_list)
+    if(x == t->t_list)
     {
         canvas_redrawallfortemplate(t, 2);
-        if (x->x_next)
+        if(x->x_next)
         {
-                /* if we were first on the list, and there are others on
-                the list, make a new template corresponding to the new
-                first-on-list and replace the existing template with it. */
-            t_template *z = template_new(&s_,
-                x->x_next->x_argc, x->x_next->x_argv);
+            /* if we were first on the list, and there are others on
+            the list, make a new template corresponding to the new
+            first-on-list and replace the existing template with it. */
+            t_template *z =
+                template_new(&s_, x->x_next->x_argc, x->x_next->x_argv);
             template_conform(t, z);
             pd_free(&t->t_pdobj);
             pd_free(&z->t_pdobj);
             z = template_new(x->x_sym, x->x_next->x_argc, x->x_next->x_argv);
             z->t_list = x->x_next;
-            for (y = z->t_list; y ; y = y->x_next)
+            for(y = z->t_list; y; y = y->x_next)
                 y->x_template = z;
         }
-        else t->t_list = 0;
+        else
+            t->t_list = 0;
         canvas_redrawallfortemplate(t, 1);
     }
     else
     {
         t_gtemplate *x2, *x3;
-        for (x2 = t->t_list; (x3 = x2->x_next); x2 = x3)
+        for(x2 = t->t_list; (x3 = x2->x_next); x2 = x3)
         {
-            if (x == x3)
+            if(x == x3)
             {
                 x2->x_next = x3->x_next;
                 break;
@@ -749,11 +747,11 @@ static void gtemplate_free(t_gtemplate *x)
 
 static void gtemplate_setup(void)
 {
-    gtemplate_class = class_new(gensym("struct"),
-        (t_newmethod)gtemplate_new, (t_method)gtemplate_free,
-        sizeof(t_gtemplate), CLASS_NOINLET, A_GIMME, 0);
-    class_addcreator((t_newmethod)gtemplate_new_old, gensym("template"),
-        A_GIMME, 0);
+    gtemplate_class = class_new(gensym("struct"), (t_newmethod) gtemplate_new,
+        (t_method) gtemplate_free, sizeof(t_gtemplate), CLASS_NOINLET, A_GIMME,
+        0);
+    class_addcreator(
+        (t_newmethod) gtemplate_new_old, gensym("template"), A_GIMME, 0);
 }
 
 /* ---------------  FIELD DESCRIPTORS ---------------------- */
@@ -766,19 +764,21 @@ every single time we draw the object.
 
 struct _fielddesc
 {
-    char fd_type;       /* LATER consider removing this? */
+    char fd_type; /* LATER consider removing this? */
     char fd_var;
+
     union
     {
-        t_float fd_float;       /* the field is a constant float */
-        t_symbol *fd_symbol;    /* the field is a constant symbol */
-        t_symbol *fd_varsym;    /* the field is variable and this is the name */
+        t_float fd_float;    /* the field is a constant float */
+        t_symbol *fd_symbol; /* the field is a constant symbol */
+        t_symbol *fd_varsym; /* the field is variable and this is the name */
     } fd_un;
-    float fd_v1;        /* min and max values */
+
+    float fd_v1; /* min and max values */
     float fd_v2;
-    float fd_screen1;   /* min and max screen values */
+    float fd_screen1; /* min and max screen values */
     float fd_screen2;
-    float fd_quantum;   /* quantization in value */
+    float fd_quantum; /* quantization in value */
 };
 
 static void fielddesc_setfloat_const(t_fielddesc *fd, t_float f)
@@ -786,8 +786,8 @@ static void fielddesc_setfloat_const(t_fielddesc *fd, t_float f)
     fd->fd_type = A_FLOAT;
     fd->fd_var = 0;
     fd->fd_un.fd_float = f;
-    fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 =
-        fd->fd_quantum = 0;
+    fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 = fd->fd_quantum =
+        0;
 }
 
 static void fielddesc_setsymbol_const(t_fielddesc *fd, t_symbol *s)
@@ -795,8 +795,8 @@ static void fielddesc_setsymbol_const(t_fielddesc *fd, t_symbol *s)
     fd->fd_type = A_SYMBOL;
     fd->fd_var = 0;
     fd->fd_un.fd_symbol = s;
-    fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 =
-        fd->fd_quantum = 0;
+    fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 = fd->fd_quantum =
+        0;
 }
 
 static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
@@ -805,8 +805,8 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
     int i;
     fd->fd_type = A_FLOAT;
     fd->fd_var = 1;
-    if (!(s1 = strchr(s->s_name, '(')) || !(s2 = strchr(s->s_name, ')'))
-        || (s1 > s2))
+    if(!(s1 = strchr(s->s_name, '(')) || !(s2 = strchr(s->s_name, ')')) ||
+        (s1 > s2))
     {
         fd->fd_un.fd_varsym = s;
         fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 =
@@ -814,30 +814,25 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
     }
     else
     {
-        int cpy = (int)(s1 - s->s_name), got;
+        int cpy = (int) (s1 - s->s_name), got;
         double v1, v2, screen1, screen2, quantum;
-        if (cpy > MAXPDSTRING-5)
-            cpy = MAXPDSTRING-5;
+        if(cpy > MAXPDSTRING - 5) cpy = MAXPDSTRING - 5;
         strncpy(strbuf, s->s_name, cpy);
         strbuf[cpy] = 0;
         fd->fd_un.fd_varsym = gensym(strbuf);
-        got = sscanf(s1, "(%lf:%lf)(%lf:%lf)(%lf)",
-            &v1, &v2, &screen1, &screen2,
-                &quantum);
-        fd->fd_v1=v1;
-        fd->fd_v2=v2;
-        fd->fd_screen1=screen1;
-        fd->fd_screen2=screen2;
-        fd->fd_quantum=quantum;
-        if (got < 2)
-            goto fail;
-        if (got == 3 || (got < 4 && strchr(s2, '(')))
-            goto fail;
-        if (got < 5 && (s3 = strchr(s2, '(')) && strchr(s3+1, '('))
-            goto fail;
-        if (got == 4)
+        got = sscanf(s1, "(%lf:%lf)(%lf:%lf)(%lf)", &v1, &v2, &screen1,
+            &screen2, &quantum);
+        fd->fd_v1 = v1;
+        fd->fd_v2 = v2;
+        fd->fd_screen1 = screen1;
+        fd->fd_screen2 = screen2;
+        fd->fd_quantum = quantum;
+        if(got < 2) goto fail;
+        if(got == 3 || (got < 4 && strchr(s2, '('))) goto fail;
+        if(got < 5 && (s3 = strchr(s2, '(')) && strchr(s3 + 1, '(')) goto fail;
+        if(got == 4)
             fd->fd_quantum = 0;
-        else if (got == 2)
+        else if(got == 2)
         {
             fd->fd_quantum = 0;
             fd->fd_screen1 = fd->fd_v1;
@@ -856,155 +851,154 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
 #define NOMOUSERUN 4  /* disable mouse interaction when in run mode  */
 #define NOMOUSEEDIT 8 /* same in edit mode */
 #define NOVERTICES 16 /* disable only vertex grabbing in run mode */
-#define A_ARRAY 55      /* LATER decide whether to enshrine this in m_pd.h */
+#define A_ARRAY 55    /* LATER decide whether to enshrine this in m_pd.h */
 
 static void fielddesc_setfloatarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
-        if (argc <= 0) fielddesc_setfloat_const(fd, 0);
-        else if (argv->a_type == A_SYMBOL)
-            fielddesc_setfloat_var(fd, argv->a_w.w_symbol);
-        else fielddesc_setfloat_const(fd, argv->a_w.w_float);
+    if(argc <= 0)
+        fielddesc_setfloat_const(fd, 0);
+    else if(argv->a_type == A_SYMBOL)
+        fielddesc_setfloat_var(fd, argv->a_w.w_symbol);
+    else
+        fielddesc_setfloat_const(fd, argv->a_w.w_float);
 }
 
 static void fielddesc_setsymbolarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
-        if (argc <= 0) fielddesc_setsymbol_const(fd, &s_);
-        else if (argv->a_type == A_SYMBOL)
-        {
-            fd->fd_type = A_SYMBOL;
-            fd->fd_var = 1;
-            fd->fd_un.fd_varsym = argv->a_w.w_symbol;
-            fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 =
-                fd->fd_quantum = 0;
-        }
-        else fielddesc_setsymbol_const(fd, &s_);
+    if(argc <= 0)
+        fielddesc_setsymbol_const(fd, &s_);
+    else if(argv->a_type == A_SYMBOL)
+    {
+        fd->fd_type = A_SYMBOL;
+        fd->fd_var = 1;
+        fd->fd_un.fd_varsym = argv->a_w.w_symbol;
+        fd->fd_v1 = fd->fd_v2 = fd->fd_screen1 = fd->fd_screen2 =
+            fd->fd_quantum = 0;
+    }
+    else
+        fielddesc_setsymbol_const(fd, &s_);
 }
 
 static void fielddesc_setarrayarg(t_fielddesc *fd, int argc, t_atom *argv)
 {
-        if (argc <= 0) fielddesc_setfloat_const(fd, 0);
-        else if (argv->a_type == A_SYMBOL)
-        {
-            fd->fd_type = A_ARRAY;
-            fd->fd_var = 1;
-            fd->fd_un.fd_varsym = argv->a_w.w_symbol;
-        }
-        else fielddesc_setfloat_const(fd, argv->a_w.w_float);
+    if(argc <= 0)
+        fielddesc_setfloat_const(fd, 0);
+    else if(argv->a_type == A_SYMBOL)
+    {
+        fd->fd_type = A_ARRAY;
+        fd->fd_var = 1;
+        fd->fd_un.fd_varsym = argv->a_w.w_symbol;
+    }
+    else
+        fielddesc_setfloat_const(fd, argv->a_w.w_float);
 }
 
-    /* getting and setting values via fielddescs -- note confusing names;
-    the above are setting up the fielddesc itself. */
-static t_float fielddesc_getfloat(t_fielddesc *f, t_template *template,
-    t_word *wp, int loud)
+/* getting and setting values via fielddescs -- note confusing names;
+the above are setting up the fielddesc itself. */
+static t_float fielddesc_getfloat(
+    t_fielddesc *f, t_template *template, t_word *wp, int loud)
 {
-    if (f->fd_type == A_FLOAT)
+    if(f->fd_type == A_FLOAT)
     {
-        if (f->fd_var)
+        if(f->fd_var)
             return (template_getfloat(template, f->fd_un.fd_varsym, wp, loud));
-        else return (f->fd_un.fd_float);
+        else
+            return (f->fd_un.fd_float);
     }
     else
     {
-        if (loud)
-            pd_error(0, "symbolic data field used as number");
+        if(loud) pd_error(0, "symbolic data field used as number");
         return (0);
     }
 }
 
-    /* convert a variable's value to a screen coordinate via its fielddesc */
+/* convert a variable's value to a screen coordinate via its fielddesc */
 t_float fielddesc_cvttocoord(t_fielddesc *f, t_float val)
 {
     t_float coord, pix, extreme, div;
-    if (f->fd_v2 == f->fd_v1)
-        return (val);
-    div = (f->fd_screen2 - f->fd_screen1)/(f->fd_v2 - f->fd_v1);
+    if(f->fd_v2 == f->fd_v1) return (val);
+    div = (f->fd_screen2 - f->fd_screen1) / (f->fd_v2 - f->fd_v1);
     coord = f->fd_screen1 + (val - f->fd_v1) * div;
-    extreme = (f->fd_screen1 < f->fd_screen2 ?
-        f->fd_screen1 : f->fd_screen2);
-    if (coord < extreme)
-        coord = extreme;
-    extreme = (f->fd_screen1 > f->fd_screen2 ?
-        f->fd_screen1 : f->fd_screen2);
-    if (coord > extreme)
-        coord = extreme;
+    extreme = (f->fd_screen1 < f->fd_screen2 ? f->fd_screen1 : f->fd_screen2);
+    if(coord < extreme) coord = extreme;
+    extreme = (f->fd_screen1 > f->fd_screen2 ? f->fd_screen1 : f->fd_screen2);
+    if(coord > extreme) coord = extreme;
     return (coord);
 }
 
-    /* read a variable via fielddesc and convert to screen coordinate */
-t_float fielddesc_getcoord(t_fielddesc *f, t_template *template,
-    t_word *wp, int loud)
+/* read a variable via fielddesc and convert to screen coordinate */
+t_float fielddesc_getcoord(
+    t_fielddesc *f, t_template *template, t_word *wp, int loud)
 {
-    if (f->fd_type == A_FLOAT)
+    if(f->fd_type == A_FLOAT)
     {
-        if (f->fd_var)
+        if(f->fd_var)
         {
-            t_float val = template_getfloat(template,
-                f->fd_un.fd_varsym, wp, loud);
+            t_float val =
+                template_getfloat(template, f->fd_un.fd_varsym, wp, loud);
             return (fielddesc_cvttocoord(f, val));
         }
-        else return (f->fd_un.fd_float);
+        else
+            return (f->fd_un.fd_float);
     }
     else
     {
-        if (loud)
-            pd_error(0, "symbolic data field used as number");
+        if(loud) pd_error(0, "symbolic data field used as number");
         return (0);
     }
 }
 
-static t_symbol *fielddesc_getsymbol(t_fielddesc *f, t_template *template,
-    t_word *wp, int loud)
+static t_symbol *fielddesc_getsymbol(
+    t_fielddesc *f, t_template *template, t_word *wp, int loud)
 {
-    if (f->fd_type == A_SYMBOL)
+    if(f->fd_type == A_SYMBOL)
     {
-        if (f->fd_var)
-            return(template_getsymbol(template, f->fd_un.fd_varsym, wp, loud));
-        else return (f->fd_un.fd_symbol);
+        if(f->fd_var)
+            return (template_getsymbol(template, f->fd_un.fd_varsym, wp, loud));
+        else
+            return (f->fd_un.fd_symbol);
     }
     else
     {
-        if (loud)
-            pd_error(0, "numeric data field used as symbol");
+        if(loud) pd_error(0, "numeric data field used as symbol");
         return (&s_);
     }
 }
 
-    /* convert from a screen coordinate to a variable value */
+/* convert from a screen coordinate to a variable value */
 t_float fielddesc_cvtfromcoord(t_fielddesc *f, t_float coord)
 {
     t_float val;
-    if (f->fd_screen2 == f->fd_screen1)
+    if(f->fd_screen2 == f->fd_screen1)
         val = coord;
     else
     {
-        t_float div = (f->fd_v2 - f->fd_v1)/(f->fd_screen2 - f->fd_screen1);
+        t_float div = (f->fd_v2 - f->fd_v1) / (f->fd_screen2 - f->fd_screen1);
         t_float extreme;
         val = f->fd_v1 + (coord - f->fd_screen1) * div;
-        if (f->fd_quantum != 0)
-            val = ((int)((val/f->fd_quantum) + 0.5)) *  f->fd_quantum;
-        extreme = (f->fd_v1 < f->fd_v2 ?
-            f->fd_v1 : f->fd_v2);
-        if (val < extreme) val = extreme;
-        extreme = (f->fd_v1 > f->fd_v2 ?
-            f->fd_v1 : f->fd_v2);
-        if (val > extreme) val = extreme;
+        if(f->fd_quantum != 0)
+            val = ((int) ((val / f->fd_quantum) + 0.5)) * f->fd_quantum;
+        extreme = (f->fd_v1 < f->fd_v2 ? f->fd_v1 : f->fd_v2);
+        if(val < extreme) val = extreme;
+        extreme = (f->fd_v1 > f->fd_v2 ? f->fd_v1 : f->fd_v2);
+        if(val > extreme) val = extreme;
     }
     return (val);
- }
+}
 
-void fielddesc_setcoord(t_fielddesc *f, t_template *template,
-    t_word *wp, t_float coord, int loud)
+void fielddesc_setcoord(
+    t_fielddesc *f, t_template *template, t_word *wp, t_float coord, int loud)
 {
-    if (f->fd_type == A_FLOAT && f->fd_var)
+    if(f->fd_type == A_FLOAT && f->fd_var)
     {
         t_float val = fielddesc_cvtfromcoord(f, coord);
-        template_setfloat(template,
-                f->fd_un.fd_varsym, wp, val, loud);
+        template_setfloat(template, f->fd_un.fd_varsym, wp, val, loud);
     }
     else
     {
-        if (loud)
-            pd_error(0, "attempt to set constant or symbolic data field to a number");
+        if(loud)
+            pd_error(0,
+                "attempt to set constant or symbolic data field to a number");
     }
 }
 
@@ -1021,7 +1015,7 @@ t_class *curve_class;
 typedef struct _curve
 {
     t_object x_obj;
-    int x_flags;    /* CLOSED, BEZ, NOMOUSERUN, NOMOUSEEDIT */
+    int x_flags; /* CLOSED, BEZ, NOMOUSERUN, NOMOUSEEDIT */
     t_fielddesc x_fillcolor;
     t_fielddesc x_outlinecolor;
     t_fielddesc x_width;
@@ -1033,75 +1027,82 @@ typedef struct _curve
 
 static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
 {
-    t_curve *x = (t_curve *)pd_new(curve_class);
+    t_curve *x = (t_curve *) pd_new(curve_class);
     const char *classname = classsym->s_name;
     int flags = 0;
     int nxy, i;
     t_fielddesc *fd;
     x->x_canvas = canvas_getcurrent();
-    if (classname[0] == 'f')
+    if(classname[0] == 'f')
     {
         classname += 6;
         flags |= CLOSED;
     }
-    else classname += 4;
-    if (classname[0] == 'c') flags |= BEZ;
+    else
+        classname += 4;
+    if(classname[0] == 'c') flags |= BEZ;
     fielddesc_setfloat_const(&x->x_vis, 1);
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         const char *flag = argv->a_w.w_symbol->s_name;
-        if (!strcmp(flag, "-n"))
+        if(!strcmp(flag, "-n"))
         {
             fielddesc_setfloat_const(&x->x_vis, 0);
         }
-        else if (!strcmp(flag, "-v") && argc > 1)
+        else if(!strcmp(flag, "-v") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_vis, 1, argv+1);
-            argc -= 1; argv += 1;
+            fielddesc_setfloatarg(&x->x_vis, 1, argv + 1);
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(flag, "-x"))
+        else if(!strcmp(flag, "-x"))
         {
             /* disable all mouse interaction */
             flags |= (NOMOUSERUN | NOMOUSEEDIT);
         }
-        else if (!strcmp(flag, "-xr"))
+        else if(!strcmp(flag, "-xr"))
         {
             /* disable mouse actions in run mode */
             flags |= NOMOUSERUN;
         }
-        else if (!strcmp(flag, "-xe"))
+        else if(!strcmp(flag, "-xe"))
         {
             /* disable mouse actions in edit mode */
             flags |= NOMOUSEEDIT;
         }
-        else if (!strcmp(flag, "-xv"))
+        else if(!strcmp(flag, "-xv"))
         {
             /* disable changing vertices in run mode */
             flags |= NOVERTICES;
         }
         else
         {
-            pd_error(x, "%s: unknown flag '%s'...", classsym->s_name,
-                flag);
+            pd_error(x, "%s: unknown flag '%s'...", classsym->s_name, flag);
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
     x->x_flags = flags;
-    if ((flags & CLOSED) && argc)
+    if((flags & CLOSED) && argc)
         fielddesc_setfloatarg(&x->x_fillcolor, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_fillcolor, 0);
-    if (argc) fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_outlinecolor, 0);
-    if (argc) fielddesc_setfloatarg(&x->x_width, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_width, 1);
-    if (argc < 0) argc = 0;
-    nxy =  (argc + (argc & 1));
-    x->x_npoints = (nxy>>1);
-    x->x_vec = (t_fielddesc *)t_getbytes(nxy * sizeof(t_fielddesc));
-    for (i = 0, fd = x->x_vec; i < argc; i++, fd++, argv++)
+    else
+        fielddesc_setfloat_const(&x->x_fillcolor, 0);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_outlinecolor, 0);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_width, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_width, 1);
+    if(argc < 0) argc = 0;
+    nxy = (argc + (argc & 1));
+    x->x_npoints = (nxy >> 1);
+    x->x_vec = (t_fielddesc *) t_getbytes(nxy * sizeof(t_fielddesc));
+    for(i = 0, fd = x->x_vec; i < argc; i++, fd++, argv++)
         fielddesc_setfloatarg(fd, 1, argv);
-    if (argc & 1) fielddesc_setfloat_const(fd, 0);
+    if(argc & 1) fielddesc_setfloat_const(fd, 0);
 
     return (x);
 }
@@ -1109,15 +1110,14 @@ static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
 void curve_float(t_curve *x, t_floatarg f)
 {
     int viswas;
-    if (x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
+    if(x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
     {
         pd_error(x, "global vis/invis for a template with variable visibility");
         return;
     }
     viswas = (x->x_vis.fd_un.fd_float != 0);
 
-    if ((f != 0 && viswas) || (f == 0 && !viswas))
-        return;
+    if((f != 0 && viswas) || (f == 0 && !viswas)) return;
     canvas_redrawallfortemplatecanvas(x->x_canvas, 2);
     fielddesc_setfloat_const(&x->x_vis, (f != 0));
     canvas_redrawallfortemplatecanvas(x->x_canvas, 1);
@@ -1125,15 +1125,15 @@ void curve_float(t_curve *x, t_floatarg f)
 
 /* -------------------- widget behavior for curve ------------ */
 
-static void curve_getrect(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void curve_getrect(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int *xp1, int *yp1,
+    int *xp2, int *yp2)
 {
-    t_curve *x = (t_curve *)z;
+    t_curve *x = (t_curve *) z;
     int i, n = x->x_npoints;
     t_fielddesc *f = x->x_vec;
     int x1 = 0x7fffffff, x2 = -0x7fffffff, y1 = 0x7fffffff, y2 = -0x7fffffff;
-    if (!fielddesc_getfloat(&x->x_vis, template, data, 0) ||
+    if(!fielddesc_getfloat(&x->x_vis, template, data, 0) ||
         (glist->gl_edit && x->x_flags & NOMOUSEEDIT) ||
         (!glist->gl_edit && x->x_flags & NOMOUSERUN))
     {
@@ -1141,16 +1141,16 @@ static void curve_getrect(t_gobj *z, t_glist *glist,
         *xp2 = *yp2 = -0x7fffffff;
         return;
     }
-    for (i = 0, f = x->x_vec; i < n; i++, f += 2)
+    for(i = 0, f = x->x_vec; i < n; i++, f += 2)
     {
-        int xloc = glist_xtopixels(glist,
-            basex + fielddesc_getcoord(f, template, data, 0));
-        int yloc = glist_ytopixels(glist,
-            basey + fielddesc_getcoord(f+1, template, data, 0));
-        if (xloc < x1) x1 = xloc;
-        if (xloc > x2) x2 = xloc;
-        if (yloc < y1) y1 = yloc;
-        if (yloc > y2) y2 = yloc;
+        int xloc = glist_xtopixels(
+            glist, basex + fielddesc_getcoord(f, template, data, 0));
+        int yloc = glist_ytopixels(
+            glist, basey + fielddesc_getcoord(f + 1, template, data, 0));
+        if(xloc < x1) x1 = xloc;
+        if(xloc > x2) x2 = xloc;
+        if(yloc < y1) y1 = yloc;
+        if(yloc > y2) y2 = yloc;
     }
     *xp1 = x1;
     *yp1 = y1;
@@ -1158,23 +1158,20 @@ static void curve_getrect(t_gobj *z, t_glist *glist,
     *yp2 = y2;
 }
 
-static void curve_displace(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int dx, int dy)
+static void curve_displace(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int dx, int dy)
 {
     /* refuse */
 }
 
-static void curve_select(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void curve_select(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
 {
     /* fill in later */
 }
 
-static void curve_activate(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void curve_activate(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
 {
     /* fill in later */
 }
@@ -1189,18 +1186,18 @@ static int rangecolor(int n)    /* 0 to 9 in 5 steps */
 }
 #endif
 
-static int rangecolor(int n)    /* 0 to 9 in 5 steps */
+static int rangecolor(int n) /* 0 to 9 in 5 steps */
 {
-    int n2 = (n == 9 ? 8 : n);               /* 0 to 8 */
-    int ret = (n2 << 5);        /* 0 to 256 in 9 steps */
-    if (ret > 255) ret = 255;
+    int n2 = (n == 9 ? 8 : n); /* 0 to 8 */
+    int ret = (n2 << 5);       /* 0 to 256 in 9 steps */
+    if(ret > 255) ret = 255;
     return (ret);
 }
 
 static void numbertocolor(int n, char *s)
 {
     int red, blue, green;
-    if (n < 0) n = 0;
+    if(n < 0) n = 0;
     red = n / 100;
     blue = ((n / 10) % 10);
     green = n % 10;
@@ -1208,146 +1205,139 @@ static void numbertocolor(int n, char *s)
         rangecolor(green));
 }
 
-static void curve_vis(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int vis)
+static void curve_vis(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int vis)
 {
-    t_curve *x = (t_curve *)z;
+    t_curve *x = (t_curve *) z;
     int i, n = x->x_npoints;
     t_fielddesc *f = x->x_vec;
 
-        /* see comment in plot_vis() */
-    if (vis && !fielddesc_getfloat(&x->x_vis, template, data, 0))
-        return;
-    if (vis)
+    /* see comment in plot_vis() */
+    if(vis && !fielddesc_getfloat(&x->x_vis, template, data, 0)) return;
+    if(vis)
     {
-        if (n > 1)
+        if(n > 1)
         {
             int flags = x->x_flags, closed = (flags & CLOSED);
             t_float width = fielddesc_getfloat(&x->x_width, template, data, 1);
             char outline[20], fill[20];
             int pix[200];
-            if (n > 100)
-                n = 100;
-                /* calculate the pixel values before we start printing
-                out the TK message so that "error" printout won't be
-                interspersed with it.  Only show up to 100 points so we don't
-                have to allocate memory here. */
-            for (i = 0, f = x->x_vec; i < n; i++, f += 2)
+            if(n > 100) n = 100;
+            /* calculate the pixel values before we start printing
+            out the TK message so that "error" printout won't be
+            interspersed with it.  Only show up to 100 points so we don't
+            have to allocate memory here. */
+            for(i = 0, f = x->x_vec; i < n; i++, f += 2)
             {
-                pix[2*i] = glist_xtopixels(glist,
-                    basex + fielddesc_getcoord(f, template, data, 1));
-                pix[2*i+1] = glist_ytopixels(glist,
-                    basey + fielddesc_getcoord(f+1, template, data, 1));
+                pix[2 * i] = glist_xtopixels(
+                    glist, basex + fielddesc_getcoord(f, template, data, 1));
+                pix[2 * i + 1] = glist_ytopixels(glist,
+                    basey + fielddesc_getcoord(f + 1, template, data, 1));
             }
-            if (width < 1) width = 1;
-            if (glist->gl_isgraph)
-                width *= glist_getzoom(glist);
+            if(width < 1) width = 1;
+            if(glist->gl_isgraph) width *= glist_getzoom(glist);
             numbertocolor(
                 fielddesc_getfloat(&x->x_outlinecolor, template, data, 1),
                 outline);
-            if (flags & CLOSED)
+            if(flags & CLOSED)
             {
                 numbertocolor(
                     fielddesc_getfloat(&x->x_fillcolor, template, data, 1),
                     fill);
-                sys_vgui(".x%lx.c create polygon\\\n",
-                    glist_getcanvas(glist));
+                sys_vgui(".x%lx.c create polygon\\\n", glist_getcanvas(glist));
             }
-            else sys_vgui(".x%lx.c create line\\\n", glist_getcanvas(glist));
-            for (i = 0; i < n; i++)
-                sys_vgui("%d %d\\\n", pix[2*i], pix[2*i+1]);
+            else
+                sys_vgui(".x%lx.c create line\\\n", glist_getcanvas(glist));
+            for(i = 0; i < n; i++)
+                sys_vgui("%d %d\\\n", pix[2 * i], pix[2 * i + 1]);
             sys_vgui("-width %f\\\n", width);
-            if (flags & CLOSED) sys_vgui("-fill %s -outline %s\\\n",
-                fill, outline);
-            else sys_vgui("-fill %s\\\n", outline);
-            if (flags & BEZ) sys_vgui("-smooth 1\\\n");
+            if(flags & CLOSED)
+                sys_vgui("-fill %s -outline %s\\\n", fill, outline);
+            else
+                sys_vgui("-fill %s\\\n", outline);
+            if(flags & BEZ) sys_vgui("-smooth 1\\\n");
             sys_vgui("-tags curve%lx\n", data);
         }
-        else post("warning: drawing shapes need at least two points to be graphed");
+        else
+            post("warning: drawing shapes need at least two points to be "
+                 "graphed");
     }
     else
     {
-        if (n > 1) sys_vgui(".x%lx.c delete curve%lx\n",
-            glist_getcanvas(glist), data);
+        if(n > 1)
+            sys_vgui(".x%lx.c delete curve%lx\n", glist_getcanvas(glist), data);
     }
 }
 
-    /* LATER protect against the template changing or the scalar disappearing
-    probably by attaching a gpointer here ... */
+/* LATER protect against the template changing or the scalar disappearing
+probably by attaching a gpointer here ... */
 
 static void curve_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
-    t_curve *x = (t_curve *)z;
+    t_curve *x = (t_curve *) z;
     t_fielddesc *f = x->x_vec + TEMPLATE->curve_motion_field;
     t_atom at;
-    if (up != 0)
-        return;
-    if (!gpointer_check(&TEMPLATE->curve_motion_gpointer, 0))
+    if(up != 0) return;
+    if(!gpointer_check(&TEMPLATE->curve_motion_gpointer, 0))
     {
         post("curve_motion: scalar disappeared");
         return;
     }
     TEMPLATE->curve_motion_xcumulative += dx;
     TEMPLATE->curve_motion_ycumulative += dy;
-    if (f->fd_var && (dx != 0))
+    if(f->fd_var && (dx != 0))
     {
         fielddesc_setcoord(f, TEMPLATE->curve_motion_template,
             TEMPLATE->curve_motion_wp,
-            TEMPLATE->curve_motion_xbase +
-            TEMPLATE->curve_motion_xcumulative * TEMPLATE->curve_motion_xper,
-                1);
+            TEMPLATE->curve_motion_xbase + TEMPLATE->curve_motion_xcumulative *
+                                               TEMPLATE->curve_motion_xper,
+            1);
     }
-    if ((f+1)->fd_var && (dy != 0))
+    if((f + 1)->fd_var && (dy != 0))
     {
-        fielddesc_setcoord(f+1, TEMPLATE->curve_motion_template,
+        fielddesc_setcoord(f + 1, TEMPLATE->curve_motion_template,
             TEMPLATE->curve_motion_wp,
-            TEMPLATE->curve_motion_ybase +
-            TEMPLATE->curve_motion_ycumulative * TEMPLATE->curve_motion_yper,
-                1);
+            TEMPLATE->curve_motion_ybase + TEMPLATE->curve_motion_ycumulative *
+                                               TEMPLATE->curve_motion_yper,
+            1);
     }
-        /* LATER figure out what to do to notify for an array? */
-    if (TEMPLATE->curve_motion_scalar)
+    /* LATER figure out what to do to notify for an array? */
+    if(TEMPLATE->curve_motion_scalar)
         template_notifyforscalar(TEMPLATE->curve_motion_template,
-            TEMPLATE->curve_motion_glist,
-            TEMPLATE->curve_motion_scalar, gensym("change"), 1, &at);
-    if (TEMPLATE->curve_motion_scalar)
-        scalar_redraw(TEMPLATE->curve_motion_scalar,
-            TEMPLATE->curve_motion_glist);
-    if (TEMPLATE->curve_motion_array)
-        array_redraw(TEMPLATE->curve_motion_array,
-            TEMPLATE->curve_motion_glist);
+            TEMPLATE->curve_motion_glist, TEMPLATE->curve_motion_scalar,
+            gensym("change"), 1, &at);
+    if(TEMPLATE->curve_motion_scalar)
+        scalar_redraw(
+            TEMPLATE->curve_motion_scalar, TEMPLATE->curve_motion_glist);
+    if(TEMPLATE->curve_motion_array)
+        array_redraw(
+            TEMPLATE->curve_motion_array, TEMPLATE->curve_motion_glist);
 }
 
-static int curve_click(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_scalar *sc, t_array *ap,
-    t_float basex, t_float basey,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int curve_click(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_scalar *sc, t_array *ap, t_float basex,
+    t_float basey, int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
-    t_curve *x = (t_curve *)z;
+    t_curve *x = (t_curve *) z;
     int i, n = x->x_npoints;
     int bestn = -1;
     int besterror = 0x7fffffff;
     t_fielddesc *f;
-    if ((x->x_flags & NOMOUSERUN) || (x->x_flags & NOVERTICES) ||
+    if((x->x_flags & NOMOUSERUN) || (x->x_flags & NOVERTICES) ||
         !fielddesc_getfloat(&x->x_vis, template, data, 0))
-            return (0);
-    for (i = 0, f = x->x_vec; i < n; i++, f += 2)
+        return (0);
+    for(i = 0, f = x->x_vec; i < n; i++, f += 2)
     {
         int xval = fielddesc_getcoord(f, template, data, 0),
             xloc = glist_xtopixels(glist, basex + xval);
-        int yval = fielddesc_getcoord(f+1, template, data, 0),
+        int yval = fielddesc_getcoord(f + 1, template, data, 0),
             yloc = glist_ytopixels(glist, basey + yval);
         int xerr = xloc - xpix, yerr = yloc - ypix;
-        if (!f->fd_var && !(f+1)->fd_var)
-            continue;
-        if (xerr < 0)
-            xerr = -xerr;
-        if (yerr < 0)
-            yerr = -yerr;
-        if (yerr > xerr)
-            xerr = yerr;
-        if (xerr < besterror)
+        if(!f->fd_var && !(f + 1)->fd_var) continue;
+        if(xerr < 0) xerr = -xerr;
+        if(yerr < 0) yerr = -yerr;
+        if(yerr > xerr) xerr = yerr;
+        if(xerr < besterror)
         {
             TEMPLATE->curve_motion_xbase = xval;
             TEMPLATE->curve_motion_ybase = yval;
@@ -1355,34 +1345,33 @@ static int curve_click(t_gobj *z, t_glist *glist,
             bestn = i;
         }
     }
-    if (besterror > 6)
-        return (0);
-    if (doit)
+    if(besterror > 6) return (0);
+    if(doit)
     {
-        TEMPLATE->curve_motion_xper = glist_pixelstox(glist, 1)
-            - glist_pixelstox(glist, 0);
-        TEMPLATE->curve_motion_yper = glist_pixelstoy(glist, 1)
-            - glist_pixelstoy(glist, 0);
+        TEMPLATE->curve_motion_xper =
+            glist_pixelstox(glist, 1) - glist_pixelstox(glist, 0);
+        TEMPLATE->curve_motion_yper =
+            glist_pixelstoy(glist, 1) - glist_pixelstoy(glist, 0);
         TEMPLATE->curve_motion_xcumulative = 0;
         TEMPLATE->curve_motion_ycumulative = 0;
         TEMPLATE->curve_motion_glist = glist;
         TEMPLATE->curve_motion_scalar = sc;
         TEMPLATE->curve_motion_array = ap;
         TEMPLATE->curve_motion_wp = data;
-        TEMPLATE->curve_motion_field = 2*bestn;
+        TEMPLATE->curve_motion_field = 2 * bestn;
         TEMPLATE->curve_motion_template = template;
-        if (TEMPLATE->curve_motion_scalar)
+        if(TEMPLATE->curve_motion_scalar)
             gpointer_setglist(&TEMPLATE->curve_motion_gpointer,
                 TEMPLATE->curve_motion_glist, TEMPLATE->curve_motion_scalar);
-        else gpointer_setarray(&TEMPLATE->curve_motion_gpointer,
+        else
+            gpointer_setarray(&TEMPLATE->curve_motion_gpointer,
                 TEMPLATE->curve_motion_array, TEMPLATE->curve_motion_wp);
         glist_grab(glist, z, curve_motionfn, 0, xpix, ypix);
     }
     return (1);
 }
 
-const t_parentwidgetbehavior curve_widgetbehavior =
-{
+const t_parentwidgetbehavior curve_widgetbehavior = {
     curve_getrect,
     curve_displace,
     curve_select,
@@ -1398,15 +1387,14 @@ static void curve_free(t_curve *x)
 
 static void curve_setup(void)
 {
-    curve_class = class_new(gensym("drawpolygon"), (t_newmethod)curve_new,
-        (t_method)curve_free, sizeof(t_curve), 0, A_GIMME, 0);
+    curve_class = class_new(gensym("drawpolygon"), (t_newmethod) curve_new,
+        (t_method) curve_free, sizeof(t_curve), 0, A_GIMME, 0);
     class_setdrawcommand(curve_class);
-    class_addcreator((t_newmethod)curve_new, gensym("drawcurve"),
-        A_GIMME, 0);
-    class_addcreator((t_newmethod)curve_new, gensym("filledpolygon"),
-        A_GIMME, 0);
-    class_addcreator((t_newmethod)curve_new, gensym("filledcurve"),
-        A_GIMME, 0);
+    class_addcreator((t_newmethod) curve_new, gensym("drawcurve"), A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) curve_new, gensym("filledpolygon"), A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) curve_new, gensym("filledcurve"), A_GIMME, 0);
     class_sethelpsymbol(curve_class, gensym("draw-shapes"));
     class_setparentwidget(curve_class, &curve_widgetbehavior);
     class_addfloat(curve_class, curve_float);
@@ -1430,14 +1418,14 @@ typedef struct _plot
     t_fielddesc x_xpoints;
     t_fielddesc x_ypoints;
     t_fielddesc x_wpoints;
-    t_fielddesc x_vis;          /* visible */
-    t_fielddesc x_scalarvis;    /* true if drawing the scalar at each point */
-    t_fielddesc x_edit;         /* enable/disable mouse editing */
+    t_fielddesc x_vis;       /* visible */
+    t_fielddesc x_scalarvis; /* true if drawing the scalar at each point */
+    t_fielddesc x_edit;      /* enable/disable mouse editing */
 } t_plot;
 
 static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
 {
-    t_plot *x = (t_plot *)pd_new(plot_class);
+    t_plot *x = (t_plot *) pd_new(plot_class);
     int defstyle = PLOTSTYLE_POLY;
     x->x_canvas = canvas_getcurrent();
 
@@ -1448,82 +1436,103 @@ static void *plot_new(t_symbol *classsym, int argc, t_atom *argv)
     fielddesc_setfloat_const(&x->x_vis, 1);
     fielddesc_setfloat_const(&x->x_scalarvis, 1);
     fielddesc_setfloat_const(&x->x_edit, 1);
-    while (1)
+    while(1)
     {
         t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-        if (!strcmp(firstarg->s_name, "curve") ||
+        if(!strcmp(firstarg->s_name, "curve") ||
             !strcmp(firstarg->s_name, "-c"))
         {
             defstyle = PLOTSTYLE_BEZ;
             argc--, argv++;
         }
-        else if (!strcmp(firstarg->s_name, "-v") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-v") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_vis, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_vis, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(firstarg->s_name, "-vs") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-vs") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_scalarvis, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_scalarvis, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(firstarg->s_name, "-x") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-x") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_xpoints, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_xpoints, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(firstarg->s_name, "-y") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-y") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_ypoints, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_ypoints, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(firstarg->s_name, "-w") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-w") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_wpoints, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_wpoints, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(firstarg->s_name, "-e") && argc > 1)
+        else if(!strcmp(firstarg->s_name, "-e") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_edit, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_edit, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else if (*firstarg->s_name == '-')
+        else if(*firstarg->s_name == '-')
         {
             pd_error(x, "%s: unknown flag '%s'...", classsym->s_name,
                 firstarg->s_name);
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else break;
+        else
+            break;
     }
-    if (argc) fielddesc_setarrayarg(&x->x_data, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_data, 1);
-    if (argc) fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_outlinecolor, 0);
-    if (argc) fielddesc_setfloatarg(&x->x_width, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_width, 1);
-    if (argc) fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_xloc, 1);
-    if (argc) fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_yloc, 1);
-    if (argc) fielddesc_setfloatarg(&x->x_xinc, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_xinc, 1);
-    if (argc) fielddesc_setfloatarg(&x->x_style, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_style, defstyle);
+    if(argc)
+        fielddesc_setarrayarg(&x->x_data, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_data, 1);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_outlinecolor, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_outlinecolor, 0);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_width, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_width, 1);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_xloc, 1);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_yloc, 1);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_xinc, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_xinc, 1);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_style, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_style, defstyle);
     return (x);
 }
 
 void plot_float(t_plot *x, t_floatarg f)
 {
     int viswas;
-    if (x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
+    if(x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
     {
         pd_error(x, "global vis/invis for a template with variable visibility");
         return;
     }
     viswas = (x->x_vis.fd_un.fd_float != 0);
 
-    if ((f != 0 && viswas) || (f == 0 && !viswas))
-        return;
+    if((f != 0 && viswas) || (f == 0 && !viswas)) return;
     canvas_redrawallfortemplatecanvas(x->x_canvas, 2);
     fielddesc_setfloat_const(&x->x_vis, (f != 0));
     canvas_redrawallfortemplatecanvas(x->x_canvas, 1);
@@ -1531,12 +1540,10 @@ void plot_float(t_plot *x, t_floatarg f)
 
 /* -------------------- widget behavior for plot ------------ */
 
-
-    /* get everything we'll need from the owner template of the array being
-    plotted. Not used for garrays, but see below */
-static int plot_readownertemplate(t_plot *x,
-    t_word *data, t_template *ownertemplate,
-    t_symbol **elemtemplatesymp, t_array **arrayp,
+/* get everything we'll need from the owner template of the array being
+plotted. Not used for garrays, but see below */
+static int plot_readownertemplate(t_plot *x, t_word *data,
+    t_template *ownertemplate, t_symbol **elemtemplatesymp, t_array **arrayp,
     t_float *linewidthp, t_float *xlocp, t_float *xincp, t_float *ylocp,
     t_float *stylep, t_float *visp, t_float *scalarvisp, t_float *editp,
     t_fielddesc **xfield, t_fielddesc **yfield, t_fielddesc **wfield)
@@ -1545,24 +1552,26 @@ static int plot_readownertemplate(t_plot *x,
     t_symbol *elemtemplatesym;
     t_array *array;
 
-        /* find the data and verify it's an array */
-    if (x->x_data.fd_type != A_ARRAY || !x->x_data.fd_var)
+    /* find the data and verify it's an array */
+    if(x->x_data.fd_type != A_ARRAY || !x->x_data.fd_var)
     {
         pd_error(0, "plot: needs an array field");
         return (-1);
     }
-    if (!template_find_field(ownertemplate, x->x_data.fd_un.fd_varsym,
-        &arrayonset, &type, &elemtemplatesym))
+    if(!template_find_field(ownertemplate, x->x_data.fd_un.fd_varsym,
+           &arrayonset, &type, &elemtemplatesym))
     {
-        pd_error(0, "plot: %s: no such field", x->x_data.fd_un.fd_varsym->s_name);
+        pd_error(
+            0, "plot: %s: no such field", x->x_data.fd_un.fd_varsym->s_name);
         return (-1);
     }
-    if (type != DT_ARRAY)
+    if(type != DT_ARRAY)
     {
-        pd_error(0, "plot: %s: not an array", x->x_data.fd_un.fd_varsym->s_name);
+        pd_error(
+            0, "plot: %s: not an array", x->x_data.fd_un.fd_varsym->s_name);
         return (-1);
     }
-    array = *(t_array **)(((char *)data) + arrayonset);
+    array = *(t_array **) (((char *) data) + arrayonset);
     *linewidthp = fielddesc_getfloat(&x->x_width, ownertemplate, data, 1);
     *xlocp = fielddesc_getfloat(&x->x_xloc, ownertemplate, data, 1);
     *xincp = fielddesc_getfloat(&x->x_xinc, ownertemplate, data, 1);
@@ -1579,55 +1588,58 @@ static int plot_readownertemplate(t_plot *x,
     return (0);
 }
 
-    /* get everything else you could possibly need about a plot,
-    either for plot's own purposes or for plotting a "garray" */
-int array_getfields(t_symbol *elemtemplatesym,
-    t_canvas **elemtemplatecanvasp,
-    t_template **elemtemplatep, int *elemsizep,
-    t_fielddesc *xfielddesc, t_fielddesc *yfielddesc, t_fielddesc *wfielddesc,
-    int *xonsetp, int *yonsetp, int *wonsetp)
+/* get everything else you could possibly need about a plot,
+either for plot's own purposes or for plotting a "garray" */
+int array_getfields(t_symbol *elemtemplatesym, t_canvas **elemtemplatecanvasp,
+    t_template **elemtemplatep, int *elemsizep, t_fielddesc *xfielddesc,
+    t_fielddesc *yfielddesc, t_fielddesc *wfielddesc, int *xonsetp,
+    int *yonsetp, int *wonsetp)
 {
     int arrayonset, elemsize, yonset, wonset, xonset, type;
     t_template *elemtemplate;
     t_symbol *dummy, *varname;
     t_canvas *elemtemplatecanvas = 0;
 
-        /* the "float" template is special in not having to have a canvas;
-        template_findbyname is hardwired to return a predefined
-        template. */
+    /* the "float" template is special in not having to have a canvas;
+    template_findbyname is hardwired to return a predefined
+    template. */
 
-    if (!(elemtemplate =  template_findbyname(elemtemplatesym)))
+    if(!(elemtemplate = template_findbyname(elemtemplatesym)))
     {
         pd_error(0, "plot: %s: no such template", elemtemplatesym->s_name);
         return (-1);
     }
-    if (!((elemtemplatesym == &s_float) ||
-        (elemtemplatecanvas = template_findcanvas(elemtemplate))))
+    if(!((elemtemplatesym == &s_float) ||
+           (elemtemplatecanvas = template_findcanvas(elemtemplate))))
     {
-        pd_error(0, "plot: %s: no canvas for this template", elemtemplatesym->s_name);
+        pd_error(0, "plot: %s: no canvas for this template",
+            elemtemplatesym->s_name);
         return (-1);
     }
     elemsize = elemtemplate->t_n * sizeof(t_word);
-    if (yfielddesc && yfielddesc->fd_var)
+    if(yfielddesc && yfielddesc->fd_var)
         varname = yfielddesc->fd_un.fd_varsym;
-    else varname = gensym("y");
-    if (!template_find_field(elemtemplate, varname, &yonset, &type, &dummy)
-        || type != DT_FLOAT)
-            yonset = -1;
-    if (xfielddesc && xfielddesc->fd_var)
+    else
+        varname = gensym("y");
+    if(!template_find_field(elemtemplate, varname, &yonset, &type, &dummy) ||
+        type != DT_FLOAT)
+        yonset = -1;
+    if(xfielddesc && xfielddesc->fd_var)
         varname = xfielddesc->fd_un.fd_varsym;
-    else varname = gensym("x");
-    if (!template_find_field(elemtemplate, varname, &xonset, &type, &dummy)
-        || type != DT_FLOAT)
-            xonset = -1;
-    if (wfielddesc && wfielddesc->fd_var)
+    else
+        varname = gensym("x");
+    if(!template_find_field(elemtemplate, varname, &xonset, &type, &dummy) ||
+        type != DT_FLOAT)
+        xonset = -1;
+    if(wfielddesc && wfielddesc->fd_var)
         varname = wfielddesc->fd_un.fd_varsym;
-    else varname = gensym("w");
-    if (!template_find_field(elemtemplate, varname, &wonset, &type, &dummy)
-        || type != DT_FLOAT)
-            wonset = -1;
+    else
+        varname = gensym("w");
+    if(!template_find_field(elemtemplate, varname, &wonset, &type, &dummy) ||
+        type != DT_FLOAT)
+        wonset = -1;
 
-        /* fill in slots for return values */
+    /* fill in slots for return values */
     *elemtemplatecanvasp = elemtemplatecanvas;
     *elemtemplatep = elemtemplate;
     *elemsizep = elemsize;
@@ -1637,11 +1649,11 @@ int array_getfields(t_symbol *elemtemplatesym,
     return (0);
 }
 
-static void plot_getrect(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void plot_getrect(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int *xp1, int *yp1,
+    int *xp2, int *yp2)
 {
-    t_plot *x = (t_plot *)z;
+    t_plot *x = (t_plot *) z;
     int elemsize, yonset, wonset, xonset;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
@@ -1653,72 +1665,67 @@ static void plot_getrect(t_gobj *z, t_glist *glist,
     int i;
     t_float xpix, ypix, wpix;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
-        /* if we're the only plot in the glist claim the whole thing */
-    if (glist->gl_list && !glist->gl_list->g_next)
+    /* if we're the only plot in the glist claim the whole thing */
+    if(glist->gl_list && !glist->gl_list->g_next)
     {
         *xp1 = *yp1 = -0x7fffffff;
         *xp2 = *yp2 = 0x7fffffff;
         return;
     }
-    if (!plot_readownertemplate(x, data, template,
-        &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-            &vis, &scalarvis, &edit, &xfielddesc, &yfielddesc, &wfielddesc) &&
-                (vis != 0) &&
-            !array_getfields(elemtemplatesym, &elemtemplatecanvas,
-                &elemtemplate, &elemsize,
-                xfielddesc, yfielddesc, wfielddesc,
-                &xonset, &yonset, &wonset))
+    if(!plot_readownertemplate(x, data, template, &elemtemplatesym, &array,
+           &linewidth, &xloc, &xinc, &yloc, &style, &vis, &scalarvis, &edit,
+           &xfielddesc, &yfielddesc, &wfielddesc) &&
+        (vis != 0) &&
+        !array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
+            &elemsize, xfielddesc, yfielddesc, wfielddesc, &xonset, &yonset,
+            &wonset))
     {
-            /* if it has more than 2000 points, just check 1000 of them. */
+        /* if it has more than 2000 points, just check 1000 of them. */
         int incr = (array->a_n <= 2000 ? 1 : array->a_n / 1000);
-        for (i = 0, xsum = 0; i < array->a_n; i += incr)
+        for(i = 0, xsum = 0; i < array->a_n; i += incr)
         {
             t_float usexloc, useyloc;
             t_gobj *y;
-                /* get the coords of the point proper */
-            array_getcoordinate(glist, (char *)(array->a_vec) + i * elemsize,
+            /* get the coords of the point proper */
+            array_getcoordinate(glist, (char *) (array->a_vec) + i * elemsize,
                 xonset, yonset, wonset, i, basex + xloc, basey + yloc, xinc,
                 xfielddesc, yfielddesc, wfielddesc, &xpix, &ypix, &wpix);
-            if (xpix < x1)
-                x1 = xpix;
-            if (xpix > x2)
-                x2 = xpix;
-            if (ypix - wpix < y1)
-                y1 = ypix - wpix;
-            if (ypix + wpix > y2)
-                y2 = ypix + wpix;
+            if(xpix < x1) x1 = xpix;
+            if(xpix > x2) x2 = xpix;
+            if(ypix - wpix < y1) y1 = ypix - wpix;
+            if(ypix + wpix > y2) y2 = ypix + wpix;
 
-            if (scalarvis != 0)
+            if(scalarvis != 0)
             {
-                    /* check also the drawing instructions for the scalar */
-                if (xonset >= 0)
-                    usexloc = basex + xloc + fielddesc_cvttocoord(xfielddesc,
-                        *(t_float *)(((char *)(array->a_vec) + elemsize * i)
-                            + xonset));
-                else usexloc = basex + xsum, xsum += xinc;
-                if (yonset >= 0)
-                    yval = *(t_float *)(((char *)(array->a_vec) + elemsize * i)
-                        + yonset);
-                else yval = 0;
+                /* check also the drawing instructions for the scalar */
+                if(xonset >= 0)
+                    usexloc = basex + xloc +
+                              fielddesc_cvttocoord(xfielddesc,
+                                  *(t_float *) (((char *) (array->a_vec) +
+                                                    elemsize * i) +
+                                                xonset));
+                else
+                    usexloc = basex + xsum, xsum += xinc;
+                if(yonset >= 0)
+                    yval =
+                        *(t_float *) (((char *) (array->a_vec) + elemsize * i) +
+                                      yonset);
+                else
+                    yval = 0;
                 useyloc = basey + yloc + fielddesc_cvttocoord(yfielddesc, yval);
-                for (y = elemtemplatecanvas->gl_list; y; y = y->g_next)
+                for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
                     int xx1, xx2, yy1, yy2;
                     const t_parentwidgetbehavior *wb =
                         pd_getparentwidget(&y->g_pd);
-                    if (!wb) continue;
+                    if(!wb) continue;
                     (*wb->w_parentgetrectfn)(y, glist,
-                        (t_word *)((char *)(array->a_vec) + elemsize * i),
-                            elemtemplate, usexloc, useyloc,
-                                &xx1, &yy1, &xx2, &yy2);
-                    if (xx1 < x1)
-                        x1 = xx1;
-                    if (yy1 < y1)
-                        y1 = yy1;
-                     if (xx2 > x2)
-                        x2 = xx2;
-                    if (yy2 > y2)
-                        y2 = yy2;
+                        (t_word *) ((char *) (array->a_vec) + elemsize * i),
+                        elemtemplate, usexloc, useyloc, &xx1, &yy1, &xx2, &yy2);
+                    if(xx1 < x1) x1 = xx1;
+                    if(yy1 < y1) y1 = yy1;
+                    if(xx2 > x2) x2 = xx2;
+                    if(yy2 > y2) y2 = yy2;
                 }
             }
         }
@@ -1730,123 +1737,121 @@ static void plot_getrect(t_gobj *z, t_glist *glist,
     *yp2 = y2;
 }
 
-static void plot_displace(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int dx, int dy)
-{
-        /* not yet */
-}
-
-static void plot_select(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void plot_displace(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int dx, int dy)
 {
     /* not yet */
 }
 
-static void plot_activate(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void plot_select(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
 {
-        /* not yet */
+    /* not yet */
+}
+
+static void plot_activate(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
+{
+    /* not yet */
 }
 
 #define CLIP(x) ((x) < 1e20 && (x) > -1e20 ? x : 0)
 
-static void plot_vis(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int tovis)
+static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int tovis)
 {
-    t_plot *x = (t_plot *)z;
+    t_plot *x = (t_plot *) z;
     int elemsize, yonset, wonset, xonset, i;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval,
-        vis, scalarvis, edit;
+    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval, vis, scalarvis,
+        edit;
     double xsum;
     t_array *array;
     int nelem;
     char *elem;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
-        /* even if the array is "invisible", if its visibility is
-        set by an instance variable you have to explicitly erase it,
-        because the flag could earlier have been on when we were getting
-        drawn.  Rather than look to try to find out whether we're
-        visible we just do the erasure.  At the TK level this should
-        cause no action because the tag matches nobody.  LATER we
-        might want to optimize this somehow.  Ditto the "vis()" routines
-        for other drawing instructions. */
+    /* even if the array is "invisible", if its visibility is
+    set by an instance variable you have to explicitly erase it,
+    because the flag could earlier have been on when we were getting
+    drawn.  Rather than look to try to find out whether we're
+    visible we just do the erasure.  At the TK level this should
+    cause no action because the tag matches nobody.  LATER we
+    might want to optimize this somehow.  Ditto the "vis()" routines
+    for other drawing instructions. */
 
-    if (plot_readownertemplate(x, data, template,
-        &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-        &vis, &scalarvis, &edit, &xfielddesc, &yfielddesc, &wfielddesc) ||
-            ((vis == 0) && tovis) /* see above for 'tovis' */
-            || array_getfields(elemtemplatesym, &elemtemplatecanvas,
-                &elemtemplate, &elemsize, xfielddesc, yfielddesc, wfielddesc,
-                &xonset, &yonset, &wonset))
-                    return;
+    if(plot_readownertemplate(x, data, template, &elemtemplatesym, &array,
+           &linewidth, &xloc, &xinc, &yloc, &style, &vis, &scalarvis, &edit,
+           &xfielddesc, &yfielddesc, &wfielddesc) ||
+        ((vis == 0) && tovis) /* see above for 'tovis' */
+        || array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
+               &elemsize, xfielddesc, yfielddesc, wfielddesc, &xonset, &yonset,
+               &wonset))
+        return;
     nelem = array->a_n;
-    elem = (char *)array->a_vec;
+    elem = (char *) array->a_vec;
 
-    if (glist->gl_isgraph)
-        linewidth *= glist_getzoom(glist);
+    if(glist->gl_isgraph) linewidth *= glist_getzoom(glist);
 
-    if (tovis)
+    if(tovis)
     {
-        if (style == PLOTSTYLE_POINTS)
+        if(style == PLOTSTYLE_POINTS)
         {
             t_float minyval = 1e20, maxyval = -1e20;
             int ndrawn = 0;
             char color[20];
-            numbertocolor(fielddesc_getfloat(&x->x_outlinecolor, template,
-                data, 1), color);
-            for (xsum = basex + xloc, i = 0; i < nelem; i++)
+            numbertocolor(
+                fielddesc_getfloat(&x->x_outlinecolor, template, data, 1),
+                color);
+            for(xsum = basex + xloc, i = 0; i < nelem; i++)
             {
                 t_float yval, xpix, ypix, nextxloc;
                 int ixpix, inextx;
 
-                if (xonset >= 0)
+                if(xonset >= 0)
                 {
                     usexloc = basex + xloc +
-                        *(t_float *)((elem + elemsize * i) + xonset);
-                    ixpix = glist_xtopixels(glist,
-                        fielddesc_cvttocoord(xfielddesc, usexloc));
+                              *(t_float *) ((elem + elemsize * i) + xonset);
+                    ixpix = glist_xtopixels(
+                        glist, fielddesc_cvttocoord(xfielddesc, usexloc));
                     inextx = ixpix + 2;
                 }
                 else
                 {
                     usexloc = xsum;
                     xsum += xinc;
-                    ixpix = glist_xtopixels(glist,
-                        fielddesc_cvttocoord(xfielddesc, usexloc));
-                    inextx = glist_xtopixels(glist,
-                        fielddesc_cvttocoord(xfielddesc, xsum));
+                    ixpix = glist_xtopixels(
+                        glist, fielddesc_cvttocoord(xfielddesc, usexloc));
+                    inextx = glist_xtopixels(
+                        glist, fielddesc_cvttocoord(xfielddesc, xsum));
                 }
 
-                if (yonset >= 0)
-                    yval = yloc + *(t_float *)((elem + elemsize * i) + yonset);
-                else yval = 0;
+                if(yonset >= 0)
+                    yval = yloc + *(t_float *) ((elem + elemsize * i) + yonset);
+                else
+                    yval = 0;
                 yval = CLIP(yval);
-                if (yval < minyval)
-                    minyval = yval;
-                if (yval > maxyval)
-                    maxyval = yval;
-                if (i == nelem-1 || inextx != ixpix)
+                if(yval < minyval) minyval = yval;
+                if(yval > maxyval) maxyval = yval;
+                if(i == nelem - 1 || inextx != ixpix)
                 {
                     sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                        "-fill %s -width 0 -tags [list plot%lx array]\n",
-                        glist_getcanvas(glist),
-                        ixpix, (int)glist_ytopixels(glist,
+                             "-fill %s -width 0 -tags [list plot%lx array]\n",
+                        glist_getcanvas(glist), ixpix,
+                        (int) glist_ytopixels(glist,
                             basey + fielddesc_cvttocoord(yfielddesc, minyval)),
-                        inextx, (int)(glist_ytopixels(glist,
-                            basey + fielddesc_cvttocoord(yfielddesc, maxyval))
-                                + linewidth), color, data);
+                        inextx,
+                        (int) (glist_ytopixels(
+                                   glist, basey + fielddesc_cvttocoord(
+                                                      yfielddesc, maxyval)) +
+                               linewidth),
+                        color, data);
                     ndrawn++;
                     minyval = 1e20;
                     maxyval = -1e20;
                 }
-                if (ndrawn > 2000 || ixpix >= 3000) break;
+                if(ndrawn > 2000 || ixpix >= 3000) break;
             }
         }
         else
@@ -1855,228 +1860,242 @@ static void plot_vis(t_gobj *z, t_glist *glist,
             int lastpixel = -1, ndrawn = 0;
             t_float yval = 0, wval = 0, xpix;
             int ixpix = 0;
-                /* draw the trace */
-            numbertocolor(fielddesc_getfloat(&x->x_outlinecolor, template,
-                data, 1), outline);
-            if (wonset >= 0)
+            /* draw the trace */
+            numbertocolor(
+                fielddesc_getfloat(&x->x_outlinecolor, template, data, 1),
+                outline);
+            if(wonset >= 0)
             {
-                    /* found "w" field which controls linewidth.  The trace is
-                    a filled polygon with 2n points. */
-                sys_vgui(".x%lx.c create polygon \\\n",
-                    glist_getcanvas(glist));
+                /* found "w" field which controls linewidth.  The trace is
+                a filled polygon with 2n points. */
+                sys_vgui(".x%lx.c create polygon \\\n", glist_getcanvas(glist));
 
-                for (i = 0, xsum = xloc; i < nelem; i++)
+                for(i = 0, xsum = xloc; i < nelem; i++)
                 {
-                    if (xonset >= 0)
-                        usexloc = xloc + *(t_float *)((elem + elemsize * i)
-                            + xonset);
-                    else usexloc = xsum, xsum += xinc;
-                    if (yonset >= 0)
-                        yval = *(t_float *)((elem + elemsize * i) + yonset);
-                    else yval = 0;
+                    if(xonset >= 0)
+                        usexloc = xloc +
+                                  *(t_float *) ((elem + elemsize * i) + xonset);
+                    else
+                        usexloc = xsum, xsum += xinc;
+                    if(yonset >= 0)
+                        yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    else
+                        yval = 0;
                     yval = CLIP(yval);
-                    wval = *(t_float *)((elem + elemsize * i) + wonset);
+                    wval = *(t_float *) ((elem + elemsize * i) + wonset);
                     wval = CLIP(wval);
                     xpix = glist_xtopixels(glist,
                         basex + fielddesc_cvttocoord(xfielddesc, usexloc));
                     ixpix = xpix + 0.5;
-                    if (xonset >= 0 || ixpix != lastpixel)
+                    if(xonset >= 0 || ixpix != lastpixel)
                     {
                         sys_vgui("%d %f \\\n", ixpix,
                             glist_ytopixels(glist,
-                                basey + fielddesc_cvttocoord(yfielddesc,
-                                    yloc + yval) -
-                                        fielddesc_cvttocoord(wfielddesc,wval)));
-                        ndrawn++;
-                    }
-                    lastpixel = ixpix;
-                    if (ndrawn >= 1000) goto ouch;
-                }
-                lastpixel = -1;
-                for (i = nelem-1; i >= 0; i--)
-                {
-                    t_float usexloc;
-                    if (xonset >= 0)
-                        usexloc = xloc + *(t_float *)((elem + elemsize * i)
-                            + xonset);
-                    else xsum -= xinc, usexloc = xsum;
-                    if (yonset >= 0)
-                        yval = *(t_float *)((elem + elemsize * i) + yonset);
-                    else yval = 0;
-                    yval = CLIP(yval);
-                    wval = *(t_float *)((elem + elemsize * i) + wonset);
-                    wval = CLIP(wval);
-                    xpix = glist_xtopixels(glist,
-                        basex + fielddesc_cvttocoord(xfielddesc, usexloc));
-                    ixpix = xpix + 0.5;
-                    if (xonset >= 0 || ixpix != lastpixel)
-                    {
-                        sys_vgui("%d %f \\\n", ixpix, glist_ytopixels(glist,
-                            basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                                yval) +
+                                basey +
+                                    fielddesc_cvttocoord(
+                                        yfielddesc, yloc + yval) -
                                     fielddesc_cvttocoord(wfielddesc, wval)));
                         ndrawn++;
                     }
                     lastpixel = ixpix;
-                    if (ndrawn >= 1000) goto ouch;
+                    if(ndrawn >= 1000) goto ouch;
                 }
-                    /* TK will complain if there aren't at least 3 points.
-                    There should be at least two already. */
-                if (ndrawn < 4)
+                lastpixel = -1;
+                for(i = nelem - 1; i >= 0; i--)
                 {
-                    sys_vgui("%d %f \\\n", ixpix + 10, glist_ytopixels(glist,
-                        basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                            yval) +
-                                fielddesc_cvttocoord(wfielddesc, wval)));
-                    sys_vgui("%d %f \\\n", ixpix + 10, glist_ytopixels(glist,
-                        basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                            yval) -
-                                fielddesc_cvttocoord(wfielddesc, wval)));
+                    t_float usexloc;
+                    if(xonset >= 0)
+                        usexloc = xloc +
+                                  *(t_float *) ((elem + elemsize * i) + xonset);
+                    else
+                        xsum -= xinc, usexloc = xsum;
+                    if(yonset >= 0)
+                        yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    else
+                        yval = 0;
+                    yval = CLIP(yval);
+                    wval = *(t_float *) ((elem + elemsize * i) + wonset);
+                    wval = CLIP(wval);
+                    xpix = glist_xtopixels(glist,
+                        basex + fielddesc_cvttocoord(xfielddesc, usexloc));
+                    ixpix = xpix + 0.5;
+                    if(xonset >= 0 || ixpix != lastpixel)
+                    {
+                        sys_vgui("%d %f \\\n", ixpix,
+                            glist_ytopixels(glist,
+                                basey + yloc +
+                                    fielddesc_cvttocoord(yfielddesc, yval) +
+                                    fielddesc_cvttocoord(wfielddesc, wval)));
+                        ndrawn++;
+                    }
+                    lastpixel = ixpix;
+                    if(ndrawn >= 1000) goto ouch;
+                }
+                /* TK will complain if there aren't at least 3 points.
+                There should be at least two already. */
+                if(ndrawn < 4)
+                {
+                    sys_vgui("%d %f \\\n", ixpix + 10,
+                        glist_ytopixels(
+                            glist, basey + yloc +
+                                       fielddesc_cvttocoord(yfielddesc, yval) +
+                                       fielddesc_cvttocoord(wfielddesc, wval)));
+                    sys_vgui("%d %f \\\n", ixpix + 10,
+                        glist_ytopixels(
+                            glist, basey + yloc +
+                                       fielddesc_cvttocoord(yfielddesc, yval) -
+                                       fielddesc_cvttocoord(wfielddesc, wval)));
                 }
             ouch:
                 sys_vgui(" -width %d -fill %s -outline %s\\\n",
-                    (glist->gl_isgraph ? glist_getzoom(glist) : 1),
-                    outline, outline);
-                if (style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
+                    (glist->gl_isgraph ? glist_getzoom(glist) : 1), outline,
+                    outline);
+                if(style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
 
                 sys_vgui("-tags [list plot%lx array]\n", data);
             }
-            else if (linewidth > 0)
+            else if(linewidth > 0)
             {
-                    /* no "w" field.  If the linewidth is positive, draw a
-                    segmented line with the requested width; otherwise don't
-                    draw the trace at all. */
+                /* no "w" field.  If the linewidth is positive, draw a
+                segmented line with the requested width; otherwise don't
+                draw the trace at all. */
                 sys_vgui(".x%lx.c create line \\\n", glist_getcanvas(glist));
 
-                for (xsum = xloc, i = 0; i < nelem; i++)
+                for(xsum = xloc, i = 0; i < nelem; i++)
                 {
                     t_float usexloc;
-                    if (xonset >= 0)
-                        usexloc = xloc + *(t_float *)((elem + elemsize * i) +
-                            xonset);
-                    else usexloc = xsum, xsum += xinc;
-                    if (yonset >= 0)
-                        yval = *(t_float *)((elem + elemsize * i) + yonset);
-                    else yval = 0;
+                    if(xonset >= 0)
+                        usexloc = xloc +
+                                  *(t_float *) ((elem + elemsize * i) + xonset);
+                    else
+                        usexloc = xsum, xsum += xinc;
+                    if(yonset >= 0)
+                        yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                    else
+                        yval = 0;
                     yval = CLIP(yval);
                     xpix = glist_xtopixels(glist,
                         basex + fielddesc_cvttocoord(xfielddesc, usexloc));
                     ixpix = xpix + 0.5;
-                    if (xonset >= 0 || ixpix != lastpixel)
+                    if(xonset >= 0 || ixpix != lastpixel)
                     {
                         sys_vgui("%d %f \\\n", ixpix,
                             glist_ytopixels(glist,
-                                basey + yloc + fielddesc_cvttocoord(yfielddesc,
-                                    yval)));
+                                basey + yloc +
+                                    fielddesc_cvttocoord(yfielddesc, yval)));
                         ndrawn++;
                     }
                     lastpixel = ixpix;
-                    if (ndrawn >= 1000) break;
+                    if(ndrawn >= 1000) break;
                 }
-                    /* TK will complain if there aren't at least 2 points... */
-                if (ndrawn == 0) sys_vgui("0 0 0 0 \\\n");
-                else if (ndrawn == 1) sys_vgui("%d %f \\\n", ixpix + 10,
-                    glist_ytopixels(glist, basey + yloc +
-                        fielddesc_cvttocoord(yfielddesc, yval)));
+                /* TK will complain if there aren't at least 2 points... */
+                if(ndrawn == 0)
+                    sys_vgui("0 0 0 0 \\\n");
+                else if(ndrawn == 1)
+                    sys_vgui("%d %f \\\n", ixpix + 10,
+                        glist_ytopixels(
+                            glist, basey + yloc +
+                                       fielddesc_cvttocoord(yfielddesc, yval)));
 
                 sys_vgui("-width %f\\\n", linewidth);
                 sys_vgui("-fill %s\\\n", outline);
-                if (style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
+                if(style == PLOTSTYLE_BEZ) sys_vgui("-smooth 1\\\n");
 
                 sys_vgui("-tags [list plot%lx array]\n", data);
             }
         }
-            /* We're done with the outline; now draw all the points.
-            This code is inefficient since the template has to be
-            searched for drawing instructions for every last point. */
-        if (scalarvis != 0)
+        /* We're done with the outline; now draw all the points.
+        This code is inefficient since the template has to be
+        searched for drawing instructions for every last point. */
+        if(scalarvis != 0)
         {
-            for (xsum = xloc, i = 0; i < nelem; i++)
+            for(xsum = xloc, i = 0; i < nelem; i++)
             {
                 t_float usexloc, useyloc;
                 t_gobj *y;
-                if (xonset >= 0)
+                if(xonset >= 0)
                     usexloc = basex + xloc +
-                        *(t_float *)((elem + elemsize * i) + xonset);
-                else usexloc = basex + xsum, xsum += xinc;
-                if (yonset >= 0)
-                    yval = *(t_float *)((elem + elemsize * i) + yonset);
-                else yval = 0;
-                useyloc = basey + yloc +
-                    fielddesc_cvttocoord(yfielddesc, yval);
-                for (y = elemtemplatecanvas->gl_list; y; y = y->g_next)
+                              *(t_float *) ((elem + elemsize * i) + xonset);
+                else
+                    usexloc = basex + xsum, xsum += xinc;
+                if(yonset >= 0)
+                    yval = *(t_float *) ((elem + elemsize * i) + yonset);
+                else
+                    yval = 0;
+                useyloc = basey + yloc + fielddesc_cvttocoord(yfielddesc, yval);
+                for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
                     const t_parentwidgetbehavior *wb =
                         pd_getparentwidget(&y->g_pd);
-                    if (!wb) continue;
+                    if(!wb) continue;
                     (*wb->w_parentvisfn)(y, glist,
-                        (t_word *)(elem + elemsize * i),
-                            elemtemplate, usexloc, useyloc, tovis);
+                        (t_word *) (elem + elemsize * i), elemtemplate, usexloc,
+                        useyloc, tovis);
                 }
             }
         }
     }
     else
     {
-            /* un-draw the individual points */
-        if (scalarvis != 0)
+        /* un-draw the individual points */
+        if(scalarvis != 0)
         {
             int i;
-            for (i = 0; i < nelem; i++)
+            for(i = 0; i < nelem; i++)
             {
                 t_gobj *y;
-                for (y = elemtemplatecanvas->gl_list; y; y = y->g_next)
+                for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
                     const t_parentwidgetbehavior *wb =
                         pd_getparentwidget(&y->g_pd);
-                    if (!wb) continue;
+                    if(!wb) continue;
                     (*wb->w_parentvisfn)(y, glist,
-                        (t_word *)(elem + elemsize * i), elemtemplate,
-                            0, 0, 0);
+                        (t_word *) (elem + elemsize * i), elemtemplate, 0, 0,
+                        0);
                 }
             }
         }
-            /* and then the trace */
-        sys_vgui(".x%lx.c delete plot%lx\n",
-            glist_getcanvas(glist), data);
+        /* and then the trace */
+        sys_vgui(".x%lx.c delete plot%lx\n", glist_getcanvas(glist), data);
     }
 }
 
-    /* LATER protect against the template changing or the scalar disappearing
-    probably by attaching a gpointer here ... */
+/* LATER protect against the template changing or the scalar disappearing
+probably by attaching a gpointer here ... */
 
 static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
-    if (up != 0)
-        return;
+    if(up != 0) return;
     TEMPLATE->array_motion_xcumulative += dx * TEMPLATE->array_motion_xperpix;
     TEMPLATE->array_motion_ycumulative += dy * TEMPLATE->array_motion_yperpix;
-    if (TEMPLATE->array_motion_xfield)
+    if(TEMPLATE->array_motion_xfield)
     {
-            /* it's an x, y plot */
+        /* it's an x, y plot */
         int i;
-        for (i = 0; i < TEMPLATE->array_motion_npoints; i++)
+        for(i = 0; i < TEMPLATE->array_motion_npoints; i++)
         {
-            t_word *thisword = (t_word *)(((char *)TEMPLATE->array_motion_wp) +
-                i * TEMPLATE->array_motion_elemsize);
+            t_word *thisword =
+                (t_word *) (((char *) TEMPLATE->array_motion_wp) +
+                            i * TEMPLATE->array_motion_elemsize);
             t_float xwas = fielddesc_getcoord(TEMPLATE->array_motion_xfield,
                 TEMPLATE->array_motion_template, thisword, 1);
-            t_float ywas = (TEMPLATE->array_motion_yfield ?
-                fielddesc_getcoord(TEMPLATE->array_motion_yfield,
-                    TEMPLATE->array_motion_template, thisword, 1) : 0);
+            t_float ywas =
+                (TEMPLATE->array_motion_yfield
+                        ? fielddesc_getcoord(TEMPLATE->array_motion_yfield,
+                              TEMPLATE->array_motion_template, thisword, 1)
+                        : 0);
             fielddesc_setcoord(TEMPLATE->array_motion_xfield,
                 TEMPLATE->array_motion_template, thisword,
-                    xwas + dx * TEMPLATE->array_motion_xperpix, 1);
-            if (TEMPLATE->array_motion_yfield)
+                xwas + dx * TEMPLATE->array_motion_xperpix, 1);
+            if(TEMPLATE->array_motion_yfield)
             {
-                if (TEMPLATE->array_motion_fatten)
+                if(TEMPLATE->array_motion_fatten)
                 {
-                    if (i == 0)
+                    if(i == 0)
                     {
-                        t_float newy = ywas +
-                            dy * TEMPLATE->array_motion_yperpix;
-                        if (newy < 0)
-                            newy = 0;
+                        t_float newy =
+                            ywas + dy * TEMPLATE->array_motion_yperpix;
+                        if(newy < 0) newy = 0;
                         fielddesc_setcoord(TEMPLATE->array_motion_yfield,
                             TEMPLATE->array_motion_template, thisword, newy, 1);
                     }
@@ -2085,116 +2104,119 @@ static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
                 {
                     fielddesc_setcoord(TEMPLATE->array_motion_yfield,
                         TEMPLATE->array_motion_template, thisword,
-                            ywas + dy * TEMPLATE->array_motion_yperpix, 1);
+                        ywas + dy * TEMPLATE->array_motion_yperpix, 1);
                 }
             }
         }
     }
-    else if (TEMPLATE->array_motion_yfield)
+    else if(TEMPLATE->array_motion_yfield)
     {
-            /* a y-only plot. */
+        /* a y-only plot. */
         int thisx = TEMPLATE->array_motion_initx +
-            TEMPLATE->array_motion_xcumulative + 0.5, x2;
+                    TEMPLATE->array_motion_xcumulative + 0.5,
+            x2;
         int increment, i, nchange;
         t_float newy = TEMPLATE->array_motion_ycumulative,
-            oldy = fielddesc_getcoord(TEMPLATE->array_motion_yfield,
-                TEMPLATE->array_motion_template,
-                    (t_word *)(((char *)TEMPLATE->array_motion_wp) +
-                        TEMPLATE->array_motion_elemsize *
-                            TEMPLATE->array_motion_lastx),
-                            1);
+                oldy = fielddesc_getcoord(TEMPLATE->array_motion_yfield,
+                    TEMPLATE->array_motion_template,
+                    (t_word *) (((char *) TEMPLATE->array_motion_wp) +
+                                TEMPLATE->array_motion_elemsize *
+                                    TEMPLATE->array_motion_lastx),
+                    1);
         t_float ydiff = newy - oldy;
-        if (thisx < 0) thisx = 0;
-        else if (thisx >= TEMPLATE->array_motion_npoints)
+        if(thisx < 0)
+            thisx = 0;
+        else if(thisx >= TEMPLATE->array_motion_npoints)
             thisx = TEMPLATE->array_motion_npoints - 1;
         increment = (thisx > TEMPLATE->array_motion_lastx ? -1 : 1);
         nchange = 1 + increment * (TEMPLATE->array_motion_lastx - thisx);
 
-        for (i = 0, x2 = thisx; i < nchange; i++, x2 += increment)
+        for(i = 0, x2 = thisx; i < nchange; i++, x2 += increment)
         {
             fielddesc_setcoord(TEMPLATE->array_motion_yfield,
                 TEMPLATE->array_motion_template,
-                    (t_word *)(((char *)TEMPLATE->array_motion_wp) +
-                        TEMPLATE->array_motion_elemsize * x2), newy, 1);
-            if (nchange > 1)
-                newy -= ydiff * (1./(nchange - 1));
-         }
-         TEMPLATE->array_motion_lastx = thisx;
+                (t_word *) (((char *) TEMPLATE->array_motion_wp) +
+                            TEMPLATE->array_motion_elemsize * x2),
+                newy, 1);
+            if(nchange > 1) newy -= ydiff * (1. / (nchange - 1));
+        }
+        TEMPLATE->array_motion_lastx = thisx;
     }
-    if (TEMPLATE->array_motion_scalar)
-        scalar_redraw(TEMPLATE->array_motion_scalar,
-            TEMPLATE->array_motion_glist);
-    if (TEMPLATE->array_motion_array)
-        array_redraw(TEMPLATE->array_motion_array,
-            TEMPLATE->array_motion_glist);
+    if(TEMPLATE->array_motion_scalar)
+        scalar_redraw(
+            TEMPLATE->array_motion_scalar, TEMPLATE->array_motion_glist);
+    if(TEMPLATE->array_motion_array)
+        array_redraw(
+            TEMPLATE->array_motion_array, TEMPLATE->array_motion_glist);
 }
 
 int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
-    t_array *ap, struct _glist *owner,
-    t_float xloc, t_float yloc, int xpix, int ypix,
-    int shift, int alt, int dbl, int doit);
+    t_array *ap, struct _glist *owner, t_float xloc, t_float yloc, int xpix,
+    int ypix, int shift, int alt, int dbl, int doit);
 
-    /* try clicking on an element of the array as a scalar (if clicking
-    on the trace of the array failed) */
+/* try clicking on an element of the array as a scalar (if clicking
+on the trace of the array failed) */
 static int array_doclick_element(t_array *array, t_glist *glist,
-    t_symbol *elemtemplatesym,
-    t_float xloc, t_float xinc, t_float yloc,
-    t_fielddesc *xfield, t_fielddesc *yfield, t_fielddesc *wfield,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+    t_symbol *elemtemplatesym, t_float xloc, t_float xinc, t_float yloc,
+    t_fielddesc *xfield, t_fielddesc *yfield, t_fielddesc *wfield, int xpix,
+    int ypix, int shift, int alt, int dbl, int doit)
 {
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     int elemsize, yonset, wonset, xonset, i, incr, hit;
     double xsum;
 
-    if (elemtemplatesym == &s_float)
+    if(elemtemplatesym == &s_float) return (0);
+    if(array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
+           &elemsize, xfield, yfield, wfield, &xonset, &yonset, &wonset))
         return (0);
-    if (array_getfields(elemtemplatesym, &elemtemplatecanvas,
-        &elemtemplate, &elemsize, xfield, yfield, wfield,
-            &xonset, &yonset, &wonset))
-                return (0);
-        /* if it has more than 2000 points, just check 300 of them. */
-    if (array->a_n < 2000)
+    /* if it has more than 2000 points, just check 300 of them. */
+    if(array->a_n < 2000)
         incr = 1;
-    else incr = array->a_n / 300;
-    for (i = 0, xsum = 0; i < array->a_n; i += incr)
+    else
+        incr = array->a_n / 300;
+    for(i = 0, xsum = 0; i < array->a_n; i += incr)
     {
         t_float usexloc, useyloc;
-        if (xonset >= 0)
-            usexloc = xloc + fielddesc_cvttocoord(xfield,
-                *(t_float *)(((char *)(array->a_vec) + elemsize * i) + xonset));
-        else usexloc = xloc + xsum, xsum += xinc;
-        useyloc = yloc + (yonset >= 0 ? fielddesc_cvttocoord(yfield,
-            *(t_float *)
-                (((char *)(array->a_vec) + elemsize * i) + yonset)) : 0);
+        if(xonset >= 0)
+            usexloc =
+                xloc +
+                fielddesc_cvttocoord(xfield,
+                    *(t_float *) (((char *) (array->a_vec) + elemsize * i) +
+                                  xonset));
+        else
+            usexloc = xloc + xsum, xsum += xinc;
+        useyloc =
+            yloc + (yonset >= 0 ? fielddesc_cvttocoord(yfield,
+                                      *(t_float *) (((char *) (array->a_vec) +
+                                                        elemsize * i) +
+                                                    yonset))
+                                : 0);
 
-        if ((hit = scalar_doclick(
-            (t_word *)((char *)(array->a_vec) + i * elemsize),
-            elemtemplate, 0, array,
-            glist, usexloc, useyloc,
-            xpix, ypix, shift, alt, dbl, doit)))
-                return (hit);
+        if((hit = scalar_doclick(
+                (t_word *) ((char *) (array->a_vec) + i * elemsize),
+                elemtemplate, 0, array, glist, usexloc, useyloc, xpix, ypix,
+                shift, alt, dbl, doit)))
+            return (hit);
     }
     return (0);
 }
 
 static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
-    t_array *ap, t_symbol *elemtemplatesym,
-    t_float xloc, t_float xinc, t_float yloc,
-    t_float scalarvis, t_float edit,
-    t_fielddesc *xfield, t_fielddesc *yfield, t_fielddesc *wfield,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+    t_array *ap, t_symbol *elemtemplatesym, t_float xloc, t_float xinc,
+    t_float yloc, t_float scalarvis, t_float edit, t_fielddesc *xfield,
+    t_fielddesc *yfield, t_fielddesc *wfield, int xpix, int ypix, int shift,
+    int alt, int dbl, int doit)
 {
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     int elemsize, yonset, wonset, xonset, i;
 
-    if (!array_getfields(elemtemplatesym, &elemtemplatecanvas,
-        &elemtemplate, &elemsize, xfield, yfield, wfield,
-        &xonset, &yonset, &wonset))
+    if(!array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
+           &elemsize, xfield, yfield, wfield, &xonset, &yonset, &wonset))
     {
         t_float best = 100;
-            /* if it has more than 2000 points, just check 1000 of them. */
+        /* if it has more than 2000 points, just check 1000 of them. */
         int incr = (array->a_n <= 2000 ? 1 : array->a_n / 1000);
         TEMPLATE->array_motion_elemsize = elemsize;
         TEMPLATE->array_motion_glist = glist;
@@ -2203,17 +2225,16 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
         TEMPLATE->array_motion_template = elemtemplate;
         TEMPLATE->array_motion_xperpix = glist_dpixtodx(glist, 1);
         TEMPLATE->array_motion_yperpix = glist_dpixtody(glist, 1);
-            /* if we're a garray, the only one here, and if we appear to have
-            only a 'y' field, click always succeeds and furthermore we'll
-            call "motion" later. */
-        if (glist->gl_list && pd_class(&glist->gl_list->g_pd) == garray_class
-            && !glist->gl_list->g_next &&
-                elemsize == sizeof(t_word))
+        /* if we're a garray, the only one here, and if we appear to have
+        only a 'y' field, click always succeeds and furthermore we'll
+        call "motion" later. */
+        if(glist->gl_list && pd_class(&glist->gl_list->g_pd) == garray_class &&
+            !glist->gl_list->g_next && elemsize == sizeof(t_word))
         {
             int xval = glist_pixelstox(glist, xpix);
-            if (xval < 0)
+            if(xval < 0)
                 xval = 0;
-            else if (xval >= array->a_n)
+            else if(xval >= array->a_n)
                 xval = array->a_n - 1;
             TEMPLATE->array_motion_yfield = yfield;
             TEMPLATE->array_motion_ycumulative = glist_pixelstoy(glist, ypix);
@@ -2222,174 +2243,166 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
             TEMPLATE->array_motion_xcumulative = 0;
             TEMPLATE->array_motion_lastx = TEMPLATE->array_motion_initx = xval;
             TEMPLATE->array_motion_npoints = array->a_n;
-            TEMPLATE->array_motion_wp = (t_word *)((char *)array->a_vec);
-            if (doit)
+            TEMPLATE->array_motion_wp = (t_word *) ((char *) array->a_vec);
+            if(doit)
             {
                 fielddesc_setcoord(yfield, elemtemplate,
-                    (t_word *)(((char *)array->a_vec) + elemsize * xval),
-                        glist_pixelstoy(glist, ypix), 1);
+                    (t_word *) (((char *) array->a_vec) + elemsize * xval),
+                    glist_pixelstoy(glist, ypix), 1);
                 glist_grab(glist, 0, array_motionfn, 0, xpix, ypix);
-                if (TEMPLATE->array_motion_scalar)
+                if(TEMPLATE->array_motion_scalar)
                     scalar_redraw(TEMPLATE->array_motion_scalar,
                         TEMPLATE->array_motion_glist);
-                if (TEMPLATE->array_motion_array)
+                if(TEMPLATE->array_motion_array)
                     array_redraw(TEMPLATE->array_motion_array,
                         TEMPLATE->array_motion_glist);
             }
         }
         else
         {
-                /* First we get the closest distance to any element */
-            for (i = 0; i < array->a_n; i += incr)
+            /* First we get the closest distance to any element */
+            for(i = 0; i < array->a_n; i += incr)
             {
                 t_float pxpix, pypix, pwpix, dx, dy;
                 array_getcoordinate(glist,
-                    (char *)(array->a_vec) + i * elemsize,
-                    xonset, yonset, wonset, i, xloc, yloc, xinc,
-                    xfield, yfield, wfield, &pxpix, &pypix, &pwpix);
-                if (pwpix < 4)
-                    pwpix = 4;
+                    (char *) (array->a_vec) + i * elemsize, xonset, yonset,
+                    wonset, i, xloc, yloc, xinc, xfield, yfield, wfield, &pxpix,
+                    &pypix, &pwpix);
+                if(pwpix < 4) pwpix = 4;
                 dx = pxpix - xpix;
-                if (dx < 0) dx = -dx;
-                if (dx > 8)
-                    continue;
+                if(dx < 0) dx = -dx;
+                if(dx > 8) continue;
                 dy = pypix - ypix;
-                if (dy < 0) dy = -dy;
-                if (dx + dy < best)
-                    best = dx + dy;
-                if (wonset >= 0)
+                if(dy < 0) dy = -dy;
+                if(dx + dy < best) best = dx + dy;
+                if(wonset >= 0)
                 {
                     dy = (pypix + pwpix) - ypix;
-                    if (dy < 0) dy = -dy;
-                    if (dx + dy < best)
-                        best = dx + dy;
+                    if(dy < 0) dy = -dy;
+                    if(dx + dy < best) best = dx + dy;
                     dy = (pypix - pwpix) - ypix;
-                    if (dy < 0) dy = -dy;
-                    if (dx + dy < best)
-                        best = dx + dy;
+                    if(dy < 0) dy = -dy;
+                    if(dx + dy < best) best = dx + dy;
                 }
             }
-                /* If we're not too close, we first try to click a scalar
-                (if visible). This would not affect the array */
-            if (best > 8)
+            /* If we're not too close, we first try to click a scalar
+            (if visible). This would not affect the array */
+            if(best > 8)
             {
-                if (scalarvis != 0)
+                if(scalarvis != 0)
                 {
-                    return (array_doclick_element(array, glist,
-                        elemtemplatesym, xloc, xinc, yloc,
-                            xfield, yfield, wfield,
-                            xpix, ypix, shift, alt, dbl, doit));
-
+                    return (array_doclick_element(array, glist, elemtemplatesym,
+                        xloc, xinc, yloc, xfield, yfield, wfield, xpix, ypix,
+                        shift, alt, dbl, doit));
                 }
-                else return (0);
+                else
+                    return (0);
             }
-                /* Now we walk over the array again and decide whether we
-                a) grab an element, b) change the line width,
-                c) delete an element or d) add a new element */
-            best += 0.001;  /* add truncation error margin */
-             /* otherwise we try to grab a vertex */
-            if (!edit)
-                return (0);
-            for (i = 0; i < array->a_n; i += incr)
+            /* Now we walk over the array again and decide whether we
+            a) grab an element, b) change the line width,
+            c) delete an element or d) add a new element */
+            best += 0.001; /* add truncation error margin */
+                           /* otherwise we try to grab a vertex */
+            if(!edit) return (0);
+            for(i = 0; i < array->a_n; i += incr)
             {
                 t_float pxpix, pypix, pwpix, dx, dy, dy2, dy3;
                 array_getcoordinate(glist,
-                    (char *)(array->a_vec) + i * elemsize,
-                    xonset, yonset, wonset, i, xloc, yloc, xinc,
-                    xfield, yfield, wfield, &pxpix, &pypix, &pwpix);
-                if (pwpix < 4)
-                    pwpix = 4;
+                    (char *) (array->a_vec) + i * elemsize, xonset, yonset,
+                    wonset, i, xloc, yloc, xinc, xfield, yfield, wfield, &pxpix,
+                    &pypix, &pwpix);
+                if(pwpix < 4) pwpix = 4;
                 dx = pxpix - xpix;
-                if (dx < 0) dx = -dx;
+                if(dx < 0) dx = -dx;
                 dy = pypix - ypix;
-                if (dy < 0) dy = -dy;
-                if (wonset >= 0)
+                if(dy < 0) dy = -dy;
+                if(wonset >= 0)
                 {
                     dy2 = (pypix + pwpix) - ypix;
-                    if (dy2 < 0) dy2 = -dy2;
+                    if(dy2 < 0) dy2 = -dy2;
                     dy3 = (pypix - pwpix) - ypix;
-                    if (dy3 < 0) dy3 = -dy3;
-                    if (yonset < 0)
-                        dy = 100;
+                    if(dy3 < 0) dy3 = -dy3;
+                    if(yonset < 0) dy = 100;
                 }
-                else dy2 = dy3 = 100;
-                if (dx + dy <= best || dx + dy2 <= best || dx + dy3 <= best)
+                else
+                    dy2 = dy3 = 100;
+                if(dx + dy <= best || dx + dy2 <= best || dx + dy3 <= best)
                 {
-                    if (dy < dy2 && dy < dy3)
+                    if(dy < dy2 && dy < dy3)
                         TEMPLATE->array_motion_fatten = 0;
-                    else if (dy2 < dy3)
+                    else if(dy2 < dy3)
                         TEMPLATE->array_motion_fatten = -1;
-                    else TEMPLATE->array_motion_fatten = 1;
-                    if (doit)
+                    else
+                        TEMPLATE->array_motion_fatten = 1;
+                    if(doit)
                     {
-                        char *elem = (char *)array->a_vec;
-                        if (alt && xpix < pxpix) /* delete a point */
+                        char *elem = (char *) array->a_vec;
+                        if(alt && xpix < pxpix) /* delete a point */
                         {
-                            if (array->a_n <= 1)
-                                return (0);
-                            memmove((char *)(array->a_vec) + elemsize * i,
-                                (char *)(array->a_vec) + elemsize * (i+1),
-                                    (array->a_n - 1 - i) * elemsize);
-                            array_resize_and_redraw(array,
-                                glist, array->a_n - 1);
+                            if(array->a_n <= 1) return (0);
+                            memmove((char *) (array->a_vec) + elemsize * i,
+                                (char *) (array->a_vec) + elemsize * (i + 1),
+                                (array->a_n - 1 - i) * elemsize);
+                            array_resize_and_redraw(
+                                array, glist, array->a_n - 1);
                             return (0);
                         }
-                        else if (alt)
+                        else if(alt)
                         {
                             /* add a point (after the clicked-on one) */
-                            array_resize_and_redraw(array, glist,
-                                array->a_n + 1);
-                            elem = (char *)array->a_vec;
-                            memmove(elem + elemsize * (i+1),
+                            array_resize_and_redraw(
+                                array, glist, array->a_n + 1);
+                            elem = (char *) array->a_vec;
+                            memmove(elem + elemsize * (i + 1),
                                 elem + elemsize * i,
-                                    (array->a_n - i - 1) * elemsize);
+                                (array->a_n - i - 1) * elemsize);
                             i++;
                         }
-                        if (xonset >= 0)
+                        if(xonset >= 0)
                         {
                             TEMPLATE->array_motion_xfield = xfield;
                             TEMPLATE->array_motion_xcumulative =
                                 fielddesc_getcoord(xfield,
                                     TEMPLATE->array_motion_template,
-                                    (t_word *)(elem + i * elemsize), 1);
-                                TEMPLATE->array_motion_wp =
-                                    (t_word *)(elem + i * elemsize);
-                            if (shift)
-                                TEMPLATE->array_motion_npoints =
-                                    array->a_n - i;
-                            else TEMPLATE->array_motion_npoints = 1;
+                                    (t_word *) (elem + i * elemsize), 1);
+                            TEMPLATE->array_motion_wp =
+                                (t_word *) (elem + i * elemsize);
+                            if(shift)
+                                TEMPLATE->array_motion_npoints = array->a_n - i;
+                            else
+                                TEMPLATE->array_motion_npoints = 1;
                         }
                         else
                         {
                             TEMPLATE->array_motion_xfield = 0;
                             TEMPLATE->array_motion_xcumulative = 0;
-                            TEMPLATE->array_motion_wp = (t_word *)elem;
+                            TEMPLATE->array_motion_wp = (t_word *) elem;
                             TEMPLATE->array_motion_npoints = array->a_n;
 
                             TEMPLATE->array_motion_initx = i;
                             TEMPLATE->array_motion_lastx = i;
                             TEMPLATE->array_motion_xperpix *=
-                                (xinc == 0 ? 1 : 1./xinc);
+                                (xinc == 0 ? 1 : 1. / xinc);
                         }
-                        if (TEMPLATE->array_motion_fatten)
+                        if(TEMPLATE->array_motion_fatten)
                         {
                             TEMPLATE->array_motion_yfield = wfield;
                             TEMPLATE->array_motion_ycumulative =
                                 fielddesc_getcoord(wfield,
                                     TEMPLATE->array_motion_template,
-                                    (t_word *)(elem + i * elemsize), 1);
-                            if (TEMPLATE->array_motion_yperpix < 0)
+                                    (t_word *) (elem + i * elemsize), 1);
+                            if(TEMPLATE->array_motion_yperpix < 0)
                                 TEMPLATE->array_motion_yperpix *= -1;
                             TEMPLATE->array_motion_yperpix *=
                                 -TEMPLATE->array_motion_fatten;
                         }
-                        else if (yonset >= 0)
+                        else if(yonset >= 0)
                         {
                             TEMPLATE->array_motion_yfield = yfield;
                             TEMPLATE->array_motion_ycumulative =
                                 fielddesc_getcoord(yfield,
                                     TEMPLATE->array_motion_template,
-                                    (t_word *)(elem + i * elemsize), 1);
+                                    (t_word *) (elem + i * elemsize), 1);
                         }
                         else
                         {
@@ -2398,14 +2411,17 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
                         }
                         glist_grab(glist, 0, array_motionfn, 0, xpix, ypix);
                     }
-                    if (alt)
+                    if(alt)
                     {
-                        if (xpix < pxpix)
+                        if(xpix < pxpix)
                             return (CURSOR_EDITMODE_DISCONNECT);
-                        else return (CURSOR_RUNMODE_ADDPOINT);
+                        else
+                            return (CURSOR_RUNMODE_ADDPOINT);
                     }
-                    else return (TEMPLATE->array_motion_fatten ?
-                        CURSOR_RUNMODE_THICKEN : CURSOR_RUNMODE_CLICKME);
+                    else
+                        return (TEMPLATE->array_motion_fatten
+                                    ? CURSOR_RUNMODE_THICKEN
+                                    : CURSOR_RUNMODE_CLICKME);
                 }
             }
         }
@@ -2413,32 +2429,30 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
     return (0);
 }
 
-static int plot_click(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_scalar *sc, t_array *ap,
-    t_float basex, t_float basey,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int plot_click(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_scalar *sc, t_array *ap, t_float basex,
+    t_float basey, int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
-    t_plot *x = (t_plot *)z;
+    t_plot *x = (t_plot *) z;
     t_symbol *elemtemplatesym;
     t_float linewidth, xloc, xinc, yloc, style, vis, scalarvis, edit;
     t_array *array;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
 
-    if (!plot_readownertemplate(x, data, template,
-        &elemtemplatesym, &array, &linewidth, &xloc, &xinc, &yloc, &style,
-        &vis, &scalarvis, &edit,
-        &xfielddesc, &yfielddesc, &wfielddesc) && (vis != 0))
+    if(!plot_readownertemplate(x, data, template, &elemtemplatesym, &array,
+           &linewidth, &xloc, &xinc, &yloc, &style, &vis, &scalarvis, &edit,
+           &xfielddesc, &yfielddesc, &wfielddesc) &&
+        (vis != 0))
     {
         return (array_doclick(array, glist, sc, ap, elemtemplatesym,
-            basex + xloc, xinc, basey + yloc, scalarvis, edit,
-            xfielddesc, yfielddesc, wfielddesc,
-            xpix, ypix, shift, alt, dbl, doit));
+            basex + xloc, xinc, basey + yloc, scalarvis, edit, xfielddesc,
+            yfielddesc, wfielddesc, xpix, ypix, shift, alt, dbl, doit));
     }
-    else return (0);
+    else
+        return (0);
 }
 
-const t_parentwidgetbehavior plot_widgetbehavior =
-{
+const t_parentwidgetbehavior plot_widgetbehavior = {
     plot_getrect,
     plot_displace,
     plot_select,
@@ -2449,7 +2463,7 @@ const t_parentwidgetbehavior plot_widgetbehavior =
 
 static void plot_setup(void)
 {
-    plot_class = class_new(gensym("plot"), (t_newmethod)plot_new, 0,
+    plot_class = class_new(gensym("plot"), (t_newmethod) plot_new, 0,
         sizeof(t_plot), 0, A_GIMME, 0);
     class_setdrawcommand(plot_class);
     class_addfloat(plot_class, plot_float);
@@ -2480,35 +2494,43 @@ typedef struct _drawnumber
 
 static void *drawnumber_new(t_symbol *classsym, int argc, t_atom *argv)
 {
-    t_drawnumber *x = (t_drawnumber *)pd_new(drawnumber_class);
+    t_drawnumber *x = (t_drawnumber *) pd_new(drawnumber_class);
     const char *classname = classsym->s_name;
 
     fielddesc_setfloat_const(&x->x_vis, 1);
     x->x_canvas = canvas_getcurrent();
-    while (1)
+    while(1)
     {
         t_symbol *firstarg = atom_getsymbolarg(0, argc, argv);
-        if (!strcmp(firstarg->s_name, "-v") && argc > 1)
+        if(!strcmp(firstarg->s_name, "-v") && argc > 1)
         {
-            fielddesc_setfloatarg(&x->x_vis, 1, argv+1);
-            argc -= 2; argv += 2;
+            fielddesc_setfloatarg(&x->x_vis, 1, argv + 1);
+            argc -= 2;
+            argv += 2;
         }
-        else break;
+        else
+            break;
     }
-        /* next argument is name of field to draw - we don't know its type yet
-        but fielddesc_setfloatarg() will do fine here. */
+    /* next argument is name of field to draw - we don't know its type yet
+    but fielddesc_setfloatarg() will do fine here. */
     x->x_fieldname = atom_getsymbolarg(0, argc, argv);
-    if (argc)
-        argc--, argv++;
-    if (argc) fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_xloc, 0);
-    if (argc) fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_yloc, 0);
-    if (argc) fielddesc_setfloatarg(&x->x_color, argc--, argv++);
-    else fielddesc_setfloat_const(&x->x_color, 1);
-    if (argc)
+    if(argc) argc--, argv++;
+    if(argc)
+        fielddesc_setfloatarg(&x->x_xloc, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_xloc, 0);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_yloc, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_yloc, 0);
+    if(argc)
+        fielddesc_setfloatarg(&x->x_color, argc--, argv++);
+    else
+        fielddesc_setfloat_const(&x->x_color, 1);
+    if(argc)
         x->x_label = atom_getsymbolarg(0, argc, argv);
-    else x->x_label = &s_;
+    else
+        x->x_label = &s_;
 
     return (x);
 }
@@ -2516,15 +2538,14 @@ static void *drawnumber_new(t_symbol *classsym, int argc, t_atom *argv)
 void drawnumber_float(t_drawnumber *x, t_floatarg f)
 {
     int viswas;
-    if (x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
+    if(x->x_vis.fd_type != A_FLOAT || x->x_vis.fd_var)
     {
         pd_error(x, "global vis/invis for a template with variable visibility");
         return;
     }
     viswas = (x->x_vis.fd_un.fd_float != 0);
 
-    if ((f != 0 && viswas) || (f == 0 && !viswas))
-        return;
+    if((f != 0 && viswas) || (f == 0 && !viswas)) return;
     canvas_redrawallfortemplatecanvas(x->x_canvas, 2);
     fielddesc_setfloat_const(&x->x_vis, (f != 0));
     canvas_redrawallfortemplatecanvas(x->x_canvas, 1);
@@ -2532,268 +2553,259 @@ void drawnumber_float(t_drawnumber *x, t_floatarg f)
 
 /* -------------------- widget behavior for drawnumber ------------ */
 
-static int drawnumber_gettype(t_drawnumber *x, t_word *data,
-    t_template *template, int *onsetp)
+static int drawnumber_gettype(
+    t_drawnumber *x, t_word *data, t_template *template, int *onsetp)
 {
     int type;
     t_symbol *arraytype;
-    if (template_find_field(template, x->x_fieldname, onsetp, &type,
-        &arraytype) && type != DT_ARRAY)
-            return (type);
-    else return (-1);
+    if(template_find_field(
+           template, x->x_fieldname, onsetp, &type, &arraytype) &&
+        type != DT_ARRAY)
+        return (type);
+    else
+        return (-1);
 }
 
 #define DRAWNUMBER_BUFSIZE 1024
-static void drawnumber_getbuf(t_drawnumber *x, t_word *data,
-    t_template *template, char *buf)
+
+static void drawnumber_getbuf(
+    t_drawnumber *x, t_word *data, t_template *template, char *buf)
 {
     int nchars, onset, type = drawnumber_gettype(x, data, template, &onset);
-    if (type < 0)
+    if(type < 0)
         buf[0] = 0;
     else
     {
         strncpy(buf, x->x_label->s_name, DRAWNUMBER_BUFSIZE);
         buf[DRAWNUMBER_BUFSIZE - 1] = 0;
-        nchars = (int)strlen(buf);
-        if (type == DT_TEXT)
+        nchars = (int) strlen(buf);
+        if(type == DT_TEXT)
         {
             char *buf2;
             int size2, ncopy;
-            binbuf_gettext(((t_word *)((char *)data + onset))->w_binbuf,
-                &buf2, &size2);
-            ncopy = (size2 > DRAWNUMBER_BUFSIZE-1-nchars ?
-                DRAWNUMBER_BUFSIZE-1-nchars: size2);
-            memcpy(buf+nchars, buf2, ncopy);
-            buf[nchars+ncopy] = 0;
-            if (nchars+ncopy == DRAWNUMBER_BUFSIZE-1)
-                strcpy(buf+(DRAWNUMBER_BUFSIZE-4), "...");
+            binbuf_gettext(
+                ((t_word *) ((char *) data + onset))->w_binbuf, &buf2, &size2);
+            ncopy = (size2 > DRAWNUMBER_BUFSIZE - 1 - nchars
+                         ? DRAWNUMBER_BUFSIZE - 1 - nchars
+                         : size2);
+            memcpy(buf + nchars, buf2, ncopy);
+            buf[nchars + ncopy] = 0;
+            if(nchars + ncopy == DRAWNUMBER_BUFSIZE - 1)
+                strcpy(buf + (DRAWNUMBER_BUFSIZE - 4), "...");
             t_freebytes(buf2, size2);
         }
         else
         {
             t_atom at;
-            if (type == DT_FLOAT)
-                SETFLOAT(&at, ((t_word *)((char *)data + onset))->w_float);
-            else SETSYMBOL(&at, ((t_word *)((char *)data + onset))->w_symbol);
+            if(type == DT_FLOAT)
+                SETFLOAT(&at, ((t_word *) ((char *) data + onset))->w_float);
+            else
+                SETSYMBOL(&at, ((t_word *) ((char *) data + onset))->w_symbol);
             atom_string(&at, buf + nchars, DRAWNUMBER_BUFSIZE - nchars);
         }
     }
 }
 
-static void drawnumber_getrect(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void drawnumber_getrect(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int *xp1, int *yp1,
+    int *xp2, int *yp2)
 {
-    t_drawnumber *x = (t_drawnumber *)z;
+    t_drawnumber *x = (t_drawnumber *) z;
     t_atom at;
     int xloc, yloc, fontwidth, fontheight, bufsize, width, height;
     char buf[DRAWNUMBER_BUFSIZE], *startline, *newline;
 
-    if (!fielddesc_getfloat(&x->x_vis, template, data, 0))
+    if(!fielddesc_getfloat(&x->x_vis, template, data, 0))
     {
         *xp1 = *yp1 = 0x7fffffff;
         *xp2 = *yp2 = -0x7fffffff;
         return;
     }
-    xloc = glist_xtopixels(glist,
-        basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
-    yloc = glist_ytopixels(glist,
-        basey + fielddesc_getcoord(&x->x_yloc, template, data, 0));
+    xloc = glist_xtopixels(
+        glist, basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
+    yloc = glist_ytopixels(
+        glist, basey + fielddesc_getcoord(&x->x_yloc, template, data, 0));
     fontwidth = glist_fontwidth(glist);
     fontheight = glist_fontheight(glist);
     drawnumber_getbuf(x, data, template, buf);
     width = 0;
     height = 1;
-    for (startline = buf; (newline = strchr(startline, '\n'));
-        startline = newline+1)
+    for(startline = buf; (newline = strchr(startline, '\n'));
+        startline = newline + 1)
     {
-        if (newline - startline > width)
-            width = (int)(newline - startline);
+        if(newline - startline > width) width = (int) (newline - startline);
         height++;
     }
-    if (strlen(startline) > (unsigned)width)
-        width = (int)strlen(startline);
+    if(strlen(startline) > (unsigned) width) width = (int) strlen(startline);
     *xp1 = xloc;
     *yp1 = yloc;
     *xp2 = xloc + fontwidth * width;
     *yp2 = yloc + fontheight * height;
 }
 
-static void drawnumber_displace(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int dx, int dy)
+static void drawnumber_displace(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int dx, int dy)
 {
     /* refuse */
 }
 
-static void drawnumber_select(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void drawnumber_select(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
 {
     post("drawnumber_select %d", state);
     /* fill in later */
 }
 
-static void drawnumber_activate(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int state)
+static void drawnumber_activate(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int state)
 {
     post("drawnumber_activate %d", state);
 }
 
-static void drawnumber_vis(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_float basex, t_float basey,
-    int vis)
+static void drawnumber_vis(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_float basex, t_float basey, int vis)
 {
-    t_drawnumber *x = (t_drawnumber *)z;
+    t_drawnumber *x = (t_drawnumber *) z;
 
-        /* see comment in plot_vis() */
-    if (vis && !fielddesc_getfloat(&x->x_vis, template, data, 0))
-        return;
-    if (vis)
+    /* see comment in plot_vis() */
+    if(vis && !fielddesc_getfloat(&x->x_vis, template, data, 0)) return;
+    if(vis)
     {
         t_atom at;
-        int xloc = glist_xtopixels(glist,
-            basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
-        int yloc = glist_ytopixels(glist,
-            basey + fielddesc_getcoord(&x->x_yloc, template, data, 0));
+        int xloc = glist_xtopixels(
+            glist, basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
+        int yloc = glist_ytopixels(
+            glist, basey + fielddesc_getcoord(&x->x_yloc, template, data, 0));
         char colorstring[20], buf[DRAWNUMBER_BUFSIZE];
-        numbertocolor(fielddesc_getfloat(&x->x_color, template, data, 1),
-            colorstring);
+        numbertocolor(
+            fielddesc_getfloat(&x->x_color, template, data, 1), colorstring);
         drawnumber_getbuf(x, data, template, buf);
         sys_vgui(".x%lx.c create text %d %d -anchor nw -fill %s -text {%s}",
-                glist_getcanvas(glist), xloc, yloc, colorstring, buf);
+            glist_getcanvas(glist), xloc, yloc, colorstring, buf);
         sys_vgui(" -font {{%s} -%d %s}", sys_font,
             sys_hostfontsize(glist_getfont(glist), glist_getzoom(glist)),
-                sys_fontweight);
+            sys_fontweight);
         sys_vgui(" -tags [list drawnumber%lx label]\n", data);
     }
-    else sys_vgui(".x%lx.c delete drawnumber%lx\n",
-        glist_getcanvas(glist), data);
+    else
+        sys_vgui(
+            ".x%lx.c delete drawnumber%lx\n", glist_getcanvas(glist), data);
 }
 
-static void drawnumber_motionfn(void *z, t_floatarg dx, t_floatarg dy,
-    t_floatarg up)
+static void drawnumber_motionfn(
+    void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
-    t_drawnumber *x = (t_drawnumber *)z;
+    t_drawnumber *x = (t_drawnumber *) z;
     t_atom at;
-    if (up != 0)
-        return;
-    if (!gpointer_check(&TEMPLATE->drawnumber_motion_gpointer, 0))
+    if(up != 0) return;
+    if(!gpointer_check(&TEMPLATE->drawnumber_motion_gpointer, 0))
     {
         post("drawnumber_motion: scalar disappeared");
         return;
     }
-    if (TEMPLATE->drawnumber_motion_type != DT_FLOAT)
-        return;
+    if(TEMPLATE->drawnumber_motion_type != DT_FLOAT) return;
     TEMPLATE->drawnumber_motion_ycumulative -= dy;
-    template_setfloat(TEMPLATE->drawnumber_motion_template,
-        x->x_fieldname,
-            TEMPLATE->drawnumber_motion_wp,
-            TEMPLATE->drawnumber_motion_ycumulative,
-                1);
-    if (TEMPLATE->drawnumber_motion_scalar)
+    template_setfloat(TEMPLATE->drawnumber_motion_template, x->x_fieldname,
+        TEMPLATE->drawnumber_motion_wp, TEMPLATE->drawnumber_motion_ycumulative,
+        1);
+    if(TEMPLATE->drawnumber_motion_scalar)
         template_notifyforscalar(TEMPLATE->drawnumber_motion_template,
             TEMPLATE->drawnumber_motion_glist,
-                TEMPLATE->drawnumber_motion_scalar,
-                gensym("change"), 1, &at);
+            TEMPLATE->drawnumber_motion_scalar, gensym("change"), 1, &at);
 
-    if (TEMPLATE->drawnumber_motion_scalar)
+    if(TEMPLATE->drawnumber_motion_scalar)
         scalar_redraw(TEMPLATE->drawnumber_motion_scalar,
             TEMPLATE->drawnumber_motion_glist);
-    if (TEMPLATE->drawnumber_motion_array)
+    if(TEMPLATE->drawnumber_motion_array)
         array_redraw(TEMPLATE->drawnumber_motion_array,
             TEMPLATE->drawnumber_motion_glist);
 }
 
 static void drawnumber_key(void *z, t_symbol *keysym, t_floatarg fkey)
 {
-    t_drawnumber *x = (t_drawnumber *)z;
+    t_drawnumber *x = (t_drawnumber *) z;
     int key = fkey;
     char sbuf[MAXPDSTRING];
     t_atom at;
-    if (!gpointer_check(&TEMPLATE->drawnumber_motion_gpointer, 0))
+    if(!gpointer_check(&TEMPLATE->drawnumber_motion_gpointer, 0))
     {
         post("drawnumber_motion: scalar disappeared");
         return;
     }
-    if (key == 0)
-        return;
-    if (TEMPLATE->drawnumber_motion_type == DT_SYMBOL)
+    if(key == 0) return;
+    if(TEMPLATE->drawnumber_motion_type == DT_SYMBOL)
     {
-            /* key entry for a symbol field */
-        if (TEMPLATE->drawnumber_motion_firstkey)
+        /* key entry for a symbol field */
+        if(TEMPLATE->drawnumber_motion_firstkey)
             sbuf[0] = 0;
-        else strncpy(sbuf,
-            template_getsymbol(TEMPLATE->drawnumber_motion_template,
-            x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1)->s_name,
+        else
+            strncpy(sbuf,
+                template_getsymbol(TEMPLATE->drawnumber_motion_template,
+                    x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1)
+                    ->s_name,
                 MAXPDSTRING);
-        sbuf[MAXPDSTRING-1] = 0;
-        if (key == '\b')
+        sbuf[MAXPDSTRING - 1] = 0;
+        if(key == '\b')
         {
-            if (*sbuf)
-                sbuf[strlen(sbuf)-1] = 0;
+            if(*sbuf) sbuf[strlen(sbuf) - 1] = 0;
         }
         else
         {
-            sbuf[strlen(sbuf)+1] = 0;
+            sbuf[strlen(sbuf) + 1] = 0;
             sbuf[strlen(sbuf)] = key;
         }
     }
-    else if (TEMPLATE->drawnumber_motion_type == DT_FLOAT)
+    else if(TEMPLATE->drawnumber_motion_type == DT_FLOAT)
     {
-            /* key entry for a numeric field.  This is just a stopgap. */
+        /* key entry for a numeric field.  This is just a stopgap. */
         double newf;
-        if (TEMPLATE->drawnumber_motion_firstkey)
+        if(TEMPLATE->drawnumber_motion_firstkey)
             sbuf[0] = 0;
-        else sprintf(sbuf, "%g",
-            template_getfloat(TEMPLATE->drawnumber_motion_template,
-            x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1));
+        else
+            sprintf(sbuf, "%g",
+                template_getfloat(TEMPLATE->drawnumber_motion_template,
+                    x->x_fieldname, TEMPLATE->drawnumber_motion_wp, 1));
         TEMPLATE->drawnumber_motion_firstkey = (key == '\n');
-        if (key == '\b')
+        if(key == '\b')
         {
-            if (*sbuf)
-                sbuf[strlen(sbuf)-1] = 0;
+            if(*sbuf) sbuf[strlen(sbuf) - 1] = 0;
         }
         else
         {
-            sbuf[strlen(sbuf)+1] = 0;
+            sbuf[strlen(sbuf) + 1] = 0;
             sbuf[strlen(sbuf)] = key;
         }
-        if (sscanf(sbuf, "%lg", &newf) < 1)
-            newf = 0;
-        template_setfloat(TEMPLATE->drawnumber_motion_template,
-            x->x_fieldname, TEMPLATE->drawnumber_motion_wp, (t_float)newf, 1);
-        if (TEMPLATE->drawnumber_motion_scalar)
+        if(sscanf(sbuf, "%lg", &newf) < 1) newf = 0;
+        template_setfloat(TEMPLATE->drawnumber_motion_template, x->x_fieldname,
+            TEMPLATE->drawnumber_motion_wp, (t_float) newf, 1);
+        if(TEMPLATE->drawnumber_motion_scalar)
             template_notifyforscalar(TEMPLATE->drawnumber_motion_template,
                 TEMPLATE->drawnumber_motion_glist,
-                    TEMPLATE->drawnumber_motion_scalar,
-                    gensym("change"), 1, &at);
-        if (TEMPLATE->drawnumber_motion_scalar)
+                TEMPLATE->drawnumber_motion_scalar, gensym("change"), 1, &at);
+        if(TEMPLATE->drawnumber_motion_scalar)
             scalar_redraw(TEMPLATE->drawnumber_motion_scalar,
                 TEMPLATE->drawnumber_motion_glist);
-        if (TEMPLATE->drawnumber_motion_array)
+        if(TEMPLATE->drawnumber_motion_array)
             array_redraw(TEMPLATE->drawnumber_motion_array,
                 TEMPLATE->drawnumber_motion_glist);
     }
-    else post("typing at text fields not yet implemented");
+    else
+        post("typing at text fields not yet implemented");
 }
 
-static int drawnumber_click(t_gobj *z, t_glist *glist,
-    t_word *data, t_template *template, t_scalar *sc, t_array *ap,
-    t_float basex, t_float basey,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int drawnumber_click(t_gobj *z, t_glist *glist, t_word *data,
+    t_template *template, t_scalar *sc, t_array *ap, t_float basex,
+    t_float basey, int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
-    t_drawnumber *x = (t_drawnumber *)z;
+    t_drawnumber *x = (t_drawnumber *) z;
     int x1, y1, x2, y2, type, onset;
-    drawnumber_getrect(z, glist,
-        data, template, basex, basey,
-        &x1, &y1, &x2, &y2);
-    if (xpix >= x1 && xpix <= x2 && ypix >= y1 && ypix <= y2 &&
+    drawnumber_getrect(
+        z, glist, data, template, basex, basey, &x1, &y1, &x2, &y2);
+    if(xpix >= x1 && xpix <= x2 && ypix >= y1 && ypix <= y2 &&
         ((type = drawnumber_gettype(x, data, template, &onset)) == DT_FLOAT ||
             type == DT_SYMBOL))
     {
-        if (doit)
+        if(doit)
         {
             TEMPLATE->drawnumber_motion_glist = glist;
             TEMPLATE->drawnumber_motion_wp = data;
@@ -2804,23 +2816,24 @@ static int drawnumber_click(t_gobj *z, t_glist *glist,
             TEMPLATE->drawnumber_motion_ycumulative =
                 template_getfloat(template, x->x_fieldname, data, 0);
             TEMPLATE->drawnumber_motion_type = type;
-            if (TEMPLATE->drawnumber_motion_scalar)
+            if(TEMPLATE->drawnumber_motion_scalar)
                 gpointer_setglist(&TEMPLATE->drawnumber_motion_gpointer,
                     TEMPLATE->drawnumber_motion_glist,
-                        TEMPLATE->drawnumber_motion_scalar);
-            else gpointer_setarray(&TEMPLATE->drawnumber_motion_gpointer,
+                    TEMPLATE->drawnumber_motion_scalar);
+            else
+                gpointer_setarray(&TEMPLATE->drawnumber_motion_gpointer,
                     TEMPLATE->drawnumber_motion_array,
-                        TEMPLATE->drawnumber_motion_wp);
-            glist_grab(glist, z, drawnumber_motionfn, drawnumber_key,
-                xpix, ypix);
+                    TEMPLATE->drawnumber_motion_wp);
+            glist_grab(
+                glist, z, drawnumber_motionfn, drawnumber_key, xpix, ypix);
         }
         return (1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
-const t_parentwidgetbehavior drawnumber_widgetbehavior =
-{
+const t_parentwidgetbehavior drawnumber_widgetbehavior = {
     drawnumber_getrect,
     drawnumber_displace,
     drawnumber_select,
@@ -2829,21 +2842,19 @@ const t_parentwidgetbehavior drawnumber_widgetbehavior =
     drawnumber_click,
 };
 
-static void drawnumber_free(t_drawnumber *x)
-{
-}
+static void drawnumber_free(t_drawnumber *x) {}
 
 static void drawnumber_setup(void)
 {
-    drawnumber_class = class_new(gensym("drawtext"),
-        (t_newmethod)drawnumber_new, (t_method)drawnumber_free,
-        sizeof(t_drawnumber), 0, A_GIMME, 0);
+    drawnumber_class =
+        class_new(gensym("drawtext"), (t_newmethod) drawnumber_new,
+            (t_method) drawnumber_free, sizeof(t_drawnumber), 0, A_GIMME, 0);
     class_setdrawcommand(drawnumber_class);
     class_addfloat(drawnumber_class, drawnumber_float);
-    class_addcreator((t_newmethod)drawnumber_new, gensym("drawsymbol"),
-        A_GIMME, 0);
-    class_addcreator((t_newmethod)drawnumber_new, gensym("drawnumber"),
-        A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) drawnumber_new, gensym("drawsymbol"), A_GIMME, 0);
+    class_addcreator(
+        (t_newmethod) drawnumber_new, gensym("drawnumber"), A_GIMME, 0);
     class_setparentwidget(drawnumber_class, &drawnumber_widgetbehavior);
 }
 
@@ -2858,12 +2869,6 @@ void g_template_setup(void)
     drawnumber_setup();
 }
 
-void g_template_newpdinstance(void)
-{
-    TEMPLATE = getbytes(sizeof(*TEMPLATE));
-}
+void g_template_newpdinstance(void) { TEMPLATE = getbytes(sizeof(*TEMPLATE)); }
 
-void g_template_freepdinstance(void)
-{
-    freebytes(TEMPLATE, sizeof(*TEMPLATE));
-}
+void g_template_freepdinstance(void) { freebytes(TEMPLATE, sizeof(*TEMPLATE)); }

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -130,8 +130,12 @@ t_template *template_new(t_symbol *templatesym, int argc, t_atom *argv)
     template_addtolist(x);
     while(argc > 0)
     {
-        int newtype, oldn, newn;
-        t_symbol *newname, *newarraytemplate = &s_, *newtypesym;
+        int newtype;
+        int oldn;
+        int newn;
+        t_symbol *newname;
+        t_symbol *newarraytemplate = &s_;
+        t_symbol *newtypesym;
         if(argc < 2 || argv[0].a_type != A_SYMBOL || argv[1].a_type != A_SYMBOL)
             goto bad;
         newtypesym = argv[0].a_w.w_symbol;
@@ -185,7 +189,8 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
     int *p_type, t_symbol **p_arraytype)
 {
     t_template *t;
-    int i, n;
+    int i;
+    int n;
     if(!x)
     {
         bug("template_find_field");
@@ -206,7 +211,8 @@ int template_find_field(t_template *x, t_symbol *name, int *p_onset,
 t_float template_getfloat(
     t_template *x, t_symbol *fieldname, t_word *wp, int loud)
 {
-    int onset, type;
+    int onset;
+    int type;
     t_symbol *arraytype;
     t_float val = 0;
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
@@ -226,7 +232,8 @@ t_float template_getfloat(
 void template_setfloat(
     t_template *x, t_symbol *fieldname, t_word *wp, t_float f, int loud)
 {
-    int onset, type;
+    int onset;
+    int type;
     t_symbol *arraytype;
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
@@ -244,7 +251,8 @@ void template_setfloat(
 t_symbol *template_getsymbol(
     t_template *x, t_symbol *fieldname, t_word *wp, int loud)
 {
-    int onset, type;
+    int onset;
+    int type;
     t_symbol *arraytype;
     t_symbol *val = &s_;
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
@@ -264,7 +272,8 @@ t_symbol *template_getsymbol(
 void template_setsymbol(
     t_template *x, t_symbol *fieldname, t_word *wp, t_symbol *s, int loud)
 {
-    int onset, type;
+    int onset;
+    int type;
     t_symbol *arraytype;
     if(template_find_field(x, fieldname, &onset, &type, &arraytype))
     {
@@ -309,7 +318,9 @@ elements might still be old ones.)
 static void template_conformwords(t_template *tfrom, t_template *tto,
     int *conformaction, t_word *wfrom, t_word *wto)
 {
-    int nfrom = tfrom->t_n, nto = tto->t_n, i;
+    int nfrom = tfrom->t_n;
+    int nto = tto->t_n;
+    int i;
     for(i = 0; i < nto; i++)
     {
         if(conformaction[i] >= 0)
@@ -329,7 +340,9 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
 {
     t_scalar *x;
     t_gpointer gp;
-    int nto = tto->t_n, nfrom = tfrom->t_n, i;
+    int nto = tto->t_n;
+    int nfrom = tfrom->t_n;
+    int i;
     t_template *scalartemplate;
     /* post("conform scalar"); */
     /* possibly replace the scalar */
@@ -357,7 +370,8 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
         }
         else
         {
-            t_gobj *y, *y2;
+            t_gobj *y;
+            t_gobj *y2;
             for(y = glist->gl_list; (y2 = y->g_next); y = y2)
                 if(y2 == &scfrom->sc_gobj)
                 {
@@ -394,13 +408,14 @@ static t_scalar *template_conformscalar(t_template *tfrom, t_template *tto,
 static void template_conformarray(
     t_template *tfrom, t_template *tto, int *conformaction, t_array *a)
 {
-    int i, j;
+    int i;
+    int j;
     t_template *scalartemplate = 0;
     if(a->a_templatesym == tfrom->t_sym)
     {
         /* the array elements must all be conformed */
-        int oldelemsize = sizeof(t_word) * tfrom->t_n,
-            newelemsize = sizeof(t_word) * tto->t_n;
+        int oldelemsize = sizeof(t_word) * tfrom->t_n;
+        int newelemsize = sizeof(t_word) * tto->t_n;
         char *newarray = getbytes(newelemsize * a->a_n);
         char *oldarray = a->a_vec;
         if(a->a_elemsize != oldelemsize) bug("template_conformarray");
@@ -462,9 +477,13 @@ static void template_conformglist(
 /* globally conform all scalars from one template to another */
 void template_conform(t_template *tfrom, t_template *tto)
 {
-    int nto = tto->t_n, nfrom = tfrom->t_n, i, j,
-        *conformaction = (int *) getbytes(sizeof(int) * nto),
-        *conformedfrom = (int *) getbytes(sizeof(int) * nfrom), doit = 0;
+    int nto = tto->t_n;
+    int nfrom = tfrom->t_n;
+    int i;
+    int j;
+    int *conformaction = (int *) getbytes(sizeof(int) * nto);
+    int *conformedfrom = (int *) getbytes(sizeof(int) * nfrom);
+    int doit = 0;
     for(i = 0; i < nto; i++)
         conformaction[i] = -1;
     for(i = 0; i < nfrom; i++)
@@ -566,7 +585,8 @@ static void *template_usetemplate(
     /* check if there's already a template by this name. */
     if((x = (t_template *) pd_findbyclass(templatesym, template_class)))
     {
-        t_template *y = template_new(&s_, argc, argv), *y2;
+        t_template *y = template_new(&s_, argc, argv);
+        t_template *y2;
         /* If the new template is the same as the old one,
         there's nothing to do.  */
         if(!template_match(x, y))
@@ -801,7 +821,10 @@ static void fielddesc_setsymbol_const(t_fielddesc *fd, t_symbol *s)
 
 static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
 {
-    char *s1, *s2, *s3, strbuf[MAXPDSTRING];
+    char *s1;
+    char *s2;
+    char *s3;
+    char strbuf[MAXPDSTRING];
     int i;
     fd->fd_type = A_FLOAT;
     fd->fd_var = 1;
@@ -814,8 +837,13 @@ static void fielddesc_setfloat_var(t_fielddesc *fd, t_symbol *s)
     }
     else
     {
-        int cpy = (int) (s1 - s->s_name), got;
-        double v1, v2, screen1, screen2, quantum;
+        int cpy = (int) (s1 - s->s_name);
+        int got;
+        double v1;
+        double v2;
+        double screen1;
+        double screen2;
+        double quantum;
         if(cpy > MAXPDSTRING - 5) cpy = MAXPDSTRING - 5;
         strncpy(strbuf, s->s_name, cpy);
         strbuf[cpy] = 0;
@@ -915,7 +943,10 @@ static t_float fielddesc_getfloat(
 /* convert a variable's value to a screen coordinate via its fielddesc */
 t_float fielddesc_cvttocoord(t_fielddesc *f, t_float val)
 {
-    t_float coord, pix, extreme, div;
+    t_float coord;
+    t_float pix;
+    t_float extreme;
+    t_float div;
     if(f->fd_v2 == f->fd_v1) return (val);
     div = (f->fd_screen2 - f->fd_screen1) / (f->fd_v2 - f->fd_v1);
     coord = f->fd_screen1 + (val - f->fd_v1) * div;
@@ -1030,7 +1061,8 @@ static void *curve_new(t_symbol *classsym, int argc, t_atom *argv)
     t_curve *x = (t_curve *) pd_new(curve_class);
     const char *classname = classsym->s_name;
     int flags = 0;
-    int nxy, i;
+    int nxy;
+    int i;
     t_fielddesc *fd;
     x->x_canvas = canvas_getcurrent();
     if(classname[0] == 'f')
@@ -1130,9 +1162,13 @@ static void curve_getrect(t_gobj *z, t_glist *glist, t_word *data,
     int *xp2, int *yp2)
 {
     t_curve *x = (t_curve *) z;
-    int i, n = x->x_npoints;
+    int i;
+    int n = x->x_npoints;
     t_fielddesc *f = x->x_vec;
-    int x1 = 0x7fffffff, x2 = -0x7fffffff, y1 = 0x7fffffff, y2 = -0x7fffffff;
+    int x1 = 0x7fffffff;
+    int x2 = -0x7fffffff;
+    int y1 = 0x7fffffff;
+    int y2 = -0x7fffffff;
     if(!fielddesc_getfloat(&x->x_vis, template, data, 0) ||
         (glist->gl_edit && x->x_flags & NOMOUSEEDIT) ||
         (!glist->gl_edit && x->x_flags & NOMOUSERUN))
@@ -1196,7 +1232,9 @@ static int rangecolor(int n) /* 0 to 9 in 5 steps */
 
 static void numbertocolor(int n, char *s)
 {
-    int red, blue, green;
+    int red;
+    int blue;
+    int green;
     if(n < 0) n = 0;
     red = n / 100;
     blue = ((n / 10) % 10);
@@ -1209,7 +1247,8 @@ static void curve_vis(t_gobj *z, t_glist *glist, t_word *data,
     t_template *template, t_float basex, t_float basey, int vis)
 {
     t_curve *x = (t_curve *) z;
-    int i, n = x->x_npoints;
+    int i;
+    int n = x->x_npoints;
     t_fielddesc *f = x->x_vec;
 
     /* see comment in plot_vis() */
@@ -1218,9 +1257,11 @@ static void curve_vis(t_gobj *z, t_glist *glist, t_word *data,
     {
         if(n > 1)
         {
-            int flags = x->x_flags, closed = (flags & CLOSED);
+            int flags = x->x_flags;
+            int closed = (flags & CLOSED);
             t_float width = fielddesc_getfloat(&x->x_width, template, data, 1);
-            char outline[20], fill[20];
+            char outline[20];
+            char fill[20];
             int pix[200];
             if(n > 100) n = 100;
             /* calculate the pixel values before we start printing
@@ -1319,7 +1360,8 @@ static int curve_click(t_gobj *z, t_glist *glist, t_word *data,
     t_float basey, int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
     t_curve *x = (t_curve *) z;
-    int i, n = x->x_npoints;
+    int i;
+    int n = x->x_npoints;
     int bestn = -1;
     int besterror = 0x7fffffff;
     t_fielddesc *f;
@@ -1328,11 +1370,12 @@ static int curve_click(t_gobj *z, t_glist *glist, t_word *data,
         return (0);
     for(i = 0, f = x->x_vec; i < n; i++, f += 2)
     {
-        int xval = fielddesc_getcoord(f, template, data, 0),
-            xloc = glist_xtopixels(glist, basex + xval);
-        int yval = fielddesc_getcoord(f + 1, template, data, 0),
-            yloc = glist_ytopixels(glist, basey + yval);
-        int xerr = xloc - xpix, yerr = yloc - ypix;
+        int xval = fielddesc_getcoord(f, template, data, 0);
+        int xloc = glist_xtopixels(glist, basex + xval);
+        int yval = fielddesc_getcoord(f + 1, template, data, 0);
+        int yloc = glist_ytopixels(glist, basey + yval);
+        int xerr = xloc - xpix;
+        int yerr = yloc - ypix;
         if(!f->fd_var && !(f + 1)->fd_var) continue;
         if(xerr < 0) xerr = -xerr;
         if(yerr < 0) yerr = -yerr;
@@ -1548,7 +1591,8 @@ static int plot_readownertemplate(t_plot *x, t_word *data,
     t_float *stylep, t_float *visp, t_float *scalarvisp, t_float *editp,
     t_fielddesc **xfield, t_fielddesc **yfield, t_fielddesc **wfield)
 {
-    int arrayonset, type;
+    int arrayonset;
+    int type;
     t_symbol *elemtemplatesym;
     t_array *array;
 
@@ -1595,9 +1639,15 @@ int array_getfields(t_symbol *elemtemplatesym, t_canvas **elemtemplatecanvasp,
     t_fielddesc *yfielddesc, t_fielddesc *wfielddesc, int *xonsetp,
     int *yonsetp, int *wonsetp)
 {
-    int arrayonset, elemsize, yonset, wonset, xonset, type;
+    int arrayonset;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
+    int type;
     t_template *elemtemplate;
-    t_symbol *dummy, *varname;
+    t_symbol *dummy;
+    t_symbol *varname;
     t_canvas *elemtemplatecanvas = 0;
 
     /* the "float" template is special in not having to have a canvas;
@@ -1654,16 +1704,32 @@ static void plot_getrect(t_gobj *z, t_glist *glist, t_word *data,
     int *xp2, int *yp2)
 {
     t_plot *x = (t_plot *) z;
-    int elemsize, yonset, wonset, xonset;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, yval, vis, scalarvis, edit;
+    t_float linewidth;
+    t_float xloc;
+    t_float xinc;
+    t_float yloc;
+    t_float style;
+    t_float yval;
+    t_float vis;
+    t_float scalarvis;
+    t_float edit;
     double xsum;
     t_array *array;
-    int x1 = 0x7fffffff, y1 = 0x7fffffff, x2 = -0x7fffffff, y2 = -0x7fffffff;
+    int x1 = 0x7fffffff;
+    int y1 = 0x7fffffff;
+    int x2 = -0x7fffffff;
+    int y2 = -0x7fffffff;
     int i;
-    t_float xpix, ypix, wpix;
+    t_float xpix;
+    t_float ypix;
+    t_float wpix;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
     /* if we're the only plot in the glist claim the whole thing */
     if(glist->gl_list && !glist->gl_list->g_next)
@@ -1684,7 +1750,8 @@ static void plot_getrect(t_gobj *z, t_glist *glist, t_word *data,
         int incr = (array->a_n <= 2000 ? 1 : array->a_n / 1000);
         for(i = 0, xsum = 0; i < array->a_n; i += incr)
         {
-            t_float usexloc, useyloc;
+            t_float usexloc;
+            t_float useyloc;
             t_gobj *y;
             /* get the coords of the point proper */
             array_getcoordinate(glist, (char *) (array->a_vec) + i * elemsize,
@@ -1715,7 +1782,10 @@ static void plot_getrect(t_gobj *z, t_glist *glist, t_word *data,
                 useyloc = basey + yloc + fielddesc_cvttocoord(yfielddesc, yval);
                 for(y = elemtemplatecanvas->gl_list; y; y = y->g_next)
                 {
-                    int xx1, xx2, yy1, yy2;
+                    int xx1;
+                    int xx2;
+                    int yy1;
+                    int yy2;
                     const t_parentwidgetbehavior *wb =
                         pd_getparentwidget(&y->g_pd);
                     if(!wb) continue;
@@ -1761,12 +1831,24 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
     t_template *template, t_float basex, t_float basey, int tovis)
 {
     t_plot *x = (t_plot *) z;
-    int elemsize, yonset, wonset, xonset, i;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
+    int i;
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, usexloc, yval, vis, scalarvis,
-        edit;
+    t_float linewidth;
+    t_float xloc;
+    t_float xinc;
+    t_float yloc;
+    t_float style;
+    t_float usexloc;
+    t_float yval;
+    t_float vis;
+    t_float scalarvis;
+    t_float edit;
     double xsum;
     t_array *array;
     int nelem;
@@ -1798,7 +1880,8 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
     {
         if(style == PLOTSTYLE_POINTS)
         {
-            t_float minyval = 1e20, maxyval = -1e20;
+            t_float minyval = 1e20;
+            t_float maxyval = -1e20;
             int ndrawn = 0;
             char color[20];
             numbertocolor(
@@ -1806,8 +1889,12 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
                 color);
             for(xsum = basex + xloc, i = 0; i < nelem; i++)
             {
-                t_float yval, xpix, ypix, nextxloc;
-                int ixpix, inextx;
+                t_float yval;
+                t_float xpix;
+                t_float ypix;
+                t_float nextxloc;
+                int ixpix;
+                int inextx;
 
                 if(xonset >= 0)
                 {
@@ -1857,8 +1944,11 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
         else
         {
             char outline[20];
-            int lastpixel = -1, ndrawn = 0;
-            t_float yval = 0, wval = 0, xpix;
+            int lastpixel = -1;
+            int ndrawn = 0;
+            t_float yval = 0;
+            t_float wval = 0;
+            t_float xpix;
             int ixpix = 0;
             /* draw the trace */
             numbertocolor(
@@ -2011,7 +2101,8 @@ static void plot_vis(t_gobj *z, t_glist *glist, t_word *data,
         {
             for(xsum = xloc, i = 0; i < nelem; i++)
             {
-                t_float usexloc, useyloc;
+                t_float usexloc;
+                t_float useyloc;
                 t_gobj *y;
                 if(xonset >= 0)
                     usexloc = basex + xloc +
@@ -2113,16 +2204,18 @@ static void array_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
     {
         /* a y-only plot. */
         int thisx = TEMPLATE->array_motion_initx +
-                    TEMPLATE->array_motion_xcumulative + 0.5,
-            x2;
-        int increment, i, nchange;
-        t_float newy = TEMPLATE->array_motion_ycumulative,
-                oldy = fielddesc_getcoord(TEMPLATE->array_motion_yfield,
-                    TEMPLATE->array_motion_template,
-                    (t_word *) (((char *) TEMPLATE->array_motion_wp) +
-                                TEMPLATE->array_motion_elemsize *
-                                    TEMPLATE->array_motion_lastx),
-                    1);
+                    TEMPLATE->array_motion_xcumulative + 0.5;
+        int x2;
+        int increment;
+        int i;
+        int nchange;
+        t_float newy = TEMPLATE->array_motion_ycumulative;
+        t_float oldy = fielddesc_getcoord(TEMPLATE->array_motion_yfield,
+            TEMPLATE->array_motion_template,
+            (t_word *) (((char *) TEMPLATE->array_motion_wp) +
+                        TEMPLATE->array_motion_elemsize *
+                            TEMPLATE->array_motion_lastx),
+            1);
         t_float ydiff = newy - oldy;
         if(thisx < 0)
             thisx = 0;
@@ -2163,7 +2256,13 @@ static int array_doclick_element(t_array *array, t_glist *glist,
 {
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
-    int elemsize, yonset, wonset, xonset, i, incr, hit;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
+    int i;
+    int incr;
+    int hit;
     double xsum;
 
     if(elemtemplatesym == &s_float) return (0);
@@ -2177,7 +2276,8 @@ static int array_doclick_element(t_array *array, t_glist *glist,
         incr = array->a_n / 300;
     for(i = 0, xsum = 0; i < array->a_n; i += incr)
     {
-        t_float usexloc, useyloc;
+        t_float usexloc;
+        t_float useyloc;
         if(xonset >= 0)
             usexloc =
                 xloc +
@@ -2210,7 +2310,11 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
 {
     t_canvas *elemtemplatecanvas;
     t_template *elemtemplate;
-    int elemsize, yonset, wonset, xonset, i;
+    int elemsize;
+    int yonset;
+    int wonset;
+    int xonset;
+    int i;
 
     if(!array_getfields(elemtemplatesym, &elemtemplatecanvas, &elemtemplate,
            &elemsize, xfield, yfield, wfield, &xonset, &yonset, &wonset))
@@ -2263,7 +2367,11 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
             /* First we get the closest distance to any element */
             for(i = 0; i < array->a_n; i += incr)
             {
-                t_float pxpix, pypix, pwpix, dx, dy;
+                t_float pxpix;
+                t_float pypix;
+                t_float pwpix;
+                t_float dx;
+                t_float dy;
                 array_getcoordinate(glist,
                     (char *) (array->a_vec) + i * elemsize, xonset, yonset,
                     wonset, i, xloc, yloc, xinc, xfield, yfield, wfield, &pxpix,
@@ -2306,7 +2414,13 @@ static int array_doclick(t_array *array, t_glist *glist, t_scalar *sc,
             if(!edit) return (0);
             for(i = 0; i < array->a_n; i += incr)
             {
-                t_float pxpix, pypix, pwpix, dx, dy, dy2, dy3;
+                t_float pxpix;
+                t_float pypix;
+                t_float pwpix;
+                t_float dx;
+                t_float dy;
+                t_float dy2;
+                t_float dy3;
                 array_getcoordinate(glist,
                     (char *) (array->a_vec) + i * elemsize, xonset, yonset,
                     wonset, i, xloc, yloc, xinc, xfield, yfield, wfield, &pxpix,
@@ -2435,7 +2549,14 @@ static int plot_click(t_gobj *z, t_glist *glist, t_word *data,
 {
     t_plot *x = (t_plot *) z;
     t_symbol *elemtemplatesym;
-    t_float linewidth, xloc, xinc, yloc, style, vis, scalarvis, edit;
+    t_float linewidth;
+    t_float xloc;
+    t_float xinc;
+    t_float yloc;
+    t_float style;
+    t_float vis;
+    t_float scalarvis;
+    t_float edit;
     t_array *array;
     t_fielddesc *xfielddesc, *yfielddesc, *wfielddesc;
 
@@ -2571,7 +2692,9 @@ static int drawnumber_gettype(
 static void drawnumber_getbuf(
     t_drawnumber *x, t_word *data, t_template *template, char *buf)
 {
-    int nchars, onset, type = drawnumber_gettype(x, data, template, &onset);
+    int nchars;
+    int onset;
+    int type = drawnumber_gettype(x, data, template, &onset);
     if(type < 0)
         buf[0] = 0;
     else
@@ -2582,7 +2705,8 @@ static void drawnumber_getbuf(
         if(type == DT_TEXT)
         {
             char *buf2;
-            int size2, ncopy;
+            int size2;
+            int ncopy;
             binbuf_gettext(
                 ((t_word *) ((char *) data + onset))->w_binbuf, &buf2, &size2);
             ncopy = (size2 > DRAWNUMBER_BUFSIZE - 1 - nchars
@@ -2612,8 +2736,16 @@ static void drawnumber_getrect(t_gobj *z, t_glist *glist, t_word *data,
 {
     t_drawnumber *x = (t_drawnumber *) z;
     t_atom at;
-    int xloc, yloc, fontwidth, fontheight, bufsize, width, height;
-    char buf[DRAWNUMBER_BUFSIZE], *startline, *newline;
+    int xloc;
+    int yloc;
+    int fontwidth;
+    int fontheight;
+    int bufsize;
+    int width;
+    int height;
+    char buf[DRAWNUMBER_BUFSIZE];
+    char *startline;
+    char *newline;
 
     if(!fielddesc_getfloat(&x->x_vis, template, data, 0))
     {
@@ -2676,7 +2808,8 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist, t_word *data,
             glist, basex + fielddesc_getcoord(&x->x_xloc, template, data, 0));
         int yloc = glist_ytopixels(
             glist, basey + fielddesc_getcoord(&x->x_yloc, template, data, 0));
-        char colorstring[20], buf[DRAWNUMBER_BUFSIZE];
+        char colorstring[20];
+        char buf[DRAWNUMBER_BUFSIZE];
         numbertocolor(
             fielddesc_getfloat(&x->x_color, template, data, 1), colorstring);
         drawnumber_getbuf(x, data, template, buf);
@@ -2798,7 +2931,12 @@ static int drawnumber_click(t_gobj *z, t_glist *glist, t_word *data,
     t_float basey, int xpix, int ypix, int shift, int alt, int dbl, int doit)
 {
     t_drawnumber *x = (t_drawnumber *) z;
-    int x1, y1, x2, y2, type, onset;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
+    int type;
+    int onset;
     drawnumber_getrect(
         z, glist, data, template, basex, basey, &x1, &y1, &x2, &y2);
     if(xpix >= x1 && xpix <= x2 && ypix >= y1 && ypix <= y2 &&

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -53,7 +53,9 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         x->te_xpix = atom_getfloatarg(0, argc, argv);
         x->te_ypix = atom_getfloatarg(1, argc, argv);
         if(argc > 2)
+        {
             binbuf_restore(x->te_binbuf, argc - 2, argv + 2);
+        }
         else
         {
             SETSYMBOL(&at, gensym("comment"));
@@ -82,8 +84,10 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         creation. */
         /* gobj_activate(&x->te_g, gl, 1); */
         if(!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+        {
             canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
                 (void *) canvas_undo_set_create(glist_getcanvas(gl)));
+        }
         canvas_startmotion(glist_getcanvas(gl));
     }
 }
@@ -105,7 +109,9 @@ static void canvas_objtext(
     if(binbuf_getnatom(b))
     {
         if(!pd_this->pd_newest)
+        {
             x = 0;
+        }
         else if(!(x = pd_checkobject(pd_this->pd_newest)))
         {
             binbuf_print(b);
@@ -165,6 +171,7 @@ static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
         t_gobj *g;
         t_gobj *selected = x->gl_editor->e_selection->sel_what;
         for(g = x->gl_list, nobj = 0; g; g = g->g_next, nobj++)
+        {
             if(g == selected)
             {
                 gobj_getrect(g, x, &x1, &y1, &x2, &y2);
@@ -172,6 +179,7 @@ static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
                 *xpixp = x1 / x->gl_zoom;
                 *ypixp = y2 / x->gl_zoom + 5.5; /* 5 pixels down, rounded */
             }
+        }
         glist_noselect(x);
         /* search back for 'selected' and if it isn't on the list,
             plan just to connect from the last item on the list. */
@@ -213,7 +221,9 @@ void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     }
     /* JMZ: don't go into interactive mode in a closed canvas */
     else if(!glist_isvisible(gl))
+    {
         post("unable to create stub object in closed canvas!");
+    }
     else
     {
         /* interactively create new object */
@@ -227,12 +237,18 @@ void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
         canvas_objtext(gl, xpix, ypix, 0, 1, b);
         if(connectme)
+        {
             canvas_connect(gl, indx, 0, nobj, 0);
+        }
         else
+        {
             canvas_startmotion(glist_getcanvas(gl));
+        }
         if(!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+        {
             canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
                 (void *) canvas_undo_set_create(glist_getcanvas(gl)));
+        }
     }
 }
 
@@ -491,7 +507,9 @@ void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         glist_add(gl, &x->m_text.te_g);
     }
     else if(!glist_isvisible(gl))
+    {
         post("unable to create stub message in closed canvas!");
+    }
     else
     {
         int connectme;
@@ -509,9 +527,13 @@ void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         glist_select(gl, &x->m_text.te_g);
         gobj_activate(&x->m_text.te_g, gl, 1);
         if(connectme)
+        {
             canvas_connect(gl, indx, 0, nobj, 0);
+        }
         else
+        {
             canvas_startmotion(glist_getcanvas(gl));
+        }
         canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
             (void *) canvas_undo_set_create(glist_getcanvas(gl)));
     }
@@ -648,20 +670,24 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
         if(ac == argc)
         {
             for(i = 0; i < argc; i++)
+            {
                 if((argv[i].a_type != av[i].a_type) ||
                     (argv[i].a_type == A_FLOAT &&
                         argv[i].a_w.w_float != av[i].a_w.w_float) ||
                     (argv[i].a_type == A_SYMBOL &&
                         argv[i].a_w.w_symbol != av[i].a_w.w_symbol))
                     break;
+            }
             if(i == argc) goto nochange;
         }
         binbuf_clear(x->a_text.te_binbuf);
         binbuf_add(x->a_text.te_binbuf, argc, argv);
         av = binbuf_getvec(x->a_text.te_binbuf);
         for(i = 0; i < argc; i++)
+        {
             if(argv[i].a_type == A_POINTER)
                 SETSYMBOL(&argv[i], gensym("(pointer)"));
+        }
         changed = 1;
     }
     if(changed) gatom_senditup(x);
@@ -678,11 +704,15 @@ static void gatom_bang(t_gatom *x)
         if(*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
         {
             if(x->a_symto == x->a_symfrom)
+            {
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
                     x->a_symto->s_name);
+            }
             else
+            {
                 pd_float(x->a_expanded_to->s_thing, ap->a_w.w_float);
+            }
         }
     }
     else if(x->a_flavor == A_SYMBOL)
@@ -692,11 +722,15 @@ static void gatom_bang(t_gatom *x)
         if(*x->a_symto->s_name && x->a_expanded_to->s_thing)
         {
             if(x->a_symto == x->a_symfrom)
+            {
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
                     x->a_symto->s_name);
+            }
             else
+            {
                 pd_symbol(x->a_expanded_to->s_thing, ap->a_w.w_symbol);
+            }
         }
     }
     else /* list */
@@ -705,21 +739,27 @@ static void gatom_bang(t_gatom *x)
         int i;
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
         for(i = 0; i < argc; i++)
+        {
             if(argv[i].a_type != A_FLOAT && argv[i].a_type != A_SYMBOL)
             {
                 pd_error(x, "list: only sends literal numbers and symbols");
                 return;
             }
+        }
         if(x->a_text.te_outlet)
             outlet_list(x->a_text.te_outlet, &s_list, argc, argv);
         if(*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
         {
             if(x->a_symto == x->a_symfrom)
+            {
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
                     x->a_symto->s_name);
+            }
             else
+            {
                 pd_list(x->a_expanded_to->s_thing, &s_list, argc, argv);
+            }
         }
     }
 }
@@ -811,11 +851,17 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
                 rtext_key(t, '\b', &s_);
             rtext_gettext(t, &buf, &bufsize);
             if(x->a_flavor == A_FLOAT)
+            {
                 ap->a_w.w_float = atof(buf);
+            }
             else if(x->a_flavor == A_SYMBOL)
+            {
                 ap->a_w.w_symbol = gensym(buf);
+            }
             else
+            {
                 text_setto(&x->a_text, x->a_glist, buf, bufsize);
+            }
             rtext_activate(t, 0);
         }
         gatom_bang(x);
@@ -832,11 +878,15 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
             rtext_key(t, 0, gensym("Home"));
         }
         if(x->a_flavor == A_SYMBOL || x->a_flavor == A_LIST)
+        {
             rtext_key(t, c, keysym); /* insert the character */
+        }
         else if(x->a_flavor == A_FLOAT &&
                 ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' ||
                     c == 'e' || c == 'E' || c == '\b'))
+        {
             rtext_key(t, c, keysym); /* insert the accepted characters */
+        }
     }
 }
 
@@ -903,7 +953,9 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos, int shift,
     if(x->a_flavor == A_FLOAT)
     {
         if(x->a_text.te_width == 1)
+        {
             gatom_float(x, (ap->a_w.w_float == 0));
+        }
         else
         {
             if(alt)
@@ -984,14 +1036,18 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
 
     gobj_vis(&x->a_text.te_g, x->a_glist, 0);
     if(!*symfrom->s_name && *x->a_symfrom->s_name)
+    {
         inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
+    }
     else if(*symfrom->s_name && !*x->a_symfrom->s_name && x->a_text.te_inlet)
     {
         canvas_deletelinesforio(x->a_glist, &x->a_text, x->a_text.te_inlet, 0);
         inlet_free(x->a_text.te_inlet);
     }
     if(!*symto->s_name && *x->a_symto->s_name)
+    {
         outlet_new(&x->a_text, 0);
+    }
     else if(*symto->s_name && !*x->a_symto->s_name && x->a_text.te_outlet)
     {
         canvas_deletelinesforio(x->a_glist, &x->a_text, 0, x->a_text.te_outlet);
@@ -1001,20 +1057,28 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
     x->a_draglo = draglo;
     x->a_draghi = draghi;
     if(width < 0)
+    {
         width = 4;
+    }
     else if(width > 1000)
+    {
         width = 1000;
+    }
     x->a_text.te_width = width;
     x->a_wherelabel = ((int) wherelabel & 3);
     x->a_label = label;
     x->a_fontsize = newfont;
     if(*x->a_symfrom->s_name)
+    {
         pd_unbind(
             &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
+    }
     x->a_symfrom = symfrom;
     if(*x->a_symfrom->s_name)
+    {
         pd_bind(
             &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
+    }
     x->a_symto = symto;
     x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
     gobj_vis(&x->a_text.te_g, x->a_glist, 1);
@@ -1069,8 +1133,10 @@ static void gatom_displace(t_gobj *z, t_glist *glist, int dx, int dy)
     t_gatom *x = (t_gatom *) z;
     text_displace(z, glist, dx, dy);
     if(glist_isvisible(glist))
+    {
         sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist), x,
             dx * glist->gl_zoom, dy * glist->gl_zoom);
+    }
 }
 
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
@@ -1132,14 +1198,18 @@ void canvas_atom(
         x->a_label = gatom_unescapit(atom_getsymbolarg(6, argc, argv));
         x->a_symfrom = gatom_unescapit(atom_getsymbolarg(7, argc, argv));
         if(*x->a_symfrom->s_name)
+        {
             pd_bind(&x->a_text.te_pd,
                 canvas_realizedollar(x->a_glist, x->a_symfrom));
+        }
 
         x->a_symto = gatom_unescapit(atom_getsymbolarg(8, argc, argv));
         x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
         if(x->a_symto == &s_)
+        {
             outlet_new(
                 &x->a_text, x->a_flavor == A_FLOAT ? &s_float : &s_symbol);
+        }
         if(x->a_symfrom == &s_) inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
         x->a_fontsize = atom_getfloatarg(9, argc, argv);
         glist_add(gl, &x->a_text.te_g);
@@ -1163,9 +1233,13 @@ void canvas_atom(
         glist_noselect(gl);
         glist_select(gl, &x->a_text.te_g);
         if(connectme)
+        {
             canvas_connect(gl, indx, 0, nobj, 0);
+        }
         else
+        {
             canvas_startmotion(glist_getcanvas(gl));
+        }
         canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
             (void *) canvas_undo_set_create(glist_getcanvas(gl)));
     }
@@ -1189,8 +1263,10 @@ void canvas_listbox(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 static void gatom_free(t_gatom *x)
 {
     if(*x->a_symfrom->s_name)
+    {
         pd_unbind(
             &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
+    }
     gfxstub_deleteforkey(x);
 }
 
@@ -1286,8 +1362,10 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
     t_rtext *y = glist_findrtext(glist, x);
     rtext_select(y, state);
     if(glist_isvisible(glist) && gobj_shouldvis(&x->te_g, glist))
+    {
         sys_vgui(".x%lx.c itemconfigure %sR -fill %s\n", glist, rtext_gettag(y),
             (state ? "blue" : "black"));
+    }
 }
 
 static void text_activate(t_gobj *z, t_glist *glist, int state)
@@ -1337,8 +1415,10 @@ static int text_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
         if(zgetfn(&x->te_pd, clicksym))
         {
             if(doit)
+            {
                 pd_vmess(&x->te_pd, clicksym, "fffff", (double) xpix,
                     (double) ypix, (double) shift, (double) 0, (double) alt);
+            }
             return (1);
         }
         return (0);
@@ -1346,8 +1426,10 @@ static int text_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     else if(x->te_type == T_MESSAGE)
     {
         if(doit)
+        {
             message_click((t_message *) x, (t_floatarg) xpix, (t_floatarg) ypix,
                 (t_floatarg) shift, (t_floatarg) 0, (t_floatarg) alt);
+        }
         return (1);
     }
     else
@@ -1374,8 +1456,10 @@ void text_save(t_gobj *z, t_binbuf *b)
             binbuf_addbinbuf(b, x->te_binbuf);
             binbuf_addv(b, ";");
             if(x->te_width)
+            {
                 binbuf_addv(
                     b, "ssi;", gensym("#X"), gensym("f"), (int) x->te_width);
+            }
         }
         else /* otherwise just save the text */
         {
@@ -1464,14 +1548,18 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     {
         int onset = x1 + (width - iow) * i / nplus;
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
                      "-tags [list %so%d outlet] -fill black\n",
                 glist_getcanvas(glist), onset, y2 - oh + glist->gl_zoom,
                 onset + iow, y2, tag, i);
+        }
         else
+        {
             sys_vgui(".x%lx.c coords %so%d %d %d %d %d\n",
                 glist_getcanvas(glist), tag, i, onset, y2 - oh + glist->gl_zoom,
                 onset + iow, y2);
+        }
     }
     n = obj_ninlets(ob);
     nplus = (n == 1 ? 1 : n - 1);
@@ -1479,14 +1567,18 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     {
         int onset = x1 + (width - iow) * i / nplus;
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
                      "-tags [list %si%d inlet] -fill black\n",
                 glist_getcanvas(glist), onset, y1, onset + iow,
                 y1 + ih - glist->gl_zoom, tag, i);
+        }
         else
+        {
             sys_vgui(".x%lx.c coords %si%d %d %d %d %d\n",
                 glist_getcanvas(glist), tag, i, onset, y1, onset + iow,
                 y1 + ih - glist->gl_zoom);
+        }
     }
 }
 
@@ -1508,11 +1600,13 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
     {
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
                      "-dash %s -width %d -capstyle projecting "
                      "-tags [list %sR obj]\n",
                 glist_getcanvas(glist), x1, y1, x2, y1, x2, y2, x1, y2, x1, y1,
                 pattern, glist->gl_zoom, tag);
+        }
         else
         {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d\n",
@@ -1528,17 +1622,21 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
         if(corner > 10 * glist->gl_zoom)
             corner = 10 * glist->gl_zoom; /* looks bad if too big */
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create line "
                      "%d %d %d %d %d %d %d %d %d %d %d %d %d %d "
                      "-width %d -capstyle projecting -tags [list %sR msg]\n",
                 glist_getcanvas(glist), x1, y1, x2 + corner, y1, x2,
                 y1 + corner, x2, y2 - corner, x2 + corner, y2, x1, y2, x1, y1,
                 glist->gl_zoom, tag);
+        }
         else
+        {
             sys_vgui(".x%lx.c coords %sR "
                      "%d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
                 glist_getcanvas(glist), tag, x1, y1, x2 + corner, y1, x2,
                 y1 + corner, x2, y2 - corner, x2 + corner, y2, x1, y2, x1, y1);
+        }
     }
     else if(x->te_type == T_ATOM && (((t_gatom *) x)->a_flavor == A_FLOAT ||
                                         ((t_gatom *) x)->a_flavor == A_SYMBOL))
@@ -1549,11 +1647,13 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
         int y1p = y1 + grabbed;
         corner = ((y2 - y1) / 4);
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d "
                      "-width %d -capstyle projecting -tags [list %sR atom]\n",
                 glist_getcanvas(glist), x1p, y1p, x2 - corner, y1p, x2,
                 y1p + corner, x2, y2, x1p, y2, x1p, y1p,
                 glist->gl_zoom + grabbed, tag);
+        }
         else
         {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d\n",
@@ -1570,12 +1670,14 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
         int y1p = y1 + grabbed;
         corner = ((y2 - y1) / 4);
         if(firsttime)
+        {
             sys_vgui(
                 ".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d %d %d "
                 "-width %d -capstyle projecting -tags [list %sR atom]\n",
                 glist_getcanvas(glist), x1p, y1p, x2 - corner, y1p, x2,
                 y1p + corner, x2, y2 - corner, x2 - corner, y2, x1p, y2, x1p,
                 y1p, glist->gl_zoom + grabbed, tag);
+        }
         else
         {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d "
@@ -1593,12 +1695,16 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
     else if(x->te_type == T_TEXT && glist->gl_edit)
     {
         if(firsttime)
+        {
             sys_vgui(".x%lx.c create line %d %d %d %d "
                      "-tags [list %sR commentbar]\n",
                 glist_getcanvas(glist), x2, y1, x2, y2, tag);
+        }
         else
+        {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d\n", glist_getcanvas(glist),
                 tag, x2, y1, x2, y2);
+        }
     }
     /* draw inlets/outlets */
 
@@ -1673,9 +1779,13 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
             if(pd_this->pd_newest)
             {
                 if(pd_class(pd_this->pd_newest) == canvas_class)
+                {
                     canvas_loadbang((t_canvas *) pd_this->pd_newest);
+                }
                 else if(zgetfn(pd_this->pd_newest, gensym("loadbang")))
+                {
                     vmess(pd_this->pd_newest, gensym("loadbang"), "f", LB_LOAD);
+                }
             }
         }
         /* if we made a new "pd" or changed a window name,
@@ -1706,9 +1816,13 @@ void text_getfont(
     t_glist *gl;
     if(pd_class(&x->te_pd) == canvas_class && ((t_glist *) (x))->gl_isgraph &&
         ((t_glist *) (x))->gl_goprect)
+    {
         gl = (t_glist *) (x);
+    }
     else
+    {
         gl = thisglist;
+    }
     font = glist_getfont(gl);
     zoom = glist_getzoom(gl);
     /* override if atom box has its own specified font size */

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -666,9 +666,9 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
     {
         t_atom *av = binbuf_getvec(x->a_text.te_binbuf);
         int ac = binbuf_getnatom(x->a_text.te_binbuf);
-        int i;
         if(ac == argc)
         {
+            int i;
             for(i = 0; i < argc; i++)
             {
                 if((argv[i].a_type != av[i].a_type) ||
@@ -683,7 +683,7 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
         binbuf_clear(x->a_text.te_binbuf);
         binbuf_add(x->a_text.te_binbuf, argc, argv);
         av = binbuf_getvec(x->a_text.te_binbuf);
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
         {
             if(argv[i].a_type == A_POINTER)
                 SETSYMBOL(&argv[i], gensym("(pointer)"));
@@ -736,9 +736,8 @@ static void gatom_bang(t_gatom *x)
     else /* list */
     {
         int argc = binbuf_getnatom(x->a_text.te_binbuf);
-        int i;
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
         {
             if(argv[i].a_type != A_FLOAT && argv[i].a_type != A_SYMBOL)
             {
@@ -1538,13 +1537,12 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
 {
     int n = obj_noutlets(ob);
     int nplus = (n == 1 ? 1 : n - 1);
-    int i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;
     int ih = IHEIGHT * glist->gl_zoom;
     int oh = OHEIGHT * glist->gl_zoom;
     /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         int onset = x1 + (width - iow) * i / nplus;
         if(firsttime)
@@ -1563,7 +1561,7 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     }
     n = obj_ninlets(ob);
     nplus = (n == 1 ? 1 : n - 1);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         int onset = x1 + (width - iow) * i / nplus;
         if(firsttime)
@@ -1716,13 +1714,12 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
 
 void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)
 {
-    int i;
     int n;
     n = obj_noutlets(ob);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         sys_vgui(".x%lx.c delete %so%d\n", glist_getcanvas(glist), tag, i);
     n = obj_ninlets(ob);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
         sys_vgui(".x%lx.c delete %si%d\n", glist_getcanvas(glist), tag, i);
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -63,7 +63,8 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        int xpix, ypix;
+        int xpix;
+        int ypix;
         pd_vmess((t_pd *) glist_getcanvas(gl), gensym("editmode"), "i", 1);
         SETSYMBOL(&at, gensym("comment"));
         glist_noselect(gl);
@@ -148,12 +149,21 @@ and whether to connect to it automatically */
 static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
     int *indexp, int *totalp)
 {
-    int xpix, ypix, indx = 0, nobj = 0, n2, x1, x2, y1, y2;
+    int xpix;
+    int ypix;
+    int indx = 0;
+    int nobj = 0;
+    int n2;
+    int x1;
+    int x2;
+    int y1;
+    int y2;
     int connectme = (x->gl_editor->e_selection &&
                      !x->gl_editor->e_selection->sel_next && !sys_noautopatch);
     if(connectme)
     {
-        t_gobj *g, *selected = x->gl_editor->e_selection->sel_what;
+        t_gobj *g;
+        t_gobj *selected = x->gl_editor->e_selection->sel_what;
         for(g = x->gl_list, nobj = 0; g; g = g->g_next, nobj++)
             if(g == selected)
             {
@@ -209,7 +219,11 @@ void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     {
         /* interactively create new object */
         t_binbuf *b = binbuf_new();
-        int connectme, xpix, ypix, indx, nobj;
+        int connectme;
+        int xpix;
+        int ypix;
+        int indx;
+        int nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
         canvas_objtext(gl, xpix, ypix, 0, 1, b);
@@ -230,7 +244,8 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
 {
     t_atom at;
     t_binbuf *b = binbuf_new();
-    int xpix, ypix;
+    int xpix;
+    int ypix;
 
     pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
     glist_noselect(gl);
@@ -480,7 +495,11 @@ void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         post("unable to create stub message in closed canvas!");
     else
     {
-        int connectme, xpix, ypix, indx, nobj;
+        int connectme;
+        int xpix;
+        int ypix;
+        int indx;
+        int nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
 
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
@@ -605,7 +624,8 @@ static t_atom *gatom_getatom(t_gatom *x)
 
 static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_atom *ap = gatom_getatom(x), oldatom;
+    t_atom *ap = gatom_getatom(x);
+    t_atom oldatom;
     int changed = 0;
     if(!argc && x->a_flavor != A_LIST) return;
     if(x->a_flavor == A_FLOAT)
@@ -626,7 +646,8 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
     else if(x->a_flavor == A_LIST) /* list */
     {
         t_atom *av = binbuf_getvec(x->a_text.te_binbuf);
-        int ac = binbuf_getnatom(x->a_text.te_binbuf), i;
+        int ac = binbuf_getnatom(x->a_text.te_binbuf);
+        int i;
         if(ac == argc)
         {
             for(i = 0; i < argc; i++)
@@ -683,7 +704,8 @@ static void gatom_bang(t_gatom *x)
     }
     else /* list */
     {
-        int argc = binbuf_getnatom(x->a_text.te_binbuf), i;
+        int argc = binbuf_getnatom(x->a_text.te_binbuf);
+        int i;
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
         for(i = 0; i < argc; i++)
             if(argv[i].a_type != A_FLOAT && argv[i].a_type != A_SYMBOL)
@@ -763,7 +785,9 @@ void gatom_undarken(t_text *x)
 void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
 {
     t_gatom *x = (t_gatom *) z;
-    int c = f, bufsize, i;
+    int c = f;
+    int bufsize;
+    int i;
     char *buf;
     t_atom *ap = gatom_getatom(x);
 
@@ -904,7 +928,12 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos, int shift,
     }
     else if(x->a_flavor == A_LIST)
     {
-        int x1, y1, x2, y2, indx, argc = binbuf_getnatom(x->a_text.te_binbuf);
+        int x1;
+        int y1;
+        int x2;
+        int y2;
+        int indx;
+        int argc = binbuf_getnatom(x->a_text.te_binbuf);
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
         gobj_getrect(z, gl, &x1, &y1, &x2, &y2);
         indx = rtext_findatomfor(t, xpos - x1, ypos - y1);
@@ -1006,8 +1035,12 @@ static int gatom_fontsize(t_gatom *x)
 /* ---------------- gatom-specific widget functions --------------- */
 static void gatom_getwherelabel(t_gatom *x, t_glist *glist, int *xp, int *yp)
 {
-    int x1, y1, x2, y2;
-    int zoom = glist_getzoom(glist), fontsize = gatom_fontsize(x);
+    int x1;
+    int y1;
+    int x2;
+    int y2;
+    int zoom = glist_getzoom(glist);
+    int fontsize = gatom_fontsize(x);
     text_getrect(&x->a_text.te_g, glist, &x1, &y1, &x2, &y2);
     if(x->a_wherelabel == ATOM_LABELLEFT)
     {
@@ -1051,7 +1084,8 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
     {
         if(vis)
         {
-            int x1, y1;
+            int x1;
+            int y1;
             gatom_getwherelabel(x, glist, &x1, &y1);
             sys_vgui(
                 "pdtk_text_new .x%lx.c {%lx.l label text} %f %f {%s } %d %s\n",
@@ -1115,7 +1149,11 @@ void canvas_atom(
     }
     else /* from menu - use default settings */
     {
-        int connectme, xpix, ypix, indx, nobj;
+        int connectme;
+        int xpix;
+        int ypix;
+        int indx;
+        int nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
         outlet_new(&x->a_text, x->a_flavor == A_FLOAT ? &s_float : &s_symbol);
         inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
@@ -1176,8 +1214,13 @@ static void text_getrect(
     t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_text *x = (t_text *) z;
-    int width, height, iscomment = (x->te_type == T_TEXT);
-    t_float x1, y1, x2, y2;
+    int width;
+    int height;
+    int iscomment = (x->te_type == T_TEXT);
+    t_float x1;
+    t_float y1;
+    t_float x2;
+    t_float y2;
 
     if(glist->gl_editor && glist->gl_editor->e_rtext)
     {
@@ -1413,10 +1456,13 @@ static const t_widgetbehavior gatom_widgetbehavior = {
 void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     const char *tag, int x1, int y1, int x2, int y2)
 {
-    int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n - 1), i;
+    int n = obj_noutlets(ob);
+    int nplus = (n == 1 ? 1 : n - 1);
+    int i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;
-    int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
+    int ih = IHEIGHT * glist->gl_zoom;
+    int oh = OHEIGHT * glist->gl_zoom;
     /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
     for(i = 0; i < n; i++)
     {
@@ -1452,7 +1498,13 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
     int height2, int firsttime)
 {
     t_object *ob;
-    int x1, y1, x2, y2, width, height, corner;
+    int x1;
+    int y1;
+    int x2;
+    int y2;
+    int width;
+    int height;
+    int corner;
     text_getrect(&x->te_g, glist, &x1, &y1, &x2, &y2);
     width = x2 - x1;
     height = y2 - y1;
@@ -1497,7 +1549,8 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
     {
         /* number or symbol */
         int grabbed = glist->gl_zoom * ((t_gatom *) x)->a_grabbed;
-        int x1p = x1 + grabbed, y1p = y1 + grabbed;
+        int x1p = x1 + grabbed;
+        int y1p = y1 + grabbed;
         corner = ((y2 - y1) / 4);
         if(firsttime)
             sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d "
@@ -1517,7 +1570,8 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
     else if(x->te_type == T_ATOM) /* list (ATOM but not float or symbol) */
     {
         int grabbed = glist->gl_zoom * ((t_gatom *) x)->a_grabbed;
-        int x1p = x1 + grabbed, y1p = y1 + grabbed;
+        int x1p = x1 + grabbed;
+        int y1p = y1 + grabbed;
         corner = ((y2 - y1) / 4);
         if(firsttime)
             sys_vgui(
@@ -1560,7 +1614,8 @@ void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
 
 void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)
 {
-    int i, n;
+    int i;
+    int n;
     n = obj_noutlets(ob);
     for(i = 0; i < n; i++)
         sys_vgui(".x%lx.c delete %so%d\n", glist_getcanvas(glist), tag, i);
@@ -1584,8 +1639,11 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
     if(x->te_type == T_OBJECT)
     {
         t_binbuf *b = binbuf_new();
-        int natom1, natom2, widthwas = x->te_width;
-        t_atom *vec1, *vec2;
+        int natom1;
+        int natom2;
+        int widthwas = x->te_width;
+        t_atom *vec1;
+        t_atom *vec2;
         binbuf_text(b, buf, bufsize);
         natom1 = binbuf_getnatom(x->te_binbuf);
         vec1 = binbuf_getvec(x->te_binbuf);
@@ -1607,7 +1665,8 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
         }
         else /* normally, just destroy the old one and make a new one. */
         {
-            int xwas = x->te_xpix, ywas = x->te_ypix;
+            int xwas = x->te_xpix;
+            int ywas = x->te_ypix;
             canvas_undo_add(glist_getcanvas(glist), UNDO_RECREATE, "recreate",
                 (void *) canvas_undo_set_recreate(
                     glist_getcanvas(glist), &x->te_g, pos));
@@ -1646,7 +1705,8 @@ static void text_anything(t_text *x, t_symbol *s, int argc, t_atom *argv) {}
 void text_getfont(
     t_text *x, t_glist *thisglist, int *fwidthp, int *fheightp, int *guifsize)
 {
-    int font, zoom;
+    int font;
+    int zoom;
     t_glist *gl;
     if(pd_class(&x->te_pd) == canvas_class && ((t_glist *) (x))->gl_isgraph &&
         ((t_glist *) (x))->gl_goprect)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -182,8 +182,7 @@ static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
                 indx = n2;
                 break;
             }
-            else if(!g->g_next)
-                indx = nobj - 1;
+            if(!g->g_next) indx = nobj - 1;
         }
     }
     else
@@ -523,8 +522,7 @@ t_pd *message_get_responder(t_gobj *x)
 {
     if(pd_class(&x->g_pd) != message_class)
         return NULL;
-    else
-        return (t_pd *) &((t_message *) x)->m_messresponder.mr_pd;
+    return (t_pd *) &((t_message *) x)->m_messresponder.mr_pd;
 }
 
 /* ---------------------- the "atom" text item ------------------------ */
@@ -562,7 +560,7 @@ static t_symbol *gatom_escapit(t_symbol *s)
 {
     if(!*s->s_name)
         return (gensym("-"));
-    else if(*s->s_name == '-')
+    if(*s->s_name == '-')
     {
         char shmo[100];
         shmo[0] = '-';
@@ -585,8 +583,7 @@ static t_symbol *gatom_unescapit(t_symbol *s)
 {
     if(*s->s_name == '-')
         return (gensym(s->s_name + 1));
-    else
-        return (iemgui_raute2dollar(s));
+    return (iemgui_raute2dollar(s));
 }
 
 static void gatom_redraw(t_gobj *client, t_glist *glist)
@@ -1344,8 +1341,7 @@ static int text_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
                     (double) ypix, (double) shift, (double) 0, (double) alt);
             return (1);
         }
-        else
-            return (0);
+        return (0);
     }
     else if(x->te_type == T_MESSAGE)
     {

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* changes by Thomas Musil IEM KUG Graz Austria 2001 */
 /* the methods for calling the gui-objects from menu are implemented */
@@ -29,31 +29,31 @@ t_class *text_class;
 static t_class *message_class;
 static t_class *gatom_class;
 static void text_vis(t_gobj *z, t_glist *glist, int vis);
-static void text_displace(t_gobj *z, t_glist *glist,
-    int dx, int dy);
-static void text_getrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2);
+static void text_displace(t_gobj *z, t_glist *glist, int dx, int dy);
+static void text_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2);
 
 void canvas_startmotion(t_canvas *x);
 int glist_getindex(t_glist *x, t_gobj *y);
 
 /* ----------------- the "text" object.  ------------------ */
 
-    /* add a "text" object (comment) to a glist.  Called without args
-    if invoked from the GUI; otherwise at least x and y are provided.  */
+/* add a "text" object (comment) to a glist.  Called without args
+if invoked from the GUI; otherwise at least x and y are provided.  */
 
 void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 {
-    t_text *x = (t_text *)pd_new(text_class);
+    t_text *x = (t_text *) pd_new(text_class);
     t_atom at;
-    x->te_width = 0;                            /* don't know it yet. */
+    x->te_width = 0; /* don't know it yet. */
     x->te_type = T_TEXT;
     x->te_binbuf = binbuf_new();
-    if (argc > 1)
+    if(argc > 1)
     {
         x->te_xpix = atom_getfloatarg(0, argc, argv);
         x->te_ypix = atom_getfloatarg(1, argc, argv);
-        if (argc > 2) binbuf_restore(x->te_binbuf, argc-2, argv+2);
+        if(argc > 2)
+            binbuf_restore(x->te_binbuf, argc - 2, argv + 2);
         else
         {
             SETSYMBOL(&at, gensym("comment"));
@@ -64,25 +64,25 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
     else
     {
         int xpix, ypix;
-        pd_vmess((t_pd *)glist_getcanvas(gl), gensym("editmode"), "i", 1);
+        pd_vmess((t_pd *) glist_getcanvas(gl), gensym("editmode"), "i", 1);
         SETSYMBOL(&at, gensym("comment"));
         glist_noselect(gl);
         glist_getnextxy(gl, &xpix, &ypix);
-        x->te_xpix = xpix/gl->gl_zoom - 1;
-        x->te_ypix = ypix/gl->gl_zoom - 1;
+        x->te_xpix = xpix / gl->gl_zoom - 1;
+        x->te_ypix = ypix / gl->gl_zoom - 1;
         binbuf_restore(x->te_binbuf, 1, &at);
         glist_add(gl, &x->te_g);
         glist_noselect(gl);
         glist_select(gl, &x->te_g);
-            /* it would be nice to "activate" here, but then the second,
-            "put-me-down" click changes the text selection, which is quite
-            irritating, so I took this back out.  It's OK in messages
-            and objects though since there's no text in them at menu
-            creation. */
-            /* gobj_activate(&x->te_g, gl, 1); */
-        if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+        /* it would be nice to "activate" here, but then the second,
+        "put-me-down" click changes the text selection, which is quite
+        irritating, so I took this back out.  It's OK in messages
+        and objects though since there's no text in them at menu
+        creation. */
+        /* gobj_activate(&x->te_g, gl, 1); */
+        if(!canvas_undo_get(glist_getcanvas(gl))->u_doing)
             canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-                (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+                (void *) canvas_undo_set_create(glist_getcanvas(gl)));
         canvas_startmotion(glist_getcanvas(gl));
     }
 }
@@ -91,31 +91,32 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 
 void canvas_getargs(int *argcp, t_atom **argvp);
 
-static void canvas_objtext(t_glist *gl, int xpix, int ypix, int width,
-    int selected, t_binbuf *b)
+static void canvas_objtext(
+    t_glist *gl, int xpix, int ypix, int width, int selected, t_binbuf *b)
 {
     t_text *x;
     int argc;
     t_atom *argv;
     pd_this->pd_newest = 0;
-    canvas_setcurrent((t_canvas *)gl);
+    canvas_setcurrent((t_canvas *) gl);
     canvas_getargs(&argc, &argv);
     binbuf_eval(b, &pd_objectmaker, argc, argv);
-    if (binbuf_getnatom(b))
+    if(binbuf_getnatom(b))
     {
-        if (!pd_this->pd_newest)
+        if(!pd_this->pd_newest)
             x = 0;
-        else if (!(x = pd_checkobject(pd_this->pd_newest)))
+        else if(!(x = pd_checkobject(pd_this->pd_newest)))
         {
             binbuf_print(b);
             pd_error(0, "... didn't return a patchable object");
         }
     }
-    else x = 0;
-    if (!x)
+    else
+        x = 0;
+    if(!x)
     {
-        x = (t_text *)pd_new(text_class);
-        if (binbuf_getnatom(b))
+        x = (t_text *) pd_new(text_class);
+        if(binbuf_getnatom(b))
         {
             binbuf_print(b);
             pd_error(x, "... couldn't create");
@@ -127,58 +128,59 @@ static void canvas_objtext(t_glist *gl, int xpix, int ypix, int width,
     x->te_width = width;
     x->te_type = T_OBJECT;
     glist_add(gl, &x->te_g);
-    if (selected)
+    if(selected)
     {
-            /* this is called if we've been created from the menu. */
+        /* this is called if we've been created from the menu. */
         glist_select(gl, &x->te_g);
         gobj_activate(&x->te_g, gl, 1);
     }
-    if (pd_class(&x->ob_pd) == vinlet_class)
+    if(pd_class(&x->ob_pd) == vinlet_class)
         canvas_resortinlets(glist_getcanvas(gl));
-    if (pd_class(&x->ob_pd) == voutlet_class)
+    if(pd_class(&x->ob_pd) == voutlet_class)
         canvas_resortoutlets(glist_getcanvas(gl));
-    canvas_unsetcurrent((t_canvas *)gl);
+    canvas_unsetcurrent((t_canvas *) gl);
 }
 
 extern int sys_noautopatch;
-    /* utility routine to figure out where to put a new text box from menu
-    and whether to connect to it automatically */
+
+/* utility routine to figure out where to put a new text box from menu
+and whether to connect to it automatically */
 static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
     int *indexp, int *totalp)
 {
     int xpix, ypix, indx = 0, nobj = 0, n2, x1, x2, y1, y2;
     int connectme = (x->gl_editor->e_selection &&
-        !x->gl_editor->e_selection->sel_next && !sys_noautopatch);
-    if (connectme)
+                     !x->gl_editor->e_selection->sel_next && !sys_noautopatch);
+    if(connectme)
     {
         t_gobj *g, *selected = x->gl_editor->e_selection->sel_what;
-        for (g = x->gl_list, nobj = 0; g; g = g->g_next, nobj++)
-            if (g == selected)
-        {
-            gobj_getrect(g, x, &x1, &y1, &x2, &y2);
-            indx = nobj;
-            *xpixp = x1 / x->gl_zoom;
-            *ypixp = y2  / x->gl_zoom + 5.5;    /* 5 pixels down, rounded */
-        }
+        for(g = x->gl_list, nobj = 0; g; g = g->g_next, nobj++)
+            if(g == selected)
+            {
+                gobj_getrect(g, x, &x1, &y1, &x2, &y2);
+                indx = nobj;
+                *xpixp = x1 / x->gl_zoom;
+                *ypixp = y2 / x->gl_zoom + 5.5; /* 5 pixels down, rounded */
+            }
         glist_noselect(x);
-            /* search back for 'selected' and if it isn't on the list,
-                plan just to connect from the last item on the list. */
-        for (g = x->gl_list, n2 = 0; g; g = g->g_next, n2++)
+        /* search back for 'selected' and if it isn't on the list,
+            plan just to connect from the last item on the list. */
+        for(g = x->gl_list, n2 = 0; g; g = g->g_next, n2++)
         {
-            if (g == selected)
+            if(g == selected)
             {
                 indx = n2;
                 break;
             }
-            else if (!g->g_next)
-                indx = nobj-1;
+            else if(!g->g_next)
+                indx = nobj - 1;
         }
     }
     else
     {
         glist_getnextxy(x, xpixp, ypixp);
-        *xpixp = *xpixp/x->gl_zoom - 3;
-        *ypixp = *ypixp/x->gl_zoom - 3;
+        *xpixp = *xpixp / x->gl_zoom - 3;
+        *ypixp = *ypixp / x->gl_zoom - 3;
         glist_noselect(x);
     }
     *connectp = connectme;
@@ -186,37 +188,38 @@ static void canvas_howputnew(t_canvas *x, int *connectp, int *xpixp, int *ypixp,
     *totalp = nobj;
 }
 
-    /* object creation routine.  These are called without any arguments if
-    they're invoked from the gui; when pasting or restoring from a file, we
-    get at least x and y. */
+/* object creation routine.  These are called without any arguments if
+they're invoked from the gui; when pasting or restoring from a file, we
+get at least x and y. */
 
 void canvas_obj(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 {
     t_text *x;
-    if (argc >= 2)
+    if(argc >= 2)
     {
         t_binbuf *b = binbuf_new();
-        binbuf_restore(b, argc-2, argv+2);
+        binbuf_restore(b, argc - 2, argv + 2);
         canvas_objtext(gl, atom_getfloatarg(0, argc, argv),
             atom_getfloatarg(1, argc, argv), 0, 0, b);
     }
-        /* JMZ: don't go into interactive mode in a closed canvas */
-    else if (!glist_isvisible(gl))
+    /* JMZ: don't go into interactive mode in a closed canvas */
+    else if(!glist_isvisible(gl))
         post("unable to create stub object in closed canvas!");
     else
     {
-            /* interactively create new object */
+        /* interactively create new object */
         t_binbuf *b = binbuf_new();
         int connectme, xpix, ypix, indx, nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
         canvas_objtext(gl, xpix, ypix, 0, 1, b);
-        if (connectme)
+        if(connectme)
             canvas_connect(gl, indx, 0, nobj, 0);
-        else canvas_startmotion(glist_getcanvas(gl));
-        if (!canvas_undo_get(glist_getcanvas(gl))->u_doing)
+        else
+            canvas_startmotion(glist_getcanvas(gl));
+        if(!canvas_undo_get(glist_getcanvas(gl))->u_doing)
             canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-                (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+                (void *) canvas_undo_set_create(glist_getcanvas(gl)));
     }
 }
 
@@ -234,10 +237,10 @@ void canvas_iemguis(t_glist *gl, t_symbol *guiobjname)
     SETSYMBOL(&at, guiobjname);
     binbuf_restore(b, 1, &at);
     glist_getnextxy(gl, &xpix, &ypix);
-    canvas_objtext(gl, xpix/gl->gl_zoom, ypix/gl->gl_zoom, 0, 1, b);
+    canvas_objtext(gl, xpix / gl->gl_zoom, ypix / gl->gl_zoom, 0, 1, b);
     canvas_startmotion(glist_getcanvas(gl));
     canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-        (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+        (void *) canvas_undo_set_create(glist_getcanvas(gl)));
 }
 
 void canvas_bng(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
@@ -299,12 +302,12 @@ void canvas_numbox(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 
 void canvas_objfor(t_glist *gl, t_text *x, int argc, t_atom *argv)
 {
-    x->te_width = 0;                            /* don't know it yet. */
+    x->te_width = 0; /* don't know it yet. */
     x->te_type = T_OBJECT;
     x->te_binbuf = binbuf_new();
     x->te_xpix = atom_getfloatarg(0, argc, argv);
     x->te_ypix = atom_getfloatarg(1, argc, argv);
-    if (argc > 2) binbuf_restore(x->te_binbuf, argc-2, argv+2);
+    if(argc > 2) binbuf_restore(x->te_binbuf, argc - 2, argv + 2);
     glist_add(gl, &x->te_g);
 }
 
@@ -341,14 +344,14 @@ static void messresponder_symbol(t_messresponder *x, t_symbol *s)
     outlet_symbol(x->mr_outlet, s);
 }
 
-static void messresponder_list(t_messresponder *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void messresponder_list(
+    t_messresponder *x, t_symbol *s, int argc, t_atom *argv)
 {
     outlet_list(x->mr_outlet, s, argc, argv);
 }
 
-static void messresponder_anything(t_messresponder *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void messresponder_anything(
+    t_messresponder *x, t_symbol *s, int argc, t_atom *argv)
 {
     outlet_anything(x->mr_outlet, s, argc, argv);
 }
@@ -405,17 +408,13 @@ static void message_addcomma(t_message *x)
     glist_retext(x->m_glist, &x->m_text);
 }
 
-static void message_addsemi(t_message *x)
-{
-    message_add(x, 0, 0, 0);
-}
+static void message_addsemi(t_message *x) { message_add(x, 0, 0, 0); }
 
 static void message_adddollar(t_message *x, t_floatarg f)
 {
     t_atom a;
     int n = f;
-    if (n < 0)
-        n = 0;
+    if(n < 0) n = 0;
     SETDOLLAR(&a, n);
     binbuf_add(x->m_text.te_binbuf, 1, &a);
     glist_retext(x->m_glist, &x->m_text);
@@ -426,18 +425,17 @@ static void message_adddollsym(t_message *x, t_symbol *s)
     t_atom a;
     char buf[MAXPDSTRING];
     buf[0] = '$';
-    strncpy(buf+1, s->s_name, MAXPDSTRING-2);
-    buf[MAXPDSTRING-1] = 0;
+    strncpy(buf + 1, s->s_name, MAXPDSTRING - 2);
+    buf[MAXPDSTRING - 1] = 0;
     SETDOLLSYM(&a, gensym(buf));
     binbuf_add(x->m_text.te_binbuf, 1, &a);
     glist_retext(x->m_glist, &x->m_text);
 }
 
-static void message_click(t_message *x,
-    t_floatarg xpos, t_floatarg ypos, t_floatarg shift,
-        t_floatarg ctrl, t_floatarg alt)
+static void message_click(t_message *x, t_floatarg xpos, t_floatarg ypos,
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
-    if (glist_isvisible(x->m_glist))
+    if(glist_isvisible(x->m_glist))
     {
         /* not zooming click width for now as it gets too fat */
         t_rtext *y = glist_findrtext(x->m_glist, &x->m_text);
@@ -450,7 +448,7 @@ static void message_click(t_message *x,
 
 static void message_tick(t_message *x)
 {
-    if (glist_isvisible(x->m_glist))
+    if(glist_isvisible(x->m_glist))
     {
         t_rtext *y = glist_findrtext(x->m_glist, &x->m_text);
         sys_vgui(".x%lx.c itemconfigure %sR -width %d\n",
@@ -459,29 +457,26 @@ static void message_tick(t_message *x)
     }
 }
 
-static void message_free(t_message *x)
-{
-    clock_free(x->m_clock);
-}
+static void message_free(t_message *x) { clock_free(x->m_clock); }
 
 void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 {
-    t_message *x = (t_message *)pd_new(message_class);
+    t_message *x = (t_message *) pd_new(message_class);
     x->m_messresponder.mr_pd = messresponder_class;
     x->m_messresponder.mr_outlet = outlet_new(&x->m_text, &s_float);
-    x->m_text.te_width = 0;                             /* don't know it yet. */
+    x->m_text.te_width = 0; /* don't know it yet. */
     x->m_text.te_type = T_MESSAGE;
     x->m_text.te_binbuf = binbuf_new();
     x->m_glist = gl;
-    x->m_clock = clock_new(x, (t_method)message_tick);
-    if (argc > 1)
+    x->m_clock = clock_new(x, (t_method) message_tick);
+    if(argc > 1)
     {
         x->m_text.te_xpix = atom_getfloatarg(0, argc, argv);
         x->m_text.te_ypix = atom_getfloatarg(1, argc, argv);
-        if (argc > 2) binbuf_restore(x->m_text.te_binbuf, argc-2, argv+2);
+        if(argc > 2) binbuf_restore(x->m_text.te_binbuf, argc - 2, argv + 2);
         glist_add(gl, &x->m_text.te_g);
     }
-    else if (!glist_isvisible(gl))
+    else if(!glist_isvisible(gl))
         post("unable to create stub message in closed canvas!");
     else
     {
@@ -495,19 +490,22 @@ void canvas_msg(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         glist_noselect(gl);
         glist_select(gl, &x->m_text.te_g);
         gobj_activate(&x->m_text.te_g, gl, 1);
-        if (connectme)
+        if(connectme)
             canvas_connect(gl, indx, 0, nobj, 0);
-        else canvas_startmotion(glist_getcanvas(gl));
+        else
+            canvas_startmotion(glist_getcanvas(gl));
         canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-            (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+            (void *) canvas_undo_set_create(glist_getcanvas(gl)));
     }
 }
 
-    /* for the needs of g_editor::glist_dofinderror() */
+/* for the needs of g_editor::glist_dofinderror() */
 t_pd *message_get_responder(t_gobj *x)
 {
-    if (pd_class(&x->g_pd) != message_class) return NULL;
-    else return (t_pd *)&((t_message *)x)->m_messresponder.mr_pd;
+    if(pd_class(&x->g_pd) != message_class)
+        return NULL;
+    else
+        return (t_pd *) &((t_message *) x)->m_messresponder.mr_pd;
 }
 
 /* ---------------------- the "atom" text item ------------------------ */
@@ -521,67 +519,67 @@ t_pd *message_get_responder(t_gobj *x)
 typedef struct _gatom
 {
     t_text a_text;
-    int a_flavor;           /* A_FLOAT, A_SYMBOL, or A_LIST */
-    t_glist *a_glist;       /* owning glist */
-    t_float a_toggle;       /* value to toggle to */
-    t_float a_draghi;       /* high end of drag range */
-    t_float a_draglo;       /* low end of drag range */
-    t_symbol *a_label;      /* symbol to show as label next to box */
-    t_symbol *a_symfrom;    /* "receive" name -- bind ourselves to this */
-    t_symbol *a_symto;      /* "send" name -- send to this on output */
-    t_binbuf *a_revertbuf;  /* binbuf to revert to if typing canceled */
-    int a_dragindex;        /* index of atom being dragged */
+    int a_flavor;          /* A_FLOAT, A_SYMBOL, or A_LIST */
+    t_glist *a_glist;      /* owning glist */
+    t_float a_toggle;      /* value to toggle to */
+    t_float a_draghi;      /* high end of drag range */
+    t_float a_draglo;      /* low end of drag range */
+    t_symbol *a_label;     /* symbol to show as label next to box */
+    t_symbol *a_symfrom;   /* "receive" name -- bind ourselves to this */
+    t_symbol *a_symto;     /* "send" name -- send to this on output */
+    t_binbuf *a_revertbuf; /* binbuf to revert to if typing canceled */
+    int a_dragindex;       /* index of atom being dragged */
     int a_fontsize;
-    unsigned int a_shift:1;         /* was shift key down when drag started? */
-    unsigned int a_wherelabel:2;    /* 0-3 for left, right, above, below */
-    unsigned int a_grabbed:1;       /* 1 if we've grabbed keyboard */
-    unsigned int a_doubleclicked:1; /* 1 if dragging from a double click */
-    t_symbol *a_expanded_to; /* a_symto after $0, $1, ...  expansion */
+    unsigned int a_shift : 1;      /* was shift key down when drag started? */
+    unsigned int a_wherelabel : 2; /* 0-3 for left, right, above, below */
+    unsigned int a_grabbed : 1;    /* 1 if we've grabbed keyboard */
+    unsigned int a_doubleclicked : 1; /* 1 if dragging from a double click */
+    t_symbol *a_expanded_to;          /* a_symto after $0, $1, ...  expansion */
 } t_gatom;
 
-    /* prepend "-" as necessary to avoid empty strings, so we can
-    use them in Pd messages. */
+/* prepend "-" as necessary to avoid empty strings, so we can
+use them in Pd messages. */
 static t_symbol *gatom_escapit(t_symbol *s)
 {
-    if (!*s->s_name)
+    if(!*s->s_name)
         return (gensym("-"));
-    else if (*s->s_name == '-')
+    else if(*s->s_name == '-')
     {
         char shmo[100];
         shmo[0] = '-';
-        strncpy(shmo+1, s->s_name, 99);
+        strncpy(shmo + 1, s->s_name, 99);
         shmo[99] = 0;
         return (gensym(shmo));
     }
-    else return (s);
+    else
+        return (s);
 }
 
-    /* undo previous operation: strip leading "-" if found.  This is used
-    both to restore send, etc, names when loading from a file, and to
-    set them from the properties dialog.  In the former case, since before
-    version 0.52 '$" was aliases to "#", we also bash any "#" characters
-    to "$".  This is unnecessary when reading files saved from 0.52 or later,
-    and really we should test for that and only bash when necessary, just
-    in case someone wants to have a "#" in a name. */
+/* undo previous operation: strip leading "-" if found.  This is used
+both to restore send, etc, names when loading from a file, and to
+set them from the properties dialog.  In the former case, since before
+version 0.52 '$" was aliases to "#", we also bash any "#" characters
+to "$".  This is unnecessary when reading files saved from 0.52 or later,
+and really we should test for that and only bash when necessary, just
+in case someone wants to have a "#" in a name. */
 static t_symbol *gatom_unescapit(t_symbol *s)
 {
-    if (*s->s_name == '-')
-        return (gensym(s->s_name+1));
-    else return (iemgui_raute2dollar(s));
+    if(*s->s_name == '-')
+        return (gensym(s->s_name + 1));
+    else
+        return (iemgui_raute2dollar(s));
 }
 
 static void gatom_redraw(t_gobj *client, t_glist *glist)
 {
-    t_gatom *x = (t_gatom *)client;
-    if (glist->gl_editor)
-        glist_retext(x->a_glist, &x->a_text);
+    t_gatom *x = (t_gatom *) client;
+    if(glist->gl_editor) glist_retext(x->a_glist, &x->a_text);
 }
 
 static void gatom_senditup(t_gatom *x)
 {
-    if (x->a_glist->gl_editor
-        && gobj_shouldvis(&x->a_text.te_g, x->a_glist))
-            sys_queuegui(x, x->a_glist, gatom_redraw);
+    if(x->a_glist->gl_editor && gobj_shouldvis(&x->a_text.te_g, x->a_glist))
+        sys_queuegui(x, x->a_glist, gatom_redraw);
 }
 
 #ifdef _MSC_VER
@@ -592,12 +590,12 @@ static t_atom *gatom_getatom(t_gatom *x)
 {
     int ac = binbuf_getnatom(x->a_text.te_binbuf);
     t_atom *av = binbuf_getvec(x->a_text.te_binbuf);
-    if (x->a_flavor == A_FLOAT && (ac != 1 || av[0].a_type != A_FLOAT))
+    if(x->a_flavor == A_FLOAT && (ac != 1 || av[0].a_type != A_FLOAT))
     {
         binbuf_clear(x->a_text.te_binbuf);
         binbuf_addv(x->a_text.te_binbuf, "f", 0.);
     }
-    else if (x->a_flavor == A_SYMBOL && (ac != 1 || av[0].a_type != A_SYMBOL))
+    else if(x->a_flavor == A_SYMBOL && (ac != 1 || av[0].a_type != A_SYMBOL))
     {
         binbuf_clear(x->a_text.te_binbuf);
         binbuf_addv(x->a_text.te_binbuf, "s", &s_);
@@ -609,100 +607,100 @@ static void gatom_set(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *ap = gatom_getatom(x), oldatom;
     int changed = 0;
-    if (!argc && x->a_flavor != A_LIST)
-        return;
-    if (x->a_flavor == A_FLOAT)
+    if(!argc && x->a_flavor != A_LIST) return;
+    if(x->a_flavor == A_FLOAT)
     {
         oldatom = *ap;
         ap->a_w.w_float = atom_getfloat(argv);
-            /* github PR 791 by Dan Bornstein: treat "-0" as different from
-            "0" and deal with NaNfoo all in one swipe by comparing bitwise: */
-        changed = memcmp(&ap->a_w.w_float, &oldatom.a_w.w_float,
-            sizeof(t_float));
+        /* github PR 791 by Dan Bornstein: treat "-0" as different from
+        "0" and deal with NaNfoo all in one swipe by comparing bitwise: */
+        changed =
+            memcmp(&ap->a_w.w_float, &oldatom.a_w.w_float, sizeof(t_float));
     }
-    else if (x->a_flavor == A_SYMBOL)
+    else if(x->a_flavor == A_SYMBOL)
     {
         oldatom = *ap;
         ap->a_w.w_symbol = atom_getsymbol(argv),
-            changed = (ap->a_w.w_symbol != oldatom.a_w.w_symbol);
+        changed = (ap->a_w.w_symbol != oldatom.a_w.w_symbol);
     }
-    else if (x->a_flavor == A_LIST)     /* list */
+    else if(x->a_flavor == A_LIST) /* list */
     {
         t_atom *av = binbuf_getvec(x->a_text.te_binbuf);
         int ac = binbuf_getnatom(x->a_text.te_binbuf), i;
-        if (ac == argc)
+        if(ac == argc)
         {
-            for (i = 0; i < argc; i++)
-                if ((argv[i].a_type != av[i].a_type) ||
-                (argv[i].a_type == A_FLOAT &&
-                     argv[i].a_w.w_float != av[i].a_w.w_float) ||
-                (argv[i].a_type == A_SYMBOL &&
-                    argv[i].a_w.w_symbol != av[i].a_w.w_symbol))
-                        break;
-            if (i == argc)
-                goto nochange;
+            for(i = 0; i < argc; i++)
+                if((argv[i].a_type != av[i].a_type) ||
+                    (argv[i].a_type == A_FLOAT &&
+                        argv[i].a_w.w_float != av[i].a_w.w_float) ||
+                    (argv[i].a_type == A_SYMBOL &&
+                        argv[i].a_w.w_symbol != av[i].a_w.w_symbol))
+                    break;
+            if(i == argc) goto nochange;
         }
-            binbuf_clear(x->a_text.te_binbuf);
-            binbuf_add(x->a_text.te_binbuf, argc, argv);
-            av = binbuf_getvec(x->a_text.te_binbuf);
-            for (i = 0; i < argc; i++)
-                if (argv[i].a_type == A_POINTER)
-                    SETSYMBOL(&argv[i], gensym("(pointer)"));
-            changed = 1;
+        binbuf_clear(x->a_text.te_binbuf);
+        binbuf_add(x->a_text.te_binbuf, argc, argv);
+        av = binbuf_getvec(x->a_text.te_binbuf);
+        for(i = 0; i < argc; i++)
+            if(argv[i].a_type == A_POINTER)
+                SETSYMBOL(&argv[i], gensym("(pointer)"));
+        changed = 1;
     }
-    if (changed)
-        gatom_senditup(x);
-nochange: ;
+    if(changed) gatom_senditup(x);
+nochange:;
 }
 
 static void gatom_bang(t_gatom *x)
 {
     t_atom *ap = gatom_getatom(x);
-    if (x->a_flavor == A_FLOAT)
+    if(x->a_flavor == A_FLOAT)
     {
-        if (x->a_text.te_outlet)
+        if(x->a_text.te_outlet)
             outlet_float(x->a_text.te_outlet, ap->a_w.w_float);
-        if (*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
+        if(*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
         {
-            if (x->a_symto == x->a_symfrom)
+            if(x->a_symto == x->a_symfrom)
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
-                        x->a_symto->s_name);
-            else pd_float(x->a_expanded_to->s_thing, ap->a_w.w_float);
+                    x->a_symto->s_name);
+            else
+                pd_float(x->a_expanded_to->s_thing, ap->a_w.w_float);
         }
     }
-    else if (x->a_flavor == A_SYMBOL)
+    else if(x->a_flavor == A_SYMBOL)
     {
-        if (x->a_text.te_outlet)
+        if(x->a_text.te_outlet)
             outlet_symbol(x->a_text.te_outlet, ap->a_w.w_symbol);
-        if (*x->a_symto->s_name && x->a_expanded_to->s_thing)
+        if(*x->a_symto->s_name && x->a_expanded_to->s_thing)
         {
-            if (x->a_symto == x->a_symfrom)
+            if(x->a_symto == x->a_symfrom)
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
-                        x->a_symto->s_name);
-            else pd_symbol(x->a_expanded_to->s_thing, ap->a_w.w_symbol);
+                    x->a_symto->s_name);
+            else
+                pd_symbol(x->a_expanded_to->s_thing, ap->a_w.w_symbol);
         }
     }
-    else    /* list */
+    else /* list */
     {
         int argc = binbuf_getnatom(x->a_text.te_binbuf), i;
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
-        for (i = 0; i < argc; i++)
-            if (argv[i].a_type != A_FLOAT && argv[i].a_type != A_SYMBOL)
-        {
-            pd_error(x, "list: only sends literal numbers and symbols");
-            return;
-        }
-        if (x->a_text.te_outlet)
+        for(i = 0; i < argc; i++)
+            if(argv[i].a_type != A_FLOAT && argv[i].a_type != A_SYMBOL)
+            {
+                pd_error(x, "list: only sends literal numbers and symbols");
+                return;
+            }
+        if(x->a_text.te_outlet)
             outlet_list(x->a_text.te_outlet, &s_list, argc, argv);
-        if (*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
+        if(*x->a_expanded_to->s_name && x->a_expanded_to->s_thing)
         {
-            if (x->a_symto == x->a_symfrom)
+            if(x->a_symto == x->a_symfrom)
                 pd_error(x,
                     "%s: atom with same send/receive name (infinite loop)",
-                        x->a_symto->s_name);
-            else pd_list(x->a_expanded_to->s_thing, &s_list, argc, argv);
+                    x->a_symto->s_name);
+            else
+                pd_list(x->a_expanded_to->s_thing, &s_list, argc, argv);
         }
     }
 }
@@ -717,12 +715,10 @@ static void gatom_float(t_gatom *x, t_float f)
 
 static void gatom_clipfloat(t_gatom *x, t_atom *ap, t_float f)
 {
-    if (x->a_draglo != 0 || x->a_draghi != 0)
+    if(x->a_draglo != 0 || x->a_draghi != 0)
     {
-        if (f < x->a_draglo)
-            f = x->a_draglo;
-        if (f > x->a_draghi)
-            f = x->a_draghi;
+        if(f < x->a_draglo) f = x->a_draglo;
+        if(f > x->a_draghi) f = x->a_draghi;
     }
     ap->a_w.w_float = f;
     gatom_senditup(x);
@@ -737,68 +733,65 @@ static void gatom_symbol(t_gatom *x, t_symbol *s)
     gatom_bang(x);
 }
 
-    /* We need a list method because, since there's both an "inlet" and a
-    "nofirstin" flag, the standard list behavior gets confused. */
+/* We need a list method because, since there's both an "inlet" and a
+"nofirstin" flag, the standard list behavior gets confused. */
 static void gatom_list(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
 {
-        /* bang outputs value for float and symbol but clears list */
-    if (argc || x->a_flavor == A_LIST)
-        gatom_set(x, s, argc, argv);
+    /* bang outputs value for float and symbol but clears list */
+    if(argc || x->a_flavor == A_LIST) gatom_set(x, s, argc, argv);
     gatom_bang(x);
 }
 
 static void gatom_reborder(t_gatom *x)
 {
     t_rtext *y = glist_findrtext(x->a_glist, &x->a_text);
-    text_drawborder(&x->a_text, x->a_glist, rtext_gettag(y),
-        rtext_width(y), rtext_height(y), 0);
+    text_drawborder(&x->a_text, x->a_glist, rtext_gettag(y), rtext_width(y),
+        rtext_height(y), 0);
 }
 
 void gatom_undarken(t_text *x)
 {
-    if (x->te_type == T_ATOM)
+    if(x->te_type == T_ATOM)
     {
-        ((t_gatom *)x)->a_doubleclicked =
-            ((t_gatom *)x)->a_grabbed = 0;
-        gatom_reborder((t_gatom *)x);
+        ((t_gatom *) x)->a_doubleclicked = ((t_gatom *) x)->a_grabbed = 0;
+        gatom_reborder((t_gatom *) x);
     }
-    else bug("gatom_undarken");
+    else
+        bug("gatom_undarken");
 }
 
 void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
 {
-    t_gatom *x = (t_gatom *)z;
+    t_gatom *x = (t_gatom *) z;
     int c = f, bufsize, i;
     char *buf;
     t_atom *ap = gatom_getatom(x);
 
     t_rtext *t = glist_findrtext(x->a_glist, &x->a_text);
-    if (c == 0 && !x->a_doubleclicked)
+    if(c == 0 && !x->a_doubleclicked)
     {
         /* we're being notified that no more keys will come for this grab */
-        if (t == x->a_glist->gl_editor->e_textedfor)
-            rtext_activate(t, 0);
+        if(t == x->a_glist->gl_editor->e_textedfor) rtext_activate(t, 0);
         x->a_grabbed = 0;
         gatom_reborder(x);
         gatom_senditup(x);
         gatom_redraw(&x->a_text.te_g, x->a_glist);
     }
-    else if (c == '\n')
+    else if(c == '\n')
     {
         x->a_doubleclicked = 0;
-        if (t == x->a_glist->gl_editor->e_textedfor)
+        if(t == x->a_glist->gl_editor->e_textedfor)
         {
             rtext_gettext(t, &buf, &bufsize);
             rtext_key(t, 0, gensym("End"));
-            for (i = 0; i < 3; i++)
-                if (buf[bufsize-i-1] != '.')
-                    break;
-            while (i--)
+            for(i = 0; i < 3; i++)
+                if(buf[bufsize - i - 1] != '.') break;
+            while(i--)
                 rtext_key(t, '\b', &s_);
             rtext_gettext(t, &buf, &bufsize);
-            if (x->a_flavor == A_FLOAT)
+            if(x->a_flavor == A_FLOAT)
                 ap->a_w.w_float = atof(buf);
-            else if (x->a_flavor == A_SYMBOL)
+            else if(x->a_flavor == A_SYMBOL)
                 ap->a_w.w_symbol = gensym(buf);
             else
                 text_setto(&x->a_text, x->a_glist, buf, bufsize);
@@ -809,7 +802,7 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
     }
     else
     {
-        if (t != x->a_glist->gl_editor->e_textedfor)
+        if(t != x->a_glist->gl_editor->e_textedfor)
         {
             rtext_activate(t, 1);
             rtext_key(t, '.', &s_);
@@ -817,53 +810,50 @@ void gatom_key(void *z, t_symbol *keysym, t_floatarg f)
             rtext_key(t, '.', &s_);
             rtext_key(t, 0, gensym("Home"));
         }
-        if (x->a_flavor == A_SYMBOL || x->a_flavor == A_LIST)
-            rtext_key(t, c, keysym);  /* insert the character */
-        else if (x->a_flavor == A_FLOAT && ((c >= '0' && c <= '9') || c == '.' ||
-            c == '-' || c == '+' || c == 'e' || c == 'E' || c == '\b'))
-                rtext_key(t, c, keysym);  /* insert the accepted characters */
+        if(x->a_flavor == A_SYMBOL || x->a_flavor == A_LIST)
+            rtext_key(t, c, keysym); /* insert the character */
+        else if(x->a_flavor == A_FLOAT &&
+                ((c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+' ||
+                    c == 'e' || c == 'E' || c == '\b'))
+            rtext_key(t, c, keysym); /* insert the accepted characters */
     }
 }
 
-static void gatom_motion(void *z, t_floatarg dx, t_floatarg dy,
-    t_floatarg up)
+static void gatom_motion(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
-    t_gatom *x = (t_gatom *)z;
-    if (up != 0)
+    t_gatom *x = (t_gatom *) z;
+    if(up != 0)
     {
         t_rtext *t = glist_findrtext(x->a_glist, &x->a_text);
         rtext_retext(t);
-        if (x->a_doubleclicked)    /* double click - activate text on release */
+        if(x->a_doubleclicked) /* double click - activate text on release */
             rtext_activate(t, 1);
     }
     else
     {
         t_atom *ap;
         x->a_doubleclicked = 0;
-        if (x->a_dragindex <0)
+        if(x->a_dragindex < 0) return;
+        if(dy == 0 || x->a_dragindex < 0 ||
+            x->a_dragindex >= binbuf_getnatom(x->a_text.te_binbuf) ||
+            binbuf_getvec(x->a_text.te_binbuf)[x->a_dragindex].a_type !=
+                A_FLOAT)
             return;
-        if (dy == 0 || x->a_dragindex < 0 ||
-            x->a_dragindex >= binbuf_getnatom(x->a_text.te_binbuf)
-            || binbuf_getvec(x->a_text.te_binbuf)[x->a_dragindex].a_type != A_FLOAT)
-                return;
         ap = &binbuf_getvec(x->a_text.te_binbuf)[x->a_dragindex];
-        if (x->a_shift)
+        if(x->a_shift)
         {
             double nval = ap->a_w.w_float - 0.01 * dy;
             double trunc = 0.01 * (floor(100. * nval + 0.5));
-            if (trunc < nval + 0.0001 && trunc > nval - 0.0001)
-                nval = trunc;
+            if(trunc < nval + 0.0001 && trunc > nval - 0.0001) nval = trunc;
             gatom_clipfloat(x, ap, nval);
         }
         else
         {
             double nval = ap->a_w.w_float - dy;
             double trunc = 0.01 * (floor(100. * nval + 0.5));
-            if (trunc < nval + 0.0001 && trunc > nval - 0.0001)
-                nval = trunc;
+            if(trunc < nval + 0.0001 && trunc > nval - 0.0001) nval = trunc;
             trunc = floor(nval + 0.5);
-            if (trunc < nval + 0.001 && trunc > nval - 0.001)
-                nval = trunc;
+            if(trunc < nval + 0.001 && trunc > nval - 0.001) nval = trunc;
             gatom_clipfloat(x, ap, nval);
         }
     }
@@ -871,18 +861,17 @@ static void gatom_motion(void *z, t_floatarg dx, t_floatarg dy,
 
 int rtext_findatomfor(t_rtext *x, int xpos, int ypos);
 
-    /* this is called when gatom is clicked on with patch in run mode. */
-static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos,
-    int shift, int alt, int dbl, int doit)
+/* this is called when gatom is clicked on with patch in run mode. */
+static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos, int shift,
+    int alt, int dbl, int doit)
 {
-    t_gatom *x = (t_gatom *)z;
+    t_gatom *x = (t_gatom *) z;
     t_atom *ap = gatom_getatom(x);
     t_rtext *t;
 
-    if (!doit)
-        return (1);
+    if(!doit) return (1);
     t = glist_findrtext(x->a_glist, &x->a_text);
-    if (t == x->a_glist->gl_editor->e_textedfor)
+    if(t == x->a_glist->gl_editor->e_textedfor)
     {
         rtext_mouse(t, xpos, ypos, (dbl ? RTEXT_DBL : RTEXT_DOWN));
         x->a_glist->gl_editor->e_onmotion = MA_DRAGTEXT;
@@ -890,20 +879,21 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos,
         x->a_glist->gl_editor->e_ywas = ypos;
         return (1);
     }
-    if (x->a_flavor == A_FLOAT)
+    if(x->a_flavor == A_FLOAT)
     {
-        if (x->a_text.te_width == 1)
+        if(x->a_text.te_width == 1)
             gatom_float(x, (ap->a_w.w_float == 0));
         else
         {
-            if (alt)
+            if(alt)
             {
-                if (ap->a_w.w_float != 0)
+                if(ap->a_w.w_float != 0)
                 {
                     x->a_toggle = ap->a_w.w_float;
                     gatom_float(x, 0);
                 }
-                else gatom_float(x, x->a_toggle);
+                else
+                    gatom_float(x, x->a_toggle);
             }
             else
             {
@@ -912,28 +902,29 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos,
             }
         }
     }
-    else if (x->a_flavor == A_LIST)
+    else if(x->a_flavor == A_LIST)
     {
         int x1, y1, x2, y2, indx, argc = binbuf_getnatom(x->a_text.te_binbuf);
         t_atom *argv = binbuf_getvec(x->a_text.te_binbuf);
         gobj_getrect(z, gl, &x1, &y1, &x2, &y2);
         indx = rtext_findatomfor(t, xpos - x1, ypos - y1);
-        if (indx >= 0 && indx < argc && argv[indx].a_type == A_FLOAT)
+        if(indx >= 0 && indx < argc && argv[indx].a_type == A_FLOAT)
         {
             x->a_dragindex = indx;
             x->a_shift = shift;
         }
-        else x->a_dragindex = -1;
+        else
+            x->a_dragindex = -1;
     }
     x->a_grabbed = 1;
     x->a_doubleclicked = dbl;
     gatom_reborder(x);
-    glist_grab(x->a_glist, &x->a_text.te_g, gatom_motion, gatom_key,
-        xpos, ypos);
+    glist_grab(
+        x->a_glist, &x->a_text.te_g, gatom_motion, gatom_key, xpos, ypos);
     return (1);
 }
 
-    /* probably never used but included in case needed for compatibility */
+/* probably never used but included in case needed for compatibility */
 static void gatom_click(t_gatom *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
@@ -941,7 +932,7 @@ static void gatom_click(t_gatom *x, t_floatarg xpos, t_floatarg ypos,
     gatom_doclick(&x->a_text.te_g, x->a_glist, xpos, ypos, shift, ctrl, 0, 1);
 }
 
-    /* message back from dialog window */
+/* message back from dialog window */
 static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_float width = atom_getfloatarg(0, argc, argv);
@@ -954,59 +945,55 @@ static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
     int newfont = atom_getfloatarg(7, argc, argv);
     t_atom undo[8];
 
-    SETFLOAT (undo+0, x->a_text.te_width);
-    SETFLOAT (undo+1, x->a_draglo);
-    SETFLOAT (undo+2, x->a_draghi);
-    SETSYMBOL(undo+3, gatom_escapit(x->a_label));
-    SETFLOAT (undo+4, x->a_wherelabel);
-    SETSYMBOL(undo+5, gatom_escapit(x->a_symfrom));
-    SETSYMBOL(undo+6, gatom_escapit(x->a_symto));
-    SETFLOAT (undo+7, x->a_fontsize);
-    pd_undo_set_objectstate(x->a_glist, (t_pd*)x, gensym("param"),
-                            8, undo,
-                            argc, argv);
+    SETFLOAT(undo + 0, x->a_text.te_width);
+    SETFLOAT(undo + 1, x->a_draglo);
+    SETFLOAT(undo + 2, x->a_draghi);
+    SETSYMBOL(undo + 3, gatom_escapit(x->a_label));
+    SETFLOAT(undo + 4, x->a_wherelabel);
+    SETSYMBOL(undo + 5, gatom_escapit(x->a_symfrom));
+    SETSYMBOL(undo + 6, gatom_escapit(x->a_symto));
+    SETFLOAT(undo + 7, x->a_fontsize);
+    pd_undo_set_objectstate(
+        x->a_glist, (t_pd *) x, gensym("param"), 8, undo, argc, argv);
 
     gobj_vis(&x->a_text.te_g, x->a_glist, 0);
-    if (!*symfrom->s_name && *x->a_symfrom->s_name)
+    if(!*symfrom->s_name && *x->a_symfrom->s_name)
         inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
-    else if (*symfrom->s_name && !*x->a_symfrom->s_name && x->a_text.te_inlet)
+    else if(*symfrom->s_name && !*x->a_symfrom->s_name && x->a_text.te_inlet)
     {
-        canvas_deletelinesforio(x->a_glist, &x->a_text,
-            x->a_text.te_inlet, 0);
+        canvas_deletelinesforio(x->a_glist, &x->a_text, x->a_text.te_inlet, 0);
         inlet_free(x->a_text.te_inlet);
     }
-    if (!*symto->s_name && *x->a_symto->s_name)
+    if(!*symto->s_name && *x->a_symto->s_name)
         outlet_new(&x->a_text, 0);
-    else if (*symto->s_name && !*x->a_symto->s_name && x->a_text.te_outlet)
+    else if(*symto->s_name && !*x->a_symto->s_name && x->a_text.te_outlet)
     {
-        canvas_deletelinesforio(x->a_glist, &x->a_text,
-            0, x->a_text.te_outlet);
+        canvas_deletelinesforio(x->a_glist, &x->a_text, 0, x->a_text.te_outlet);
         outlet_free(x->a_text.te_outlet);
     }
-    if (draglo >= draghi)
-        draglo = draghi = 0;
+    if(draglo >= draghi) draglo = draghi = 0;
     x->a_draglo = draglo;
     x->a_draghi = draghi;
-    if (width < 0)
+    if(width < 0)
         width = 4;
-    else if (width > 1000)
+    else if(width > 1000)
         width = 1000;
     x->a_text.te_width = width;
-    x->a_wherelabel = ((int)wherelabel & 3);
+    x->a_wherelabel = ((int) wherelabel & 3);
     x->a_label = label;
     x->a_fontsize = newfont;
-    if (*x->a_symfrom->s_name)
-        pd_unbind(&x->a_text.te_pd,
-            canvas_realizedollar(x->a_glist, x->a_symfrom));
+    if(*x->a_symfrom->s_name)
+        pd_unbind(
+            &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
     x->a_symfrom = symfrom;
-    if (*x->a_symfrom->s_name)
-        pd_bind(&x->a_text.te_pd,
-            canvas_realizedollar(x->a_glist, x->a_symfrom));
+    if(*x->a_symfrom->s_name)
+        pd_bind(
+            &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
     x->a_symto = symto;
     x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
     gobj_vis(&x->a_text.te_g, x->a_glist, 1);
     canvas_dirty(x->a_glist, 1);
-    canvas_fixlinesfor(x->a_glist, (t_text*)x);
+    canvas_fixlinesfor(x->a_glist, (t_text *) x);
 
     /* glist_retext(x->a_glist, &x->a_text); */
 }
@@ -1016,25 +1003,26 @@ static int gatom_fontsize(t_gatom *x)
     return (x->a_fontsize ? x->a_fontsize : glist_getfont(x->a_glist));
 }
 
-    /* ---------------- gatom-specific widget functions --------------- */
+/* ---------------- gatom-specific widget functions --------------- */
 static void gatom_getwherelabel(t_gatom *x, t_glist *glist, int *xp, int *yp)
 {
     int x1, y1, x2, y2;
     int zoom = glist_getzoom(glist), fontsize = gatom_fontsize(x);
     text_getrect(&x->a_text.te_g, glist, &x1, &y1, &x2, &y2);
-    if (x->a_wherelabel == ATOM_LABELLEFT)
+    if(x->a_wherelabel == ATOM_LABELLEFT)
     {
-        *xp = x1 - 3 * zoom - (
-            (int)strlen(canvas_realizedollar(x->a_glist, x->a_label)->s_name) *
-                sys_zoomfontwidth(fontsize, zoom, 0));
+        *xp = x1 - 3 * zoom -
+              ((int) strlen(
+                   canvas_realizedollar(x->a_glist, x->a_label)->s_name) *
+                  sys_zoomfontwidth(fontsize, zoom, 0));
         *yp = y1 + 2 * zoom;
     }
-    else if (x->a_wherelabel == ATOM_LABELRIGHT)
+    else if(x->a_wherelabel == ATOM_LABELRIGHT)
     {
         *xp = x2 + 2 * zoom;
         *yp = y1 + 2 * zoom;
     }
-    else if (x->a_wherelabel == ATOM_LABELUP)
+    else if(x->a_wherelabel == ATOM_LABELUP)
     {
         *xp = x1 - 1 * zoom;
         *yp = y1 - 1 * zoom - sys_zoomfontheight(fontsize, zoom, 0);
@@ -1046,42 +1034,41 @@ static void gatom_getwherelabel(t_gatom *x, t_glist *glist, int *xp, int *yp)
     }
 }
 
-static void gatom_displace(t_gobj *z, t_glist *glist,
-    int dx, int dy)
+static void gatom_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
-    t_gatom *x = (t_gatom*)z;
+    t_gatom *x = (t_gatom *) z;
     text_displace(z, glist, dx, dy);
-    if (glist_isvisible(glist))
-        sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist),
-            x, dx * glist->gl_zoom, dy * glist->gl_zoom);
+    if(glist_isvisible(glist))
+        sys_vgui(".x%lx.c move %lx.l %d %d\n", glist_getcanvas(glist), x,
+            dx * glist->gl_zoom, dy * glist->gl_zoom);
 }
 
 static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
 {
-    t_gatom *x = (t_gatom*)z;
+    t_gatom *x = (t_gatom *) z;
     text_vis(z, glist, vis);
-    if (*x->a_label->s_name)
+    if(*x->a_label->s_name)
     {
-        if (vis)
+        if(vis)
         {
             int x1, y1;
             gatom_getwherelabel(x, glist, &x1, &y1);
             sys_vgui(
                 "pdtk_text_new .x%lx.c {%lx.l label text} %f %f {%s } %d %s\n",
-                glist_getcanvas(glist), x,
-                (double)x1, (double)y1,
+                glist_getcanvas(glist), x, (double) x1, (double) y1,
                 canvas_realizedollar(x->a_glist, x->a_label)->s_name,
                 gatom_fontsize(x) * glist_getzoom(glist), "black");
         }
-        else sys_vgui(".x%lx.c delete %lx.l\n", glist_getcanvas(glist), x);
+        else
+            sys_vgui(".x%lx.c delete %lx.l\n", glist_getcanvas(glist), x);
     }
 }
 
-void canvas_atom(t_glist *gl, t_atomtype type,
-    t_symbol *s, int argc, t_atom *argv)
+void canvas_atom(
+    t_glist *gl, t_atomtype type, t_symbol *s, int argc, t_atom *argv)
 {
-    t_gatom *x = (t_gatom *)pd_new(gatom_class);
-    x->a_text.te_width = 0;                        /* don't know it yet. */
+    t_gatom *x = (t_gatom *) pd_new(gatom_class);
+    x->a_text.te_width = 0; /* don't know it yet. */
     x->a_text.te_type = T_ATOM;
     x->a_text.te_binbuf = binbuf_new();
     x->a_glist = gl;
@@ -1096,57 +1083,56 @@ void canvas_atom(t_glist *gl, t_atomtype type,
     x->a_grabbed = 0;
     x->a_revertbuf = 0;
     x->a_fontsize = 0;
-    (void)gatom_getatom(x);  /* this forces initialization of binbuf */
-    if (argc > 1)
-        /* create from file. x, y, width, low-range, high-range, flags,
-            label, receive-name, send-name, fontsize */
+    (void) gatom_getatom(x); /* this forces initialization of binbuf */
+    if(argc > 1)
+    /* create from file. x, y, width, low-range, high-range, flags,
+        label, receive-name, send-name, fontsize */
     {
         x->a_text.te_xpix = atom_getfloatarg(0, argc, argv);
         x->a_text.te_ypix = atom_getfloatarg(1, argc, argv);
         x->a_text.te_width = atom_getfloatarg(2, argc, argv);
-            /* sanity check because some very old patches have trash in this
-            field... remove this in 2003 or so: */
-        if (x->a_text.te_width < 0 || x->a_text.te_width > 500)
+        /* sanity check because some very old patches have trash in this
+        field... remove this in 2003 or so: */
+        if(x->a_text.te_width < 0 || x->a_text.te_width > 500)
             x->a_text.te_width = 4;
         x->a_draglo = atom_getfloatarg(3, argc, argv);
         x->a_draghi = atom_getfloatarg(4, argc, argv);
-        x->a_wherelabel = (((int)atom_getfloatarg(5, argc, argv)) & 3);
+        x->a_wherelabel = (((int) atom_getfloatarg(5, argc, argv)) & 3);
         x->a_label = gatom_unescapit(atom_getsymbolarg(6, argc, argv));
         x->a_symfrom = gatom_unescapit(atom_getsymbolarg(7, argc, argv));
-        if (*x->a_symfrom->s_name)
+        if(*x->a_symfrom->s_name)
             pd_bind(&x->a_text.te_pd,
                 canvas_realizedollar(x->a_glist, x->a_symfrom));
 
         x->a_symto = gatom_unescapit(atom_getsymbolarg(8, argc, argv));
         x->a_expanded_to = canvas_realizedollar(x->a_glist, x->a_symto);
-        if (x->a_symto == &s_)
-            outlet_new(&x->a_text,
-                x->a_flavor == A_FLOAT ? &s_float: &s_symbol);
-        if (x->a_symfrom == &s_)
-            inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
+        if(x->a_symto == &s_)
+            outlet_new(
+                &x->a_text, x->a_flavor == A_FLOAT ? &s_float : &s_symbol);
+        if(x->a_symfrom == &s_) inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
         x->a_fontsize = atom_getfloatarg(9, argc, argv);
         glist_add(gl, &x->a_text.te_g);
     }
-    else    /* from menu - use default settings */
+    else /* from menu - use default settings */
     {
         int connectme, xpix, ypix, indx, nobj;
         canvas_howputnew(gl, &connectme, &xpix, &ypix, &indx, &nobj);
-        outlet_new(&x->a_text,
-            x->a_flavor == A_FLOAT ? &s_float: &s_symbol);
+        outlet_new(&x->a_text, x->a_flavor == A_FLOAT ? &s_float : &s_symbol);
         inlet_new(&x->a_text, &x->a_text.te_pd, 0, 0);
         pd_vmess(&gl->gl_pd, gensym("editmode"), "i", 1);
         x->a_text.te_xpix = xpix;
         x->a_text.te_ypix = ypix;
-        x->a_text.te_width = (x->a_flavor == A_FLOAT ? 5 :
-            (x->a_flavor == A_SYMBOL ? 10 : 20));
+        x->a_text.te_width =
+            (x->a_flavor == A_FLOAT ? 5 : (x->a_flavor == A_SYMBOL ? 10 : 20));
         glist_add(gl, &x->a_text.te_g);
         glist_noselect(gl);
         glist_select(gl, &x->a_text.te_g);
-        if (connectme)
+        if(connectme)
             canvas_connect(gl, indx, 0, nobj, 0);
-        else canvas_startmotion(glist_getcanvas(gl));
+        else
+            canvas_startmotion(glist_getcanvas(gl));
         canvas_undo_add(glist_getcanvas(gl), UNDO_CREATE, "create",
-            (void *)canvas_undo_set_create(glist_getcanvas(gl)));
+            (void *) canvas_undo_set_create(glist_getcanvas(gl)));
     }
 }
 
@@ -1167,49 +1153,46 @@ void canvas_listbox(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 
 static void gatom_free(t_gatom *x)
 {
-    if (*x->a_symfrom->s_name)
-        pd_unbind(&x->a_text.te_pd,
-            canvas_realizedollar(x->a_glist, x->a_symfrom));
+    if(*x->a_symfrom->s_name)
+        pd_unbind(
+            &x->a_text.te_pd, canvas_realizedollar(x->a_glist, x->a_symfrom));
     gfxstub_deleteforkey(x);
 }
 
 static void gatom_properties(t_gobj *z, t_glist *owner)
 {
-    t_gatom *x = (t_gatom *)z;
+    t_gatom *x = (t_gatom *) z;
     char buf[200];
     sprintf(buf, "pdtk_gatom_dialog %%s %d %g %g %d {%s} {%s} {%s} %d\n",
-        x->a_text.te_width, x->a_draglo, x->a_draghi,
-            x->a_wherelabel, gatom_escapit(x->a_label)->s_name,
-                gatom_escapit(x->a_symfrom)->s_name,
-                    gatom_escapit(x->a_symto)->s_name,
-                        x->a_fontsize);
+        x->a_text.te_width, x->a_draglo, x->a_draghi, x->a_wherelabel,
+        gatom_escapit(x->a_label)->s_name, gatom_escapit(x->a_symfrom)->s_name,
+        gatom_escapit(x->a_symto)->s_name, x->a_fontsize);
     gfxstub_new(&x->a_text.te_pd, x, buf);
 }
 
-
 /* -------------------- widget behavior for text objects ------------ */
 
-static void text_getrect(t_gobj *z, t_glist *glist,
-    int *xp1, int *yp1, int *xp2, int *yp2)
+static void text_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_text *x = (t_text *)z;
+    t_text *x = (t_text *) z;
     int width, height, iscomment = (x->te_type == T_TEXT);
     t_float x1, y1, x2, y2;
 
-    if (glist->gl_editor && glist->gl_editor->e_rtext)
+    if(glist->gl_editor && glist->gl_editor->e_rtext)
     {
         t_rtext *y = glist_findrtext(glist, x);
         width = rtext_width(y);
         height = rtext_height(y) - (iscomment << 1);
     }
-        /* for number boxes, we know width and height a priori, and should
-        report them here so that graphs can get swelled to fit. */
+    /* for number boxes, we know width and height a priori, and should
+    report them here so that graphs can get swelled to fit. */
 
-    else if (x->te_type == T_ATOM && x->te_width > 0)
+    else if(x->te_type == T_ATOM && x->te_width > 0)
     {
         width = (x->te_width > 0 ? x->te_width : 6) * glist_fontwidth(glist);
         height = glist_fontheight(glist);
-        if (glist_getzoom(glist) > 1)
+        if(glist_getzoom(glist) > 1)
         {
             /* zoom margins */
             width += ATOM_RMARGIN * glist_getzoom(glist);
@@ -1221,15 +1204,16 @@ static void text_getrect(t_gobj *z, t_glist *glist,
             height += ATOM_BMARGIN;
         }
     }
-        /* if we're invisible we don't know our size so we just lie about
-        it.  This is called on invisible boxes to establish order of inlets
-        and possibly other reasons.
-           To find out if the box is visible we can't just check the "vis"
-        flag because we might be within the vis() routine and not have set
-        that yet.  So we check directly whether the "rtext" list has been
-        built.  LATER reconsider when "vis" flag should be on and off? */
+    /* if we're invisible we don't know our size so we just lie about
+    it.  This is called on invisible boxes to establish order of inlets
+    and possibly other reasons.
+       To find out if the box is visible we can't just check the "vis"
+    flag because we might be within the vis() routine and not have set
+    that yet.  So we check directly whether the "rtext" list has been
+    built.  LATER reconsider when "vis" flag should be on and off? */
 
-    else width = height = 10;
+    else
+        width = height = 10;
     x1 = text_xpix(x, glist);
     y1 = text_ypix(x, glist);
     x2 = x1 + width;
@@ -1241,63 +1225,61 @@ static void text_getrect(t_gobj *z, t_glist *glist,
     *yp2 = y2;
 }
 
-static void text_displace(t_gobj *z, t_glist *glist,
-    int dx, int dy)
+static void text_displace(t_gobj *z, t_glist *glist, int dx, int dy)
 {
-    t_text *x = (t_text *)z;
+    t_text *x = (t_text *) z;
     x->te_xpix += dx;
     x->te_ypix += dy;
-    if (glist_isvisible(glist))
+    if(glist_isvisible(glist))
     {
         t_rtext *y = glist_findrtext(glist, x);
         rtext_displace(y, glist->gl_zoom * dx, glist->gl_zoom * dy);
-        text_drawborder(x, glist, rtext_gettag(y),
-            rtext_width(y), rtext_height(y), 0);
+        text_drawborder(
+            x, glist, rtext_gettag(y), rtext_width(y), rtext_height(y), 0);
         canvas_fixlinesfor(glist, x);
     }
 }
 
 static void text_select(t_gobj *z, t_glist *glist, int state)
 {
-    t_text *x = (t_text *)z;
+    t_text *x = (t_text *) z;
     t_rtext *y = glist_findrtext(glist, x);
     rtext_select(y, state);
-    if (glist_isvisible(glist) && gobj_shouldvis(&x->te_g, glist))
-        sys_vgui(".x%lx.c itemconfigure %sR -fill %s\n", glist,
-            rtext_gettag(y), (state? "blue" : "black"));
+    if(glist_isvisible(glist) && gobj_shouldvis(&x->te_g, glist))
+        sys_vgui(".x%lx.c itemconfigure %sR -fill %s\n", glist, rtext_gettag(y),
+            (state ? "blue" : "black"));
 }
 
 static void text_activate(t_gobj *z, t_glist *glist, int state)
 {
-    t_text *x = (t_text *)z;
+    t_text *x = (t_text *) z;
     t_rtext *y = glist_findrtext(glist, x);
-    if (z->g_pd != gatom_class)
-        rtext_activate(y, state);
+    if(z->g_pd != gatom_class) rtext_activate(y, state);
 }
 
 static void text_delete(t_gobj *z, t_glist *glist)
 {
-    t_text *x = (t_text *)z;
-        canvas_deletelinesfor(glist, x);
+    t_text *x = (t_text *) z;
+    canvas_deletelinesfor(glist, x);
 }
 
 static void text_vis(t_gobj *z, t_glist *glist, int vis)
 {
-    t_text *x = (t_text *)z;
-    if (vis)
+    t_text *x = (t_text *) z;
+    if(vis)
     {
-        if (gobj_shouldvis(&x->te_g, glist))
+        if(gobj_shouldvis(&x->te_g, glist))
         {
             t_rtext *y = glist_findrtext(glist, x);
-            text_drawborder(x, glist, rtext_gettag(y),
-                rtext_width(y), rtext_height(y), 1);
+            text_drawborder(
+                x, glist, rtext_gettag(y), rtext_width(y), rtext_height(y), 1);
             rtext_draw(y);
         }
     }
     else
     {
         t_rtext *y = glist_findrtext(glist, x);
-        if (gobj_shouldvis(&x->te_g, glist))
+        if(gobj_shouldvis(&x->te_g, glist))
         {
             text_eraseborder(x, glist, rtext_gettag(y));
             rtext_erase(y);
@@ -1305,107 +1287,107 @@ static void text_vis(t_gobj *z, t_glist *glist, int vis)
     }
 }
 
-static int text_click(t_gobj *z, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int text_click(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_text *x = (t_text *)z;
-    if (x->te_type == T_OBJECT)
+    t_text *x = (t_text *) z;
+    if(x->te_type == T_OBJECT)
     {
         t_symbol *clicksym = gensym("click");
-        if (zgetfn(&x->te_pd, clicksym))
+        if(zgetfn(&x->te_pd, clicksym))
         {
-            if (doit)
-                pd_vmess(&x->te_pd, clicksym, "fffff",
-                    (double)xpix, (double)ypix,
-                        (double)shift, (double)0, (double)alt);
+            if(doit)
+                pd_vmess(&x->te_pd, clicksym, "fffff", (double) xpix,
+                    (double) ypix, (double) shift, (double) 0, (double) alt);
             return (1);
         }
-        else return (0);
+        else
+            return (0);
     }
-    else if (x->te_type == T_MESSAGE)
+    else if(x->te_type == T_MESSAGE)
     {
-        if (doit)
-            message_click((t_message *)x, (t_floatarg)xpix, (t_floatarg)ypix,
-                (t_floatarg)shift, (t_floatarg)0, (t_floatarg)alt);
+        if(doit)
+            message_click((t_message *) x, (t_floatarg) xpix, (t_floatarg) ypix,
+                (t_floatarg) shift, (t_floatarg) 0, (t_floatarg) alt);
         return (1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
 void canvas_statesavers_doit(t_glist *x, t_binbuf *b);
+
 void text_save(t_gobj *z, t_binbuf *b)
 {
-    t_text *x = (t_text *)z;
-    if (x->te_type == T_OBJECT)
+    t_text *x = (t_text *) z;
+    if(x->te_type == T_OBJECT)
     {
-            /* if we have a "saveto" method, and if we don't happen to be
-            a canvas that's an abstraction, the saveto method does the work */
-        if (zgetfn(&x->te_pd, gensym("saveto")) &&
+        /* if we have a "saveto" method, and if we don't happen to be
+        a canvas that's an abstraction, the saveto method does the work */
+        if(zgetfn(&x->te_pd, gensym("saveto")) &&
             !((pd_class(&x->te_pd) == canvas_class) &&
-                (canvas_isabstraction((t_canvas *)x)
-                    || canvas_istable((t_canvas *)x))))
+                (canvas_isabstraction((t_canvas *) x) ||
+                    canvas_istable((t_canvas *) x))))
         {
             mess1(&x->te_pd, gensym("saveto"), b);
             binbuf_addv(b, "ssii", gensym("#X"), gensym("restore"),
-                (int)x->te_xpix, (int)x->te_ypix);
+                (int) x->te_xpix, (int) x->te_ypix);
             binbuf_addbinbuf(b, x->te_binbuf);
             binbuf_addv(b, ";");
-            if (x->te_width)
-                binbuf_addv(b, "ssi;",
-                    gensym("#X"), gensym("f"), (int)x->te_width);
+            if(x->te_width)
+                binbuf_addv(
+                    b, "ssi;", gensym("#X"), gensym("f"), (int) x->te_width);
         }
-        else    /* otherwise just save the text */
+        else /* otherwise just save the text */
         {
             binbuf_addv(b, "ssii", gensym("#X"), gensym("obj"),
-                (int)x->te_xpix, (int)x->te_ypix);
+                (int) x->te_xpix, (int) x->te_ypix);
             binbuf_addbinbuf(b, x->te_binbuf);
-            if (x->te_width)
-                binbuf_addv(b, ",si", gensym("f"), (int)x->te_width);
+            if(x->te_width)
+                binbuf_addv(b, ",si", gensym("f"), (int) x->te_width);
             binbuf_addv(b, ";");
         }
-            /* if an abstraction, give it a chance to save state */
-        if (pd_class(&x->te_pd) == canvas_class &&
-            canvas_isabstraction((t_canvas *)x))
-                canvas_statesavers_doit((t_glist *)x, b);
+        /* if an abstraction, give it a chance to save state */
+        if(pd_class(&x->te_pd) == canvas_class &&
+            canvas_isabstraction((t_canvas *) x))
+            canvas_statesavers_doit((t_glist *) x, b);
     }
-    else if (x->te_type == T_MESSAGE)
+    else if(x->te_type == T_MESSAGE)
     {
-        binbuf_addv(b, "ssii", gensym("#X"), gensym("msg"),
-            (int)x->te_xpix, (int)x->te_ypix);
+        binbuf_addv(b, "ssii", gensym("#X"), gensym("msg"), (int) x->te_xpix,
+            (int) x->te_ypix);
         binbuf_addbinbuf(b, x->te_binbuf);
-        if (x->te_width)
-            binbuf_addv(b, ",si", gensym("f"), (int)x->te_width);
+        if(x->te_width) binbuf_addv(b, ",si", gensym("f"), (int) x->te_width);
         binbuf_addv(b, ";");
     }
-    else if (x->te_type == T_ATOM)
+    else if(x->te_type == T_ATOM)
     {
-        t_atomtype t = ((t_gatom *)x)->a_flavor;
-        t_symbol *sel = (t == A_SYMBOL ? gensym("symbolatom") :
-            (t == A_FLOAT ? gensym("floatatom") : gensym("listbox")));
-        t_symbol *label = gatom_escapit(((t_gatom *)x)->a_label);
-        t_symbol *symfrom = gatom_escapit(((t_gatom *)x)->a_symfrom);
-        t_symbol *symto = gatom_escapit(((t_gatom *)x)->a_symto);
-        binbuf_addv(b, "ssiiifffsssf;", gensym("#X"), sel,
-            (int)x->te_xpix, (int)x->te_ypix, (int)x->te_width,
-            (double)((t_gatom *)x)->a_draglo,
-            (double)((t_gatom *)x)->a_draghi,
-            (double)((t_gatom *)x)->a_wherelabel,
-            label, symfrom, symto, (double)((t_gatom *)x)->a_fontsize);
+        t_atomtype t = ((t_gatom *) x)->a_flavor;
+        t_symbol *sel = (t == A_SYMBOL ? gensym("symbolatom")
+                                       : (t == A_FLOAT ? gensym("floatatom")
+                                                       : gensym("listbox")));
+        t_symbol *label = gatom_escapit(((t_gatom *) x)->a_label);
+        t_symbol *symfrom = gatom_escapit(((t_gatom *) x)->a_symfrom);
+        t_symbol *symto = gatom_escapit(((t_gatom *) x)->a_symto);
+        binbuf_addv(b, "ssiiifffsssf;", gensym("#X"), sel, (int) x->te_xpix,
+            (int) x->te_ypix, (int) x->te_width,
+            (double) ((t_gatom *) x)->a_draglo,
+            (double) ((t_gatom *) x)->a_draghi,
+            (double) ((t_gatom *) x)->a_wherelabel, label, symfrom, symto,
+            (double) ((t_gatom *) x)->a_fontsize);
     }
     else
     {
-        binbuf_addv(b, "ssii", gensym("#X"), gensym("text"),
-            (int)x->te_xpix, (int)x->te_ypix);
+        binbuf_addv(b, "ssii", gensym("#X"), gensym("text"), (int) x->te_xpix,
+            (int) x->te_ypix);
         binbuf_addbinbuf(b, x->te_binbuf);
-        if (x->te_width)
-            binbuf_addv(b, ",si", gensym("f"), (int)x->te_width);
+        if(x->te_width) binbuf_addv(b, ",si", gensym("f"), (int) x->te_width);
         binbuf_addv(b, ";");
     }
 }
 
-    /* this one is for everyone but "gatoms"; it's imposed in m_class.c */
-const t_widgetbehavior text_widgetbehavior =
-{
+/* this one is for everyone but "gatoms"; it's imposed in m_class.c */
+const t_widgetbehavior text_widgetbehavior = {
     text_getrect,
     text_displace,
     text_select,
@@ -1415,8 +1397,7 @@ const t_widgetbehavior text_widgetbehavior =
     text_click,
 };
 
-static const t_widgetbehavior gatom_widgetbehavior =
-{
+static const t_widgetbehavior gatom_widgetbehavior = {
     text_getrect,
     gatom_displace,
     text_select,
@@ -1428,166 +1409,152 @@ static const t_widgetbehavior gatom_widgetbehavior =
 
 /* -------------------- the "text" class  ------------ */
 
-    /* draw inlets and outlets for a text object or for a graph. */
+/* draw inlets and outlets for a text object or for a graph. */
 void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     const char *tag, int x1, int y1, int x2, int y2)
 {
-    int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
+    int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n - 1), i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;
     int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
     /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
         int onset = x1 + (width - iow) * i / nplus;
-        if (firsttime)
+        if(firsttime)
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                "-tags [list %so%d outlet] -fill black\n",
-                glist_getcanvas(glist),
-                onset, y2 - oh + glist->gl_zoom,
-                onset + iow, y2,
-                tag, i);
+                     "-tags [list %so%d outlet] -fill black\n",
+                glist_getcanvas(glist), onset, y2 - oh + glist->gl_zoom,
+                onset + iow, y2, tag, i);
         else
             sys_vgui(".x%lx.c coords %so%d %d %d %d %d\n",
-                glist_getcanvas(glist), tag, i,
-                onset, y2 - oh + glist->gl_zoom,
+                glist_getcanvas(glist), tag, i, onset, y2 - oh + glist->gl_zoom,
                 onset + iow, y2);
     }
     n = obj_ninlets(ob);
-    nplus = (n == 1 ? 1 : n-1);
-    for (i = 0; i < n; i++)
+    nplus = (n == 1 ? 1 : n - 1);
+    for(i = 0; i < n; i++)
     {
         int onset = x1 + (width - iow) * i / nplus;
-        if (firsttime)
+        if(firsttime)
             sys_vgui(".x%lx.c create rectangle %d %d %d %d "
-                "-tags [list %si%d inlet] -fill black\n",
-                glist_getcanvas(glist),
-                onset, y1,
-                onset + iow, y1 + ih - glist->gl_zoom,
-                tag, i);
+                     "-tags [list %si%d inlet] -fill black\n",
+                glist_getcanvas(glist), onset, y1, onset + iow,
+                y1 + ih - glist->gl_zoom, tag, i);
         else
             sys_vgui(".x%lx.c coords %si%d %d %d %d %d\n",
-                glist_getcanvas(glist), tag, i,
-                onset, y1,
-                onset + iow, y1 + ih - glist->gl_zoom);
+                glist_getcanvas(glist), tag, i, onset, y1, onset + iow,
+                y1 + ih - glist->gl_zoom);
     }
 }
 
-void text_drawborder(t_text *x, t_glist *glist,
-    const char *tag, int width2, int height2, int firsttime)
+void text_drawborder(t_text *x, t_glist *glist, const char *tag, int width2,
+    int height2, int firsttime)
 {
     t_object *ob;
     int x1, y1, x2, y2, width, height, corner;
     text_getrect(&x->te_g, glist, &x1, &y1, &x2, &y2);
     width = x2 - x1;
     height = y2 - y1;
-    if (x->te_type == T_OBJECT)
+    if(x->te_type == T_OBJECT)
     {
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
-        if (firsttime)
+        if(firsttime)
             sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d "
-                "-dash %s -width %d -capstyle projecting "
-                "-tags [list %sR obj]\n",
-                glist_getcanvas(glist),
-                x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1,  pattern,
-                glist->gl_zoom, tag);
+                     "-dash %s -width %d -capstyle projecting "
+                     "-tags [list %sR obj]\n",
+                glist_getcanvas(glist), x1, y1, x2, y1, x2, y2, x1, y2, x1, y1,
+                pattern, glist->gl_zoom, tag);
         else
         {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d\n",
-                glist_getcanvas(glist), tag,
-                x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1);
+                glist_getcanvas(glist), tag, x1, y1, x2, y1, x2, y2, x1, y2, x1,
+                y1);
             sys_vgui(".x%lx.c itemconfigure %sR -dash %s\n",
                 glist_getcanvas(glist), tag, pattern);
         }
     }
-    else if (x->te_type == T_MESSAGE)
+    else if(x->te_type == T_MESSAGE)
     {
-        corner = ((y2-y1)/4);
-        if (corner > 10*glist->gl_zoom)
-            corner = 10*glist->gl_zoom; /* looks bad if too big */
-        if (firsttime)
+        corner = ((y2 - y1) / 4);
+        if(corner > 10 * glist->gl_zoom)
+            corner = 10 * glist->gl_zoom; /* looks bad if too big */
+        if(firsttime)
             sys_vgui(".x%lx.c create line "
-                "%d %d %d %d %d %d %d %d %d %d %d %d %d %d "
-                "-width %d -capstyle projecting -tags [list %sR msg]\n",
-                glist_getcanvas(glist),
-                x1, y1,  x2+corner, y1,  x2, y1+corner,  x2,
-                y2-corner,  x2+corner, y2, x1, y2,  x1, y1,
+                     "%d %d %d %d %d %d %d %d %d %d %d %d %d %d "
+                     "-width %d -capstyle projecting -tags [list %sR msg]\n",
+                glist_getcanvas(glist), x1, y1, x2 + corner, y1, x2,
+                y1 + corner, x2, y2 - corner, x2 + corner, y2, x1, y2, x1, y1,
                 glist->gl_zoom, tag);
         else
             sys_vgui(".x%lx.c coords %sR "
-            "%d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
-                glist_getcanvas(glist), tag,
-                x1, y1,  x2+corner, y1,  x2, y1+corner,  x2,
-                y2-corner,  x2+corner, y2, x1, y2,  x1, y1);
+                     "%d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+                glist_getcanvas(glist), tag, x1, y1, x2 + corner, y1, x2,
+                y1 + corner, x2, y2 - corner, x2 + corner, y2, x1, y2, x1, y1);
     }
-    else if (x->te_type == T_ATOM && (((t_gatom *)x)->a_flavor == A_FLOAT ||
-           ((t_gatom *)x)->a_flavor == A_SYMBOL))
+    else if(x->te_type == T_ATOM && (((t_gatom *) x)->a_flavor == A_FLOAT ||
+                                        ((t_gatom *) x)->a_flavor == A_SYMBOL))
     {
-            /* number or symbol */
-        int grabbed = glist->gl_zoom * ((t_gatom *)x)->a_grabbed;
+        /* number or symbol */
+        int grabbed = glist->gl_zoom * ((t_gatom *) x)->a_grabbed;
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
-        corner = ((y2-y1)/4);
-        if (firsttime)
+        corner = ((y2 - y1) / 4);
+        if(firsttime)
             sys_vgui(".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d "
-                "-width %d -capstyle projecting -tags [list %sR atom]\n",
-                glist_getcanvas(glist),
-                x1p, y1p,  x2-corner, y1p,  x2, y1p+corner, x2, y2,
-                    x1p, y2,  x1p, y1p, glist->gl_zoom+grabbed, tag);
+                     "-width %d -capstyle projecting -tags [list %sR atom]\n",
+                glist_getcanvas(glist), x1p, y1p, x2 - corner, y1p, x2,
+                y1p + corner, x2, y2, x1p, y2, x1p, y1p,
+                glist->gl_zoom + grabbed, tag);
         else
         {
             sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d\n",
-                glist_getcanvas(glist), tag,
-                x1p, y1p,  x2-corner, y1p,  x2, y1p+corner,  x2, y2,
-                    x1p, y2,  x1p, y1p);
+                glist_getcanvas(glist), tag, x1p, y1p, x2 - corner, y1p, x2,
+                y1p + corner, x2, y2, x1p, y2, x1p, y1p);
             sys_vgui(".x%lx.c itemconfigure %sR -width %d\n",
-                glist_getcanvas(glist), tag, glist->gl_zoom+grabbed);
+                glist_getcanvas(glist), tag, glist->gl_zoom + grabbed);
         }
     }
-    else if (x->te_type == T_ATOM ) /* list (ATOM but not float or symbol) */
+    else if(x->te_type == T_ATOM) /* list (ATOM but not float or symbol) */
     {
-        int grabbed = glist->gl_zoom * ((t_gatom *)x)->a_grabbed;
+        int grabbed = glist->gl_zoom * ((t_gatom *) x)->a_grabbed;
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
-        corner = ((y2-y1)/4);
-        if (firsttime)
+        corner = ((y2 - y1) / 4);
+        if(firsttime)
             sys_vgui(
-            ".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d %d %d "
+                ".x%lx.c create line %d %d %d %d %d %d %d %d %d %d %d %d %d %d "
                 "-width %d -capstyle projecting -tags [list %sR atom]\n",
-                glist_getcanvas(glist),
-                x1p, y1p,  x2-corner, y1p,  x2, y1p+corner,
-                x2, y2-corner, x2-corner, y2,
-                x1p, y2,  x1p, y1p,
-                    glist->gl_zoom+grabbed, tag);
+                glist_getcanvas(glist), x1p, y1p, x2 - corner, y1p, x2,
+                y1p + corner, x2, y2 - corner, x2 - corner, y2, x1p, y2, x1p,
+                y1p, glist->gl_zoom + grabbed, tag);
         else
         {
-            sys_vgui(
-            ".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
-                glist_getcanvas(glist), tag,
-                x1p, y1p,  x2-corner, y1p,  x2, y1p+corner,
-                    x2, y2-corner, x2-corner, y2,
-                    x1p, y2,  x1p, y1p);
+            sys_vgui(".x%lx.c coords %sR %d %d %d %d %d %d %d %d %d %d %d %d "
+                     "%d %d\n",
+                glist_getcanvas(glist), tag, x1p, y1p, x2 - corner, y1p, x2,
+                y1p + corner, x2, y2 - corner, x2 - corner, y2, x1p, y2, x1p,
+                y1p);
             sys_vgui(".x%lx.c itemconfigure %sR -width %d\n",
-                glist_getcanvas(glist), tag, glist->gl_zoom+grabbed);
+                glist_getcanvas(glist), tag, glist->gl_zoom + grabbed);
         }
     }
-        /* for comments, just draw a bar on RHS if unlocked; when a visible
-        canvas is unlocked we have to call this anew on all comments, and when
-        locked we erase them all via the annoying "commentbar" tag. */
-    else if (x->te_type == T_TEXT && glist->gl_edit)
+    /* for comments, just draw a bar on RHS if unlocked; when a visible
+    canvas is unlocked we have to call this anew on all comments, and when
+    locked we erase them all via the annoying "commentbar" tag. */
+    else if(x->te_type == T_TEXT && glist->gl_edit)
     {
-        if (firsttime)
+        if(firsttime)
             sys_vgui(".x%lx.c create line %d %d %d %d "
-            "-tags [list %sR commentbar]\n",
-                glist_getcanvas(glist),
-                x2, y1,  x2, y2, tag);
+                     "-tags [list %sR commentbar]\n",
+                glist_getcanvas(glist), x2, y1, x2, y2, tag);
         else
-            sys_vgui(".x%lx.c coords %sR %d %d %d %d\n",
-                glist_getcanvas(glist), tag, x2, y1,  x2, y2);
+            sys_vgui(".x%lx.c coords %sR %d %d %d %d\n", glist_getcanvas(glist),
+                tag, x2, y1, x2, y2);
     }
-        /* draw inlets/outlets */
+    /* draw inlets/outlets */
 
-    if ((ob = pd_checkobject(&x->te_pd)))
+    if((ob = pd_checkobject(&x->te_pd)))
         glist_drawiofor(glist, ob, firsttime, tag, x1, y1, x2, y2);
-    if (firsttime) /* raise cords over everything else */
+    if(firsttime) /* raise cords over everything else */
         sys_vgui(".x%lx.c raise cord\n", glist_getcanvas(glist));
 }
 
@@ -1595,28 +1562,26 @@ void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)
 {
     int i, n;
     n = obj_noutlets(ob);
-    for (i = 0; i < n; i++)
-        sys_vgui(".x%lx.c delete %so%d\n",
-            glist_getcanvas(glist), tag, i);
+    for(i = 0; i < n; i++)
+        sys_vgui(".x%lx.c delete %so%d\n", glist_getcanvas(glist), tag, i);
     n = obj_ninlets(ob);
-    for (i = 0; i < n; i++)
-        sys_vgui(".x%lx.c delete %si%d\n",
-            glist_getcanvas(glist), tag, i);
+    for(i = 0; i < n; i++)
+        sys_vgui(".x%lx.c delete %si%d\n", glist_getcanvas(glist), tag, i);
 }
 
 void text_eraseborder(t_text *x, t_glist *glist, const char *tag)
 {
-    if (x->te_type == T_TEXT && !glist->gl_edit) return;
-    sys_vgui(".x%lx.c delete %sR\n",
-        glist_getcanvas(glist), tag);
+    if(x->te_type == T_TEXT && !glist->gl_edit) return;
+    sys_vgui(".x%lx.c delete %sR\n", glist_getcanvas(glist), tag);
     glist_eraseiofor(glist, x, tag);
 }
 
-    /* change text; if T_OBJECT, remake it.  */
+/* change text; if T_OBJECT, remake it.  */
 void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
 {
-    int pos = glist_getindex(glist_getcanvas(glist), &x->te_g);;
-    if (x->te_type == T_OBJECT)
+    int pos = glist_getindex(glist_getcanvas(glist), &x->te_g);
+    ;
+    if(x->te_type == T_OBJECT)
     {
         t_binbuf *b = binbuf_new();
         int natom1, natom2, widthwas = x->te_width;
@@ -1626,81 +1591,77 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
         vec1 = binbuf_getvec(x->te_binbuf);
         natom2 = binbuf_getnatom(b);
         vec2 = binbuf_getvec(b);
-            /* special case: if  pd args change just pass the message on. */
-        if (natom1 >= 1 && natom2 >= 1 && vec1[0].a_type == A_SYMBOL
-            && !strcmp(vec1[0].a_w.w_symbol->s_name, "pd") &&
-             vec2[0].a_type == A_SYMBOL
-            && !strcmp(vec2[0].a_w.w_symbol->s_name, "pd"))
+        /* special case: if  pd args change just pass the message on. */
+        if(natom1 >= 1 && natom2 >= 1 && vec1[0].a_type == A_SYMBOL &&
+            !strcmp(vec1[0].a_w.w_symbol->s_name, "pd") &&
+            vec2[0].a_type == A_SYMBOL &&
+            !strcmp(vec2[0].a_w.w_symbol->s_name, "pd"))
         {
             canvas_undo_add(glist_getcanvas(glist), UNDO_RECREATE, "recreate",
-                (void *)canvas_undo_set_recreate(glist_getcanvas(glist),
-                &x->te_g, pos));
+                (void *) canvas_undo_set_recreate(
+                    glist_getcanvas(glist), &x->te_g, pos));
 
-            typedmess(&x->te_pd, gensym("rename"), natom2-1, vec2+1);
+            typedmess(&x->te_pd, gensym("rename"), natom2 - 1, vec2 + 1);
             binbuf_free(x->te_binbuf);
             x->te_binbuf = b;
         }
-        else  /* normally, just destroy the old one and make a new one. */
+        else /* normally, just destroy the old one and make a new one. */
         {
             int xwas = x->te_xpix, ywas = x->te_ypix;
             canvas_undo_add(glist_getcanvas(glist), UNDO_RECREATE, "recreate",
-                (void *)canvas_undo_set_recreate(glist_getcanvas(glist),
-                &x->te_g, pos));
+                (void *) canvas_undo_set_recreate(
+                    glist_getcanvas(glist), &x->te_g, pos));
             glist_delete(glist, &x->te_g);
             canvas_objtext(glist, xwas, ywas, widthwas, 0, b);
             canvas_restoreconnections(glist_getcanvas(glist));
-                /* if it's an abstraction loadbang it here */
-            if (pd_this->pd_newest)
+            /* if it's an abstraction loadbang it here */
+            if(pd_this->pd_newest)
             {
-                if (pd_class(pd_this->pd_newest) == canvas_class)
-                    canvas_loadbang((t_canvas *)pd_this->pd_newest);
-                else if (zgetfn(pd_this->pd_newest, gensym("loadbang")))
+                if(pd_class(pd_this->pd_newest) == canvas_class)
+                    canvas_loadbang((t_canvas *) pd_this->pd_newest);
+                else if(zgetfn(pd_this->pd_newest, gensym("loadbang")))
                     vmess(pd_this->pd_newest, gensym("loadbang"), "f", LB_LOAD);
             }
         }
-            /* if we made a new "pd" or changed a window name,
-                update window list */
-        if (natom2 >= 1  && vec2[0].a_type == A_SYMBOL
-            && !strcmp(vec2[0].a_w.w_symbol->s_name, "pd"))
-                canvas_updatewindowlist();
+        /* if we made a new "pd" or changed a window name,
+            update window list */
+        if(natom2 >= 1 && vec2[0].a_type == A_SYMBOL &&
+            !strcmp(vec2[0].a_w.w_symbol->s_name, "pd"))
+            canvas_updatewindowlist();
     }
     else
     {
         canvas_undo_add(glist_getcanvas(glist), UNDO_RECREATE, "recreate",
-           (void *)canvas_undo_set_recreate(glist_getcanvas(glist),
-            &x->te_g, pos));
+            (void *) canvas_undo_set_recreate(
+                glist_getcanvas(glist), &x->te_g, pos));
         binbuf_text(x->te_binbuf, buf, bufsize);
-
     }
 }
 
-    /* this gets called when a message gets sent to an object whose creation
-    failed, presumably because of loading a patch with a missing extern or
-    abstraction */
-static void text_anything(t_text *x, t_symbol *s, int argc, t_atom *argv)
-{
-}
+/* this gets called when a message gets sent to an object whose creation
+failed, presumably because of loading a patch with a missing extern or
+abstraction */
+static void text_anything(t_text *x, t_symbol *s, int argc, t_atom *argv) {}
 
-void text_getfont(t_text *x, t_glist *thisglist,
-    int *fwidthp, int *fheightp, int *guifsize)
+void text_getfont(
+    t_text *x, t_glist *thisglist, int *fwidthp, int *fheightp, int *guifsize)
 {
     int font, zoom;
     t_glist *gl;
-    if (pd_class(&x->te_pd) == canvas_class &&
-        ((t_glist *)(x))->gl_isgraph &&
-        ((t_glist *)(x))->gl_goprect)
-            gl = (t_glist *)(x);
-    else gl = thisglist;
-    font =  glist_getfont(gl);
+    if(pd_class(&x->te_pd) == canvas_class && ((t_glist *) (x))->gl_isgraph &&
+        ((t_glist *) (x))->gl_goprect)
+        gl = (t_glist *) (x);
+    else
+        gl = thisglist;
+    font = glist_getfont(gl);
     zoom = glist_getzoom(gl);
-        /* override if atom box has its own specified font size */
-    if (x->te_type == T_ATOM && ((t_gatom *)x)->a_fontsize > 0)
-        font = ((t_gatom *)x)->a_fontsize;
+    /* override if atom box has its own specified font size */
+    if(x->te_type == T_ATOM && ((t_gatom *) x)->a_fontsize > 0)
+        font = ((t_gatom *) x)->a_fontsize;
     *fwidthp = sys_zoomfontwidth(font, zoom, 0);
     *fheightp = sys_zoomfontheight(font, zoom, 0);
     *guifsize = sys_hostfontsize(font, zoom);
 }
-
 
 /*
         *fontwidthp =  glist_fontwidth((t_glist *)(x->x_text));
@@ -1714,7 +1675,7 @@ void g_text_setup(void)
         CLASS_NOINLET | CLASS_PATCHABLE, 0);
     class_addanything(text_class, text_anything);
 
-    message_class = class_new(gensym("message"), 0, (t_method)message_free,
+    message_class = class_new(gensym("message"), 0, (t_method) message_free,
         sizeof(t_message), CLASS_PATCHABLE, 0);
     class_addbang(message_class, message_bang);
     class_addfloat(message_class, message_float);
@@ -1722,43 +1683,43 @@ void g_text_setup(void)
     class_addlist(message_class, message_list);
     class_addanything(message_class, message_list);
 
-    class_addmethod(message_class, (t_method)message_click, gensym("click"),
+    class_addmethod(message_class, (t_method) message_click, gensym("click"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(message_class, (t_method)message_set, gensym("set"),
-        A_GIMME, 0);
-    class_addmethod(message_class, (t_method)message_add, gensym("add"),
-        A_GIMME, 0);
-    class_addmethod(message_class, (t_method)message_add2, gensym("add2"),
-        A_GIMME, 0);
-    class_addmethod(message_class, (t_method)message_addcomma,
-        gensym("addcomma"), 0);
-    class_addmethod(message_class, (t_method)message_addsemi,
-        gensym("addsemi"), 0);
-    class_addmethod(message_class, (t_method)message_adddollar,
+    class_addmethod(
+        message_class, (t_method) message_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(
+        message_class, (t_method) message_add, gensym("add"), A_GIMME, 0);
+    class_addmethod(
+        message_class, (t_method) message_add2, gensym("add2"), A_GIMME, 0);
+    class_addmethod(
+        message_class, (t_method) message_addcomma, gensym("addcomma"), 0);
+    class_addmethod(
+        message_class, (t_method) message_addsemi, gensym("addsemi"), 0);
+    class_addmethod(message_class, (t_method) message_adddollar,
         gensym("adddollar"), A_FLOAT, 0);
-    class_addmethod(message_class, (t_method)message_adddollsym,
+    class_addmethod(message_class, (t_method) message_adddollsym,
         gensym("adddollsym"), A_SYMBOL, 0);
 
-    messresponder_class = class_new(gensym("messresponder"), 0, 0,
-        sizeof(t_text), CLASS_PD, 0);
+    messresponder_class =
+        class_new(gensym("messresponder"), 0, 0, sizeof(t_text), CLASS_PD, 0);
     class_addbang(messresponder_class, messresponder_bang);
     class_addfloat(messresponder_class, (t_method) messresponder_float);
     class_addsymbol(messresponder_class, messresponder_symbol);
     class_addlist(messresponder_class, messresponder_list);
     class_addanything(messresponder_class, messresponder_anything);
 
-    gatom_class = class_new(gensym("gatom"), 0, (t_method)gatom_free,
+    gatom_class = class_new(gensym("gatom"), 0, (t_method) gatom_free,
         sizeof(t_gatom), CLASS_NOINLET | CLASS_PATCHABLE, 0);
     class_addbang(gatom_class, gatom_bang);
     class_addfloat(gatom_class, gatom_float);
     class_addsymbol(gatom_class, gatom_symbol);
     class_addlist(gatom_class, gatom_list);
-    class_addmethod(gatom_class, (t_method)gatom_set, gensym("set"),
-        A_GIMME, 0);
-    class_addmethod(gatom_class, (t_method)gatom_click, gensym("click"),
+    class_addmethod(
+        gatom_class, (t_method) gatom_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(gatom_class, (t_method) gatom_click, gensym("click"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(gatom_class, (t_method)gatom_param, gensym("param"),
-        A_GIMME, 0);
+    class_addmethod(
+        gatom_class, (t_method) gatom_param, gensym("param"), A_GIMME, 0);
     class_setwidget(gatom_class, &gatom_widgetbehavior);
     class_setpropertiesfn(gatom_class, gatom_properties);
     class_sethelpsymbol(gatom_class, gensym("gui-boxes"));

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -72,14 +72,18 @@ void toggle_draw_new(t_toggle *x, t_glist *glist)
         ypos + crossw + IEMGUI_ZOOM(x), crossw,
         (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
             xpos + iow, ypos + x->x_gui.x_h, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
+    }
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
         canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -114,12 +118,16 @@ void toggle_draw_move(t_toggle *x, t_glist *glist)
         ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
         xpos + x->x_gui.x_w - crossw, ypos + crossw);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
             ypos + x->x_gui.x_h);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
         xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
         ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
@@ -212,19 +220,33 @@ void toggle_draw_select(t_toggle *x, t_glist *glist)
 void toggle_draw(t_toggle *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         toggle_draw_update(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         toggle_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         toggle_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         toggle_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         toggle_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         toggle_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         toggle_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ tgl widgetbehaviour----------------------------- */
@@ -328,8 +350,10 @@ static int toggle_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     int shift, int alt, int dbl, int doit)
 {
     if(doit)
+    {
         toggle_click((t_toggle *) z, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
+    }
     return (1);
 }
 
@@ -473,9 +497,13 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;
@@ -483,9 +511,13 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
     }
     x->x_nonzero = (nonzero != 0.0) ? nonzero : 1.0;
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_on = (on != 0.0) ? nonzero : 0.0;
+    }
     else
+    {
         x->x_on = 0.0;
+    }
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -45,8 +45,10 @@ void toggle_draw_new(t_toggle *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int crossw = 1, w = x->x_gui.x_w / IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int crossw = 1;
+    int w = x->x_gui.x_w / IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     if(w >= 30) crossw = 2;
     if(w >= 60) crossw = 3;
@@ -91,9 +93,11 @@ void toggle_draw_move(t_toggle *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
-    int crossw = 1, w = x->x_gui.x_w / IEMGUI_ZOOM(x);
+    int crossw = 1;
+    int w = x->x_gui.x_w / IEMGUI_ZOOM(x);
     if(w >= 30) crossw = 2;
     if(w >= 60) crossw = 3;
     crossw *= IEMGUI_ZOOM(x);
@@ -158,7 +162,8 @@ void toggle_draw_io(t_toggle *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -423,10 +428,13 @@ static void toggle_nonzero(t_toggle *x, t_floatarg f)
 static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_toggle *x = (t_toggle *) pd_new(toggle_class);
-    int a = IEM_GUI_DEFAULTSIZE, f = 0;
-    int ldx = 17, ldy = 7;
+    int a = IEM_GUI_DEFAULTSIZE;
+    int f = 0;
+    int ldx = 17;
+    int ldy = 7;
     int fs = 10;
-    t_float on = 0.0, nonzero = 1.0;
+    t_float on = 0.0;
+    t_float nonzero = 1.0;
     char str[144];
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -5,7 +5,6 @@
 /* g_7_guis.c written by Thomas Musil (c) IEM KUG Graz Austria 2000-2001 */
 /* thanks to Miller Puckette, Guenther Geiger and Krzystof Czaja */
 
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -36,9 +35,9 @@ void toggle_draw_update(t_toggle *x, t_glist *glist)
         t_canvas *canvas = glist_getcanvas(glist);
 
         sys_vgui(".x%lx.c itemconfigure %lxX1 -fill #%06x\n", canvas, x,
-                 (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+            (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
         sys_vgui(".x%lx.c itemconfigure %lxX2 -fill #%06x\n", canvas, x,
-                 (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+            (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
     }
 }
 
@@ -49,46 +48,43 @@ void toggle_draw_new(t_toggle *x, t_glist *glist)
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int crossw = 1, w = x->x_gui.x_w / IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
-    if(w >= 30)
-        crossw = 2;
-    if(w >= 60)
-        crossw = 3;
+    if(w >= 30) crossw = 2;
+    if(w >= 60) crossw = 3;
     crossw *= IEMGUI_ZOOM(x);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE\n",
-             canvas, xpos, ypos,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
-             IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxX1\n",
-             canvas,
-             xpos + crossw + IEMGUI_ZOOM(x), ypos + crossw + IEMGUI_ZOOM(x),
-             xpos + x->x_gui.x_w - crossw - IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
-             crossw, (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxX2\n",
-             canvas,
-             xpos + crossw + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
-             xpos + x->x_gui.x_w - crossw - IEMGUI_ZOOM(x), ypos + crossw + IEMGUI_ZOOM(x),
-             crossw, (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags "
+             "%lxBASE\n",
+        canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
+        IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
+    sys_vgui(
+        ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxX1\n",
+        canvas, xpos + crossw + IEMGUI_ZOOM(x), ypos + crossw + IEMGUI_ZOOM(x),
+        xpos + x->x_gui.x_w - crossw - IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x), crossw,
+        (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x);
+    sys_vgui(
+        ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxX2\n",
+        canvas, xpos + crossw + IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
+        xpos + x->x_gui.x_w - crossw - IEMGUI_ZOOM(x),
+        ypos + crossw + IEMGUI_ZOOM(x), crossw,
+        (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 void toggle_draw_move(t_toggle *x, t_glist *glist)
@@ -98,42 +94,34 @@ void toggle_draw_move(t_toggle *x, t_glist *glist)
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     int crossw = 1, w = x->x_gui.x_w / IEMGUI_ZOOM(x);
-    if(w >= 30)
-        crossw = 2;
-    if(w >= 60)
-        crossw = 3;
+    if(w >= 30) crossw = 2;
+    if(w >= 60) crossw = 3;
     crossw *= IEMGUI_ZOOM(x);
 
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x, xpos, ypos,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos, ypos,
+        xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     sys_vgui(".x%lx.c itemconfigure %lxX1 -width %d\n", canvas, x, crossw);
-    sys_vgui(".x%lx.c coords %lxX1 %d %d %d %d\n",
-             canvas, x,
-             xpos + crossw + IEMGUI_ZOOM(x), ypos + crossw + IEMGUI_ZOOM(x),
-             xpos + x->x_gui.x_w - crossw, ypos + x->x_gui.x_h - crossw);
+    sys_vgui(".x%lx.c coords %lxX1 %d %d %d %d\n", canvas, x,
+        xpos + crossw + IEMGUI_ZOOM(x), ypos + crossw + IEMGUI_ZOOM(x),
+        xpos + x->x_gui.x_w - crossw, ypos + x->x_gui.x_h - crossw);
     sys_vgui(".x%lx.c itemconfigure %lxX2 -width %d\n", canvas, x, crossw);
-    sys_vgui(".x%lx.c coords %lxX2 %d %d %d %d\n",
-             canvas, x,
-             xpos + crossw + IEMGUI_ZOOM(x), ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
-             xpos + x->x_gui.x_w - crossw, ypos + crossw);
+    sys_vgui(".x%lx.c coords %lxX2 %d %d %d %d\n", canvas, x,
+        xpos + crossw + IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_h - crossw - IEMGUI_ZOOM(x),
+        xpos + x->x_gui.x_w - crossw, ypos + crossw);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh, xpos + iow,
+            ypos + x->x_gui.x_h);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x,
-             xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-void toggle_draw_erase(t_toggle* x, t_glist* glist)
+void toggle_draw_erase(t_toggle *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -147,46 +135,48 @@ void toggle_draw_erase(t_toggle* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void toggle_draw_config(t_toggle* x, t_glist* glist)
+void toggle_draw_config(t_toggle *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name
+                                                 : ""));
     sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x,
-             x->x_gui.x_bcol);
+        x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxX1 -fill #%06x\n", canvas, x,
-             x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+        x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxX2 -fill #%06x\n", canvas, x,
-             x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+        x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol);
 }
 
-void toggle_draw_io(t_toggle* x, t_glist* glist, int old_snd_rcv_flags)
+void toggle_draw_io(t_toggle *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep above outlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 0);
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
-    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able) {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos, ypos,
-             xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+    if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
+    {
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep above inlet */
         sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 0);
     }
@@ -194,19 +184,23 @@ void toggle_draw_io(t_toggle* x, t_glist* glist, int old_snd_rcv_flags)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void toggle_draw_select(t_toggle* x, t_glist* glist)
+void toggle_draw_select(t_toggle *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            x->x_gui.x_lcol);
     }
 }
 
@@ -230,10 +224,10 @@ void toggle_draw(t_toggle *x, t_glist *glist, int mode)
 
 /* ------------------------ tgl widgetbehaviour----------------------------- */
 
-static void toggle_getrect(t_gobj *z, t_glist *glist,
-                           int *xp1, int *yp1, int *xp2, int *yp2)
+static void toggle_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_toggle *x = (t_toggle *)z;
+    t_toggle *x = (t_toggle *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -243,28 +237,24 @@ static void toggle_getrect(t_gobj *z, t_glist *glist,
 
 static void toggle_save(t_gobj *z, t_binbuf *b)
 {
-    t_toggle *x = (t_toggle *)z;
+    t_toggle *x = (t_toggle *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiisssiiiisssff", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix,
-                (int)x->x_gui.x_obj.te_ypix,
-                gensym("tgl"), x->x_gui.x_w/IEMGUI_ZOOM(x),
-                iem_symargstoint(&x->x_gui.x_isa),
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_on:0.f,
-                x->x_nonzero);
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("tgl"), x->x_gui.x_w / IEMGUI_ZOOM(x),
+        iem_symargstoint(&x->x_gui.x_isa), srl[0], srl[1], srl[2],
+        x->x_gui.x_ldx, x->x_gui.x_ldy, iem_fstyletoint(&x->x_gui.x_fsf),
+        x->x_gui.x_fontsize, bflcol[0], bflcol[1], bflcol[2],
+        x->x_gui.x_isa.x_loadinit ? x->x_on : 0.f, x->x_nonzero);
     binbuf_addv(b, ";");
 }
 
 static void toggle_properties(t_gobj *z, t_glist *owner)
 {
-    t_toggle *x = (t_toggle *)z;
+    t_toggle *x = (t_toggle *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -277,13 +267,13 @@ static void toggle_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_nonzero, 1.0,/*non_zero-schedule*/
-            x->x_gui.x_isa.x_loadinit, -1, -1,/*no multi*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, x->x_nonzero,
+        1.0,                               /*non_zero-schedule*/
+        x->x_gui.x_isa.x_loadinit, -1, -1, /*no multi*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
@@ -299,40 +289,42 @@ static void toggle_bang(t_toggle *x)
 static void toggle_dialog(t_toggle *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getfloatarg(0, argc, argv);
-    t_float nonzero = (t_float)atom_getfloatarg(2, argc, argv);
+    int a = (int) atom_getfloatarg(0, argc, argv);
+    t_float nonzero = (t_float) atom_getfloatarg(2, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT (undo+1, 0);
-    SETFLOAT (undo+2, x->x_nonzero);
-    SETFLOAT (undo+3, 0);
+    SETFLOAT(undo + 1, 0);
+    SETFLOAT(undo + 2, x->x_nonzero);
+    SETFLOAT(undo + 3, 0);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
-    if(nonzero == 0.0)
-        nonzero = 1.0;
+    if(nonzero == 0.0) nonzero = 1.0;
     x->x_nonzero = nonzero;
-    if(x->x_on != 0.0)
-        x->x_on = x->x_nonzero;
+    if(x->x_on != 0.0) x->x_on = x->x_nonzero;
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_w = iemgui_clip_size(a) * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
-static void toggle_click(t_toggle *x, t_floatarg xpos, t_floatarg ypos, t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
-{toggle_bang(x);}
+static void toggle_click(t_toggle *x, t_floatarg xpos, t_floatarg ypos,
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+{
+    toggle_bang(x);
+}
 
-static int toggle_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int toggle_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
     if(doit)
-        toggle_click((t_toggle *)z, (t_floatarg)xpix, (t_floatarg)ypix, (t_floatarg)shift, 0, (t_floatarg)alt);
+        toggle_click((t_toggle *) z, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
     return (1);
 }
 
@@ -340,9 +332,8 @@ static void toggle_set(t_toggle *x, t_floatarg f)
 {
     int old = (x->x_on != 0);
     x->x_on = f;
-    if (f != 0.0 && pd_compatibilitylevel < 46)
-        x->x_nonzero = f;
-    if ((x->x_on != 0) != old)
+    if(f != 0.0 && pd_compatibilitylevel < 46) x->x_nonzero = f;
+    if((x->x_on != 0) != old)
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
 }
 
@@ -367,40 +358,57 @@ static void toggle_fout(t_toggle *x, t_floatarg f)
 
 static void toggle_loadbang(t_toggle *x, t_floatarg action)
 {
-    if (action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
-        toggle_fout(x, (t_float)x->x_on);
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
+        toggle_fout(x, (t_float) x->x_on);
 }
 
 static void toggle_size(t_toggle *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void toggle_delta(t_toggle *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void toggle_pos(t_toggle *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void toggle_color(t_toggle *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void toggle_send(t_toggle *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void toggle_receive(t_toggle *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void toggle_label(t_toggle *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void toggle_label_font(t_toggle *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void toggle_label_pos(t_toggle *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void toggle_init(t_toggle *x, t_floatarg f)
 {
@@ -409,13 +417,12 @@ static void toggle_init(t_toggle *x, t_floatarg f)
 
 static void toggle_nonzero(t_toggle *x, t_floatarg f)
 {
-    if(f != 0.0)
-        x->x_nonzero = f;
+    if(f != 0.0) x->x_nonzero = f;
 }
 
 static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_toggle *x = (t_toggle *)pd_new(toggle_class);
+    t_toggle *x = (t_toggle *) pd_new(toggle_class);
     int a = IEM_GUI_DEFAULTSIZE, f = 0;
     int ldx = 17, ldy = 7;
     int fs = 10;
@@ -429,51 +436,53 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if(((argc == 13)||(argc == 14))&&IS_A_FLOAT(argv,0)
-       &&IS_A_FLOAT(argv,1)
-       &&(IS_A_SYMBOL(argv,2)||IS_A_FLOAT(argv,2))
-       &&(IS_A_SYMBOL(argv,3)||IS_A_FLOAT(argv,3))
-       &&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4))
-       &&IS_A_FLOAT(argv,5)&&IS_A_FLOAT(argv,6)
-       &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)&&IS_A_FLOAT(argv,12))
+    if(((argc == 13) || (argc == 14)) && IS_A_FLOAT(argv, 0) &&
+        IS_A_FLOAT(argv, 1) && (IS_A_SYMBOL(argv, 2) || IS_A_FLOAT(argv, 2)) &&
+        (IS_A_SYMBOL(argv, 3) || IS_A_FLOAT(argv, 3)) &&
+        (IS_A_SYMBOL(argv, 4) || IS_A_FLOAT(argv, 4)) && IS_A_FLOAT(argv, 5) &&
+        IS_A_FLOAT(argv, 6) && IS_A_FLOAT(argv, 7) && IS_A_FLOAT(argv, 8) &&
+        IS_A_FLOAT(argv, 12))
     {
-        a = (int)atom_getfloatarg(0, argc, argv);
+        a = (int) atom_getfloatarg(0, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(1, argc, argv));
         iemgui_new_getnames(&x->x_gui, 2, argv);
-        ldx = (int)atom_getfloatarg(5, argc, argv);
-        ldy = (int)atom_getfloatarg(6, argc, argv);
+        ldx = (int) atom_getfloatarg(5, argc, argv);
+        ldy = (int) atom_getfloatarg(6, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(7, argc, argv));
-        fs = (int)atom_getfloatarg(8, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+9, argv+10, argv+11);
-        on = (t_float)atom_getfloatarg(12, argc, argv);
+        fs = (int) atom_getfloatarg(8, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 9, argv + 10, argv + 11);
+        on = (t_float) atom_getfloatarg(12, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 2, 0);
-    if((argc == 14)&&IS_A_FLOAT(argv,13))
-        nonzero = (t_float)atom_getfloatarg(13, argc, argv);
-    x->x_gui.x_draw = (t_iemfunptr)toggle_draw;
+    else
+        iemgui_new_getnames(&x->x_gui, 2, 0);
+    if((argc == 14) && IS_A_FLOAT(argv, 13))
+        nonzero = (t_float) atom_getfloatarg(13, argc, argv);
+    x->x_gui.x_draw = (t_iemfunptr) toggle_draw;
 
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if (!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
     x->x_nonzero = (nonzero != 0.0) ? nonzero : 1.0;
     if(x->x_gui.x_isa.x_loadinit)
         x->x_on = (on != 0.0) ? nonzero : 0.0;
     else
         x->x_on = 0.0;
-    if (x->x_gui.x_fsf.x_rcv_able)
+    if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
@@ -492,31 +501,43 @@ static void toggle_ff(t_toggle *x)
 
 void g_toggle_setup(void)
 {
-    toggle_class = class_new(gensym("tgl"), (t_newmethod)toggle_new,
-                             (t_method)toggle_ff, sizeof(t_toggle), 0, A_GIMME, 0);
-    class_addcreator((t_newmethod)toggle_new, gensym("toggle"), A_GIMME, 0);
+    toggle_class = class_new(gensym("tgl"), (t_newmethod) toggle_new,
+        (t_method) toggle_ff, sizeof(t_toggle), 0, A_GIMME, 0);
+    class_addcreator((t_newmethod) toggle_new, gensym("toggle"), A_GIMME, 0);
     class_addbang(toggle_class, toggle_bang);
     class_addfloat(toggle_class, toggle_float);
-    class_addmethod(toggle_class, (t_method)toggle_click, gensym("click"),
-                    A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(toggle_class, (t_method)toggle_dialog, gensym("dialog"),
-                    A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_loadbang,
+    class_addmethod(toggle_class, (t_method) toggle_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(toggle_class, (t_method) toggle_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(toggle_class, (t_method)toggle_set, gensym("set"), A_FLOAT, 0);
-    class_addmethod(toggle_class, (t_method)toggle_size, gensym("size"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_delta, gensym("delta"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_pos, gensym("pos"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_color, gensym("color"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_send, gensym("send"), A_DEFSYM, 0);
-    class_addmethod(toggle_class, (t_method)toggle_receive, gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(toggle_class, (t_method)toggle_label, gensym("label"), A_DEFSYM, 0);
-    class_addmethod(toggle_class, (t_method)toggle_label_pos, gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_label_font, gensym("label_font"), A_GIMME, 0);
-    class_addmethod(toggle_class, (t_method)toggle_init, gensym("init"), A_FLOAT, 0);
-    class_addmethod(toggle_class, (t_method)toggle_nonzero, gensym("nonzero"), A_FLOAT, 0);
-    class_addmethod(toggle_class, (t_method)iemgui_zoom, gensym("zoom"),
-        A_CANT, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(toggle_class, (t_method) toggle_receive, gensym("receive"),
+        A_DEFSYM, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(toggle_class, (t_method) toggle_label_pos,
+        gensym("label_pos"), A_GIMME, 0);
+    class_addmethod(toggle_class, (t_method) toggle_label_font,
+        gensym("label_font"), A_GIMME, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        toggle_class, (t_method) toggle_nonzero, gensym("nonzero"), A_FLOAT, 0);
+    class_addmethod(
+        toggle_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     toggle_widgetbehavior.w_getrectfn = toggle_getrect;
     toggle_widgetbehavior.w_displacefn = iemgui_displace;
     toggle_widgetbehavior.w_selectfn = iemgui_select;

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -78,9 +78,13 @@ static void ptrobj_traverse(t_ptrobj *x, t_symbol *s)
 {
     t_glist *glist = (t_glist *) pd_findbyclass(s, canvas_class);
     if(glist)
+    {
         gpointer_setglist(&x->x_gp, glist, 0);
+    }
     else
+    {
         pd_error(x, "pointer: list '%s' not found", s->s_name);
+    }
 }
 
 static void ptrobj_vnext(t_ptrobj *x, t_float f)
@@ -116,9 +120,13 @@ static void ptrobj_vnext(t_ptrobj *x, t_float f)
     gobj = &gp->gp_un.gp_scalar->sc_gobj;
 
     if(!gobj)
+    {
         gobj = glist->gl_list;
+    }
     else
+    {
         gobj = gobj->g_next;
+    }
     while(gobj && ((pd_class(&gobj->g_pd) != scalar_class) ||
                       (wantselected && !glist_isselected(glist, gobj))))
         gobj = gobj->g_next;
@@ -272,7 +280,9 @@ static void ptrobj_sendwindow(t_ptrobj *x, t_symbol *s, int argc, t_atom *argv)
     }
     gs = x->x_gp.gp_stub;
     if(gs->gs_which == GP_GLIST)
+    {
         glist = gs->gs_un.gs_glist;
+    }
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
@@ -282,20 +292,30 @@ static void ptrobj_sendwindow(t_ptrobj *x, t_symbol *s, int argc, t_atom *argv)
     }
     canvas = (t_pd *) glist_getcanvas(glist);
     if(argc && argv->a_type == A_SYMBOL)
+    {
         pd_typedmess(canvas, argv->a_w.w_symbol, argc - 1, argv + 1);
+    }
     else
+    {
         pd_error(x, "send-window: no message?");
+    }
 }
 
 /* send the pointer to the named object */
 static void ptrobj_send(t_ptrobj *x, t_symbol *s)
 {
     if(!s->s_thing)
+    {
         pd_error(x, "%s: no such object", s->s_name);
+    }
     else if(!gpointer_check(&x->x_gp, 1))
+    {
         pd_error(x, "pointer_send: empty pointer");
+    }
     else
+    {
         pd_pointer(s->s_thing, &x->x_gp);
+    }
 }
 
 static void ptrobj_bang(t_ptrobj *x)
@@ -434,7 +454,9 @@ static void *get_new(t_symbol *why, int argc, t_atom *argv)
 static void get_set(t_get *x, t_symbol *templatesym, t_symbol *field)
 {
     if(x->x_nout != 1)
+    {
         pd_error(x, "get: cannot set multiple fields.");
+    }
     else
     {
         x->x_templatesym = template_getbindsym(templatesym);
@@ -474,9 +496,13 @@ static void get_pointer(t_get *x, t_gpointer *gp)
         return;
     }
     if(gs->gs_which == GP_ARRAY)
+    {
         vec = gp->gp_un.gp_w;
+    }
     else
+    {
         vec = gp->gp_un.gp_scalar->sc_vec;
+    }
     for(i = nitems - 1, vp = x->x_variables + i; i >= 0; i--, vp--)
     {
         int onset;
@@ -485,18 +511,26 @@ static void get_pointer(t_get *x, t_gpointer *gp)
         if(template_find_field(template, vp->gv_sym, &onset, &type, &arraytype))
         {
             if(type == DT_FLOAT)
+            {
                 outlet_float(
                     vp->gv_outlet, *(t_float *) (((char *) vec) + onset));
+            }
             else if(type == DT_SYMBOL)
+            {
                 outlet_symbol(
                     vp->gv_outlet, *(t_symbol **) (((char *) vec) + onset));
+            }
             else
+            {
                 pd_error(x, "get: %s.%s is not a number or symbol",
                     template->t_sym->s_name, vp->gv_sym->s_name);
+            }
         }
         else
+        {
             pd_error(x, "get: %s.%s: no such field", template->t_sym->s_name,
                 vp->gv_sym->s_name);
+        }
     }
 }
 
@@ -567,15 +601,23 @@ static void *set_new(t_symbol *why, int argc, t_atom *argv)
     {
         sp->gv_sym = atom_getsymbolarg(i, varcount, varvec);
         if(x->x_issymbol)
+        {
             sp->gv_w.w_symbol = &s_;
+        }
         else
+        {
             sp->gv_w.w_float = 0;
+        }
         if(i)
         {
             if(x->x_issymbol)
+            {
                 symbolinlet_new(&x->x_obj, &sp->gv_w.w_symbol);
+            }
             else
+            {
                 floatinlet_new(&x->x_obj, &sp->gv_w.w_float);
+            }
         }
     }
     pointerinlet_new(&x->x_obj, &x->x_gp);
@@ -586,15 +628,21 @@ static void *set_new(t_symbol *why, int argc, t_atom *argv)
 static void set_set(t_set *x, t_symbol *templatesym, t_symbol *field)
 {
     if(x->x_nin != 1)
+    {
         pd_error(x, "set: cannot set multiple fields.");
+    }
     else
     {
         x->x_templatesym = template_getbindsym(templatesym);
         x->x_variables->gv_sym = field;
         if(x->x_issymbol)
+        {
             x->x_variables->gv_w.w_symbol = &s_;
+        }
         else
+        {
             x->x_variables->gv_w.w_float = 0;
+        }
     }
 }
 
@@ -631,17 +679,27 @@ static void set_bang(t_set *x)
     }
     if(!nitems) return;
     if(gs->gs_which == GP_ARRAY)
+    {
         vec = gp->gp_un.gp_w;
+    }
     else
+    {
         vec = gp->gp_un.gp_scalar->sc_vec;
+    }
     if(x->x_issymbol)
+    {
         for(i = 0, vp = x->x_variables; i < nitems; i++, vp++)
             template_setsymbol(template, vp->gv_sym, vec, vp->gv_w.w_symbol, 1);
+    }
     else
+    {
         for(i = 0, vp = x->x_variables; i < nitems; i++, vp++)
             template_setfloat(template, vp->gv_sym, vec, vp->gv_w.w_float, 1);
+    }
     if(gs->gs_which == GP_GLIST)
+    {
         scalar_redraw(gp->gp_un.gp_scalar, gs->gs_un.gs_glist);
+    }
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
@@ -760,9 +818,13 @@ static void elem_float(t_elem *x, t_float f)
         return;
     }
     if(gparent->gp_stub->gs_which == GP_ARRAY)
+    {
         w = gparent->gp_un.gp_w;
+    }
     else
+    {
         w = gparent->gp_un.gp_scalar->sc_vec;
+    }
     if(!template)
     {
         pd_error(x, "element: couldn't find template %s", templatesym->s_name);
@@ -886,9 +948,13 @@ static void getsize_pointer(t_getsize *x, t_gpointer *gp)
         return;
     }
     if(gs->gs_which == GP_ARRAY)
+    {
         w = gp->gp_un.gp_w;
+    }
     else
+    {
         w = gp->gp_un.gp_scalar->sc_vec;
+    }
 
     array = *(t_array **) (((char *) w) + onset);
     outlet_float(x->x_obj.ob_outlet, (t_float) (array->a_n));
@@ -984,9 +1050,13 @@ static void setsize_float(t_setsize *x, t_float f)
         return;
     }
     if(gs->gs_which == GP_ARRAY)
+    {
         w = gp->gp_un.gp_w;
+    }
     else
+    {
         w = gp->gp_un.gp_scalar->sc_vec;
+    }
 
     if(!(elemtemplate = template_findbyname(elemtemplatesym)))
     {
@@ -1021,8 +1091,10 @@ static void setsize_float(t_setsize *x, t_float f)
         while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
         if(glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
+        {
             gobj_vis((t_gobj *) (owner_array->a_gp.gp_un.gp_scalar),
                 owner_array->a_gp.gp_stub->gs_un.gs_glist, 0);
+        }
     }
     /* if shrinking, free the scalars that will disappear */
     if(newsize < nitems)
@@ -1063,8 +1135,10 @@ static void setsize_float(t_setsize *x, t_float f)
         while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
         if(glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
+        {
             gobj_vis((t_gobj *) (owner_array->a_gp.gp_un.gp_scalar),
                 owner_array->a_gp.gp_stub->gs_un.gs_glist, 1);
+        }
     }
 }
 
@@ -1135,7 +1209,9 @@ static void *append_new(t_symbol *why, int argc, t_atom *argv)
 static void append_set(t_append *x, t_symbol *templatesym, t_symbol *field)
 {
     if(x->x_nin != 1)
+    {
         pd_error(x, "set: cannot set multiple fields.");
+    }
     else
     {
         x->x_templatesym = template_getbindsym(templatesym);

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -32,8 +32,7 @@ static t_symbol *template_getbindsym(t_symbol *s)
 {
     if(!*s->s_name || !strcmp(s->s_name, "-"))
         return (&s_);
-    else
-        return (canvas_makebindsym(s));
+    return (canvas_makebindsym(s));
 }
 
 /* ---------------------- pointers ----------------------------- */

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -153,7 +153,8 @@ static void ptrobj_next(t_ptrobj *x) { ptrobj_vnext(x, 0); }
 
 static void ptrobj_delete(t_ptrobj *x)
 {
-    t_gobj *gobj, *old;
+    t_gobj *gobj;
+    t_gobj *old;
     t_gpointer *gp = &x->x_gp;
     t_gstub *gs = gp->gp_stub;
     t_glist *glist;
@@ -225,7 +226,9 @@ t_symbol *gpointer_gettemplatesym(const t_gpointer *gp);
 static void ptrobj_equal(t_ptrobj *x, t_gpointer *gp)
 {
     t_symbol *templatesym;
-    int n, which, result;
+    int n;
+    int which;
+    int result;
     t_typedout *to;
     if(!gpointer_check(&x->x_gp, 1))
     {
@@ -400,8 +403,10 @@ typedef struct _get
 static void *get_new(t_symbol *why, int argc, t_atom *argv)
 {
     t_get *x = (t_get *) pd_new(get_class);
-    int varcount, i;
-    t_atom at, *varvec;
+    int varcount;
+    int i;
+    t_atom at;
+    t_atom *varvec;
     t_getvariable *sp;
 
     x->x_templatesym = template_getbindsym(atom_getsymbolarg(0, argc, argv));
@@ -440,7 +445,8 @@ static void get_set(t_get *x, t_symbol *templatesym, t_symbol *field)
 
 static void get_pointer(t_get *x, t_gpointer *gp)
 {
-    int nitems = x->x_nout, i;
+    int nitems = x->x_nout;
+    int i;
     t_symbol *templatesym;
     t_template *template;
     t_gstub *gs = gp->gp_stub;
@@ -474,7 +480,8 @@ static void get_pointer(t_get *x, t_gpointer *gp)
         vec = gp->gp_un.gp_scalar->sc_vec;
     for(i = nitems - 1, vp = x->x_variables + i; i >= 0; i--, vp--)
     {
-        int onset, type;
+        int onset;
+        int type;
         t_symbol *arraytype;
         if(template_find_field(template, vp->gv_sym, &onset, &type, &arraytype))
         {
@@ -531,9 +538,11 @@ typedef struct _set
 static void *set_new(t_symbol *why, int argc, t_atom *argv)
 {
     t_set *x = (t_set *) pd_new(set_class);
-    int i, varcount;
+    int i;
+    int varcount;
     t_setvariable *sp;
-    t_atom at, *varvec;
+    t_atom at;
+    t_atom *varvec;
     if(argc && (argv[0].a_type == A_SYMBOL) &&
         !strcmp(argv[0].a_w.w_symbol->s_name, "-symbol"))
     {
@@ -592,7 +601,8 @@ static void set_set(t_set *x, t_symbol *templatesym, t_symbol *field)
 
 static void set_bang(t_set *x)
 {
-    int nitems = x->x_nin, i;
+    int nitems = x->x_nin;
+    int i;
     t_symbol *templatesym;
     t_template *template;
     t_setvariable *vp;
@@ -715,14 +725,19 @@ static void elem_set(t_elem *x, t_symbol *templatesym, t_symbol *fieldsym)
 
 static void elem_float(t_elem *x, t_float f)
 {
-    int indx = f, nitems, onset;
-    t_symbol *templatesym, *fieldsym = x->x_fieldsym, *elemtemplatesym;
+    int indx = f;
+    int nitems;
+    int onset;
+    t_symbol *templatesym;
+    t_symbol *fieldsym = x->x_fieldsym;
+    t_symbol *elemtemplatesym;
     t_template *template;
     t_template *elemtemplate;
     t_gpointer *gparent = &x->x_gparent;
     t_word *w;
     t_array *array;
-    int elemsize, type;
+    int elemsize;
+    int type;
 
     if(!gpointer_check(gparent, 0))
     {
@@ -828,8 +843,12 @@ static void getsize_set(t_getsize *x, t_symbol *templatesym, t_symbol *fieldsym)
 
 static void getsize_pointer(t_getsize *x, t_gpointer *gp)
 {
-    int nitems, onset, type;
-    t_symbol *templatesym, *fieldsym = x->x_fieldsym, *elemtemplatesym;
+    int nitems;
+    int onset;
+    int type;
+    t_symbol *templatesym;
+    t_symbol *fieldsym = x->x_fieldsym;
+    t_symbol *elemtemplatesym;
     t_template *template;
     t_word *w;
     t_array *array;
@@ -917,8 +936,12 @@ static void setsize_set(t_setsize *x, t_symbol *templatesym, t_symbol *fieldsym)
 
 static void setsize_float(t_setsize *x, t_float f)
 {
-    int nitems, onset, type;
-    t_symbol *templatesym, *fieldsym = x->x_fieldsym, *elemtemplatesym;
+    int nitems;
+    int onset;
+    int type;
+    t_symbol *templatesym;
+    t_symbol *fieldsym = x->x_fieldsym;
+    t_symbol *elemtemplatesym;
     t_template *template;
     t_template *elemtemplate;
     t_word *w;
@@ -1080,8 +1103,10 @@ typedef struct _append
 static void *append_new(t_symbol *why, int argc, t_atom *argv)
 {
     t_append *x = (t_append *) pd_new(append_class);
-    int varcount, i;
-    t_atom at, *varvec;
+    int varcount;
+    int i;
+    t_atom at;
+    t_atom *varvec;
     t_appendvariable *sp;
 
     x->x_templatesym = template_getbindsym(atom_getsymbolarg(0, argc, argv));
@@ -1122,14 +1147,16 @@ static void append_set(t_append *x, t_symbol *templatesym, t_symbol *field)
 
 static void append_float(t_append *x, t_float f)
 {
-    int nitems = x->x_nin, i;
+    int nitems = x->x_nin;
+    int i;
     t_symbol *templatesym = x->x_templatesym;
     t_template *template;
     t_appendvariable *vp;
     t_gpointer *gp = &x->x_gp;
     t_gstub *gs = gp->gp_stub;
     t_word *vec;
-    t_scalar *sc, *oldsc;
+    t_scalar *sc;
+    t_scalar *oldsc;
     t_glist *glist;
 
     if(!templatesym->s_name)

--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* This file defines Text objects which traverse data contained in scalars
 and arrays:
@@ -18,23 +18,23 @@ sublist - get a pointer into a list which is an element of another scalar
 
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>      /* for read/write to files */
+#include <stdio.h> /* for read/write to files */
 #include "m_pd.h"
 #include "g_canvas.h"
 
-    /* templates are named using the name-bashing by which canvases bind
-    thenselves, with a leading "pd-".  LATER see if we can have templates
-    occupy their real names.  Meanwhile, if a template has an empty name
-    or is named "-" (as when passed as a "-" argument to "get", etc.), just
-    return &s_; objects should check for this and allow it as a wild
-    card when appropriate. */
+/* templates are named using the name-bashing by which canvases bind
+thenselves, with a leading "pd-".  LATER see if we can have templates
+occupy their real names.  Meanwhile, if a template has an empty name
+or is named "-" (as when passed as a "-" argument to "get", etc.), just
+return &s_; objects should check for this and allow it as a wild
+card when appropriate. */
 static t_symbol *template_getbindsym(t_symbol *s)
 {
-    if (!*s->s_name || !strcmp(s->s_name, "-"))
+    if(!*s->s_name || !strcmp(s->s_name, "-"))
         return (&s_);
-    else return (canvas_makebindsym(s));
+    else
+        return (canvas_makebindsym(s));
 }
-
 
 /* ---------------------- pointers ----------------------------- */
 
@@ -58,13 +58,13 @@ typedef struct _ptrobj
 
 static void *ptrobj_new(t_symbol *classname, int argc, t_atom *argv)
 {
-    t_ptrobj *x = (t_ptrobj *)pd_new(ptrobj_class);
+    t_ptrobj *x = (t_ptrobj *) pd_new(ptrobj_class);
     t_typedout *to;
     int n;
     gpointer_init(&x->x_gp);
-    x->x_typedout = to = (t_typedout *)getbytes(argc * sizeof (*to));
+    x->x_typedout = to = (t_typedout *) getbytes(argc * sizeof(*to));
     x->x_ntypedout = n = argc;
-    for (; n--; to++)
+    for(; n--; to++)
     {
         to->to_outlet = outlet_new(&x->x_obj, &s_pointer);
         to->to_type = template_getbindsym(atom_getsymbol(argv++));
@@ -77,9 +77,11 @@ static void *ptrobj_new(t_symbol *classname, int argc, t_atom *argv)
 
 static void ptrobj_traverse(t_ptrobj *x, t_symbol *s)
 {
-    t_glist *glist = (t_glist *)pd_findbyclass(s, canvas_class);
-    if (glist) gpointer_setglist(&x->x_gp, glist, 0);
-    else pd_error(x, "pointer: list '%s' not found", s->s_name);
+    t_glist *glist = (t_glist *) pd_findbyclass(s, canvas_class);
+    if(glist)
+        gpointer_setglist(&x->x_gp, glist, 0);
+    else
+        pd_error(x, "pointer: list '%s' not found", s->s_name);
 }
 
 static void ptrobj_vnext(t_ptrobj *x, t_float f)
@@ -90,47 +92,49 @@ static void ptrobj_vnext(t_ptrobj *x, t_float f)
     t_glist *glist;
     int wantselected = (f != 0);
 
-    if (!gs)
+    if(!gs)
     {
         pd_error(x, "ptrobj_next: no current pointer");
         return;
     }
-    if (gs->gs_which != GP_GLIST)
+    if(gs->gs_which != GP_GLIST)
     {
         pd_error(x, "ptrobj_next: lists only, not arrays");
         return;
     }
     glist = gs->gs_un.gs_glist;
-    if (glist->gl_valid != gp->gp_valid)
+    if(glist->gl_valid != gp->gp_valid)
     {
         pd_error(x, "ptrobj_next: stale pointer");
         return;
     }
-    if (wantselected && !glist_isvisible(glist))
+    if(wantselected && !glist_isvisible(glist))
     {
-        pd_error(x,
-            "ptrobj_vnext: next-selected only works for a visible window");
+        pd_error(
+            x, "ptrobj_vnext: next-selected only works for a visible window");
         return;
     }
     gobj = &gp->gp_un.gp_scalar->sc_gobj;
 
-    if (!gobj) gobj = glist->gl_list;
-    else gobj = gobj->g_next;
-    while (gobj && ((pd_class(&gobj->g_pd) != scalar_class) ||
-        (wantselected && !glist_isselected(glist, gobj))))
-            gobj = gobj->g_next;
+    if(!gobj)
+        gobj = glist->gl_list;
+    else
+        gobj = gobj->g_next;
+    while(gobj && ((pd_class(&gobj->g_pd) != scalar_class) ||
+                      (wantselected && !glist_isselected(glist, gobj))))
+        gobj = gobj->g_next;
 
-    if (gobj)
+    if(gobj)
     {
         t_typedout *to;
         int n;
-        t_scalar *sc = (t_scalar *)gobj;
+        t_scalar *sc = (t_scalar *) gobj;
         t_symbol *templatesym = sc->sc_template;
 
         gp->gp_un.gp_scalar = sc;
-        for (n = x->x_ntypedout, to = x->x_typedout; n--; to++)
+        for(n = x->x_ntypedout, to = x->x_typedout; n--; to++)
         {
-            if (to->to_type == templatesym)
+            if(to->to_type == templatesym)
             {
                 outlet_pointer(to->to_outlet, &x->x_gp);
                 return;
@@ -145,10 +149,7 @@ static void ptrobj_vnext(t_ptrobj *x, t_float f)
     }
 }
 
-static void ptrobj_next(t_ptrobj *x)
-{
-    ptrobj_vnext(x, 0);
-}
+static void ptrobj_next(t_ptrobj *x) { ptrobj_vnext(x, 0); }
 
 static void ptrobj_delete(t_ptrobj *x)
 {
@@ -156,33 +157,33 @@ static void ptrobj_delete(t_ptrobj *x)
     t_gpointer *gp = &x->x_gp;
     t_gstub *gs = gp->gp_stub;
     t_glist *glist;
-    if (!gs)
+    if(!gs)
     {
         pd_error(x, "ptrobj_delete: no current pointer");
         return;
     }
-    if (gs->gs_which != GP_GLIST)
+    if(gs->gs_which != GP_GLIST)
     {
         pd_error(x, "ptrobj_delete: lists only, not arrays");
         return;
     }
     glist = gs->gs_un.gs_glist;
-    if (glist->gl_valid != gp->gp_valid)
+    if(glist->gl_valid != gp->gp_valid)
     {
         pd_error(x, "ptrobj_delete: stale pointer");
         return;
     }
-    if (!gp->gp_un.gp_scalar)
+    if(!gp->gp_un.gp_scalar)
     {
         pd_error(x, "ptrobj_delete: pointing to head");
         return;
     }
-    if (gp->gp_un.gp_scalar->sc_template == gensym("pd-text"))
+    if(gp->gp_un.gp_scalar->sc_template == gensym("pd-text"))
     {
         pd_error(x, "ptrobj_delete: can't delete 'pd-text' scalar");
         return;
     }
-    if (gp->gp_un.gp_scalar->sc_template == gensym("pd-float-array"))
+    if(gp->gp_un.gp_scalar->sc_template == gensym("pd-float-array"))
     {
         pd_error(x, "ptrobj_delete: can't delete 'pd-float-array' scalar");
         return;
@@ -190,21 +191,21 @@ static void ptrobj_delete(t_ptrobj *x)
 
     old = &gp->gp_un.gp_scalar->sc_gobj;
     gobj = old->g_next;
-    while (gobj && (pd_class(&gobj->g_pd) != scalar_class))
+    while(gobj && (pd_class(&gobj->g_pd) != scalar_class))
         gobj = gobj->g_next;
     glist_delete(glist, old);
     gp->gp_valid = glist->gl_valid;
-    if (gobj)
+    if(gobj)
     {
         t_typedout *to;
         int n;
-        t_scalar *sc = (t_scalar *)gobj;
+        t_scalar *sc = (t_scalar *) gobj;
         t_symbol *templatesym = sc->sc_template;
 
         gp->gp_un.gp_scalar = sc;
-        for (n = x->x_ntypedout, to = x->x_typedout; n--; to++)
+        for(n = x->x_ntypedout, to = x->x_typedout; n--; to++)
         {
-            if (to->to_type == templatesym)
+            if(to->to_type == templatesym)
             {
                 outlet_pointer(to->to_outlet, &x->x_gp);
                 return;
@@ -226,23 +227,24 @@ static void ptrobj_equal(t_ptrobj *x, t_gpointer *gp)
     t_symbol *templatesym;
     int n, which, result;
     t_typedout *to;
-    if (!gpointer_check(&x->x_gp, 1))
+    if(!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "pointer_bang: empty pointer");
         return;
     }
-    /* we don't care for the actual type in the union because they are all pointers */
+    /* we don't care for the actual type in the union because they are all
+     * pointers */
     result = (gp->gp_stub->gs_un.gs_glist == x->x_gp.gp_stub->gs_un.gs_glist) &&
-        (gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
-    if (!result)
+             (gp->gp_un.gp_scalar == x->x_gp.gp_un.gp_scalar);
+    if(!result)
     {
         outlet_bang(x->x_bangout);
         return;
     }
     templatesym = gpointer_gettemplatesym(&x->x_gp);
-    for (n = x->x_ntypedout, to = x->x_typedout; n--; to++)
+    for(n = x->x_ntypedout, to = x->x_typedout; n--; to++)
     {
-        if (to->to_type == templatesym)
+        if(to->to_type == templatesym)
         {
             outlet_pointer(to->to_outlet, &x->x_gp);
             return;
@@ -251,7 +253,7 @@ static void ptrobj_equal(t_ptrobj *x, t_gpointer *gp)
     outlet_pointer(x->x_otherout, &x->x_gp);
 }
 
-    /* send a message to the window containing the object pointed to */
+/* send a message to the window containing the object pointed to */
 static void ptrobj_sendwindow(t_ptrobj *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_scalar *sc;
@@ -261,36 +263,37 @@ static void ptrobj_sendwindow(t_ptrobj *x, t_symbol *s, int argc, t_atom *argv)
     t_glist *glist;
     t_pd *canvas;
     t_gstub *gs;
-    if (!gpointer_check(&x->x_gp, 1))
+    if(!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "send-window: empty pointer");
         return;
     }
     gs = x->x_gp.gp_stub;
-    if (gs->gs_which == GP_GLIST)
+    if(gs->gs_which == GP_GLIST)
         glist = gs->gs_un.gs_glist;
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
-        while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+        while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
         glist = owner_array->a_gp.gp_stub->gs_un.gs_glist;
     }
-    canvas = (t_pd *)glist_getcanvas(glist);
-    if (argc && argv->a_type == A_SYMBOL)
-        pd_typedmess(canvas, argv->a_w.w_symbol, argc-1, argv+1);
-    else pd_error(x, "send-window: no message?");
+    canvas = (t_pd *) glist_getcanvas(glist);
+    if(argc && argv->a_type == A_SYMBOL)
+        pd_typedmess(canvas, argv->a_w.w_symbol, argc - 1, argv + 1);
+    else
+        pd_error(x, "send-window: no message?");
 }
 
-
-    /* send the pointer to the named object */
+/* send the pointer to the named object */
 static void ptrobj_send(t_ptrobj *x, t_symbol *s)
 {
-    if (!s->s_thing)
+    if(!s->s_thing)
         pd_error(x, "%s: no such object", s->s_name);
-    else if (!gpointer_check(&x->x_gp, 1))
+    else if(!gpointer_check(&x->x_gp, 1))
         pd_error(x, "pointer_send: empty pointer");
-    else pd_pointer(s->s_thing, &x->x_gp);
+    else
+        pd_pointer(s->s_thing, &x->x_gp);
 }
 
 static void ptrobj_bang(t_ptrobj *x)
@@ -298,15 +301,15 @@ static void ptrobj_bang(t_ptrobj *x)
     t_symbol *templatesym;
     int n;
     t_typedout *to;
-    if (!gpointer_check(&x->x_gp, 1))
+    if(!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "pointer_bang: empty pointer");
         return;
     }
     templatesym = gpointer_gettemplatesym(&x->x_gp);
-    for (n = x->x_ntypedout, to = x->x_typedout; n--; to++)
+    for(n = x->x_ntypedout, to = x->x_typedout; n--; to++)
     {
-        if (to->to_type == templatesym)
+        if(to->to_type == templatesym)
         {
             outlet_pointer(to->to_outlet, &x->x_gp);
             return;
@@ -315,14 +318,12 @@ static void ptrobj_bang(t_ptrobj *x)
     outlet_pointer(x->x_otherout, &x->x_gp);
 }
 
-
 static void ptrobj_pointer(t_ptrobj *x, t_gpointer *gp)
 {
     gpointer_unset(&x->x_gp);
     gpointer_copy(gp, &x->x_gp);
     ptrobj_bang(x);
 }
-
 
 static void ptrobj_rewind(t_ptrobj *x)
 {
@@ -333,13 +334,13 @@ static void ptrobj_rewind(t_ptrobj *x)
     t_glist *glist;
     t_pd *canvas;
     t_gstub *gs;
-    if (!gpointer_check(&x->x_gp, 1))
+    if(!gpointer_check(&x->x_gp, 1))
     {
         pd_error(x, "pointer_rewind: empty pointer");
         return;
     }
     gs = x->x_gp.gp_stub;
-    if (gs->gs_which != GP_GLIST)
+    if(gs->gs_which != GP_GLIST)
     {
         pd_error(x, "pointer_rewind: sorry, unavailable for arrays");
         return;
@@ -351,27 +352,29 @@ static void ptrobj_rewind(t_ptrobj *x)
 
 static void ptrobj_free(t_ptrobj *x)
 {
-    freebytes(x->x_typedout, x->x_ntypedout * sizeof (*x->x_typedout));
+    freebytes(x->x_typedout, x->x_ntypedout * sizeof(*x->x_typedout));
     gpointer_unset(&x->x_gp);
 }
 
 static void ptrobj_setup(void)
 {
-    ptrobj_class = class_new(gensym("pointer"), (t_newmethod)ptrobj_new,
-        (t_method)ptrobj_free, sizeof(t_ptrobj), 0, A_GIMME, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_next, gensym("next"), 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_send, gensym("send"),
-        A_SYMBOL, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_traverse, gensym("traverse"),
-        A_SYMBOL, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_vnext, gensym("vnext"),
-        A_DEFFLOAT, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_delete, gensym("delete"), 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_equal, gensym("equal"), A_POINTER, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_sendwindow,
+    ptrobj_class = class_new(gensym("pointer"), (t_newmethod) ptrobj_new,
+        (t_method) ptrobj_free, sizeof(t_ptrobj), 0, A_GIMME, 0);
+    class_addmethod(ptrobj_class, (t_method) ptrobj_next, gensym("next"), 0);
+    class_addmethod(
+        ptrobj_class, (t_method) ptrobj_send, gensym("send"), A_SYMBOL, 0);
+    class_addmethod(ptrobj_class, (t_method) ptrobj_traverse,
+        gensym("traverse"), A_SYMBOL, 0);
+    class_addmethod(
+        ptrobj_class, (t_method) ptrobj_vnext, gensym("vnext"), A_DEFFLOAT, 0);
+    class_addmethod(
+        ptrobj_class, (t_method) ptrobj_delete, gensym("delete"), 0);
+    class_addmethod(
+        ptrobj_class, (t_method) ptrobj_equal, gensym("equal"), A_POINTER, 0);
+    class_addmethod(ptrobj_class, (t_method) ptrobj_sendwindow,
         gensym("send-window"), A_GIMME, 0);
-    class_addmethod(ptrobj_class, (t_method)ptrobj_rewind,
-        gensym("rewind"), 0);
+    class_addmethod(
+        ptrobj_class, (t_method) ptrobj_rewind, gensym("rewind"), 0);
     class_addpointer(ptrobj_class, ptrobj_pointer);
     class_addbang(ptrobj_class, ptrobj_bang);
 }
@@ -396,36 +399,37 @@ typedef struct _get
 
 static void *get_new(t_symbol *why, int argc, t_atom *argv)
 {
-    t_get *x = (t_get *)pd_new(get_class);
+    t_get *x = (t_get *) pd_new(get_class);
     int varcount, i;
     t_atom at, *varvec;
     t_getvariable *sp;
 
     x->x_templatesym = template_getbindsym(atom_getsymbolarg(0, argc, argv));
-    if (argc < 2)
+    if(argc < 2)
     {
         varcount = 1;
         varvec = &at;
         SETSYMBOL(&at, &s_);
     }
-    else varcount = argc - 1, varvec = argv + 1;
-    x->x_variables
-        = (t_getvariable *)getbytes(varcount * sizeof (*x->x_variables));
+    else
+        varcount = argc - 1, varvec = argv + 1;
+    x->x_variables =
+        (t_getvariable *) getbytes(varcount * sizeof(*x->x_variables));
     x->x_nout = varcount;
-    for (i = 0, sp = x->x_variables; i < varcount; i++, sp++)
+    for(i = 0, sp = x->x_variables; i < varcount; i++, sp++)
     {
         sp->gv_sym = atom_getsymbolarg(i, varcount, varvec);
         sp->gv_outlet = outlet_new(&x->x_obj, 0);
-            /* LATER connect with the template and set the outlet's type
-            correctly.  We can't yet guarantee that the template is there
-            before we hit this routine. */
+        /* LATER connect with the template and set the outlet's type
+        correctly.  We can't yet guarantee that the template is there
+        before we hit this routine. */
     }
     return (x);
 }
 
 static void get_set(t_get *x, t_symbol *templatesym, t_symbol *field)
 {
-    if (x->x_nout != 1)
+    if(x->x_nout != 1)
         pd_error(x, "get: cannot set multiple fields.");
     else
     {
@@ -443,60 +447,65 @@ static void get_pointer(t_get *x, t_gpointer *gp)
     t_word *vec;
     t_getvariable *vp;
 
-    if (!gpointer_check(gp, 0))
+    if(!gpointer_check(gp, 0))
     {
         pd_error(x, "get: stale or empty pointer");
         return;
     }
-    if (*x->x_templatesym->s_name)
+    if(*x->x_templatesym->s_name)
     {
-        if ((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
+        if((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
         {
-            pd_error(x, "get %s: got wrong template (%s)",
-                templatesym->s_name, gpointer_gettemplatesym(gp)->s_name);
+            pd_error(x, "get %s: got wrong template (%s)", templatesym->s_name,
+                gpointer_gettemplatesym(gp)->s_name);
             return;
         }
     }
-    else templatesym = gpointer_gettemplatesym(gp);
-    if (!(template = template_findbyname(templatesym)))
+    else
+        templatesym = gpointer_gettemplatesym(gp);
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(x, "get: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (gs->gs_which == GP_ARRAY) vec = gp->gp_un.gp_w;
-    else vec = gp->gp_un.gp_scalar->sc_vec;
-    for (i = nitems - 1, vp = x->x_variables + i; i >= 0; i--, vp--)
+    if(gs->gs_which == GP_ARRAY)
+        vec = gp->gp_un.gp_w;
+    else
+        vec = gp->gp_un.gp_scalar->sc_vec;
+    for(i = nitems - 1, vp = x->x_variables + i; i >= 0; i--, vp--)
     {
         int onset, type;
         t_symbol *arraytype;
-        if (template_find_field(template, vp->gv_sym, &onset, &type, &arraytype))
+        if(template_find_field(template, vp->gv_sym, &onset, &type, &arraytype))
         {
-            if (type == DT_FLOAT)
-                outlet_float(vp->gv_outlet,
-                    *(t_float *)(((char *)vec) + onset));
-            else if (type == DT_SYMBOL)
-                outlet_symbol(vp->gv_outlet,
-                    *(t_symbol **)(((char *)vec) + onset));
-            else pd_error(x, "get: %s.%s is not a number or symbol",
+            if(type == DT_FLOAT)
+                outlet_float(
+                    vp->gv_outlet, *(t_float *) (((char *) vec) + onset));
+            else if(type == DT_SYMBOL)
+                outlet_symbol(
+                    vp->gv_outlet, *(t_symbol **) (((char *) vec) + onset));
+            else
+                pd_error(x, "get: %s.%s is not a number or symbol",
                     template->t_sym->s_name, vp->gv_sym->s_name);
         }
-        else pd_error(x, "get: %s.%s: no such field",
-            template->t_sym->s_name, vp->gv_sym->s_name);
+        else
+            pd_error(x, "get: %s.%s: no such field", template->t_sym->s_name,
+                vp->gv_sym->s_name);
     }
 }
 
 static void get_free(t_get *x)
 {
-    freebytes(x->x_variables, x->x_nout * sizeof (*x->x_variables));
+    freebytes(x->x_variables, x->x_nout * sizeof(*x->x_variables));
 }
 
 static void get_setup(void)
 {
-    get_class = class_new(gensym("get"), (t_newmethod)get_new,
-        (t_method)get_free, sizeof(t_get), 0, A_GIMME, 0);
+    get_class = class_new(gensym("get"), (t_newmethod) get_new,
+        (t_method) get_free, sizeof(t_get), 0, A_GIMME, 0);
     class_addpointer(get_class, get_pointer);
-    class_addmethod(get_class, (t_method)get_set, gensym("set"),
-        A_SYMBOL, A_SYMBOL, 0);
+    class_addmethod(
+        get_class, (t_method) get_set, gensym("set"), A_SYMBOL, A_SYMBOL, 0);
 }
 
 /* ---------------------- set ----------------------------- */
@@ -521,40 +530,44 @@ typedef struct _set
 
 static void *set_new(t_symbol *why, int argc, t_atom *argv)
 {
-    t_set *x = (t_set *)pd_new(set_class);
+    t_set *x = (t_set *) pd_new(set_class);
     int i, varcount;
     t_setvariable *sp;
     t_atom at, *varvec;
-    if (argc && (argv[0].a_type == A_SYMBOL) &&
+    if(argc && (argv[0].a_type == A_SYMBOL) &&
         !strcmp(argv[0].a_w.w_symbol->s_name, "-symbol"))
     {
         x->x_issymbol = 1;
         argc--;
         argv++;
     }
-    else x->x_issymbol = 0;
+    else
+        x->x_issymbol = 0;
     x->x_templatesym = template_getbindsym(atom_getsymbolarg(0, argc, argv));
-    if (argc < 2)
+    if(argc < 2)
     {
         varcount = 1;
         varvec = &at;
         SETSYMBOL(&at, &s_);
     }
-    else varcount = argc - 1, varvec = argv + 1;
-    x->x_variables
-        = (t_setvariable *)getbytes(varcount * sizeof (*x->x_variables));
+    else
+        varcount = argc - 1, varvec = argv + 1;
+    x->x_variables =
+        (t_setvariable *) getbytes(varcount * sizeof(*x->x_variables));
     x->x_nin = varcount;
-    for (i = 0, sp = x->x_variables; i < varcount; i++, sp++)
+    for(i = 0, sp = x->x_variables; i < varcount; i++, sp++)
     {
         sp->gv_sym = atom_getsymbolarg(i, varcount, varvec);
-        if (x->x_issymbol)
+        if(x->x_issymbol)
             sp->gv_w.w_symbol = &s_;
-        else sp->gv_w.w_float = 0;
-        if (i)
+        else
+            sp->gv_w.w_float = 0;
+        if(i)
         {
-            if (x->x_issymbol)
+            if(x->x_issymbol)
                 symbolinlet_new(&x->x_obj, &sp->gv_w.w_symbol);
-            else floatinlet_new(&x->x_obj, &sp->gv_w.w_float);
+            else
+                floatinlet_new(&x->x_obj, &sp->gv_w.w_float);
         }
     }
     pointerinlet_new(&x->x_obj, &x->x_gp);
@@ -564,16 +577,16 @@ static void *set_new(t_symbol *why, int argc, t_atom *argv)
 
 static void set_set(t_set *x, t_symbol *templatesym, t_symbol *field)
 {
-    if (x->x_nin != 1)
+    if(x->x_nin != 1)
         pd_error(x, "set: cannot set multiple fields.");
     else
     {
-       x->x_templatesym = template_getbindsym(templatesym);
-       x->x_variables->gv_sym = field;
-       if (x->x_issymbol)
-           x->x_variables->gv_w.w_symbol = &s_;
-       else
-           x->x_variables->gv_w.w_float = 0;
+        x->x_templatesym = template_getbindsym(templatesym);
+        x->x_variables->gv_sym = field;
+        if(x->x_issymbol)
+            x->x_variables->gv_w.w_symbol = &s_;
+        else
+            x->x_variables->gv_w.w_float = 0;
     }
 }
 
@@ -586,42 +599,44 @@ static void set_bang(t_set *x)
     t_gpointer *gp = &x->x_gp;
     t_gstub *gs = gp->gp_stub;
     t_word *vec;
-    if (!gpointer_check(gp, 0))
+    if(!gpointer_check(gp, 0))
     {
         pd_error(x, "set: empty pointer");
         return;
     }
-    if (*x->x_templatesym->s_name)
+    if(*x->x_templatesym->s_name)
     {
-        if ((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
+        if((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
         {
-            pd_error(x, "set %s: got wrong template (%s)",
-                templatesym->s_name, gpointer_gettemplatesym(gp)->s_name);
+            pd_error(x, "set %s: got wrong template (%s)", templatesym->s_name,
+                gpointer_gettemplatesym(gp)->s_name);
             return;
         }
     }
-    else templatesym = gpointer_gettemplatesym(gp);
-    if (!(template = template_findbyname(templatesym)))
+    else
+        templatesym = gpointer_gettemplatesym(gp);
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(x, "set: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (!nitems)
-        return;
-    if (gs->gs_which == GP_ARRAY)
+    if(!nitems) return;
+    if(gs->gs_which == GP_ARRAY)
         vec = gp->gp_un.gp_w;
-    else vec = gp->gp_un.gp_scalar->sc_vec;
-    if (x->x_issymbol)
-        for (i = 0, vp = x->x_variables; i < nitems; i++, vp++)
+    else
+        vec = gp->gp_un.gp_scalar->sc_vec;
+    if(x->x_issymbol)
+        for(i = 0, vp = x->x_variables; i < nitems; i++, vp++)
             template_setsymbol(template, vp->gv_sym, vec, vp->gv_w.w_symbol, 1);
-    else for (i = 0, vp = x->x_variables; i < nitems; i++, vp++)
-        template_setfloat(template, vp->gv_sym, vec, vp->gv_w.w_float, 1);
-    if (gs->gs_which == GP_GLIST)
+    else
+        for(i = 0, vp = x->x_variables; i < nitems; i++, vp++)
+            template_setfloat(template, vp->gv_sym, vec, vp->gv_w.w_float, 1);
+    if(gs->gs_which == GP_GLIST)
         scalar_redraw(gp->gp_un.gp_scalar, gs->gs_un.gs_glist);
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
-        while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+        while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
         scalar_redraw(owner_array->a_gp.gp_un.gp_scalar,
             owner_array->a_gp.gp_stub->gs_un.gs_glist);
@@ -630,39 +645,41 @@ static void set_bang(t_set *x)
 
 static void set_float(t_set *x, t_float f)
 {
-    if (x->x_nin && !x->x_issymbol)
+    if(x->x_nin && !x->x_issymbol)
     {
         x->x_variables[0].gv_w.w_float = f;
         set_bang(x);
     }
-    else pd_error(x, "type mismatch or no field specified");
+    else
+        pd_error(x, "type mismatch or no field specified");
 }
 
 static void set_symbol(t_set *x, t_symbol *s)
 {
-    if (x->x_nin && x->x_issymbol)
+    if(x->x_nin && x->x_issymbol)
     {
         x->x_variables[0].gv_w.w_symbol = s;
         set_bang(x);
     }
-    else pd_error(x, "type mismatch or no field specified");
+    else
+        pd_error(x, "type mismatch or no field specified");
 }
 
 static void set_free(t_set *x)
 {
-    freebytes(x->x_variables, x->x_nin * sizeof (*x->x_variables));
+    freebytes(x->x_variables, x->x_nin * sizeof(*x->x_variables));
     gpointer_unset(&x->x_gp);
 }
 
 static void set_setup(void)
 {
-    set_class = class_new(gensym("set"), (t_newmethod)set_new,
-        (t_method)set_free, sizeof(t_set), 0, A_GIMME, 0);
+    set_class = class_new(gensym("set"), (t_newmethod) set_new,
+        (t_method) set_free, sizeof(t_set), 0, A_GIMME, 0);
     class_addfloat(set_class, set_float);
     class_addsymbol(set_class, set_symbol);
     class_addbang(set_class, set_bang);
-    class_addmethod(set_class, (t_method)set_set, gensym("set"),
-        A_SYMBOL, A_SYMBOL, 0);
+    class_addmethod(
+        set_class, (t_method) set_set, gensym("set"), A_SYMBOL, A_SYMBOL, 0);
 }
 
 /* ---------------------- elem ----------------------------- */
@@ -680,7 +697,7 @@ typedef struct _elem
 
 static void *elem_new(t_symbol *templatesym, t_symbol *fieldsym)
 {
-    t_elem *x = (t_elem *)pd_new(elem_class);
+    t_elem *x = (t_elem *) pd_new(elem_class);
     x->x_templatesym = template_getbindsym(templatesym);
     x->x_fieldsym = fieldsym;
     gpointer_init(&x->x_gp);
@@ -707,46 +724,48 @@ static void elem_float(t_elem *x, t_float f)
     t_array *array;
     int elemsize, type;
 
-    if (!gpointer_check(gparent, 0))
+    if(!gpointer_check(gparent, 0))
     {
         pd_error(x, "element: empty pointer");
         return;
     }
-    if (*x->x_templatesym->s_name)
+    if(*x->x_templatesym->s_name)
     {
-        if ((templatesym = x->x_templatesym) !=
-            gpointer_gettemplatesym(gparent))
+        if((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gparent))
         {
-            pd_error(x, "elem %s: got wrong template (%s)",
-                templatesym->s_name, gpointer_gettemplatesym(gparent)->s_name);
+            pd_error(x, "elem %s: got wrong template (%s)", templatesym->s_name,
+                gpointer_gettemplatesym(gparent)->s_name);
             return;
         }
     }
-    else templatesym = gpointer_gettemplatesym(gparent);
-    if (!(template = template_findbyname(templatesym)))
+    else
+        templatesym = gpointer_gettemplatesym(gparent);
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(x, "elem: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (gparent->gp_stub->gs_which == GP_ARRAY) w = gparent->gp_un.gp_w;
-    else w = gparent->gp_un.gp_scalar->sc_vec;
-    if (!template)
+    if(gparent->gp_stub->gs_which == GP_ARRAY)
+        w = gparent->gp_un.gp_w;
+    else
+        w = gparent->gp_un.gp_scalar->sc_vec;
+    if(!template)
     {
         pd_error(x, "element: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (!template_find_field(template, fieldsym,
-        &onset, &type, &elemtemplatesym))
+    if(!template_find_field(
+           template, fieldsym, &onset, &type, &elemtemplatesym))
     {
         pd_error(x, "element: couldn't find array field %s", fieldsym->s_name);
         return;
     }
-    if (type != DT_ARRAY)
+    if(type != DT_ARRAY)
     {
         pd_error(x, "element: field %s not of type array", fieldsym->s_name);
         return;
     }
-    if (!(elemtemplate = template_findbyname(elemtemplatesym)))
+    if(!(elemtemplate = template_findbyname(elemtemplatesym)))
     {
         pd_error(x, "element: couldn't find field template %s",
             elemtemplatesym->s_name);
@@ -755,14 +774,14 @@ static void elem_float(t_elem *x, t_float f)
 
     elemsize = elemtemplate->t_n * sizeof(t_word);
 
-    array = *(t_array **)(((char *)w) + onset);
+    array = *(t_array **) (((char *) w) + onset);
 
     nitems = array->a_n;
-    if (indx < 0) indx = 0;
-    if (indx >= nitems) indx = nitems-1;
+    if(indx < 0) indx = 0;
+    if(indx >= nitems) indx = nitems - 1;
 
     gpointer_setarray(&x->x_gp, array,
-        (t_word *)((char *)(array->a_vec) + indx * elemsize));
+        (t_word *) ((char *) (array->a_vec) + indx * elemsize));
     outlet_pointer(x->x_obj.ob_outlet, &x->x_gp);
 }
 
@@ -774,11 +793,11 @@ static void elem_free(t_elem *x, t_gpointer *gp)
 
 static void elem_setup(void)
 {
-    elem_class = class_new(gensym("element"), (t_newmethod)elem_new,
-        (t_method)elem_free, sizeof(t_elem), 0, A_DEFSYM, A_DEFSYM, 0);
+    elem_class = class_new(gensym("element"), (t_newmethod) elem_new,
+        (t_method) elem_free, sizeof(t_elem), 0, A_DEFSYM, A_DEFSYM, 0);
     class_addfloat(elem_class, elem_float);
-    class_addmethod(elem_class, (t_method)elem_set, gensym("set"),
-        A_SYMBOL, A_SYMBOL, 0);
+    class_addmethod(
+        elem_class, (t_method) elem_set, gensym("set"), A_SYMBOL, A_SYMBOL, 0);
 }
 
 /* ---------------------- getsize ----------------------------- */
@@ -794,7 +813,7 @@ typedef struct _getsize
 
 static void *getsize_new(t_symbol *templatesym, t_symbol *fieldsym)
 {
-    t_getsize *x = (t_getsize *)pd_new(getsize_class);
+    t_getsize *x = (t_getsize *) pd_new(getsize_class);
     x->x_templatesym = template_getbindsym(templatesym);
     x->x_fieldsym = fieldsym;
     outlet_new(&x->x_obj, &s_float);
@@ -816,51 +835,53 @@ static void getsize_pointer(t_getsize *x, t_gpointer *gp)
     t_array *array;
     int elemsize;
     t_gstub *gs = gp->gp_stub;
-    if (!gpointer_check(gp, 0))
+    if(!gpointer_check(gp, 0))
     {
         pd_error(x, "getsize: stale or empty pointer");
         return;
     }
-    if (*x->x_templatesym->s_name)
+    if(*x->x_templatesym->s_name)
     {
-        if ((templatesym = x->x_templatesym) !=
-            gpointer_gettemplatesym(gp))
+        if((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
         {
-            pd_error(x, "elem %s: got wrong template (%s)",
-                templatesym->s_name, gpointer_gettemplatesym(gp)->s_name);
+            pd_error(x, "elem %s: got wrong template (%s)", templatesym->s_name,
+                gpointer_gettemplatesym(gp)->s_name);
             return;
         }
     }
-    else templatesym = gpointer_gettemplatesym(gp);
-    if (!(template = template_findbyname(templatesym)))
+    else
+        templatesym = gpointer_gettemplatesym(gp);
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(x, "elem: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (!template_find_field(template, fieldsym,
-        &onset, &type, &elemtemplatesym))
+    if(!template_find_field(
+           template, fieldsym, &onset, &type, &elemtemplatesym))
     {
         pd_error(x, "getsize: couldn't find array field %s", fieldsym->s_name);
         return;
     }
-    if (type != DT_ARRAY)
+    if(type != DT_ARRAY)
     {
         pd_error(x, "getsize: field %s not of type array", fieldsym->s_name);
         return;
     }
-    if (gs->gs_which == GP_ARRAY) w = gp->gp_un.gp_w;
-    else w = gp->gp_un.gp_scalar->sc_vec;
+    if(gs->gs_which == GP_ARRAY)
+        w = gp->gp_un.gp_w;
+    else
+        w = gp->gp_un.gp_scalar->sc_vec;
 
-    array = *(t_array **)(((char *)w) + onset);
-    outlet_float(x->x_obj.ob_outlet, (t_float)(array->a_n));
+    array = *(t_array **) (((char *) w) + onset);
+    outlet_float(x->x_obj.ob_outlet, (t_float) (array->a_n));
 }
 
 static void getsize_setup(void)
 {
-    getsize_class = class_new(gensym("getsize"), (t_newmethod)getsize_new, 0,
+    getsize_class = class_new(gensym("getsize"), (t_newmethod) getsize_new, 0,
         sizeof(t_getsize), 0, A_DEFSYM, A_DEFSYM, 0);
     class_addpointer(getsize_class, getsize_pointer);
-    class_addmethod(getsize_class, (t_method)getsize_set, gensym("set"),
+    class_addmethod(getsize_class, (t_method) getsize_set, gensym("set"),
         A_SYMBOL, A_SYMBOL, 0);
 }
 
@@ -876,10 +897,10 @@ typedef struct _setsize
     t_gpointer x_gp;
 } t_setsize;
 
-static void *setsize_new(t_symbol *templatesym, t_symbol *fieldsym,
-    t_floatarg newsize)
+static void *setsize_new(
+    t_symbol *templatesym, t_symbol *fieldsym, t_floatarg newsize)
 {
-    t_setsize *x = (t_setsize *)pd_new(setsize_class);
+    t_setsize *x = (t_setsize *) pd_new(setsize_class);
     x->x_templatesym = template_getbindsym(templatesym);
     x->x_fieldsym = fieldsym;
     gpointer_init(&x->x_gp);
@@ -907,135 +928,134 @@ static void setsize_float(t_setsize *x, t_float f)
     int newsize = f;
     t_gpointer *gp = &x->x_gp;
     t_gstub *gs = gp->gp_stub;
-    if (!gpointer_check(&x->x_gp, 0))
+    if(!gpointer_check(&x->x_gp, 0))
     {
         pd_error(x, "setsize: empty pointer");
         return;
     }
-    if (*x->x_templatesym->s_name)
+    if(*x->x_templatesym->s_name)
     {
-        if ((templatesym = x->x_templatesym) !=
-            gpointer_gettemplatesym(gp))
+        if((templatesym = x->x_templatesym) != gpointer_gettemplatesym(gp))
         {
-            pd_error(x, "elem %s: got wrong template (%s)",
-                templatesym->s_name, gpointer_gettemplatesym(gp)->s_name);
+            pd_error(x, "elem %s: got wrong template (%s)", templatesym->s_name,
+                gpointer_gettemplatesym(gp)->s_name);
             return;
         }
     }
-    else templatesym = gpointer_gettemplatesym(gp);
-    if (!(template = template_findbyname(templatesym)))
+    else
+        templatesym = gpointer_gettemplatesym(gp);
+    if(!(template = template_findbyname(templatesym)))
     {
         pd_error(x, "elem: couldn't find template %s", templatesym->s_name);
         return;
     }
 
-    if (!template_find_field(template, fieldsym,
-        &onset, &type, &elemtemplatesym))
+    if(!template_find_field(
+           template, fieldsym, &onset, &type, &elemtemplatesym))
     {
-        pd_error(x,"setsize: couldn't find array field %s", fieldsym->s_name);
+        pd_error(x, "setsize: couldn't find array field %s", fieldsym->s_name);
         return;
     }
-    if (type != DT_ARRAY)
+    if(type != DT_ARRAY)
     {
-        pd_error(x,"setsize: field %s not of type array", fieldsym->s_name);
+        pd_error(x, "setsize: field %s not of type array", fieldsym->s_name);
         return;
     }
-    if (gs->gs_which == GP_ARRAY) w = gp->gp_un.gp_w;
-    else w = gp->gp_un.gp_scalar->sc_vec;
+    if(gs->gs_which == GP_ARRAY)
+        w = gp->gp_un.gp_w;
+    else
+        w = gp->gp_un.gp_scalar->sc_vec;
 
-    if (!(elemtemplate = template_findbyname(elemtemplatesym)))
+    if(!(elemtemplate = template_findbyname(elemtemplatesym)))
     {
-        pd_error(x,"element: couldn't find field template %s",
+        pd_error(x, "element: couldn't find field template %s",
             elemtemplatesym->s_name);
         return;
     }
 
     elemsize = elemtemplate->t_n * sizeof(t_word);
 
-    array = *(t_array **)(((char *)w) + onset);
+    array = *(t_array **) (((char *) w) + onset);
 
-    if (elemsize != array->a_elemsize) bug("setsize_gpointer");
+    if(elemsize != array->a_elemsize) bug("setsize_gpointer");
 
     nitems = array->a_n;
-    if (newsize < 1) newsize = 1;
-    if (newsize == nitems) return;
+    if(newsize < 1) newsize = 1;
+    if(newsize == nitems) return;
 
-        /* erase the array before resizing it.  If we belong to a
-        scalar it's easy, but if we belong to an element of another
-        array we have to search back until we get to a scalar to erase.
-        When graphics updates become queueable this may fall apart... */
+    /* erase the array before resizing it.  If we belong to a
+    scalar it's easy, but if we belong to an element of another
+    array we have to search back until we get to a scalar to erase.
+    When graphics updates become queueable this may fall apart... */
 
-
-    if (gs->gs_which == GP_GLIST)
+    if(gs->gs_which == GP_GLIST)
     {
-        if (glist_isvisible(gs->gs_un.gs_glist))
-            gobj_vis((t_gobj *)(gp->gp_un.gp_scalar), gs->gs_un.gs_glist, 0);
+        if(glist_isvisible(gs->gs_un.gs_glist))
+            gobj_vis((t_gobj *) (gp->gp_un.gp_scalar), gs->gs_un.gs_glist, 0);
     }
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
-        while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+        while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
-        if (glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
-            gobj_vis((t_gobj *)(owner_array->a_gp.gp_un.gp_scalar),
+        if(glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
+            gobj_vis((t_gobj *) (owner_array->a_gp.gp_un.gp_scalar),
                 owner_array->a_gp.gp_stub->gs_un.gs_glist, 0);
     }
-        /* if shrinking, free the scalars that will disappear */
-    if (newsize < nitems)
+    /* if shrinking, free the scalars that will disappear */
+    if(newsize < nitems)
     {
         char *elem;
         int count;
-        for (elem = ((char *)array->a_vec) + newsize * elemsize,
-            count = nitems - newsize; count--; elem += elemsize)
-                word_free((t_word *)elem, elemtemplate);
+        for(elem = ((char *) array->a_vec) + newsize * elemsize,
+        count = nitems - newsize;
+            count--; elem += elemsize)
+            word_free((t_word *) elem, elemtemplate);
     }
-        /* resize the array  */
-    array->a_vec = (char *)resizebytes(array->a_vec,
-        elemsize * nitems, elemsize * newsize);
+    /* resize the array  */
+    array->a_vec = (char *) resizebytes(
+        array->a_vec, elemsize * nitems, elemsize * newsize);
     array->a_n = newsize;
-        /* if growing, initialize new scalars */
-    if (newsize > nitems)
+    /* if growing, initialize new scalars */
+    if(newsize > nitems)
     {
         char *elem;
         int count;
-        for (elem = ((char *)array->a_vec) + nitems * elemsize,
-            count = newsize - nitems; count--; elem += elemsize)
-                word_init((t_word *)elem, elemtemplate, gp);
+        for(elem = ((char *) array->a_vec) + nitems * elemsize,
+        count = newsize - nitems;
+            count--; elem += elemsize)
+            word_init((t_word *) elem, elemtemplate, gp);
     }
-        /* invalidate all gpointers into the array */
+    /* invalidate all gpointers into the array */
     array->a_valid++;
 
     /* redraw again. */
-    if (gs->gs_which == GP_GLIST)
+    if(gs->gs_which == GP_GLIST)
     {
-        if (glist_isvisible(gs->gs_un.gs_glist))
-            gobj_vis((t_gobj *)(gp->gp_un.gp_scalar), gs->gs_un.gs_glist, 1);
+        if(glist_isvisible(gs->gs_un.gs_glist))
+            gobj_vis((t_gobj *) (gp->gp_un.gp_scalar), gs->gs_un.gs_glist, 1);
     }
     else
     {
         t_array *owner_array = gs->gs_un.gs_array;
-        while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+        while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
             owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
-        if (glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
-            gobj_vis((t_gobj *)(owner_array->a_gp.gp_un.gp_scalar),
+        if(glist_isvisible(owner_array->a_gp.gp_stub->gs_un.gs_glist))
+            gobj_vis((t_gobj *) (owner_array->a_gp.gp_un.gp_scalar),
                 owner_array->a_gp.gp_stub->gs_un.gs_glist, 1);
     }
 }
 
-static void setsize_free(t_setsize *x)
-{
-    gpointer_unset(&x->x_gp);
-}
+static void setsize_free(t_setsize *x) { gpointer_unset(&x->x_gp); }
 
 static void setsize_setup(void)
 {
-    setsize_class = class_new(gensym("setsize"), (t_newmethod)setsize_new,
-        (t_method)setsize_free, sizeof(t_setsize), 0,
-        A_DEFSYM, A_DEFSYM, A_DEFFLOAT, 0);
+    setsize_class = class_new(gensym("setsize"), (t_newmethod) setsize_new,
+        (t_method) setsize_free, sizeof(t_setsize), 0, A_DEFSYM, A_DEFSYM,
+        A_DEFFLOAT, 0);
     class_addfloat(setsize_class, setsize_float);
-    class_addmethod(setsize_class, (t_method)setsize_set, gensym("set"),
+    class_addmethod(setsize_class, (t_method) setsize_set, gensym("set"),
         A_SYMBOL, A_SYMBOL, 0);
-
 }
 
 /* ---------------------- append ----------------------------- */
@@ -1059,27 +1079,28 @@ typedef struct _append
 
 static void *append_new(t_symbol *why, int argc, t_atom *argv)
 {
-    t_append *x = (t_append *)pd_new(append_class);
+    t_append *x = (t_append *) pd_new(append_class);
     int varcount, i;
     t_atom at, *varvec;
     t_appendvariable *sp;
 
     x->x_templatesym = template_getbindsym(atom_getsymbolarg(0, argc, argv));
-    if (argc < 2)
+    if(argc < 2)
     {
         varcount = 1;
         varvec = &at;
         SETSYMBOL(&at, &s_);
     }
-    else varcount = argc - 1, varvec = argv + 1;
-    x->x_variables
-        = (t_appendvariable *)getbytes(varcount * sizeof (*x->x_variables));
+    else
+        varcount = argc - 1, varvec = argv + 1;
+    x->x_variables =
+        (t_appendvariable *) getbytes(varcount * sizeof(*x->x_variables));
     x->x_nin = varcount;
-    for (i = 0, sp = x->x_variables; i < varcount; i++, sp++)
+    for(i = 0, sp = x->x_variables; i < varcount; i++, sp++)
     {
         sp->gv_sym = atom_getsymbolarg(i, varcount, varvec);
         sp->gv_f = 0;
-        if (i) floatinlet_new(&x->x_obj, &sp->gv_f);
+        if(i) floatinlet_new(&x->x_obj, &sp->gv_f);
     }
     pointerinlet_new(&x->x_obj, &x->x_gp);
     outlet_new(&x->x_obj, &s_pointer);
@@ -1089,13 +1110,13 @@ static void *append_new(t_symbol *why, int argc, t_atom *argv)
 
 static void append_set(t_append *x, t_symbol *templatesym, t_symbol *field)
 {
-    if (x->x_nin != 1)
+    if(x->x_nin != 1)
         pd_error(x, "set: cannot set multiple fields.");
     else
     {
-       x->x_templatesym = template_getbindsym(templatesym);
-       x->x_variables->gv_sym = field;
-       x->x_variables->gv_f = 0;
+        x->x_templatesym = template_getbindsym(templatesym);
+        x->x_variables->gv_sym = field;
+        x->x_variables->gv_f = 0;
     }
 }
 
@@ -1111,45 +1132,45 @@ static void append_float(t_append *x, t_float f)
     t_scalar *sc, *oldsc;
     t_glist *glist;
 
-    if (!templatesym->s_name)
+    if(!templatesym->s_name)
     {
         pd_error(x, "append: no template supplied");
         return;
     }
     template = template_findbyname(templatesym);
-    if (!template)
+    if(!template)
     {
         pd_error(x, "append: couldn't find template %s", templatesym->s_name);
         return;
     }
-    if (!gs)
+    if(!gs)
     {
         pd_error(x, "append: no current pointer");
         return;
     }
-    if (gs->gs_which != GP_GLIST)
+    if(gs->gs_which != GP_GLIST)
     {
         pd_error(x, "append: lists only, not arrays");
         return;
     }
     glist = gs->gs_un.gs_glist;
-    if (glist->gl_valid != gp->gp_valid)
+    if(glist->gl_valid != gp->gp_valid)
     {
         pd_error(x, "append: stale pointer");
         return;
     }
-    if (!nitems) return;
+    if(!nitems) return;
     x->x_variables[0].gv_f = f;
 
     sc = scalar_new(glist, templatesym);
-    if (!sc)
+    if(!sc)
     {
         pd_error(x, "%s: couldn't create scalar", templatesym->s_name);
         return;
     }
     oldsc = gp->gp_un.gp_scalar;
 
-    if (oldsc)
+    if(oldsc)
     {
         sc->sc_gobj.g_next = oldsc->sc_gobj.g_next;
         oldsc->sc_gobj.g_next = &sc->sc_gobj;
@@ -1162,12 +1183,12 @@ static void append_float(t_append *x, t_float f)
 
     gp->gp_un.gp_scalar = sc;
     vec = sc->sc_vec;
-    for (i = 0, vp = x->x_variables; i < nitems; i++, vp++)
+    for(i = 0, vp = x->x_variables; i < nitems; i++, vp++)
     {
         template_setfloat(template, vp->gv_sym, vec, vp->gv_f, 1);
     }
 
-    if (glist_isvisible(glist_getcanvas(glist)))
+    if(glist_isvisible(glist_getcanvas(glist)))
         gobj_vis(&sc->sc_gobj, glist, 1);
     /*  scalar_redraw(sc, glist);  ... have to do 'vis' instead here because
     redraw assumes we're already visible??? ... */
@@ -1177,16 +1198,16 @@ static void append_float(t_append *x, t_float f)
 
 static void append_free(t_append *x)
 {
-    freebytes(x->x_variables, x->x_nin * sizeof (*x->x_variables));
+    freebytes(x->x_variables, x->x_nin * sizeof(*x->x_variables));
     gpointer_unset(&x->x_gp);
 }
 
 static void append_setup(void)
 {
-    append_class = class_new(gensym("append"), (t_newmethod)append_new,
-        (t_method)append_free, sizeof(t_append), 0, A_GIMME, 0);
+    append_class = class_new(gensym("append"), (t_newmethod) append_new,
+        (t_method) append_free, sizeof(t_append), 0, A_GIMME, 0);
     class_addfloat(append_class, append_float);
-    class_addmethod(append_class, (t_method)append_set, gensym("set"),
+    class_addmethod(append_class, (t_method) append_set, gensym("set"),
         A_SYMBOL, A_SYMBOL, 0);
 }
 

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -4,72 +4,73 @@
 #include "g_undo.h"
 
 #if 0
-# define DEBUG_UNDO(x) startpost("[%s:%d] ", __FILE__, __LINE__), x
+#define DEBUG_UNDO(x) startpost("[%s:%d] ", __FILE__, __LINE__), x
 #else
-# define DEBUG_UNDO(x) do { } while(0)
+#define DEBUG_UNDO(x) \
+    do                \
+    {                 \
+    } while(0)
 #endif
 
 /* used for canvas_objtext to differentiate between objects being created
    by user vs. those (re)created by the undo/redo actions */
 
-void canvas_undo_set_name(const char*name);
+void canvas_undo_set_name(const char *name);
 
 /* --------- 12. internal object state --------------- */
 int glist_getindex(t_glist *x, t_gobj *y);
+
 static t_gobj *glist_nth(t_glist *x, int n)
 {
     t_gobj *y;
     int indx;
-    for (y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
-        if (indx == n)
-            return (y);
+    for(y = x->gl_list, indx = 0; y; y = y->g_next, indx++)
+        if(indx == n) return (y);
     return (0);
 }
-typedef struct _undo_object_state {
+
+typedef struct _undo_object_state
+{
     int u_obj;
-    t_symbol*u_symbol;
-    t_binbuf*u_undo;
-    t_binbuf*u_redo;
+    t_symbol *u_symbol;
+    t_binbuf *u_undo;
+    t_binbuf *u_redo;
 } t_undo_object_state;
 
-static int atom_equal(const t_atom*v0, const t_atom*v1)
+static int atom_equal(const t_atom *v0, const t_atom *v1)
 {
-    if(v0->a_type != v1->a_type)
-        return 0;
-    switch(v0->a_type) {
-    case (A_FLOAT):
-        return (v0->a_w.w_float == v1->a_w.w_float);
-    case (A_SYMBOL):
-        return (v0->a_w.w_symbol == v1->a_w.w_symbol);
-    default:
-        break;
+    if(v0->a_type != v1->a_type) return 0;
+    switch(v0->a_type)
+    {
+        case(A_FLOAT):
+            return (v0->a_w.w_float == v1->a_w.w_float);
+        case(A_SYMBOL):
+            return (v0->a_w.w_symbol == v1->a_w.w_symbol);
+        default:
+            break;
     }
     return 0;
-
 }
-static int lists_are_equal(int c0, const t_atom*v0, int c1, const t_atom*v1)
+
+static int lists_are_equal(int c0, const t_atom *v0, int c1, const t_atom *v1)
 {
     int i;
-    if(c0 != c1)
-        return 0;
-    for(i=0; i<c0; i++)
-        if(!atom_equal(v0++, v1++))
-            return 0;
+    if(c0 != c1) return 0;
+    for(i = 0; i < c0; i++)
+        if(!atom_equal(v0++, v1++)) return 0;
     return 1;
 }
-void pd_undo_set_objectstate(t_canvas*canvas, t_pd*x, t_symbol*s,
-                                    int undo_argc, t_atom*undo_argv,
-                                    int redo_argc, t_atom*redo_argv)
+
+void pd_undo_set_objectstate(t_canvas *canvas, t_pd *x, t_symbol *s,
+    int undo_argc, t_atom *undo_argv, int redo_argc, t_atom *redo_argv)
 {
     t_undo_object_state *buf;
-    int pos = glist_getindex(canvas, (t_gobj*)x);
+    int pos = glist_getindex(canvas, (t_gobj *) x);
     t_undo *udo = canvas_undo_get(canvas);
-    if (udo && udo->u_doing)
-        return;
-    if(lists_are_equal(undo_argc, undo_argv, redo_argc, redo_argv))
-        return;
+    if(udo && udo->u_doing) return;
+    if(lists_are_equal(undo_argc, undo_argv, redo_argc, redo_argv)) return;
 
-    buf = (t_undo_object_state*)getbytes(sizeof(t_undo_object_state));
+    buf = (t_undo_object_state *) getbytes(sizeof(t_undo_object_state));
     buf->u_obj = pos;
     buf->u_symbol = s;
     buf->u_undo = binbuf_new();
@@ -83,97 +84,101 @@ void pd_undo_set_objectstate(t_canvas*canvas, t_pd*x, t_symbol*s,
     canvas_undo_add(canvas, UNDO_OBJECT_STATE, "state", buf);
 }
 
-int canvas_undo_objectstate(t_canvas *cnv, void *z, int action) {
+int canvas_undo_objectstate(t_canvas *cnv, void *z, int action)
+{
     t_undo_object_state *buf = z;
-    t_binbuf*bbuf = buf->u_undo;
-    t_pd*x = (t_pd*)glist_nth(cnv, buf->u_obj);
-    switch(action) {
-    case UNDO_FREE:
-        binbuf_free(buf->u_undo);
-        binbuf_free(buf->u_redo);
-        t_freebytes(buf, sizeof(*buf));
-        break;
-    case UNDO_REDO:
-        bbuf = buf->u_redo;     /* falls through */
-    case UNDO_UNDO:
-        if(x)
-            pd_typedmess(x, buf->u_symbol, binbuf_getnatom(bbuf), binbuf_getvec(bbuf));
-        break;
+    t_binbuf *bbuf = buf->u_undo;
+    t_pd *x = (t_pd *) glist_nth(cnv, buf->u_obj);
+    switch(action)
+    {
+        case UNDO_FREE:
+            binbuf_free(buf->u_undo);
+            binbuf_free(buf->u_redo);
+            t_freebytes(buf, sizeof(*buf));
+            break;
+        case UNDO_REDO:
+            bbuf = buf->u_redo; /* falls through */
+        case UNDO_UNDO:
+            if(x)
+                pd_typedmess(x, buf->u_symbol, binbuf_getnatom(bbuf),
+                    binbuf_getvec(bbuf));
+            break;
     }
     return 1;
 }
 
-
 /* --------------- */
 
-static void canvas_show_undomenu(t_canvas*x, const char* undo_action, const char* redo_action)
+static void canvas_show_undomenu(
+    t_canvas *x, const char *undo_action, const char *redo_action)
 {
-    if (glist_isvisible(x) && glist_istoplevel(x))
+    if(glist_isvisible(x) && glist_istoplevel(x))
         sys_vgui("pdtk_undomenu .x%lx %s %s\n", x, undo_action, redo_action);
 }
 
 static void canvas_undo_docleardirty(t_canvas *x)
 {
     t_undo *udo = canvas_undo_get(x);
-    if (udo) udo->u_cleanstate = udo->u_last;
+    if(udo) udo->u_cleanstate = udo->u_last;
 }
+
 void canvas_undo_cleardirty(t_canvas *x)
 {
-        /* clear dirty flags of this canvas
-         * and all sub-canvases (but not abstractions/
-         */
-    t_gobj*y;
+    /* clear dirty flags of this canvas
+     * and all sub-canvases (but not abstractions/
+     */
+    t_gobj *y;
     canvas_undo_docleardirty(x);
-    for(y=x->gl_list; y; y=y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class && !canvas_isabstraction((t_canvas*)y))
-            canvas_undo_cleardirty((t_canvas*)y);
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class &&
+            !canvas_isabstraction((t_canvas *) y))
+            canvas_undo_cleardirty((t_canvas *) y);
 }
 
-static int canvas_undo_doisdirty(t_canvas*x)
+static int canvas_undo_doisdirty(t_canvas *x)
 {
-    t_undo *udo = x?canvas_undo_get(x):0;
-    t_gobj*y;
-    if (!udo) return 0;
-    if (udo->u_last != udo->u_cleanstate) return 1;
+    t_undo *udo = x ? canvas_undo_get(x) : 0;
+    t_gobj *y;
+    if(!udo) return 0;
+    if(udo->u_last != udo->u_cleanstate) return 1;
 
-    for(y=x->gl_list; y; y=y->g_next)
-        if (pd_class(&y->g_pd) == canvas_class && !canvas_isabstraction((t_canvas*)y))
-            if (canvas_undo_doisdirty((t_canvas*)y))
-                return 1;
+    for(y = x->gl_list; y; y = y->g_next)
+        if(pd_class(&y->g_pd) == canvas_class &&
+            !canvas_isabstraction((t_canvas *) y))
+            if(canvas_undo_doisdirty((t_canvas *) y)) return 1;
     return 0;
 }
+
 static int canvas_undo_isdirty(t_canvas *x)
 {
-    t_undo *udo = x?canvas_undo_get(x):0;
-    return (0 != udo)
-        && ((udo->u_last != udo->u_cleanstate)
-            || canvas_undo_doisdirty(canvas_getrootfor(x)));
+    t_undo *udo = x ? canvas_undo_get(x) : 0;
+    return (0 != udo) && ((udo->u_last != udo->u_cleanstate) ||
+                             canvas_undo_doisdirty(canvas_getrootfor(x)));
 }
 
 t_undo_action *canvas_undo_init(t_canvas *x)
 {
     t_undo_action *a = 0;
     t_undo *udo = canvas_undo_get(x);
-    if (!udo) return 0;
-    a = (t_undo_action *)getbytes(sizeof(*a));
+    if(!udo) return 0;
+    a = (t_undo_action *) getbytes(sizeof(*a));
     a->type = 0;
     a->x = x;
     a->next = NULL;
 
-    if (!udo->u_queue)
+    if(!udo->u_queue)
     {
         DEBUG_UNDO(post("%s: first init", __FUNCTION__));
-        //this is the first init
+        // this is the first init
         udo->u_queue = a;
         udo->u_last = a;
 
         canvas_undo_cleardirty(x);
-            /* invalidate clean-state for re-created subpatches
-             * since we do not know whether the re-created subpatch
-             * is clean or unclean (it's undo-queue got lost when
-             * it was deleted), we assume the worst */
-        if (!canvas_isabstraction(x))
-            udo->u_cleanstate = (void*)1;
+        /* invalidate clean-state for re-created subpatches
+         * since we do not know whether the re-created subpatch
+         * is clean or unclean (it's undo-queue got lost when
+         * it was deleted), we assume the worst */
+        if(!canvas_isabstraction(x)) udo->u_cleanstate = (void *) 1;
 
         a->prev = NULL;
         a->name = "no";
@@ -182,29 +187,28 @@ t_undo_action *canvas_undo_init(t_canvas *x)
     else
     {
         DEBUG_UNDO(post("%s: re-init %p", __FUNCTION__, udo->u_last->next));
-        if (udo->u_last->next)
+        if(udo->u_last->next)
         {
-            //we need to rebranch first then add the new action
+            // we need to rebranch first then add the new action
             canvas_undo_rebranch(x);
         }
         udo->u_last->next = a;
         a->prev = udo->u_last;
         udo->u_last = a;
     }
-    return(a);
+    return (a);
 }
 
-t_undo_action *canvas_undo_add(t_canvas *x, t_undo_type type, const char *name,
-    void *data)
+t_undo_action *canvas_undo_add(
+    t_canvas *x, t_undo_type type, const char *name, void *data)
 {
     t_undo_action *a = 0;
-    t_undo * udo = canvas_undo_get(x);
+    t_undo *udo = canvas_undo_get(x);
     DEBUG_UNDO(post("%s: %d %s %p!", __FUNCTION__, type, name, data));
-    if(UNDO_SEQUENCE_END == type
-       && udo && udo->u_last
-       && UNDO_SEQUENCE_START == udo->u_last->type)
+    if(UNDO_SEQUENCE_END == type && udo && udo->u_last &&
+        UNDO_SEQUENCE_START == udo->u_last->type)
     {
-            /* empty undo sequence...get rid of it */
+        /* empty undo sequence...get rid of it */
         udo->u_last = udo->u_last->prev;
         canvas_undo_rebranch(x);
         udo->u_last->next = 0;
@@ -214,40 +218,59 @@ t_undo_action *canvas_undo_add(t_canvas *x, t_undo_type type, const char *name,
     }
 
     a = canvas_undo_init(x);
-    if(!a)return a;
+    if(!a) return a;
     a->type = type;
-    a->data = (void *)data;
-    a->name = (char *)name;
+    a->data = (void *) data;
+    a->name = (char *) name;
     canvas_undo_set_name(name);
     canvas_show_undomenu(x, a->name, "no");
     DEBUG_UNDO(post("%s: done!", __FUNCTION__));
-    return(a);
+    return (a);
 }
 
-static int canvas_undo_doit(t_canvas *x, t_undo_action *udo, int action, const char*funname)
+static int canvas_undo_doit(
+    t_canvas *x, t_undo_action *udo, int action, const char *funname)
 {
-    DEBUG_UNDO(post("%s: %s(%d) %d %p", __FUNCTION__, funname, action, udo->type, udo->data));
+    DEBUG_UNDO(post("%s: %s(%d) %d %p", __FUNCTION__, funname, action,
+        udo->type, udo->data));
 
     switch(udo->type)
     {
-    case UNDO_CONNECT:      return canvas_undo_connect(x, udo->data, action);      //connect
-    case UNDO_DISCONNECT:   return canvas_undo_disconnect(x, udo->data, action);   //disconnect
-    case UNDO_CUT:          return canvas_undo_cut(x, udo->data, action);          //cut
-    case UNDO_MOTION:       return canvas_undo_move(x, udo->data, action);         //move
-    case UNDO_PASTE:        return canvas_undo_paste(x, udo->data, action);        //paste
-    case UNDO_APPLY:        return canvas_undo_apply(x, udo->data, action);        //apply
-    case UNDO_ARRANGE:      return canvas_undo_arrange(x, udo->data, action);      //arrange
-    case UNDO_CANVAS_APPLY: return canvas_undo_canvas_apply(x, udo->data, action); //canvas apply
-    case UNDO_CREATE:       return canvas_undo_create(x, udo->data, action);       //create
-    case UNDO_RECREATE:     return canvas_undo_recreate(x, udo->data, action);     //recreate
-    case UNDO_FONT:         return canvas_undo_font(x, udo->data, action);         //font
-    case UNDO_OBJECT_STATE: return canvas_undo_objectstate(x, udo->data, action);  //font
-            /* undo sequences are handled in canvas_undo_undo resp canvas_undo_redo */
-    case UNDO_SEQUENCE_START: return 1;                                            //start undo sequence
-    case UNDO_SEQUENCE_END: return 1;                                              //end undo sequence
-    case UNDO_INIT:         if (UNDO_FREE == action) return 1;/* FALLS THROUGH */  //init
-    default:
-        pd_error(0, "%s: unsupported undo command %d", funname, udo->type);
+        case UNDO_CONNECT:
+            return canvas_undo_connect(x, udo->data, action); // connect
+        case UNDO_DISCONNECT:
+            return canvas_undo_disconnect(x, udo->data, action); // disconnect
+        case UNDO_CUT:
+            return canvas_undo_cut(x, udo->data, action); // cut
+        case UNDO_MOTION:
+            return canvas_undo_move(x, udo->data, action); // move
+        case UNDO_PASTE:
+            return canvas_undo_paste(x, udo->data, action); // paste
+        case UNDO_APPLY:
+            return canvas_undo_apply(x, udo->data, action); // apply
+        case UNDO_ARRANGE:
+            return canvas_undo_arrange(x, udo->data, action); // arrange
+        case UNDO_CANVAS_APPLY:
+            return canvas_undo_canvas_apply(
+                x, udo->data, action); // canvas apply
+        case UNDO_CREATE:
+            return canvas_undo_create(x, udo->data, action); // create
+        case UNDO_RECREATE:
+            return canvas_undo_recreate(x, udo->data, action); // recreate
+        case UNDO_FONT:
+            return canvas_undo_font(x, udo->data, action); // font
+        case UNDO_OBJECT_STATE:
+            return canvas_undo_objectstate(x, udo->data, action); // font
+            /* undo sequences are handled in canvas_undo_undo resp
+             * canvas_undo_redo */
+        case UNDO_SEQUENCE_START:
+            return 1; // start undo sequence
+        case UNDO_SEQUENCE_END:
+            return 1; // end undo sequence
+        case UNDO_INIT:
+            if(UNDO_FREE == action) return 1; /* FALLS THROUGH */ // init
+        default:
+            pd_error(0, "%s: unsupported undo command %d", funname, udo->type);
     }
     return 0;
 }
@@ -257,10 +280,10 @@ void canvas_undo_undo(t_canvas *x)
     t_undo *udo = canvas_undo_get(x);
     int dspwas;
 
-    if (!udo) return;
+    if(!udo) return;
     dspwas = canvas_suspend_dsp();
     DEBUG_UNDO(post("%s: %p != %p", __FUNCTION__, udo->u_queue, udo->u_last));
-    if (udo->u_queue && udo->u_last != udo->u_queue)
+    if(udo->u_queue && udo->u_last != udo->u_queue)
     {
         udo->u_doing = 1;
         canvas_editmode(x, 1);
@@ -270,27 +293,28 @@ void canvas_undo_undo(t_canvas *x)
         if(UNDO_SEQUENCE_END == udo->u_last->type)
         {
             int sequence_depth = 1;
-            while((udo->u_last = udo->u_last->prev)
-                  && (UNDO_INIT != udo->u_last->type))
+            while((udo->u_last = udo->u_last->prev) &&
+                  (UNDO_INIT != udo->u_last->type))
             {
-                DEBUG_UNDO(post("%s:sequence[%d] %d", __FUNCTION__, sequence_depth, udo->u_last->type));
+                DEBUG_UNDO(post("%s:sequence[%d] %d", __FUNCTION__,
+                    sequence_depth, udo->u_last->type));
                 switch(udo->u_last->type)
                 {
-                case UNDO_SEQUENCE_START:
-                    sequence_depth--;
-                    break;
-                case UNDO_SEQUENCE_END:
-                    sequence_depth++;
-                    break;
-                default:
-                    canvas_undo_doit(x, udo->u_last, UNDO_UNDO, __FUNCTION__);
+                    case UNDO_SEQUENCE_START:
+                        sequence_depth--;
+                        break;
+                    case UNDO_SEQUENCE_END:
+                        sequence_depth++;
+                        break;
+                    default:
+                        canvas_undo_doit(
+                            x, udo->u_last, UNDO_UNDO, __FUNCTION__);
                 }
-                if (sequence_depth < 1)
-                    break;
+                if(sequence_depth < 1) break;
             }
-            if (sequence_depth < 0)
+            if(sequence_depth < 0)
                 bug("undo sequence missing end");
-            else if (sequence_depth > 0)
+            else if(sequence_depth > 0)
                 bug("undo sequence missing start");
         }
 
@@ -302,9 +326,9 @@ void canvas_undo_undo(t_canvas *x)
             redo_action = udo->u_last->next->name;
 
             udo->u_doing = 0;
-                /* here we call updating of all unpaired hubs and nodes since
-                   their regular call will fail in case their position needed
-                   to be updated by undo/redo first to reflect the old one */
+            /* here we call updating of all unpaired hubs and nodes since
+               their regular call will fail in case their position needed
+               to be updated by undo/redo first to reflect the old one */
             canvas_show_undomenu(x, undo_action, redo_action);
             canvas_dirty(x, canvas_undo_isdirty(x));
         }
@@ -316,9 +340,9 @@ void canvas_undo_redo(t_canvas *x)
 {
     int dspwas;
     t_undo *udo = canvas_undo_get(x);
-    if (!udo) return;
+    if(!udo) return;
     dspwas = canvas_suspend_dsp();
-    if (udo->u_queue && udo->u_last->next)
+    if(udo->u_queue && udo->u_last->next)
     {
         char *undo_action, *redo_action;
         udo->u_doing = 1;
@@ -332,24 +356,25 @@ void canvas_undo_redo(t_canvas *x)
             int sequence_depth = 1;
             while(udo->u_last->next && (udo->u_last = udo->u_last->next))
             {
-                DEBUG_UNDO(post("%s:sequence[%d] %d", __FUNCTION__, sequence_depth, udo->u_last->type));
+                DEBUG_UNDO(post("%s:sequence[%d] %d", __FUNCTION__,
+                    sequence_depth, udo->u_last->type));
                 switch(udo->u_last->type)
                 {
-                case UNDO_SEQUENCE_END:
-                    sequence_depth--;
-                    break;
-                case UNDO_SEQUENCE_START:
-                    sequence_depth++;
-                    break;
-                default:
-                    canvas_undo_doit(x, udo->u_last, UNDO_REDO, __FUNCTION__);
+                    case UNDO_SEQUENCE_END:
+                        sequence_depth--;
+                        break;
+                    case UNDO_SEQUENCE_START:
+                        sequence_depth++;
+                        break;
+                    default:
+                        canvas_undo_doit(
+                            x, udo->u_last, UNDO_REDO, __FUNCTION__);
                 }
-                if (sequence_depth < 1)
-                    break;
+                if(sequence_depth < 1) break;
             }
-            if (sequence_depth < 0)
+            if(sequence_depth < 0)
                 bug("undo sequence end without start");
-            else if (sequence_depth > 0)
+            else if(sequence_depth > 0)
                 bug("undo sequence start without end");
         }
 
@@ -371,8 +396,8 @@ void canvas_undo_rebranch(t_canvas *x)
     int dspwas = canvas_suspend_dsp();
     t_undo_action *a1, *a2;
     t_undo *udo = canvas_undo_get(x);
-    if (!udo) return;
-    if (udo->u_last->next)
+    if(!udo) return;
+    if(udo->u_last->next)
     {
         a1 = udo->u_last->next;
         while(a1)
@@ -405,9 +430,9 @@ void canvas_undo_free(t_canvas *x)
     int dspwas;
     t_undo_action *a1, *a2;
     t_undo *udo = canvas_undo_get(x);
-    if (!udo) return;
+    if(!udo) return;
     dspwas = canvas_suspend_dsp();
-    if (udo->u_queue)
+    if(udo->u_queue)
     {
         a1 = udo->u_queue;
         while(a1)

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -54,9 +54,8 @@ static int atom_equal(const t_atom *v0, const t_atom *v1)
 
 static int lists_are_equal(int c0, const t_atom *v0, int c1, const t_atom *v1)
 {
-    int i;
     if(c0 != c1) return 0;
-    for(i = 0; i < c0; i++)
+    for(int i = 0; i < c0; i++)
         if(!atom_equal(v0++, v1++)) return 0;
     return 1;
 }

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -320,7 +320,8 @@ void canvas_undo_undo(t_canvas *x)
 
         if(canvas_undo_doit(x, udo->u_last, UNDO_UNDO, __FUNCTION__))
         {
-            char *undo_action, *redo_action;
+            char *undo_action;
+            char *redo_action;
             udo->u_last = udo->u_last->prev;
             undo_action = udo->u_last->name;
             redo_action = udo->u_last->next->name;
@@ -344,7 +345,8 @@ void canvas_undo_redo(t_canvas *x)
     dspwas = canvas_suspend_dsp();
     if(udo->u_queue && udo->u_last->next)
     {
-        char *undo_action, *redo_action;
+        char *undo_action;
+        char *redo_action;
         udo->u_doing = 1;
         udo->u_last = udo->u_last->next;
         canvas_editmode(x, 1);

--- a/src/g_undo.c
+++ b/src/g_undo.c
@@ -100,8 +100,10 @@ int canvas_undo_objectstate(t_canvas *cnv, void *z, int action)
             bbuf = buf->u_redo; /* falls through */
         case UNDO_UNDO:
             if(x)
+            {
                 pd_typedmess(x, buf->u_symbol, binbuf_getnatom(bbuf),
                     binbuf_getvec(bbuf));
+            }
             break;
     }
     return 1;
@@ -130,9 +132,11 @@ void canvas_undo_cleardirty(t_canvas *x)
     t_gobj *y;
     canvas_undo_docleardirty(x);
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class &&
             !canvas_isabstraction((t_canvas *) y))
             canvas_undo_cleardirty((t_canvas *) y);
+    }
 }
 
 static int canvas_undo_doisdirty(t_canvas *x)
@@ -143,9 +147,11 @@ static int canvas_undo_doisdirty(t_canvas *x)
     if(udo->u_last != udo->u_cleanstate) return 1;
 
     for(y = x->gl_list; y; y = y->g_next)
+    {
         if(pd_class(&y->g_pd) == canvas_class &&
             !canvas_isabstraction((t_canvas *) y))
             if(canvas_undo_doisdirty((t_canvas *) y)) return 1;
+    }
     return 0;
 }
 
@@ -313,9 +319,13 @@ void canvas_undo_undo(t_canvas *x)
                 if(sequence_depth < 1) break;
             }
             if(sequence_depth < 0)
+            {
                 bug("undo sequence missing end");
+            }
             else if(sequence_depth > 0)
+            {
                 bug("undo sequence missing start");
+            }
         }
 
         if(canvas_undo_doit(x, udo->u_last, UNDO_UNDO, __FUNCTION__))
@@ -375,9 +385,13 @@ void canvas_undo_redo(t_canvas *x)
                 if(sequence_depth < 1) break;
             }
             if(sequence_depth < 0)
+            {
                 bug("undo sequence end without start");
+            }
             else if(sequence_depth > 0)
+            {
                 bug("undo sequence start without end");
+            }
         }
 
         canvas_undo_doit(x, udo->u_last, UNDO_REDO, __FUNCTION__);

--- a/src/g_undo.h
+++ b/src/g_undo.h
@@ -23,8 +23,9 @@ location). Then we need to call check_canvas_pointers to update all of the old
 (stale) undo actions to corresepond with the new memory location.
 
 What about abstractions? Once they are recreated  (e.g. after delete, followed
-by an undo) all undo actions (except for its deletion in the parent window should
-be purged since abstraction's state will now default to its original (saved) state.
+by an undo) all undo actions (except for its deletion in the parent window
+should be purged since abstraction's state will now default to its original
+(saved) state.
 
 Types of undo data:
 0  - init data (start of the queue)
@@ -49,32 +50,33 @@ Types of undo data:
 typedef enum
 {
     UNDO_INIT = 0,
-    UNDO_CONNECT,      /* 1: OK */
-    UNDO_DISCONNECT,   /* 2: OK */
-    UNDO_CUT,          /* 3: OK */
-    UNDO_MOTION,       /* 4: OK */
-    UNDO_PASTE,        /* 5: OK */
-    UNDO_APPLY,        /* 6: how to test? */
-    UNDO_ARRANGE,      /* 7: FIXME: skipped */
-    UNDO_CANVAS_APPLY, /* 8: OK */
-    UNDO_CREATE,       /* 9: OK */
-    UNDO_RECREATE,     /* 10: OK */
-    UNDO_FONT,         /* 11: OK */
+    UNDO_CONNECT,        /* 1: OK */
+    UNDO_DISCONNECT,     /* 2: OK */
+    UNDO_CUT,            /* 3: OK */
+    UNDO_MOTION,         /* 4: OK */
+    UNDO_PASTE,          /* 5: OK */
+    UNDO_APPLY,          /* 6: how to test? */
+    UNDO_ARRANGE,        /* 7: FIXME: skipped */
+    UNDO_CANVAS_APPLY,   /* 8: OK */
+    UNDO_CREATE,         /* 9: OK */
+    UNDO_RECREATE,       /* 10: OK */
+    UNDO_FONT,           /* 11: OK */
     UNDO_SEQUENCE_START, /* 12 start an atomic sequence of undo actions*/
     UNDO_SEQUENCE_END,   /* 13 end an atomic sequence of undo actions */
-    UNDO_OBJECT_STATE,  /* 14: internal object state: t_atom-list to send to the object */
+    UNDO_OBJECT_STATE, /* 14: internal object state: t_atom-list to send to the
+                          object */
 
     UNDO_LAST
 } t_undo_type;
 
 struct _undo_action
 {
-	t_canvas *x;				/* canvas undo is associated with */
-	t_undo_type type;			/* defines what kind of data container it is */
-	void *data;					/* each action will have a different data container */
-	char *name;					/* name of current action */
-	struct _undo_action *prev;	/* previous undo action */
-	struct _undo_action *next;	/* next undo action */
+    t_canvas *x;      /* canvas undo is associated with */
+    t_undo_type type; /* defines what kind of data container it is */
+    void *data;       /* each action will have a different data container */
+    char *name;       /* name of current action */
+    struct _undo_action *prev; /* previous undo action */
+    struct _undo_action *next; /* next undo action */
 };
 
 #ifndef t_undo_action
@@ -86,18 +88,18 @@ struct _undo
     t_undo_action *u_queue;
     t_undo_action *u_last;
     void *u_cleanstate; /* pointer to non-dirty state */
-    int u_doing; /* currently undoing */
+    int u_doing;        /* currently undoing */
 };
+
 #define t_undo struct _undo
 
-
-EXTERN t_undo*canvas_undo_get(t_canvas*x);
+EXTERN t_undo *canvas_undo_get(t_canvas *x);
 
 EXTERN void canvas_undo_cleardirty(t_canvas *x);
 
 EXTERN t_undo_action *canvas_undo_init(t_canvas *x);
-EXTERN t_undo_action *canvas_undo_add(t_canvas *x,
-	t_undo_type type, const char *name, void *data);
+EXTERN t_undo_action *canvas_undo_add(
+    t_canvas *x, t_undo_type type, const char *name, void *data);
 EXTERN void canvas_undo_undo(t_canvas *x);
 EXTERN void canvas_undo_redo(t_canvas *x);
 EXTERN void canvas_undo_rebranch(t_canvas *x);
@@ -107,20 +109,19 @@ EXTERN void canvas_undo_free(t_canvas *x);
 
 /* --------- 1. connect ---------- */
 
-EXTERN void *canvas_undo_set_connect(t_canvas *x,
-    int index1, int outno, int index2, int inno);
+EXTERN void *canvas_undo_set_connect(
+    t_canvas *x, int index1, int outno, int index2, int inno);
 EXTERN int canvas_undo_connect(t_canvas *x, void *z, int action);
 
 /* --------- 2. disconnect ------- */
 
-EXTERN void *canvas_undo_set_disconnect(t_canvas *x,
-    int index1, int outno, int index2, int inno);
+EXTERN void *canvas_undo_set_disconnect(
+    t_canvas *x, int index1, int outno, int index2, int inno);
 EXTERN int canvas_undo_disconnect(t_canvas *x, void *z, int action);
 
 /* --------- 3. cut -------------- */
 
-EXTERN void *canvas_undo_set_cut(t_canvas *x,
-    int mode);
+EXTERN void *canvas_undo_set_cut(t_canvas *x, int mode);
 EXTERN int canvas_undo_cut(t_canvas *x, void *z, int action);
 
 /* --------- 4. move ------------- */
@@ -130,20 +131,18 @@ EXTERN int canvas_undo_move(t_canvas *x, void *z, int action);
 
 /* --------- 5. paste ------------ */
 
-EXTERN void *canvas_undo_set_paste(t_canvas *x,
-    int offset, int duplicate, int d_offset);
+EXTERN void *canvas_undo_set_paste(
+    t_canvas *x, int offset, int duplicate, int d_offset);
 EXTERN int canvas_undo_paste(t_canvas *x, void *z, int action);
 
 /* --------- 6. apply ------------ */
 
-EXTERN void *canvas_undo_set_apply(t_canvas *x,
-    int n);
+EXTERN void *canvas_undo_set_apply(t_canvas *x, int n);
 EXTERN int canvas_undo_apply(t_canvas *x, void *z, int action);
 
 /* --------- 7. arrange ---------- */
 
-EXTERN void *canvas_undo_set_arrange(t_canvas *x,
-    t_gobj *obj, int newindex);
+EXTERN void *canvas_undo_set_arrange(t_canvas *x, t_gobj *obj, int newindex);
 EXTERN int canvas_undo_arrange(t_canvas *x, void *z, int action);
 
 /* --------- 8. canvas apply ----- */
@@ -158,14 +157,13 @@ EXTERN int canvas_undo_create(t_canvas *x, void *z, int action);
 
 /* --------- 10. recreate -------- */
 
-EXTERN void *canvas_undo_set_recreate(t_canvas *x,
-    t_gobj *y, int old_pos);
+EXTERN void *canvas_undo_set_recreate(t_canvas *x, t_gobj *y, int old_pos);
 EXTERN int canvas_undo_recreate(t_canvas *x, void *z, int action);
 
 /* --------- 11. font ------------ */
 
-EXTERN void *canvas_undo_set_font(t_canvas *x,
-    int font, t_float realresize, int whichresize);
+EXTERN void *canvas_undo_set_font(
+    t_canvas *x, int font, t_float realresize, int whichresize);
 EXTERN int canvas_undo_font(t_canvas *x, void *z, int action);
 
 /* ------------------------------- */

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -76,14 +76,18 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
         x->x_drawn = x->x_on;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xx11, yy11 + IEMGUI_ZOOM(x) - ioh, xx11 + iow, yy11, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xx11, yy11b, xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh, x,
             0);
+    }
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
              "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
         canvas, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
@@ -124,11 +128,15 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
         yy22 += dy;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xx11,
             yy11 + IEMGUI_ZOOM(x) - ioh, xx11 + iow, yy11);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xx11,
             yy11b, xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
         xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
         yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
@@ -248,19 +256,33 @@ void vradio_draw_select(t_vradio *x, t_glist *glist)
 void vradio_draw(t_vradio *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         sys_queuegui(x, glist, vradio_draw_update);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         vradio_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         vradio_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         vradio_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         vradio_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         vradio_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         vradio_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ vdl widgetbehaviour----------------------------- */
@@ -524,8 +546,10 @@ static int vradio_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
     int shift, int alt, int dbl, int doit)
 {
     if(doit)
+    {
         vradio_click((t_vradio *) z, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
+    }
     return (1);
 }
 
@@ -657,9 +681,13 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;
@@ -673,9 +701,13 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     if(on < 0) on = 0;
     if(on >= x->x_number) on = x->x_number - 1;
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_on = on;
+    }
     else
+    {
         x->x_on = 0;
+    }
     x->x_on_old = x->x_on;
     x->x_change = (chg == 0) ? 0 : 1;
     if(x->x_gui.x_fsf.x_rcv_able)

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -26,17 +26,15 @@ static t_class *vradio_class, *vradio_old_class;
 
 void vradio_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_hradio *x = (t_hradio *)client;
+    t_hradio *x = (t_hradio *) client;
     if(glist_isvisible(glist))
     {
-        t_canvas *canvas=glist_getcanvas(glist);
+        t_canvas *canvas = glist_getcanvas(glist);
 
         sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
-                 canvas, x, x->x_drawn,
-                 x->x_gui.x_bcol, x->x_gui.x_bcol);
+            canvas, x, x->x_drawn, x->x_gui.x_bcol, x->x_gui.x_bcol);
         sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
-                 canvas, x, x->x_on,
-                 x->x_gui.x_fcol, x->x_gui.x_fcol);
+            canvas, x, x->x_on, x->x_gui.x_fcol, x->x_gui.x_fcol);
         x->x_drawn = x->x_on;
     }
 }
@@ -54,13 +52,15 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
 
     for(i = 0; i < n; i++)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE%d\n",
-                 canvas, xx11, yy11, xx12, yy12, IEMGUI_ZOOM(x),
-                 x->x_gui.x_bcol, x, i);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x -tags %lxBUT%d\n",
-                 canvas, xx21, yy21, xx22, yy22,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x, i);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x "
+                 "-tags %lxBASE%d\n",
+            canvas, xx11, yy11, xx12, yy12, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x,
+            i);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline "
+                 "#%06x -tags %lxBUT%d\n",
+            canvas, xx21, yy21, xx22, yy22,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol, x, i);
         yy11 += dy;
         yy12 += dy;
         yy21 += dy;
@@ -68,23 +68,21 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
         x->x_drawn = x->x_on;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xx11, yy11 + IEMGUI_ZOOM(x) - ioh,
-             xx11 + iow, yy11,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xx11, yy11 + IEMGUI_ZOOM(x) - ioh, xx11 + iow, yy11, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xx11, yy11b,
-             xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xx11, yy11b, xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh, x,
+            0);
+    sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w -font {{%s} -%d "
+             "%s} -fill #%06x -tags [list %lxLABEL label text]\n",
+        canvas, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 void vradio_draw_move(t_vradio *x, t_glist *glist)
@@ -100,31 +98,27 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
 
     for(i = 0; i < n; i++)
     {
-        sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n",
-                 canvas, x, i, xx11, yy11, xx12, yy12);
-        sys_vgui(".x%lx.c coords %lxBUT%d %d %d %d %d\n",
-                 canvas, x, i, xx21, yy21, xx22, yy22);
+        sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n", canvas, x, i, xx11,
+            yy11, xx12, yy12);
+        sys_vgui(".x%lx.c coords %lxBUT%d %d %d %d %d\n", canvas, x, i, xx21,
+            yy21, xx22, yy22);
         yy11 += dy;
         yy12 += dy;
         yy21 += dy;
         yy22 += dy;
     }
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xx11, yy11 + IEMGUI_ZOOM(x) - ioh,
-             xx11 + iow, yy11);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xx11,
+            yy11 + IEMGUI_ZOOM(x) - ioh, xx11 + iow, yy11);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xx11, yy11b,
-             xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xx11,
+            yy11b, xx11 + iow, yy11b - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xx11 + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        yy11b + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-void vradio_draw_erase(t_vradio* x, t_glist* glist)
+void vradio_draw_erase(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
@@ -141,26 +135,28 @@ void vradio_draw_erase(t_vradio* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void vradio_draw_config(t_vradio* x, t_glist* glist)
+void vradio_draw_config(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
-             strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
-    for(i=0; i<n; i++)
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
+        strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
+    for(i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c itemconfigure %lxBASE%d -fill #%06x\n", canvas, x, i,
-                 x->x_gui.x_bcol);
-        sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n", canvas, x, i,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
-                 (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+            x->x_gui.x_bcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBUT%d -fill #%06x -outline #%06x\n",
+            canvas, x, i, (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol,
+            (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol);
     }
 }
 
-void vradio_draw_io(t_vradio* x, t_glist* glist, int old_snd_rcv_flags)
+void vradio_draw_io(t_vradio *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
@@ -169,37 +165,40 @@ void vradio_draw_io(t_vradio* x, t_glist* glist, int old_snd_rcv_flags)
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-                 canvas,
-                 xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
-                 xpos + iow, ypos + x->x_gui.x_h,
-                 x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h, x, 0);
         /* keep these above outlet */
-        if(x->x_on == 0) {
-            sys_vgui(".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
-            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        if(x->x_on == 0)
+        {
+            sys_vgui(
+                ".x%lx.c raise %lxBUT%d %lxOUT%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(
+                ".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
         }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && x->x_gui.x_fsf.x_snd_able)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
     if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-                 canvas,
-                 xpos, ypos,
-                 xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh,
-                 x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos, xpos + iow, ypos - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep these above inlet */
-        if(x->x_on == 0) {
-            sys_vgui(".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
-            sys_vgui(".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
+        if(x->x_on == 0)
+        {
+            sys_vgui(
+                ".x%lx.c raise %lxBUT%d %lxIN%d\n", canvas, x, x->x_on, x, 0);
+            sys_vgui(
+                ".x%lx.c raise %lxLABEL %lxBUT%d\n", canvas, x, x, x->x_on);
         }
     }
     if(!(old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && x->x_gui.x_fsf.x_rcv_able)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-void vradio_draw_select(t_vradio* x, t_glist* glist)
+void vradio_draw_select(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
@@ -208,20 +207,21 @@ void vradio_draw_select(t_vradio* x, t_glist* glist)
     {
         for(i = 0; i < n; i++)
         {
-            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas, x, i,
-                     IEM_GUI_COLOR_SELECTED);
+            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
+                x, i, IEM_GUI_COLOR_SELECTED);
         }
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
         for(i = 0; i < n; i++)
         {
-            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas, x, i,
-                     IEM_GUI_COLOR_NORMAL);
+            sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
+                x, i, IEM_GUI_COLOR_NORMAL);
         }
         sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
-                 x->x_gui.x_lcol);
+            x->x_gui.x_lcol);
     }
 }
 
@@ -245,9 +245,10 @@ void vradio_draw(t_vradio *x, t_glist *glist, int mode)
 
 /* ------------------------ vdl widgetbehaviour----------------------------- */
 
-static void vradio_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
+static void vradio_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_vradio *x = (t_vradio *)z;
+    t_vradio *x = (t_vradio *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
     *yp1 = text_ypix(&x->x_gui.x_obj, glist);
@@ -257,29 +258,27 @@ static void vradio_getrect(t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *x
 
 static void vradio_save(t_gobj *z, t_binbuf *b)
 {
-    t_vradio *x = (t_vradio *)z;
+    t_vradio *x = (t_vradio *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiiiisssiiiisssf", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix,
-                (int)x->x_gui.x_obj.te_ypix,
-                (pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class ?
-                    gensym("vdl") : gensym("vradio")),
-                x->x_gui.x_w/IEMGUI_ZOOM(x),
-                x->x_change, iem_symargstoint(&x->x_gui.x_isa), x->x_number,
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_fval:0.);
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        (pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class
+                ? gensym("vdl")
+                : gensym("vradio")),
+        x->x_gui.x_w / IEMGUI_ZOOM(x), x->x_change,
+        iem_symargstoint(&x->x_gui.x_isa), x->x_number, srl[0], srl[1], srl[2],
+        x->x_gui.x_ldx, x->x_gui.x_ldy, iem_fstyletoint(&x->x_gui.x_fsf),
+        x->x_gui.x_fontsize, bflcol[0], bflcol[1], bflcol[2],
+        x->x_gui.x_isa.x_loadinit ? x->x_fval : 0.);
     binbuf_addv(b, ";");
 }
 
 static void vradio_properties(t_gobj *z, t_glist *owner)
 {
-    t_vradio *x = (t_vradio *)z;
+    t_vradio *x = (t_vradio *) z;
     char buf[800];
     t_symbol *srl[3];
     int hchange = -1;
@@ -295,34 +294,34 @@ static void vradio_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            0,/*no_schedule*/
-            hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number,
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, 0, /*no_schedule*/
+        hchange, x->x_gui.x_isa.x_loadinit, -1, x->x_number, srl[0]->s_name,
+        srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
 static void vradio_dialog(t_vradio *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int a = (int)atom_getfloatarg(0, argc, argv);
-    int chg = (int)atom_getfloatarg(4, argc, argv);
-    int num = (int)atom_getfloatarg(6, argc, argv);
+    int a = (int) atom_getfloatarg(0, argc, argv);
+    int chg = (int) atom_getfloatarg(4, argc, argv);
+    int num = (int) atom_getfloatarg(6, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+1, 0);
-    SETFLOAT(undo+2, 0);
-    SETFLOAT(undo+3, 0);
-    SETFLOAT(undo+4, (pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)?x->x_change:-1);
-    SETFLOAT(undo+6, x->x_number);
+    SETFLOAT(undo + 1, 0);
+    SETFLOAT(undo + 2, 0);
+    SETFLOAT(undo + 3, 0);
+    SETFLOAT(undo + 4, (pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)
+                           ? x->x_change
+                           : -1);
+    SETFLOAT(undo + 6, x->x_number);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     if(chg != 0) chg = 1;
     x->x_change = chg;
@@ -343,22 +342,21 @@ static void vradio_dialog(t_vradio *x, t_symbol *s, int argc, t_atom *argv)
     else
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
-        (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
+        (*x->x_gui.x_draw)(
+            x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-        canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+        canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
     }
 }
 
 static void vradio_set(t_vradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
     int old;
 
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
     if(x->x_on != x->x_on_old)
     {
         old = x->x_on_old;
@@ -376,20 +374,20 @@ static void vradio_set(t_vradio *x, t_floatarg f)
 
 static void vradio_bang(t_vradio *x)
 {
-        /* compatibility with earlier "vdial" behavior */
+    /* compatibility with earlier "vdial" behavior */
     if(pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)
     {
         if((x->x_change) && (x->x_on != x->x_on_old))
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on_old);
-            SETFLOAT(x->x_at+1, 0.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on_old);
+            SETFLOAT(x->x_at + 1, 0.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
         }
         x->x_on_old = x->x_on;
-        SETFLOAT(x->x_at, (t_float)x->x_on);
-        SETFLOAT(x->x_at+1, 1.0);
+        SETFLOAT(x->x_at, (t_float) x->x_on);
+        SETFLOAT(x->x_at + 1, 1.0);
         outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
         if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
             pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -405,32 +403,29 @@ static void vradio_bang(t_vradio *x)
 
 static void vradio_fout(t_vradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
 
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
 
     if(pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)
     {
-            /* compatibility with earlier  "vdial" behavior */
+        /* compatibility with earlier  "vdial" behavior */
         if((x->x_change) && (i != x->x_on_old))
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on_old);
-            SETFLOAT(x->x_at+1, 0.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on_old);
+            SETFLOAT(x->x_at + 1, 0.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
         }
-        if(x->x_on != x->x_on_old)
-            x->x_on_old = x->x_on;
+        if(x->x_on != x->x_on_old) x->x_on_old = x->x_on;
         x->x_on = i;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         x->x_on_old = x->x_on;
-        SETFLOAT(x->x_at, (t_float)x->x_on);
-        SETFLOAT(x->x_at+1, 1.0);
+        SETFLOAT(x->x_at, (t_float) x->x_on);
+        SETFLOAT(x->x_at + 1, 1.0);
         outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
         if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
             pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -449,37 +444,34 @@ static void vradio_fout(t_vradio *x, t_floatarg f)
 
 static void vradio_float(t_vradio *x, t_floatarg f)
 {
-    int i = (int)f;
+    int i = (int) f;
 
     x->x_fval = f;
-    if(i < 0)
-        i = 0;
-    if(i >= x->x_number)
-        i = x->x_number - 1;
+    if(i < 0) i = 0;
+    if(i >= x->x_number) i = x->x_number - 1;
 
     if(pd_class(&x->x_gui.x_obj.ob_pd) == vradio_old_class)
     {
-            /* compatibility with earlier "vdial" behavior */
+        /* compatibility with earlier "vdial" behavior */
         if((x->x_change) && (i != x->x_on_old))
         {
             if(x->x_gui.x_fsf.x_put_in2out)
             {
-                SETFLOAT(x->x_at, (t_float)x->x_on_old);
-                SETFLOAT(x->x_at+1, 0.0);
+                SETFLOAT(x->x_at, (t_float) x->x_on_old);
+                SETFLOAT(x->x_at + 1, 0.0);
                 outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
                 if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                     pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
             }
         }
-        if(x->x_on != x->x_on_old)
-            x->x_on_old = x->x_on;
+        if(x->x_on != x->x_on_old) x->x_on_old = x->x_on;
         x->x_on = i;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         x->x_on_old = x->x_on;
         if(x->x_gui.x_fsf.x_put_in2out)
         {
-            SETFLOAT(x->x_at, (t_float)x->x_on);
-            SETFLOAT(x->x_at+1, 1.0);
+            SETFLOAT(x->x_at, (t_float) x->x_on);
+            SETFLOAT(x->x_at + 1, 1.0);
             outlet_list(x->x_gui.x_obj.ob_outlet, &s_list, 2, x->x_at);
             if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
                 pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
@@ -503,93 +495,107 @@ static void vradio_float(t_vradio *x, t_floatarg f)
 static void vradio_click(t_vradio *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
-    int yy =  (int)ypos - text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist);
+    int yy = (int) ypos - text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist);
 
-    vradio_fout(x, (t_float)(yy / x->x_gui.x_h));
+    vradio_fout(x, (t_float) (yy / x->x_gui.x_h));
 }
 
-static int vradio_newclick(t_gobj *z, struct _glist *glist,
-    int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int vradio_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
     if(doit)
-        vradio_click((t_vradio *)z, (t_floatarg)xpix, (t_floatarg)ypix,
-            (t_floatarg)shift, 0, (t_floatarg)alt);
+        vradio_click((t_vradio *) z, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
     return (1);
 }
 
 static void vradio_loadbang(t_vradio *x, t_floatarg action)
 {
-    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
-        vradio_bang(x);
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit) vradio_bang(x);
 }
 
 static void vradio_number(t_vradio *x, t_floatarg num)
 {
-    int n = (int)num;
+    int n = (int) num;
 
-    if(n < 1)
-        n = 1;
-    if(n > IEM_RADIO_MAX)
-        n = IEM_RADIO_MAX;
+    if(n < 1) n = 1;
+    if(n > IEM_RADIO_MAX) n = IEM_RADIO_MAX;
     if(n != x->x_number)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_ERASE);
         x->x_number = n;
-        if(x->x_on >= x->x_number)
-            x->x_on = x->x_number - 1;
+        if(x->x_on >= x->x_number) x->x_on = x->x_number - 1;
         x->x_on_old = x->x_on;
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_NEW);
-        canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+        canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
     }
 }
 
 static void vradio_size(t_vradio *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     x->x_gui.x_h = x->x_gui.x_w;
-    iemgui_size((void *)x, &x->x_gui);
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void vradio_delta(t_vradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vradio_pos(t_vradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vradio_color(t_vradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vradio_send(t_vradio *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void vradio_receive(t_vradio *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void vradio_label(t_vradio *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void vradio_label_pos(t_vradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vradio_label_font(t_vradio *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vradio_init(t_vradio *x, t_floatarg f)
-{x->x_gui.x_isa.x_loadinit = (f == 0.0) ? 0 : 1;}
+{
+    x->x_gui.x_isa.x_loadinit = (f == 0.0) ? 0 : 1;
+}
 
-static void vradio_double_change(t_vradio *x)
-{x->x_change = 1;}
+static void vradio_double_change(t_vradio *x) { x->x_change = 1; }
 
-static void vradio_single_change(t_vradio *x)
-{x->x_change = 0;}
+static void vradio_single_change(t_vradio *x) { x->x_change = 0; }
 
 static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
 {
-    t_vradio *x = (t_vradio *)pd_new(old ? vradio_old_class : vradio_class);
+    t_vradio *x = (t_vradio *) pd_new(old ? vradio_old_class : vradio_class);
     int a = IEM_GUI_DEFAULTSIZE, on = 0, f = 0;
     int ldx = 0, ldy = -8, chg = 1, num = 8;
     int fs = 10;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME, fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
+    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
+        fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
     char str[144];
     float fval = 0;
 
@@ -597,50 +603,50 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if((argc == 15)&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2)
-       &&IS_A_FLOAT(argv,3)
-       &&(IS_A_SYMBOL(argv,4)||IS_A_FLOAT(argv,4))
-       &&(IS_A_SYMBOL(argv,5)||IS_A_FLOAT(argv,5))
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&IS_A_FLOAT(argv,7)&&IS_A_FLOAT(argv,8)
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)&&IS_A_FLOAT(argv,14))
+    if((argc == 15) && IS_A_FLOAT(argv, 0) && IS_A_FLOAT(argv, 1) &&
+        IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) &&
+        (IS_A_SYMBOL(argv, 4) || IS_A_FLOAT(argv, 4)) &&
+        (IS_A_SYMBOL(argv, 5) || IS_A_FLOAT(argv, 5)) &&
+        (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) && IS_A_FLOAT(argv, 7) &&
+        IS_A_FLOAT(argv, 8) && IS_A_FLOAT(argv, 9) && IS_A_FLOAT(argv, 10) &&
+        IS_A_FLOAT(argv, 14))
     {
-        a = (int)atom_getfloatarg(0, argc, argv);
-        chg = (int)atom_getfloatarg(1, argc, argv);
+        a = (int) atom_getfloatarg(0, argc, argv);
+        chg = (int) atom_getfloatarg(1, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(2, argc, argv));
-        num = (int)atom_getfloatarg(3, argc, argv);
+        num = (int) atom_getfloatarg(3, argc, argv);
         iemgui_new_getnames(&x->x_gui, 4, argv);
-        ldx = (int)atom_getfloatarg(7, argc, argv);
-        ldy = (int)atom_getfloatarg(8, argc, argv);
+        ldx = (int) atom_getfloatarg(7, argc, argv);
+        ldy = (int) atom_getfloatarg(8, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(9, argc, argv));
-        fs = (int)atom_getfloatarg(10, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+11, argv+12, argv+13);
+        fs = (int) atom_getfloatarg(10, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 11, argv + 12, argv + 13);
         fval = atom_getfloatarg(14, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 4, 0);
-    x->x_gui.x_draw = (t_iemfunptr)vradio_draw;
+    else
+        iemgui_new_getnames(&x->x_gui, 4, 0);
+    x->x_gui.x_draw = (t_iemfunptr) vradio_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if(!strcmp(x->x_gui.x_snd->s_name, "empty"))
-        x->x_gui.x_fsf.x_snd_able = 0;
-    if(!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
-    if(num < 1)
-        num = 1;
-    if(num > IEM_RADIO_MAX)
-        num = IEM_RADIO_MAX;
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
+    if(num < 1) num = 1;
+    if(num > IEM_RADIO_MAX) num = IEM_RADIO_MAX;
     x->x_number = num;
     x->x_fval = fval;
     on = fval;
-    if(on < 0)
-        on = 0;
-    if(on >= x->x_number)
-        on = x->x_number - 1;
+    if(on < 0) on = 0;
+    if(on >= x->x_number) on = x->x_number - 1;
     if(x->x_gui.x_isa.x_loadinit)
         x->x_on = on;
     else
@@ -651,8 +657,7 @@ static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
@@ -681,42 +686,42 @@ static void vradio_ff(t_vradio *x)
 
 void g_vradio_setup(void)
 {
-    vradio_class = class_new(gensym("vradio"), (t_newmethod)vradio_new,
-        (t_method)vradio_ff, sizeof(t_vradio), 0, A_GIMME, 0);
+    vradio_class = class_new(gensym("vradio"), (t_newmethod) vradio_new,
+        (t_method) vradio_ff, sizeof(t_vradio), 0, A_GIMME, 0);
     class_addbang(vradio_class, vradio_bang);
     class_addfloat(vradio_class, vradio_float);
-    class_addmethod(vradio_class, (t_method)vradio_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(vradio_class, (t_method)vradio_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_loadbang,
+    class_addmethod(vradio_class, (t_method) vradio_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(vradio_class, (t_method) vradio_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(vradio_class, (t_method)vradio_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(vradio_class, (t_method)vradio_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(vradio_class, (t_method)vradio_receive,
-        gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(vradio_class, (t_method)vradio_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(vradio_class, (t_method)vradio_label_pos,
+    class_addmethod(
+        vradio_class, (t_method) vradio_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(vradio_class, (t_method) vradio_receive, gensym("receive"),
+        A_DEFSYM, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(vradio_class, (t_method) vradio_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_label_font,
+    class_addmethod(vradio_class, (t_method) vradio_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(vradio_class, (t_method)vradio_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(vradio_class, (t_method)vradio_number,
-        gensym("number"), A_FLOAT, 0);
-    class_addmethod(vradio_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        vradio_class, (t_method) vradio_number, gensym("number"), A_FLOAT, 0);
+    class_addmethod(
+        vradio_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     vradio_widgetbehavior.w_getrectfn = vradio_getrect;
     vradio_widgetbehavior.w_displacefn = iemgui_displace;
     vradio_widgetbehavior.w_selectfn = iemgui_select;
@@ -729,46 +734,46 @@ void g_vradio_setup(void)
     class_setsavefn(vradio_class, vradio_save);
     class_setpropertiesfn(vradio_class, vradio_properties);
 
-        /* obsolete version (0.34-0.35) */
-    vradio_old_class = class_new(gensym("vdl"), (t_newmethod)vdial_new,
-        (t_method)vradio_ff, sizeof(t_vradio), 0, A_GIMME, 0);
+    /* obsolete version (0.34-0.35) */
+    vradio_old_class = class_new(gensym("vdl"), (t_newmethod) vdial_new,
+        (t_method) vradio_ff, sizeof(t_vradio), 0, A_GIMME, 0);
     class_addbang(vradio_old_class, vradio_bang);
     class_addfloat(vradio_old_class, vradio_float);
-    class_addmethod(vradio_old_class, (t_method)vradio_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_dialog,
+    class_addmethod(vradio_old_class, (t_method) vradio_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(vradio_old_class, (t_method) vradio_dialog,
         gensym("dialog"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_loadbang,
-        gensym("loadbang"), 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_receive,
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_loadbang, gensym("loadbang"), 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(vradio_old_class, (t_method) vradio_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_label_pos,
+    class_addmethod(vradio_old_class, (t_method) vradio_label, gensym("label"),
+        A_DEFSYM, 0);
+    class_addmethod(vradio_old_class, (t_method) vradio_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_label_font,
+    class_addmethod(vradio_old_class, (t_method) vradio_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_number,
+    class_addmethod(
+        vradio_old_class, (t_method) vradio_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(vradio_old_class, (t_method) vradio_number,
         gensym("number"), A_FLOAT, 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_single_change,
+    class_addmethod(vradio_old_class, (t_method) vradio_single_change,
         gensym("single_change"), 0);
-    class_addmethod(vradio_old_class, (t_method)vradio_double_change,
+    class_addmethod(vradio_old_class, (t_method) vradio_double_change,
         gensym("double_change"), 0);
-    class_addmethod(vradio_old_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
+    class_addmethod(
+        vradio_old_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
     class_setwidget(vradio_old_class, &vradio_widgetbehavior);
 }

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -42,7 +42,6 @@ void vradio_draw_update(t_gobj *client, t_glist *glist)
 void vradio_draw_new(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     int dy = x->x_gui.x_h;
     int s4 = dy / 4;
     int yy11b = text_ypix(&x->x_gui.x_obj, glist);
@@ -58,7 +57,7 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
     int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x "
                  "-tags %lxBASE%d\n",
@@ -100,7 +99,6 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
 void vradio_draw_move(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     int dy = x->x_gui.x_h;
     int s4 = dy / 4;
     int yy11b = text_ypix(&x->x_gui.x_obj, glist);
@@ -116,7 +114,7 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
     int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c coords %lxBASE%d %d %d %d %d\n", canvas, x, i, xx11,
             yy11, xx12, yy12);
@@ -145,10 +143,9 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
 void vradio_draw_erase(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c delete %lxBASE%d\n", canvas, x, i);
         sys_vgui(".x%lx.c delete %lxBUT%d\n", canvas, x, i);
@@ -163,7 +160,6 @@ void vradio_draw_erase(t_vradio *x, t_glist *glist)
 void vradio_draw_config(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
@@ -172,7 +168,7 @@ void vradio_draw_config(t_vradio *x, t_glist *glist)
         sys_fontweight,
         x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
         strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         sys_vgui(".x%lx.c itemconfigure %lxBASE%d -fill #%06x\n", canvas, x, i,
             x->x_gui.x_bcol);
@@ -228,12 +224,11 @@ void vradio_draw_io(t_vradio *x, t_glist *glist, int old_snd_rcv_flags)
 void vradio_draw_select(t_vradio *x, t_glist *glist)
 {
     int n = x->x_number;
-    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
                 x, i, IEM_GUI_COLOR_SELECTED);
@@ -243,7 +238,7 @@ void vradio_draw_select(t_vradio *x, t_glist *glist)
     }
     else
     {
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             sys_vgui(".x%lx.c itemconfigure %lxBASE%d -outline #%06x\n", canvas,
                 x, i, IEM_GUI_COLOR_NORMAL);

--- a/src/g_vdial.c
+++ b/src/g_vdial.c
@@ -41,13 +41,21 @@ void vradio_draw_update(t_gobj *client, t_glist *glist)
 
 void vradio_draw_new(t_vradio *x, t_glist *glist)
 {
-    int n = x->x_number, i, dy = x->x_gui.x_h, s4 = dy / 4;
+    int n = x->x_number;
+    int i;
+    int dy = x->x_gui.x_h;
+    int s4 = dy / 4;
     int yy11b = text_ypix(&x->x_gui.x_obj, glist);
-    int yy11 = yy11b, yy12 = yy11 + dy;
-    int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11 = text_xpix(&x->x_gui.x_obj, glist), xx12 = xx11 + dy;
-    int xx21 = xx11 + s4, xx22 = xx12 - s4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int yy11 = yy11b;
+    int yy12 = yy11 + dy;
+    int yy21 = yy11 + s4;
+    int yy22 = yy12 - s4;
+    int xx11 = text_xpix(&x->x_gui.x_obj, glist);
+    int xx12 = xx11 + dy;
+    int xx21 = xx11 + s4;
+    int xx22 = xx12 - s4;
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
@@ -87,13 +95,21 @@ void vradio_draw_new(t_vradio *x, t_glist *glist)
 
 void vradio_draw_move(t_vradio *x, t_glist *glist)
 {
-    int n = x->x_number, i, dy = x->x_gui.x_h, s4 = dy / 4;
+    int n = x->x_number;
+    int i;
+    int dy = x->x_gui.x_h;
+    int s4 = dy / 4;
     int yy11b = text_ypix(&x->x_gui.x_obj, glist);
-    int yy11 = yy11b, yy12 = yy11 + dy;
-    int yy21 = yy11 + s4, yy22 = yy12 - s4;
-    int xx11 = text_xpix(&x->x_gui.x_obj, glist), xx12 = xx11 + dy;
-    int xx21 = xx11 + s4, xx22 = xx12 - s4;
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int yy11 = yy11b;
+    int yy12 = yy11 + dy;
+    int yy21 = yy11 + s4;
+    int yy22 = yy12 - s4;
+    int xx11 = text_xpix(&x->x_gui.x_obj, glist);
+    int xx12 = xx11 + dy;
+    int xx21 = xx11 + s4;
+    int xx22 = xx12 - s4;
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
@@ -120,7 +136,8 @@ void vradio_draw_move(t_vradio *x, t_glist *glist)
 
 void vradio_draw_erase(t_vradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     for(i = 0; i < n; i++)
@@ -137,7 +154,8 @@ void vradio_draw_erase(t_vradio *x, t_glist *glist)
 
 void vradio_draw_config(t_vradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
@@ -160,7 +178,8 @@ void vradio_draw_io(t_vradio *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -200,7 +219,8 @@ void vradio_draw_io(t_vradio *x, t_glist *glist, int old_snd_rcv_flags)
 
 void vradio_draw_select(t_vradio *x, t_glist *glist)
 {
-    int n = x->x_number, i;
+    int n = x->x_number;
+    int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
@@ -591,11 +611,16 @@ static void vradio_single_change(t_vradio *x) { x->x_change = 0; }
 static void *vradio_donew(t_symbol *s, int argc, t_atom *argv, int old)
 {
     t_vradio *x = (t_vradio *) pd_new(old ? vradio_old_class : vradio_class);
-    int a = IEM_GUI_DEFAULTSIZE, on = 0, f = 0;
-    int ldx = 0, ldy = -8, chg = 1, num = 8;
+    int a = IEM_GUI_DEFAULTSIZE;
+    int on = 0;
+    int f = 0;
+    int ldx = 0;
+    int ldy = -8;
+    int chg = 1;
+    int num = 8;
     int fs = 10;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
-        fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
+    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME;
+    int fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
     char str[144];
     float fval = 0;
 

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -62,15 +62,19 @@ static void vslider_draw_new(t_vslider *x, t_glist *glist)
         canvas, xpos, ypos - tmargin, xpos + x->x_gui.x_w,
         ypos + x->x_gui.x_h + bmargin, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxOUT%d outlet]\n",
             canvas, xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
             xpos + iow, ypos + x->x_gui.x_h + bmargin, x, 0);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
                  "%lxIN%d inlet]\n",
             canvas, xpos, ypos - tmargin, xpos + iow,
             ypos - tmargin - IEMGUI_ZOOM(x) + ioh, x, 0);
+    }
     sys_vgui(
         ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
         canvas, xpos + IEMGUI_ZOOM(x), r, xpos + x->x_gui.x_w - IEMGUI_ZOOM(x),
@@ -98,12 +102,16 @@ static void vslider_draw_move(t_vslider *x, t_glist *glist)
     sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos,
         ypos - tmargin, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h + bmargin);
     if(!x->x_gui.x_fsf.x_snd_able)
+    {
         sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh, xpos + iow,
             ypos + x->x_gui.x_h + bmargin);
+    }
     if(!x->x_gui.x_fsf.x_rcv_able)
+    {
         sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
             ypos - tmargin, xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh);
+    }
     sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", canvas, x,
         xpos + IEMGUI_ZOOM(x), r, xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r);
     sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
@@ -200,19 +208,33 @@ static void vslider_draw_select(t_vslider *x, t_glist *glist)
 void vslider_draw(t_vslider *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_UPDATE)
+    {
         sys_queuegui(x, glist, vslider_draw_update);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         vslider_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         vslider_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         vslider_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         vslider_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         vslider_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         vslider_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ vsl widgetbehaviour----------------------------- */
@@ -257,11 +279,15 @@ void vslider_check_height(t_vslider *x, int h)
         x->x_val = x->x_pos;
     }
     if(x->x_lin0_log1)
+    {
         x->x_k = log(x->x_max / x->x_min) /
                  (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
+    }
     else
+    {
         x->x_k = (x->x_max - x->x_min) /
                  (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
+    }
 }
 
 void vslider_check_minmax(t_vslider *x, double min, double max)
@@ -281,11 +307,15 @@ void vslider_check_minmax(t_vslider *x, double min, double max)
     x->x_min = min;
     x->x_max = max;
     if(x->x_lin0_log1)
+    {
         x->x_k = log(x->x_max / x->x_min) /
                  (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
+    }
     else
+    {
         x->x_k = (x->x_max - x->x_min) /
                  (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
+    }
 }
 
 static void vslider_properties(t_gobj *z, t_glist *owner)
@@ -325,9 +355,13 @@ static t_float vslider_getfval(t_vslider *x)
                       : (x->x_val / (100 * IEMGUI_ZOOM(x))) * 100;
 
     if(x->x_lin0_log1)
+    {
         fval = x->x_min * exp(x->x_k * (double) (zoomval) *0.01);
+    }
     else
+    {
         fval = (double) (zoomval) *0.01 * x->x_k + x->x_min;
+    }
     if((fval < 1.0e-10) && (fval > -1.0e-10)) fval = 0.0;
     return (fval);
 }
@@ -337,9 +371,13 @@ static void vslider_bang(t_vslider *x)
     double out;
 
     if(pd_compatibilitylevel < 46)
+    {
         out = vslider_getfval(x);
+    }
     else
+    {
         out = x->x_fval;
+    }
     outlet_float(x->x_gui.x_obj.ob_outlet, out);
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
         pd_float(x->x_gui.x_snd->s_thing, out);
@@ -369,9 +407,13 @@ static void vslider_dialog(t_vslider *x, t_symbol *s, int argc, t_atom *argv)
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
     if(steady)
+    {
         x->x_steady = 1;
+    }
     else
+    {
         x->x_steady = 0;
+    }
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_w = iemgui_clip_size(w) * IEMGUI_ZOOM(x);
     vslider_check_height(x, h);
@@ -389,9 +431,13 @@ static void vslider_motion(
     if(up != 0) return;
 
     if(x->x_gui.x_fsf.x_finemoved)
+    {
         x->x_pos -= (int) dy;
+    }
     else
+    {
         x->x_pos -= 100 * (int) dy;
+    }
     x->x_val = x->x_pos;
     if(x->x_val > (100 * x->x_gui.x_h - 100))
     {
@@ -417,10 +463,12 @@ static void vslider_click(t_vslider *x, t_floatarg xpos, t_floatarg ypos,
     t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     if(!x->x_steady)
+    {
         x->x_val =
             (int) (100.0 *
                    (x->x_gui.x_h +
                        text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - ypos));
+    }
     if(x->x_val > (100 * x->x_gui.x_h - 100))
         x->x_val = 100 * x->x_gui.x_h - 100;
     if(x->x_val < 0) x->x_val = 0;
@@ -442,9 +490,13 @@ static int vslider_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
         vslider_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
             (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
+        {
             x->x_gui.x_fsf.x_finemoved = 1;
+        }
         else
+        {
             x->x_gui.x_fsf.x_finemoved = 0;
+        }
     }
     return (1);
 }
@@ -466,9 +518,13 @@ static void vslider_set(t_vslider *x, t_floatarg f)
         if(f < x->x_min) f = x->x_min;
     }
     if(x->x_lin0_log1)
+    {
         g = log(f / x->x_min) / x->x_k;
+    }
     else
+    {
         g = (f - x->x_min) / x->x_k;
+    }
     x->x_val = IEMGUI_ZOOM(x) * (int) (100.0 * g + 0.49999);
     x->x_pos = x->x_val;
     if(x->x_val != old)
@@ -486,8 +542,10 @@ static void vslider_size(t_vslider *x, t_symbol *s, int ac, t_atom *av)
     x->x_gui.x_w =
         iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     if(ac > 1)
+    {
         vslider_check_height(
             x, (int) atom_getfloatarg(1, ac, av) * IEMGUI_ZOOM(x));
+    }
     iemgui_size((void *) x, &x->x_gui);
 }
 
@@ -632,9 +690,13 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fsf.x_rcv_able = 1;
     x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
     if(x->x_gui.x_isa.x_loadinit)
+    {
         x->x_val = v;
+    }
     else
+    {
         x->x_val = 0;
+    }
     x->x_pos = x->x_val;
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
@@ -643,9 +705,13 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -50,8 +50,10 @@ static void vslider_draw_new(t_vslider *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int tmargin = TMARGIN * IEMGUI_ZOOM(x), bmargin = BMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int tmargin = TMARGIN * IEMGUI_ZOOM(x);
+    int bmargin = BMARGIN * IEMGUI_ZOOM(x);
     int r = ypos + x->x_gui.x_h - ((x->x_val + 50) / 100);
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -86,8 +88,10 @@ static void vslider_draw_move(t_vslider *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int tmargin = TMARGIN * IEMGUI_ZOOM(x), bmargin = BMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int tmargin = TMARGIN * IEMGUI_ZOOM(x);
+    int bmargin = BMARGIN * IEMGUI_ZOOM(x);
     int r = ypos + x->x_gui.x_h - ((x->x_val + 50) / 100);
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -141,8 +145,10 @@ static void vslider_draw_io(t_vslider *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int tmargin = TMARGIN * IEMGUI_ZOOM(x), bmargin = BMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int tmargin = TMARGIN * IEMGUI_ZOOM(x);
+    int bmargin = BMARGIN * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -574,10 +580,16 @@ static void vslider_loadbang(t_vslider *x, t_floatarg action)
 static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_vslider *x = (t_vslider *) pd_new(vslider_class);
-    int w = IEM_GUI_DEFAULTSIZE, h = IEM_SL_DEFAULTSIZE;
-    int lilo = 0, f = 0, ldx = 0, ldy = -9;
-    int fs = 10, steady = 1;
-    double min = 0.0, max = (double) (IEM_SL_DEFAULTSIZE - 1);
+    int w = IEM_GUI_DEFAULTSIZE;
+    int h = IEM_SL_DEFAULTSIZE;
+    int lilo = 0;
+    int f = 0;
+    int ldx = 0;
+    int ldy = -9;
+    int fs = 10;
+    int steady = 1;
+    double min = 0.0;
+    double max = (double) (IEM_SL_DEFAULTSIZE - 1);
     char str[144];
     float v = 0;
 

--- a/src/g_vslider.c
+++ b/src/g_vslider.c
@@ -33,16 +33,16 @@ static t_class *vslider_class;
 
 static void vslider_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_vslider *x = (t_vslider *)client;
-    if (glist_isvisible(glist))
+    t_vslider *x = (t_vslider *) client;
+    if(glist_isvisible(glist))
     {
         int r = text_ypix(&x->x_gui.x_obj, glist) + x->x_gui.x_h -
-            ((x->x_val + 50)/100);
+                ((x->x_val + 50) / 100);
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
 
-        sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
-                 glist_getcanvas(glist), x, xpos + IEMGUI_ZOOM(x), r,
-                 xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r);
+        sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", glist_getcanvas(glist),
+            x, xpos + IEMGUI_ZOOM(x), r, xpos + x->x_gui.x_w - IEMGUI_ZOOM(x),
+            r);
     }
 }
 
@@ -52,37 +52,34 @@ static void vslider_draw_new(t_vslider *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int tmargin = TMARGIN * IEMGUI_ZOOM(x), bmargin = BMARGIN * IEMGUI_ZOOM(x);
-    int r = ypos + x->x_gui.x_h - ((x->x_val + 50)/100);
+    int r = ypos + x->x_gui.x_h - ((x->x_val + 50) / 100);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE\n",
-             canvas, xpos, ypos - tmargin,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h + bmargin,
-             IEMGUI_ZOOM(x),
-             x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags "
+             "%lxBASE\n",
+        canvas, xpos, ypos - tmargin, xpos + x->x_gui.x_w,
+        ypos + x->x_gui.x_h + bmargin, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h + bmargin,
-             x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h + bmargin, x, 0);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos, ypos - tmargin,
-             xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
-             canvas, xpos + IEMGUI_ZOOM(x), r,
-             xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r,
-             1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos, ypos - tmargin, xpos + iow,
+            ypos - tmargin - IEMGUI_ZOOM(x) + ioh, x, 0);
+    sys_vgui(
+        ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxKNOB\n",
+        canvas, xpos + IEMGUI_ZOOM(x), r, xpos + x->x_gui.x_w - IEMGUI_ZOOM(x),
+        r, 1 + 2 * IEMGUI_ZOOM(x), x->x_gui.x_fcol, x);
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
+        x->x_gui.x_lcol, x);
 }
 
 static void vslider_draw_move(t_vslider *x, t_glist *glist)
@@ -91,32 +88,26 @@ static void vslider_draw_move(t_vslider *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     int tmargin = TMARGIN * IEMGUI_ZOOM(x), bmargin = BMARGIN * IEMGUI_ZOOM(x);
-    int r = ypos + x->x_gui.x_h - ((x->x_val+ 50)/100);
+    int r = ypos + x->x_gui.x_h - ((x->x_val + 50) / 100);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x,
-             xpos, ypos - tmargin,
-             xpos + x->x_gui.x_w, ypos + x->x_gui.x_h + bmargin);
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos,
+        ypos - tmargin, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h + bmargin);
     if(!x->x_gui.x_fsf.x_snd_able)
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h + bmargin);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh, xpos + iow,
+            ypos + x->x_gui.x_h + bmargin);
     if(!x->x_gui.x_fsf.x_rcv_able)
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos, ypos - tmargin,
-             xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh);
-    sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n",
-             canvas, x, xpos + IEMGUI_ZOOM(x), r,
-             xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0, xpos,
+            ypos - tmargin, xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh);
+    sys_vgui(".x%lx.c coords %lxKNOB %d %d %d %d\n", canvas, x,
+        xpos + IEMGUI_ZOOM(x), r, xpos + x->x_gui.x_w - IEMGUI_ZOOM(x), r);
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
 }
 
-static void vslider_draw_erase(t_vslider* x, t_glist* glist)
+static void vslider_draw_erase(t_vslider *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
@@ -129,21 +120,24 @@ static void vslider_draw_erase(t_vslider* x, t_glist* glist)
         sys_vgui(".x%lx.c delete %lxIN%d\n", canvas, x, 0);
 }
 
-static void vslider_draw_config(t_vslider* x, t_glist* glist)
+static void vslider_draw_config(t_vslider *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x), sys_fontweight,
-             (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""));
-    sys_vgui(".x%lx.c itemconfigure %lxKNOB -fill #%06x\n", canvas,
-             x, x->x_gui.x_fcol);
-    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas,
-             x, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, x->x_gui.x_fontsize * IEMGUI_ZOOM(x),
+        sys_fontweight,
+        (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name
+                                                 : ""));
+    sys_vgui(".x%lx.c itemconfigure %lxKNOB -fill #%06x\n", canvas, x,
+        x->x_gui.x_fcol);
+    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x,
+        x->x_gui.x_bcol);
 }
 
-static void vslider_draw_io(t_vslider* x, t_glist* glist, int old_snd_rcv_flags)
+static void vslider_draw_io(t_vslider *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
@@ -153,11 +147,10 @@ static void vslider_draw_io(t_vslider* x, t_glist* glist, int old_snd_rcv_flags)
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + iow, ypos + x->x_gui.x_h + bmargin,
-             x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos, ypos + x->x_gui.x_h + bmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos + iow, ypos + x->x_gui.x_h + bmargin, x, 0);
         /* keep these above outlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxOUT%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
@@ -166,11 +159,10 @@ static void vslider_draw_io(t_vslider* x, t_glist* glist, int old_snd_rcv_flags)
         sys_vgui(".x%lx.c delete %lxOUT%d\n", canvas, x, 0);
     if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos, ypos - tmargin,
-             xpos + iow, ypos - tmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos, ypos - tmargin, xpos + iow,
+            ypos - tmargin - IEMGUI_ZOOM(x) + ioh, x, 0);
         /* keep these above inlet */
         sys_vgui(".x%lx.c raise %lxKNOB %lxIN%d\n", canvas, x, x, 0);
         sys_vgui(".x%lx.c raise %lxLABEL %lxKNOB\n", canvas, x, x);
@@ -185,13 +177,17 @@ static void vslider_draw_select(t_vslider *x, t_glist *glist)
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            x->x_gui.x_lcol);
     }
 }
 
@@ -215,82 +211,80 @@ void vslider_draw(t_vslider *x, t_glist *glist, int mode)
 
 /* ------------------------ vsl widgetbehaviour----------------------------- */
 
-
-static void vslider_getrect(t_gobj *z, t_glist *glist,
-                            int *xp1, int *yp1, int *xp2, int *yp2)
+static void vslider_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_vslider* x = (t_vslider*)z;
+    t_vslider *x = (t_vslider *) z;
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist);
-    *yp1 = text_ypix(&x->x_gui.x_obj, glist) - TMARGIN*glist_getzoom(glist);
+    *yp1 = text_ypix(&x->x_gui.x_obj, glist) - TMARGIN * glist_getzoom(glist);
     *xp2 = *xp1 + x->x_gui.x_w;
-    *yp2 = *yp1 + x->x_gui.x_h + (TMARGIN + BMARGIN)*glist_getzoom(glist);
+    *yp2 = *yp1 + x->x_gui.x_h + (TMARGIN + BMARGIN) * glist_getzoom(glist);
 }
 
 static void vslider_save(t_gobj *z, t_binbuf *b)
 {
-    t_vslider *x = (t_vslider *)z;
+    t_vslider *x = (t_vslider *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiiffiisssiiiisssii", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("vsl"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_gui.x_h/IEMGUI_ZOOM(x),
-                (t_float)x->x_min, (t_float)x->x_max,
-                x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
-                srl[0], srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[1], bflcol[2],
-                x->x_gui.x_isa.x_loadinit?x->x_val:0, x->x_steady);
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("vsl"), x->x_gui.x_w / IEMGUI_ZOOM(x),
+        x->x_gui.x_h / IEMGUI_ZOOM(x), (t_float) x->x_min, (t_float) x->x_max,
+        x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa), srl[0], srl[1],
+        srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
+        iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize, bflcol[0],
+        bflcol[1], bflcol[2], x->x_gui.x_isa.x_loadinit ? x->x_val : 0,
+        x->x_steady);
     binbuf_addv(b, ";");
 }
 
 void vslider_check_height(t_vslider *x, int h)
 {
-    if(h < IEM_SL_MINSIZE * IEMGUI_ZOOM(x))
-        h = IEM_SL_MINSIZE * IEMGUI_ZOOM(x);
+    if(h < IEM_SL_MINSIZE * IEMGUI_ZOOM(x)) h = IEM_SL_MINSIZE * IEMGUI_ZOOM(x);
     x->x_gui.x_h = h;
-    if(x->x_val > (x->x_gui.x_h*100 - 100))
+    if(x->x_val > (x->x_gui.x_h * 100 - 100))
     {
-        x->x_pos = x->x_gui.x_h*100 - 100;
+        x->x_pos = x->x_gui.x_h * 100 - 100;
         x->x_val = x->x_pos;
     }
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max / x->x_min) / (double)(x->x_gui.x_h/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max / x->x_min) /
+                 (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_h/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) /
+                 (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
 }
 
 void vslider_check_minmax(t_vslider *x, double min, double max)
 {
     if(x->x_lin0_log1)
     {
-        if((min == 0.0) && (max == 0.0))
-            max = 1.0;
+        if((min == 0.0) && (max == 0.0)) max = 1.0;
         if(max > 0.0)
         {
-            if(min <= 0.0)
-                min = 0.01 * max;
+            if(min <= 0.0) min = 0.01 * max;
         }
         else
         {
-            if(min > 0.0)
-                max = 0.01 * min;
+            if(min > 0.0) max = 0.01 * min;
         }
     }
     x->x_min = min;
     x->x_max = max;
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max/x->x_min) / (double)(x->x_gui.x_h/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max / x->x_min) /
+                 (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_h/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) /
+                 (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
 }
 
 static void vslider_properties(t_gobj *z, t_glist *owner)
 {
-    t_vslider *x = (t_vslider *)z;
+    t_vslider *x = (t_vslider *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -304,28 +298,31 @@ static void vslider_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x #%06x #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE, x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_SL_MINSIZE,
-            x->x_min, x->x_max, 0,/*no_schedule*/
-            x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady, -1,/*no multi, but iem-characteristic*/
-            srl[0]->s_name, srl[1]->s_name,
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+        x->x_gui.x_h / IEMGUI_ZOOM(x), IEM_SL_MINSIZE, x->x_min, x->x_max,
+        0, /*no_schedule*/
+        x->x_lin0_log1, x->x_gui.x_isa.x_loadinit, x->x_steady,
+        -1, /*no multi, but iem-characteristic*/
+        srl[0]->s_name, srl[1]->s_name, srl[2]->s_name, x->x_gui.x_ldx,
+        x->x_gui.x_ldy, x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_fcol,
+        0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
-    /* compute numeric value (fval) from pixel location (val) and range */
+/* compute numeric value (fval) from pixel location (val) and range */
 static t_float vslider_getfval(t_vslider *x)
 {
     t_float fval;
-    int zoomval = (x->x_gui.x_fsf.x_finemoved) ?
-        x->x_val/IEMGUI_ZOOM(x) : (x->x_val / (100*IEMGUI_ZOOM(x))) * 100;
+    int zoomval = (x->x_gui.x_fsf.x_finemoved)
+                      ? x->x_val / IEMGUI_ZOOM(x)
+                      : (x->x_val / (100 * IEMGUI_ZOOM(x))) * 100;
 
-    if (x->x_lin0_log1)
-        fval = x->x_min * exp(x->x_k * (double)(zoomval) * 0.01);
-    else fval = (double)(zoomval) * 0.01 * x->x_k + x->x_min;
-    if ((fval < 1.0e-10) && (fval > -1.0e-10))
-        fval = 0.0;
+    if(x->x_lin0_log1)
+        fval = x->x_min * exp(x->x_k * (double) (zoomval) *0.01);
+    else
+        fval = (double) (zoomval) *0.01 * x->x_k + x->x_min;
+    if((fval < 1.0e-10) && (fval > -1.0e-10)) fval = 0.0;
     return (fval);
 }
 
@@ -333,9 +330,10 @@ static void vslider_bang(t_vslider *x)
 {
     double out;
 
-    if (pd_compatibilitylevel < 46)
+    if(pd_compatibilitylevel < 46)
         out = vslider_getfval(x);
-    else out = x->x_fval;
+    else
+        out = x->x_fval;
     outlet_float(x->x_gui.x_obj.ob_outlet, out);
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
         pd_float(x->x_gui.x_snd->s_thing, out);
@@ -344,24 +342,23 @@ static void vslider_bang(t_vslider *x)
 static void vslider_dialog(t_vslider *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getfloatarg(0, argc, argv);
-    int h = (int)atom_getfloatarg(1, argc, argv) * IEMGUI_ZOOM(x);
-    double min = (double)atom_getfloatarg(2, argc, argv);
-    double max = (double)atom_getfloatarg(3, argc, argv);
-    int lilo = (int)atom_getfloatarg(4, argc, argv);
-    int steady = (int)atom_getfloatarg(17, argc, argv);
+    int w = (int) atom_getfloatarg(0, argc, argv);
+    int h = (int) atom_getfloatarg(1, argc, argv) * IEMGUI_ZOOM(x);
+    double min = (double) atom_getfloatarg(2, argc, argv);
+    double max = (double) atom_getfloatarg(3, argc, argv);
+    int lilo = (int) atom_getfloatarg(4, argc, argv);
+    int steady = (int) atom_getfloatarg(17, argc, argv);
     int sr_flags;
     t_atom undo[18];
 
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+2, x->x_min);
-    SETFLOAT(undo+3, x->x_max);
-    SETFLOAT(undo+4, x->x_lin0_log1);
-    SETFLOAT(undo+17, x->x_steady);
+    SETFLOAT(undo + 2, x->x_min);
+    SETFLOAT(undo + 3, x->x_max);
+    SETFLOAT(undo + 4, x->x_lin0_log1);
+    SETFLOAT(undo + 17, x->x_steady);
 
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
@@ -376,24 +373,23 @@ static void vslider_dialog(t_vslider *x, t_symbol *s, int argc, t_atom *argv)
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
-static void vslider_motion(t_vslider *x, t_floatarg dx, t_floatarg dy,
-    t_floatarg up)
+static void vslider_motion(
+    t_vslider *x, t_floatarg dx, t_floatarg dy, t_floatarg up)
 {
     int old = x->x_val;
-    if (up != 0)
-        return;
+    if(up != 0) return;
 
     if(x->x_gui.x_fsf.x_finemoved)
-        x->x_pos -= (int)dy;
+        x->x_pos -= (int) dy;
     else
-        x->x_pos -= 100 * (int)dy;
+        x->x_pos -= 100 * (int) dy;
     x->x_val = x->x_pos;
-    if(x->x_val > (100*x->x_gui.x_h - 100))
+    if(x->x_val > (100 * x->x_gui.x_h - 100))
     {
-        x->x_val = 100*x->x_gui.x_h - 100;
+        x->x_val = 100 * x->x_gui.x_h - 100;
         x->x_pos += 50;
         x->x_pos -= x->x_pos % 100;
     }
@@ -404,7 +400,7 @@ static void vslider_motion(t_vslider *x, t_floatarg dx, t_floatarg dy,
         x->x_pos -= x->x_pos % 100;
     }
     x->x_fval = vslider_getfval(x);
-    if (old != x->x_val)
+    if(old != x->x_val)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         vslider_bang(x);
@@ -412,31 +408,33 @@ static void vslider_motion(t_vslider *x, t_floatarg dx, t_floatarg dy,
 }
 
 static void vslider_click(t_vslider *x, t_floatarg xpos, t_floatarg ypos,
-                          t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
+    t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
     if(!x->x_steady)
-        x->x_val = (int)(100.0 * (x->x_gui.x_h + text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - ypos));
-    if(x->x_val > (100*x->x_gui.x_h - 100))
-        x->x_val = 100*x->x_gui.x_h - 100;
-    if(x->x_val < 0)
-        x->x_val = 0;
+        x->x_val =
+            (int) (100.0 *
+                   (x->x_gui.x_h +
+                       text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - ypos));
+    if(x->x_val > (100 * x->x_gui.x_h - 100))
+        x->x_val = 100 * x->x_gui.x_h - 100;
+    if(x->x_val < 0) x->x_val = 0;
     x->x_fval = vslider_getfval(x);
     x->x_pos = x->x_val;
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
     vslider_bang(x);
     glist_grab(x->x_gui.x_glist, &x->x_gui.x_obj.te_g,
-        (t_glistmotionfn)vslider_motion, 0, xpos, ypos);
+        (t_glistmotionfn) vslider_motion, 0, xpos, ypos);
 }
 
-static int vslider_newclick(t_gobj *z, struct _glist *glist,
-                            int xpix, int ypix, int shift, int alt, int dbl, int doit)
+static int vslider_newclick(t_gobj *z, struct _glist *glist, int xpix, int ypix,
+    int shift, int alt, int dbl, int doit)
 {
-    t_vslider* x = (t_vslider *)z;
+    t_vslider *x = (t_vslider *) z;
 
     if(doit)
     {
-        vslider_click(x, (t_floatarg)xpix, (t_floatarg)ypix, (t_floatarg)shift,
-                      0, (t_floatarg)alt);
+        vslider_click(x, (t_floatarg) xpix, (t_floatarg) ypix,
+            (t_floatarg) shift, 0, (t_floatarg) alt);
         if(shift)
             x->x_gui.x_fsf.x_finemoved = 1;
         else
@@ -451,25 +449,21 @@ static void vslider_set(t_vslider *x, t_floatarg f)
     double g;
 
     x->x_fval = f;
-    if (x->x_min > x->x_max)
+    if(x->x_min > x->x_max)
     {
-        if(f > x->x_min)
-            f = x->x_min;
-        if(f < x->x_max)
-            f = x->x_max;
+        if(f > x->x_min) f = x->x_min;
+        if(f < x->x_max) f = x->x_max;
     }
     else
     {
-        if(f > x->x_max)
-            f = x->x_max;
-        if(f < x->x_min)
-            f = x->x_min;
+        if(f > x->x_max) f = x->x_max;
+        if(f < x->x_min) f = x->x_min;
     }
     if(x->x_lin0_log1)
-        g = log(f/x->x_min) / x->x_k;
+        g = log(f / x->x_min) / x->x_k;
     else
         g = (f - x->x_min) / x->x_k;
-    x->x_val = IEMGUI_ZOOM(x) * (int)(100.0*g + 0.49999);
+    x->x_val = IEMGUI_ZOOM(x) * (int) (100.0 * g + 0.49999);
     x->x_pos = x->x_val;
     if(x->x_val != old)
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
@@ -478,47 +472,64 @@ static void vslider_set(t_vslider *x, t_floatarg f)
 static void vslider_float(t_vslider *x, t_floatarg f)
 {
     vslider_set(x, f);
-    if(x->x_gui.x_fsf.x_put_in2out)
-        vslider_bang(x);
+    if(x->x_gui.x_fsf.x_put_in2out) vslider_bang(x);
 }
 
 static void vslider_size(t_vslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av))*IEMGUI_ZOOM(x);
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
     if(ac > 1)
-        vslider_check_height(x, (int)atom_getfloatarg(1, ac, av)*IEMGUI_ZOOM(x));
-    iemgui_size((void *)x, &x->x_gui);
+        vslider_check_height(
+            x, (int) atom_getfloatarg(1, ac, av) * IEMGUI_ZOOM(x));
+    iemgui_size((void *) x, &x->x_gui);
 }
 
 static void vslider_delta(t_vslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vslider_pos(t_vslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vslider_range(t_vslider *x, t_symbol *s, int ac, t_atom *av)
 {
-    vslider_check_minmax(x, (double)atom_getfloatarg(0, ac, av),
-                            (double)atom_getfloatarg(1, ac, av));
+    vslider_check_minmax(x, (double) atom_getfloatarg(0, ac, av),
+        (double) atom_getfloatarg(1, ac, av));
 }
 
 static void vslider_color(t_vslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vslider_send(t_vslider *x, t_symbol *s)
-{iemgui_send(x, &x->x_gui, s);}
+{
+    iemgui_send(x, &x->x_gui, s);
+}
 
 static void vslider_receive(t_vslider *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void vslider_label(t_vslider *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void vslider_label_pos(t_vslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vslider_label_font(t_vslider *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vslider_log(t_vslider *x)
 {
@@ -529,7 +540,8 @@ static void vslider_log(t_vslider *x)
 static void vslider_lin(t_vslider *x)
 {
     x->x_lin0_log1 = 0;
-    x->x_k = (x->x_max - x->x_min) / (double)(x->x_gui.x_h/IEMGUI_ZOOM(x) - 1);
+    x->x_k =
+        (x->x_max - x->x_min) / (double) (x->x_gui.x_h / IEMGUI_ZOOM(x) - 1);
 }
 
 static void vslider_init(t_vslider *x, t_floatarg f)
@@ -545,14 +557,14 @@ static void vslider_steady(t_vslider *x, t_floatarg f)
 static void vslider_zoom(t_vslider *x, t_floatarg f)
 {
     /* scale current pixel value */
-    x->x_val = (IEMGUI_ZOOM(x) == 2 ? (x->x_val)/2 : (x->x_val)*2);
+    x->x_val = (IEMGUI_ZOOM(x) == 2 ? (x->x_val) / 2 : (x->x_val) * 2);
     x->x_pos = x->x_val;
     iemgui_zoom(&x->x_gui, f);
 }
 
 static void vslider_loadbang(t_vslider *x, t_floatarg action)
 {
-    if (action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
+    if(action == LB_LOAD && x->x_gui.x_isa.x_loadinit)
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
         vslider_bang(x);
@@ -561,11 +573,11 @@ static void vslider_loadbang(t_vslider *x, t_floatarg action)
 
 static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_vslider *x = (t_vslider *)pd_new(vslider_class);
+    t_vslider *x = (t_vslider *) pd_new(vslider_class);
     int w = IEM_GUI_DEFAULTSIZE, h = IEM_SL_DEFAULTSIZE;
     int lilo = 0, f = 0, ldx = 0, ldy = -9;
     int fs = 10, steady = 1;
-    double min = 0.0, max = (double)(IEM_SL_DEFAULTSIZE-1);
+    double min = 0.0, max = (double) (IEM_SL_DEFAULTSIZE - 1);
     char str[144];
     float v = 0;
 
@@ -576,39 +588,41 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if(((argc == 17)||(argc == 18))&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)
-       &&IS_A_FLOAT(argv,2)&&IS_A_FLOAT(argv,3)
-       &&IS_A_FLOAT(argv,4)&&IS_A_FLOAT(argv,5)
-       &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
-       &&(IS_A_SYMBOL(argv,7)||IS_A_FLOAT(argv,7))
-       &&(IS_A_SYMBOL(argv,8)||IS_A_FLOAT(argv,8))
-       &&IS_A_FLOAT(argv,9)&&IS_A_FLOAT(argv,10)
-       &&IS_A_FLOAT(argv,11)&&IS_A_FLOAT(argv,12)&&IS_A_FLOAT(argv,16))
+    if(((argc == 17) || (argc == 18)) && IS_A_FLOAT(argv, 0) &&
+        IS_A_FLOAT(argv, 1) && IS_A_FLOAT(argv, 2) && IS_A_FLOAT(argv, 3) &&
+        IS_A_FLOAT(argv, 4) && IS_A_FLOAT(argv, 5) &&
+        (IS_A_SYMBOL(argv, 6) || IS_A_FLOAT(argv, 6)) &&
+        (IS_A_SYMBOL(argv, 7) || IS_A_FLOAT(argv, 7)) &&
+        (IS_A_SYMBOL(argv, 8) || IS_A_FLOAT(argv, 8)) && IS_A_FLOAT(argv, 9) &&
+        IS_A_FLOAT(argv, 10) && IS_A_FLOAT(argv, 11) && IS_A_FLOAT(argv, 12) &&
+        IS_A_FLOAT(argv, 16))
     {
-        w = (int)atom_getfloatarg(0, argc, argv);
-        h = (int)atom_getfloatarg(1, argc, argv);
-        min = (double)atom_getfloatarg(2, argc, argv);
-        max = (double)atom_getfloatarg(3, argc, argv);
-        lilo = (int)atom_getfloatarg(4, argc, argv);
+        w = (int) atom_getfloatarg(0, argc, argv);
+        h = (int) atom_getfloatarg(1, argc, argv);
+        min = (double) atom_getfloatarg(2, argc, argv);
+        max = (double) atom_getfloatarg(3, argc, argv);
+        lilo = (int) atom_getfloatarg(4, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
-        ldx = (int)atom_getfloatarg(9, argc, argv);
-        ldy = (int)atom_getfloatarg(10, argc, argv);
+        ldx = (int) atom_getfloatarg(9, argc, argv);
+        ldy = (int) atom_getfloatarg(10, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(11, argc, argv));
-        fs = (int)atom_getfloatarg(12, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
+        fs = (int) atom_getfloatarg(12, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 13, argv + 14, argv + 15);
         v = atom_getfloatarg(16, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 6, 0);
-    if((argc == 18)&&IS_A_FLOAT(argv,17))
-        steady = (int)atom_getfloatarg(17, argc, argv);
-    x->x_gui.x_draw = (t_iemfunptr)vslider_draw;
+    else
+        iemgui_new_getnames(&x->x_gui, 6, 0);
+    if((argc == 18) && IS_A_FLOAT(argv, 17))
+        steady = (int) atom_getfloatarg(17, argc, argv);
+    x->x_gui.x_draw = (t_iemfunptr) vslider_draw;
     x->x_gui.x_fsf.x_snd_able = 1;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (x->x_gui.x_isa.x_loadinit)
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(x->x_gui.x_isa.x_loadinit)
         x->x_val = v;
-    else x->x_val = 0;
+    else
+        x->x_val = 0;
     x->x_pos = x->x_val;
     if(lilo != 0) lilo = 1;
     x->x_lin0_log1 = lilo;
@@ -616,15 +630,20 @@ static void *vslider_new(t_symbol *s, int argc, t_atom *argv)
     x->x_steady = steady;
     if(!strcmp(x->x_gui.x_snd->s_name, "empty")) x->x_gui.x_fsf.x_snd_able = 0;
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
-    if(x->x_gui.x_fsf.x_font_style == 1) strcpy(x->x_gui.x_font, "helvetica");
-    else if(x->x_gui.x_fsf.x_font_style == 2) strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
-    if(x->x_gui.x_fsf.x_rcv_able) pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
+    if(x->x_gui.x_fsf.x_font_style == 1)
+        strcpy(x->x_gui.x_font, "helvetica");
+    else if(x->x_gui.x_fsf.x_font_style == 2)
+        strcpy(x->x_gui.x_font, "times");
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
+    if(x->x_gui.x_fsf.x_rcv_able)
+        pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(w);
     vslider_check_height(x, h);
@@ -645,58 +664,56 @@ static void vslider_free(t_vslider *x)
 
 void g_vslider_setup(void)
 {
-    vslider_class = class_new(gensym("vsl"), (t_newmethod)vslider_new,
-        (t_method)vslider_free, sizeof(t_vslider), 0, A_GIMME, 0);
-    class_addcreator((t_newmethod)vslider_new, gensym("vslider"), A_GIMME, 0);
-    class_addbang(vslider_class,vslider_bang);
-    class_addfloat(vslider_class,vslider_float);
-    class_addmethod(vslider_class, (t_method)vslider_click,
-        gensym("click"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_motion,
-        gensym("motion"), A_FLOAT, A_FLOAT, A_DEFFLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_loadbang,
+    vslider_class = class_new(gensym("vsl"), (t_newmethod) vslider_new,
+        (t_method) vslider_free, sizeof(t_vslider), 0, A_GIMME, 0);
+    class_addcreator((t_newmethod) vslider_new, gensym("vslider"), A_GIMME, 0);
+    class_addbang(vslider_class, vslider_bang);
+    class_addfloat(vslider_class, vslider_float);
+    class_addmethod(vslider_class, (t_method) vslider_click, gensym("click"),
+        A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, 0);
+    class_addmethod(vslider_class, (t_method) vslider_motion, gensym("motion"),
+        A_FLOAT, A_FLOAT, A_DEFFLOAT, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(vslider_class, (t_method) vslider_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_range,
-        gensym("range"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_send,
-        gensym("send"), A_DEFSYM, 0);
-    class_addmethod(vslider_class, (t_method)vslider_receive,
+    class_addmethod(
+        vslider_class, (t_method) vslider_set, gensym("set"), A_FLOAT, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_range, gensym("range"), A_GIMME, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_send, gensym("send"), A_DEFSYM, 0);
+    class_addmethod(vslider_class, (t_method) vslider_receive,
         gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(vslider_class, (t_method)vslider_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(vslider_class, (t_method)vslider_label_pos,
+    class_addmethod(
+        vslider_class, (t_method) vslider_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(vslider_class, (t_method) vslider_label_pos,
         gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_label_font,
+    class_addmethod(vslider_class, (t_method) vslider_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(vslider_class, (t_method)vslider_log,
-        gensym("log"), 0);
-    class_addmethod(vslider_class, (t_method)vslider_lin,
-        gensym("lin"), 0);
-    class_addmethod(vslider_class, (t_method)vslider_init,
-        gensym("init"), A_FLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_steady,
-        gensym("steady"), A_FLOAT, 0);
-    class_addmethod(vslider_class, (t_method)vslider_zoom,
-        gensym("zoom"), A_CANT, 0);
-    vslider_widgetbehavior.w_getrectfn =    vslider_getrect;
-    vslider_widgetbehavior.w_displacefn =   iemgui_displace;
-    vslider_widgetbehavior.w_selectfn =     iemgui_select;
-    vslider_widgetbehavior.w_activatefn =   NULL;
-    vslider_widgetbehavior.w_deletefn =     iemgui_delete;
-    vslider_widgetbehavior.w_visfn =        iemgui_vis;
-    vslider_widgetbehavior.w_clickfn =      vslider_newclick;
+    class_addmethod(vslider_class, (t_method) vslider_log, gensym("log"), 0);
+    class_addmethod(vslider_class, (t_method) vslider_lin, gensym("lin"), 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_init, gensym("init"), A_FLOAT, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_steady, gensym("steady"), A_FLOAT, 0);
+    class_addmethod(
+        vslider_class, (t_method) vslider_zoom, gensym("zoom"), A_CANT, 0);
+    vslider_widgetbehavior.w_getrectfn = vslider_getrect;
+    vslider_widgetbehavior.w_displacefn = iemgui_displace;
+    vslider_widgetbehavior.w_selectfn = iemgui_select;
+    vslider_widgetbehavior.w_activatefn = NULL;
+    vslider_widgetbehavior.w_deletefn = iemgui_delete;
+    vslider_widgetbehavior.w_visfn = iemgui_vis;
+    vslider_widgetbehavior.w_clickfn = vslider_newclick;
     class_setwidget(vslider_class, &vslider_widgetbehavior);
     class_sethelpsymbol(vslider_class, gensym("vslider"));
     class_setsavefn(vslider_class, vslider_save);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -5,7 +5,6 @@
 /* g_7_guis.c written by Thomas Musil (c) IEM KUG Graz Austria 2000-2001 */
 /* thanks to Miller Puckette, Guenther Geiger and Krzystof Czaja */
 
-
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -37,13 +36,16 @@ static void vu_update_rms(t_vu *x, t_glist *glist)
 {
     if(glist_isvisible(glist))
     {
-        int w4 = x->x_gui.x_w / 4, off = text_ypix(&x->x_gui.x_obj, glist) - IEMGUI_ZOOM(x);
+        int w4 = x->x_gui.x_w / 4,
+            off = text_ypix(&x->x_gui.x_obj, glist) - IEMGUI_ZOOM(x);
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
-        int quad1 = xpos + w4 - IEMGUI_ZOOM(x), quad3 = xpos + x->x_gui.x_w - w4 + IEMGUI_ZOOM(x);
+        int quad1 = xpos + w4 - IEMGUI_ZOOM(x),
+            quad3 = xpos + x->x_gui.x_w - w4 + IEMGUI_ZOOM(x);
 
         sys_vgui(".x%lx.c coords %lxRCOVER %d %d %d %d\n",
-             glist_getcanvas(glist), x, quad1, off, quad3,
-             off + (x->x_led_size+1)*IEMGUI_ZOOM(x)*(IEM_VU_STEPS-x->x_rms));
+            glist_getcanvas(glist), x, quad1, off, quad3,
+            off + (x->x_led_size + 1) * IEMGUI_ZOOM(x) *
+                      (IEM_VU_STEPS - x->x_rms));
     }
 }
 
@@ -60,36 +62,37 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
         {
             int i = iemgui_vu_col[x->x_peak];
             int j = ypos +
-                   (x->x_led_size+1)*IEMGUI_ZOOM(x)*(IEM_VU_STEPS+1-x->x_peak) -
-                   (x->x_led_size+1)*IEMGUI_ZOOM(x)/2;
+                    (x->x_led_size + 1) * IEMGUI_ZOOM(x) *
+                        (IEM_VU_STEPS + 1 - x->x_peak) -
+                    (x->x_led_size + 1) * IEMGUI_ZOOM(x) / 2;
 
-            sys_vgui(".x%lx.c coords %lxPLED %d %d %d %d\n", canvas, x,
-                     xpos, j, xpos + x->x_gui.x_w + IEMGUI_ZOOM(x), j);
+            sys_vgui(".x%lx.c coords %lxPLED %d %d %d %d\n", canvas, x, xpos, j,
+                xpos + x->x_gui.x_w + IEMGUI_ZOOM(x), j);
             sys_vgui(".x%lx.c itemconfigure %lxPLED -fill #%06x\n", canvas, x,
-                     iemgui_color_hex[i]);
+                iemgui_color_hex[i]);
         }
         else
         {
-            int mid = xpos + x->x_gui.x_w/2;
+            int mid = xpos + x->x_gui.x_w / 2;
             int pkh = PEAKHEIGHT * IEMGUI_ZOOM(x);
 
-            sys_vgui(".x%lx.c itemconfigure %lxPLED -fill #%06x\n",
-                     canvas, x, x->x_gui.x_bcol);
-            sys_vgui(".x%lx.c coords %lxPLED %d %d %d %d\n",
-                     canvas, x, mid, ypos + pkh, mid, ypos + pkh);
+            sys_vgui(".x%lx.c itemconfigure %lxPLED -fill #%06x\n", canvas, x,
+                x->x_gui.x_bcol);
+            sys_vgui(".x%lx.c coords %lxPLED %d %d %d %d\n", canvas, x, mid,
+                ypos + pkh, mid, ypos + pkh);
         }
     }
 }
 
 static void vu_draw_update(t_gobj *client, t_glist *glist)
 {
-    t_vu *x = (t_vu *)client;
-    if (x->x_updaterms)
+    t_vu *x = (t_vu *) client;
+    if(x->x_updaterms)
     {
         vu_update_rms(x, glist);
         x->x_updaterms = 0;
     }
-    if (x->x_updatepeak)
+    if(x->x_updatepeak)
     {
         vu_update_peak(x, glist);
         x->x_updatepeak = 0;
@@ -102,33 +105,34 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int w4 = x->x_gui.x_w/4, mid = xpos + x->x_gui.x_w/2,
+    int w4 = x->x_gui.x_w / 4, mid = xpos + x->x_gui.x_w / 2,
         quad1 = xpos + w4 + IEMGUI_ZOOM(x);
     int quad3 = xpos + x->x_gui.x_w - w4,
-        end = xpos + x->x_gui.x_w + 4*IEMGUI_ZOOM(x);
-    int k1 = (x->x_led_size+1)*IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS+1, k3 = k1/2;
+        end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
+    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
+        k3 = k1 / 2;
     int led_col, yyy, i, k4 = ypos - k3;
     int ledw = x->x_led_size * IEMGUI_ZOOM(x);
     int fs = x->x_gui.x_fontsize * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags %lxBASE\n",
-             canvas, xpos - hmargin, ypos - vmargin,
-             xpos+x->x_gui.x_w + hmargin,
-             ypos+x->x_gui.x_h + vmargin, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -width %d -fill #%06x -tags "
+             "%lxBASE\n",
+        canvas, xpos - hmargin, ypos - vmargin, xpos + x->x_gui.x_w + hmargin,
+        ypos + x->x_gui.x_h + vmargin, IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     for(i = 1; i <= IEM_VU_STEPS; i++)
     {
         led_col = iemgui_vu_col[i];
-        yyy = k4 + k1*(k2-i);
-        sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxRLED%d\n",
-                 canvas, quad1, yyy, quad3, yyy, ledw,
-                 iemgui_color_hex[led_col], x, i);
-        if(((i+2) & 3) && (x->x_scale))
+        yyy = k4 + k1 * (k2 - i);
+        sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags "
+                 "%lxRLED%d\n",
+            canvas, quad1, yyy, quad3, yyy, ledw, iemgui_color_hex[led_col], x,
+            i);
+        if(((i + 2) & 3) && (x->x_scale))
             sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                      -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
-                     canvas, end, yyy + k3, iemgui_vu_scale_str[i],
-                     x->x_gui.x_font, fs,
-                     sys_fontweight, x->x_gui.x_lcol, x, i);
+                canvas, end, yyy + k3, iemgui_vu_scale_str[i], x->x_gui.x_font,
+                fs, sys_fontweight, x->x_gui.x_lcol, x, i);
     }
     if(x->x_scale)
     {
@@ -136,49 +140,50 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
         yyy = k4 + k1 * (k2 - i);
         sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                  -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
-                 canvas, end, yyy + k3, iemgui_vu_scale_str[i],
-                 x->x_gui.x_font, fs,
-                 sys_fontweight, x->x_gui.x_lcol, x, i);
+            canvas, end, yyy + k3, iemgui_vu_scale_str[i], x->x_gui.x_font, fs,
+            sys_fontweight, x->x_gui.x_lcol, x, i);
     }
-    sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x -tags %lxRCOVER\n",
-             canvas, quad1 - IEMGUI_ZOOM(x), ypos - IEMGUI_ZOOM(x), quad3 + IEMGUI_ZOOM(x),
-             ypos - IEMGUI_ZOOM(x) + k1*IEM_VU_STEPS, x->x_gui.x_bcol, x->x_gui.x_bcol, x);
-    sys_vgui(".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxPLED\n",
-             canvas, mid, ypos + PEAKHEIGHT * IEMGUI_ZOOM(x),
-             mid, ypos + PEAKHEIGHT * IEMGUI_ZOOM(x),
-             (x->x_led_size+1)*IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
+    sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill #%06x -outline #%06x "
+             "-tags %lxRCOVER\n",
+        canvas, quad1 - IEMGUI_ZOOM(x), ypos - IEMGUI_ZOOM(x),
+        quad3 + IEMGUI_ZOOM(x), ypos - IEMGUI_ZOOM(x) + k1 * IEM_VU_STEPS,
+        x->x_gui.x_bcol, x->x_gui.x_bcol, x);
+    sys_vgui(
+        ".x%lx.c create line %d %d %d %d -width %d -fill #%06x -tags %lxPLED\n",
+        canvas, mid, ypos + PEAKHEIGHT * IEMGUI_ZOOM(x), mid,
+        ypos + PEAKHEIGHT * IEMGUI_ZOOM(x),
+        (x->x_led_size + 1) * IEMGUI_ZOOM(x), x->x_gui.x_bcol, x);
     if(!x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]\n",
-             canvas,
-             xpos - hmargin, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin,
-             x, 0);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxOUT%d outlet]x\n",
-             canvas,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin,
-             x, 1);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]\n",
+            canvas, xpos - hmargin,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin, x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxOUT%d outlet]x\n",
+            canvas, xpos + x->x_gui.x_w + hmargin - iow,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin, x, 1);
     }
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos - hmargin, ypos - vmargin,
-             xpos - hmargin + iow, ypos - vmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list %lxIN%d inlet]\n",
-             canvas,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
-             xpos + x->x_gui.x_w + hmargin, ypos - vmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 1);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos - hmargin, ypos - vmargin, xpos - hmargin + iow,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh, x, 0);
+        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags [list "
+                 "%lxIN%d inlet]\n",
+            canvas, xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
+            xpos + x->x_gui.x_w + hmargin,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh, x, 1);
     }
     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
              -font {{%s} -%d %s} -fill #%06x -tags [list %lxLABEL label text]\n",
-             canvas, xpos+x->x_gui.x_ldx * IEMGUI_ZOOM(x), ypos+x->x_gui.x_ldy * IEMGUI_ZOOM(x),
-             (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
-             x->x_gui.x_font, fs, sys_fontweight,
-             x->x_gui.x_lcol, x);
+        canvas, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x),
+        (strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : ""),
+        x->x_gui.x_font, fs, sys_fontweight, x->x_gui.x_lcol, x);
     x->x_updaterms = x->x_updatepeak = 1;
     sys_queuegui(x, x->x_gui.x_glist, vu_draw_update);
 }
@@ -189,62 +194,62 @@ static void vu_draw_move(t_vu *x, t_glist *glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
     int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int w4 = x->x_gui.x_w/4, quad1 = xpos + w4 + IEMGUI_ZOOM(x);
+    int w4 = x->x_gui.x_w / 4, quad1 = xpos + w4 + IEMGUI_ZOOM(x);
     int quad3 = xpos + x->x_gui.x_w - w4,
-        end = xpos + x->x_gui.x_w + 4*IEMGUI_ZOOM(x);
-    int k1 = (x->x_led_size+1)*IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS+1, k3 = k1/2;
+        end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
+    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
+        k3 = k1 / 2;
     int yyy, i, k4 = ypos - k3;
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n",
-             canvas, x, xpos - hmargin, ypos - vmargin,
-             xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin);
+    sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos - hmargin,
+        ypos - vmargin, xpos + x->x_gui.x_w + hmargin,
+        ypos + x->x_gui.x_h + vmargin);
     for(i = 1; i <= IEM_VU_STEPS; i++)
     {
         yyy = k4 + k1 * (k2 - i);
-        sys_vgui(".x%lx.c coords %lxRLED%d %d %d %d %d\n",
-                 canvas, x, i, quad1, yyy, quad3, yyy);
-        if(((i+2) & 3) && (x->x_scale))
-            sys_vgui(".x%lx.c coords %lxSCALE%d %d %d\n",
-                     canvas, x, i, end, yyy + k3);
+        sys_vgui(".x%lx.c coords %lxRLED%d %d %d %d %d\n", canvas, x, i, quad1,
+            yyy, quad3, yyy);
+        if(((i + 2) & 3) && (x->x_scale))
+            sys_vgui(".x%lx.c coords %lxSCALE%d %d %d\n", canvas, x, i, end,
+                yyy + k3);
     }
     if(x->x_scale)
     {
         i = IEM_VU_STEPS + 1;
         yyy = k4 + k1 * (k2 - i);
-        sys_vgui(".x%lx.c coords %lxSCALE%d %d %d\n",
-                 canvas, x, i, end, yyy + k3);
+        sys_vgui(
+            ".x%lx.c coords %lxSCALE%d %d %d\n", canvas, x, i, end, yyy + k3);
     }
     x->x_updaterms = x->x_updatepeak = 1;
     sys_queuegui(x, glist, vu_draw_update);
-    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n",
-             canvas, x, xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
-             ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
+    sys_vgui(".x%lx.c coords %lxLABEL %d %d\n", canvas, x,
+        xpos + x->x_gui.x_ldx * IEMGUI_ZOOM(x),
+        ypos + x->x_gui.x_ldy * IEMGUI_ZOOM(x));
     if(!x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos - hmargin, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin);
-        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n",
-             canvas, x, 1,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 0,
+            xpos - hmargin,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin);
+        sys_vgui(".x%lx.c coords %lxOUT%d %d %d %d %d\n", canvas, x, 1,
+            xpos + x->x_gui.x_w + hmargin - iow,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin);
     }
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 0,
-             xpos - hmargin, ypos - vmargin,
-             xpos - hmargin + iow, ypos - vmargin - IEMGUI_ZOOM(x) + ioh);
-        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n",
-             canvas, x, 1,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
-             xpos + x->x_gui.x_w + hmargin, ypos - vmargin - IEMGUI_ZOOM(x) + ioh);
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 0,
+            xpos - hmargin, ypos - vmargin, xpos - hmargin + iow,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh);
+        sys_vgui(".x%lx.c coords %lxIN%d %d %d %d %d\n", canvas, x, 1,
+            xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
+            xpos + x->x_gui.x_w + hmargin,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh);
     }
 }
 
-static void vu_draw_erase(t_vu* x,t_glist* glist)
+static void vu_draw_erase(t_vu *x, t_glist *glist)
 {
     int i;
     t_canvas *canvas = glist_getcanvas(glist);
@@ -253,7 +258,7 @@ static void vu_draw_erase(t_vu* x,t_glist* glist)
     for(i = 1; i <= IEM_VU_STEPS; i++)
     {
         sys_vgui(".x%lx.c delete %lxRLED%d\n", canvas, x, i);
-        if(((i+2) & 3) && (x->x_scale))
+        if(((i + 2) & 3) && (x->x_scale))
             sys_vgui(".x%lx.c delete %lxSCALE%d\n", canvas, x, i);
     }
     if(x->x_scale)
@@ -276,42 +281,49 @@ static void vu_draw_erase(t_vu* x,t_glist* glist)
     }
 }
 
-static void vu_draw_config(t_vu* x, t_glist* glist)
+static void vu_draw_config(t_vu *x, t_glist *glist)
 {
     int i;
     int ledw = x->x_led_size * IEMGUI_ZOOM(x);
     int fs = x->x_gui.x_fontsize * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
-    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxBASE -fill #%06x\n", canvas, x,
+        x->x_gui.x_bcol);
     for(i = 1; i <= IEM_VU_STEPS; i++)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxRLED%d -width %d\n", canvas, x, i, ledw);
-        if(((i+2) & 3) && (x->x_scale))
-            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -text {%s} -font {{%s} -%d %s} -fill #%06x\n",
-                     canvas, x, i, iemgui_vu_scale_str[i], x->x_gui.x_font,
-                     fs, sys_fontweight,
-                     x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol);
+        sys_vgui(
+            ".x%lx.c itemconfigure %lxRLED%d -width %d\n", canvas, x, i, ledw);
+        if(((i + 2) & 3) && (x->x_scale))
+            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -text {%s} -font {{%s} "
+                     "-%d %s} -fill #%06x\n",
+                canvas, x, i, iemgui_vu_scale_str[i], x->x_gui.x_font, fs,
+                sys_fontweight,
+                x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED
+                                          : x->x_gui.x_lcol);
     }
     if(x->x_scale)
     {
         i = IEM_VU_STEPS + 1;
-        sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -text {%s} -font {{%s} -%d %s} -fill #%06x\n",
-                 canvas, x, i, iemgui_vu_scale_str[i], x->x_gui.x_font,
-                 fs, sys_fontweight,
-                 x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -text {%s} -font {{%s} -%d "
+                 "%s} -fill #%06x\n",
+            canvas, x, i, iemgui_vu_scale_str[i], x->x_gui.x_font, fs,
+            sys_fontweight,
+            x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED
+                                      : x->x_gui.x_lcol);
     }
-    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x -text {%s} \n",
-             canvas, x, x->x_gui.x_font, fs, sys_fontweight,
-             x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
-             strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
+    sys_vgui(".x%lx.c itemconfigure %lxLABEL -font {{%s} -%d %s} -fill #%06x "
+             "-text {%s} \n",
+        canvas, x, x->x_gui.x_font, fs, sys_fontweight,
+        x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol,
+        strcmp(x->x_gui.x_lab->s_name, "empty") ? x->x_gui.x_lab->s_name : "");
 
-    sys_vgui(".x%lx.c itemconfigure %lxRCOVER -fill #%06x -outline #%06x\n", canvas,
-             x, x->x_gui.x_bcol, x->x_gui.x_bcol);
+    sys_vgui(".x%lx.c itemconfigure %lxRCOVER -fill #%06x -outline #%06x\n",
+        canvas, x, x->x_gui.x_bcol, x->x_gui.x_bcol);
     sys_vgui(".x%lx.c itemconfigure %lxPLED -width %d\n", canvas, x, ledw);
 }
 
-static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
+static void vu_draw_io(t_vu *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
@@ -321,16 +333,16 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos - hmargin, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin,
-             x, 0);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
-             canvas,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
-             xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin,
-             x, 1);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos - hmargin,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin, x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxOUT%d\n",
+            canvas, xpos + x->x_gui.x_w + hmargin - iow,
+            ypos + x->x_gui.x_h + vmargin + IEMGUI_ZOOM(x) - ioh,
+            xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin, x, 1);
         /* keep above outlets */
         sys_vgui(".x%lx.c raise %lxLABEL %lxOUT%d\n", canvas, x, x, 1);
     }
@@ -341,16 +353,15 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     }
     if((old_snd_rcv_flags & IEM_GUI_OLD_RCV_FLAG) && !x->x_gui.x_fsf.x_rcv_able)
     {
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos - hmargin, ypos - vmargin,
-             xpos - hmargin + iow, ypos - vmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 0);
-        sys_vgui(".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
-             canvas,
-             xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
-             xpos + x->x_gui.x_w + hmargin, ypos - vmargin - IEMGUI_ZOOM(x) + ioh,
-             x, 1);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos - hmargin, ypos - vmargin, xpos - hmargin + iow,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh, x, 0);
+        sys_vgui(
+            ".x%lx.c create rectangle %d %d %d %d -fill black -tags %lxIN%d\n",
+            canvas, xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
+            xpos + x->x_gui.x_w + hmargin,
+            ypos - vmargin - IEMGUI_ZOOM(x) + ioh, x, 1);
         /* keep above inlets */
         sys_vgui(".x%lx.c raise %lxLABEL %lxIN%d\n", canvas, x, x, 1);
     }
@@ -361,44 +372,48 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     }
 }
 
-static void vu_draw_select(t_vu* x,t_glist* glist)
+static void vu_draw_select(t_vu *x, t_glist *glist)
 {
     int i;
     t_canvas *canvas = glist_getcanvas(glist);
 
     if(x->x_gui.x_fsf.x_selected)
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
         for(i = 1; i <= IEM_VU_STEPS; i++)
         {
-            if(((i+2) & 3) && (x->x_scale))
+            if(((i + 2) & 3) && (x->x_scale))
                 sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
-                         canvas, x, i, IEM_GUI_COLOR_SELECTED);
+                    canvas, x, i, IEM_GUI_COLOR_SELECTED);
         }
         if(x->x_scale)
         {
             i = IEM_VU_STEPS + 1;
-            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
-                     canvas, x, i, IEM_GUI_COLOR_SELECTED);
+            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n", canvas,
+                x, i, IEM_GUI_COLOR_SELECTED);
         }
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, IEM_GUI_COLOR_SELECTED);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            IEM_GUI_COLOR_SELECTED);
     }
     else
     {
-        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x, IEM_GUI_COLOR_NORMAL);
+        sys_vgui(".x%lx.c itemconfigure %lxBASE -outline #%06x\n", canvas, x,
+            IEM_GUI_COLOR_NORMAL);
         for(i = 1; i <= IEM_VU_STEPS; i++)
         {
-            if(((i+2) & 3) && (x->x_scale))
+            if(((i + 2) & 3) && (x->x_scale))
                 sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
-                         canvas, x, i, x->x_gui.x_lcol);
+                    canvas, x, i, x->x_gui.x_lcol);
         }
         if(x->x_scale)
         {
-            i = IEM_VU_STEPS+1;
-            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
-                     canvas, x, i, x->x_gui.x_lcol);
+            i = IEM_VU_STEPS + 1;
+            sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n", canvas,
+                x, i, x->x_gui.x_lcol);
         }
-        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x, x->x_gui.x_lcol);
+        sys_vgui(".x%lx.c itemconfigure %lxLABEL -fill #%06x\n", canvas, x,
+            x->x_gui.x_lcol);
     }
 }
 
@@ -420,33 +435,31 @@ void vu_draw(t_vu *x, t_glist *glist, int mode)
 
 /* ------------------------ vu widgetbehaviour----------------------------- */
 
-static void vu_getrect(t_gobj *z, t_glist *glist,
-                       int *xp1, int *yp1, int *xp2, int *yp2)
+static void vu_getrect(
+    t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
-    t_vu* x = (t_vu*)z;
+    t_vu *x = (t_vu *) z;
     int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist) - hmargin;
     *yp1 = text_ypix(&x->x_gui.x_obj, glist) - vmargin;
-    *xp2 = *xp1 + x->x_gui.x_w + hmargin*2;
-    *yp2 = *yp1 + x->x_gui.x_h + vmargin*2;
+    *xp2 = *xp1 + x->x_gui.x_w + hmargin * 2;
+    *yp2 = *yp1 + x->x_gui.x_h + vmargin * 2;
 }
 
 static void vu_save(t_gobj *z, t_binbuf *b)
 {
-    t_vu *x = (t_vu *)z;
+    t_vu *x = (t_vu *) z;
     t_symbol *bflcol[3];
     t_symbol *srl[3];
 
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiissiiiissii", gensym("#X"), gensym("obj"),
-                (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("vu"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_gui.x_h/IEMGUI_ZOOM(x),
-                srl[1], srl[2],
-                x->x_gui.x_ldx, x->x_gui.x_ldy,
-                iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
-                bflcol[0], bflcol[2], x->x_scale,
-                iem_symargstoint(&x->x_gui.x_isa));
+        (int) x->x_gui.x_obj.te_xpix, (int) x->x_gui.x_obj.te_ypix,
+        gensym("vu"), x->x_gui.x_w / IEMGUI_ZOOM(x),
+        x->x_gui.x_h / IEMGUI_ZOOM(x), srl[1], srl[2], x->x_gui.x_ldx,
+        x->x_gui.x_ldy, iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
+        bflcol[0], bflcol[2], x->x_scale, iem_symargstoint(&x->x_gui.x_isa));
     binbuf_addv(b, ";");
 }
 
@@ -455,27 +468,26 @@ void vu_check_height(t_vu *x, int h)
     int n;
 
     n = h / IEM_VU_STEPS;
-    if(n < IEM_VU_MINSIZE)
-        n = IEM_VU_MINSIZE;
+    if(n < IEM_VU_MINSIZE) n = IEM_VU_MINSIZE;
     x->x_led_size = n - 1;
     x->x_gui.x_h = (IEM_VU_STEPS * n) * IEMGUI_ZOOM(x);
 }
 
 static void vu_scale(t_vu *x, t_floatarg fscale)
 {
-    int i, scale = (int)fscale;
+    int i, scale = (int) fscale;
 
     if(scale != 0) scale = 1;
     if(x->x_scale && !scale)
     {
         t_canvas *canvas = glist_getcanvas(x->x_gui.x_glist);
 
-        x->x_scale = (int)scale;
+        x->x_scale = (int) scale;
         if(glist_isvisible(x->x_gui.x_glist))
         {
             for(i = 1; i <= IEM_VU_STEPS; i++)
             {
-                if((i+2) & 3)
+                if((i + 2) & 3)
                     sys_vgui(".x%lx.c delete %lxSCALE%d\n", canvas, x, i);
             }
             i = IEM_VU_STEPS + 1;
@@ -484,40 +496,41 @@ static void vu_scale(t_vu *x, t_floatarg fscale)
     }
     if(!x->x_scale && scale)
     {
-        int w4 = x->x_gui.x_w/4;
-        int end = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist) + x->x_gui.x_w + 4*IEMGUI_ZOOM(x);
-        int k1 = (x->x_led_size+1)*IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS+1, k3 = k1/2;
+        int w4 = x->x_gui.x_w / 4;
+        int end = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist) + x->x_gui.x_w +
+                  4 * IEMGUI_ZOOM(x);
+        int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
+            k3 = k1 / 2;
         int yyy, k4 = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - k3;
         int fs = x->x_gui.x_fontsize * IEMGUI_ZOOM(x);
         t_canvas *canvas = glist_getcanvas(x->x_gui.x_glist);
 
-        x->x_scale = (int)scale;
+        x->x_scale = (int) scale;
         if(glist_isvisible(x->x_gui.x_glist))
         {
             for(i = 1; i <= IEM_VU_STEPS; i++)
             {
                 yyy = k4 + k1 * (k2 - i);
-                if((i+2) & 3)
+                if((i + 2) & 3)
                     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                              -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
-                             canvas, end, yyy + k3, iemgui_vu_scale_str[i],
-                             x->x_gui.x_font, fs,
-                             sys_fontweight, x->x_gui.x_lcol, x, i);
+                        canvas, end, yyy + k3, iemgui_vu_scale_str[i],
+                        x->x_gui.x_font, fs, sys_fontweight, x->x_gui.x_lcol, x,
+                        i);
             }
             i = IEM_VU_STEPS + 1;
             yyy = k4 + k1 * (k2 - i);
             sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                      -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
-                     canvas, end, yyy + k3, iemgui_vu_scale_str[i],
-                     x->x_gui.x_font, fs,
-                     sys_fontweight, x->x_gui.x_lcol, x, i);
+                canvas, end, yyy + k3, iemgui_vu_scale_str[i], x->x_gui.x_font,
+                fs, sys_fontweight, x->x_gui.x_lcol, x, i);
         }
     }
 }
 
 static void vu_properties(t_gobj *z, t_glist *owner)
 {
-    t_vu *x = (t_vu *)z;
+    t_vu *x = (t_vu *) z;
     char buf[800];
     t_symbol *srl[3];
 
@@ -530,34 +543,33 @@ static void vu_properties(t_gobj *z, t_glist *owner)
             %s %d %d \
             %d %d \
             #%06x none #%06x\n",
-            x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
-            x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_VU_STEPS*IEM_VU_MINSIZE,
-            0,/*no_schedule*/
-            x->x_scale, -1, -1, -1,/*no linlog, no init, no multi*/
-            srl[0]->s_name, srl[1]->s_name,/*no send*/
-            srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
-            x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
-            0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
+        x->x_gui.x_w / IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+        x->x_gui.x_h / IEMGUI_ZOOM(x), IEM_VU_STEPS * IEM_VU_MINSIZE,
+        0,                              /*no_schedule*/
+        x->x_scale, -1, -1, -1,         /*no linlog, no init, no multi*/
+        srl[0]->s_name, srl[1]->s_name, /*no send*/
+        srl[2]->s_name, x->x_gui.x_ldx, x->x_gui.x_ldy,
+        x->x_gui.x_fsf.x_font_style, x->x_gui.x_fontsize,
+        0xffffff & x->x_gui.x_bcol, 0xffffff & x->x_gui.x_lcol);
     gfxstub_new(&x->x_gui.x_obj.ob_pd, x, buf);
 }
 
 static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *srl[3];
-    int w = (int)atom_getfloatarg(0, argc, argv);
-    int h = (int)atom_getfloatarg(1, argc, argv);
-    int scale = (int)atom_getfloatarg(4, argc, argv);
+    int w = (int) atom_getfloatarg(0, argc, argv);
+    int h = (int) atom_getfloatarg(1, argc, argv);
+    int scale = (int) atom_getfloatarg(4, argc, argv);
     int sr_flags;
     t_atom undo[18];
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
-    SETFLOAT(undo+2, 0.01);
-    SETFLOAT(undo+3, 1);
-    SETFLOAT(undo+4, x->x_scale);
-    SETFLOAT(undo+5, -1);
-    SETSYMBOL(undo+15, gensym("none"));
-    pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
-                            argc, argv);
+    SETFLOAT(undo + 2, 0.01);
+    SETFLOAT(undo + 3, 1);
+    SETFLOAT(undo + 4, x->x_scale);
+    SETFLOAT(undo + 5, -1);
+    SETSYMBOL(undo + 15, gensym("none"));
+    pd_undo_set_objectstate(
+        x->x_gui.x_glist, (t_pd *) x, gensym("dialog"), 18, undo, argc, argv);
 
     srl[0] = gensym("empty");
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
@@ -565,48 +577,61 @@ static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_isa.x_loadinit = 0;
     x->x_gui.x_w = iemgui_clip_size(w) * IEMGUI_ZOOM(x);
     vu_check_height(x, h);
-    if(scale != 0)
-        scale = 1;
-    vu_scale(x, (t_float)scale);
+    if(scale != 0) scale = 1;
+    vu_scale(x, (t_float) scale);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO + sr_flags);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
-    canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+    canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
 }
 
 static void vu_size(t_vu *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
-    if(ac > 1)
-        vu_check_height(x, (int)atom_getfloatarg(1, ac, av));
+    x->x_gui.x_w =
+        iemgui_clip_size((int) atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    if(ac > 1) vu_check_height(x, (int) atom_getfloatarg(1, ac, av));
     if(glist_isvisible(x->x_gui.x_glist))
     {
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_MOVE);
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_CONFIG);
-        canvas_fixlinesfor(x->x_gui.x_glist, (t_text*)x);
+        canvas_fixlinesfor(x->x_gui.x_glist, (t_text *) x);
     }
 }
 
 static void vu_delta(t_vu *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_delta((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_delta((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vu_pos(t_vu *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vu_color(t_vu *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_color((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_color((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vu_receive(t_vu *x, t_symbol *s)
-{iemgui_receive(x, &x->x_gui, s);}
+{
+    iemgui_receive(x, &x->x_gui, s);
+}
 
 static void vu_label(t_vu *x, t_symbol *s)
-{iemgui_label((void *)x, &x->x_gui, s);}
+{
+    iemgui_label((void *) x, &x->x_gui, s);
+}
 
 static void vu_label_pos(t_vu *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_pos((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_pos((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vu_label_font(t_vu *x, t_symbol *s, int ac, t_atom *av)
-{iemgui_label_font((void *)x, &x->x_gui, s, ac, av);}
+{
+    iemgui_label_font((void *) x, &x->x_gui, s, ac, av);
+}
 
 static void vu_float(t_vu *x, t_floatarg rms)
 {
@@ -618,16 +643,15 @@ static void vu_float(t_vu *x, t_floatarg rms)
         x->x_rms = IEM_VU_STEPS;
     else
     {
-        int i = (int)(2.0*(rms + IEM_VU_OFFSET));
+        int i = (int) (2.0 * (rms + IEM_VU_OFFSET));
         x->x_rms = iemgui_vu_db2i[i];
     }
-    i = (int)(100.0*rms + 10000.5);
-    rms = 0.01*(t_float)(i - 10000);
+    i = (int) (100.0 * rms + 10000.5);
+    rms = 0.01 * (t_float) (i - 10000);
     x->x_fr = rms;
     outlet_float(x->x_out_rms, rms);
     x->x_updaterms = 1;
-    if(x->x_rms != old)
-        sys_queuegui(x, x->x_gui.x_glist, vu_draw_update);
+    if(x->x_rms != old) sys_queuegui(x, x->x_gui.x_glist, vu_draw_update);
 }
 
 static void vu_ft1(t_vu *x, t_floatarg peak)
@@ -640,15 +664,14 @@ static void vu_ft1(t_vu *x, t_floatarg peak)
         x->x_peak = IEM_VU_STEPS;
     else
     {
-        int i = (int)(2.0*(peak + IEM_VU_OFFSET));
+        int i = (int) (2.0 * (peak + IEM_VU_OFFSET));
         x->x_peak = iemgui_vu_db2i[i];
     }
-    i = (int)(100.0*peak + 10000.5);
-    peak = 0.01*(t_float)(i - 10000);
+    i = (int) (100.0 * peak + 10000.5);
+    peak = 0.01 * (t_float) (i - 10000);
     x->x_fp = peak;
     x->x_updatepeak = 1;
-    if(x->x_peak != old)
-        sys_queuegui(x, x->x_gui.x_glist, vu_draw_update);
+    if(x->x_peak != old) sys_queuegui(x, x->x_gui.x_glist, vu_draw_update);
     outlet_float(x->x_out_peak, peak);
 }
 
@@ -662,10 +685,11 @@ static void vu_bang(t_vu *x)
 
 static void *vu_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_vu *x = (t_vu *)pd_new(vu_class);
-    int w = IEM_GUI_DEFAULTSIZE, h = IEM_VU_STEPS*IEM_VU_DEFAULTSIZE;
-    int ldx = -1, ldy = -8, f = 0, fs = 10, scale  =1;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME, fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
+    t_vu *x = (t_vu *) pd_new(vu_class);
+    int w = IEM_GUI_DEFAULTSIZE, h = IEM_VU_STEPS * IEM_VU_DEFAULTSIZE;
+    int ldx = -1, ldy = -8, f = 0, fs = 10, scale = 1;
+    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
+        fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
     char str[144];
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);
@@ -675,51 +699,52 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_fcol = 0x00;
     x->x_gui.x_lcol = 0x00;
 
-    if((argc >= 11)&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)
-       &&(IS_A_SYMBOL(argv,2)||IS_A_FLOAT(argv,2))
-       &&(IS_A_SYMBOL(argv,3)||IS_A_FLOAT(argv,3))
-       &&IS_A_FLOAT(argv,4)&&IS_A_FLOAT(argv,5)
-       &&IS_A_FLOAT(argv,6)&&IS_A_FLOAT(argv,7)
-       &&IS_A_FLOAT(argv,10))
+    if((argc >= 11) && IS_A_FLOAT(argv, 0) && IS_A_FLOAT(argv, 1) &&
+        (IS_A_SYMBOL(argv, 2) || IS_A_FLOAT(argv, 2)) &&
+        (IS_A_SYMBOL(argv, 3) || IS_A_FLOAT(argv, 3)) && IS_A_FLOAT(argv, 4) &&
+        IS_A_FLOAT(argv, 5) && IS_A_FLOAT(argv, 6) && IS_A_FLOAT(argv, 7) &&
+        IS_A_FLOAT(argv, 10))
     {
-        w = (int)atom_getfloatarg(0, argc, argv);
-        h = (int)atom_getfloatarg(1, argc, argv);
+        w = (int) atom_getfloatarg(0, argc, argv);
+        h = (int) atom_getfloatarg(1, argc, argv);
         iemgui_new_getnames(&x->x_gui, 1, argv);
-        x->x_gui.x_snd_unexpanded = x->x_gui.x_snd = gensym("nosndno"); /*no send*/
-        ldx = (int)atom_getfloatarg(4, argc, argv);
-        ldy = (int)atom_getfloatarg(5, argc, argv);
+        x->x_gui.x_snd_unexpanded = x->x_gui.x_snd =
+            gensym("nosndno"); /*no send*/
+        ldx = (int) atom_getfloatarg(4, argc, argv);
+        ldy = (int) atom_getfloatarg(5, argc, argv);
         iem_inttofstyle(&x->x_gui.x_fsf, atom_getfloatarg(6, argc, argv));
-        fs = (int)atom_getfloatarg(7, argc, argv);
-        iemgui_all_loadcolors(&x->x_gui, argv+8, NULL, argv+9);
-        scale = (int)atom_getfloatarg(10, argc, argv);
+        fs = (int) atom_getfloatarg(7, argc, argv);
+        iemgui_all_loadcolors(&x->x_gui, argv + 8, NULL, argv + 9);
+        scale = (int) atom_getfloatarg(10, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 1, 0);
-    if((argc == 12)&&IS_A_FLOAT(argv,11))
+    else
+        iemgui_new_getnames(&x->x_gui, 1, 0);
+    if((argc == 12) && IS_A_FLOAT(argv, 11))
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(11, argc, argv));
-    x->x_gui.x_draw = (t_iemfunptr)vu_draw;
+    x->x_gui.x_draw = (t_iemfunptr) vu_draw;
 
     x->x_gui.x_fsf.x_snd_able = 0;
     x->x_gui.x_fsf.x_rcv_able = 1;
-    x->x_gui.x_glist = (t_glist *)canvas_getcurrent();
-    if (!strcmp(x->x_gui.x_rcv->s_name, "empty"))
-        x->x_gui.x_fsf.x_rcv_able = 0;
-    if (x->x_gui.x_fsf.x_font_style == 1)
+    x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
+    if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
+    if(x->x_gui.x_fsf.x_font_style == 1)
         strcpy(x->x_gui.x_font, "helvetica");
     else if(x->x_gui.x_fsf.x_font_style == 2)
         strcpy(x->x_gui.x_font, "times");
-    else { x->x_gui.x_fsf.x_font_style = 0;
-        strcpy(x->x_gui.x_font, sys_font); }
+    else
+    {
+        x->x_gui.x_fsf.x_font_style = 0;
+        strcpy(x->x_gui.x_font, sys_font);
+    }
     if(x->x_gui.x_fsf.x_rcv_able)
         pd_bind(&x->x_gui.x_obj.ob_pd, x->x_gui.x_rcv);
     x->x_gui.x_ldx = ldx;
     x->x_gui.x_ldy = ldy;
-    if(fs < 4)
-        fs = 4;
+    if(fs < 4) fs = 4;
     x->x_gui.x_fontsize = fs;
     x->x_gui.x_w = iemgui_clip_size(w);
     vu_check_height(x, h);
-    if(scale != 0)
-        scale = 1;
+    if(scale != 0) scale = 1;
     x->x_scale = scale;
     x->x_peak = 0;
     x->x_rms = 0;
@@ -729,7 +754,8 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
     inlet_new(&x->x_gui.x_obj, &x->x_gui.x_obj.ob_pd, &s_float, gensym("ft1"));
     x->x_out_rms = outlet_new(&x->x_gui.x_obj, &s_float);
     x->x_out_peak = outlet_new(&x->x_gui.x_obj, &s_float);
-    x->x_gui.x_h /= IEMGUI_ZOOM(x); /* unzoom, to prevent double-application in iemgui_newzoom */
+    x->x_gui.x_h /= IEMGUI_ZOOM(
+        x); /* unzoom, to prevent double-application in iemgui_newzoom */
     iemgui_newzoom(&x->x_gui);
     return (x);
 }
@@ -743,42 +769,37 @@ static void vu_free(t_vu *x)
 
 void g_vumeter_setup(void)
 {
-    vu_class = class_new(gensym("vu"), (t_newmethod)vu_new,
-        (t_method)vu_free, sizeof(t_vu), 0, A_GIMME, 0);
-    class_addbang(vu_class,vu_bang);
-    class_addfloat(vu_class,vu_float);
-    class_addmethod(vu_class, (t_method)vu_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(vu_class, (t_method)vu_dialog,
-        gensym("dialog"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_size,
-        gensym("size"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_scale,
-        gensym("scale"), A_DEFFLOAT, 0);
-    class_addmethod(vu_class, (t_method)vu_delta,
-        gensym("delta"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_pos,
-        gensym("pos"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_color,
-        gensym("color"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_receive,
-        gensym("receive"), A_DEFSYM, 0);
-    class_addmethod(vu_class, (t_method)vu_label,
-        gensym("label"), A_DEFSYM, 0);
-    class_addmethod(vu_class, (t_method)vu_label_pos,
-        gensym("label_pos"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)vu_label_font,
-        gensym("label_font"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
-    vu_widgetbehavior.w_getrectfn =    vu_getrect;
-    vu_widgetbehavior.w_displacefn =   iemgui_displace;
-    vu_widgetbehavior.w_selectfn =     iemgui_select;
-    vu_widgetbehavior.w_activatefn =   NULL;
-    vu_widgetbehavior.w_deletefn =     iemgui_delete;
-    vu_widgetbehavior.w_visfn =        iemgui_vis;
-    vu_widgetbehavior.w_clickfn =      NULL;
-    class_setwidget(vu_class,&vu_widgetbehavior);
+    vu_class = class_new(gensym("vu"), (t_newmethod) vu_new, (t_method) vu_free,
+        sizeof(t_vu), 0, A_GIMME, 0);
+    class_addbang(vu_class, vu_bang);
+    class_addfloat(vu_class, vu_float);
+    class_addmethod(vu_class, (t_method) vu_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_dialog, gensym("dialog"), A_GIMME, 0);
+    class_addmethod(vu_class, (t_method) vu_size, gensym("size"), A_GIMME, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_scale, gensym("scale"), A_DEFFLOAT, 0);
+    class_addmethod(vu_class, (t_method) vu_delta, gensym("delta"), A_GIMME, 0);
+    class_addmethod(vu_class, (t_method) vu_pos, gensym("pos"), A_GIMME, 0);
+    class_addmethod(vu_class, (t_method) vu_color, gensym("color"), A_GIMME, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_receive, gensym("receive"), A_DEFSYM, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_label, gensym("label"), A_DEFSYM, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_label_pos, gensym("label_pos"), A_GIMME, 0);
+    class_addmethod(
+        vu_class, (t_method) vu_label_font, gensym("label_font"), A_GIMME, 0);
+    class_addmethod(
+        vu_class, (t_method) iemgui_zoom, gensym("zoom"), A_CANT, 0);
+    vu_widgetbehavior.w_getrectfn = vu_getrect;
+    vu_widgetbehavior.w_displacefn = iemgui_displace;
+    vu_widgetbehavior.w_selectfn = iemgui_select;
+    vu_widgetbehavior.w_activatefn = NULL;
+    vu_widgetbehavior.w_deletefn = iemgui_delete;
+    vu_widgetbehavior.w_visfn = iemgui_vis;
+    vu_widgetbehavior.w_clickfn = NULL;
+    class_setwidget(vu_class, &vu_widgetbehavior);
     class_sethelpsymbol(vu_class, gensym("vu"));
     class_setsavefn(vu_class, vu_save);
     class_setpropertiesfn(vu_class, vu_properties);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -136,10 +136,12 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
             canvas, quad1, yyy, quad3, yyy, ledw, iemgui_color_hex[led_col], x,
             i);
         if(((i + 2) & 3) && (x->x_scale))
+        {
             sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                      -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
                 canvas, end, yyy + k3, iemgui_vu_scale_str[i], x->x_gui.x_font,
                 fs, sys_fontweight, x->x_gui.x_lcol, x, i);
+        }
     }
     if(x->x_scale)
     {
@@ -224,8 +226,10 @@ static void vu_draw_move(t_vu *x, t_glist *glist)
         sys_vgui(".x%lx.c coords %lxRLED%d %d %d %d %d\n", canvas, x, i, quad1,
             yyy, quad3, yyy);
         if(((i + 2) & 3) && (x->x_scale))
+        {
             sys_vgui(".x%lx.c coords %lxSCALE%d %d %d\n", canvas, x, i, end,
                 yyy + k3);
+        }
     }
     if(x->x_scale)
     {
@@ -308,12 +312,14 @@ static void vu_draw_config(t_vu *x, t_glist *glist)
         sys_vgui(
             ".x%lx.c itemconfigure %lxRLED%d -width %d\n", canvas, x, i, ledw);
         if(((i + 2) & 3) && (x->x_scale))
+        {
             sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -text {%s} -font {{%s} "
                      "-%d %s} -fill #%06x\n",
                 canvas, x, i, iemgui_vu_scale_str[i], x->x_gui.x_font, fs,
                 sys_fontweight,
                 x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED
                                           : x->x_gui.x_lcol);
+        }
     }
     if(x->x_scale)
     {
@@ -399,8 +405,10 @@ static void vu_draw_select(t_vu *x, t_glist *glist)
         for(i = 1; i <= IEM_VU_STEPS; i++)
         {
             if(((i + 2) & 3) && (x->x_scale))
+            {
                 sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
                     canvas, x, i, IEM_GUI_COLOR_SELECTED);
+            }
         }
         if(x->x_scale)
         {
@@ -418,8 +426,10 @@ static void vu_draw_select(t_vu *x, t_glist *glist)
         for(i = 1; i <= IEM_VU_STEPS; i++)
         {
             if(((i + 2) & 3) && (x->x_scale))
+            {
                 sys_vgui(".x%lx.c itemconfigure %lxSCALE%d -fill #%06x\n",
                     canvas, x, i, x->x_gui.x_lcol);
+            }
         }
         if(x->x_scale)
         {
@@ -435,17 +445,29 @@ static void vu_draw_select(t_vu *x, t_glist *glist)
 void vu_draw(t_vu *x, t_glist *glist, int mode)
 {
     if(mode == IEM_GUI_DRAW_MODE_MOVE)
+    {
         vu_draw_move(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_NEW)
+    {
         vu_draw_new(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_SELECT)
+    {
         vu_draw_select(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_ERASE)
+    {
         vu_draw_erase(x, glist);
+    }
     else if(mode == IEM_GUI_DRAW_MODE_CONFIG)
+    {
         vu_draw_config(x, glist);
+    }
     else if(mode >= IEM_GUI_DRAW_MODE_IO)
+    {
         vu_draw_io(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
+    }
 }
 
 /* ------------------------ vu widgetbehaviour----------------------------- */
@@ -531,11 +553,13 @@ static void vu_scale(t_vu *x, t_floatarg fscale)
             {
                 yyy = k4 + k1 * (k2 - i);
                 if((i + 2) & 3)
+                {
                     sys_vgui(".x%lx.c create text %d %d -text {%s} -anchor w \
                              -font {{%s} -%d %s} -fill #%06x -tags %lxSCALE%d\n",
                         canvas, end, yyy + k3, iemgui_vu_scale_str[i],
                         x->x_gui.x_font, fs, sys_fontweight, x->x_gui.x_lcol, x,
                         i);
+                }
             }
             i = IEM_VU_STEPS + 1;
             yyy = k4 + k1 * (k2 - i);
@@ -657,9 +681,13 @@ static void vu_float(t_vu *x, t_floatarg rms)
     int i;
     int old = x->x_rms;
     if(rms <= IEM_VU_MINDB)
+    {
         x->x_rms = 0;
+    }
     else if(rms >= IEM_VU_MAXDB)
+    {
         x->x_rms = IEM_VU_STEPS;
+    }
     else
     {
         int i = (int) (2.0 * (rms + IEM_VU_OFFSET));
@@ -678,9 +706,13 @@ static void vu_ft1(t_vu *x, t_floatarg peak)
     int i;
     int old = x->x_peak;
     if(peak <= IEM_VU_MINDB)
+    {
         x->x_peak = 0;
+    }
     else if(peak >= IEM_VU_MAXDB)
+    {
         x->x_peak = IEM_VU_STEPS;
+    }
     else
     {
         int i = (int) (2.0 * (peak + IEM_VU_OFFSET));
@@ -752,9 +784,13 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_glist = (t_glist *) canvas_getcurrent();
     if(!strcmp(x->x_gui.x_rcv->s_name, "empty")) x->x_gui.x_fsf.x_rcv_able = 0;
     if(x->x_gui.x_fsf.x_font_style == 1)
+    {
         strcpy(x->x_gui.x_font, "helvetica");
+    }
     else if(x->x_gui.x_fsf.x_font_style == 2)
+    {
         strcpy(x->x_gui.x_font, "times");
+    }
     else
     {
         x->x_gui.x_fsf.x_font_style = 0;

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -36,11 +36,11 @@ static void vu_update_rms(t_vu *x, t_glist *glist)
 {
     if(glist_isvisible(glist))
     {
-        int w4 = x->x_gui.x_w / 4,
-            off = text_ypix(&x->x_gui.x_obj, glist) - IEMGUI_ZOOM(x);
+        int w4 = x->x_gui.x_w / 4;
+        int off = text_ypix(&x->x_gui.x_obj, glist) - IEMGUI_ZOOM(x);
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
-        int quad1 = xpos + w4 - IEMGUI_ZOOM(x),
-            quad3 = xpos + x->x_gui.x_w - w4 + IEMGUI_ZOOM(x);
+        int quad1 = xpos + w4 - IEMGUI_ZOOM(x);
+        int quad3 = xpos + x->x_gui.x_w - w4 + IEMGUI_ZOOM(x);
 
         sys_vgui(".x%lx.c coords %lxRCOVER %d %d %d %d\n",
             glist_getcanvas(glist), x, quad1, off, quad3,
@@ -103,15 +103,22 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int w4 = x->x_gui.x_w / 4, mid = xpos + x->x_gui.x_w / 2,
-        quad1 = xpos + w4 + IEMGUI_ZOOM(x);
-    int quad3 = xpos + x->x_gui.x_w - w4,
-        end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
-    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
-        k3 = k1 / 2;
-    int led_col, yyy, i, k4 = ypos - k3;
+    int hmargin = HMARGIN * IEMGUI_ZOOM(x);
+    int vmargin = VMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int w4 = x->x_gui.x_w / 4;
+    int mid = xpos + x->x_gui.x_w / 2;
+    int quad1 = xpos + w4 + IEMGUI_ZOOM(x);
+    int quad3 = xpos + x->x_gui.x_w - w4;
+    int end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
+    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x);
+    int k2 = IEM_VU_STEPS + 1;
+    int k3 = k1 / 2;
+    int led_col;
+    int yyy;
+    int i;
+    int k4 = ypos - k3;
     int ledw = x->x_led_size * IEMGUI_ZOOM(x);
     int fs = x->x_gui.x_fontsize * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
@@ -192,14 +199,20 @@ static void vu_draw_move(t_vu *x, t_glist *glist)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
-    int w4 = x->x_gui.x_w / 4, quad1 = xpos + w4 + IEMGUI_ZOOM(x);
-    int quad3 = xpos + x->x_gui.x_w - w4,
-        end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
-    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
-        k3 = k1 / 2;
-    int yyy, i, k4 = ypos - k3;
+    int hmargin = HMARGIN * IEMGUI_ZOOM(x);
+    int vmargin = VMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int w4 = x->x_gui.x_w / 4;
+    int quad1 = xpos + w4 + IEMGUI_ZOOM(x);
+    int quad3 = xpos + x->x_gui.x_w - w4;
+    int end = xpos + x->x_gui.x_w + 4 * IEMGUI_ZOOM(x);
+    int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x);
+    int k2 = IEM_VU_STEPS + 1;
+    int k3 = k1 / 2;
+    int yyy;
+    int i;
+    int k4 = ypos - k3;
     t_canvas *canvas = glist_getcanvas(glist);
 
     sys_vgui(".x%lx.c coords %lxBASE %d %d %d %d\n", canvas, x, xpos - hmargin,
@@ -327,8 +340,10 @@ static void vu_draw_io(t_vu *x, t_glist *glist, int old_snd_rcv_flags)
 {
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
-    int iow = IOWIDTH * IEMGUI_ZOOM(x), ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
+    int hmargin = HMARGIN * IEMGUI_ZOOM(x);
+    int vmargin = VMARGIN * IEMGUI_ZOOM(x);
+    int iow = IOWIDTH * IEMGUI_ZOOM(x);
+    int ioh = IEM_GUI_IOHEIGHT * IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
 
     if((old_snd_rcv_flags & IEM_GUI_OLD_SND_FLAG) && !x->x_gui.x_fsf.x_snd_able)
@@ -439,7 +454,8 @@ static void vu_getrect(
     t_gobj *z, t_glist *glist, int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_vu *x = (t_vu *) z;
-    int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
+    int hmargin = HMARGIN * IEMGUI_ZOOM(x);
+    int vmargin = VMARGIN * IEMGUI_ZOOM(x);
 
     *xp1 = text_xpix(&x->x_gui.x_obj, glist) - hmargin;
     *yp1 = text_ypix(&x->x_gui.x_obj, glist) - vmargin;
@@ -475,7 +491,8 @@ void vu_check_height(t_vu *x, int h)
 
 static void vu_scale(t_vu *x, t_floatarg fscale)
 {
-    int i, scale = (int) fscale;
+    int i;
+    int scale = (int) fscale;
 
     if(scale != 0) scale = 1;
     if(x->x_scale && !scale)
@@ -499,9 +516,11 @@ static void vu_scale(t_vu *x, t_floatarg fscale)
         int w4 = x->x_gui.x_w / 4;
         int end = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist) + x->x_gui.x_w +
                   4 * IEMGUI_ZOOM(x);
-        int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x), k2 = IEM_VU_STEPS + 1,
-            k3 = k1 / 2;
-        int yyy, k4 = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - k3;
+        int k1 = (x->x_led_size + 1) * IEMGUI_ZOOM(x);
+        int k2 = IEM_VU_STEPS + 1;
+        int k3 = k1 / 2;
+        int yyy;
+        int k4 = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - k3;
         int fs = x->x_gui.x_fontsize * IEMGUI_ZOOM(x);
         t_canvas *canvas = glist_getcanvas(x->x_gui.x_glist);
 
@@ -686,10 +705,15 @@ static void vu_bang(t_vu *x)
 static void *vu_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_vu *x = (t_vu *) pd_new(vu_class);
-    int w = IEM_GUI_DEFAULTSIZE, h = IEM_VU_STEPS * IEM_VU_DEFAULTSIZE;
-    int ldx = -1, ldy = -8, f = 0, fs = 10, scale = 1;
-    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME,
-        fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
+    int w = IEM_GUI_DEFAULTSIZE;
+    int h = IEM_VU_STEPS * IEM_VU_DEFAULTSIZE;
+    int ldx = -1;
+    int ldy = -8;
+    int f = 0;
+    int fs = 10;
+    int scale = 1;
+    int ftbreak = IEM_BNG_DEFAULTBREAKFLASHTIME;
+    int fthold = IEM_BNG_DEFAULTHOLDFLASHTIME;
     char str[144];
 
     iem_inttosymargs(&x->x_gui.x_isa, 0);

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -1,48 +1,54 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 #include <stdio.h>
 #include <string.h>
 
-    /* convenience routines for checking and getting values of
-        atoms.  There's no "pointer" version since there's nothing
-        safe to return if there's an error. */
+/* convenience routines for checking and getting values of
+    atoms.  There's no "pointer" version since there's nothing
+    safe to return if there's an error. */
 
 t_float atom_getfloat(const t_atom *a)
 {
-    if (a->a_type == A_FLOAT) return (a->a_w.w_float);
-    else return (0);
+    if(a->a_type == A_FLOAT)
+        return (a->a_w.w_float);
+    else
+        return (0);
 }
 
-t_int atom_getint(const t_atom *a)
+t_int atom_getint(const t_atom *a) { return (atom_getfloat(a)); }
+
+t_symbol *atom_getsymbol(
+    const t_atom *a) /* LATER think about this more carefully */
 {
-    return (atom_getfloat(a));
+    if(a->a_type == A_SYMBOL)
+        return (a->a_w.w_symbol);
+    else
+        return (&s_float);
 }
 
-t_symbol *atom_getsymbol(const t_atom *a)  /* LATER think about this more carefully */
-{
-    if (a->a_type == A_SYMBOL) return (a->a_w.w_symbol);
-    else return (&s_float);
-}
-
-t_symbol *atom_gensym(const t_atom *a)  /* this works  better for graph labels */
+t_symbol *atom_gensym(const t_atom *a) /* this works  better for graph labels */
 {
     char buf[30];
-    if (a->a_type == A_SYMBOL) return (a->a_w.w_symbol);
-    else if (a->a_type == A_FLOAT)
+    if(a->a_type == A_SYMBOL)
+        return (a->a_w.w_symbol);
+    else if(a->a_type == A_FLOAT)
         sprintf(buf, "%g", a->a_w.w_float);
-    else strcpy(buf, "???");
+    else
+        strcpy(buf, "???");
     return (gensym(buf));
 }
 
 t_float atom_getfloatarg(int which, int argc, const t_atom *argv)
 {
-    if (argc <= which) return (0);
+    if(argc <= which) return (0);
     argv += which;
-    if (argv->a_type == A_FLOAT) return (argv->a_w.w_float);
-    else return (0);
+    if(argv->a_type == A_FLOAT)
+        return (argv->a_w.w_float);
+    else
+        return (0);
 }
 
 t_int atom_getintarg(int which, int argc, const t_atom *argv)
@@ -52,76 +58,87 @@ t_int atom_getintarg(int which, int argc, const t_atom *argv)
 
 t_symbol *atom_getsymbolarg(int which, int argc, const t_atom *argv)
 {
-    if (argc <= which) return (&s_);
+    if(argc <= which) return (&s_);
     argv += which;
-    if (argv->a_type == A_SYMBOL) return (argv->a_w.w_symbol);
-    else return (&s_);
+    if(argv->a_type == A_SYMBOL)
+        return (argv->a_w.w_symbol);
+    else
+        return (&s_);
 }
 
 /* convert an atom into a string, in the reverse sense of binbuf_text (q.v.)
-* special attention is paid to symbols containing the special characters
-* ';', ',', '$', and '\'; these are quoted with a preceding '\', except that
-* the '$' only gets quoted if followed by a digit.
-*/
+ * special attention is paid to symbols containing the special characters
+ * ';', ',', '$', and '\'; these are quoted with a preceding '\', except that
+ * the '$' only gets quoted if followed by a digit.
+ */
 
 void atom_string(const t_atom *a, char *buf, unsigned int bufsize)
 {
     char tbuf[30];
     switch(a->a_type)
     {
-    case A_SEMI: strcpy(buf, ";"); break;
-    case A_COMMA: strcpy(buf, ","); break;
-    case A_POINTER:
-        strcpy(buf, "(pointer)");
-        break;
-    case A_FLOAT:
-        sprintf(tbuf, "%g", a->a_w.w_float);
-        if (strlen(tbuf) < bufsize-1) strcpy(buf, tbuf);
-        else if (a->a_w.w_float < 0) strcpy(buf, "-");
-        else  strcpy(buf, "+");
-        break;
-    case A_SYMBOL:
-    case A_DOLLSYM:
-    {
-        const char *sp;
-        unsigned int len;
-        int quote;
-        for (sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp; sp++, len++)
-            if (*sp == ';' || *sp == ',' || *sp == '\\' || *sp == ' ' ||
-                (a->a_type == A_SYMBOL && *sp == '$' &&
-                    sp[1] >= '0' && sp[1] <= '9'))
-                        quote = 1;
-        if (quote)
+        case A_SEMI:
+            strcpy(buf, ";");
+            break;
+        case A_COMMA:
+            strcpy(buf, ",");
+            break;
+        case A_POINTER:
+            strcpy(buf, "(pointer)");
+            break;
+        case A_FLOAT:
+            sprintf(tbuf, "%g", a->a_w.w_float);
+            if(strlen(tbuf) < bufsize - 1)
+                strcpy(buf, tbuf);
+            else if(a->a_w.w_float < 0)
+                strcpy(buf, "-");
+            else
+                strcpy(buf, "+");
+            break;
+        case A_SYMBOL:
+        case A_DOLLSYM:
         {
-            char *bp = buf, *ep = buf + (bufsize-2);
-            sp = a->a_w.w_symbol->s_name;
-            while (bp < ep && *sp)
+            const char *sp;
+            unsigned int len;
+            int quote;
+            for(sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp;
+                sp++, len++)
+                if(*sp == ';' || *sp == ',' || *sp == '\\' || *sp == ' ' ||
+                    (a->a_type == A_SYMBOL && *sp == '$' && sp[1] >= '0' &&
+                        sp[1] <= '9'))
+                    quote = 1;
+            if(quote)
             {
-                if (*sp == ';' || *sp == ',' || *sp == '\\' || *sp == ' ' ||
-                    (a->a_type == A_SYMBOL && *sp == '$' &&
-                        sp[1] >= '0' && sp[1] <= '9'))
-                            *bp++ = '\\';
-                *bp++ = *sp++;
+                char *bp = buf, *ep = buf + (bufsize - 2);
+                sp = a->a_w.w_symbol->s_name;
+                while(bp < ep && *sp)
+                {
+                    if(*sp == ';' || *sp == ',' || *sp == '\\' || *sp == ' ' ||
+                        (a->a_type == A_SYMBOL && *sp == '$' && sp[1] >= '0' &&
+                            sp[1] <= '9'))
+                        *bp++ = '\\';
+                    *bp++ = *sp++;
+                }
+                if(*sp) *bp++ = '*';
+                *bp = 0;
+                /* post("quote %s -> %s", a->a_w.w_symbol->s_name, buf); */
             }
-            if (*sp) *bp++ = '*';
-            *bp = 0;
-            /* post("quote %s -> %s", a->a_w.w_symbol->s_name, buf); */
-        }
-        else
-        {
-            if (len < bufsize-1) strcpy(buf, a->a_w.w_symbol->s_name);
             else
             {
-                strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);
-                strcpy(buf + (bufsize - 2), "*");
+                if(len < bufsize - 1)
+                    strcpy(buf, a->a_w.w_symbol->s_name);
+                else
+                {
+                    strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);
+                    strcpy(buf + (bufsize - 2), "*");
+                }
             }
         }
-    }
         break;
-    case A_DOLLAR:
-        sprintf(buf, "$%d", a->a_w.w_index);
-        break;
-    default:
-        bug("atom_string");
+        case A_DOLLAR:
+            sprintf(buf, "$%d", a->a_w.w_index);
+            break;
+        default:
+            bug("atom_string");
     }
 }

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -14,8 +14,7 @@ t_float atom_getfloat(const t_atom *a)
 {
     if(a->a_type == A_FLOAT)
         return (a->a_w.w_float);
-    else
-        return (0);
+    return (0);
 }
 
 t_int atom_getint(const t_atom *a) { return (atom_getfloat(a)); }
@@ -25,8 +24,7 @@ t_symbol *atom_getsymbol(
 {
     if(a->a_type == A_SYMBOL)
         return (a->a_w.w_symbol);
-    else
-        return (&s_float);
+    return (&s_float);
 }
 
 t_symbol *atom_gensym(const t_atom *a) /* this works  better for graph labels */
@@ -34,7 +32,7 @@ t_symbol *atom_gensym(const t_atom *a) /* this works  better for graph labels */
     char buf[30];
     if(a->a_type == A_SYMBOL)
         return (a->a_w.w_symbol);
-    else if(a->a_type == A_FLOAT)
+    if(a->a_type == A_FLOAT)
         sprintf(buf, "%g", a->a_w.w_float);
     else
         strcpy(buf, "???");
@@ -47,8 +45,7 @@ t_float atom_getfloatarg(int which, int argc, const t_atom *argv)
     argv += which;
     if(argv->a_type == A_FLOAT)
         return (argv->a_w.w_float);
-    else
-        return (0);
+    return (0);
 }
 
 t_int atom_getintarg(int which, int argc, const t_atom *argv)
@@ -62,8 +59,7 @@ t_symbol *atom_getsymbolarg(int which, int argc, const t_atom *argv)
     argv += which;
     if(argv->a_type == A_SYMBOL)
         return (argv->a_w.w_symbol);
-    else
-        return (&s_);
+    return (&s_);
 }
 
 /* convert an atom into a string, in the reverse sense of binbuf_text (q.v.)

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -33,9 +33,13 @@ t_symbol *atom_gensym(const t_atom *a) /* this works  better for graph labels */
     if(a->a_type == A_SYMBOL)
         return (a->a_w.w_symbol);
     if(a->a_type == A_FLOAT)
+    {
         sprintf(buf, "%g", a->a_w.w_float);
+    }
     else
+    {
         strcpy(buf, "???");
+    }
     return (gensym(buf));
 }
 
@@ -85,11 +89,17 @@ void atom_string(const t_atom *a, char *buf, unsigned int bufsize)
         case A_FLOAT:
             sprintf(tbuf, "%g", a->a_w.w_float);
             if(strlen(tbuf) < bufsize - 1)
+            {
                 strcpy(buf, tbuf);
+            }
             else if(a->a_w.w_float < 0)
+            {
                 strcpy(buf, "-");
+            }
             else
+            {
                 strcpy(buf, "+");
+            }
             break;
         case A_SYMBOL:
         case A_DOLLSYM:
@@ -99,10 +109,12 @@ void atom_string(const t_atom *a, char *buf, unsigned int bufsize)
             int quote;
             for(sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp;
                 sp++, len++)
+            {
                 if(*sp == ';' || *sp == ',' || *sp == '\\' || *sp == ' ' ||
                     (a->a_type == A_SYMBOL && *sp == '$' && sp[1] >= '0' &&
                         sp[1] <= '9'))
                     quote = 1;
+            }
             if(quote)
             {
                 char *bp = buf;
@@ -123,7 +135,9 @@ void atom_string(const t_atom *a, char *buf, unsigned int bufsize)
             else
             {
                 if(len < bufsize - 1)
+                {
                     strcpy(buf, a->a_w.w_symbol->s_name);
+                }
                 else
                 {
                     strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);

--- a/src/m_atom.c
+++ b/src/m_atom.c
@@ -109,7 +109,8 @@ void atom_string(const t_atom *a, char *buf, unsigned int bufsize)
                     quote = 1;
             if(quote)
             {
-                char *bp = buf, *ep = buf + (bufsize - 2);
+                char *bp = buf;
+                char *ep = buf + (bufsize - 2);
                 sp = a->a_w.w_symbol->s_name;
                 while(bp < ep && *sp)
                 {

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -562,7 +562,7 @@ static int binbuf_expanddollsym(const char *s, char *buf, t_atom *dollar0,
         sprintf(buf, "$");
         return 0;
     }
-    else if(argno < 0 || argno > ac) /* undefined argument */
+    if(argno < 0 || argno > ac) /* undefined argument */
     {
         if(!tonew) return 0;
         sprintf(buf, "$%d", argno);
@@ -775,11 +775,9 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                 /* LATER eat args until semicolon and continue */
                 continue;
             }
-            else
-            {
-                at++, ac--;
-                break;
-            }
+
+            at++, ac--;
+            break;
         }
         if(!ac) break;
         nargs = 0;
@@ -958,12 +956,10 @@ int binbuf_read_via_canvas(
         pd_error(0, "%s: can't open", filename);
         return (1);
     }
-    else
-        close(filedesc);
+    close(filedesc);
     if(binbuf_read(b, bufptr, buf, crflag))
         return (1);
-    else
-        return (0);
+    return (0);
 }
 
 /* old version */
@@ -979,12 +975,10 @@ int binbuf_read_via_path(
         pd_error(0, "%s: can't open", filename);
         return (1);
     }
-    else
-        close(filedesc);
+    close(filedesc);
     if(binbuf_read(b, bufptr, buf, crflag))
         return (1);
-    else
-        return (0);
+    return (0);
 }
 
 #define WBUFSIZE 4096

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -1,7 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
-
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include "m_pd.h"
@@ -31,7 +30,7 @@ struct _binbuf
 
 t_binbuf *binbuf_new(void)
 {
-    t_binbuf *x = (t_binbuf *)t_getbytes(sizeof(*x));
+    t_binbuf *x = (t_binbuf *) t_getbytes(sizeof(*x));
     x->b_n = 0;
     x->b_vec = t_getbytes(0);
     return (x);
@@ -40,12 +39,12 @@ t_binbuf *binbuf_new(void)
 void binbuf_free(t_binbuf *x)
 {
     t_freebytes(x->b_vec, x->b_n * sizeof(*x->b_vec));
-    t_freebytes(x,  sizeof(*x));
+    t_freebytes(x, sizeof(*x));
 }
 
 t_binbuf *binbuf_duplicate(const t_binbuf *y)
 {
-    t_binbuf *x = (t_binbuf *)t_getbytes(sizeof(*x));
+    t_binbuf *x = (t_binbuf *) t_getbytes(sizeof(*x));
     x->b_n = y->b_n;
     x->b_vec = t_getbytes(x->b_n * sizeof(*x->b_vec));
     memcpy(x->b_vec, y->b_vec, x->b_n * sizeof(*x->b_vec));
@@ -58,28 +57,31 @@ void binbuf_clear(t_binbuf *x)
     x->b_n = 0;
 }
 
-    /* convert text to a binbuf */
+/* convert text to a binbuf */
 void binbuf_text(t_binbuf *x, const char *text, size_t size)
 {
-    char buf[MAXPDSTRING+1], *bufp, *ebuf = buf+MAXPDSTRING;
-    const char *textp = text, *etext = text+size;
+    char buf[MAXPDSTRING + 1], *bufp, *ebuf = buf + MAXPDSTRING;
+    const char *textp = text, *etext = text + size;
     t_atom *ap;
     int nalloc = 16, natom = 0;
     binbuf_clear(x);
-    if (!binbuf_resize(x, nalloc)) return;
+    if(!binbuf_resize(x, nalloc)) return;
     ap = x->b_vec;
-    while (1)
+    while(1)
     {
         int type;
-            /* skip leading space */
-        while ((textp != etext) && (*textp == ' ' || *textp == '\n'
-            || *textp == '\r' || *textp == '\t')) textp++;
-        if (textp == etext) break;
-        if (*textp == ';') SETSEMI(ap), textp++;
-        else if (*textp == ',') SETCOMMA(ap), textp++;
+        /* skip leading space */
+        while((textp != etext) && (*textp == ' ' || *textp == '\n' ||
+                                      *textp == '\r' || *textp == '\t'))
+            textp++;
+        if(textp == etext) break;
+        if(*textp == ';')
+            SETSEMI(ap), textp++;
+        else if(*textp == ',')
+            SETCOMMA(ap), textp++;
         else
         {
-                /* it's an atom other than a comma or semi */
+            /* it's an atom other than a comma or semi */
             char c;
             int floatstate = 0, slash = 0, lastslash = 0, dollar = 0;
             bufp = buf;
@@ -89,115 +91,137 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
                 lastslash = slash;
                 slash = (c == '\\');
 
-                if (floatstate >= 0)
+                if(floatstate >= 0)
                 {
-                    int digit = (c >= '0' && c <= '9'),
-                        dot = (c == '.'), minus = (c == '-'),
-                        plusminus = (minus || (c == '+')),
+                    int digit = (c >= '0' && c <= '9'), dot = (c == '.'),
+                        minus = (c == '-'), plusminus = (minus || (c == '+')),
                         expon = (c == 'e' || c == 'E');
-                    if (floatstate == 0)    /* beginning */
+                    if(floatstate == 0) /* beginning */
                     {
-                        if (minus) floatstate = 1;
-                        else if (digit) floatstate = 2;
-                        else if (dot) floatstate = 3;
-                        else floatstate = -1;
+                        if(minus)
+                            floatstate = 1;
+                        else if(digit)
+                            floatstate = 2;
+                        else if(dot)
+                            floatstate = 3;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 1)   /* got minus */
+                    else if(floatstate == 1) /* got minus */
                     {
-                        if (digit) floatstate = 2;
-                        else if (dot) floatstate = 3;
-                        else floatstate = -1;
+                        if(digit)
+                            floatstate = 2;
+                        else if(dot)
+                            floatstate = 3;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 2)   /* got digits */
+                    else if(floatstate == 2) /* got digits */
                     {
-                        if (dot) floatstate = 4;
-                        else if (expon) floatstate = 6;
-                        else if (!digit) floatstate = -1;
+                        if(dot)
+                            floatstate = 4;
+                        else if(expon)
+                            floatstate = 6;
+                        else if(!digit)
+                            floatstate = -1;
                     }
-                    else if (floatstate == 3)   /* got '.' without digits */
+                    else if(floatstate == 3) /* got '.' without digits */
                     {
-                        if (digit) floatstate = 5;
-                        else floatstate = -1;
+                        if(digit)
+                            floatstate = 5;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 4)   /* got '.' after digits */
+                    else if(floatstate == 4) /* got '.' after digits */
                     {
-                        if (digit) floatstate = 5;
-                        else if (expon) floatstate = 6;
-                        else floatstate = -1;
+                        if(digit)
+                            floatstate = 5;
+                        else if(expon)
+                            floatstate = 6;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 5)   /* got digits after . */
+                    else if(floatstate == 5) /* got digits after . */
                     {
-                        if (expon) floatstate = 6;
-                        else if (!digit) floatstate = -1;
+                        if(expon)
+                            floatstate = 6;
+                        else if(!digit)
+                            floatstate = -1;
                     }
-                    else if (floatstate == 6)   /* got 'e' */
+                    else if(floatstate == 6) /* got 'e' */
                     {
-                        if (plusminus) floatstate = 7;
-                        else if (digit) floatstate = 8;
-                        else floatstate = -1;
+                        if(plusminus)
+                            floatstate = 7;
+                        else if(digit)
+                            floatstate = 8;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 7)   /* got plus or minus */
+                    else if(floatstate == 7) /* got plus or minus */
                     {
-                        if (digit) floatstate = 8;
-                        else floatstate = -1;
+                        if(digit)
+                            floatstate = 8;
+                        else
+                            floatstate = -1;
                     }
-                    else if (floatstate == 8)   /* got digits */
+                    else if(floatstate == 8) /* got digits */
                     {
-                        if (!digit) floatstate = -1;
+                        if(!digit) floatstate = -1;
                     }
                 }
-                if (!lastslash && c == '$' && (textp != etext &&
-                    textp[0] >= '0' && textp[0] <= '9'))
-                        dollar = 1;
-                if (!slash) bufp++;
-                else if (lastslash)
+                if(!lastslash && c == '$' &&
+                    (textp != etext && textp[0] >= '0' && textp[0] <= '9'))
+                    dollar = 1;
+                if(!slash)
+                    bufp++;
+                else if(lastslash)
                 {
                     bufp++;
                     slash = 0;
                 }
-            }
-            while (textp != etext && bufp != ebuf &&
-                (slash || (*textp != ' ' && *textp != '\n' && *textp != '\r'
-                    && *textp != '\t' &&*textp != ',' && *textp != ';')));
+            } while(textp != etext && bufp != ebuf &&
+                    (slash ||
+                        (*textp != ' ' && *textp != '\n' && *textp != '\r' &&
+                            *textp != '\t' && *textp != ',' && *textp != ';')));
             *bufp = 0;
 #if 0
             post("binbuf_text: buf %s", buf);
 #endif
-            if (floatstate == 2 || floatstate == 4 || floatstate == 5 ||
+            if(floatstate == 2 || floatstate == 4 || floatstate == 5 ||
                 floatstate == 8)
-                    SETFLOAT(ap, atof(buf));
-                /* LATER try to figure out how to mix "$" and "\$" correctly;
-                here, the backslashes were already stripped so we assume all
-                "$" chars are real dollars.  In fact, we only know at least one
-                was. */
-            else if (dollar)
+                SETFLOAT(ap, atof(buf));
+            /* LATER try to figure out how to mix "$" and "\$" correctly;
+            here, the backslashes were already stripped so we assume all
+            "$" chars are real dollars.  In fact, we only know at least one
+            was. */
+            else if(dollar)
             {
-                if (buf[0] != '$')
-                    dollar = 0;
-                for (bufp = buf+1; *bufp; bufp++)
-                    if (*bufp < '0' || *bufp > '9')
-                        dollar = 0;
-                if (dollar)
-                    SETDOLLAR(ap, atoi(buf+1));
-                else SETDOLLSYM(ap, gensym(buf));
+                if(buf[0] != '$') dollar = 0;
+                for(bufp = buf + 1; *bufp; bufp++)
+                    if(*bufp < '0' || *bufp > '9') dollar = 0;
+                if(dollar)
+                    SETDOLLAR(ap, atoi(buf + 1));
+                else
+                    SETDOLLSYM(ap, gensym(buf));
             }
-            else SETSYMBOL(ap, gensym(buf));
+            else
+                SETSYMBOL(ap, gensym(buf));
         }
         ap++;
         natom++;
-        if (natom == nalloc)
+        if(natom == nalloc)
         {
-            if (!binbuf_resize(x, nalloc*2)) break;
+            if(!binbuf_resize(x, nalloc * 2)) break;
             nalloc = nalloc * 2;
             ap = x->b_vec + natom;
         }
-        if (textp == etext) break;
+        if(textp == etext) break;
     }
     /* reallocate the vector to exactly the right size */
     binbuf_resize(x, natom);
 }
 
-    /* convert a binbuf to text; no null termination. */
+/* convert a binbuf to text; no null termination. */
 void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp)
 {
     char *buf = getbytes(0), *newbuf;
@@ -206,23 +230,26 @@ void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp)
     const t_atom *ap;
     int indx;
 
-    for (ap = x->b_vec, indx = x->b_n; indx--; ap++)
+    for(ap = x->b_vec, indx = x->b_n; indx--; ap++)
     {
         int newlength;
-        if ((ap->a_type == A_SEMI || ap->a_type == A_COMMA) &&
-                length && buf[length-1] == ' ') length--;
+        if((ap->a_type == A_SEMI || ap->a_type == A_COMMA) && length &&
+            buf[length - 1] == ' ')
+            length--;
         atom_string(ap, string, MAXPDSTRING);
-        newlength = length + (int)strlen(string) + 1;
-        if (!(newbuf = resizebytes(buf, length, newlength))) break;
+        newlength = length + (int) strlen(string) + 1;
+        if(!(newbuf = resizebytes(buf, length, newlength))) break;
         buf = newbuf;
         strcpy(buf + length, string);
         length = newlength;
-        if (ap->a_type == A_SEMI) buf[length-1] = '\n';
-        else buf[length-1] = ' ';
+        if(ap->a_type == A_SEMI)
+            buf[length - 1] = '\n';
+        else
+            buf[length - 1] = ' ';
     }
-    if (length && buf[length-1] == ' ')
+    if(length && buf[length - 1] == ' ')
     {
-        if ((newbuf = t_resizebytes(buf, length, length-1)))
+        if((newbuf = t_resizebytes(buf, length, length - 1)))
         {
             buf = newbuf;
             length--;
@@ -241,7 +268,7 @@ void binbuf_add(t_binbuf *x, int argc, const t_atom *argv)
     int newsize = previoussize + argc, i;
     t_atom *ap;
 
-    if (!binbuf_resize(x, newsize))
+    if(!binbuf_resize(x, newsize))
     {
         pd_error(0, "binbuf_addmessage: out of space");
         return;
@@ -251,34 +278,46 @@ void binbuf_add(t_binbuf *x, int argc, const t_atom *argv)
     postatom(argc, argv);
     endpost();
 #endif
-    for (ap = x->b_vec + previoussize, i = argc; i--; ap++)
+    for(ap = x->b_vec + previoussize, i = argc; i--; ap++)
         *ap = *(argv++);
 }
 
 #define MAXADDMESSV 100
+
 void binbuf_addv(t_binbuf *x, const char *fmt, ...)
 {
     va_list ap;
-    t_atom arg[MAXADDMESSV], *at =arg;
+    t_atom arg[MAXADDMESSV], *at = arg;
     int nargs = 0;
     const char *fp = fmt;
 
     va_start(ap, fmt);
-    while (1)
+    while(1)
     {
-        if (nargs >= MAXADDMESSV)
+        if(nargs >= MAXADDMESSV)
         {
             pd_error(0, "binbuf_addmessv: only %d allowed", MAXADDMESSV);
             break;
         }
         switch(*fp++)
         {
-        case 'i': SETFLOAT(at, va_arg(ap, int)); break;
-        case 'f': SETFLOAT(at, va_arg(ap, double)); break;
-        case 's': SETSYMBOL(at, va_arg(ap, t_symbol *)); break;
-        case ';': SETSEMI(at); break;
-        case ',': SETCOMMA(at); break;
-        default: goto done;
+            case 'i':
+                SETFLOAT(at, va_arg(ap, int));
+                break;
+            case 'f':
+                SETFLOAT(at, va_arg(ap, double));
+                break;
+            case 's':
+                SETSYMBOL(at, va_arg(ap, t_symbol *));
+                break;
+            case ';':
+                SETSEMI(at);
+                break;
+            case ',':
+                SETCOMMA(at);
+                break;
+            default:
+                goto done;
         }
         at++;
         nargs++;
@@ -298,40 +337,40 @@ void binbuf_addbinbuf(t_binbuf *x, const t_binbuf *y)
     int i, fixit;
     t_atom *ap;
     binbuf_add(z, y->b_n, y->b_vec);
-    for (i = 0, ap = z->b_vec; i < z->b_n; i++, ap++)
+    for(i = 0, ap = z->b_vec; i < z->b_n; i++, ap++)
     {
         char tbuf[MAXPDSTRING];
         const char *s;
-        switch (ap->a_type)
+        switch(ap->a_type)
         {
-        case A_FLOAT:
-            break;
-        case A_SEMI:
-            SETSYMBOL(ap, gensym(";"));
-            break;
-        case A_COMMA:
-            SETSYMBOL(ap, gensym(","));
-            break;
-        case A_DOLLAR:
-            sprintf(tbuf, "$%d", ap->a_w.w_index);
-            SETSYMBOL(ap, gensym(tbuf));
-            break;
-        case A_DOLLSYM:
-            atom_string(ap, tbuf, MAXPDSTRING);
-            SETSYMBOL(ap, gensym(tbuf));
-            break;
-        case A_SYMBOL:
-            for (s = ap->a_w.w_symbol->s_name, fixit = 0; *s; s++)
-                if (*s == ';' || *s == ',' || *s == '$' || *s == '\\')
-                    fixit = 1;
-            if (fixit)
-            {
+            case A_FLOAT:
+                break;
+            case A_SEMI:
+                SETSYMBOL(ap, gensym(";"));
+                break;
+            case A_COMMA:
+                SETSYMBOL(ap, gensym(","));
+                break;
+            case A_DOLLAR:
+                sprintf(tbuf, "$%d", ap->a_w.w_index);
+                SETSYMBOL(ap, gensym(tbuf));
+                break;
+            case A_DOLLSYM:
                 atom_string(ap, tbuf, MAXPDSTRING);
                 SETSYMBOL(ap, gensym(tbuf));
-            }
-            break;
-        default:
-            bug("binbuf_addbinbuf");
+                break;
+            case A_SYMBOL:
+                for(s = ap->a_w.w_symbol->s_name, fixit = 0; *s; s++)
+                    if(*s == ';' || *s == ',' || *s == '$' || *s == '\\')
+                        fixit = 1;
+                if(fixit)
+                {
+                    atom_string(ap, tbuf, MAXPDSTRING);
+                    SETSYMBOL(ap, gensym(tbuf));
+                }
+                break;
+            default:
+                bug("binbuf_addbinbuf");
         }
     }
 
@@ -355,38 +394,39 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
     int newsize = previoussize + argc, i;
     t_atom *ap;
 
-    if (!binbuf_resize(x, newsize))
+    if(!binbuf_resize(x, newsize))
     {
         pd_error(0, "binbuf_restore: out of space");
         return;
     }
 
-    for (ap = x->b_vec + previoussize, i = argc; i--; ap++)
+    for(ap = x->b_vec + previoussize, i = argc; i--; ap++)
     {
-        if (argv->a_type == A_SYMBOL)
+        if(argv->a_type == A_SYMBOL)
         {
             const char *str = argv->a_w.w_symbol->s_name, *str2;
-            if (!strcmp(str, ";")) SETSEMI(ap);
-            else if (!strcmp(str, ",")) SETCOMMA(ap);
+            if(!strcmp(str, ";"))
+                SETSEMI(ap);
+            else if(!strcmp(str, ","))
+                SETCOMMA(ap);
             else
             {
                 char buf[MAXPDSTRING], *sp1;
                 const char *sp2, *usestr;
                 int dollar = 0;
-                if (strchr(str, '\\'))
+                if(strchr(str, '\\'))
                 {
                     int slashed = 0;
-                    for (sp1 = buf, sp2 = argv->a_w.w_symbol->s_name;
-                        *sp2 && sp1 < buf + (MAXPDSTRING-1);
-                            sp2++)
+                    for(sp1 = buf, sp2 = argv->a_w.w_symbol->s_name;
+                        *sp2 && sp1 < buf + (MAXPDSTRING - 1); sp2++)
                     {
-                        if (slashed)
+                        if(slashed)
                             *sp1++ = *sp2, slashed = 0;
-                        else if (*sp2 == '\\')
+                        else if(*sp2 == '\\')
                             slashed = 1;
                         else
                         {
-                            if (*sp2 == '$' && sp2[1] >= '0' && sp2[1] <= '9')
+                            if(*sp2 == '$' && sp2[1] >= '0' && sp2[1] <= '9')
                                 dollar = 1;
                             *sp1++ = *sp2;
                             slashed = 0;
@@ -395,22 +435,24 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                     *sp1 = 0;
                     usestr = buf;
                 }
-                else usestr = str;
-                if (dollar || (usestr== str && (str2 = strchr(usestr, '$')) &&
-                    str2[1] >= '0' && str2[1] <= '9'))
+                else
+                    usestr = str;
+                if(dollar || (usestr == str && (str2 = strchr(usestr, '$')) &&
+                                 str2[1] >= '0' && str2[1] <= '9'))
                 {
                     int dollsym = 0;
-                    if (*usestr != '$')
+                    if(*usestr != '$')
                         dollsym = 1;
-                    else for (str2 = usestr + 1; *str2; str2++)
-                        if (*str2 < '0' || *str2 > '9')
-                    {
-                        dollsym = 1;
-                        break;
-                    }
-                    if (dollsym)
-                        SETDOLLSYM(ap, usestr == str ?
-                            argv->a_w.w_symbol : gensym(usestr));
+                    else
+                        for(str2 = usestr + 1; *str2; str2++)
+                            if(*str2 < '0' || *str2 > '9')
+                            {
+                                dollsym = 1;
+                                break;
+                            }
+                    if(dollsym)
+                        SETDOLLSYM(ap, usestr == str ? argv->a_w.w_symbol
+                                                     : gensym(usestr));
                     else
                     {
                         int dollar = 0;
@@ -418,52 +460,48 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                         SETDOLLAR(ap, dollar);
                     }
                 }
-                else SETSYMBOL(ap, usestr == str ?
-                    argv->a_w.w_symbol : gensym(usestr));
+                else
+                    SETSYMBOL(ap,
+                        usestr == str ? argv->a_w.w_symbol : gensym(usestr));
                 /* fprintf(stderr, "arg %s -> binbuf %s type %d\n",
                     argv->a_w.w_symbol->s_name, usestr, ap->a_type); */
             }
             argv++;
         }
-        else *ap = *(argv++);
+        else
+            *ap = *(argv++);
     }
 }
 
 void binbuf_print(const t_binbuf *x)
 {
     int i, startedpost = 0, newline = 1;
-    for (i = 0; i < x->b_n; i++)
+    for(i = 0; i < x->b_n; i++)
     {
-        if (newline)
+        if(newline)
         {
-            if (startedpost) endpost();
+            if(startedpost) endpost();
             startpost("");
             startedpost = 1;
         }
         postatom(1, x->b_vec + i);
-        if (x->b_vec[i].a_type == A_SEMI)
+        if(x->b_vec[i].a_type == A_SEMI)
             newline = 1;
-        else newline = 0;
+        else
+            newline = 0;
     }
-    if (startedpost) endpost();
+    if(startedpost) endpost();
 }
 
-int binbuf_getnatom(const t_binbuf *x)
-{
-    return (x->b_n);
-}
+int binbuf_getnatom(const t_binbuf *x) { return (x->b_n); }
 
-t_atom *binbuf_getvec(const t_binbuf *x)
-{
-    return (x->b_vec);
-}
+t_atom *binbuf_getvec(const t_binbuf *x) { return (x->b_vec); }
 
 int binbuf_resize(t_binbuf *x, int newsize)
 {
-    t_atom *new = t_resizebytes(x->b_vec,
-        x->b_n * sizeof(*x->b_vec), newsize * sizeof(*x->b_vec));
-    if (new)
-        x->b_vec = new, x->b_n = newsize;
+    t_atom *new = t_resizebytes(
+        x->b_vec, x->b_n * sizeof(*x->b_vec), newsize * sizeof(*x->b_vec));
+    if(new) x->b_vec = new, x->b_n = newsize;
     return (new != 0);
 }
 
@@ -488,40 +526,41 @@ int canvas_getdollarzero(void);
 static int binbuf_expanddollsym(const char *s, char *buf, t_atom *dollar0,
     int ac, const t_atom *av, int tonew)
 {
-    int argno = (int)atol(s);
+    int argno = (int) atol(s);
     int arglen = 0;
     const char *cs = s;
     char c = *cs;
 
-    *buf=0;
-    while (c && (c>='0') && (c<='9'))
+    *buf = 0;
+    while(c && (c >= '0') && (c <= '9'))
     {
         c = *cs++;
         arglen++;
     }
 
-    if (cs==s)      /* invalid $-expansion (like "$bla") */
+    if(cs == s) /* invalid $-expansion (like "$bla") */
     {
         sprintf(buf, "$");
         return 0;
     }
-    else if (argno < 0 || argno > ac) /* undefined argument */
+    else if(argno < 0 || argno > ac) /* undefined argument */
     {
-        if (!tonew)
-            return 0;
+        if(!tonew) return 0;
         sprintf(buf, "$%d", argno);
     }
-    else        /* well formed; expand it */
+    else /* well formed; expand it */
     {
-        const t_atom *dollarvalue = (argno ? &av[argno-1] : dollar0);
-        if (dollarvalue->a_type == A_SYMBOL)
+        const t_atom *dollarvalue = (argno ? &av[argno - 1] : dollar0);
+        if(dollarvalue->a_type == A_SYMBOL)
         {
-            strncpy(buf, dollarvalue->a_w.w_symbol->s_name, MAXPDSTRING/2-1);
-            buf[MAXPDSTRING/2-2] = 0;
+            strncpy(
+                buf, dollarvalue->a_w.w_symbol->s_name, MAXPDSTRING / 2 - 1);
+            buf[MAXPDSTRING / 2 - 2] = 0;
         }
-        else atom_string(dollarvalue, buf, MAXPDSTRING/2-1);
+        else
+            atom_string(dollarvalue, buf, MAXPDSTRING / 2 - 1);
     }
-    return (arglen-1);
+    return (arglen - 1);
 }
 
 /* expand any '$' variables in the symbol s.  "tonow" is set if this is in the
@@ -530,54 +569,55 @@ args become 0 - otherwise zero is returned and the caller has to check the
 result. */
 /* LATER remove the dependence on the current canvas for $0; should be another
 argument. */
-t_symbol *binbuf_realizedollsym(t_symbol *s, int ac, const t_atom *av,
-    int tonew)
+t_symbol *binbuf_realizedollsym(
+    t_symbol *s, int ac, const t_atom *av, int tonew)
 {
     char buf[MAXPDSTRING];
     char buf2[MAXPDSTRING];
-    const char*str=s->s_name;
-    char*substr;
-    int next=0;
+    const char *str = s->s_name;
+    char *substr;
+    int next = 0;
     t_atom dollarnull;
     SETFLOAT(&dollarnull, canvas_getdollarzero());
-    buf2[0] = buf2[MAXPDSTRING-1] = 0;
+    buf2[0] = buf2[MAXPDSTRING - 1] = 0;
 
-    substr=strchr(str, '$');
-    if (!substr || substr-str >= MAXPDSTRING)
-        return (s);
+    substr = strchr(str, '$');
+    if(!substr || substr - str >= MAXPDSTRING) return (s);
 
-    strncpy(buf2, str, (substr-str));
-    buf2[substr-str] = 0;
-    str=substr+1;
+    strncpy(buf2, str, (substr - str));
+    buf2[substr - str] = 0;
+    str = substr + 1;
 
-    while((next=binbuf_expanddollsym(str, buf, &dollarnull, ac, av, tonew))>=0)
+    while((next = binbuf_expanddollsym(str, buf, &dollarnull, ac, av, tonew)) >=
+          0)
     {
         /*
-        * JMZ: i am not sure what this means, so i might have broken it
-        * it seems like that if "tonew" is set and the $arg cannot be expanded
-        * (or the dollarsym is in reality a A_DOLLAR)
-        * 0 is returned from binbuf_realizedollsym
-        * this happens, when expanding in a message-box, but does not happen
-        * when the A_DOLLSYM is the name of a subpatch
-        */
-        if (!tonew && (0==next) && (0==*buf))
+         * JMZ: i am not sure what this means, so i might have broken it
+         * it seems like that if "tonew" is set and the $arg cannot be expanded
+         * (or the dollarsym is in reality a A_DOLLAR)
+         * 0 is returned from binbuf_realizedollsym
+         * this happens, when expanding in a message-box, but does not happen
+         * when the A_DOLLSYM is the name of a subpatch
+         */
+        if(!tonew && (0 == next) && (0 == *buf))
         {
             return 0; /* JMZ: this should mimic the original behaviour */
         }
 
-        strncat(buf2, buf, MAXPDSTRING-strlen(buf2)-1);
-        str+=next;
-        substr=strchr(str, '$');
-        if (substr)
+        strncat(buf2, buf, MAXPDSTRING - strlen(buf2) - 1);
+        str += next;
+        substr = strchr(str, '$');
+        if(substr)
         {
-            unsigned long n = substr-str;
-            if(n>MAXPDSTRING-strlen(buf2)-1) n=MAXPDSTRING-strlen(buf2)-1;
+            unsigned long n = substr - str;
+            if(n > MAXPDSTRING - strlen(buf2) - 1)
+                n = MAXPDSTRING - strlen(buf2) - 1;
             strncat(buf2, str, n);
-            str=substr+1;
+            str = substr + 1;
         }
         else
         {
-            strncat(buf2, str, MAXPDSTRING-strlen(buf2)-1);
+            strncat(buf2, str, MAXPDSTRING - strlen(buf2) - 1);
             goto done;
         }
     }
@@ -588,26 +628,27 @@ done:
 #define SMALLMSG 5
 #define HUGEMSG 1000
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+#ifndef HAVE_ALLOCA /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1
 #endif
 
 #ifdef HAVE_ALLOCA
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < HUGEMSG ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < HUGEMSG || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#define ATOMS_ALLOCA(x, n)                                          \
+    ((x) = (t_atom *) ((n) < HUGEMSG ? alloca((n) * sizeof(t_atom)) \
+                                     : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) \
+    (((n) < HUGEMSG || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 #else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *) getbytes((n) * sizeof(t_atom)))
 #define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
 #endif
 
@@ -619,91 +660,96 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
     int nargs, maxnargs = 0;
     t_pd *initial_target = target;
 
-    if (ac <= SMALLMSG)
+    if(ac <= SMALLMSG)
         mstack = smallstack;
     else
     {
 #if 1
-            /* count number of args in biggest message.  The weird
-            treatment of "pd_objectmaker" is because when the message
-            goes out to objectmaker, commas and semis are passed
-            on as regular args (see below).  We're tacitly assuming here
-            that the pd_objectmaker target can't come up via a named
-            destination in the message, only because the original "target"
-            points there. */
-        if (target == &pd_objectmaker)
+        /* count number of args in biggest message.  The weird
+        treatment of "pd_objectmaker" is because when the message
+        goes out to objectmaker, commas and semis are passed
+        on as regular args (see below).  We're tacitly assuming here
+        that the pd_objectmaker target can't come up via a named
+        destination in the message, only because the original "target"
+        points there. */
+        if(target == &pd_objectmaker)
             maxnargs = ac;
         else
         {
             int i, j = (target ? 0 : -1);
-            for (i = 0; i < ac; i++)
+            for(i = 0; i < ac; i++)
             {
-                if (at[i].a_type == A_SEMI)
+                if(at[i].a_type == A_SEMI)
                     j = -1;
-                else if (at[i].a_type == A_COMMA)
+                else if(at[i].a_type == A_COMMA)
                     j = 0;
-                else if (++j > maxnargs)
+                else if(++j > maxnargs)
                     maxnargs = j;
             }
         }
-        if (maxnargs <= SMALLMSG)
+        if(maxnargs <= SMALLMSG)
             mstack = smallstack;
-        else ATOMS_ALLOCA(mstack, maxnargs);
+        else
+            ATOMS_ALLOCA(mstack, maxnargs);
 #else
-            /* just pessimistically allocate enough to hold everything
-            at once.  This turned out to run slower in a simple benchmark
-            I tried, perhaps because the extra memory allocation
-            hurt the cache hit rate. */
+        /* just pessimistically allocate enough to hold everything
+        at once.  This turned out to run slower in a simple benchmark
+        I tried, perhaps because the extra memory allocation
+        hurt the cache hit rate. */
         maxnargs = ac;
         ATOMS_ALLOCA(mstack, maxnargs);
 #endif
-
     }
     msp = mstack;
-    while (1)
+    while(1)
     {
         t_pd *nexttarget;
-            /* get a target. */
-        while (!target)
+        /* get a target. */
+        while(!target)
         {
             t_symbol *s;
-            while (ac && (at->a_type == A_SEMI || at->a_type == A_COMMA))
-                ac--,  at++;
-            if (!ac) break;
-            if (at->a_type == A_DOLLAR)
+            while(ac && (at->a_type == A_SEMI || at->a_type == A_COMMA))
+                ac--, at++;
+            if(!ac) break;
+            if(at->a_type == A_DOLLAR)
             {
-                if (at->a_w.w_index <= 0 || at->a_w.w_index > argc)
+                if(at->a_w.w_index <= 0 || at->a_w.w_index > argc)
                 {
-                    pd_error(initial_target, "$%d: not enough arguments supplied",
-                            at->a_w.w_index);
+                    pd_error(initial_target,
+                        "$%d: not enough arguments supplied", at->a_w.w_index);
                     goto cleanup;
                 }
-                else if (argv[at->a_w.w_index-1].a_type != A_SYMBOL)
+                else if(argv[at->a_w.w_index - 1].a_type != A_SYMBOL)
                 {
-                    pd_error(initial_target, "$%d: symbol needed as message destination",
+                    pd_error(initial_target,
+                        "$%d: symbol needed as message destination",
                         at->a_w.w_index);
                     goto cleanup;
                 }
-                else s = argv[at->a_w.w_index-1].a_w.w_symbol;
+                else
+                    s = argv[at->a_w.w_index - 1].a_w.w_symbol;
             }
-            else if (at->a_type == A_DOLLSYM)
+            else if(at->a_type == A_DOLLSYM)
             {
-                if (!(s = binbuf_realizedollsym(at->a_w.w_symbol,
-                    argc, argv, 0)))
+                if(!(s = binbuf_realizedollsym(
+                         at->a_w.w_symbol, argc, argv, 0)))
                 {
-                    pd_error(initial_target, "$%s: not enough arguments supplied",
+                    pd_error(initial_target,
+                        "$%s: not enough arguments supplied",
                         at->a_w.w_symbol->s_name);
                     goto cleanup;
                 }
             }
-            else s = atom_getsymbol(at);
-            if (!(target = s->s_thing))
+            else
+                s = atom_getsymbol(at);
+            if(!(target = s->s_thing))
             {
                 pd_error(initial_target, "%s: no such object ", s->s_name);
             cleanup:
-                do at++, ac--;
-                while (ac && at->a_type != A_SEMI);
-                    /* LATER eat args until semicolon and continue */
+                do
+                    at++, ac--;
+                while(ac && at->a_type != A_SEMI);
+                /* LATER eat args until semicolon and continue */
                 continue;
             }
             else
@@ -712,69 +758,73 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                 break;
             }
         }
-        if (!ac) break;
+        if(!ac) break;
         nargs = 0;
         nexttarget = target;
-        while (1)
+        while(1)
         {
             t_symbol *s9;
-            if (!ac) goto gotmess;
-            switch (at->a_type)
+            if(!ac) goto gotmess;
+            switch(at->a_type)
             {
-            case A_SEMI:
+                case A_SEMI:
                     /* semis and commas in new message just get bashed to
                     a symbol.  This is needed so you can pass them to "expr." */
-                if (target == &pd_objectmaker)
-                {
-                    SETSYMBOL(msp, gensym(";"));
-                    break;
-                }
-                else
-                {
-                    nexttarget = 0;
-                    goto gotmess;
-                }
-            case A_COMMA:
-                if (target == &pd_objectmaker)
-                {
-                    SETSYMBOL(msp, gensym(","));
-                    break;
-                }
-                else goto gotmess;
-            case A_FLOAT:
-            case A_SYMBOL:
-                *msp = *at;
-                break;
-            case A_DOLLAR:
-                if (at->a_w.w_index > 0 && at->a_w.w_index <= argc)
-                    *msp = argv[at->a_w.w_index-1];
-                else if (at->a_w.w_index == 0)
-                    SETFLOAT(msp, canvas_getdollarzero());
-                else
-                {
-                    if (target == &pd_objectmaker)
-                        SETFLOAT(msp, 0);
+                    if(target == &pd_objectmaker)
+                    {
+                        SETSYMBOL(msp, gensym(";"));
+                        break;
+                    }
                     else
                     {
-                        pd_error(target, "$%d: argument number out of range",
-                            at->a_w.w_index);
-                        SETFLOAT(msp, 0);
+                        nexttarget = 0;
+                        goto gotmess;
                     }
-                }
-                break;
-            case A_DOLLSYM:
-                s9 = binbuf_realizedollsym(at->a_w.w_symbol, argc, argv,
-                    target == &pd_objectmaker);
-                if (!s9)
-                {
-                    pd_error(target, "%s: argument number out of range", at->a_w.w_symbol->s_name);
-                    SETSYMBOL(msp, at->a_w.w_symbol);
-                }
-                else SETSYMBOL(msp, s9);
-                break;
-            default:
-                bug("bad item in binbuf");
-                goto broken;
+                case A_COMMA:
+                    if(target == &pd_objectmaker)
+                    {
+                        SETSYMBOL(msp, gensym(","));
+                        break;
+                    }
+                    else
+                        goto gotmess;
+                case A_FLOAT:
+                case A_SYMBOL:
+                    *msp = *at;
+                    break;
+                case A_DOLLAR:
+                    if(at->a_w.w_index > 0 && at->a_w.w_index <= argc)
+                        *msp = argv[at->a_w.w_index - 1];
+                    else if(at->a_w.w_index == 0)
+                        SETFLOAT(msp, canvas_getdollarzero());
+                    else
+                    {
+                        if(target == &pd_objectmaker)
+                            SETFLOAT(msp, 0);
+                        else
+                        {
+                            pd_error(target,
+                                "$%d: argument number out of range",
+                                at->a_w.w_index);
+                            SETFLOAT(msp, 0);
+                        }
+                    }
+                    break;
+                case A_DOLLSYM:
+                    s9 = binbuf_realizedollsym(at->a_w.w_symbol, argc, argv,
+                        target == &pd_objectmaker);
+                    if(!s9)
+                    {
+                        pd_error(target, "%s: argument number out of range",
+                            at->a_w.w_symbol->s_name);
+                        SETSYMBOL(msp, at->a_w.w_symbol);
+                    }
+                    else
+                        SETSYMBOL(msp, s9);
+                    break;
+                default:
+                    bug("bad item in binbuf");
+                    goto broken;
             }
             msp++;
             ac--;
@@ -782,38 +832,43 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
             nargs++;
         }
     gotmess:
-        if (nargs)
+        if(nargs)
         {
-            switch (mstack->a_type)
+            switch(mstack->a_type)
             {
-            case A_SYMBOL:
-                typedmess(target, mstack->a_w.w_symbol, nargs-1, mstack+1);
-                break;
-            case A_FLOAT:
-                if (nargs == 1) pd_float(target, mstack->a_w.w_float);
-                else pd_list(target, 0, nargs, mstack);
-                break;
-            case A_POINTER:
-                if (nargs == 1) pd_pointer(target, mstack->a_w.w_gpointer);
-                else pd_list(target, 0, nargs, mstack);
-                break;
-            default:
-                bug("bad selector");
-                break;
+                case A_SYMBOL:
+                    typedmess(
+                        target, mstack->a_w.w_symbol, nargs - 1, mstack + 1);
+                    break;
+                case A_FLOAT:
+                    if(nargs == 1)
+                        pd_float(target, mstack->a_w.w_float);
+                    else
+                        pd_list(target, 0, nargs, mstack);
+                    break;
+                case A_POINTER:
+                    if(nargs == 1)
+                        pd_pointer(target, mstack->a_w.w_gpointer);
+                    else
+                        pd_list(target, 0, nargs, mstack);
+                    break;
+                default:
+                    bug("bad selector");
+                    break;
             }
         }
         msp = mstack;
-        if (!ac) break;
+        if(!ac) break;
         target = nexttarget;
         at++;
         ac--;
     }
 broken:
-    if (maxnargs > SMALLMSG)
-         ATOMS_FREEA(mstack, maxnargs);
+    if(maxnargs > SMALLMSG) ATOMS_FREEA(mstack, maxnargs);
 }
 
-int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crflag)
+int binbuf_read(
+    t_binbuf *b, const char *filename, const char *dirname, int crflag)
 {
     long length;
     int fd;
@@ -821,41 +876,40 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
     char *buf;
     char namebuf[MAXPDSTRING];
 
-    if (*dirname)
-        snprintf(namebuf, MAXPDSTRING-1, "%s/%s", dirname, filename);
+    if(*dirname)
+        snprintf(namebuf, MAXPDSTRING - 1, "%s/%s", dirname, filename);
     else
-        snprintf(namebuf, MAXPDSTRING-1, "%s", filename);
-    namebuf[MAXPDSTRING-1] = 0;
+        snprintf(namebuf, MAXPDSTRING - 1, "%s", filename);
+    namebuf[MAXPDSTRING - 1] = 0;
 
-    if ((fd = sys_open(namebuf, 0)) < 0)
+    if((fd = sys_open(namebuf, 0)) < 0)
     {
         fprintf(stderr, "open: ");
         perror(namebuf);
         return (1);
     }
-    if ((length = (long)lseek(fd, 0, SEEK_END)) < 0 || lseek(fd, 0, SEEK_SET) < 0
-        || !(buf = t_getbytes(length)))
+    if((length = (long) lseek(fd, 0, SEEK_END)) < 0 ||
+        lseek(fd, 0, SEEK_SET) < 0 || !(buf = t_getbytes(length)))
     {
         fprintf(stderr, "lseek: ");
         perror(namebuf);
         close(fd);
-        return(1);
+        return (1);
     }
-    if ((readret = (int)read(fd, buf, length)) < length)
+    if((readret = (int) read(fd, buf, length)) < length)
     {
         fprintf(stderr, "read (%d %ld) -> %d\n", fd, length, readret);
         perror(namebuf);
         close(fd);
         t_freebytes(buf, length);
-        return(1);
+        return (1);
     }
-        /* optionally map carriage return to semicolon */
-    if (crflag)
+    /* optionally map carriage return to semicolon */
+    if(crflag)
     {
         int i;
-        for (i = 0; i < length; i++)
-            if (buf[i] == '\n')
-                buf[i] = ';';
+        for(i = 0; i < length; i++)
+            if(buf[i] == '\n') buf[i] = ';';
     }
     binbuf_text(b, buf, length);
 
@@ -868,48 +922,53 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
     return (0);
 }
 
-    /* read a binbuf from a file, via the search patch of a canvas */
-int binbuf_read_via_canvas(t_binbuf *b, const char *filename,
-    const t_canvas *canvas, int crflag)
+/* read a binbuf from a file, via the search patch of a canvas */
+int binbuf_read_via_canvas(
+    t_binbuf *b, const char *filename, const t_canvas *canvas, int crflag)
 {
     int filedesc;
     char buf[MAXPDSTRING], *bufptr;
-    if ((filedesc = canvas_open(canvas, filename, "",
-        buf, &bufptr, MAXPDSTRING, 0)) < 0)
+    if((filedesc = canvas_open(
+            canvas, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
     {
         pd_error(0, "%s: can't open", filename);
         return (1);
     }
-    else close (filedesc);
-    if (binbuf_read(b, bufptr, buf, crflag))
+    else
+        close(filedesc);
+    if(binbuf_read(b, bufptr, buf, crflag))
         return (1);
-    else return (0);
+    else
+        return (0);
 }
 
-    /* old version */
-int binbuf_read_via_path(t_binbuf *b, const char *filename, const char *dirname,
-    int crflag)
+/* old version */
+int binbuf_read_via_path(
+    t_binbuf *b, const char *filename, const char *dirname, int crflag)
 {
     int filedesc;
     char buf[MAXPDSTRING], *bufptr;
-    if ((filedesc = open_via_path(
-        dirname, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
+    if((filedesc = open_via_path(
+            dirname, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
     {
         pd_error(0, "%s: can't open", filename);
         return (1);
     }
-    else close (filedesc);
-    if (binbuf_read(b, bufptr, buf, crflag))
+    else
+        close(filedesc);
+    if(binbuf_read(b, bufptr, buf, crflag))
         return (1);
-    else return (0);
+    else
+        return (0);
 }
 
 #define WBUFSIZE 4096
 static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd);
 
-    /* write a binbuf to a text file.  If "crflag" is set we suppress
-    semicolons. */
-int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int crflag)
+/* write a binbuf to a text file.  If "crflag" is set we suppress
+semicolons. */
+int binbuf_write(
+    const t_binbuf *x, const char *filename, const char *dir, int crflag)
 {
     FILE *f = 0;
     char sbuf[WBUFSIZE], fbuf[MAXPDSTRING], *bp = sbuf, *ep = sbuf + WBUFSIZE;
@@ -919,45 +978,45 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
     int indx;
     int ncolumn = 0;
 
-    if (*dir)
-        snprintf(fbuf, MAXPDSTRING-1, "%s/%s", dir, filename);
+    if(*dir)
+        snprintf(fbuf, MAXPDSTRING - 1, "%s/%s", dir, filename);
     else
-        snprintf(fbuf, MAXPDSTRING-1, "%s", filename);
-    fbuf[MAXPDSTRING-1] = 0;
+        snprintf(fbuf, MAXPDSTRING - 1, "%s", filename);
+    fbuf[MAXPDSTRING - 1] = 0;
 
-    if (!strcmp(filename + strlen(filename) - 4, ".pat") ||
+    if(!strcmp(filename + strlen(filename) - 4, ".pat") ||
         !strcmp(filename + strlen(filename) - 4, ".mxt"))
     {
         y = binbuf_convert(x, 0);
         z = y;
     }
 
-    if (!(f = sys_fopen(fbuf, "w")))
-        goto fail;
-    for (ap = z->b_vec, indx = z->b_n; indx--; ap++)
+    if(!(f = sys_fopen(fbuf, "w"))) goto fail;
+    for(ap = z->b_vec, indx = z->b_n; indx--; ap++)
     {
         int length;
-            /* estimate how many characters will be needed.  Printing out
-            symbols may need extra characters for inserting backslashes. */
-        if (ap->a_type == A_SYMBOL || ap->a_type == A_DOLLSYM)
-            length = 80 + (int)strlen(ap->a_w.w_symbol->s_name);
-        else length = 40;
-        if (ep - bp < length)
+        /* estimate how many characters will be needed.  Printing out
+        symbols may need extra characters for inserting backslashes. */
+        if(ap->a_type == A_SYMBOL || ap->a_type == A_DOLLSYM)
+            length = 80 + (int) strlen(ap->a_w.w_symbol->s_name);
+        else
+            length = 40;
+        if(ep - bp < length)
         {
-            if (fwrite(sbuf, bp-sbuf, 1, f) < 1)
-                goto fail;
+            if(fwrite(sbuf, bp - sbuf, 1, f) < 1) goto fail;
             bp = sbuf;
         }
-        if ((ap->a_type == A_SEMI || ap->a_type == A_COMMA) &&
-            bp > sbuf && bp[-1] == ' ') bp--;
-        if (!crflag || ap->a_type != A_SEMI)
+        if((ap->a_type == A_SEMI || ap->a_type == A_COMMA) && bp > sbuf &&
+            bp[-1] == ' ')
+            bp--;
+        if(!crflag || ap->a_type != A_SEMI)
         {
-            atom_string(ap, bp, (unsigned int)((ep-bp)-2));
-            length = (int)strlen(bp);
+            atom_string(ap, bp, (unsigned int) ((ep - bp) - 2));
+            length = (int) strlen(bp);
             bp += length;
             ncolumn += length;
         }
-        if (ap->a_type == A_SEMI || (!crflag && ncolumn > 65))
+        if(ap->a_type == A_SEMI || (!crflag && ncolumn > 65))
         {
             *bp++ = '\n';
             ncolumn = 0;
@@ -968,21 +1027,16 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
             ncolumn++;
         }
     }
-    if (fwrite(sbuf, bp-sbuf, 1, f) < 1)
-        goto fail;
+    if(fwrite(sbuf, bp - sbuf, 1, f) < 1) goto fail;
 
-    if (fflush(f) != 0)
-        goto fail;
+    if(fflush(f) != 0) goto fail;
 
-    if (y)
-        binbuf_free(y);
+    if(y) binbuf_free(y);
     fclose(f);
     return (0);
 fail:
-    if (y)
-        binbuf_free(y);
-    if (f)
-        fclose(f);
+    if(y) binbuf_free(y);
+    if(f) fclose(f);
     return (1);
 }
 
@@ -993,260 +1047,242 @@ from Pd to Max hasn't been tested for patches with subpatches yet!  */
 
 #define MAXSTACK 1000
 
-#define ISSYMBOL(a, b) ((a)->a_type == A_SYMBOL && \
-    !strcmp((a)->a_w.w_symbol->s_name, (b)))
+#define ISSYMBOL(a, b) \
+    ((a)->a_type == A_SYMBOL && !strcmp((a)->a_w.w_symbol->s_name, (b)))
 
 static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
 {
     t_binbuf *newb = binbuf_new();
     t_atom *vec = oldb->b_vec;
     t_int n = oldb->b_n, nextindex, stackdepth = 0, stack[MAXSTACK] = {0},
-        nobj = 0, gotfontsize = 0;
-	int i;
+          nobj = 0, gotfontsize = 0;
+    int i;
     t_atom outmess[MAXSTACK], *nextmess;
     t_float fontsize = 10;
-    if (!maxtopd)
-        binbuf_addv(newb, "ss;", gensym("max"), gensym("v2"));
-    for (nextindex = 0; nextindex < n; )
+    if(!maxtopd) binbuf_addv(newb, "ss;", gensym("max"), gensym("v2"));
+    for(nextindex = 0; nextindex < n;)
     {
         int endmess, natom;
         const char *first, *second, *third;
-        for (endmess = (int)nextindex; endmess < n && vec[endmess].a_type != A_SEMI;
-            endmess++)
-                ;
-        if (endmess == n) break;
-        if (endmess == nextindex || endmess == nextindex + 1
-            || vec[nextindex].a_type != A_SYMBOL ||
-                vec[nextindex+1].a_type != A_SYMBOL)
+        for(endmess = (int) nextindex;
+            endmess < n && vec[endmess].a_type != A_SEMI; endmess++)
+            ;
+        if(endmess == n) break;
+        if(endmess == nextindex || endmess == nextindex + 1 ||
+            vec[nextindex].a_type != A_SYMBOL ||
+            vec[nextindex + 1].a_type != A_SYMBOL)
         {
             nextindex = endmess + 1;
             continue;
         }
-        natom = endmess - (int)nextindex;
-        if (natom > MAXSTACK-10) natom = MAXSTACK-10;
+        natom = endmess - (int) nextindex;
+        if(natom > MAXSTACK - 10) natom = MAXSTACK - 10;
         nextmess = vec + nextindex;
         first = nextmess->a_w.w_symbol->s_name;
-        second = (nextmess+1)->a_w.w_symbol->s_name;
-        if (maxtopd)
+        second = (nextmess + 1)->a_w.w_symbol->s_name;
+        if(maxtopd)
         {
-                /* case 1: importing a ".pat" file into Pd. */
+            /* case 1: importing a ".pat" file into Pd. */
 
-                /* dollar signs in file translate to symbols */
-            for (i = 0; i < natom; i++)
+            /* dollar signs in file translate to symbols */
+            for(i = 0; i < natom; i++)
             {
-                if (nextmess[i].a_type == A_DOLLAR)
+                if(nextmess[i].a_type == A_DOLLAR)
                 {
                     char buf[100];
                     sprintf(buf, "$%d", nextmess[i].a_w.w_index);
-                    SETSYMBOL(nextmess+i, gensym(buf));
+                    SETSYMBOL(nextmess + i, gensym(buf));
                 }
-                else if (nextmess[i].a_type == A_DOLLSYM)
+                else if(nextmess[i].a_type == A_DOLLSYM)
                 {
                     char buf[100];
                     sprintf(buf, "%s", nextmess[i].a_w.w_symbol->s_name);
-                    SETSYMBOL(nextmess+i, gensym(buf));
+                    SETSYMBOL(nextmess + i, gensym(buf));
                 }
             }
-            if (!strcmp(first, "#N"))
+            if(!strcmp(first, "#N"))
             {
-                if (!strcmp(second, "vpatcher"))
+                if(!strcmp(second, "vpatcher"))
                 {
-                    if (stackdepth >= MAXSTACK)
+                    if(stackdepth >= MAXSTACK)
                     {
-                        pd_error(0, "stack depth exceeded: too many embedded patches");
+                        pd_error(0,
+                            "stack depth exceeded: too many embedded patches");
                         return (newb);
                     }
                     stack[stackdepth] = nobj;
                     stackdepth++;
                     nobj = 0;
-                    binbuf_addv(newb, "ssfffff;",
-                        gensym("#N"), gensym("canvas"),
+                    binbuf_addv(newb, "ssfffff;", gensym("#N"),
+                        gensym("canvas"), atom_getfloatarg(2, natom, nextmess),
+                        atom_getfloatarg(3, natom, nextmess),
+                        atom_getfloatarg(4, natom, nextmess) -
                             atom_getfloatarg(2, natom, nextmess),
+                        atom_getfloatarg(5, natom, nextmess) -
                             atom_getfloatarg(3, natom, nextmess),
-                            atom_getfloatarg(4, natom, nextmess) -
-                                atom_getfloatarg(2, natom, nextmess),
-                            atom_getfloatarg(5, natom, nextmess) -
-                                atom_getfloatarg(3, natom, nextmess),
-                            (t_float)sys_defaultfont);
+                        (t_float) sys_defaultfont);
                 }
             }
-            if (!strcmp(first, "#P"))
+            if(!strcmp(first, "#P"))
             {
-                    /* drop initial "hidden" flag */
-                if (!strcmp(second, "hidden"))
+                /* drop initial "hidden" flag */
+                if(!strcmp(second, "hidden"))
                 {
                     nextmess++;
                     natom--;
-                    second = (nextmess+1)->a_w.w_symbol->s_name;
+                    second = (nextmess + 1)->a_w.w_symbol->s_name;
                 }
-                if (natom >= 7 && !strcmp(second, "newobj")
-                    && (ISSYMBOL(&nextmess[6], "patcher") ||
+                if(natom >= 7 && !strcmp(second, "newobj") &&
+                    (ISSYMBOL(&nextmess[6], "patcher") ||
                         ISSYMBOL(&nextmess[6], "p")))
                 {
-                    binbuf_addv(newb, "ssffss;",
-                        gensym("#X"), gensym("restore"),
-                        atom_getfloatarg(2, natom, nextmess),
-                        atom_getfloatarg(3, natom, nextmess),
-                        gensym("pd"), atom_getsymbolarg(7, natom, nextmess));
-                    if (stackdepth) stackdepth--;
+                    binbuf_addv(newb, "ssffss;", gensym("#X"),
+                        gensym("restore"), atom_getfloatarg(2, natom, nextmess),
+                        atom_getfloatarg(3, natom, nextmess), gensym("pd"),
+                        atom_getsymbolarg(7, natom, nextmess));
+                    if(stackdepth) stackdepth--;
                     nobj = stack[stackdepth];
                     nobj++;
                 }
-                else if (!strcmp(second, "newex") || !strcmp(second, "newobj"))
+                else if(!strcmp(second, "newex") || !strcmp(second, "newobj"))
                 {
-                    t_symbol *classname =
-                        atom_getsymbolarg(6, natom, nextmess);
-                    if (classname == gensym("trigger") ||
+                    t_symbol *classname = atom_getsymbolarg(6, natom, nextmess);
+                    if(classname == gensym("trigger") ||
                         classname == gensym("t"))
                     {
-                        for (i = 7; i < natom; i++)
-                            if (nextmess[i].a_type == A_SYMBOL &&
+                        for(i = 7; i < natom; i++)
+                            if(nextmess[i].a_type == A_SYMBOL &&
                                 nextmess[i].a_w.w_symbol == gensym("i"))
-                                    nextmess[i].a_w.w_symbol = gensym("f");
+                                nextmess[i].a_w.w_symbol = gensym("f");
                     }
-                    if (classname == gensym("table"))
+                    if(classname == gensym("table"))
                         classname = gensym("TABLE");
                     SETSYMBOL(outmess, gensym("#X"));
                     SETSYMBOL(outmess + 1, gensym("obj"));
                     outmess[2] = nextmess[2];
                     outmess[3] = nextmess[3];
-                    SETSYMBOL(outmess+4, classname);
-                    for (i = 7; i < natom; i++)
-                        outmess[i-2] = nextmess[i];
+                    SETSYMBOL(outmess + 4, classname);
+                    for(i = 7; i < natom; i++)
+                        outmess[i - 2] = nextmess[i];
                     SETSEMI(outmess + natom - 2);
                     binbuf_add(newb, natom - 1, outmess);
                     nobj++;
                 }
-                else if (!strcmp(second, "message") ||
-                    !strcmp(second, "comment"))
+                else if(!strcmp(second, "message") ||
+                        !strcmp(second, "comment"))
                 {
                     SETSYMBOL(outmess, gensym("#X"));
-                    SETSYMBOL(outmess + 1, gensym(
-                        (strcmp(second, "message") ? "text" : "msg")));
+                    SETSYMBOL(outmess + 1,
+                        gensym((strcmp(second, "message") ? "text" : "msg")));
                     outmess[2] = nextmess[2];
                     outmess[3] = nextmess[3];
-                    for (i = 6; i < natom; i++)
-                        outmess[i-2] = nextmess[i];
+                    for(i = 6; i < natom; i++)
+                        outmess[i - 2] = nextmess[i];
                     SETSEMI(outmess + natom - 2);
                     binbuf_add(newb, natom - 1, outmess);
                     nobj++;
                 }
-                else if (!strcmp(second, "button"))
+                else if(!strcmp(second, "button"))
                 {
-                    binbuf_addv(newb, "ssffs;",
-                        gensym("#X"), gensym("obj"),
+                    binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
                         atom_getfloatarg(2, natom, nextmess),
-                        atom_getfloatarg(3, natom, nextmess),
-                        gensym("bng"));
+                        atom_getfloatarg(3, natom, nextmess), gensym("bng"));
                     nobj++;
                 }
-                else if (!strcmp(second, "number") || !strcmp(second, "flonum"))
+                else if(!strcmp(second, "number") || !strcmp(second, "flonum"))
                 {
-                    binbuf_addv(newb, "ssff;",
-                        gensym("#X"), gensym("floatatom"),
+                    binbuf_addv(newb, "ssff;", gensym("#X"),
+                        gensym("floatatom"),
                         atom_getfloatarg(2, natom, nextmess),
                         atom_getfloatarg(3, natom, nextmess));
                     nobj++;
                 }
-                else if (!strcmp(second, "slider"))
+                else if(!strcmp(second, "slider"))
                 {
                     t_float inc = atom_getfloatarg(7, natom, nextmess);
-                    if (inc <= 0)
-                        inc = 1;
-                    binbuf_addv(newb, "ssffsffffffsssfffffffff;",
-                        gensym("#X"), gensym("obj"),
-                        atom_getfloatarg(2, natom, nextmess),
-                        atom_getfloatarg(3, natom, nextmess),
-                        gensym("vsl"),
+                    if(inc <= 0) inc = 1;
+                    binbuf_addv(newb, "ssffsffffffsssfffffffff;", gensym("#X"),
+                        gensym("obj"), atom_getfloatarg(2, natom, nextmess),
+                        atom_getfloatarg(3, natom, nextmess), gensym("vsl"),
                         atom_getfloatarg(4, natom, nextmess),
                         atom_getfloatarg(5, natom, nextmess),
                         atom_getfloatarg(6, natom, nextmess),
-                        atom_getfloatarg(6, natom, nextmess)
-                            + (atom_getfloatarg(5, natom, nextmess) - 1) * inc,
-                        0., 0.,
-                        gensym("empty"), gensym("empty"), gensym("empty"),
-                        0., -8., 0., 8., -262144., -1., -1., 0., 1.);
+                        atom_getfloatarg(6, natom, nextmess) +
+                            (atom_getfloatarg(5, natom, nextmess) - 1) * inc,
+                        0., 0., gensym("empty"), gensym("empty"),
+                        gensym("empty"), 0., -8., 0., 8., -262144., -1., -1.,
+                        0., 1.);
                     nobj++;
                 }
-                else if (!strcmp(second, "toggle"))
+                else if(!strcmp(second, "toggle"))
                 {
-                    binbuf_addv(newb, "ssffs;",
-                        gensym("#X"), gensym("obj"),
+                    binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
                         atom_getfloatarg(2, natom, nextmess),
-                        atom_getfloatarg(3, natom, nextmess),
-                        gensym("tgl"));
+                        atom_getfloatarg(3, natom, nextmess), gensym("tgl"));
                     nobj++;
                 }
-                else if (!strcmp(second, "inlet"))
+                else if(!strcmp(second, "inlet"))
                 {
-                    binbuf_addv(newb, "ssffs;",
-                        gensym("#X"), gensym("obj"),
+                    binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
                         atom_getfloatarg(2, natom, nextmess),
                         atom_getfloatarg(3, natom, nextmess),
                         gensym((natom > 5 ? "inlet~" : "inlet")));
                     nobj++;
                 }
-                else if (!strcmp(second, "outlet"))
+                else if(!strcmp(second, "outlet"))
                 {
-                    binbuf_addv(newb, "ssffs;",
-                        gensym("#X"), gensym("obj"),
+                    binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
                         atom_getfloatarg(2, natom, nextmess),
                         atom_getfloatarg(3, natom, nextmess),
                         gensym((natom > 5 ? "outlet~" : "outlet")));
                     nobj++;
                 }
-                else if (!strcmp(second, "user"))
+                else if(!strcmp(second, "user"))
                 {
-                    third = (nextmess+2)->a_w.w_symbol->s_name;
-                    if (!strcmp(third, "hslider"))
+                    third = (nextmess + 2)->a_w.w_symbol->s_name;
+                    if(!strcmp(third, "hslider"))
                     {
                         t_float range = atom_getfloatarg(7, natom, nextmess);
-                        t_float multiplier = atom_getfloatarg(8, natom, nextmess);
+                        t_float multiplier =
+                            atom_getfloatarg(8, natom, nextmess);
                         t_float offset = atom_getfloatarg(9, natom, nextmess);
                         binbuf_addv(newb, "ssffsffffffsssfffffffff;",
-                                    gensym("#X"), gensym("obj"),
-                                    atom_getfloatarg(3, natom, nextmess),
-                                    atom_getfloatarg(4, natom, nextmess),
-                                    gensym("hsl"),
-                                    atom_getfloatarg(6, natom, nextmess),
-                                    atom_getfloatarg(5, natom, nextmess),
-                                    offset,
-                                    range + offset,
-                                    0., 0.,
-                                    gensym("empty"), gensym("empty"), gensym("empty"),
-                                    0., -8., 0., 8., -262144., -1., -1., 0., 1.);
-                   }
-                    else if (!strcmp(third, "uslider"))
+                            gensym("#X"), gensym("obj"),
+                            atom_getfloatarg(3, natom, nextmess),
+                            atom_getfloatarg(4, natom, nextmess), gensym("hsl"),
+                            atom_getfloatarg(6, natom, nextmess),
+                            atom_getfloatarg(5, natom, nextmess), offset,
+                            range + offset, 0., 0., gensym("empty"),
+                            gensym("empty"), gensym("empty"), 0., -8., 0., 8.,
+                            -262144., -1., -1., 0., 1.);
+                    }
+                    else if(!strcmp(third, "uslider"))
                     {
                         t_float range = atom_getfloatarg(7, natom, nextmess);
-                        t_float multiplier = atom_getfloatarg(8, natom, nextmess);
+                        t_float multiplier =
+                            atom_getfloatarg(8, natom, nextmess);
                         t_float offset = atom_getfloatarg(9, natom, nextmess);
                         binbuf_addv(newb, "ssffsffffffsssfffffffff;",
-                                    gensym("#X"), gensym("obj"),
-                                    atom_getfloatarg(3, natom, nextmess),
-                                    atom_getfloatarg(4, natom, nextmess),
-                                    gensym("vsl"),
-                                    atom_getfloatarg(5, natom, nextmess),
-                                    atom_getfloatarg(6, natom, nextmess),
-                                    offset,
-                                    range + offset,
-                                    0., 0.,
-                                    gensym("empty"), gensym("empty"), gensym("empty"),
-                                    0., -8., 0., 8., -262144., -1., -1., 0., 1.);
+                            gensym("#X"), gensym("obj"),
+                            atom_getfloatarg(3, natom, nextmess),
+                            atom_getfloatarg(4, natom, nextmess), gensym("vsl"),
+                            atom_getfloatarg(5, natom, nextmess),
+                            atom_getfloatarg(6, natom, nextmess), offset,
+                            range + offset, 0., 0., gensym("empty"),
+                            gensym("empty"), gensym("empty"), 0., -8., 0., 8.,
+                            -262144., -1., -1., 0., 1.);
                     }
                     else
-                        binbuf_addv(newb, "ssffs;",
-                                    gensym("#X"), gensym("obj"),
-                                    atom_getfloatarg(3, natom, nextmess),
-                                    atom_getfloatarg(4, natom, nextmess),
-                                    atom_getsymbolarg(2, natom, nextmess));
+                        binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
+                            atom_getfloatarg(3, natom, nextmess),
+                            atom_getfloatarg(4, natom, nextmess),
+                            atom_getsymbolarg(2, natom, nextmess));
                     nobj++;
                 }
-                else if (!strcmp(second, "connect")||
-                    !strcmp(second, "fasten"))
+                else if(!strcmp(second, "connect") || !strcmp(second, "fasten"))
                 {
-                    binbuf_addv(newb, "ssffff;",
-                        gensym("#X"), gensym("connect"),
+                    binbuf_addv(newb, "ssffff;", gensym("#X"),
+                        gensym("connect"),
                         nobj - atom_getfloatarg(2, natom, nextmess) - 1,
                         atom_getfloatarg(3, natom, nextmess),
                         nobj - atom_getfloatarg(4, natom, nextmess) - 1,
@@ -1254,96 +1290,96 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                 }
             }
         }
-        else        /* Pd to Max */
+        else /* Pd to Max */
         {
-            if (!strcmp(first, "#N"))
+            if(!strcmp(first, "#N"))
             {
-                if (!strcmp(second, "canvas"))
+                if(!strcmp(second, "canvas"))
                 {
                     t_float x, y;
-                    if (stackdepth >= MAXSTACK)
+                    if(stackdepth >= MAXSTACK)
                     {
-                        pd_error(0, "stack depth exceeded: too many embedded patches");
+                        pd_error(0,
+                            "stack depth exceeded: too many embedded patches");
                         return (newb);
                     }
                     stack[stackdepth] = nobj;
                     stackdepth++;
                     nobj = 0;
-                    if(!gotfontsize) { /* only the first canvas sets the font size */
+                    if(!gotfontsize)
+                    { /* only the first canvas sets the font size */
                         fontsize = atom_getfloatarg(6, natom, nextmess);
                         gotfontsize = 1;
                     }
                     x = atom_getfloatarg(2, natom, nextmess);
                     y = atom_getfloatarg(3, natom, nextmess);
-                    binbuf_addv(newb, "ssffff;",
-                        gensym("#N"), gensym("vpatcher"),
-                            x, y,
-                            atom_getfloatarg(4, natom, nextmess) + x,
-                            atom_getfloatarg(5, natom, nextmess) + y);
+                    binbuf_addv(newb, "ssffff;", gensym("#N"),
+                        gensym("vpatcher"), x, y,
+                        atom_getfloatarg(4, natom, nextmess) + x,
+                        atom_getfloatarg(5, natom, nextmess) + y);
                 }
             }
-            if (!strcmp(first, "#X"))
+            if(!strcmp(first, "#X"))
             {
-                if (natom >= 5 && !strcmp(second, "restore")
-                    && (ISSYMBOL (&nextmess[4], "pd")))
+                if(natom >= 5 && !strcmp(second, "restore") &&
+                    (ISSYMBOL(&nextmess[4], "pd")))
                 {
                     binbuf_addv(newb, "ss;", gensym("#P"), gensym("pop"));
                     SETSYMBOL(outmess, gensym("#P"));
                     SETSYMBOL(outmess + 1, gensym("newobj"));
                     outmess[2] = nextmess[2];
                     outmess[3] = nextmess[3];
-                    SETFLOAT(outmess + 4, 50.*(natom-5));
+                    SETFLOAT(outmess + 4, 50. * (natom - 5));
                     SETFLOAT(outmess + 5, fontsize);
                     SETSYMBOL(outmess + 6, gensym("p"));
-                    for (i = 5; i < natom; i++)
-                        outmess[i+2] = nextmess[i];
+                    for(i = 5; i < natom; i++)
+                        outmess[i + 2] = nextmess[i];
                     SETSEMI(outmess + natom + 2);
                     binbuf_add(newb, natom + 3, outmess);
-                    if (stackdepth) stackdepth--;
+                    if(stackdepth) stackdepth--;
                     nobj = stack[stackdepth];
                     nobj++;
                 }
-                else if (!strcmp(second, "obj"))
+                else if(!strcmp(second, "obj"))
                 {
-                    t_symbol *classname =
-                        atom_getsymbolarg(4, natom, nextmess);
-                    if (classname == gensym("inlet"))
+                    t_symbol *classname = atom_getsymbolarg(4, natom, nextmess);
+                    if(classname == gensym("inlet"))
                         binbuf_addv(newb, "ssfff;", gensym("#P"),
                             gensym("inlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize);
-                    else if (classname == gensym("inlet~"))
+                    else if(classname == gensym("inlet~"))
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("inlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize, 1.);
-                    else if (classname == gensym("outlet"))
+                    else if(classname == gensym("outlet"))
                         binbuf_addv(newb, "ssfff;", gensym("#P"),
                             gensym("outlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize);
-                    else if (classname == gensym("outlet~"))
+                    else if(classname == gensym("outlet~"))
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("outlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize, 1.);
-                    else if (classname == gensym("bng"))
+                    else if(classname == gensym("bng"))
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("button"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(5, natom, nextmess), 0.);
-                    else if (classname == gensym("tgl"))
+                    else if(classname == gensym("tgl"))
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("toggle"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(5, natom, nextmess), 0.);
-                    else if (classname == gensym("vsl"))
+                    else if(classname == gensym("vsl"))
                         binbuf_addv(newb, "ssffffff;", gensym("#P"),
                             gensym("slider"),
                             atom_getfloatarg(2, natom, nextmess),
@@ -1352,52 +1388,54 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                             atom_getfloatarg(6, natom, nextmess),
                             (atom_getfloatarg(8, natom, nextmess) -
                                 atom_getfloatarg(7, natom, nextmess)) /
-                                    (atom_getfloatarg(6, natom, nextmess) == 1? 1 :
-                                         atom_getfloatarg(6, natom, nextmess) - 1),
+                                (atom_getfloatarg(6, natom, nextmess) == 1
+                                        ? 1
+                                        : atom_getfloatarg(6, natom, nextmess) -
+                                              1),
                             atom_getfloatarg(7, natom, nextmess));
-                    else if (classname == gensym("hsl"))
+                    else if(classname == gensym("hsl"))
                     {
                         t_float slmin = atom_getfloatarg(7, natom, nextmess);
                         t_float slmax = atom_getfloatarg(8, natom, nextmess);
                         binbuf_addv(newb, "sssffffffff;", gensym("#P"),
-                            gensym("user"),
-                            gensym("hslider"),
+                            gensym("user"), gensym("hslider"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(6, natom, nextmess),
                             atom_getfloatarg(5, natom, nextmess),
                             slmax - slmin + 1, /* range */
-                            1.,            /* multiplier */
-                            slmin,         /* offset */
+                            1.,                /* multiplier */
+                            slmin,             /* offset */
                             0.);
                     }
-                    else if ( (classname == gensym("trigger")) ||
-                              (classname == gensym("t")) )
+                    else if((classname == gensym("trigger")) ||
+                            (classname == gensym("t")))
                     {
                         t_symbol *arg;
                         SETSYMBOL(outmess, gensym("#P"));
                         SETSYMBOL(outmess + 1, gensym("newex"));
                         outmess[2] = nextmess[2];
                         outmess[3] = nextmess[3];
-                        SETFLOAT(outmess + 4, 50.*(natom-4));
+                        SETFLOAT(outmess + 4, 50. * (natom - 4));
                         SETFLOAT(outmess + 5, fontsize);
                         outmess[6] = nextmess[4];
-                        for (i = 5; i < natom; i++) {
+                        for(i = 5; i < natom; i++)
+                        {
                             arg = atom_getsymbolarg(i, natom, nextmess);
-                            if (arg == gensym("a"))
+                            if(arg == gensym("a"))
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
-                            else if (arg == gensym("anything"))
+                            else if(arg == gensym("anything"))
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
-                            else if (arg == gensym("bang"))
+                            else if(arg == gensym("bang"))
                                 SETSYMBOL(outmess + i + 2, gensym("b"));
-                            else if (arg == gensym("float"))
+                            else if(arg == gensym("float"))
                                 SETSYMBOL(outmess + i + 2, gensym("f"));
-                            else if (arg == gensym("list"))
+                            else if(arg == gensym("list"))
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
-                            else if (arg == gensym("symbol"))
+                            else if(arg == gensym("symbol"))
                                 SETSYMBOL(outmess + i + 2, gensym("s"));
                             else
-                                outmess[i+2] = nextmess[i];
+                                outmess[i + 2] = nextmess[i];
                         }
                         SETSEMI(outmess + natom + 2);
                         binbuf_add(newb, natom + 3, outmess);
@@ -1408,49 +1446,47 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                         SETSYMBOL(outmess + 1, gensym("newex"));
                         outmess[2] = nextmess[2];
                         outmess[3] = nextmess[3];
-                        SETFLOAT(outmess + 4, 50.*(natom-4));
+                        SETFLOAT(outmess + 4, 50. * (natom - 4));
                         SETFLOAT(outmess + 5, fontsize);
-                        for (i = 4; i < natom; i++)
-                            outmess[i+2] = nextmess[i];
-                        if (classname == gensym("osc~"))
+                        for(i = 4; i < natom; i++)
+                            outmess[i + 2] = nextmess[i];
+                        if(classname == gensym("osc~"))
                             SETSYMBOL(outmess + 6, gensym("cycle~"));
                         SETSEMI(outmess + natom + 2);
                         binbuf_add(newb, natom + 3, outmess);
                     }
                     nobj++;
-
                 }
-                else if (!strcmp(second, "msg") ||
-                    !strcmp(second, "text"))
+                else if(!strcmp(second, "msg") || !strcmp(second, "text"))
                 {
                     SETSYMBOL(outmess, gensym("#P"));
-                    SETSYMBOL(outmess + 1, gensym(
-                        (strcmp(second, "msg") ? "comment" : "message")));
+                    SETSYMBOL(outmess + 1,
+                        gensym(
+                            (strcmp(second, "msg") ? "comment" : "message")));
                     outmess[2] = nextmess[2];
                     outmess[3] = nextmess[3];
-                    SETFLOAT(outmess + 4, 50.*(natom-4));
+                    SETFLOAT(outmess + 4, 50. * (natom - 4));
                     SETFLOAT(outmess + 5, fontsize);
-                    for (i = 4; i < natom; i++)
-                        outmess[i+2] = nextmess[i];
+                    for(i = 4; i < natom; i++)
+                        outmess[i + 2] = nextmess[i];
                     SETSEMI(outmess + natom + 2);
                     binbuf_add(newb, natom + 3, outmess);
                     nobj++;
                 }
-                else if (!strcmp(second, "floatatom"))
+                else if(!strcmp(second, "floatatom"))
                 {
-                    t_float width = atom_getfloatarg(4, natom, nextmess)*fontsize;
-                    if(width<8) width = 150; /* if pd width=0, set it big */
-                    binbuf_addv(newb, "ssfff;",
-                        gensym("#P"), gensym("flonum"),
+                    t_float width =
+                        atom_getfloatarg(4, natom, nextmess) * fontsize;
+                    if(width < 8) width = 150; /* if pd width=0, set it big */
+                    binbuf_addv(newb, "ssfff;", gensym("#P"), gensym("flonum"),
                         atom_getfloatarg(2, natom, nextmess),
-                        atom_getfloatarg(3, natom, nextmess),
-                        width);
+                        atom_getfloatarg(3, natom, nextmess), width);
                     nobj++;
                 }
-                else if (!strcmp(second, "connect"))
+                else if(!strcmp(second, "connect"))
                 {
-                    binbuf_addv(newb, "ssffff;",
-                        gensym("#P"), gensym("connect"),
+                    binbuf_addv(newb, "ssffff;", gensym("#P"),
+                        gensym("connect"),
                         nobj - atom_getfloatarg(2, natom, nextmess) - 1,
                         atom_getfloatarg(3, natom, nextmess),
                         nobj - atom_getfloatarg(4, natom, nextmess) - 1,
@@ -1460,8 +1496,7 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
         }
         nextindex = endmess + 1;
     }
-    if (!maxtopd)
-        binbuf_addv(newb, "ss;", gensym("#P"), gensym("pop"));
+    if(!maxtopd) binbuf_addv(newb, "ss;", gensym("#P"), gensym("pop"));
 #if 0
     binbuf_write(newb, "import-result.pd", "/tmp", 0);
 #endif
@@ -1474,28 +1509,28 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
 {
     t_binbuf *b = binbuf_new();
     int import = !strcmp(name->s_name + strlen(name->s_name) - 4, ".pat") ||
-        !strcmp(name->s_name + strlen(name->s_name) - 4, ".mxt");
+                 !strcmp(name->s_name + strlen(name->s_name) - 4, ".mxt");
     int dspstate = canvas_suspend_dsp();
-        /* set filename so that new canvases can pick them up */
+    /* set filename so that new canvases can pick them up */
     glob_setfilename(0, name, dir);
-    if (binbuf_read(b, name->s_name, dir->s_name, 0))
+    if(binbuf_read(b, name->s_name, dir->s_name, 0))
         pd_error(0, "%s: read failed; %s", name->s_name, strerror(errno));
     else
     {
-            /* save bindings of symbols #N, #A (and restore afterward) */
+        /* save bindings of symbols #N, #A (and restore afterward) */
         t_pd *bounda = gensym("#A")->s_thing, *boundn = s__N.s_thing;
         gensym("#A")->s_thing = 0;
         s__N.s_thing = &pd_canvasmaker;
-        if (import)
+        if(import)
         {
             t_binbuf *newb = binbuf_convert(b, 1);
             binbuf_free(b);
             b = newb;
         }
         binbuf_eval(b, 0, 0, 0);
-            /* avoid crashing if no canvas was created by binbuf eval */
-        if (s__X.s_thing && *s__X.s_thing == canvas_class)
-            canvas_initbang((t_canvas *)(s__X.s_thing)); /* JMZ*/
+        /* avoid crashing if no canvas was created by binbuf eval */
+        if(s__X.s_thing && *s__X.s_thing == canvas_class)
+            canvas_initbang((t_canvas *) (s__X.s_thing)); /* JMZ*/
         gensym("#A")->s_thing = bounda;
         s__N.s_thing = boundn;
     }
@@ -1504,23 +1539,23 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
     canvas_resume_dsp(dspstate);
 }
 
-    /* save a text object to a binbuf for a file or copy buf */
+/* save a text object to a binbuf for a file or copy buf */
 void binbuf_savetext(const t_binbuf *bfrom, t_binbuf *bto)
 {
     int k, n = binbuf_getnatom(bfrom);
     const t_atom *ap = binbuf_getvec(bfrom);
     t_atom at;
-    for (k = 0; k < n; k++)
+    for(k = 0; k < n; k++)
     {
-        if (ap[k].a_type == A_FLOAT ||
+        if(ap[k].a_type == A_FLOAT ||
             (ap[k].a_type == A_SYMBOL &&
                 !strchr(ap[k].a_w.w_symbol->s_name, ';') &&
                 !strchr(ap[k].a_w.w_symbol->s_name, ',') &&
                 !strchr(ap[k].a_w.w_symbol->s_name, '$')))
-                    binbuf_add(bto, 1, &ap[k]);
+            binbuf_add(bto, 1, &ap[k]);
         else
         {
-            char buf[MAXPDSTRING+1];
+            char buf[MAXPDSTRING + 1];
             atom_string(&ap[k], buf, MAXPDSTRING);
             SETSYMBOL(&at, gensym(buf));
             binbuf_add(bto, 1, &at);
@@ -1528,4 +1563,3 @@ void binbuf_savetext(const t_binbuf *bfrom, t_binbuf *bto)
     }
     binbuf_addsemi(bto);
 }
-

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -80,9 +80,13 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
             textp++;
         if(textp == etext) break;
         if(*textp == ';')
+        {
             SETSEMI(ap), textp++;
+        }
         else if(*textp == ',')
+        {
             SETCOMMA(ap), textp++;
+        }
         else
         {
             /* it's an atom other than a comma or semi */
@@ -108,70 +112,114 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
                     if(floatstate == 0) /* beginning */
                     {
                         if(minus)
+                        {
                             floatstate = 1;
+                        }
                         else if(digit)
+                        {
                             floatstate = 2;
+                        }
                         else if(dot)
+                        {
                             floatstate = 3;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 1) /* got minus */
                     {
                         if(digit)
+                        {
                             floatstate = 2;
+                        }
                         else if(dot)
+                        {
                             floatstate = 3;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 2) /* got digits */
                     {
                         if(dot)
+                        {
                             floatstate = 4;
+                        }
                         else if(expon)
+                        {
                             floatstate = 6;
+                        }
                         else if(!digit)
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 3) /* got '.' without digits */
                     {
                         if(digit)
+                        {
                             floatstate = 5;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 4) /* got '.' after digits */
                     {
                         if(digit)
+                        {
                             floatstate = 5;
+                        }
                         else if(expon)
+                        {
                             floatstate = 6;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 5) /* got digits after . */
                     {
                         if(expon)
+                        {
                             floatstate = 6;
+                        }
                         else if(!digit)
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 6) /* got 'e' */
                     {
                         if(plusminus)
+                        {
                             floatstate = 7;
+                        }
                         else if(digit)
+                        {
                             floatstate = 8;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 7) /* got plus or minus */
                     {
                         if(digit)
+                        {
                             floatstate = 8;
+                        }
                         else
+                        {
                             floatstate = -1;
+                        }
                     }
                     else if(floatstate == 8) /* got digits */
                     {
@@ -182,7 +230,9 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
                     (textp != etext && textp[0] >= '0' && textp[0] <= '9'))
                     dollar = 1;
                 if(!slash)
+                {
                     bufp++;
+                }
                 else if(lastslash)
                 {
                     bufp++;
@@ -198,20 +248,26 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
 #endif
             if(floatstate == 2 || floatstate == 4 || floatstate == 5 ||
                 floatstate == 8)
+            {
                 SETFLOAT(ap, atof(buf));
             /* LATER try to figure out how to mix "$" and "\$" correctly;
             here, the backslashes were already stripped so we assume all
             "$" chars are real dollars.  In fact, we only know at least one
             was. */
+            }
             else if(dollar)
             {
                 if(buf[0] != '$') dollar = 0;
                 for(bufp = buf + 1; *bufp; bufp++)
                     if(*bufp < '0' || *bufp > '9') dollar = 0;
                 if(dollar)
+                {
                     SETDOLLAR(ap, atoi(buf + 1));
+                }
                 else
+                {
                     SETDOLLSYM(ap, gensym(buf));
+                }
             }
             else
                 SETSYMBOL(ap, gensym(buf));
@@ -253,9 +309,13 @@ void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp)
         strcpy(buf + length, string);
         length = newlength;
         if(ap->a_type == A_SEMI)
+        {
             buf[length - 1] = '\n';
+        }
         else
+        {
             buf[length - 1] = ' ';
+        }
     }
     if(length && buf[length - 1] == ' ')
     {
@@ -374,8 +434,10 @@ void binbuf_addbinbuf(t_binbuf *x, const t_binbuf *y)
                 break;
             case A_SYMBOL:
                 for(s = ap->a_w.w_symbol->s_name, fixit = 0; *s; s++)
+                {
                     if(*s == ';' || *s == ',' || *s == '$' || *s == '\\')
                         fixit = 1;
+                }
                 if(fixit)
                 {
                     atom_string(ap, tbuf, MAXPDSTRING);
@@ -421,9 +483,13 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
             const char *str = argv->a_w.w_symbol->s_name;
             const char *str2;
             if(!strcmp(str, ";"))
+            {
                 SETSEMI(ap);
+            }
             else if(!strcmp(str, ","))
+            {
                 SETCOMMA(ap);
+            }
             else
             {
                 char buf[MAXPDSTRING];
@@ -438,9 +504,13 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                         *sp2 && sp1 < buf + (MAXPDSTRING - 1); sp2++)
                     {
                         if(slashed)
+                        {
                             *sp1++ = *sp2, slashed = 0;
+                        }
                         else if(*sp2 == '\\')
+                        {
                             slashed = 1;
+                        }
                         else
                         {
                             if(*sp2 == '$' && sp2[1] >= '0' && sp2[1] <= '9')
@@ -459,17 +529,25 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                 {
                     int dollsym = 0;
                     if(*usestr != '$')
+                    {
                         dollsym = 1;
+                    }
                     else
+                    {
                         for(str2 = usestr + 1; *str2; str2++)
+                        {
                             if(*str2 < '0' || *str2 > '9')
                             {
                                 dollsym = 1;
                                 break;
                             }
+                        }
+                    }
                     if(dollsym)
+                    {
                         SETDOLLSYM(ap, usestr == str ? argv->a_w.w_symbol
                                                      : gensym(usestr));
+                    }
                     else
                     {
                         int dollar = 0;
@@ -478,8 +556,10 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                     }
                 }
                 else
+                {
                     SETSYMBOL(ap,
                         usestr == str ? argv->a_w.w_symbol : gensym(usestr));
+                }
                 /* fprintf(stderr, "arg %s -> binbuf %s type %d\n",
                     argv->a_w.w_symbol->s_name, usestr, ap->a_type); */
             }
@@ -505,9 +585,13 @@ void binbuf_print(const t_binbuf *x)
         }
         postatom(1, x->b_vec + i);
         if(x->b_vec[i].a_type == A_SEMI)
+        {
             newline = 1;
+        }
         else
+        {
             newline = 0;
+        }
     }
     if(startedpost) endpost();
 }
@@ -683,7 +767,9 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
     t_pd *initial_target = target;
 
     if(ac <= SMALLMSG)
+    {
         mstack = smallstack;
+    }
     else
     {
 #if 1
@@ -695,7 +781,9 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
         destination in the message, only because the original "target"
         points there. */
         if(target == &pd_objectmaker)
+        {
             maxnargs = ac;
+        }
         else
         {
             int i;
@@ -703,17 +791,27 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
             for(i = 0; i < ac; i++)
             {
                 if(at[i].a_type == A_SEMI)
+                {
                     j = -1;
+                }
                 else if(at[i].a_type == A_COMMA)
+                {
                     j = 0;
+                }
                 else if(++j > maxnargs)
+                {
                     maxnargs = j;
+                }
             }
         }
         if(maxnargs <= SMALLMSG)
+        {
             mstack = smallstack;
+        }
         else
+        {
             ATOMS_ALLOCA(mstack, maxnargs);
+        }
 #else
         /* just pessimistically allocate enough to hold everything
         at once.  This turned out to run slower in a simple benchmark
@@ -770,8 +868,9 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                 pd_error(initial_target, "%s: no such object ", s->s_name);
             cleanup:
                 do
+                {
                     at++, ac--;
-                while(ac && at->a_type != A_SEMI);
+                } while(ac && at->a_type != A_SEMI);
                 /* LATER eat args until semicolon and continue */
                 continue;
             }
@@ -815,13 +914,19 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                     break;
                 case A_DOLLAR:
                     if(at->a_w.w_index > 0 && at->a_w.w_index <= argc)
+                    {
                         *msp = argv[at->a_w.w_index - 1];
+                    }
                     else if(at->a_w.w_index == 0)
+                    {
                         SETFLOAT(msp, canvas_getdollarzero());
+                    }
                     else
                     {
                         if(target == &pd_objectmaker)
+                        {
                             SETFLOAT(msp, 0);
+                        }
                         else
                         {
                             pd_error(target,
@@ -863,15 +968,23 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
                     break;
                 case A_FLOAT:
                     if(nargs == 1)
+                    {
                         pd_float(target, mstack->a_w.w_float);
+                    }
                     else
+                    {
                         pd_list(target, 0, nargs, mstack);
+                    }
                     break;
                 case A_POINTER:
                     if(nargs == 1)
+                    {
                         pd_pointer(target, mstack->a_w.w_gpointer);
+                    }
                     else
+                    {
                         pd_list(target, 0, nargs, mstack);
+                    }
                     break;
                 default:
                     bug("bad selector");
@@ -898,9 +1011,13 @@ int binbuf_read(
     char namebuf[MAXPDSTRING];
 
     if(*dirname)
+    {
         snprintf(namebuf, MAXPDSTRING - 1, "%s/%s", dirname, filename);
+    }
     else
+    {
         snprintf(namebuf, MAXPDSTRING - 1, "%s", filename);
+    }
     namebuf[MAXPDSTRING - 1] = 0;
 
     if((fd = sys_open(namebuf, 0)) < 0)
@@ -1001,9 +1118,13 @@ int binbuf_write(
     int ncolumn = 0;
 
     if(*dir)
+    {
         snprintf(fbuf, MAXPDSTRING - 1, "%s/%s", dir, filename);
+    }
     else
+    {
         snprintf(fbuf, MAXPDSTRING - 1, "%s", filename);
+    }
     fbuf[MAXPDSTRING - 1] = 0;
 
     if(!strcmp(filename + strlen(filename) - 4, ".pat") ||
@@ -1020,9 +1141,13 @@ int binbuf_write(
         /* estimate how many characters will be needed.  Printing out
         symbols may need extra characters for inserting backslashes. */
         if(ap->a_type == A_SYMBOL || ap->a_type == A_DOLLSYM)
+        {
             length = 80 + (int) strlen(ap->a_w.w_symbol->s_name);
+        }
         else
+        {
             length = 40;
+        }
         if(ep - bp < length)
         {
             if(fwrite(sbuf, bp - sbuf, 1, f) < 1) goto fail;
@@ -1181,9 +1306,11 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                         classname == gensym("t"))
                     {
                         for(i = 7; i < natom; i++)
+                        {
                             if(nextmess[i].a_type == A_SYMBOL &&
                                 nextmess[i].a_w.w_symbol == gensym("i"))
                                 nextmess[i].a_w.w_symbol = gensym("f");
+                        }
                     }
                     if(classname == gensym("table"))
                         classname = gensym("TABLE");
@@ -1303,10 +1430,12 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                             -262144., -1., -1., 0., 1.);
                     }
                     else
+                    {
                         binbuf_addv(newb, "ssffs;", gensym("#X"), gensym("obj"),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(4, natom, nextmess),
                             atom_getsymbolarg(2, natom, nextmess));
+                    }
                     nobj++;
                 }
                 else if(!strcmp(second, "connect") || !strcmp(second, "fasten"))
@@ -1375,42 +1504,55 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                 {
                     t_symbol *classname = atom_getsymbolarg(4, natom, nextmess);
                     if(classname == gensym("inlet"))
+                    {
                         binbuf_addv(newb, "ssfff;", gensym("#P"),
                             gensym("inlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize);
+                    }
                     else if(classname == gensym("inlet~"))
+                    {
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("inlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize, 1.);
+                    }
                     else if(classname == gensym("outlet"))
+                    {
                         binbuf_addv(newb, "ssfff;", gensym("#P"),
                             gensym("outlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize);
+                    }
                     else if(classname == gensym("outlet~"))
+                    {
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("outlet"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             10. + fontsize, 1.);
+                    }
                     else if(classname == gensym("bng"))
+                    {
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("button"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(5, natom, nextmess), 0.);
+                    }
                     else if(classname == gensym("tgl"))
+                    {
                         binbuf_addv(newb, "ssffff;", gensym("#P"),
                             gensym("toggle"),
                             atom_getfloatarg(2, natom, nextmess),
                             atom_getfloatarg(3, natom, nextmess),
                             atom_getfloatarg(5, natom, nextmess), 0.);
+                    }
                     else if(classname == gensym("vsl"))
+                    {
                         binbuf_addv(newb, "ssffffff;", gensym("#P"),
                             gensym("slider"),
                             atom_getfloatarg(2, natom, nextmess),
@@ -1424,6 +1566,7 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                                         : atom_getfloatarg(6, natom, nextmess) -
                                               1),
                             atom_getfloatarg(7, natom, nextmess));
+                    }
                     else if(classname == gensym("hsl"))
                     {
                         t_float slmin = atom_getfloatarg(7, natom, nextmess);
@@ -1454,19 +1597,33 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
                         {
                             arg = atom_getsymbolarg(i, natom, nextmess);
                             if(arg == gensym("a"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
+                            }
                             else if(arg == gensym("anything"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
+                            }
                             else if(arg == gensym("bang"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("b"));
+                            }
                             else if(arg == gensym("float"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("f"));
+                            }
                             else if(arg == gensym("list"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("l"));
+                            }
                             else if(arg == gensym("symbol"))
+                            {
                                 SETSYMBOL(outmess + i + 2, gensym("s"));
+                            }
                             else
+                            {
                                 outmess[i + 2] = nextmess[i];
+                            }
                         }
                         SETSEMI(outmess + natom + 2);
                         binbuf_add(newb, natom + 3, outmess);
@@ -1545,7 +1702,9 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
     /* set filename so that new canvases can pick them up */
     glob_setfilename(0, name, dir);
     if(binbuf_read(b, name->s_name, dir->s_name, 0))
+    {
         pd_error(0, "%s: read failed; %s", name->s_name, strerror(errno));
+    }
     else
     {
         /* save bindings of symbols #N, #A (and restore afterward) */
@@ -1585,7 +1744,9 @@ void binbuf_savetext(const t_binbuf *bfrom, t_binbuf *bto)
                 !strchr(ap[k].a_w.w_symbol->s_name, ';') &&
                 !strchr(ap[k].a_w.w_symbol->s_name, ',') &&
                 !strchr(ap[k].a_w.w_symbol->s_name, '$')))
+        {
             binbuf_add(bto, 1, &ap[k]);
+        }
         else
         {
             char buf[MAXPDSTRING + 1];

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -572,10 +572,9 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
 
 void binbuf_print(const t_binbuf *x)
 {
-    int i;
     int startedpost = 0;
     int newline = 1;
-    for(i = 0; i < x->b_n; i++)
+    for(int i = 0; i < x->b_n; i++)
     {
         if(newline)
         {
@@ -786,9 +785,8 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
         }
         else
         {
-            int i;
             int j = (target ? 0 : -1);
-            for(i = 0; i < ac; i++)
+            for(int i = 0; i < ac; i++)
             {
                 if(at[i].a_type == A_SEMI)
                 {
@@ -1045,8 +1043,7 @@ int binbuf_read(
     /* optionally map carriage return to semicolon */
     if(crflag)
     {
-        int i;
-        for(i = 0; i < length; i++)
+        for(int i = 0; i < length; i++)
             if(buf[i] == '\n') buf[i] = ';';
     }
     binbuf_text(b, buf, length);
@@ -1240,7 +1237,7 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
             /* case 1: importing a ".pat" file into Pd. */
 
             /* dollar signs in file translate to symbols */
-            for(i = 0; i < natom; i++)
+            for(int i = 0; i < natom; i++)
             {
                 if(nextmess[i].a_type == A_DOLLAR)
                 {

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -60,10 +60,14 @@ void binbuf_clear(t_binbuf *x)
 /* convert text to a binbuf */
 void binbuf_text(t_binbuf *x, const char *text, size_t size)
 {
-    char buf[MAXPDSTRING + 1], *bufp, *ebuf = buf + MAXPDSTRING;
-    const char *textp = text, *etext = text + size;
+    char buf[MAXPDSTRING + 1];
+    char *bufp;
+    char *ebuf = buf + MAXPDSTRING;
+    const char *textp = text;
+    const char *etext = text + size;
     t_atom *ap;
-    int nalloc = 16, natom = 0;
+    int nalloc = 16;
+    int natom = 0;
     binbuf_clear(x);
     if(!binbuf_resize(x, nalloc)) return;
     ap = x->b_vec;
@@ -83,7 +87,10 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
         {
             /* it's an atom other than a comma or semi */
             char c;
-            int floatstate = 0, slash = 0, lastslash = 0, dollar = 0;
+            int floatstate = 0;
+            int slash = 0;
+            int lastslash = 0;
+            int dollar = 0;
             bufp = buf;
             do
             {
@@ -93,9 +100,11 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
 
                 if(floatstate >= 0)
                 {
-                    int digit = (c >= '0' && c <= '9'), dot = (c == '.'),
-                        minus = (c == '-'), plusminus = (minus || (c == '+')),
-                        expon = (c == 'e' || c == 'E');
+                    int digit = (c >= '0' && c <= '9');
+                    int dot = (c == '.');
+                    int minus = (c == '-');
+                    int plusminus = (minus || (c == '+'));
+                    int expon = (c == 'e' || c == 'E');
                     if(floatstate == 0) /* beginning */
                     {
                         if(minus)
@@ -224,7 +233,8 @@ void binbuf_text(t_binbuf *x, const char *text, size_t size)
 /* convert a binbuf to text; no null termination. */
 void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp)
 {
-    char *buf = getbytes(0), *newbuf;
+    char *buf = getbytes(0);
+    char *newbuf;
     int length = 0;
     char string[MAXPDSTRING];
     const t_atom *ap;
@@ -265,7 +275,8 @@ writing to file doesn't buffer everything together. */
 void binbuf_add(t_binbuf *x, int argc, const t_atom *argv)
 {
     int previoussize = x->b_n;
-    int newsize = previoussize + argc, i;
+    int newsize = previoussize + argc;
+    int i;
     t_atom *ap;
 
     if(!binbuf_resize(x, newsize))
@@ -287,7 +298,8 @@ void binbuf_add(t_binbuf *x, int argc, const t_atom *argv)
 void binbuf_addv(t_binbuf *x, const char *fmt, ...)
 {
     va_list ap;
-    t_atom arg[MAXADDMESSV], *at = arg;
+    t_atom arg[MAXADDMESSV];
+    t_atom *at = arg;
     int nargs = 0;
     const char *fp = fmt;
 
@@ -334,7 +346,8 @@ escaped.  LATER also figure out about escaping white space */
 void binbuf_addbinbuf(t_binbuf *x, const t_binbuf *y)
 {
     t_binbuf *z = binbuf_new();
-    int i, fixit;
+    int i;
+    int fixit;
     t_atom *ap;
     binbuf_add(z, y->b_n, y->b_vec);
     for(i = 0, ap = z->b_vec; i < z->b_n; i++, ap++)
@@ -391,7 +404,8 @@ from binbuf_addbinbuf.  The symbol ";" goes to a semicolon, etc. */
 void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
 {
     int previoussize = x->b_n;
-    int newsize = previoussize + argc, i;
+    int newsize = previoussize + argc;
+    int i;
     t_atom *ap;
 
     if(!binbuf_resize(x, newsize))
@@ -404,15 +418,18 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
     {
         if(argv->a_type == A_SYMBOL)
         {
-            const char *str = argv->a_w.w_symbol->s_name, *str2;
+            const char *str = argv->a_w.w_symbol->s_name;
+            const char *str2;
             if(!strcmp(str, ";"))
                 SETSEMI(ap);
             else if(!strcmp(str, ","))
                 SETCOMMA(ap);
             else
             {
-                char buf[MAXPDSTRING], *sp1;
-                const char *sp2, *usestr;
+                char buf[MAXPDSTRING];
+                char *sp1;
+                const char *sp2;
+                const char *usestr;
                 int dollar = 0;
                 if(strchr(str, '\\'))
                 {
@@ -475,7 +492,9 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
 
 void binbuf_print(const t_binbuf *x)
 {
-    int i, startedpost = 0, newline = 1;
+    int i;
+    int startedpost = 0;
+    int newline = 1;
     for(i = 0; i < x->b_n; i++)
     {
         if(newline)
@@ -654,10 +673,13 @@ done:
 
 void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
 {
-    t_atom smallstack[SMALLMSG], *mstack, *msp;
+    t_atom smallstack[SMALLMSG];
+    t_atom *mstack;
+    t_atom *msp;
     const t_atom *at = x->b_vec;
     int ac = x->b_n;
-    int nargs, maxnargs = 0;
+    int nargs;
+    int maxnargs = 0;
     t_pd *initial_target = target;
 
     if(ac <= SMALLMSG)
@@ -676,7 +698,8 @@ void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv)
             maxnargs = ac;
         else
         {
-            int i, j = (target ? 0 : -1);
+            int i;
+            int j = (target ? 0 : -1);
             for(i = 0; i < ac; i++)
             {
                 if(at[i].a_type == A_SEMI)
@@ -927,7 +950,8 @@ int binbuf_read_via_canvas(
     t_binbuf *b, const char *filename, const t_canvas *canvas, int crflag)
 {
     int filedesc;
-    char buf[MAXPDSTRING], *bufptr;
+    char buf[MAXPDSTRING];
+    char *bufptr;
     if((filedesc = canvas_open(
             canvas, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
     {
@@ -947,7 +971,8 @@ int binbuf_read_via_path(
     t_binbuf *b, const char *filename, const char *dirname, int crflag)
 {
     int filedesc;
-    char buf[MAXPDSTRING], *bufptr;
+    char buf[MAXPDSTRING];
+    char *bufptr;
     if((filedesc = open_via_path(
             dirname, filename, "", buf, &bufptr, MAXPDSTRING, 0)) < 0)
     {
@@ -971,7 +996,10 @@ int binbuf_write(
     const t_binbuf *x, const char *filename, const char *dir, int crflag)
 {
     FILE *f = 0;
-    char sbuf[WBUFSIZE], fbuf[MAXPDSTRING], *bp = sbuf, *ep = sbuf + WBUFSIZE;
+    char sbuf[WBUFSIZE];
+    char fbuf[MAXPDSTRING];
+    char *bp = sbuf;
+    char *ep = sbuf + WBUFSIZE;
     t_atom *ap;
     t_binbuf *y = 0;
     const t_binbuf *z = x;
@@ -1054,16 +1082,24 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
 {
     t_binbuf *newb = binbuf_new();
     t_atom *vec = oldb->b_vec;
-    t_int n = oldb->b_n, nextindex, stackdepth = 0, stack[MAXSTACK] = {0},
-          nobj = 0, gotfontsize = 0;
+    t_int n = oldb->b_n;
+    t_int nextindex;
+    t_int stackdepth = 0;
+    t_int stack[MAXSTACK] = {0};
+    t_int nobj = 0;
+    t_int gotfontsize = 0;
     int i;
-    t_atom outmess[MAXSTACK], *nextmess;
+    t_atom outmess[MAXSTACK];
+    t_atom *nextmess;
     t_float fontsize = 10;
     if(!maxtopd) binbuf_addv(newb, "ss;", gensym("max"), gensym("v2"));
     for(nextindex = 0; nextindex < n;)
     {
-        int endmess, natom;
-        const char *first, *second, *third;
+        int endmess;
+        int natom;
+        const char *first;
+        const char *second;
+        const char *third;
         for(endmess = (int) nextindex;
             endmess < n && vec[endmess].a_type != A_SEMI; endmess++)
             ;
@@ -1296,7 +1332,8 @@ static t_binbuf *binbuf_convert(const t_binbuf *oldb, int maxtopd)
             {
                 if(!strcmp(second, "canvas"))
                 {
-                    t_float x, y;
+                    t_float x;
+                    t_float y;
                     if(stackdepth >= MAXSTACK)
                     {
                         pd_error(0,
@@ -1518,7 +1555,8 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
     else
     {
         /* save bindings of symbols #N, #A (and restore afterward) */
-        t_pd *bounda = gensym("#A")->s_thing, *boundn = s__N.s_thing;
+        t_pd *bounda = gensym("#A")->s_thing;
+        t_pd *boundn = s__N.s_thing;
         gensym("#A")->s_thing = 0;
         s__N.s_thing = &pd_canvasmaker;
         if(import)
@@ -1542,7 +1580,8 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
 /* save a text object to a binbuf for a file or copy buf */
 void binbuf_savetext(const t_binbuf *bfrom, t_binbuf *bto)
 {
-    int k, n = binbuf_getnatom(bfrom);
+    int k;
+    int n = binbuf_getnatom(bfrom);
     const t_atom *ap = binbuf_getvec(bfrom);
     t_atom at;
     for(k = 0; k < n; k++)

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -424,8 +424,10 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     size_t size, int flags, t_atomtype type1, ...)
 {
     va_list ap;
-    t_atomtype vec[MAXPDARG + 1], *vp = vec;
-    int count = 0, i;
+    t_atomtype vec[MAXPDARG + 1];
+    t_atomtype *vp = vec;
+    int count = 0;
+    int i;
     t_class *c;
     int typeflag = flags & CLASS_TYPEMASK;
     if(!typeflag) typeflag = CLASS_PATCHABLE;
@@ -464,7 +466,8 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
             longer file name; in this case, make this an admissible name
             too. */
             const char *loadstring = class_loadsym->s_name;
-            size_t l1 = strlen(s->s_name), l2 = strlen(loadstring);
+            size_t l1 = strlen(s->s_name);
+            size_t l2 = strlen(loadstring);
             if(l2 > l1 && !strcmp(s->s_name, loadstring + (l2 - l1)))
                 class_addmethod(pd_objectmaker, (t_method) newmethod,
                     class_loadsym, vec[0], vec[1], vec[2], vec[3], vec[4],
@@ -552,7 +555,8 @@ called back (and the new method explicitly takes care of this.) */
 void class_addcreator(t_newmethod newmethod, t_symbol *s, t_atomtype type1, ...)
 {
     va_list ap;
-    t_atomtype vec[MAXPDARG + 1], *vp = vec;
+    t_atomtype vec[MAXPDARG + 1];
+    t_atomtype *vp = vec;
     int count = 0;
     *vp = type1;
 
@@ -584,7 +588,8 @@ void class_addmethod(
 {
     va_list ap;
     t_atomtype argtype = arg1;
-    int nargs, i;
+    int nargs;
+    int i;
     if(!c) return;
     va_start(ap, arg1);
     /* "signal" method specifies that we take audio signals but
@@ -813,7 +818,8 @@ static t_symbol *dogensym(
     const char *s, t_symbol *oldsym, t_pdinstance *pdinstance)
 {
     char *symname = 0;
-    t_symbol **symhashloc, *sym2;
+    t_symbol **symhashloc;
+    t_symbol *sym2;
     unsigned int hash = 5381;
     int length = 0;
     const char *s2 = s;
@@ -868,7 +874,9 @@ doesn't know.  Pd tries to load it as an extern, then as an abstraction. */
 void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int fd;
-    char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
+    char dirbuf[MAXPDSTRING];
+    char classslashclass[MAXPDSTRING];
+    char *nameptr;
     if(tryingalready > MAXOBJDEPTH)
     {
         pd_error(0, "maximum object loading depth %d reached", MAXOBJDEPTH);
@@ -922,11 +930,15 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_method *f;
     t_class *c = *x;
-    t_methodentry *m, *mlist;
-    unsigned char *wp, wanttype;
+    t_methodentry *m;
+    t_methodentry *mlist;
+    unsigned char *wp;
+    unsigned char wanttype;
     int i;
-    t_int ai[MAXPDARG + 1], *ap = ai;
-    t_floatarg ad[MAXPDARG + 1], *dp = ad;
+    t_int ai[MAXPDARG + 1];
+    t_int *ap = ai;
+    t_floatarg ad[MAXPDARG + 1];
+    t_floatarg *dp = ad;
     int narg = 0;
     t_pd *bonzo;
 
@@ -1103,7 +1115,8 @@ longer messages are likely to be programmatically generated anyway. */
 void pd_vmess(t_pd *x, t_symbol *sel, const char *fmt, ...)
 {
     va_list ap;
-    t_atom arg[10], *at = arg;
+    t_atom arg[10];
+    t_atom *at = arg;
     int nargs = 0;
     const char *fp = fmt;
 
@@ -1171,7 +1184,8 @@ void nullfn(void) {}
 t_gotfn getfn(const t_pd *x, t_symbol *s)
 {
     const t_class *c = *x;
-    t_methodentry *m, *mlist;
+    t_methodentry *m;
+    t_methodentry *mlist;
     int i;
 
 #ifdef PDINSTANCE
@@ -1188,7 +1202,8 @@ t_gotfn getfn(const t_pd *x, t_symbol *s)
 t_gotfn zgetfn(const t_pd *x, t_symbol *s)
 {
     const t_class *c = *x;
-    t_methodentry *m, *mlist;
+    t_methodentry *m;
+    t_methodentry *mlist;
     int i;
 
 #ifdef PDINSTANCE

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -377,8 +377,8 @@ static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv)
             (*(*x)->c_floatmethod)(x, argv->a_w.w_float);
             return;
         }
-        else if(argv->a_type == A_SYMBOL &&
-                *(*x)->c_symbolmethod != pd_defaultsymbol)
+        if(argv->a_type == A_SYMBOL &&
+            *(*x)->c_symbolmethod != pd_defaultsymbol)
         {
             (*(*x)->c_symbolmethod)(x, argv->a_w.w_symbol);
             return;

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #define PD_CLASS_DEF
 #include "m_pd.h"
@@ -19,15 +19,15 @@
 #include <string.h>
 #include <stdio.h>
 
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
+#ifdef _MSC_VER /* This is only for Microsoft's compiler, not cygwin, e.g. */
 #define snprintf _snprintf
 #endif
 
-static t_symbol *class_loadsym;     /* name under which an extern is invoked */
+static t_symbol *class_loadsym; /* name under which an extern is invoked */
 static void pd_defaultfloat(t_pd *x, t_float f);
 static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv);
-t_pd pd_objectmaker;    /* factory for creating "object" boxes */
-t_pd pd_canvasmaker;    /* factory for creating canvases */
+t_pd pd_objectmaker; /* factory for creating "object" boxes */
+t_pd pd_canvasmaker; /* factory for creating canvases */
 
 static t_symbol *class_extern_dir;
 
@@ -37,38 +37,35 @@ PERTHREAD t_pdinstance *pd_this = NULL;
 t_pdinstance **pd_instances;
 int pd_ninstances;
 #else
-t_symbol s_pointer, s_float, s_symbol, s_bang, s_list, s_anything,
-   s_signal, s__N, s__X, s_x, s_y, s_;
+t_symbol s_pointer, s_float, s_symbol, s_bang, s_list, s_anything, s_signal,
+    s__N, s__X, s_x, s_y, s_;
 #endif
 t_pdinstance pd_maininstance;
 
-static t_symbol *dogensym(const char *s, t_symbol *oldsym,
-    t_pdinstance *pdinstance);
-void x_midi_newpdinstance( void);
-void x_midi_freepdinstance( void);
-void s_inter_newpdinstance( void);
+static t_symbol *dogensym(
+    const char *s, t_symbol *oldsym, t_pdinstance *pdinstance);
+void x_midi_newpdinstance(void);
+void x_midi_freepdinstance(void);
+void s_inter_newpdinstance(void);
 void s_inter_free(t_instanceinter *inter);
-void g_canvas_newpdinstance( void);
-void g_canvas_freepdinstance( void);
-void d_ugen_newpdinstance( void);
-void d_ugen_freepdinstance( void);
+void g_canvas_newpdinstance(void);
+void g_canvas_freepdinstance(void);
+void d_ugen_newpdinstance(void);
+void d_ugen_freepdinstance(void);
 void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv);
 
 void s_stuff_newpdinstance(void)
 {
     STUFF = getbytes(sizeof(*STUFF));
-    STUFF->st_externlist = STUFF->st_searchpath =
-        STUFF->st_staticpath = STUFF->st_helppath = STUFF->st_temppath = 0;
+    STUFF->st_externlist = STUFF->st_searchpath = STUFF->st_staticpath =
+        STUFF->st_helppath = STUFF->st_temppath = 0;
     STUFF->st_schedblocksize = STUFF->st_blocksize = DEFDACBLKSIZE;
     STUFF->st_dacsr = DEFDACSAMPLERATE;
     STUFF->st_printhook = sys_printhook;
     STUFF->st_impdata = NULL;
 }
 
-void s_stuff_freepdinstance(void)
-{
-    freebytes(STUFF, sizeof(*STUFF));
-}
+void s_stuff_freepdinstance(void) { freebytes(STUFF, sizeof(*STUFF)); }
 
 static t_pdinstance *pdinstance_init(t_pdinstance *x)
 {
@@ -78,35 +75,35 @@ static t_pdinstance *pdinstance_init(t_pdinstance *x)
     x->pd_canvaslist = 0;
     x->pd_templatelist = 0;
     x->pd_symhash = getbytes(SYMTABHASHSIZE * sizeof(*x->pd_symhash));
-    for (i = 0; i < SYMTABHASHSIZE; i++)
+    for(i = 0; i < SYMTABHASHSIZE; i++)
         x->pd_symhash[i] = 0;
 #ifdef PDINSTANCE
-    dogensym("pointer",   &x->pd_s_pointer,  x);
-    dogensym("float",     &x->pd_s_float,    x);
-    dogensym("symbol",    &x->pd_s_symbol,   x);
-    dogensym("bang",      &x->pd_s_bang,     x);
-    dogensym("list",      &x->pd_s_list,     x);
-    dogensym("anything",  &x->pd_s_anything, x);
-    dogensym("signal",    &x->pd_s_signal,   x);
-    dogensym("#N",        &x->pd_s__N,       x);
-    dogensym("#X",        &x->pd_s__X,       x);
-    dogensym("x",         &x->pd_s_x,        x);
-    dogensym("y",         &x->pd_s_y,        x);
-    dogensym("",          &x->pd_s_,         x);
+    dogensym("pointer", &x->pd_s_pointer, x);
+    dogensym("float", &x->pd_s_float, x);
+    dogensym("symbol", &x->pd_s_symbol, x);
+    dogensym("bang", &x->pd_s_bang, x);
+    dogensym("list", &x->pd_s_list, x);
+    dogensym("anything", &x->pd_s_anything, x);
+    dogensym("signal", &x->pd_s_signal, x);
+    dogensym("#N", &x->pd_s__N, x);
+    dogensym("#X", &x->pd_s__X, x);
+    dogensym("x", &x->pd_s_x, x);
+    dogensym("y", &x->pd_s_y, x);
+    dogensym("", &x->pd_s_, x);
     pd_this = x;
 #else
-    dogensym("pointer",   &s_pointer,  x);
-    dogensym("float",     &s_float,    x);
-    dogensym("symbol",    &s_symbol,   x);
-    dogensym("bang",      &s_bang,     x);
-    dogensym("list",      &s_list,     x);
-    dogensym("anything",  &s_anything, x);
-    dogensym("signal",    &s_signal,   x);
-    dogensym("#N",        &s__N,       x);
-    dogensym("#X",        &s__X,       x);
-    dogensym("x",         &s_x,        x);
-    dogensym("y",         &s_y,        x);
-    dogensym("",          &s_,         x);
+    dogensym("pointer", &s_pointer, x);
+    dogensym("float", &s_float, x);
+    dogensym("symbol", &s_symbol, x);
+    dogensym("bang", &s_bang, x);
+    dogensym("list", &s_list, x);
+    dogensym("anything", &s_anything, x);
+    dogensym("signal", &s_signal, x);
+    dogensym("#N", &s__N, x);
+    dogensym("#X", &s__X, x);
+    dogensym("x", &s_x, x);
+    dogensym("y", &s_y, x);
+    dogensym("", &s_, x);
 #endif
     x_midi_newpdinstance();
     g_canvas_newpdinstance();
@@ -117,42 +114,41 @@ static t_pdinstance *pdinstance_init(t_pdinstance *x)
 
 static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
     int nmethod, t_gotfn fn, t_symbol *sel, unsigned char *args,
-        t_pdinstance *pdinstance)
+    t_pdinstance *pdinstance)
 {
     int i;
     t_methodentry *m;
-    for (i = 0; i < nmethod; i++)
-        if (sel && (*methodlist)[i].me_name == sel)
-    {
-        char nbuf[80];
-        snprintf(nbuf, 80, "%s_aliased", sel->s_name);
-        nbuf[79] = 0;
-        (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
-        if (c == pd_objectmaker)
-            logpost(NULL, PD_VERBOSE, "warning: class '%s' overwritten; old one renamed '%s'",
-                sel->s_name, nbuf);
-        else logpost(NULL, PD_VERBOSE, "warning: old method '%s' for class '%s' renamed '%s'",
-            sel->s_name, c->c_name->s_name, nbuf);
-    }
-    (*methodlist) = t_resizebytes((*methodlist),
-        nmethod * sizeof(**methodlist),
+    for(i = 0; i < nmethod; i++)
+        if(sel && (*methodlist)[i].me_name == sel)
+        {
+            char nbuf[80];
+            snprintf(nbuf, 80, "%s_aliased", sel->s_name);
+            nbuf[79] = 0;
+            (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
+            if(c == pd_objectmaker)
+                logpost(NULL, PD_VERBOSE,
+                    "warning: class '%s' overwritten; old one renamed '%s'",
+                    sel->s_name, nbuf);
+            else
+                logpost(NULL, PD_VERBOSE,
+                    "warning: old method '%s' for class '%s' renamed '%s'",
+                    sel->s_name, c->c_name->s_name, nbuf);
+        }
+    (*methodlist) = t_resizebytes((*methodlist), nmethod * sizeof(**methodlist),
         (nmethod + 1) * sizeof(**methodlist));
     m = (*methodlist) + nmethod;
     m->me_name = sel;
-    m->me_fun = (t_gotfn)fn;
-    memcpy(m->me_arg, args, MAXPDARG+1);
+    m->me_fun = (t_gotfn) fn;
+    memcpy(m->me_arg, args, MAXPDARG + 1);
 }
 
 #ifdef PDINSTANCE
-EXTERN void pd_setinstance(t_pdinstance *x)
-{
-    pd_this = x;
-}
+EXTERN void pd_setinstance(t_pdinstance *x) { pd_this = x; }
 
 static void pdinstance_renumber(void)
 {
     int i;
-    for (i = 0; i < pd_ninstances; i++)
+    for(i = 0; i < pd_ninstances; i++)
         pd_instances[i]->pd_instanceno = i;
 }
 
@@ -161,7 +157,7 @@ extern void garray_init(void);
 
 EXTERN t_pdinstance *pdinstance_new(void)
 {
-    t_pdinstance *x = (t_pdinstance *)getbytes(sizeof(t_pdinstance));
+    t_pdinstance *x = (t_pdinstance *) getbytes(sizeof(t_pdinstance));
     t_class *c;
     int i;
     pd_this = x;
@@ -169,21 +165,21 @@ EXTERN t_pdinstance *pdinstance_new(void)
     pdinstance_init(x);
     sys_lock();
     pd_globallock();
-    pd_instances = (t_pdinstance **)resizebytes(pd_instances,
+    pd_instances = (t_pdinstance **) resizebytes(pd_instances,
         pd_ninstances * sizeof(*pd_instances),
-        (pd_ninstances+1) * sizeof(*pd_instances));
+        (pd_ninstances + 1) * sizeof(*pd_instances));
     pd_instances[pd_ninstances] = x;
-    for (c = class_list; c; c = c->c_next)
+    for(c = class_list; c; c = c->c_next)
     {
-        c->c_methods = (t_methodentry **)t_resizebytes(c->c_methods,
+        c->c_methods = (t_methodentry **) t_resizebytes(c->c_methods,
             pd_ninstances * sizeof(*c->c_methods),
             (pd_ninstances + 1) * sizeof(*c->c_methods));
         c->c_methods[pd_ninstances] = t_getbytes(0);
-        for (i = 0; i < c->c_nmethod; i++)
+        for(i = 0; i < c->c_nmethod; i++)
             class_addmethodtolist(c, &c->c_methods[pd_ninstances], i,
                 c->c_methods[0][i].me_fun,
                 dogensym(c->c_methods[0][i].me_name->s_name, 0, x),
-                    c->c_methods[0][i].me_arg, x);
+                c->c_methods[0][i].me_arg, x);
     }
     pd_ninstances++;
     pdinstance_renumber();
@@ -205,76 +201,69 @@ EXTERN void pdinstance_free(t_pdinstance *x)
     pd_setinstance(x);
     sys_lock();
     pd_globallock();
-    
+
     instanceno = x->pd_instanceno;
     inter = x->pd_inter;
     canvas_suspend_dsp();
-    while (x->pd_canvaslist)
-        pd_free((t_pd *)x->pd_canvaslist);
-    while (x->pd_templatelist)
-        pd_free((t_pd *)x->pd_templatelist);
-    for (c = class_list; c; c = c->c_next)
+    while(x->pd_canvaslist)
+        pd_free((t_pd *) x->pd_canvaslist);
+    while(x->pd_templatelist)
+        pd_free((t_pd *) x->pd_templatelist);
+    for(c = class_list; c; c = c->c_next)
     {
         if(c->c_methods[instanceno])
             freebytes(c->c_methods[instanceno],
-                      c->c_nmethod * sizeof(**c->c_methods));
+                c->c_nmethod * sizeof(**c->c_methods));
         c->c_methods[instanceno] = NULL;
-        for (i = instanceno; i < pd_ninstances-1; i++)
-            c->c_methods[i] = c->c_methods[i+1];
-        c->c_methods = (t_methodentry **)t_resizebytes(c->c_methods,
+        for(i = instanceno; i < pd_ninstances - 1; i++)
+            c->c_methods[i] = c->c_methods[i + 1];
+        c->c_methods = (t_methodentry **) t_resizebytes(c->c_methods,
             pd_ninstances * sizeof(*c->c_methods),
             (pd_ninstances - 1) * sizeof(*c->c_methods));
     }
-    for (i =0; i < SYMTABHASHSIZE; i++)
+    for(i = 0; i < SYMTABHASHSIZE; i++)
     {
-        while ((s = x->pd_symhash[i]))
+        while((s = x->pd_symhash[i]))
         {
             x->pd_symhash[i] = s->s_next;
-            if(s != &x->pd_s_pointer &&
-               s != &x->pd_s_float &&
-               s != &x->pd_s_symbol &&
-               s != &x->pd_s_bang &&
-               s != &x->pd_s_list &&
-               s != &x->pd_s_anything &&
-               s != &x->pd_s_signal &&
-               s != &x->pd_s__N &&
-               s != &x->pd_s__X &&
-               s != &x->pd_s_x &&
-               s != &x->pd_s_y &&
-               s != &x->pd_s_)
+            if(s != &x->pd_s_pointer && s != &x->pd_s_float &&
+                s != &x->pd_s_symbol && s != &x->pd_s_bang &&
+                s != &x->pd_s_list && s != &x->pd_s_anything &&
+                s != &x->pd_s_signal && s != &x->pd_s__N && s != &x->pd_s__X &&
+                s != &x->pd_s_x && s != &x->pd_s_y && s != &x->pd_s_)
             {
-                freebytes((void *)s->s_name, strlen(s->s_name)+1);
+                freebytes((void *) s->s_name, strlen(s->s_name) + 1);
                 freebytes(s, sizeof(*s));
             }
         }
     }
-    freebytes(x->pd_symhash, SYMTABHASHSIZE * sizeof (*x->pd_symhash));
+    freebytes(x->pd_symhash, SYMTABHASHSIZE * sizeof(*x->pd_symhash));
     x_midi_freepdinstance();
     g_canvas_freepdinstance();
     d_ugen_freepdinstance();
     s_stuff_freepdinstance();
-    for (i = instanceno; i < pd_ninstances-1; i++)
-        pd_instances[i] = pd_instances[i+1];
-    pd_instances = (t_pdinstance **)resizebytes(pd_instances,
+    for(i = instanceno; i < pd_ninstances - 1; i++)
+        pd_instances[i] = pd_instances[i + 1];
+    pd_instances = (t_pdinstance **) resizebytes(pd_instances,
         pd_ninstances * sizeof(*pd_instances),
-        (pd_ninstances-1) * sizeof(*pd_instances));
+        (pd_ninstances - 1) * sizeof(*pd_instances));
     pd_ninstances--;
     pdinstance_renumber();
     pd_globalunlock();
     sys_unlock();
     pd_setinstance(&pd_maininstance);
-    s_inter_free(inter);  /* must happen after sys_unlock() */
+    s_inter_free(inter); /* must happen after sys_unlock() */
 }
 
 #endif /* PDINSTANCE */
 
 /* this bootstraps the class management system (pd_objectmaker, pd_canvasmaker)
- * it has been moved from the bottom of the file up here, before the class_new() undefine
+ * it has been moved from the bottom of the file up here, before the class_new()
+ * undefine
  */
 void mess_init(void)
 {
-    if (pd_objectmaker)
-        return;
+    if(pd_objectmaker) return;
 #ifdef PDINSTANCE
     pd_this = &pd_maininstance;
 #endif
@@ -283,11 +272,11 @@ void mess_init(void)
     pd_globallock();
     pdinstance_init(&pd_maininstance);
     class_extern_dir = &s_;
-    pd_objectmaker = class_new(gensym("objectmaker"), 0, 0, sizeof(t_pd),
-        CLASS_DEFAULT, A_NULL);
-    pd_canvasmaker = class_new(gensym("canvasmaker"), 0, 0, sizeof(t_pd),
-        CLASS_DEFAULT, A_NULL);
-    class_addanything(pd_objectmaker, (t_method)new_anything);
+    pd_objectmaker = class_new(
+        gensym("objectmaker"), 0, 0, sizeof(t_pd), CLASS_DEFAULT, A_NULL);
+    pd_canvasmaker = class_new(
+        gensym("canvasmaker"), 0, 0, sizeof(t_pd), CLASS_DEFAULT, A_NULL);
+    class_addanything(pd_objectmaker, (t_method) new_anything);
     pd_globalunlock();
     sys_unlock();
 }
@@ -299,26 +288,28 @@ static void pd_defaultanything(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 
 static void pd_defaultbang(t_pd *x)
 {
-    if (*(*x)->c_listmethod != pd_defaultlist)
+    if(*(*x)->c_listmethod != pd_defaultlist)
         (*(*x)->c_listmethod)(x, 0, 0, 0);
-    else (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
+    else
+        (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
 }
 
-    /* am empty list calls the 'bang' method unless it's the default
-    bang method -- that might turn around and call our 'list' method
-    which could be an infinite recorsion.  Fall through to calling our
-    'anything' method.  That had better not turn around and call us with
-    an empty list.  */
+/* am empty list calls the 'bang' method unless it's the default
+bang method -- that might turn around and call our 'list' method
+which could be an infinite recorsion.  Fall through to calling our
+'anything' method.  That had better not turn around and call us with
+an empty list.  */
 void pd_emptylist(t_pd *x)
 {
-    if (*(*x)->c_bangmethod != pd_defaultbang)
+    if(*(*x)->c_bangmethod != pd_defaultbang)
         (*(*x)->c_bangmethod)(x);
-    else (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
+    else
+        (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
 }
 
 static void pd_defaultpointer(t_pd *x, t_gpointer *gp)
 {
-    if (*(*x)->c_listmethod != pd_defaultlist)
+    if(*(*x)->c_listmethod != pd_defaultlist)
     {
         t_atom at;
         SETPOINTER(&at, gp);
@@ -334,7 +325,7 @@ static void pd_defaultpointer(t_pd *x, t_gpointer *gp)
 
 static void pd_defaultfloat(t_pd *x, t_float f)
 {
-    if (*(*x)->c_listmethod != pd_defaultlist)
+    if(*(*x)->c_listmethod != pd_defaultlist)
     {
         t_atom at;
         SETFLOAT(&at, f);
@@ -350,7 +341,7 @@ static void pd_defaultfloat(t_pd *x, t_float f)
 
 static void pd_defaultsymbol(t_pd *x, t_symbol *s)
 {
-    if (*(*x)->c_listmethod != pd_defaultlist)
+    if(*(*x)->c_listmethod != pd_defaultlist)
     {
         t_atom at;
         SETSYMBOL(&at, s);
@@ -367,65 +358,65 @@ static void pd_defaultsymbol(t_pd *x, t_symbol *s)
 void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv);
 static void class_nosavefn(t_gobj *z, t_binbuf *b);
 
-    /* handle "list" messages to Pds without explicit list methods defined. */
+/* handle "list" messages to Pds without explicit list methods defined. */
 static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
-            /* a list with no elements is handled by the 'bang' method if
-            one exists. */
-    if (argc == 0 && *(*x)->c_bangmethod != pd_defaultbang)
+    /* a list with no elements is handled by the 'bang' method if
+    one exists. */
+    if(argc == 0 && *(*x)->c_bangmethod != pd_defaultbang)
     {
         (*(*x)->c_bangmethod)(x);
         return;
     }
-            /* a list with one element which is a number can be handled by a
-            "float" method if any is defined; same for "symbol", "pointer". */
-    if (argc == 1)
+    /* a list with one element which is a number can be handled by a
+    "float" method if any is defined; same for "symbol", "pointer". */
+    if(argc == 1)
     {
-        if (argv->a_type == A_FLOAT &&
-        *(*x)->c_floatmethod != pd_defaultfloat)
+        if(argv->a_type == A_FLOAT && *(*x)->c_floatmethod != pd_defaultfloat)
         {
             (*(*x)->c_floatmethod)(x, argv->a_w.w_float);
             return;
         }
-        else if (argv->a_type == A_SYMBOL &&
-            *(*x)->c_symbolmethod != pd_defaultsymbol)
+        else if(argv->a_type == A_SYMBOL &&
+                *(*x)->c_symbolmethod != pd_defaultsymbol)
         {
             (*(*x)->c_symbolmethod)(x, argv->a_w.w_symbol);
             return;
         }
-        else if (argv->a_type == A_POINTER &&
-            *(*x)->c_pointermethod != pd_defaultpointer)
+        else if(argv->a_type == A_POINTER &&
+                *(*x)->c_pointermethod != pd_defaultpointer)
         {
             (*(*x)->c_pointermethod)(x, argv->a_w.w_gpointer);
             return;
         }
     }
-        /* Next try for an "anything" method */
-    if ((*x)->c_anymethod != pd_defaultanything)
+    /* Next try for an "anything" method */
+    if((*x)->c_anymethod != pd_defaultanything)
         (*(*x)->c_anymethod)(x, &s_list, argc, argv);
 
-        /* if the object is patchable (i.e., can have proper inlets)
-            send it on to obj_list which will unpack the list into the inlets */
-    else if ((*x)->c_patchable)
-        obj_list((t_object *)x, s, argc, argv);
-            /* otherwise gove up and complain. */
-    else pd_defaultanything(x, &s_list, argc, argv);
+    /* if the object is patchable (i.e., can have proper inlets)
+        send it on to obj_list which will unpack the list into the inlets */
+    else if((*x)->c_patchable)
+        obj_list((t_object *) x, s, argc, argv);
+    /* otherwise gove up and complain. */
+    else
+        pd_defaultanything(x, &s_list, argc, argv);
 }
 
-    /* for now we assume that all "gobjs" are text unless explicitly
-    overridden later by calling class_setbehavior().  I'm not sure
-    how to deal with Pds that aren't gobjs; shouldn't there be a
-    way to check that at run time?  Perhaps the presence of a "newmethod"
-    should be our cue, or perhaps the "tiny" flag.  */
+/* for now we assume that all "gobjs" are text unless explicitly
+overridden later by calling class_setbehavior().  I'm not sure
+how to deal with Pds that aren't gobjs; shouldn't there be a
+way to check that at run time?  Perhaps the presence of a "newmethod"
+should be our cue, or perhaps the "tiny" flag.  */
 
-    /* another matter.  This routine does two unrelated things: it creates
-    a Pd class, but also adds a "new" method to create an instance of it.
-    These are combined for historical reasons and for brevity in writing
-    objects.  To avoid adding a "new" method send a null function pointer.
-    To add additional ones, use class_addcreator below.  Some "classes", like
-    "select", are actually two classes of the same name, one for the single-
-    argument form, one for the multiple one; see select_setup() to find out
-    how this is handled.  */
+/* another matter.  This routine does two unrelated things: it creates
+a Pd class, but also adds a "new" method to create an instance of it.
+These are combined for historical reasons and for brevity in writing
+objects.  To avoid adding a "new" method send a null function pointer.
+To add additional ones, use class_addcreator below.  Some "classes", like
+"select", are actually two classes of the same name, one for the single-
+argument form, one for the multiple one; see select_setup() to find out
+how this is handled.  */
 
 extern void text_save(t_gobj *z, t_binbuf *b);
 
@@ -433,24 +424,27 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     size_t size, int flags, t_atomtype type1, ...)
 {
     va_list ap;
-    t_atomtype vec[MAXPDARG+1], *vp = vec;
+    t_atomtype vec[MAXPDARG + 1], *vp = vec;
     int count = 0, i;
     t_class *c;
     int typeflag = flags & CLASS_TYPEMASK;
-    if (!typeflag) typeflag = CLASS_PATCHABLE;
+    if(!typeflag) typeflag = CLASS_PATCHABLE;
     *vp = type1;
 
     va_start(ap, type1);
-    while (*vp)
+    while(*vp)
     {
-        if (count == MAXPDARG)
+        if(count == MAXPDARG)
         {
-            if (s)
-                pd_error(0, "class %s: sorry: only %d args typechecked; use A_GIMME",
-                      s->s_name, MAXPDARG);
+            if(s)
+                pd_error(0,
+                    "class %s: sorry: only %d args typechecked; use A_GIMME",
+                    s->s_name, MAXPDARG);
             else
-                pd_error(0, "unnamed class: sorry: only %d args typechecked; use A_GIMME",
-                      MAXPDARG);
+                pd_error(0,
+                    "unnamed class: sorry: only %d args typechecked; use "
+                    "A_GIMME",
+                    MAXPDARG);
             break;
         }
         vp++;
@@ -459,29 +453,29 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     }
     va_end(ap);
 
-    if (pd_objectmaker && newmethod)
+    if(pd_objectmaker && newmethod)
     {
-            /* add a "new" method by the name specified by the object */
-        class_addmethod(pd_objectmaker, (t_method)newmethod, s,
-            vec[0], vec[1], vec[2], vec[3], vec[4], vec[5]);
-        if (s && class_loadsym && !zgetfn(&pd_objectmaker, class_loadsym))
+        /* add a "new" method by the name specified by the object */
+        class_addmethod(pd_objectmaker, (t_method) newmethod, s, vec[0], vec[1],
+            vec[2], vec[3], vec[4], vec[5]);
+        if(s && class_loadsym && !zgetfn(&pd_objectmaker, class_loadsym))
         {
-                /* if we're loading an extern it might have been invoked by a
-                longer file name; in this case, make this an admissible name
-                too. */
+            /* if we're loading an extern it might have been invoked by a
+            longer file name; in this case, make this an admissible name
+            too. */
             const char *loadstring = class_loadsym->s_name;
             size_t l1 = strlen(s->s_name), l2 = strlen(loadstring);
-            if (l2 > l1 && !strcmp(s->s_name, loadstring + (l2 - l1)))
-                class_addmethod(pd_objectmaker, (t_method)newmethod,
-                    class_loadsym,
-                    vec[0], vec[1], vec[2], vec[3], vec[4], vec[5]);
+            if(l2 > l1 && !strcmp(s->s_name, loadstring + (l2 - l1)))
+                class_addmethod(pd_objectmaker, (t_method) newmethod,
+                    class_loadsym, vec[0], vec[1], vec[2], vec[3], vec[4],
+                    vec[5]);
         }
     }
-    c = (t_class *)t_getbytes(sizeof(*c));
+    c = (t_class *) t_getbytes(sizeof(*c));
     c->c_name = c->c_helpname = s;
     c->c_size = size;
     c->c_nmethod = 0;
-    c->c_freemethod = (t_method)freemethod;
+    c->c_freemethod = (t_method) freemethod;
     c->c_bangmethod = pd_defaultbang;
     c->c_pointermethod = pd_defaultpointer;
     c->c_floatmethod = pd_defaultfloat;
@@ -499,16 +493,16 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     c->c_savefn = (typeflag == CLASS_PATCHABLE ? text_save : class_nosavefn);
     c->c_classfreefn = 0;
 #ifdef PDINSTANCE
-    c->c_methods = (t_methodentry **)t_getbytes(
-        pd_ninstances * sizeof(*c->c_methods));
-    for (i = 0; i < pd_ninstances; i++)
+    c->c_methods =
+        (t_methodentry **) t_getbytes(pd_ninstances * sizeof(*c->c_methods));
+    for(i = 0; i < pd_ninstances; i++)
         c->c_methods[i] = t_getbytes(0);
     c->c_next = class_list;
     class_list = c;
 #else
     c->c_methods = t_getbytes(0);
 #endif
-#if 0       /* enable this if you want to see a list of all classes */
+#if 0 /* enable this if you want to see a list of all classes */
     post("class: %s", c->c_name->s_name);
 #endif
     return (c);
@@ -519,20 +513,19 @@ void class_free(t_class *c)
     int i;
 #ifdef PDINSTANCE
     t_class *prev;
-    if (class_list == c)
+    if(class_list == c)
         class_list = c->c_next;
     else
     {
         prev = class_list;
-        while (prev->c_next != c)
-          prev = prev->c_next;
+        while(prev->c_next != c)
+            prev = prev->c_next;
         prev->c_next = c->c_next;
     }
 #endif
-    if (c->c_classfreefn)
-        c->c_classfreefn(c);
+    if(c->c_classfreefn) c->c_classfreefn(c);
 #ifdef PDINSTANCE
-    for (i = 0; i < pd_ninstances; i++)
+    for(i = 0; i < pd_ninstances; i++)
     {
         if(c->c_methods[i])
             freebytes(c->c_methods[i], c->c_nmethod * sizeof(*c->c_methods[i]));
@@ -545,42 +538,36 @@ void class_free(t_class *c)
     freebytes(c, sizeof(*c));
 }
 
-void class_setfreefn(t_class *c, t_classfreefn fn)
-{
-    c->c_classfreefn = fn;
-}
+void class_setfreefn(t_class *c, t_classfreefn fn) { c->c_classfreefn = fn; }
 
 #ifdef PDINSTANCE
-t_class *class_getfirst(void)
-{
-    return class_list;
-}
+t_class *class_getfirst(void) { return class_list; }
 #endif
 
-    /* add a creation method, which is a function that returns a Pd object
-    suitable for putting in an object box.  We presume you've got a class it
-    can belong to, but this won't be used until the newmethod is actually
-    called back (and the new method explicitly takes care of this.) */
+/* add a creation method, which is a function that returns a Pd object
+suitable for putting in an object box.  We presume you've got a class it
+can belong to, but this won't be used until the newmethod is actually
+called back (and the new method explicitly takes care of this.) */
 
-void class_addcreator(t_newmethod newmethod, t_symbol *s,
-    t_atomtype type1, ...)
+void class_addcreator(t_newmethod newmethod, t_symbol *s, t_atomtype type1, ...)
 {
     va_list ap;
-    t_atomtype vec[MAXPDARG+1], *vp = vec;
+    t_atomtype vec[MAXPDARG + 1], *vp = vec;
     int count = 0;
     *vp = type1;
 
     va_start(ap, type1);
-    while (*vp)
+    while(*vp)
     {
-        if (count == MAXPDARG)
+        if(count == MAXPDARG)
         {
             if(s)
                 pd_error(0, "class %s: sorry: only %d creation args allowed",
-                      s->s_name, MAXPDARG);
+                    s->s_name, MAXPDARG);
             else
-                pd_error(0, "unnamed class: sorry: only %d creation args allowed",
-                      MAXPDARG);
+                pd_error(0,
+                    "unnamed class: sorry: only %d creation args allowed",
+                    MAXPDARG);
             break;
         }
         vp++;
@@ -588,165 +575,157 @@ void class_addcreator(t_newmethod newmethod, t_symbol *s,
         *vp = va_arg(ap, t_atomtype);
     }
     va_end(ap);
-    class_addmethod(pd_objectmaker, (t_method)newmethod, s,
-        vec[0], vec[1], vec[2], vec[3], vec[4], vec[5]);
+    class_addmethod(pd_objectmaker, (t_method) newmethod, s, vec[0], vec[1],
+        vec[2], vec[3], vec[4], vec[5]);
 }
 
-void class_addmethod(t_class *c, t_method fn, t_symbol *sel,
-    t_atomtype arg1, ...)
+void class_addmethod(
+    t_class *c, t_method fn, t_symbol *sel, t_atomtype arg1, ...)
 {
     va_list ap;
     t_atomtype argtype = arg1;
     int nargs, i;
-    if(!c)
-        return;
+    if(!c) return;
     va_start(ap, arg1);
-        /* "signal" method specifies that we take audio signals but
-        that we don't want automatic float to signal conversion.  This
-        is obsolete; you should now use the CLASS_MAINSIGNALIN macro. */
-    if (sel == &s_signal)
+    /* "signal" method specifies that we take audio signals but
+    that we don't want automatic float to signal conversion.  This
+    is obsolete; you should now use the CLASS_MAINSIGNALIN macro. */
+    if(sel == &s_signal)
     {
-        if (c->c_floatsignalin)
+        if(c->c_floatsignalin)
             post("warning: signal method overrides class_mainsignalin");
         c->c_floatsignalin = -1;
     }
-        /* check for special cases.  "Pointer" is missing here so that
-        pd_objectmaker's pointer method can be typechecked differently.  */
-    if (sel == &s_bang)
+    /* check for special cases.  "Pointer" is missing here so that
+    pd_objectmaker's pointer method can be typechecked differently.  */
+    if(sel == &s_bang)
     {
-        if (argtype) goto phooey;
+        if(argtype) goto phooey;
         class_addbang(c, fn);
     }
-    else if (sel == &s_float)
+    else if(sel == &s_float)
     {
-        if (argtype != A_FLOAT || va_arg(ap, t_atomtype)) goto phooey;
+        if(argtype != A_FLOAT || va_arg(ap, t_atomtype)) goto phooey;
         class_doaddfloat(c, fn);
     }
-    else if (sel == &s_symbol)
+    else if(sel == &s_symbol)
     {
-        if (argtype != A_SYMBOL || va_arg(ap, t_atomtype)) goto phooey;
+        if(argtype != A_SYMBOL || va_arg(ap, t_atomtype)) goto phooey;
         class_addsymbol(c, fn);
     }
-    else if (sel == &s_list)
+    else if(sel == &s_list)
     {
-        if (argtype != A_GIMME) goto phooey;
+        if(argtype != A_GIMME) goto phooey;
         class_addlist(c, fn);
     }
-    else if (sel == &s_anything)
+    else if(sel == &s_anything)
     {
-        if (argtype != A_GIMME) goto phooey;
+        if(argtype != A_GIMME) goto phooey;
         class_addanything(c, fn);
     }
     else
     {
-        unsigned char argvec[MAXPDARG+1];
+        unsigned char argvec[MAXPDARG + 1];
         nargs = 0;
-        while (argtype != A_NULL && nargs < MAXPDARG)
+        while(argtype != A_NULL && nargs < MAXPDARG)
         {
             argvec[nargs++] = argtype;
             argtype = va_arg(ap, t_atomtype);
         }
-        if (argtype != A_NULL)
-            pd_error(0, "%s_%s: only 5 arguments are typecheckable; use A_GIMME",
-                (c->c_name)?(c->c_name->s_name):"<anon>", sel?(sel->s_name):"<nomethod>");
+        if(argtype != A_NULL)
+            pd_error(0,
+                "%s_%s: only 5 arguments are typecheckable; use A_GIMME",
+                (c->c_name) ? (c->c_name->s_name) : "<anon>",
+                sel ? (sel->s_name) : "<nomethod>");
         argvec[nargs] = 0;
 #ifdef PDINSTANCE
-        for (i = 0; i < pd_ninstances; i++)
+        for(i = 0; i < pd_ninstances; i++)
         {
             class_addmethodtolist(c, &c->c_methods[i], c->c_nmethod,
-                (t_gotfn)fn, sel?dogensym(sel->s_name, 0, pd_instances[i]):0,
-                    argvec, pd_instances[i]);
+                (t_gotfn) fn,
+                sel ? dogensym(sel->s_name, 0, pd_instances[i]) : 0, argvec,
+                pd_instances[i]);
         }
 #else
-        class_addmethodtolist(c, &c->c_methods, c->c_nmethod,
-            (t_gotfn)fn, sel, argvec, &pd_maininstance);
+        class_addmethodtolist(c, &c->c_methods, c->c_nmethod, (t_gotfn) fn, sel,
+            argvec, &pd_maininstance);
 #endif
         c->c_nmethod++;
     }
     goto done;
 phooey:
     bug("class_addmethod: %s_%s: bad argument types\n",
-        (c->c_name)?(c->c_name->s_name):"<anon>", sel?(sel->s_name):"<nomethod>");
+        (c->c_name) ? (c->c_name->s_name) : "<anon>",
+        sel ? (sel->s_name) : "<nomethod>");
 done:
     va_end(ap);
     return;
 }
 
-    /* Instead of these, see the "class_addfloat", etc.,  macros in m_pd.h */
+/* Instead of these, see the "class_addfloat", etc.,  macros in m_pd.h */
 void class_addbang(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_bangmethod = (t_bangmethod)fn;
+    if(!c) return;
+    c->c_bangmethod = (t_bangmethod) fn;
 }
 
 void class_addpointer(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_pointermethod = (t_pointermethod)fn;
+    if(!c) return;
+    c->c_pointermethod = (t_pointermethod) fn;
 }
 
 void class_doaddfloat(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_floatmethod = (t_floatmethod)fn;
+    if(!c) return;
+    c->c_floatmethod = (t_floatmethod) fn;
 }
 
 void class_addsymbol(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_symbolmethod = (t_symbolmethod)fn;
+    if(!c) return;
+    c->c_symbolmethod = (t_symbolmethod) fn;
 }
 
 void class_addlist(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_listmethod = (t_listmethod)fn;
+    if(!c) return;
+    c->c_listmethod = (t_listmethod) fn;
 }
 
 void class_addanything(t_class *c, t_method fn)
 {
-    if(!c)
-        return;
-    c->c_anymethod = (t_anymethod)fn;
+    if(!c) return;
+    c->c_anymethod = (t_anymethod) fn;
 }
 
 void class_setwidget(t_class *c, const t_widgetbehavior *w)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_wb = w;
 }
 
 void class_setparentwidget(t_class *c, const t_parentwidgetbehavior *pw)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_pwb = pw;
 }
 
 const char *class_getname(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_name->s_name);
 }
 
 const char *class_gethelpname(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_helpname->s_name);
 }
 
 void class_sethelpsymbol(t_class *c, t_symbol *s)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_helpname = s;
 }
 
@@ -757,51 +736,45 @@ const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x)
 
 void class_setdrawcommand(t_class *c)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_drawcommand = 1;
 }
 
 int class_isdrawcommand(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_drawcommand);
 }
 
 static void pd_floatforsignal(t_pd *x, t_float f)
 {
     int offset = (*x)->c_floatsignalin;
-    if (offset > 0)
-        *(t_float *)(((char *)x) + offset) = f;
+    if(offset > 0)
+        *(t_float *) (((char *) x) + offset) = f;
     else
-        pd_error(x, "%s: float unexpected for signal input",
-            (*x)->c_name->s_name);
+        pd_error(
+            x, "%s: float unexpected for signal input", (*x)->c_name->s_name);
 }
 
 void class_domainsignalin(t_class *c, int onset)
 {
-    if(!c)
-        return;
-    if (onset <= 0) onset = -1;
+    if(!c) return;
+    if(onset <= 0)
+        onset = -1;
     else
     {
-        if (c->c_floatmethod != pd_defaultfloat)
+        if(c->c_floatmethod != pd_defaultfloat)
             post("warning: %s: float method overwritten", c->c_name->s_name);
-        c->c_floatmethod = (t_floatmethod)pd_floatforsignal;
+        c->c_floatmethod = (t_floatmethod) pd_floatforsignal;
     }
     c->c_floatsignalin = onset;
 }
 
-void class_set_extern_dir(t_symbol *s)
-{
-    class_extern_dir = s;
-}
+void class_set_extern_dir(t_symbol *s) { class_extern_dir = s; }
 
 const char *class_gethelpdir(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_externdir->s_name);
 }
 
@@ -812,59 +785,55 @@ static void class_nosavefn(t_gobj *z, t_binbuf *b)
 
 void class_setsavefn(t_class *c, t_savefn f)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_savefn = f;
 }
 
 t_savefn class_getsavefn(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_savefn);
 }
 
 void class_setpropertiesfn(t_class *c, t_propertiesfn f)
 {
-    if(!c)
-        return;
+    if(!c) return;
     c->c_propertiesfn = f;
 }
 
 t_propertiesfn class_getpropertiesfn(const t_class *c)
 {
-    if(!c)
-        return 0;
+    if(!c) return 0;
     return (c->c_propertiesfn);
 }
 
 /* ---------------- the symbol table ------------------------ */
 
-static t_symbol *dogensym(const char *s, t_symbol *oldsym,
-    t_pdinstance *pdinstance)
+static t_symbol *dogensym(
+    const char *s, t_symbol *oldsym, t_pdinstance *pdinstance)
 {
     char *symname = 0;
     t_symbol **symhashloc, *sym2;
     unsigned int hash = 5381;
     int length = 0;
     const char *s2 = s;
-    while (*s2) /* djb2 hash algo */
+    while(*s2) /* djb2 hash algo */
     {
         hash = ((hash << 5) + hash) + *s2;
         length++;
         s2++;
     }
-    symhashloc = pdinstance->pd_symhash + (hash & (SYMTABHASHSIZE-1));
-    while ((sym2 = *symhashloc))
+    symhashloc = pdinstance->pd_symhash + (hash & (SYMTABHASHSIZE - 1));
+    while((sym2 = *symhashloc))
     {
-        if (!strcmp(sym2->s_name, s))
-            return(sym2);
+        if(!strcmp(sym2->s_name, s)) return (sym2);
         symhashloc = &sym2->s_next;
     }
-    if (oldsym)
+    if(oldsym)
         sym2 = oldsym;
-    else sym2 = (t_symbol *)t_getbytes(sizeof(*sym2));
-    symname = t_getbytes(length+1);
+    else
+        sym2 = (t_symbol *) t_getbytes(sizeof(*sym2));
+    symname = t_getbytes(length + 1);
     sym2->s_next = 0;
     sym2->s_thing = 0;
     strcpy(symname, s);
@@ -873,19 +842,16 @@ static t_symbol *dogensym(const char *s, t_symbol *oldsym,
     return (sym2);
 }
 
-t_symbol *gensym(const char *s)
-{
-    return(dogensym(s, 0, pd_this));
-}
+t_symbol *gensym(const char *s) { return (dogensym(s, 0, pd_this)); }
 
 static t_symbol *addfileextent(t_symbol *s)
 {
     char namebuf[MAXPDSTRING];
     const char *str = s->s_name;
-    int ln = (int)strlen(str);
-    if (!strcmp(str + ln - 3, ".pd")) return (s);
+    int ln = (int) strlen(str);
+    if(!strcmp(str + ln - 3, ".pd")) return (s);
     strcpy(namebuf, str);
-    strcpy(namebuf+ln, ".pd");
+    strcpy(namebuf + ln, ".pd");
     return (gensym(namebuf));
 }
 
@@ -894,27 +860,29 @@ static int tryingalready;
 
 void canvas_popabstraction(t_canvas *x);
 
-t_symbol* pathsearch(t_symbol *s,char* ext);
+t_symbol *pathsearch(t_symbol *s, char *ext);
 int pd_setloadingabstraction(t_symbol *sym);
 
-    /* this routine is called when a new "object" is requested whose class Pd
-    doesn't know.  Pd tries to load it as an extern, then as an abstraction. */
+/* this routine is called when a new "object" is requested whose class Pd
+doesn't know.  Pd tries to load it as an extern, then as an abstraction. */
 void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int fd;
     char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
-    if (tryingalready>MAXOBJDEPTH){
-      pd_error(0, "maximum object loading depth %d reached", MAXOBJDEPTH);
-      return;
+    if(tryingalready > MAXOBJDEPTH)
+    {
+        pd_error(0, "maximum object loading depth %d reached", MAXOBJDEPTH);
+        return;
     }
-    if (s == &s_anything){
-      pd_error(0, "object name \"%s\" not allowed", s->s_name);
-      return;
+    if(s == &s_anything)
+    {
+        pd_error(0, "object name \"%s\" not allowed", s->s_name);
+        return;
     }
     pd_this->pd_newest = 0;
     class_loadsym = s;
     pd_globallock();
-    if (sys_load_lib(canvas_getcurrent(), s->s_name))
+    if(sys_load_lib(canvas_getcurrent(), s->s_name))
     {
         tryingalready++;
         typedmess(dummy, s, argc, argv);
@@ -927,30 +895,28 @@ void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv)
 
 /* This is externally available, but note that it might later disappear; the
 whole "newest" thing is a hack which needs to be redesigned. */
-t_pd *pd_newest(void)
-{
-    return (pd_this->pd_newest);
-}
+t_pd *pd_newest(void) { return (pd_this->pd_newest); }
 
-    /* horribly, we need prototypes for each of the artificial function
-    calls in typedmess(), to keep the compiler quiet. */
+/* horribly, we need prototypes for each of the artificial function
+calls in typedmess(), to keep the compiler quiet. */
 typedef t_pd *(*t_newgimme)(t_symbol *s, int argc, t_atom *argv);
-typedef void(*t_messgimme)(t_pd *x, t_symbol *s, int argc, t_atom *argv);
+typedef void (*t_messgimme)(t_pd *x, t_symbol *s, int argc, t_atom *argv);
 
 typedef t_pd *(*t_fun0)(
     t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
-typedef t_pd *(*t_fun1)(t_int i1,
-    t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
-typedef t_pd *(*t_fun2)(t_int i1, t_int i2,
-    t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
-typedef t_pd *(*t_fun3)(t_int i1, t_int i2, t_int i3,
-    t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
-typedef t_pd *(*t_fun4)(t_int i1, t_int i2, t_int i3, t_int i4,
-    t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
+typedef t_pd *(*t_fun1)(t_int i1, t_floatarg d1, t_floatarg d2, t_floatarg d3,
+    t_floatarg d4, t_floatarg d5);
+typedef t_pd *(*t_fun2)(t_int i1, t_int i2, t_floatarg d1, t_floatarg d2,
+    t_floatarg d3, t_floatarg d4, t_floatarg d5);
+typedef t_pd *(*t_fun3)(t_int i1, t_int i2, t_int i3, t_floatarg d1,
+    t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
+typedef t_pd *(*t_fun4)(t_int i1, t_int i2, t_int i3, t_int i4, t_floatarg d1,
+    t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
 typedef t_pd *(*t_fun5)(t_int i1, t_int i2, t_int i3, t_int i4, t_int i5,
     t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
-typedef t_pd *(*t_fun6)(t_int i1, t_int i2, t_int i3, t_int i4, t_int i5, t_int i6,
-    t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4, t_floatarg d5);
+typedef t_pd *(*t_fun6)(t_int i1, t_int i2, t_int i3, t_int i4, t_int i5,
+    t_int i6, t_floatarg d1, t_floatarg d2, t_floatarg d3, t_floatarg d4,
+    t_floatarg d5);
 
 void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
@@ -959,46 +925,49 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     t_methodentry *m, *mlist;
     unsigned char *wp, wanttype;
     int i;
-    t_int ai[MAXPDARG+1], *ap = ai;
-    t_floatarg ad[MAXPDARG+1], *dp = ad;
+    t_int ai[MAXPDARG + 1], *ap = ai;
+    t_floatarg ad[MAXPDARG + 1], *dp = ad;
     int narg = 0;
     t_pd *bonzo;
 
-        /* check for messages that are handled by fixed slots in the class
-        structure. */
-    if (s == &s_float)
+    /* check for messages that are handled by fixed slots in the class
+    structure. */
+    if(s == &s_float)
     {
-        if (!argc) (*c->c_floatmethod)(x, 0.);
-        else if (argv->a_type == A_FLOAT)
+        if(!argc)
+            (*c->c_floatmethod)(x, 0.);
+        else if(argv->a_type == A_FLOAT)
             (*c->c_floatmethod)(x, argv->a_w.w_float);
-        else goto badarg;
+        else
+            goto badarg;
         return;
     }
-    if (s == &s_bang)
+    if(s == &s_bang)
     {
         (*c->c_bangmethod)(x);
         return;
     }
-    if (s == &s_list)
+    if(s == &s_list)
     {
         (*c->c_listmethod)(x, s, argc, argv);
         return;
     }
-    if (s == &s_symbol)
+    if(s == &s_symbol)
     {
-        if (argc && argv->a_type == A_SYMBOL)
+        if(argc && argv->a_type == A_SYMBOL)
             (*c->c_symbolmethod)(x, argv->a_w.w_symbol);
         else
             (*c->c_symbolmethod)(x, &s_);
         return;
     }
-        /* pd_objectmaker doesn't require
-        an actual pointer value */
-    if (s == &s_pointer && x != &pd_objectmaker)
+    /* pd_objectmaker doesn't require
+    an actual pointer value */
+    if(s == &s_pointer && x != &pd_objectmaker)
     {
-        if (argc && argv->a_type == A_POINTER)
+        if(argc && argv->a_type == A_POINTER)
             (*c->c_pointermethod)(x, argv->a_w.w_gpointer);
-        else goto badarg;
+        else
+            goto badarg;
         return;
     }
 #ifdef PDINSTANCE
@@ -1006,112 +975,131 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 #else
     mlist = c->c_methods;
 #endif
-    for (i = c->c_nmethod, m = mlist; i--; m++)
-        if (m->me_name == s)
-    {
-        wp = m->me_arg;
-        if (*wp == A_GIMME)
+    for(i = c->c_nmethod, m = mlist; i--; m++)
+        if(m->me_name == s)
         {
-            if (x == &pd_objectmaker)
-                pd_this->pd_newest =
-                    (*((t_newgimme)(m->me_fun)))(s, argc, argv);
-            else (*((t_messgimme)(m->me_fun)))(x, s, argc, argv);
-            return;
-        }
-        if (argc > MAXPDARG) argc = MAXPDARG;
-        if (x != &pd_objectmaker) *(ap++) = (t_int)x, narg++;
-        while ((wanttype = *wp++))
-        {
-            switch (wanttype)
+            wp = m->me_arg;
+            if(*wp == A_GIMME)
             {
-            case A_POINTER:
-                if (!argc) goto badarg;
+                if(x == &pd_objectmaker)
+                    pd_this->pd_newest =
+                        (*((t_newgimme) (m->me_fun)))(s, argc, argv);
                 else
+                    (*((t_messgimme) (m->me_fun)))(x, s, argc, argv);
+                return;
+            }
+            if(argc > MAXPDARG) argc = MAXPDARG;
+            if(x != &pd_objectmaker) *(ap++) = (t_int) x, narg++;
+            while((wanttype = *wp++))
+            {
+                switch(wanttype)
                 {
-                    if (argv->a_type == A_POINTER)
-                        *ap = (t_int)(argv->a_w.w_gpointer);
-                    else goto badarg;
-                    argc--;
-                    argv++;
-                }
-                narg++;
-                ap++;
-                break;
-            case A_FLOAT:
-                if (!argc) goto badarg;  /* falls through */
-            case A_DEFFLOAT:
-                if (!argc) *dp = 0;
-                else
-                {
-                    if (argv->a_type == A_FLOAT)
-                        *dp = argv->a_w.w_float;
-                    else goto badarg;
-                    argc--;
-                    argv++;
-                }
-                dp++;
-                break;
-            case A_SYMBOL:
-                if (!argc) goto badarg;  /* falls through */
-            case A_DEFSYM:
-                if (!argc) *ap = (t_int)(&s_);
-                else
-                {
-                    if (argv->a_type == A_SYMBOL)
-                        *ap = (t_int)(argv->a_w.w_symbol);
+                    case A_POINTER:
+                        if(!argc)
+                            goto badarg;
+                        else
+                        {
+                            if(argv->a_type == A_POINTER)
+                                *ap = (t_int) (argv->a_w.w_gpointer);
+                            else
+                                goto badarg;
+                            argc--;
+                            argv++;
+                        }
+                        narg++;
+                        ap++;
+                        break;
+                    case A_FLOAT:
+                        if(!argc) goto badarg; /* falls through */
+                    case A_DEFFLOAT:
+                        if(!argc)
+                            *dp = 0;
+                        else
+                        {
+                            if(argv->a_type == A_FLOAT)
+                                *dp = argv->a_w.w_float;
+                            else
+                                goto badarg;
+                            argc--;
+                            argv++;
+                        }
+                        dp++;
+                        break;
+                    case A_SYMBOL:
+                        if(!argc) goto badarg; /* falls through */
+                    case A_DEFSYM:
+                        if(!argc)
+                            *ap = (t_int) (&s_);
+                        else
+                        {
+                            if(argv->a_type == A_SYMBOL)
+                                *ap = (t_int) (argv->a_w.w_symbol);
                             /* if it's an unfilled "dollar" argument it appears
                             as zero here; cheat and bash it to the null
                             symbol.  Unfortunately, this lets real zeros
                             pass as symbols too, which seems wrong... */
-                    else if (x == &pd_objectmaker && argv->a_type == A_FLOAT
-                        && argv->a_w.w_float == 0)
-                        *ap = (t_int)(&s_);
-                    else goto badarg;
-                    argc--;
-                    argv++;
+                            else if(x == &pd_objectmaker &&
+                                    argv->a_type == A_FLOAT &&
+                                    argv->a_w.w_float == 0)
+                                *ap = (t_int) (&s_);
+                            else
+                                goto badarg;
+                            argc--;
+                            argv++;
+                        }
+                        narg++;
+                        ap++;
+                        break;
+                    default:
+                        goto badarg;
                 }
-                narg++;
-                ap++;
-                break;
-            default:
-                goto badarg;
             }
+            switch(narg)
+            {
+                case 0:
+                    bonzo = (*(t_fun0) (m->me_fun))(
+                        ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 1:
+                    bonzo = (*(t_fun1) (m->me_fun))(
+                        ai[0], ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 2:
+                    bonzo = (*(t_fun2) (m->me_fun))(
+                        ai[0], ai[1], ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 3:
+                    bonzo = (*(t_fun3) (m->me_fun))(
+                        ai[0], ai[1], ai[2], ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 4:
+                    bonzo = (*(t_fun4) (m->me_fun))(ai[0], ai[1], ai[2], ai[3],
+                        ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 5:
+                    bonzo = (*(t_fun5) (m->me_fun))(ai[0], ai[1], ai[2], ai[3],
+                        ai[4], ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                case 6:
+                    bonzo = (*(t_fun6) (m->me_fun))(ai[0], ai[1], ai[2], ai[3],
+                        ai[4], ai[5], ad[0], ad[1], ad[2], ad[3], ad[4]);
+                    break;
+                default:
+                    bonzo = 0;
+            }
+            if(x == &pd_objectmaker) pd_this->pd_newest = bonzo;
+            return;
         }
-        switch (narg)
-        {
-        case 0 : bonzo = (*(t_fun0)(m->me_fun))
-            (ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 1 : bonzo = (*(t_fun1)(m->me_fun))
-            (ai[0], ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 2 : bonzo = (*(t_fun2)(m->me_fun))
-            (ai[0], ai[1], ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 3 : bonzo = (*(t_fun3)(m->me_fun))
-            (ai[0], ai[1], ai[2], ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 4 : bonzo = (*(t_fun4)(m->me_fun))
-            (ai[0], ai[1], ai[2], ai[3],
-                ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 5 : bonzo = (*(t_fun5)(m->me_fun))
-            (ai[0], ai[1], ai[2], ai[3], ai[4],
-                ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        case 6 : bonzo = (*(t_fun6)(m->me_fun))
-            (ai[0], ai[1], ai[2], ai[3], ai[4], ai[5],
-                ad[0], ad[1], ad[2], ad[3], ad[4]); break;
-        default: bonzo = 0;
-        }
-        if (x == &pd_objectmaker)
-            pd_this->pd_newest = bonzo;
-        return;
-    }
     (*c->c_anymethod)(x, s, argc, argv);
     return;
 badarg:
-    pd_error(x, "bad arguments for message '%s' to object '%s'",
-        s->s_name, c->c_name->s_name);
+    pd_error(x, "bad arguments for message '%s' to object '%s'", s->s_name,
+        c->c_name->s_name);
 }
 
-    /* convenience routine giving a stdarg interface to typedmess().  Only
-    ten args supported; it seems unlikely anyone will need more since
-    longer messages are likely to be programmatically generated anyway. */
+/* convenience routine giving a stdarg interface to typedmess().  Only
+ten args supported; it seems unlikely anyone will need more since
+longer messages are likely to be programmatically generated anyway. */
 void pd_vmess(t_pd *x, t_symbol *sel, const char *fmt, ...)
 {
     va_list ap;
@@ -1120,20 +1108,29 @@ void pd_vmess(t_pd *x, t_symbol *sel, const char *fmt, ...)
     const char *fp = fmt;
 
     va_start(ap, fmt);
-    while (1)
+    while(1)
     {
-        if (nargs >= 10)
+        if(nargs >= 10)
         {
             pd_error(x, "pd_vmess: only 10 allowed");
             break;
         }
         switch(*fp++)
         {
-        case 'f': SETFLOAT(at, va_arg(ap, double)); break;
-        case 's': SETSYMBOL(at, va_arg(ap, t_symbol *)); break;
-        case 'i': SETFLOAT(at, va_arg(ap, t_int)); break;
-        case 'p': SETPOINTER(at, va_arg(ap, t_gpointer *)); break;
-        default: goto done;
+            case 'f':
+                SETFLOAT(at, va_arg(ap, double));
+                break;
+            case 's':
+                SETSYMBOL(at, va_arg(ap, t_symbol *));
+                break;
+            case 'i':
+                SETFLOAT(at, va_arg(ap, t_int));
+                break;
+            case 'p':
+                SETPOINTER(at, va_arg(ap, t_gpointer *));
+                break;
+            default:
+                goto done;
         }
         at++;
         nargs++;
@@ -1145,23 +1142,28 @@ done:
 
 void pd_forwardmess(t_pd *x, int argc, t_atom *argv)
 {
-    if (argc)
+    if(argc)
     {
         t_atomtype t = argv->a_type;
-        if (t == A_SYMBOL) pd_typedmess(x, argv->a_w.w_symbol, argc-1, argv+1);
-        else if (t == A_POINTER)
+        if(t == A_SYMBOL)
+            pd_typedmess(x, argv->a_w.w_symbol, argc - 1, argv + 1);
+        else if(t == A_POINTER)
         {
-            if (argc == 1) pd_pointer(x, argv->a_w.w_gpointer);
-            else pd_list(x, &s_list, argc, argv);
+            if(argc == 1)
+                pd_pointer(x, argv->a_w.w_gpointer);
+            else
+                pd_list(x, &s_list, argc, argv);
         }
-        else if (t == A_FLOAT)
+        else if(t == A_FLOAT)
         {
-            if (argc == 1) pd_float(x, argv->a_w.w_float);
-            else pd_list(x, &s_list, argc, argv);
+            if(argc == 1)
+                pd_float(x, argv->a_w.w_float);
+            else
+                pd_list(x, &s_list, argc, argv);
         }
-        else bug("pd_forwardmess");
+        else
+            bug("pd_forwardmess");
     }
-
 }
 
 void nullfn(void) {}
@@ -1177,10 +1179,10 @@ t_gotfn getfn(const t_pd *x, t_symbol *s)
 #else
     mlist = c->c_methods;
 #endif
-    for (i = c->c_nmethod, m = mlist; i--; m++)
-        if (m->me_name == s) return(m->me_fun);
+    for(i = c->c_nmethod, m = mlist; i--; m++)
+        if(m->me_name == s) return (m->me_fun);
     pd_error(x, "%s: no method for message '%s'", c->c_name->s_name, s->s_name);
-    return((t_gotfn)nullfn);
+    return ((t_gotfn) nullfn);
 }
 
 t_gotfn zgetfn(const t_pd *x, t_symbol *s)
@@ -1194,17 +1196,17 @@ t_gotfn zgetfn(const t_pd *x, t_symbol *s)
 #else
     mlist = c->c_methods;
 #endif
-    for (i = c->c_nmethod, m = mlist; i--; m++)
-        if (m->me_name == s) return(m->me_fun);
-    return(0);
+    for(i = c->c_nmethod, m = mlist; i--; m++)
+        if(m->me_name == s) return (m->me_fun);
+    return (0);
 }
 
-void c_extern(t_externclass *cls, t_newmethod newroutine,
-    t_method freeroutine, t_symbol *name, size_t size, int tiny, \
-    t_atomtype arg1, ...)
+void c_extern(t_externclass *cls, t_newmethod newroutine, t_method freeroutine,
+    t_symbol *name, size_t size, int tiny, t_atomtype arg1, ...)
 {
     bug("'c_extern' not implemented.");
 }
+
 void c_addmess(t_method fn, t_symbol *sel, t_atomtype arg1, ...)
 {
     bug("'c_addmess' not implemented.");
@@ -1214,16 +1216,16 @@ void c_addmess(t_method fn, t_symbol *sel, t_atomtype arg1, ...)
  * load a single-precision external, or vice versa
  */
 #ifdef class_new
-# undef class_new
+#undef class_new
 #endif
 t_class *
 #if PD_FLOATSIZE == 32
-  class_new64
+class_new64
 #else
-  class_new
+class_new
 #endif
-   (t_symbol *s, t_newmethod newmethod, t_method freemethod,
-    size_t size, int flags, t_atomtype type1, ...)
+    (t_symbol *s, t_newmethod newmethod, t_method freemethod, size_t size,
+        int flags, t_atomtype type1, ...)
 {
     const int ext_floatsize =
 #if PD_FLOATSIZE == 32
@@ -1233,11 +1235,17 @@ t_class *
 #endif
         ;
     static int loglevel = 0;
-    if(s) {
-        logpost(0, loglevel, "refusing to load %dbit-float object '%s' into %dbit-float Pd", ext_floatsize, s->s_name, PD_FLOATSIZE);
-        loglevel=3;
-    } else
-        logpost(0, 3, "refusing to load unnamed %dbit-float object into %dbit-float Pd", ext_floatsize, PD_FLOATSIZE);
+    if(s)
+    {
+        logpost(0, loglevel,
+            "refusing to load %dbit-float object '%s' into %dbit-float Pd",
+            ext_floatsize, s->s_name, PD_FLOATSIZE);
+        loglevel = 3;
+    }
+    else
+        logpost(0, 3,
+            "refusing to load unnamed %dbit-float object into %dbit-float Pd",
+            ext_floatsize, PD_FLOATSIZE);
 
     return 0;
 }

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -119,6 +119,7 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
     int i;
     t_methodentry *m;
     for(i = 0; i < nmethod; i++)
+    {
         if(sel && (*methodlist)[i].me_name == sel)
         {
             char nbuf[80];
@@ -126,14 +127,19 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
             nbuf[79] = 0;
             (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
             if(c == pd_objectmaker)
+            {
                 logpost(NULL, PD_VERBOSE,
                     "warning: class '%s' overwritten; old one renamed '%s'",
                     sel->s_name, nbuf);
+            }
             else
+            {
                 logpost(NULL, PD_VERBOSE,
                     "warning: old method '%s' for class '%s' renamed '%s'",
                     sel->s_name, c->c_name->s_name, nbuf);
+            }
         }
+    }
     (*methodlist) = t_resizebytes((*methodlist), nmethod * sizeof(**methodlist),
         (nmethod + 1) * sizeof(**methodlist));
     m = (*methodlist) + nmethod;
@@ -289,9 +295,13 @@ static void pd_defaultanything(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 static void pd_defaultbang(t_pd *x)
 {
     if(*(*x)->c_listmethod != pd_defaultlist)
+    {
         (*(*x)->c_listmethod)(x, 0, 0, 0);
+    }
     else
+    {
         (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
+    }
 }
 
 /* am empty list calls the 'bang' method unless it's the default
@@ -302,9 +312,13 @@ an empty list.  */
 void pd_emptylist(t_pd *x)
 {
     if(*(*x)->c_bangmethod != pd_defaultbang)
+    {
         (*(*x)->c_bangmethod)(x);
+    }
     else
+    {
         (*(*x)->c_anymethod)(x, &s_bang, 0, 0);
+    }
 }
 
 static void pd_defaultpointer(t_pd *x, t_gpointer *gp)
@@ -392,15 +406,21 @@ static void pd_defaultlist(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     }
     /* Next try for an "anything" method */
     if((*x)->c_anymethod != pd_defaultanything)
+    {
         (*(*x)->c_anymethod)(x, &s_list, argc, argv);
 
     /* if the object is patchable (i.e., can have proper inlets)
         send it on to obj_list which will unpack the list into the inlets */
+    }
     else if((*x)->c_patchable)
+    {
         obj_list((t_object *) x, s, argc, argv);
     /* otherwise gove up and complain. */
+    }
     else
+    {
         pd_defaultanything(x, &s_list, argc, argv);
+    }
 }
 
 /* for now we assume that all "gobjs" are text unless explicitly
@@ -439,14 +459,18 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
         if(count == MAXPDARG)
         {
             if(s)
+            {
                 pd_error(0,
                     "class %s: sorry: only %d args typechecked; use A_GIMME",
                     s->s_name, MAXPDARG);
+            }
             else
+            {
                 pd_error(0,
                     "unnamed class: sorry: only %d args typechecked; use "
                     "A_GIMME",
                     MAXPDARG);
+            }
             break;
         }
         vp++;
@@ -469,9 +493,11 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
             size_t l1 = strlen(s->s_name);
             size_t l2 = strlen(loadstring);
             if(l2 > l1 && !strcmp(s->s_name, loadstring + (l2 - l1)))
+            {
                 class_addmethod(pd_objectmaker, (t_method) newmethod,
                     class_loadsym, vec[0], vec[1], vec[2], vec[3], vec[4],
                     vec[5]);
+            }
         }
     }
     c = (t_class *) t_getbytes(sizeof(*c));
@@ -566,12 +592,16 @@ void class_addcreator(t_newmethod newmethod, t_symbol *s, t_atomtype type1, ...)
         if(count == MAXPDARG)
         {
             if(s)
+            {
                 pd_error(0, "class %s: sorry: only %d creation args allowed",
                     s->s_name, MAXPDARG);
+            }
             else
+            {
                 pd_error(0,
                     "unnamed class: sorry: only %d creation args allowed",
                     MAXPDARG);
+            }
             break;
         }
         vp++;
@@ -638,10 +668,12 @@ void class_addmethod(
             argtype = va_arg(ap, t_atomtype);
         }
         if(argtype != A_NULL)
+        {
             pd_error(0,
                 "%s_%s: only 5 arguments are typecheckable; use A_GIMME",
                 (c->c_name) ? (c->c_name->s_name) : "<anon>",
                 sel ? (sel->s_name) : "<nomethod>");
+        }
         argvec[nargs] = 0;
 #ifdef PDINSTANCE
         for(i = 0; i < pd_ninstances; i++)
@@ -754,17 +786,23 @@ static void pd_floatforsignal(t_pd *x, t_float f)
 {
     int offset = (*x)->c_floatsignalin;
     if(offset > 0)
+    {
         *(t_float *) (((char *) x) + offset) = f;
+    }
     else
+    {
         pd_error(
             x, "%s: float unexpected for signal input", (*x)->c_name->s_name);
+    }
 }
 
 void class_domainsignalin(t_class *c, int onset)
 {
     if(!c) return;
     if(onset <= 0)
+    {
         onset = -1;
+    }
     else
     {
         if(c->c_floatmethod != pd_defaultfloat)
@@ -835,9 +873,13 @@ static t_symbol *dogensym(
         symhashloc = &sym2->s_next;
     }
     if(oldsym)
+    {
         sym2 = oldsym;
+    }
     else
+    {
         sym2 = (t_symbol *) t_getbytes(sizeof(*sym2));
+    }
     symname = t_getbytes(length + 1);
     sym2->s_next = 0;
     sym2->s_thing = 0;
@@ -946,11 +988,17 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     if(s == &s_float)
     {
         if(!argc)
+        {
             (*c->c_floatmethod)(x, 0.);
+        }
         else if(argv->a_type == A_FLOAT)
+        {
             (*c->c_floatmethod)(x, argv->a_w.w_float);
+        }
         else
+        {
             goto badarg;
+        }
         return;
     }
     if(s == &s_bang)
@@ -966,9 +1014,13 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     if(s == &s_symbol)
     {
         if(argc && argv->a_type == A_SYMBOL)
+        {
             (*c->c_symbolmethod)(x, argv->a_w.w_symbol);
+        }
         else
+        {
             (*c->c_symbolmethod)(x, &s_);
+        }
         return;
     }
     /* pd_objectmaker doesn't require
@@ -976,9 +1028,13 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     if(s == &s_pointer && x != &pd_objectmaker)
     {
         if(argc && argv->a_type == A_POINTER)
+        {
             (*c->c_pointermethod)(x, argv->a_w.w_gpointer);
+        }
         else
+        {
             goto badarg;
+        }
         return;
     }
 #ifdef PDINSTANCE
@@ -987,16 +1043,21 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     mlist = c->c_methods;
 #endif
     for(i = c->c_nmethod, m = mlist; i--; m++)
+    {
         if(m->me_name == s)
         {
             wp = m->me_arg;
             if(*wp == A_GIMME)
             {
                 if(x == &pd_objectmaker)
+                {
                     pd_this->pd_newest =
                         (*((t_newgimme) (m->me_fun)))(s, argc, argv);
+                }
                 else
+                {
                     (*((t_messgimme) (m->me_fun)))(x, s, argc, argv);
+                }
                 return;
             }
             if(argc > MAXPDARG) argc = MAXPDARG;
@@ -1007,13 +1068,19 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
                 {
                     case A_POINTER:
                         if(!argc)
+                        {
                             goto badarg;
+                        }
                         else
                         {
                             if(argv->a_type == A_POINTER)
+                            {
                                 *ap = (t_int) (argv->a_w.w_gpointer);
+                            }
                             else
+                            {
                                 goto badarg;
+                            }
                             argc--;
                             argv++;
                         }
@@ -1024,13 +1091,19 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
                         if(!argc) goto badarg; /* falls through */
                     case A_DEFFLOAT:
                         if(!argc)
+                        {
                             *dp = 0;
+                        }
                         else
                         {
                             if(argv->a_type == A_FLOAT)
+                            {
                                 *dp = argv->a_w.w_float;
+                            }
                             else
+                            {
                                 goto badarg;
+                            }
                             argc--;
                             argv++;
                         }
@@ -1040,21 +1113,29 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
                         if(!argc) goto badarg; /* falls through */
                     case A_DEFSYM:
                         if(!argc)
+                        {
                             *ap = (t_int) (&s_);
+                        }
                         else
                         {
                             if(argv->a_type == A_SYMBOL)
+                            {
                                 *ap = (t_int) (argv->a_w.w_symbol);
                             /* if it's an unfilled "dollar" argument it appears
                             as zero here; cheat and bash it to the null
                             symbol.  Unfortunately, this lets real zeros
                             pass as symbols too, which seems wrong... */
+                            }
                             else if(x == &pd_objectmaker &&
                                     argv->a_type == A_FLOAT &&
                                     argv->a_w.w_float == 0)
+                            {
                                 *ap = (t_int) (&s_);
+                            }
                             else
+                            {
                                 goto badarg;
+                            }
                             argc--;
                             argv++;
                         }
@@ -1101,6 +1182,7 @@ void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv)
             if(x == &pd_objectmaker) pd_this->pd_newest = bonzo;
             return;
         }
+    }
     (*c->c_anymethod)(x, s, argc, argv);
     return;
 badarg:
@@ -1158,20 +1240,30 @@ void pd_forwardmess(t_pd *x, int argc, t_atom *argv)
     {
         t_atomtype t = argv->a_type;
         if(t == A_SYMBOL)
+        {
             pd_typedmess(x, argv->a_w.w_symbol, argc - 1, argv + 1);
+        }
         else if(t == A_POINTER)
         {
             if(argc == 1)
+            {
                 pd_pointer(x, argv->a_w.w_gpointer);
+            }
             else
+            {
                 pd_list(x, &s_list, argc, argv);
+            }
         }
         else if(t == A_FLOAT)
         {
             if(argc == 1)
+            {
                 pd_float(x, argv->a_w.w_float);
+            }
             else
+            {
                 pd_list(x, &s_list, argc, argv);
+            }
         }
         else
             bug("pd_forwardmess");
@@ -1257,9 +1349,11 @@ class_new
         loglevel = 3;
     }
     else
+    {
         logpost(0, 3,
             "refusing to load unnamed %dbit-float object into %dbit-float Pd",
             ext_floatsize, PD_FLOATSIZE);
+    }
 
     return 0;
 }

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -664,7 +664,6 @@ phooey:
         sel ? (sel->s_name) : "<nomethod>");
 done:
     va_end(ap);
-    return;
 }
 
 /* Instead of these, see the "class_addfloat", etc.,  macros in m_pd.h */

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -75,7 +75,7 @@ static t_pdinstance *pdinstance_init(t_pdinstance *x)
     x->pd_canvaslist = 0;
     x->pd_templatelist = 0;
     x->pd_symhash = getbytes(SYMTABHASHSIZE * sizeof(*x->pd_symhash));
-    for(i = 0; i < SYMTABHASHSIZE; i++)
+    for(int i = 0; i < SYMTABHASHSIZE; i++)
         x->pd_symhash[i] = 0;
 #ifdef PDINSTANCE
     dogensym("pointer", &x->pd_s_pointer, x);
@@ -116,9 +116,8 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
     int nmethod, t_gotfn fn, t_symbol *sel, unsigned char *args,
     t_pdinstance *pdinstance)
 {
-    int i;
     t_methodentry *m;
-    for(i = 0; i < nmethod; i++)
+    for(int i = 0; i < nmethod; i++)
     {
         if(sel && (*methodlist)[i].me_name == sel)
         {
@@ -153,8 +152,7 @@ EXTERN void pd_setinstance(t_pdinstance *x) { pd_this = x; }
 
 static void pdinstance_renumber(void)
 {
-    int i;
-    for(i = 0; i < pd_ninstances; i++)
+    for(int i = 0; i < pd_ninstances; i++)
         pd_instances[i]->pd_instanceno = i;
 }
 
@@ -165,7 +163,6 @@ EXTERN t_pdinstance *pdinstance_new(void)
 {
     t_pdinstance *x = (t_pdinstance *) getbytes(sizeof(t_pdinstance));
     t_class *c;
-    int i;
     pd_this = x;
     s_inter_newpdinstance();
     pdinstance_init(x);
@@ -181,7 +178,7 @@ EXTERN t_pdinstance *pdinstance_new(void)
             pd_ninstances * sizeof(*c->c_methods),
             (pd_ninstances + 1) * sizeof(*c->c_methods));
         c->c_methods[pd_ninstances] = t_getbytes(0);
-        for(i = 0; i < c->c_nmethod; i++)
+        for(int i = 0; i < c->c_nmethod; i++)
             class_addmethodtolist(c, &c->c_methods[pd_ninstances], i,
                 c->c_methods[0][i].me_fun,
                 dogensym(c->c_methods[0][i].me_name->s_name, 0, x),
@@ -201,8 +198,7 @@ EXTERN void pdinstance_free(t_pdinstance *x)
 {
     t_symbol *s;
     t_canvas *canvas;
-    int i, instanceno;
-    t_class *c;
+    int instanceno;
     t_instanceinter *inter;
     pd_setinstance(x);
     sys_lock();
@@ -215,7 +211,7 @@ EXTERN void pdinstance_free(t_pdinstance *x)
         pd_free((t_pd *) x->pd_canvaslist);
     while(x->pd_templatelist)
         pd_free((t_pd *) x->pd_templatelist);
-    for(c = class_list; c; c = c->c_next)
+    for(t_class *c = class_list; c; c = c->c_next)
     {
         if(c->c_methods[instanceno])
             freebytes(c->c_methods[instanceno],
@@ -227,7 +223,7 @@ EXTERN void pdinstance_free(t_pdinstance *x)
             pd_ninstances * sizeof(*c->c_methods),
             (pd_ninstances - 1) * sizeof(*c->c_methods));
     }
-    for(i = 0; i < SYMTABHASHSIZE; i++)
+    for(int i = 0; i < SYMTABHASHSIZE; i++)
     {
         while((s = x->pd_symhash[i]))
         {
@@ -447,7 +443,6 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
     t_atomtype vec[MAXPDARG + 1];
     t_atomtype *vp = vec;
     int count = 0;
-    int i;
     t_class *c;
     int typeflag = flags & CLASS_TYPEMASK;
     if(!typeflag) typeflag = CLASS_PATCHABLE;
@@ -524,7 +519,7 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
 #ifdef PDINSTANCE
     c->c_methods =
         (t_methodentry **) t_getbytes(pd_ninstances * sizeof(*c->c_methods));
-    for(i = 0; i < pd_ninstances; i++)
+    for(int i = 0; i < pd_ninstances; i++)
         c->c_methods[i] = t_getbytes(0);
     c->c_next = class_list;
     class_list = c;
@@ -539,7 +534,6 @@ t_class *class_new(t_symbol *s, t_newmethod newmethod, t_method freemethod,
 
 void class_free(t_class *c)
 {
-    int i;
 #ifdef PDINSTANCE
     t_class *prev;
     if(class_list == c)
@@ -554,7 +548,7 @@ void class_free(t_class *c)
 #endif
     if(c->c_classfreefn) c->c_classfreefn(c);
 #ifdef PDINSTANCE
-    for(i = 0; i < pd_ninstances; i++)
+    for(int i = 0; i < pd_ninstances; i++)
     {
         if(c->c_methods[i])
             freebytes(c->c_methods[i], c->c_nmethod * sizeof(*c->c_methods[i]));
@@ -619,7 +613,6 @@ void class_addmethod(
     va_list ap;
     t_atomtype argtype = arg1;
     int nargs;
-    int i;
     if(!c) return;
     va_start(ap, arg1);
     /* "signal" method specifies that we take audio signals but
@@ -676,7 +669,7 @@ void class_addmethod(
         }
         argvec[nargs] = 0;
 #ifdef PDINSTANCE
-        for(i = 0; i < pd_ninstances; i++)
+        for(int i = 0; i < pd_ninstances; i++)
         {
             class_addmethodtolist(c, &c->c_methods[i], c->c_nmethod,
                 (t_gotfn) fn,

--- a/src/m_conf.c
+++ b/src/m_conf.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* changes by Thomas Musil IEM KUG Graz Austria 2001 */
 /* all changes are labeled with      iemlib      */
@@ -62,7 +62,7 @@ void conf_init(void)
     g_array_setup();
     g_canvas_setup();
     g_guiconnect_setup();
-/* iemlib */
+    /* iemlib */
     g_bang_setup();
     g_hradio_setup();
     g_hslider_setup();
@@ -72,7 +72,7 @@ void conf_init(void)
     g_vradio_setup();
     g_vslider_setup();
     g_vumeter_setup();
-/* iemlib */
+    /* iemlib */
     g_io_setup();
     g_scalar_setup();
     g_template_setup();

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -91,10 +91,9 @@ static void glob_perf(t_pd *dummy, t_float f) { sys_perf = (f != 0); }
 
 void max_default(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     char str[80];
     startpost("%s: unknown message %s ", class_getname(pd_class(x)), s->s_name);
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         atom_string(argv + i, str, 80);
         poststring(str);
@@ -104,10 +103,9 @@ void max_default(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 
 void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     char str[80];
     sys_vgui("pdtk_plugin_dispatch ");
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         atom_string(argv + i, str, 80);
         sys_vgui("%s", str);

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 #include "m_imp.h"
@@ -9,8 +9,8 @@
 t_class *glob_pdobject;
 static t_class *maxclass;
 
-int sys_perf;   /* true if we should query user on close and quit */
-int pd_compatibilitylevel = 100000;  /* e.g., 43 for pd 0.43 compatibility */
+int sys_perf; /* true if we should query user on close and quit */
+int pd_compatibilitylevel = 100000; /* e.g., 43 for pd 0.43 compatibility */
 
 /* These "glob" routines, which implement messages to Pd, are from all
 over.  Some others are prototyped in m_imp.h as well. */
@@ -21,7 +21,7 @@ void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_key(void *dummy, t_symbol *s, int ac, t_atom *av);
 void glob_audiostatus(void *dummy);
 void glob_finderror(t_pd *dummy);
-void glob_findinstance(t_pd *dummy, t_symbol*s);
+void glob_findinstance(t_pd *dummy, t_symbol *s);
 void glob_audio_properties(t_pd *dummy, t_floatarg flongform);
 void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_audio_setapi(t_pd *dummy, t_floatarg f);
@@ -43,10 +43,7 @@ void glob_open(t_pd *ignore, t_symbol *name, t_symbol *dir, t_floatarg f);
 void glob_fastforward(t_pd *ignore, t_floatarg f);
 void glob_settracing(void *dummy, t_float f);
 
-static void glob_helpintro(t_pd *dummy)
-{
-    open_via_helppath("intro.pd", "");
-}
+static void glob_helpintro(t_pd *dummy) { open_via_helppath("intro.pd", ""); }
 
 static void glob_compatibility(t_pd *dummy, t_floatarg level)
 {
@@ -74,32 +71,28 @@ void glob_foo(void *dummy, t_symbol *s, int argc, t_atom *argv)
 
 static void glob_version(t_pd *dummy, t_float f)
 {
-    if (f > (PD_MAJOR_VERSION + 0.01*PD_MINOR_VERSION + 0.001))
+    if(f > (PD_MAJOR_VERSION + 0.01 * PD_MINOR_VERSION + 0.001))
     {
         static int warned;
-        if (warned < 1)
+        if(warned < 1)
             post("warning: file format (%g) newer than this version (%g) of Pd",
-                f, PD_MAJOR_VERSION + 0.01*PD_MINOR_VERSION);
-        else if (warned < 2)
+                f, PD_MAJOR_VERSION + 0.01 * PD_MINOR_VERSION);
+        else if(warned < 2)
             post("(... more file format messages suppressed)");
         warned++;
     }
 }
 
-static void glob_perf(t_pd *dummy, t_float f)
-{
-    sys_perf = (f != 0);
-}
+static void glob_perf(t_pd *dummy, t_float f) { sys_perf = (f != 0); }
 
 void max_default(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     char str[80];
-    startpost("%s: unknown message %s ", class_getname(pd_class(x)),
-        s->s_name);
-    for (i = 0; i < argc; i++)
+    startpost("%s: unknown message %s ", class_getname(pd_class(x)), s->s_name);
+    for(i = 0; i < argc; i++)
     {
-        atom_string(argv+i, str, 80);
+        atom_string(argv + i, str, 80);
         poststring(str);
     }
     endpost();
@@ -110,11 +103,12 @@ void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int i;
     char str[80];
     sys_vgui("pdtk_plugin_dispatch ");
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
-        atom_string(argv+i, str, 80);
+        atom_string(argv + i, str, 80);
         sys_vgui("%s", str);
-        if (i < argc-1) {
+        if(i < argc - 1)
+        {
             sys_vgui(" ");
         }
     }
@@ -122,6 +116,7 @@ void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 }
 
 int sys_zoom_open = 1;
+
 void glob_zoom_open(t_pd *dummy, t_floatarg f)
 {
     sys_zoom_open = (f != 0 ? 2 : 1);
@@ -129,93 +124,93 @@ void glob_zoom_open(t_pd *dummy, t_floatarg f)
 
 void glob_init(void)
 {
-    maxclass = class_new(gensym("max"), 0, 0, sizeof(t_pd),
-        CLASS_DEFAULT, A_NULL);
+    maxclass =
+        class_new(gensym("max"), 0, 0, sizeof(t_pd), CLASS_DEFAULT, A_NULL);
     class_addanything(maxclass, max_default);
     pd_bind(&maxclass, gensym("max"));
 
-    glob_pdobject = class_new(gensym("pd"), 0, 0, sizeof(t_pd),
-        CLASS_DEFAULT, A_NULL);
-    class_addmethod(glob_pdobject, (t_method)glob_initfromgui, gensym("init"),
-        A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_menunew, gensym("menunew"),
+    glob_pdobject =
+        class_new(gensym("pd"), 0, 0, sizeof(t_pd), CLASS_DEFAULT, A_NULL);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_initfromgui, gensym("init"), A_GIMME, 0);
+    class_addmethod(glob_pdobject, (t_method) glob_menunew, gensym("menunew"),
         A_SYMBOL, A_SYMBOL, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_open, gensym("open"),
+    class_addmethod(glob_pdobject, (t_method) glob_open, gensym("open"),
         A_SYMBOL, A_SYMBOL, A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_exit, gensym("quit"), A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_verifyquit,
+    class_addmethod(
+        glob_pdobject, (t_method) glob_exit, gensym("quit"), A_DEFFLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method) glob_verifyquit,
         gensym("verifyquit"), A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_foo, gensym("foo"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_dsp, gensym("dsp"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_key, gensym("key"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_audiostatus,
-        gensym("audiostatus"), 0);
-    class_addmethod(glob_pdobject, (t_method)glob_finderror,
-        gensym("finderror"), 0);
-    class_addmethod(glob_pdobject, (t_method)glob_findinstance,
+    class_addmethod(
+        glob_pdobject, (t_method) glob_foo, gensym("foo"), A_GIMME, 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_dsp, gensym("dsp"), A_GIMME, 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_key, gensym("key"), A_GIMME, 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_audiostatus, gensym("audiostatus"), 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_finderror, gensym("finderror"), 0);
+    class_addmethod(glob_pdobject, (t_method) glob_findinstance,
         gensym("findinstance"), A_SYMBOL, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_audio_properties,
+    class_addmethod(glob_pdobject, (t_method) glob_audio_properties,
         gensym("audio-properties"), A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_audio_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_audio_dialog,
         gensym("audio-dialog"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_audio_setapi,
+    class_addmethod(glob_pdobject, (t_method) glob_audio_setapi,
         gensym("audio-setapi"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_midi_setapi,
+    class_addmethod(glob_pdobject, (t_method) glob_midi_setapi,
         gensym("midi-setapi"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_midi_properties,
+    class_addmethod(glob_pdobject, (t_method) glob_midi_properties,
         gensym("midi-properties"), A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_midi_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_midi_dialog,
         gensym("midi-dialog"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_start_path_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_start_path_dialog,
         gensym("start-path-dialog"), 0);
-    class_addmethod(glob_pdobject, (t_method)glob_path_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_path_dialog,
         gensym("path-dialog"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_addtopath,
+    class_addmethod(glob_pdobject, (t_method) glob_addtopath,
         gensym("add-to-path"), A_SYMBOL, A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_start_startup_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_start_startup_dialog,
         gensym("start-startup-dialog"), 0);
-    class_addmethod(glob_pdobject, (t_method)glob_startup_dialog,
+    class_addmethod(glob_pdobject, (t_method) glob_startup_dialog,
         gensym("startup-dialog"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_ping, gensym("ping"), 0);
-    class_addmethod(glob_pdobject, (t_method)glob_loadpreferences,
+    class_addmethod(glob_pdobject, (t_method) glob_ping, gensym("ping"), 0);
+    class_addmethod(glob_pdobject, (t_method) glob_loadpreferences,
         gensym("load-preferences"), A_DEFSYM, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_savepreferences,
+    class_addmethod(glob_pdobject, (t_method) glob_savepreferences,
         gensym("save-preferences"), A_DEFSYM, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_forgetpreferences,
+    class_addmethod(glob_pdobject, (t_method) glob_forgetpreferences,
         gensym("forget-preferences"), A_DEFSYM, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_zoom_open,
+    class_addmethod(glob_pdobject, (t_method) glob_zoom_open,
         gensym("zoom-open"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_version,
-        gensym("version"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_perf,
-        gensym("perf"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_compatibility,
+    class_addmethod(
+        glob_pdobject, (t_method) glob_version, gensym("version"), A_FLOAT, 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_perf, gensym("perf"), A_FLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method) glob_compatibility,
         gensym("compatibility"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_plugindispatch,
+    class_addmethod(glob_pdobject, (t_method) glob_plugindispatch,
         gensym("plugin-dispatch"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_helpintro,
+    class_addmethod(glob_pdobject, (t_method) glob_helpintro,
         gensym("help-intro"), A_GIMME, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_fastforward,
-         gensym("fast-forward"), A_FLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_settracing,
-         gensym("set-tracing"), A_FLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method) glob_fastforward,
+        gensym("fast-forward"), A_FLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method) glob_settracing,
+        gensym("set-tracing"), A_FLOAT, 0);
 #if defined(__linux__) || defined(__FreeBSD_kernel__)
-    class_addmethod(glob_pdobject, (t_method)glob_watchdog,
-        gensym("watchdog"), 0);
+    class_addmethod(
+        glob_pdobject, (t_method) glob_watchdog, gensym("watchdog"), 0);
 #endif
     class_addanything(glob_pdobject, max_default);
     pd_bind(&glob_pdobject, gensym("pd"));
 }
 
-    /* function to return version number at run time.  Any of the
-    calling pointers may be zero in case you don't need all of them. */
+/* function to return version number at run time.  Any of the
+calling pointers may be zero in case you don't need all of them. */
 void sys_getversion(int *major, int *minor, int *bugfix)
 {
-    if (major)
-        *major = PD_MAJOR_VERSION;
-    if (minor)
-        *minor = PD_MINOR_VERSION;
-    if (bugfix)
-        *bugfix = PD_BUGFIX_VERSION;
+    if(major) *major = PD_MAJOR_VERSION;
+    if(minor) *minor = PD_MINOR_VERSION;
+    if(bugfix) *bugfix = PD_BUGFIX_VERSION;
 }
-

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -75,10 +75,14 @@ static void glob_version(t_pd *dummy, t_float f)
     {
         static int warned;
         if(warned < 1)
+        {
             post("warning: file format (%g) newer than this version (%g) of Pd",
                 f, PD_MAJOR_VERSION + 0.01 * PD_MINOR_VERSION);
+        }
         else if(warned < 2)
+        {
             post("(... more file format messages suppressed)");
+        }
         warned++;
     }
 }

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* This file contains function prototypes and data types used to implement
 Pd, but not shared with Pd objects. */
@@ -16,7 +16,7 @@ typedef struct _methodentry
 {
     t_symbol *me_name;
     t_gotfn me_fun;
-    unsigned char me_arg[MAXPDARG+1];
+    unsigned char me_arg[MAXPDARG + 1];
 } t_methodentry;
 
 EXTERN_STRUCT _widgetbehavior;
@@ -30,34 +30,34 @@ typedef void (*t_anymethod)(t_pd *x, t_symbol *s, int argc, t_atom *argv);
 
 struct _class
 {
-    t_symbol *c_name;                   /* name (mostly for error reporting) */
-    t_symbol *c_helpname;               /* name of help file */
-    t_symbol *c_externdir;              /* directory extern was loaded from */
-    size_t c_size;                      /* size of an instance */
+    t_symbol *c_name;      /* name (mostly for error reporting) */
+    t_symbol *c_helpname;  /* name of help file */
+    t_symbol *c_externdir; /* directory extern was loaded from */
+    size_t c_size;         /* size of an instance */
 #ifdef PDINSTANCE
-    t_methodentry **c_methods;          /* methods other than bang, etc below */
+    t_methodentry **c_methods; /* methods other than bang, etc below */
 #else
     t_methodentry *c_methods;
 #endif
-    int c_nmethod;                      /* number of methods */
-    t_method c_freemethod;              /* function to call before freeing */
-    t_bangmethod c_bangmethod;          /* common methods */
+    int c_nmethod;             /* number of methods */
+    t_method c_freemethod;     /* function to call before freeing */
+    t_bangmethod c_bangmethod; /* common methods */
     t_pointermethod c_pointermethod;
     t_floatmethod c_floatmethod;
     t_symbolmethod c_symbolmethod;
     t_listmethod c_listmethod;
     t_anymethod c_anymethod;
-    const struct _widgetbehavior *c_wb; /* "gobjs" only */
-    const struct _parentwidgetbehavior *c_pwb;/* widget behavior in parent */
-    t_savefn c_savefn;                  /* function to call when saving */
-    t_propertiesfn c_propertiesfn;      /* function to start prop dialog */
+    const struct _widgetbehavior *c_wb;        /* "gobjs" only */
+    const struct _parentwidgetbehavior *c_pwb; /* widget behavior in parent */
+    t_savefn c_savefn;             /* function to call when saving */
+    t_propertiesfn c_propertiesfn; /* function to start prop dialog */
     struct _class *c_next;
-    int c_floatsignalin;                /* onset to float for signal input */
-    char c_gobj;                        /* true if is a gobj */
-    char c_patchable;                   /* true if we have a t_object header */
-    char c_firstin;                 /* if patchable, true if draw first inlet */
-    char c_drawcommand;             /* a drawing command for a template */
-    t_classfreefn c_classfreefn;    /* function to call before freeing class */
+    int c_floatsignalin;         /* onset to float for signal input */
+    char c_gobj;                 /* true if is a gobj */
+    char c_patchable;            /* true if we have a t_object header */
+    char c_firstin;              /* if patchable, true if draw first inlet */
+    char c_drawcommand;          /* a drawing command for a template */
+    t_classfreefn c_classfreefn; /* function to call before freeing class */
 };
 
 /* m_pd.c */
@@ -70,14 +70,14 @@ EXTERN void pd_emptylist(t_pd *x);
 /* m_obj.c */
 EXTERN int obj_noutlets(const t_object *x);
 EXTERN int obj_ninlets(const t_object *x);
-EXTERN t_outconnect *obj_starttraverseoutlet(const t_object *x, t_outlet **op,
-    int nout);
-EXTERN t_outconnect *obj_nexttraverseoutlet(t_outconnect *lastconnect,
-    t_object **destp, t_inlet **inletp, int *whichp);
-EXTERN t_outconnect *obj_connect(t_object *source, int outno,
-    t_object *sink, int inno);
-EXTERN void obj_disconnect(t_object *source, int outno, t_object *sink,
-    int inno);
+EXTERN t_outconnect *obj_starttraverseoutlet(
+    const t_object *x, t_outlet **op, int nout);
+EXTERN t_outconnect *obj_nexttraverseoutlet(
+    t_outconnect *lastconnect, t_object **destp, t_inlet **inletp, int *whichp);
+EXTERN t_outconnect *obj_connect(
+    t_object *source, int outno, t_object *sink, int inno);
+EXTERN void obj_disconnect(
+    t_object *source, int outno, t_object *sink, int inno);
 EXTERN void outlet_setstacklim(void);
 EXTERN int obj_issignalinlet(const t_object *x, int m);
 EXTERN int obj_issignaloutlet(const t_object *x, int m);
@@ -92,7 +92,7 @@ void pd_globallock(void);
 void pd_globalunlock(void);
 
 /* misc */
-#ifndef SYMTABHASHSIZE  /* set this to, say, 1024 for small memory footprint */
+#ifndef SYMTABHASHSIZE /* set this to, say, 1024 for small memory footprint */
 #define SYMTABHASHSIZE 16384
 #endif /* SYMTABHASHSIZE */
 
@@ -101,7 +101,6 @@ EXTERN void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv);
 EXTERN void glob_quit(void *dummy); /* glob_exit(0); */
 EXTERN void glob_exit(void *dummy, t_float status);
 EXTERN void open_via_helppath(const char *name, const char *dir);
-
 
 #define __m_imp_h_
 #endif /* __m_imp_h_ */

--- a/src/m_memory.c
+++ b/src/m_memory.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include <string.h>
@@ -20,20 +20,19 @@ static int totalmem = 0;
 void *getbytes(size_t nbytes)
 {
     void *ret;
-    if (nbytes < 1) nbytes = 1;
-    ret = (void *)calloc(nbytes, 1);
+    if(nbytes < 1) nbytes = 1;
+    ret = (void *) calloc(nbytes, 1);
 #ifdef LOUD
-    fprintf(stderr, "new  %lx %d\n", (int)ret, nbytes);
+    fprintf(stderr, "new  %lx %d\n", (int) ret, nbytes);
 #endif /* LOUD */
 #ifdef DEBUGMEM
     totalmem += nbytes;
 #endif
-    if (!ret)
-        post("pd: getbytes() failed -- out of memory");
+    if(!ret) post("pd: getbytes() failed -- out of memory");
     return (ret);
 }
 
-void *getzbytes(size_t nbytes)  /* obsolete name */
+void *getzbytes(size_t nbytes) /* obsolete name */
 {
     return (getbytes(nbytes));
 }
@@ -42,36 +41,34 @@ void *copybytes(const void *src, size_t nbytes)
 {
     void *ret;
     ret = getbytes(nbytes);
-    if (nbytes && ret)
-        memcpy(ret, src, nbytes);
+    if(nbytes && ret) memcpy(ret, src, nbytes);
     return (ret);
 }
 
 void *resizebytes(void *old, size_t oldsize, size_t newsize)
 {
     void *ret;
-    if (newsize < 1) newsize = 1;
-    if (oldsize < 1) oldsize = 1;
-    ret = (void *)realloc((char *)old, newsize);
-    if (newsize > oldsize && ret)
-        memset(((char *)ret) + oldsize, 0, newsize - oldsize);
+    if(newsize < 1) newsize = 1;
+    if(oldsize < 1) oldsize = 1;
+    ret = (void *) realloc((char *) old, newsize);
+    if(newsize > oldsize && ret)
+        memset(((char *) ret) + oldsize, 0, newsize - oldsize);
 #ifdef LOUD
-    fprintf(stderr, "resize %lx %d --> %lx %d\n", (int)old, oldsize, (int)ret, newsize);
+    fprintf(stderr, "resize %lx %d --> %lx %d\n", (int) old, oldsize, (int) ret,
+        newsize);
 #endif /* LOUD */
 #ifdef DEBUGMEM
     totalmem += (newsize - oldsize);
 #endif
-    if (!ret)
-        post("pd: resizebytes() failed -- out of memory");
+    if(!ret) post("pd: resizebytes() failed -- out of memory");
     return (ret);
 }
 
 void freebytes(void *fatso, size_t nbytes)
 {
-    if (nbytes == 0)
-        nbytes = 1;
+    if(nbytes == 0) nbytes = 1;
 #ifdef LOUD
-    fprintf(stderr, "free %lx %d\n", (int)fatso, nbytes);
+    fprintf(stderr, "free %lx %d\n", (int) fatso, nbytes);
 #endif /* LOUD */
 #ifdef DEBUGMEM
     totalmem -= nbytes;

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -62,9 +62,13 @@ t_inlet *inlet_new(t_object *owner, t_pd *dest, t_symbol *s1, t_symbol *s2)
     x->i_owner = owner;
     x->i_dest = dest;
     if(s1 == &s_signal)
+    {
         x->i_un.iu_floatsignalvalue = 0;
+    }
     else
+    {
         x->i_symto = s2;
+    }
     x->i_symfrom = s1;
     x->i_next = 0;
     if((y = owner->ob_inlet))
@@ -98,23 +102,37 @@ extern t_class *vinlet_class;
 static void inlet_bang(t_inlet *x)
 {
     if(x->i_symfrom == &s_bang)
+    {
         pd_vmess(x->i_dest, x->i_symto, "");
+    }
     else if(!x->i_symfrom)
+    {
         pd_bang(x->i_dest);
+    }
     else if(x->i_symfrom == &s_list)
+    {
         inlet_list(x, &s_bang, 0, 0);
+    }
     else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    {
         vmess(x->i_dest, gensym("fwd"), "s", &s_bang);
+    }
     else
+    {
         inlet_wrong(x, &s_bang);
+    }
 }
 
 static void inlet_pointer(t_inlet *x, t_gpointer *gp)
 {
     if(x->i_symfrom == &s_pointer)
+    {
         pd_vmess(x->i_dest, x->i_symto, "p", gp);
+    }
     else if(!x->i_symfrom)
+    {
         pd_pointer(x->i_dest, gp);
+    }
     else if(x->i_symfrom == &s_list)
     {
         t_atom a;
@@ -128,11 +146,17 @@ static void inlet_pointer(t_inlet *x, t_gpointer *gp)
 static void inlet_float(t_inlet *x, t_float f)
 {
     if(x->i_symfrom == &s_float)
+    {
         pd_vmess(x->i_dest, x->i_symto, "f", (t_floatarg) f);
+    }
     else if(x->i_symfrom == &s_signal)
+    {
         x->i_un.iu_floatsignalvalue = f;
+    }
     else if(!x->i_symfrom)
+    {
         pd_float(x->i_dest, f);
+    }
     else if(x->i_symfrom == &s_list)
     {
         t_atom a;
@@ -146,9 +170,13 @@ static void inlet_float(t_inlet *x, t_float f)
 static void inlet_symbol(t_inlet *x, t_symbol *s)
 {
     if(x->i_symfrom == &s_symbol)
+    {
         pd_vmess(x->i_dest, x->i_symto, "s", s);
+    }
     else if(!x->i_symfrom)
+    {
         pd_symbol(x->i_dest, s);
+    }
     else if(x->i_symfrom == &s_list)
     {
         t_atom a;
@@ -156,9 +184,13 @@ static void inlet_symbol(t_inlet *x, t_symbol *s)
         inlet_list(x, &s_symbol, 1, &a);
     }
     else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    {
         vmess(x->i_dest, gensym("fwd"), "ss", &s_symbol, s);
+    }
     else
+    {
         inlet_wrong(x, &s_symbol);
+    }
 }
 
 /* forward a message to an inlet~ object */
@@ -177,31 +209,53 @@ static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
     t_atom at;
     if(x->i_symfrom == &s_list || x->i_symfrom == &s_float ||
         x->i_symfrom == &s_symbol || x->i_symfrom == &s_pointer)
+    {
         typedmess(x->i_dest, x->i_symto, argc, argv);
+    }
     else if(!x->i_symfrom)
+    {
         pd_list(x->i_dest, s, argc, argv);
+    }
     else if(!argc)
+    {
         inlet_bang(x);
+    }
     else if(argc == 1 && argv->a_type == A_FLOAT)
+    {
         inlet_float(x, atom_getfloat(argv));
+    }
     else if(argc == 1 && argv->a_type == A_SYMBOL)
+    {
         inlet_symbol(x, atom_getsymbol(argv));
+    }
     else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    {
         inlet_fwd(x, &s_list, argc, argv);
+    }
     else
+    {
         post("class %s", class_getname(*x->i_dest)), inlet_wrong(x, &s_list);
+    }
 }
 
 static void inlet_anything(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     if(x->i_symfrom == s)
+    {
         typedmess(x->i_dest, x->i_symto, argc, argv);
+    }
     else if(!x->i_symfrom)
+    {
         typedmess(x->i_dest, s, argc, argv);
+    }
     else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    {
         inlet_fwd(x, s, argc, argv);
+    }
     else
+    {
         inlet_wrong(x, s);
+    }
 }
 
 void inlet_free(t_inlet *x)
@@ -209,14 +263,20 @@ void inlet_free(t_inlet *x)
     t_object *y = x->i_owner;
     t_inlet *x2;
     if(y->ob_inlet == x)
+    {
         y->ob_inlet = x->i_next;
+    }
     else
+    {
         for(x2 = y->ob_inlet; x2; x2 = x2->i_next)
+        {
             if(x2->i_next == x)
             {
                 x2->i_next = x->i_next;
                 break;
             }
+        }
+    }
     t_freebytes(x, sizeof(*x));
 }
 
@@ -308,18 +368,30 @@ void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv)
     for(count = argc - 1, ap = argv + 1; ip && count--; ap++, ip = ip->i_next)
     {
         if(ap->a_type == A_POINTER)
+        {
             pd_pointer(&ip->i_pd, ap->a_w.w_gpointer);
+        }
         else if(ap->a_type == A_FLOAT)
+        {
             pd_float(&ip->i_pd, ap->a_w.w_float);
+        }
         else
+        {
             pd_symbol(&ip->i_pd, ap->a_w.w_symbol);
+        }
     }
     if(argv->a_type == A_POINTER)
+    {
         pd_pointer(&x->ob_pd, argv->a_w.w_gpointer);
+    }
     else if(argv->a_type == A_FLOAT)
+    {
         pd_float(&x->ob_pd, argv->a_w.w_float);
+    }
     else
+    {
         pd_symbol(&x->ob_pd, argv->a_w.w_symbol);
+    }
 }
 
 /* --------------------------- outlets ------------------------------ */
@@ -401,6 +473,7 @@ static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
     snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
     nchar = strlen(msgbuf);
     for(i = 0; i < nprint && nchar < 100; i++)
+    {
         if(nchar < 100)
         {
             char buf[100];
@@ -408,10 +481,15 @@ static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
             snprintf(msgbuf + nchar, 100 - nchar, " %s", buf);
             nchar = strlen(msgbuf);
         }
+    }
     if(argc > nprint && nchar < 100)
+    {
         sprintf(msgbuf + nchar, "...");
+    }
     else
+    {
         memcpy(msgbuf + 100, "...", 4); /* in case we didn't finish */
+    }
     logpost(who, 2, "%s", msgbuf);
 }
 
@@ -490,15 +568,21 @@ void glob_settracing(void *dummy, t_float f)
     if(f != 0)
     {
         if(backtracer_cantrace)
+        {
             post("pd: tracing already enabled");
+        }
         else
+        {
             canvas_settracing(1);
+        }
         backtracer_cantrace = 1;
     }
     else
     {
         if(!backtracer_cantrace)
+        {
             post("pd: tracing already disabled");
+        }
         else if(!backtrace_unsetclock)
         {
             backtrace_unsetclock =
@@ -572,10 +656,14 @@ void outlet_bang(t_outlet *x)
 {
     t_outconnect *oc;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
+    {
         for(oc = x->o_connections; oc; oc = oc->oc_next)
             pd_bang(oc->oc_to);
+    }
     --stackcount;
 }
 
@@ -584,7 +672,9 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
     t_outconnect *oc;
     t_gpointer gpointer;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
     {
         gpointer = *gp;
@@ -598,10 +688,14 @@ void outlet_float(t_outlet *x, t_float f)
 {
     t_outconnect *oc;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
+    {
         for(oc = x->o_connections; oc; oc = oc->oc_next)
             pd_float(oc->oc_to, f);
+    }
     --stackcount;
 }
 
@@ -609,10 +703,14 @@ void outlet_symbol(t_outlet *x, t_symbol *s)
 {
     t_outconnect *oc;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
+    {
         for(oc = x->o_connections; oc; oc = oc->oc_next)
             pd_symbol(oc->oc_to, s);
+    }
     --stackcount;
 }
 
@@ -620,10 +718,14 @@ void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
+    {
         for(oc = x->o_connections; oc; oc = oc->oc_next)
             pd_list(oc->oc_to, s, argc, argv);
+    }
     --stackcount;
 }
 
@@ -631,10 +733,14 @@ void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_outconnect *oc;
     if(++stackcount >= STACKITER)
+    {
         outlet_stackerror(x);
+    }
     else
+    {
         for(oc = x->o_connections; oc; oc = oc->oc_next)
             typedmess(oc->oc_to, s, argc, argv);
+    }
     --stackcount;
 }
 
@@ -646,14 +752,20 @@ void outlet_free(t_outlet *x)
     t_object *y = x->o_owner;
     t_outlet *x2;
     if(y->ob_outlet == x)
+    {
         y->ob_outlet = x->o_next;
+    }
     else
+    {
         for(x2 = y->ob_outlet; x2; x2 = x2->o_next)
+        {
             if(x2->o_next == x)
             {
                 x2->o_next = x->o_next;
                 break;
             }
+        }
+    }
     t_freebytes(x, sizeof(*x));
 }
 
@@ -827,6 +939,7 @@ void obj_moveinletfirst(t_object *x, t_inlet *i)
     if(x->ob_inlet == i)
         return;
     for(i2 = x->ob_inlet; i2; i2 = i2->i_next)
+    {
         if(i2->i_next == i)
         {
             i2->i_next = i->i_next;
@@ -834,6 +947,7 @@ void obj_moveinletfirst(t_object *x, t_inlet *i)
             x->ob_inlet = i;
             return;
         }
+    }
 }
 
 void obj_moveoutletfirst(t_object *x, t_outlet *o)
@@ -842,6 +956,7 @@ void obj_moveoutletfirst(t_object *x, t_outlet *o)
     if(x->ob_outlet == o)
         return;
     for(o2 = x->ob_outlet; o2; o2 = o2->o_next)
+    {
         if(o2->o_next == o)
         {
             o2->o_next = o->o_next;
@@ -849,6 +964,7 @@ void obj_moveoutletfirst(t_object *x, t_outlet *o)
             x->ob_outlet = o;
             return;
         }
+    }
 }
 
 /* routines for DSP sorting, which are used in d_ugen.c and g_canvas.c */
@@ -875,11 +991,13 @@ int obj_siginletindex(const t_object *x, int m)
         if(x->ob_pd->c_floatsignalin) n++;
     }
     for(i = x->ob_inlet; i; i = i->i_next, m--)
+    {
         if(i->i_symfrom == &s_signal)
         {
             if(m == 0) return (n);
             n++;
         }
+    }
     return (-1);
 }
 
@@ -911,11 +1029,13 @@ int obj_sigoutletindex(const t_object *x, int m)
     int n;
     t_outlet *o2;
     for(o2 = x->ob_outlet, n = 0; o2; o2 = o2->o_next, m--)
+    {
         if(o2->o_sym == &s_signal)
         {
             if(m == 0) return (n);
             n++;
         }
+    }
     return (-1);
 }
 
@@ -934,15 +1054,19 @@ t_float *obj_findsignalscalar(const t_object *x, int m)
     if(x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin)
     {
         if(!m--)
+        {
             return (x->ob_pd->c_floatsignalin > 0
                         ? (t_float *) (((char *) x) + x->ob_pd->c_floatsignalin)
                         : 0);
+        }
     }
     for(i = x->ob_inlet; i; i = i->i_next)
+    {
         if(i->i_symfrom == &s_signal)
         {
             if(m-- == 0) return (&i->i_un.iu_floatsignalvalue);
         }
+    }
     return (0);
 }
 
@@ -981,9 +1105,13 @@ void obj_sendinlet(t_object *x, int n, t_symbol *s, int argc, t_atom *argv)
     for(i = x->ob_inlet; i && n; i = i->i_next, n--)
         ;
     if(i)
+    {
         typedmess(&i->i_pd, s, argc, argv);
+    }
     else
+    {
         bug("obj_sendinlet");
+    }
 }
 
 /* ------------------- setup routine, somewhat misnamed */

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -389,8 +389,7 @@ static t_outconnect **outlet_getconnectionpointer(t_outlet *x)
 {
     if(x->o_connections && *(x->o_connections->oc_to) == backtracer_class)
         return (&((t_backtracer *) (x->o_connections->oc_to))->b_connections);
-    else
-        return (&x->o_connections);
+    return (&x->o_connections);
 }
 
 static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
@@ -454,11 +453,9 @@ int backtracer_settracing(void *x, int tracing)
             pd_error(x, "trace: already tracing");
             return (0);
         }
-        else
-        {
-            backtracer_tracing = 1;
-            return (1);
-        }
+
+        backtracer_tracing = 1;
+        return (1);
     }
     else /* when stopping, print backtrace to here */
     {
@@ -785,8 +782,7 @@ t_outconnect *obj_starttraverseoutlet(
     *op = o;
     if(o)
         return (*outlet_getconnectionpointer(o));
-    else
-        return (0);
+    return (0);
 }
 
 t_outconnect *obj_nexttraverseoutlet(
@@ -821,8 +817,7 @@ t_object *pd_checkobject(t_pd *x)
 {
     if((*x)->c_patchable)
         return ((t_object *) x);
-    else
-        return (0);
+    return (0);
 }
 
 /* move an inlet or outlet to the head of the list */
@@ -831,15 +826,14 @@ void obj_moveinletfirst(t_object *x, t_inlet *i)
     t_inlet *i2;
     if(x->ob_inlet == i)
         return;
-    else
-        for(i2 = x->ob_inlet; i2; i2 = i2->i_next)
-            if(i2->i_next == i)
-            {
-                i2->i_next = i->i_next;
-                i->i_next = x->ob_inlet;
-                x->ob_inlet = i;
-                return;
-            }
+    for(i2 = x->ob_inlet; i2; i2 = i2->i_next)
+        if(i2->i_next == i)
+        {
+            i2->i_next = i->i_next;
+            i->i_next = x->ob_inlet;
+            x->ob_inlet = i;
+            return;
+        }
 }
 
 void obj_moveoutletfirst(t_object *x, t_outlet *o)
@@ -847,15 +841,14 @@ void obj_moveoutletfirst(t_object *x, t_outlet *o)
     t_outlet *o2;
     if(x->ob_outlet == o)
         return;
-    else
-        for(o2 = x->ob_outlet; o2; o2 = o2->o_next)
-            if(o2->o_next == o)
-            {
-                o2->o_next = o->o_next;
-                o->o_next = x->ob_outlet;
-                x->ob_outlet = o;
-                return;
-            }
+    for(o2 = x->ob_outlet; o2; o2 = o2->o_next)
+        if(o2->o_next == o)
+        {
+            o2->o_next = o->o_next;
+            o->o_next = x->ob_outlet;
+            x->ob_outlet = o;
+            return;
+        }
 }
 
 /* routines for DSP sorting, which are used in d_ugen.c and g_canvas.c */
@@ -897,8 +890,7 @@ int obj_issignalinlet(const t_object *x, int m)
     {
         if(!m)
             return (x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin);
-        else
-            m--;
+        m--;
     }
     for(i = x->ob_inlet; i && m; i = i->i_next, m--)
         ;

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* this file handles Max-style patchable objects, i.e., objects which
 can interconnect via inlets and outlets; also, the (terse) generic
@@ -11,9 +11,9 @@ behavior for "gobjs" appears at the end of this file.  */
 #include <string.h>
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #endif
 #ifdef _MSC_VER
 #define snprintf _snprintf
@@ -50,29 +50,31 @@ struct _inlet
 static t_class *inlet_class, *pointerinlet_class, *floatinlet_class,
     *symbolinlet_class;
 
-#define ISINLET(pd) ((*(pd) == inlet_class) || \
-    (*(pd) == pointerinlet_class) || \
-    (*(pd) == floatinlet_class) || \
-    (*(pd) == symbolinlet_class))
+#define ISINLET(pd)                                             \
+    ((*(pd) == inlet_class) || (*(pd) == pointerinlet_class) || \
+        (*(pd) == floatinlet_class) || (*(pd) == symbolinlet_class))
 
 /* --------------------- generic inlets ala max ------------------ */
 
 t_inlet *inlet_new(t_object *owner, t_pd *dest, t_symbol *s1, t_symbol *s2)
 {
-    t_inlet *x = (t_inlet *)pd_new(inlet_class), *y, *y2;
+    t_inlet *x = (t_inlet *) pd_new(inlet_class), *y, *y2;
     x->i_owner = owner;
     x->i_dest = dest;
-    if (s1 == &s_signal)
+    if(s1 == &s_signal)
         x->i_un.iu_floatsignalvalue = 0;
-    else x->i_symto = s2;
+    else
+        x->i_symto = s2;
     x->i_symfrom = s1;
     x->i_next = 0;
-    if ((y = owner->ob_inlet))
+    if((y = owner->ob_inlet))
     {
-        while ((y2 = y->i_next)) y = y2;
+        while((y2 = y->i_next))
+            y = y2;
         y->i_next = x;
     }
-    else owner->ob_inlet = x;
+    else
+        owner->ob_inlet = x;
     return (x);
 }
 
@@ -92,117 +94,129 @@ static void inlet_wrong(t_inlet *x, t_symbol *s)
 static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv);
 extern t_class *vinlet_class;
 
-    /* LATER figure out how to make these efficient: */
+/* LATER figure out how to make these efficient: */
 static void inlet_bang(t_inlet *x)
 {
-    if (x->i_symfrom == &s_bang)
+    if(x->i_symfrom == &s_bang)
         pd_vmess(x->i_dest, x->i_symto, "");
-    else if (!x->i_symfrom) pd_bang(x->i_dest);
-    else if (x->i_symfrom == &s_list)
+    else if(!x->i_symfrom)
+        pd_bang(x->i_dest);
+    else if(x->i_symfrom == &s_list)
         inlet_list(x, &s_bang, 0, 0);
-    else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
         vmess(x->i_dest, gensym("fwd"), "s", &s_bang);
-    else inlet_wrong(x, &s_bang);
+    else
+        inlet_wrong(x, &s_bang);
 }
 
 static void inlet_pointer(t_inlet *x, t_gpointer *gp)
 {
-    if (x->i_symfrom == &s_pointer)
+    if(x->i_symfrom == &s_pointer)
         pd_vmess(x->i_dest, x->i_symto, "p", gp);
-    else if (!x->i_symfrom) pd_pointer(x->i_dest, gp);
-    else if (x->i_symfrom == &s_list)
+    else if(!x->i_symfrom)
+        pd_pointer(x->i_dest, gp);
+    else if(x->i_symfrom == &s_list)
     {
         t_atom a;
         SETPOINTER(&a, gp);
         inlet_list(x, &s_pointer, 1, &a);
     }
-    else inlet_wrong(x, &s_pointer);
+    else
+        inlet_wrong(x, &s_pointer);
 }
 
 static void inlet_float(t_inlet *x, t_float f)
 {
-    if (x->i_symfrom == &s_float)
-        pd_vmess(x->i_dest, x->i_symto, "f", (t_floatarg)f);
-    else if (x->i_symfrom == &s_signal)
+    if(x->i_symfrom == &s_float)
+        pd_vmess(x->i_dest, x->i_symto, "f", (t_floatarg) f);
+    else if(x->i_symfrom == &s_signal)
         x->i_un.iu_floatsignalvalue = f;
-    else if (!x->i_symfrom)
+    else if(!x->i_symfrom)
         pd_float(x->i_dest, f);
-    else if (x->i_symfrom == &s_list)
+    else if(x->i_symfrom == &s_list)
     {
         t_atom a;
         SETFLOAT(&a, f);
         inlet_list(x, &s_float, 1, &a);
     }
-    else inlet_wrong(x, &s_float);
+    else
+        inlet_wrong(x, &s_float);
 }
 
 static void inlet_symbol(t_inlet *x, t_symbol *s)
 {
-    if (x->i_symfrom == &s_symbol)
+    if(x->i_symfrom == &s_symbol)
         pd_vmess(x->i_dest, x->i_symto, "s", s);
-    else if (!x->i_symfrom) pd_symbol(x->i_dest, s);
-    else if (x->i_symfrom == &s_list)
+    else if(!x->i_symfrom)
+        pd_symbol(x->i_dest, s);
+    else if(x->i_symfrom == &s_list)
     {
         t_atom a;
         SETSYMBOL(&a, s);
         inlet_list(x, &s_symbol, 1, &a);
     }
-    else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
         vmess(x->i_dest, gensym("fwd"), "ss", &s_symbol, s);
-    else inlet_wrong(x, &s_symbol);
+    else
+        inlet_wrong(x, &s_symbol);
 }
 
-    /* forward a message to an inlet~ object */
+/* forward a message to an inlet~ object */
 static void inlet_fwd(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_atom *argvec = (t_atom *)alloca((argc+1) * sizeof(t_atom));
+    t_atom *argvec = (t_atom *) alloca((argc + 1) * sizeof(t_atom));
     int i;
     SETSYMBOL(argvec, s);
-    for (i = 0; i < argc; i++)
-        argvec[i+1] = argv[i];
-    typedmess(x->i_dest, gensym("fwd"), argc+1, argvec);
+    for(i = 0; i < argc; i++)
+        argvec[i + 1] = argv[i];
+    typedmess(x->i_dest, gensym("fwd"), argc + 1, argvec);
 }
 
 static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom at;
-    if (x->i_symfrom == &s_list || x->i_symfrom == &s_float
-        || x->i_symfrom == &s_symbol || x->i_symfrom == &s_pointer)
-            typedmess(x->i_dest, x->i_symto, argc, argv);
-    else if (!x->i_symfrom) pd_list(x->i_dest, s, argc, argv);
-    else if (!argc)
-      inlet_bang(x);
-    else if (argc==1 && argv->a_type == A_FLOAT)
-      inlet_float(x, atom_getfloat(argv));
-    else if (argc==1 && argv->a_type == A_SYMBOL)
-      inlet_symbol(x, atom_getsymbol(argv));
-    else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    if(x->i_symfrom == &s_list || x->i_symfrom == &s_float ||
+        x->i_symfrom == &s_symbol || x->i_symfrom == &s_pointer)
+        typedmess(x->i_dest, x->i_symto, argc, argv);
+    else if(!x->i_symfrom)
+        pd_list(x->i_dest, s, argc, argv);
+    else if(!argc)
+        inlet_bang(x);
+    else if(argc == 1 && argv->a_type == A_FLOAT)
+        inlet_float(x, atom_getfloat(argv));
+    else if(argc == 1 && argv->a_type == A_SYMBOL)
+        inlet_symbol(x, atom_getsymbol(argv));
+    else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
         inlet_fwd(x, &s_list, argc, argv);
-    else post("class %s", class_getname(*x->i_dest)), inlet_wrong(x, &s_list);
+    else
+        post("class %s", class_getname(*x->i_dest)), inlet_wrong(x, &s_list);
 }
 
 static void inlet_anything(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->i_symfrom == s)
+    if(x->i_symfrom == s)
         typedmess(x->i_dest, x->i_symto, argc, argv);
-    else if (!x->i_symfrom)
+    else if(!x->i_symfrom)
         typedmess(x->i_dest, s, argc, argv);
-    else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+    else if(x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
         inlet_fwd(x, s, argc, argv);
-    else inlet_wrong(x, s);
+    else
+        inlet_wrong(x, s);
 }
 
 void inlet_free(t_inlet *x)
 {
     t_object *y = x->i_owner;
     t_inlet *x2;
-    if (y->ob_inlet == x) y->ob_inlet = x->i_next;
-    else for (x2 = y->ob_inlet; x2; x2 = x2->i_next)
-        if (x2->i_next == x)
-    {
-        x2->i_next = x->i_next;
-        break;
-    }
+    if(y->ob_inlet == x)
+        y->ob_inlet = x->i_next;
+    else
+        for(x2 = y->ob_inlet; x2; x2 = x2->i_next)
+            if(x2->i_next == x)
+            {
+                x2->i_next = x->i_next;
+                break;
+            }
     t_freebytes(x, sizeof(*x));
 }
 
@@ -212,98 +226,103 @@ static void pointerinlet_pointer(t_inlet *x, t_gpointer *gp)
 {
     gpointer_unset(x->i_pointerslot);
     *(x->i_pointerslot) = *gp;
-    if (gp->gp_stub) gp->gp_stub->gs_refcount++;
+    if(gp->gp_stub) gp->gp_stub->gs_refcount++;
 }
 
 t_inlet *pointerinlet_new(t_object *owner, t_gpointer *gp)
 {
-    t_inlet *x = (t_inlet *)pd_new(pointerinlet_class), *y, *y2;
+    t_inlet *x = (t_inlet *) pd_new(pointerinlet_class), *y, *y2;
     x->i_owner = owner;
     x->i_dest = 0;
     x->i_symfrom = &s_pointer;
     x->i_pointerslot = gp;
     x->i_next = 0;
-    if ((y = owner->ob_inlet))
+    if((y = owner->ob_inlet))
     {
-        while ((y2 = y->i_next)) y = y2;
+        while((y2 = y->i_next))
+            y = y2;
         y->i_next = x;
     }
-    else owner->ob_inlet = x;
+    else
+        owner->ob_inlet = x;
     return (x);
 }
 
-static void floatinlet_float(t_inlet *x, t_float f)
-{
-    *(x->i_floatslot) = f;
-}
+static void floatinlet_float(t_inlet *x, t_float f) { *(x->i_floatslot) = f; }
 
 t_inlet *floatinlet_new(t_object *owner, t_float *fp)
 {
-    t_inlet *x = (t_inlet *)pd_new(floatinlet_class), *y, *y2;
+    t_inlet *x = (t_inlet *) pd_new(floatinlet_class), *y, *y2;
     x->i_owner = owner;
     x->i_dest = 0;
     x->i_symfrom = &s_float;
     x->i_floatslot = fp;
     x->i_next = 0;
-    if ((y = owner->ob_inlet))
+    if((y = owner->ob_inlet))
     {
-        while ((y2 = y->i_next)) y = y2;
+        while((y2 = y->i_next))
+            y = y2;
         y->i_next = x;
     }
-    else owner->ob_inlet = x;
+    else
+        owner->ob_inlet = x;
     return (x);
 }
 
-static void symbolinlet_symbol(t_inlet *x, t_symbol *s)
-{
-    *(x->i_symslot) = s;
-}
+static void symbolinlet_symbol(t_inlet *x, t_symbol *s) { *(x->i_symslot) = s; }
 
 t_inlet *symbolinlet_new(t_object *owner, t_symbol **sp)
 {
-    t_inlet *x = (t_inlet *)pd_new(symbolinlet_class), *y, *y2;
+    t_inlet *x = (t_inlet *) pd_new(symbolinlet_class), *y, *y2;
     x->i_owner = owner;
     x->i_dest = 0;
     x->i_symfrom = &s_symbol;
     x->i_symslot = sp;
     x->i_next = 0;
-    if ((y = owner->ob_inlet))
+    if((y = owner->ob_inlet))
     {
-        while ((y2 = y->i_next)) y = y2;
+        while((y2 = y->i_next))
+            y = y2;
         y->i_next = x;
     }
-    else owner->ob_inlet = x;
+    else
+        owner->ob_inlet = x;
     return (x);
 }
 
 /* ---------------------- routine to handle lists ---------------------- */
 
-    /* objects interpret lists by feeding them to the individual inlets.
-    Before you call this check that the object doesn't have a more
-    specific way to handle lists. */
+/* objects interpret lists by feeding them to the individual inlets.
+Before you call this check that the object doesn't have a more
+specific way to handle lists. */
 void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *ap;
     int count;
-    t_inlet *ip = ((t_object *)x)->ob_inlet;
-    if (!argc)
+    t_inlet *ip = ((t_object *) x)->ob_inlet;
+    if(!argc)
     {
         pd_emptylist(&x->ob_pd);
         return;
     }
-    for (count = argc-1, ap = argv+1; ip && count--; ap++, ip = ip->i_next)
+    for(count = argc - 1, ap = argv + 1; ip && count--; ap++, ip = ip->i_next)
     {
-        if (ap->a_type == A_POINTER) pd_pointer(&ip->i_pd, ap->a_w.w_gpointer);
-        else if (ap->a_type == A_FLOAT) pd_float(&ip->i_pd, ap->a_w.w_float);
-        else pd_symbol(&ip->i_pd, ap->a_w.w_symbol);
+        if(ap->a_type == A_POINTER)
+            pd_pointer(&ip->i_pd, ap->a_w.w_gpointer);
+        else if(ap->a_type == A_FLOAT)
+            pd_float(&ip->i_pd, ap->a_w.w_float);
+        else
+            pd_symbol(&ip->i_pd, ap->a_w.w_symbol);
     }
-    if (argv->a_type == A_POINTER) pd_pointer(&x->ob_pd, argv->a_w.w_gpointer);
-    else if (argv->a_type == A_FLOAT) pd_float(&x->ob_pd, argv->a_w.w_float);
-    else pd_symbol(&x->ob_pd, argv->a_w.w_symbol);
+    if(argv->a_type == A_POINTER)
+        pd_pointer(&x->ob_pd, argv->a_w.w_gpointer);
+    else if(argv->a_type == A_FLOAT)
+        pd_float(&x->ob_pd, argv->a_w.w_float);
+    else
+        pd_symbol(&x->ob_pd, argv->a_w.w_symbol);
 }
 
 /* --------------------------- outlets ------------------------------ */
-
 
 struct _outconnect
 {
@@ -321,6 +340,7 @@ struct _outlet
 
 /* ------- backtracer - keep track of stack for backtracing  --------- */
 #define NARGS 5
+
 typedef struct _msgstack
 {
     struct _backtracer *m_owner;
@@ -343,74 +363,72 @@ int backtracer_tracing;
 t_class *backtracer_class;
 
 static PERTHREAD int stackcount = 0; /* iteration counter */
-#define STACKITER 1000 /* maximum iterations allowed */
+#define STACKITER 1000               /* maximum iterations allowed */
 
 static PERTHREAD int outlet_eventno;
 
-    /* initialize stack depth count on each incoming event that can set off
-    messages so that  the outlet functions can check to prevent stack overflow]
-    from message recursion.  Also count message initiations. */
+/* initialize stack depth count on each incoming event that can set off
+messages so that  the outlet functions can check to prevent stack overflow]
+from message recursion.  Also count message initiations. */
 
 void outlet_setstacklim(void)
 {
     t_msgstack *m;
-    while ((m = backtracer_stack))
-        backtracer_stack = m->m_next; t_freebytes(m, sizeof (*m));
+    while((m = backtracer_stack))
+        backtracer_stack = m->m_next;
+    t_freebytes(m, sizeof(*m));
     stackcount = 0;
     outlet_eventno++;
 }
 
-    /* get a number unique to the (clock, MIDI, GUI, etc.) event we're on */
-int sched_geteventno(void)
-{
-    return (outlet_eventno);
-}
+/* get a number unique to the (clock, MIDI, GUI, etc.) event we're on */
+int sched_geteventno(void) { return (outlet_eventno); }
 
-    /* get pointer to connection list for an outlet (for editing/traversing) */
+/* get pointer to connection list for an outlet (for editing/traversing) */
 static t_outconnect **outlet_getconnectionpointer(t_outlet *x)
 {
-    if (x->o_connections && *(x->o_connections->oc_to) == backtracer_class)
-        return (&((t_backtracer *)(x->o_connections->oc_to))->b_connections);
-    else return (&x->o_connections);
+    if(x->o_connections && *(x->o_connections->oc_to) == backtracer_class)
+        return (&((t_backtracer *) (x->o_connections->oc_to))->b_connections);
+    else
+        return (&x->o_connections);
 }
 
-static void backtracer_printmsg(t_pd *who, t_symbol *s,
-    int argc, t_atom *argv)
+static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
 {
     char msgbuf[104];
     int nprint = (argc > NARGS ? NARGS : argc), nchar, i;
     snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
     nchar = strlen(msgbuf);
-    for (i = 0; i < nprint && nchar < 100; i++)
-        if (nchar < 100)
-    {
-        char buf[100];
-        atom_string(&argv[i], buf, 100);
-        snprintf(msgbuf + nchar, 100-nchar, " %s", buf);
-        nchar = strlen(msgbuf);
-    }
-    if (argc > nprint && nchar < 100)
+    for(i = 0; i < nprint && nchar < 100; i++)
+        if(nchar < 100)
+        {
+            char buf[100];
+            atom_string(&argv[i], buf, 100);
+            snprintf(msgbuf + nchar, 100 - nchar, " %s", buf);
+            nchar = strlen(msgbuf);
+        }
+    if(argc > nprint && nchar < 100)
         sprintf(msgbuf + nchar, "...");
-    else memcpy(msgbuf+100, "...", 4); /* in case we didn't finish */
+    else
+        memcpy(msgbuf + 100, "...", 4); /* in case we didn't finish */
     logpost(who, 2, "%s", msgbuf);
 }
 
-static void backtracer_anything(t_backtracer *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void backtracer_anything(
+    t_backtracer *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_msgstack *m = (t_msgstack *)t_getbytes(sizeof(t_msgstack));
+    t_msgstack *m = (t_msgstack *) t_getbytes(sizeof(t_msgstack));
     t_outconnect *oc;
     int ncopy = (argc > NARGS ? NARGS : argc), i;
     m->m_next = backtracer_stack;
     backtracer_stack = m;
     m->m_sel = s;
     m->m_argc = argc;
-    for (i = 0; i < ncopy; i++)
+    for(i = 0; i < ncopy; i++)
         m->m_argv[i] = argv[i];
     m->m_owner = x;
-    if (backtracer_tracing)
-        backtracer_printmsg(x->b_owner, s, argc, argv);
-    for (oc = x->b_connections; oc; oc = oc->oc_next)
+    if(backtracer_tracing) backtracer_printmsg(x->b_owner, s, argc, argv);
+    for(oc = x->b_connections; oc; oc = oc->oc_next)
         typedmess(oc->oc_to, s, argc, argv);
     backtracer_stack = m->m_next;
     t_freebytes(m, sizeof(*m));
@@ -418,7 +436,7 @@ static void backtracer_anything(t_backtracer *x, t_symbol *s,
 
 t_backtracer *backtracer_new(t_pd *owner)
 {
-    t_backtracer *x = (t_backtracer *)pd_new(backtracer_class);
+    t_backtracer *x = (t_backtracer *) pd_new(backtracer_class);
     x->b_connections = 0;
     x->b_owner = owner;
     return (x);
@@ -426,9 +444,9 @@ t_backtracer *backtracer_new(t_pd *owner)
 
 int backtracer_settracing(void *x, int tracing)
 {
-    if (tracing)
+    if(tracing)
     {
-        if (backtracer_tracing)
+        if(backtracer_tracing)
         {
             pd_error(x, "trace: already tracing");
             return (0);
@@ -439,14 +457,14 @@ int backtracer_settracing(void *x, int tracing)
             return (1);
         }
     }
-    else    /* when stopping, print backtrace to here */
+    else /* when stopping, print backtrace to here */
     {
         t_msgstack *m = backtracer_stack;
         post("backtrace:");
-        while (m)
+        while(m)
         {
-            backtracer_printmsg(m->m_owner->b_owner, m->m_sel,
-                m->m_argc, m->m_argv);
+            backtracer_printmsg(
+                m->m_owner->b_owner, m->m_sel, m->m_argc, m->m_argv);
             m = m->m_next;
         }
         backtracer_tracing = 0;
@@ -465,76 +483,82 @@ static void backtrace_dounsettracing(void *dummy)
     backtrace_unsetclock = 0;
 }
 
-    /* globally turn tracing on and off. */
+/* globally turn tracing on and off. */
 void glob_settracing(void *dummy, t_float f)
 {
-#ifndef PDINSTANCE  /* this won't work with pd instances so just don't */
-    if (f != 0)
+#ifndef PDINSTANCE /* this won't work with pd instances so just don't */
+    if(f != 0)
     {
-        if (backtracer_cantrace)
+        if(backtracer_cantrace)
             post("pd: tracing already enabled");
-        else canvas_settracing(1);
+        else
+            canvas_settracing(1);
         backtracer_cantrace = 1;
     }
     else
     {
-        if (!backtracer_cantrace)
+        if(!backtracer_cantrace)
             post("pd: tracing already disabled");
-        else if (!backtrace_unsetclock)
+        else if(!backtrace_unsetclock)
         {
-            backtrace_unsetclock = clock_new(dummy,
-                (t_method)backtrace_dounsettracing);
+            backtrace_unsetclock =
+                clock_new(dummy, (t_method) backtrace_dounsettracing);
             clock_delay(backtrace_unsetclock, 0);
         }
     }
 #endif
 }
 
-    /* this is called on every object, via canvas_settracing() call above */
+/* this is called on every object, via canvas_settracing() call above */
 void obj_dosettracing(t_object *ob, int onoff)
 {
     t_outlet *o;
-    for (o = ob->ob_outlet; o; o = o->o_next)
+    for(o = ob->ob_outlet; o; o = o->o_next)
     {
-        if (onoff)
+        if(onoff)
         {
             t_backtracer *b = backtracer_new(&ob->ob_pd);
             b->b_connections = o->o_connections;
-            o->o_connections =  (t_outconnect *)t_getbytes(sizeof(t_outconnect));
+            o->o_connections =
+                (t_outconnect *) t_getbytes(sizeof(t_outconnect));
             o->o_connections->oc_next = 0;
             o->o_connections->oc_to = &b->b_pd;
         }
-        else if (o->o_connections &&
-            (*o->o_connections->oc_to == backtracer_class))
+        else if(o->o_connections &&
+                (*o->o_connections->oc_to == backtracer_class))
         {
-            t_backtracer *b = (t_backtracer *)o->o_connections->oc_to;
+            t_backtracer *b = (t_backtracer *) o->o_connections->oc_to;
             t_freebytes(o->o_connections, sizeof(*o->o_connections));
             o->o_connections = b->b_connections;
             t_freebytes(b, sizeof(*b));
         }
-        else bug("obj_dosettracing");
+        else
+            bug("obj_dosettracing");
     }
 }
 
 t_outlet *outlet_new(t_object *owner, t_symbol *s)
 {
-    t_outlet *x = (t_outlet *)getbytes(sizeof(*x)), *y, *y2;
+    t_outlet *x = (t_outlet *) getbytes(sizeof(*x)), *y, *y2;
     x->o_owner = owner;
     x->o_next = 0;
-    if ((y = owner->ob_outlet))
+    if((y = owner->ob_outlet))
     {
-        while ((y2 = y->o_next)) y = y2;
+        while((y2 = y->o_next))
+            y = y2;
         y->o_next = x;
     }
-    else owner->ob_outlet = x;
-    if (backtracer_cantrace)
+    else
+        owner->ob_outlet = x;
+    if(backtracer_cantrace)
     {
         t_backtracer *b = backtracer_new(&owner->ob_pd);
-        x->o_connections =  (t_outconnect *)t_getbytes(sizeof(t_outconnect));
+        x->o_connections = (t_outconnect *) t_getbytes(sizeof(t_outconnect));
         x->o_connections->oc_next = 0;
         x->o_connections->oc_to = &b->b_pd;
     }
-    else x->o_connections = 0;
+    else
+        x->o_connections = 0;
     x->o_sym = s;
     return (x);
 }
@@ -550,8 +574,8 @@ void outlet_bang(t_outlet *x)
     if(++stackcount >= STACKITER)
         outlet_stackerror(x);
     else
-    for (oc = x->o_connections; oc; oc = oc->oc_next)
-        pd_bang(oc->oc_to);
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
+            pd_bang(oc->oc_to);
     --stackcount;
 }
 
@@ -564,7 +588,7 @@ void outlet_pointer(t_outlet *x, t_gpointer *gp)
     else
     {
         gpointer = *gp;
-        for (oc = x->o_connections; oc; oc = oc->oc_next)
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
             pd_pointer(oc->oc_to, &gpointer);
     }
     --stackcount;
@@ -576,8 +600,8 @@ void outlet_float(t_outlet *x, t_float f)
     if(++stackcount >= STACKITER)
         outlet_stackerror(x);
     else
-    for (oc = x->o_connections; oc; oc = oc->oc_next)
-        pd_float(oc->oc_to, f);
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
+            pd_float(oc->oc_to, f);
     --stackcount;
 }
 
@@ -587,8 +611,8 @@ void outlet_symbol(t_outlet *x, t_symbol *s)
     if(++stackcount >= STACKITER)
         outlet_stackerror(x);
     else
-    for (oc = x->o_connections; oc; oc = oc->oc_next)
-        pd_symbol(oc->oc_to, s);
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
+            pd_symbol(oc->oc_to, s);
     --stackcount;
 }
 
@@ -598,8 +622,8 @@ void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
     if(++stackcount >= STACKITER)
         outlet_stackerror(x);
     else
-    for (oc = x->o_connections; oc; oc = oc->oc_next)
-        pd_list(oc->oc_to, s, argc, argv);
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
+            pd_list(oc->oc_to, s, argc, argv);
     --stackcount;
 }
 
@@ -609,72 +633,74 @@ void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv)
     if(++stackcount >= STACKITER)
         outlet_stackerror(x);
     else
-    for (oc = x->o_connections; oc; oc = oc->oc_next)
-        typedmess(oc->oc_to, s, argc, argv);
+        for(oc = x->o_connections; oc; oc = oc->oc_next)
+            typedmess(oc->oc_to, s, argc, argv);
     --stackcount;
 }
 
-    /* get the outlet's declared symbol */
-t_symbol *outlet_getsymbol(t_outlet *x)
-{
-    return (x->o_sym);
-}
+/* get the outlet's declared symbol */
+t_symbol *outlet_getsymbol(t_outlet *x) { return (x->o_sym); }
 
 void outlet_free(t_outlet *x)
 {
     t_object *y = x->o_owner;
     t_outlet *x2;
-    if (y->ob_outlet == x) y->ob_outlet = x->o_next;
-    else for (x2 = y->ob_outlet; x2; x2 = x2->o_next)
-        if (x2->o_next == x)
-    {
-        x2->o_next = x->o_next;
-        break;
-    }
+    if(y->ob_outlet == x)
+        y->ob_outlet = x->o_next;
+    else
+        for(x2 = y->ob_outlet; x2; x2 = x2->o_next)
+            if(x2->o_next == x)
+            {
+                x2->o_next = x->o_next;
+                break;
+            }
     t_freebytes(x, sizeof(*x));
 }
 
-    /* connect an outlet of one object to an inlet of another.  The receiving
-    "pd" is usually a patchable object, but this may be used to add a
-    non-patchable pd to an outlet by specifying the 0th inlet. */
-t_outconnect *obj_connect(t_object *source, int outno,
-    t_object *sink, int inno)
+/* connect an outlet of one object to an inlet of another.  The receiving
+"pd" is usually a patchable object, but this may be used to add a
+non-patchable pd to an outlet by specifying the 0th inlet. */
+t_outconnect *obj_connect(t_object *source, int outno, t_object *sink, int inno)
 {
     t_inlet *i;
     t_outlet *o;
     t_pd *to;
     t_outconnect *oc, *oc2, **ochead;
 
-    for (o = source->ob_outlet; o && outno; o = o->o_next, outno--) ;
-    if (!o) return (0);
+    for(o = source->ob_outlet; o && outno; o = o->o_next, outno--)
+        ;
+    if(!o) return (0);
 
-    if (sink->ob_pd->c_firstin)
+    if(sink->ob_pd->c_firstin)
     {
-        if (!inno)
+        if(!inno)
         {
             to = &sink->ob_pd;
             goto doit;
         }
-        else inno--;
+        else
+            inno--;
     }
-    for (i = sink->ob_inlet; i && inno; i = i->i_next, inno--) ;
-    if (!i) return (0);
+    for(i = sink->ob_inlet; i && inno; i = i->i_next, inno--)
+        ;
+    if(!i) return (0);
     to = &i->i_pd;
 doit:
     ochead = outlet_getconnectionpointer(o);
-    oc = (t_outconnect *)t_getbytes(sizeof(*oc));
+    oc = (t_outconnect *) t_getbytes(sizeof(*oc));
     oc->oc_next = 0;
     oc->oc_to = to;
-        /* append it to the end of the list */
-        /* LATER we might cache the last "oc" to make this faster. */
-    if ((oc2 = *ochead))
+    /* append it to the end of the list */
+    /* LATER we might cache the last "oc" to make this faster. */
+    if((oc2 = *ochead))
     {
-        while (oc2->oc_next)
+        while(oc2->oc_next)
             oc2 = oc2->oc_next;
         oc2->oc_next = oc;
     }
-    else *ochead = oc;
-    if (o->o_sym == &s_signal) canvas_update_dsp();
+    else
+        *ochead = oc;
+    if(o->o_sym == &s_signal) canvas_update_dsp();
 
     return (oc);
 }
@@ -686,32 +712,35 @@ void obj_disconnect(t_object *source, int outno, t_object *sink, int inno)
     t_pd *to;
     t_outconnect *oc, *oc2, **ochead;
 
-    for (o = source->ob_outlet; o && outno; o = o->o_next, outno--) ;
-    if (!o) return;
-    if (sink->ob_pd->c_firstin)
+    for(o = source->ob_outlet; o && outno; o = o->o_next, outno--)
+        ;
+    if(!o) return;
+    if(sink->ob_pd->c_firstin)
     {
-        if (!inno)
+        if(!inno)
         {
             to = &sink->ob_pd;
             goto doit;
         }
-        else inno--;
+        else
+            inno--;
     }
-    for (i = sink->ob_inlet; i && inno; i = i->i_next, inno--) ;
-    if (!i) return;
+    for(i = sink->ob_inlet; i && inno; i = i->i_next, inno--)
+        ;
+    if(!i) return;
     to = &i->i_pd;
 doit:
     ochead = outlet_getconnectionpointer(o);
-    if (!(oc = *ochead)) return;
-    if (oc->oc_to == to)
+    if(!(oc = *ochead)) return;
+    if(oc->oc_to == to)
     {
         *ochead = oc->oc_next;
         freebytes(oc, sizeof(*oc));
         goto done;
     }
-    while ((oc2 = oc->oc_next))
+    while((oc2 = oc->oc_next))
     {
-        if (oc2->oc_to == to)
+        if(oc2->oc_to == to)
         {
             oc->oc_next = oc2->oc_next;
             freebytes(oc2, sizeof(*oc2));
@@ -720,7 +749,7 @@ doit:
         oc = oc2;
     }
 done:
-    if (o->o_sym == &s_signal) canvas_update_dsp();
+    if(o->o_sym == &s_signal) canvas_update_dsp();
 }
 
 /* ------ traversal routines for code that can't see our structures ------ */
@@ -729,7 +758,8 @@ int obj_noutlets(const t_object *x)
 {
     int n;
     t_outlet *o;
-    for (o = x->ob_outlet, n = 0; o; o = o->o_next) n++;
+    for(o = x->ob_outlet, n = 0; o; o = o->o_next)
+        n++;
     return (n);
 }
 
@@ -737,33 +767,38 @@ int obj_ninlets(const t_object *x)
 {
     int n;
     t_inlet *i;
-    for (i = x->ob_inlet, n = 0; i; i = i->i_next) n++;
-    if (x->ob_pd->c_firstin) n++;
+    for(i = x->ob_inlet, n = 0; i; i = i->i_next)
+        n++;
+    if(x->ob_pd->c_firstin) n++;
     return (n);
 }
 
-t_outconnect *obj_starttraverseoutlet(const t_object *x, t_outlet **op, int nout)
+t_outconnect *obj_starttraverseoutlet(
+    const t_object *x, t_outlet **op, int nout)
 {
     t_outlet *o = x->ob_outlet;
-    while (nout-- && o) o = o->o_next;
+    while(nout-- && o)
+        o = o->o_next;
     *op = o;
-    if (o)
+    if(o)
         return (*outlet_getconnectionpointer(o));
-    else return (0);
+    else
+        return (0);
 }
 
-t_outconnect *obj_nexttraverseoutlet(t_outconnect *lastconnect,
-    t_object **destp, t_inlet **inletp, int *whichp)
+t_outconnect *obj_nexttraverseoutlet(
+    t_outconnect *lastconnect, t_object **destp, t_inlet **inletp, int *whichp)
 {
     t_pd *y;
     y = lastconnect->oc_to;
-    if (ISINLET(y))
+    if(ISINLET(y))
     {
         int n;
-        t_inlet *i = (t_inlet *)y, *i2;
+        t_inlet *i = (t_inlet *) y, *i2;
         t_object *dest = i->i_owner;
-        for (n = dest->ob_pd->c_firstin, i2 = dest->ob_inlet;
-            i2 && i2 != i; i2 = i2->i_next) n++;
+        for(n = dest->ob_pd->c_firstin, i2 = dest->ob_inlet; i2 && i2 != i;
+            i2 = i2->i_next)
+            n++;
         *whichp = n;
         *destp = dest;
         *inletp = i;
@@ -772,92 +807,97 @@ t_outconnect *obj_nexttraverseoutlet(t_outconnect *lastconnect,
     {
         *whichp = 0;
         *inletp = 0;
-        *destp = ((t_object *)y);
+        *destp = ((t_object *) y);
     }
     return (lastconnect->oc_next);
 }
 
-    /* this one checks that a pd is indeed a patchable object, and returns
-    it, correctly typed, or zero if the check failed. */
+/* this one checks that a pd is indeed a patchable object, and returns
+it, correctly typed, or zero if the check failed. */
 t_object *pd_checkobject(t_pd *x)
 {
-    if ((*x)->c_patchable) return ((t_object *)x);
-    else return (0);
+    if((*x)->c_patchable)
+        return ((t_object *) x);
+    else
+        return (0);
 }
 
-    /* move an inlet or outlet to the head of the list */
+/* move an inlet or outlet to the head of the list */
 void obj_moveinletfirst(t_object *x, t_inlet *i)
 {
     t_inlet *i2;
-    if (x->ob_inlet == i) return;
-    else for (i2 = x->ob_inlet; i2; i2 = i2->i_next)
-        if (i2->i_next == i)
-    {
-        i2->i_next = i->i_next;
-        i->i_next = x->ob_inlet;
-        x->ob_inlet = i;
+    if(x->ob_inlet == i)
         return;
-    }
+    else
+        for(i2 = x->ob_inlet; i2; i2 = i2->i_next)
+            if(i2->i_next == i)
+            {
+                i2->i_next = i->i_next;
+                i->i_next = x->ob_inlet;
+                x->ob_inlet = i;
+                return;
+            }
 }
 
 void obj_moveoutletfirst(t_object *x, t_outlet *o)
 {
     t_outlet *o2;
-    if (x->ob_outlet == o) return;
-    else for (o2 = x->ob_outlet; o2; o2 = o2->o_next)
-        if (o2->o_next == o)
-    {
-        o2->o_next = o->o_next;
-        o->o_next = x->ob_outlet;
-        x->ob_outlet = o;
+    if(x->ob_outlet == o)
         return;
-    }
+    else
+        for(o2 = x->ob_outlet; o2; o2 = o2->o_next)
+            if(o2->o_next == o)
+            {
+                o2->o_next = o->o_next;
+                o->o_next = x->ob_outlet;
+                x->ob_outlet = o;
+                return;
+            }
 }
 
-    /* routines for DSP sorting, which are used in d_ugen.c and g_canvas.c */
-    /* LATER try to consolidate all the slightly different routines. */
+/* routines for DSP sorting, which are used in d_ugen.c and g_canvas.c */
+/* LATER try to consolidate all the slightly different routines. */
 
 int obj_nsiginlets(const t_object *x)
 {
     int n;
     t_inlet *i;
-    for (i = x->ob_inlet, n = 0; i; i = i->i_next)
-        if (i->i_symfrom == &s_signal) n++;
-    if (x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin) n++;
+    for(i = x->ob_inlet, n = 0; i; i = i->i_next)
+        if(i->i_symfrom == &s_signal) n++;
+    if(x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin) n++;
     return (n);
 }
 
-    /* get the index, among signal inlets, of the mth inlet overall */
+/* get the index, among signal inlets, of the mth inlet overall */
 int obj_siginletindex(const t_object *x, int m)
 {
     int n = 0;
     t_inlet *i;
-    if (x->ob_pd->c_firstin)
+    if(x->ob_pd->c_firstin)
     {
-        if (!m--)
-            return (0);
-        if (x->ob_pd->c_floatsignalin)
+        if(!m--) return (0);
+        if(x->ob_pd->c_floatsignalin) n++;
+    }
+    for(i = x->ob_inlet; i; i = i->i_next, m--)
+        if(i->i_symfrom == &s_signal)
+        {
+            if(m == 0) return (n);
             n++;
-    }
-    for (i = x->ob_inlet; i; i = i->i_next, m--)
-        if (i->i_symfrom == &s_signal)
-    {
-        if (m == 0) return (n);
-        n++;
-    }
+        }
     return (-1);
 }
 
 int obj_issignalinlet(const t_object *x, int m)
 {
     t_inlet *i;
-    if (x->ob_pd->c_firstin)
+    if(x->ob_pd->c_firstin)
     {
-        if (!m)
+        if(!m)
             return (x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin);
-        else m--;
+        else
+            m--;
     }
-    for (i = x->ob_inlet; i && m; i = i->i_next, m--)
+    for(i = x->ob_inlet; i && m; i = i->i_next, m--)
         ;
     return (i && (i->i_symfrom == &s_signal));
 }
@@ -866,8 +906,8 @@ int obj_nsigoutlets(const t_object *x)
 {
     int n;
     t_outlet *o;
-    for (o = x->ob_outlet, n = 0; o; o = o->o_next)
-        if (o->o_sym == &s_signal) n++;
+    for(o = x->ob_outlet, n = 0; o; o = o->o_next)
+        if(o->o_sym == &s_signal) n++;
     return (n);
 }
 
@@ -875,12 +915,12 @@ int obj_sigoutletindex(const t_object *x, int m)
 {
     int n;
     t_outlet *o2;
-    for (o2 = x->ob_outlet, n = 0; o2; o2 = o2->o_next, m--)
-        if (o2->o_sym == &s_signal)
-    {
-        if (m == 0) return (n);
-        n++;
-    }
+    for(o2 = x->ob_outlet, n = 0; o2; o2 = o2->o_next, m--)
+        if(o2->o_sym == &s_signal)
+        {
+            if(m == 0) return (n);
+            n++;
+        }
     return (-1);
 }
 
@@ -888,25 +928,26 @@ int obj_issignaloutlet(const t_object *x, int m)
 {
     int n;
     t_outlet *o2;
-    for (o2 = x->ob_outlet, n = 0; o2 && m--; o2 = o2->o_next);
+    for(o2 = x->ob_outlet, n = 0; o2 && m--; o2 = o2->o_next)
+        ;
     return (o2 && (o2->o_sym == &s_signal));
 }
 
 t_float *obj_findsignalscalar(const t_object *x, int m)
 {
     t_inlet *i;
-    if (x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin)
+    if(x->ob_pd->c_firstin && x->ob_pd->c_floatsignalin)
     {
-        if (!m--)
-            return (x->ob_pd->c_floatsignalin > 0 ?
-                (t_float *)(((char *)x) + x->ob_pd->c_floatsignalin) : 0);
+        if(!m--)
+            return (x->ob_pd->c_floatsignalin > 0
+                        ? (t_float *) (((char *) x) + x->ob_pd->c_floatsignalin)
+                        : 0);
     }
-    for (i = x->ob_inlet; i; i = i->i_next)
-        if (i->i_symfrom == &s_signal)
-    {
-        if (m-- == 0)
-            return (&i->i_un.iu_floatsignalvalue);
-    }
+    for(i = x->ob_inlet; i; i = i->i_next)
+        if(i->i_symfrom == &s_signal)
+        {
+            if(m-- == 0) return (&i->i_un.iu_floatsignalvalue);
+        }
     return (0);
 }
 
@@ -916,10 +957,9 @@ int inlet_getsignalindex(t_inlet *x)
 {
     int n = 0;
     t_inlet *i;
-    if (x->i_symfrom != &s_signal)
-        bug("inlet_getsignalindex");
-    for (i = x->i_owner->ob_inlet, n = 0; i && i != x; i = i->i_next)
-        if (i->i_symfrom == &s_signal) n++;
+    if(x->i_symfrom != &s_signal) bug("inlet_getsignalindex");
+    for(i = x->i_owner->ob_inlet, n = 0; i && i != x; i = i->i_next)
+        if(i->i_symfrom == &s_signal) n++;
     return (n);
 }
 
@@ -927,15 +967,15 @@ int outlet_getsignalindex(t_outlet *x)
 {
     int n = 0;
     t_outlet *o;
-    for (o = x->o_owner->ob_outlet, n = 0; o && o != x; o = o->o_next)
-        if (o->o_sym == &s_signal) n++;
+    for(o = x->o_owner->ob_outlet, n = 0; o && o != x; o = o->o_next)
+        if(o->o_sym == &s_signal) n++;
     return (n);
 }
 
 void obj_saveformat(const t_object *x, t_binbuf *bb)
 {
-    if (x->te_width)
-        binbuf_addv(bb, "ssf;", &s__X, gensym("f"), (float)x->te_width);
+    if(x->te_width)
+        binbuf_addv(bb, "ssf;", &s__X, gensym("f"), (float) x->te_width);
 }
 
 /* this one only in g_clone.c -- LATER consider sending the message
@@ -943,18 +983,19 @@ without having to chase the linked list every time? */
 void obj_sendinlet(t_object *x, int n, t_symbol *s, int argc, t_atom *argv)
 {
     t_inlet *i;
-    for (i = x->ob_inlet; i && n; i = i->i_next, n--)
+    for(i = x->ob_inlet; i && n; i = i->i_next, n--)
         ;
-    if (i)
+    if(i)
         typedmess(&i->i_pd, s, argc, argv);
-    else bug("obj_sendinlet");
+    else
+        bug("obj_sendinlet");
 }
 
 /* ------------------- setup routine, somewhat misnamed */
 void obj_init(void)
 {
-    inlet_class = class_new(gensym("inlet"), 0, 0,
-        sizeof(t_inlet), CLASS_PD, 0);
+    inlet_class =
+        class_new(gensym("inlet"), 0, 0, sizeof(t_inlet), CLASS_PD, 0);
     class_addbang(inlet_class, inlet_bang);
     class_addpointer(inlet_class, inlet_pointer);
     class_addfloat(inlet_class, inlet_float);
@@ -962,25 +1003,22 @@ void obj_init(void)
     class_addlist(inlet_class, inlet_list);
     class_addanything(inlet_class, inlet_anything);
 
-    pointerinlet_class = class_new(gensym("inlet"), 0, 0,
-        sizeof(t_inlet), CLASS_PD, 0);
+    pointerinlet_class =
+        class_new(gensym("inlet"), 0, 0, sizeof(t_inlet), CLASS_PD, 0);
     class_addpointer(pointerinlet_class, pointerinlet_pointer);
     class_addanything(pointerinlet_class, inlet_wrong);
 
-    floatinlet_class = class_new(gensym("inlet"), 0, 0,
-        sizeof(t_inlet), CLASS_PD, 0);
-    class_addfloat(floatinlet_class, (t_method)floatinlet_float);
+    floatinlet_class =
+        class_new(gensym("inlet"), 0, 0, sizeof(t_inlet), CLASS_PD, 0);
+    class_addfloat(floatinlet_class, (t_method) floatinlet_float);
     class_addanything(floatinlet_class, inlet_wrong);
 
-    symbolinlet_class = class_new(gensym("inlet"), 0, 0,
-        sizeof(t_inlet), CLASS_PD, 0);
+    symbolinlet_class =
+        class_new(gensym("inlet"), 0, 0, sizeof(t_inlet), CLASS_PD, 0);
     class_addsymbol(symbolinlet_class, symbolinlet_symbol);
     class_addanything(symbolinlet_class, inlet_wrong);
 
-    backtracer_class = class_new(gensym("backtracer"), 0, 0,
-        sizeof(t_backtracer), CLASS_PD, 0);
+    backtracer_class = class_new(
+        gensym("backtracer"), 0, 0, sizeof(t_backtracer), CLASS_PD, 0);
     class_addanything(backtracer_class, backtracer_anything);
-
 }
-
-

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -396,7 +396,9 @@ static t_outconnect **outlet_getconnectionpointer(t_outlet *x)
 static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
 {
     char msgbuf[104];
-    int nprint = (argc > NARGS ? NARGS : argc), nchar, i;
+    int nprint = (argc > NARGS ? NARGS : argc);
+    int nchar;
+    int i;
     snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
     nchar = strlen(msgbuf);
     for(i = 0; i < nprint && nchar < 100; i++)
@@ -419,7 +421,8 @@ static void backtracer_anything(
 {
     t_msgstack *m = (t_msgstack *) t_getbytes(sizeof(t_msgstack));
     t_outconnect *oc;
-    int ncopy = (argc > NARGS ? NARGS : argc), i;
+    int ncopy = (argc > NARGS ? NARGS : argc);
+    int i;
     m->m_next = backtracer_stack;
     backtracer_stack = m;
     m->m_sel = s;

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -197,9 +197,8 @@ static void inlet_symbol(t_inlet *x, t_symbol *s)
 static void inlet_fwd(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *argvec = (t_atom *) alloca((argc + 1) * sizeof(t_atom));
-    int i;
     SETSYMBOL(argvec, s);
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         argvec[i + 1] = argv[i];
     typedmess(x->i_dest, gensym("fwd"), argc + 1, argvec);
 }
@@ -472,7 +471,7 @@ static void backtracer_printmsg(t_pd *who, t_symbol *s, int argc, t_atom *argv)
     int i;
     snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
     nchar = strlen(msgbuf);
-    for(i = 0; i < nprint && nchar < 100; i++)
+    for(int i = 0; i < nprint && nchar < 100; i++)
     {
         if(nchar < 100)
         {
@@ -499,12 +498,11 @@ static void backtracer_anything(
     t_msgstack *m = (t_msgstack *) t_getbytes(sizeof(t_msgstack));
     t_outconnect *oc;
     int ncopy = (argc > NARGS ? NARGS : argc);
-    int i;
     m->m_next = backtracer_stack;
     backtracer_stack = m;
     m->m_sel = s;
     m->m_argc = argc;
-    for(i = 0; i < ncopy; i++)
+    for(int i = 0; i < ncopy; i++)
         m->m_argv[i] = argv[i];
     m->m_owner = x;
     if(backtracer_tracing) backtracer_printmsg(x->b_owner, s, argc, argv);

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -1,28 +1,29 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include <stdlib.h>
 #include <string.h>
 #include "m_pd.h"
 #include "m_imp.h"
-#include "g_canvas.h"   /* just for LB_LOAD */
+#include "g_canvas.h" /* just for LB_LOAD */
 
-    /* FIXME no out-of-memory testing yet! */
+/* FIXME no out-of-memory testing yet! */
 
 t_pd *pd_new(t_class *c)
 {
     t_pd *x;
-    if (!c) {
-        bug ("pd_new: apparently called before setup routine");
+    if(!c)
+    {
+        bug("pd_new: apparently called before setup routine");
         return NULL;
     }
-    x = (t_pd *)t_getbytes(c->c_size);
+    x = (t_pd *) t_getbytes(c->c_size);
     *x = c;
-    if (c->c_patchable)
+    if(c->c_patchable)
     {
-        ((t_object *)x)->ob_inlet = 0;
-        ((t_object *)x)->ob_outlet = 0;
+        ((t_object *) x)->ob_inlet = 0;
+        ((t_object *) x)->ob_outlet = 0;
     }
     return (x);
 }
@@ -30,24 +31,23 @@ t_pd *pd_new(t_class *c)
 void pd_free(t_pd *x)
 {
     t_class *c = *x;
-    if (c->c_freemethod) (*(t_gotfn)(c->c_freemethod))(x);
-    if (c->c_patchable)
+    if(c->c_freemethod) (*(t_gotfn) (c->c_freemethod))(x);
+    if(c->c_patchable)
     {
-        while (((t_object *)x)->ob_outlet)
-            outlet_free(((t_object *)x)->ob_outlet);
-        while (((t_object *)x)->ob_inlet)
-            inlet_free(((t_object *)x)->ob_inlet);
-        if (((t_object *)x)->ob_binbuf)
-            binbuf_free(((t_object *)x)->ob_binbuf);
+        while(((t_object *) x)->ob_outlet)
+            outlet_free(((t_object *) x)->ob_outlet);
+        while(((t_object *) x)->ob_inlet)
+            inlet_free(((t_object *) x)->ob_inlet);
+        if(((t_object *) x)->ob_binbuf)
+            binbuf_free(((t_object *) x)->ob_binbuf);
     }
-    if (c->c_size) t_freebytes(x, c->c_size);
+    if(c->c_size) t_freebytes(x, c->c_size);
 }
 
 void gobj_save(t_gobj *x, t_binbuf *b)
 {
     t_class *c = x->g_pd;
-    if (c->c_savefn)
-        (c->c_savefn)(x, b);
+    if(c->c_savefn) (c->c_savefn)(x, b);
 }
 
 /* deal with several objects bound to the same symbol.  If more than one, we
@@ -71,53 +71,52 @@ typedef struct _bindlist
 static void bindlist_bang(t_bindlist *x)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_bang(e->e_who);
 }
 
 static void bindlist_float(t_bindlist *x, t_float f)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_float(e->e_who, f);
 }
 
 static void bindlist_symbol(t_bindlist *x, t_symbol *s)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_symbol(e->e_who, s);
 }
 
 static void bindlist_pointer(t_bindlist *x, t_gpointer *gp)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_pointer(e->e_who, gp);
 }
 
-static void bindlist_list(t_bindlist *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void bindlist_list(t_bindlist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_list(e->e_who, s, argc, argv);
 }
 
-static void bindlist_anything(t_bindlist *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void bindlist_anything(
+    t_bindlist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_bindelem *e;
-    for (e = x->b_list; e; e = e->e_next)
+    for(e = x->b_list; e; e = e->e_next)
         pd_typedmess(e->e_who, s, argc, argv);
 }
 
 void m_pd_setup(void)
 {
-    bindlist_class = class_new(gensym("bindlist"), 0, 0,
-        sizeof(t_bindlist), CLASS_PD, 0);
+    bindlist_class =
+        class_new(gensym("bindlist"), 0, 0, sizeof(t_bindlist), CLASS_PD, 0);
     class_addbang(bindlist_class, bindlist_bang);
-    class_addfloat(bindlist_class, (t_method)bindlist_float);
+    class_addfloat(bindlist_class, (t_method) bindlist_float);
     class_addsymbol(bindlist_class, bindlist_symbol);
     class_addpointer(bindlist_class, bindlist_pointer);
     class_addlist(bindlist_class, bindlist_list);
@@ -126,21 +125,21 @@ void m_pd_setup(void)
 
 void pd_bind(t_pd *x, t_symbol *s)
 {
-    if (s->s_thing)
+    if(s->s_thing)
     {
-        if (*s->s_thing == bindlist_class)
+        if(*s->s_thing == bindlist_class)
         {
-            t_bindlist *b = (t_bindlist *)s->s_thing;
-            t_bindelem *e = (t_bindelem *)getbytes(sizeof(t_bindelem));
+            t_bindlist *b = (t_bindlist *) s->s_thing;
+            t_bindelem *e = (t_bindelem *) getbytes(sizeof(t_bindelem));
             e->e_next = b->b_list;
             e->e_who = x;
             b->b_list = e;
         }
         else
         {
-            t_bindlist *b = (t_bindlist *)pd_new(bindlist_class);
-            t_bindelem *e1 = (t_bindelem *)getbytes(sizeof(t_bindelem));
-            t_bindelem *e2 = (t_bindelem *)getbytes(sizeof(t_bindelem));
+            t_bindlist *b = (t_bindlist *) pd_new(bindlist_class);
+            t_bindelem *e1 = (t_bindelem *) getbytes(sizeof(t_bindelem));
+            t_bindelem *e2 = (t_bindelem *) getbytes(sizeof(t_bindelem));
             b->b_list = e1;
             e1->e_who = x;
             e1->e_next = e2;
@@ -149,69 +148,73 @@ void pd_bind(t_pd *x, t_symbol *s)
             s->s_thing = &b->b_pd;
         }
     }
-    else s->s_thing = x;
+    else
+        s->s_thing = x;
 }
 
 void pd_unbind(t_pd *x, t_symbol *s)
 {
-    if (s->s_thing == x) s->s_thing = 0;
-    else if (s->s_thing && *s->s_thing == bindlist_class)
+    if(s->s_thing == x)
+        s->s_thing = 0;
+    else if(s->s_thing && *s->s_thing == bindlist_class)
     {
-            /* bindlists always have at least two elements... if the number
-            goes down to one, get rid of the bindlist and bind the symbol
-            straight to the remaining element. */
+        /* bindlists always have at least two elements... if the number
+        goes down to one, get rid of the bindlist and bind the symbol
+        straight to the remaining element. */
 
-        t_bindlist *b = (t_bindlist *)s->s_thing;
+        t_bindlist *b = (t_bindlist *) s->s_thing;
         t_bindelem *e, *e2;
-        if ((e = b->b_list)->e_who == x)
+        if((e = b->b_list)->e_who == x)
         {
             b->b_list = e->e_next;
             freebytes(e, sizeof(t_bindelem));
         }
-        else for (e = b->b_list; (e2 = e->e_next); e = e2)
-            if (e2->e_who == x)
-        {
-            e->e_next = e2->e_next;
-            freebytes(e2, sizeof(t_bindelem));
-            break;
-        }
-        if (!b->b_list->e_next)
+        else
+            for(e = b->b_list; (e2 = e->e_next); e = e2)
+                if(e2->e_who == x)
+                {
+                    e->e_next = e2->e_next;
+                    freebytes(e2, sizeof(t_bindelem));
+                    break;
+                }
+        if(!b->b_list->e_next)
         {
             s->s_thing = b->b_list->e_who;
             freebytes(b->b_list, sizeof(t_bindelem));
             pd_free(&b->b_pd);
         }
     }
-    else pd_error(x, "%s: couldn't unbind", s->s_name);
+    else
+        pd_error(x, "%s: couldn't unbind", s->s_name);
 }
 
 t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
 {
     t_pd *x = 0;
 
-    if (!s->s_thing) return (0);
-    if (*s->s_thing == c) return (s->s_thing);
-    if (*s->s_thing == bindlist_class)
+    if(!s->s_thing) return (0);
+    if(*s->s_thing == c) return (s->s_thing);
+    if(*s->s_thing == bindlist_class)
     {
-        t_bindlist *b = (t_bindlist *)s->s_thing;
+        t_bindlist *b = (t_bindlist *) s->s_thing;
         t_bindelem *e, *e2;
         int warned = 0;
-        for (e = b->b_list; e; e = e->e_next)
-            if (*e->e_who == c)
-        {
-            if (x && !warned)
+        for(e = b->b_list; e; e = e->e_next)
+            if(*e->e_who == c)
             {
-                post("warning: %s: multiply defined", s->s_name);
-                warned = 1;
+                if(x && !warned)
+                {
+                    post("warning: %s: multiply defined", s->s_name);
+                    warned = 1;
+                }
+                x = e->e_who;
             }
-            x = e->e_who;
-        }
     }
     return x;
 }
 
 /* stack for maintaining bindings for the #X symbol during nestable loads.
-*/
+ */
 
 typedef struct _gstack
 {
@@ -227,16 +230,15 @@ static t_symbol *pd_loadingabstraction;
 int pd_setloadingabstraction(t_symbol *sym)
 {
     t_gstack *foo = gstack_head;
-    for (foo = gstack_head; foo; foo = foo->g_next)
-        if (foo->g_loadingabstraction == sym)
-            return (1);
+    for(foo = gstack_head; foo; foo = foo->g_next)
+        if(foo->g_loadingabstraction == sym) return (1);
     pd_loadingabstraction = sym;
     return (0);
 }
 
 void pd_pushsym(t_pd *x)
 {
-    t_gstack *y = (t_gstack *)t_getbytes(sizeof(*y));
+    t_gstack *y = (t_gstack *) t_getbytes(sizeof(*y));
     y->g_what = s__X.s_thing;
     y->g_next = gstack_head;
     y->g_loadingabstraction = pd_loadingabstraction;
@@ -247,7 +249,8 @@ void pd_pushsym(t_pd *x)
 
 void pd_popsym(t_pd *x)
 {
-    if (!gstack_head || s__X.s_thing != x) bug("gstack_pop");
+    if(!gstack_head || s__X.s_thing != x)
+        bug("gstack_pop");
     else
     {
         t_gstack *headwas = gstack_head;
@@ -260,30 +263,17 @@ void pd_popsym(t_pd *x)
 
 void pd_doloadbang(void)
 {
-    if (lastpopped)
-        pd_vmess(lastpopped, gensym("loadbang"), "f", LB_LOAD);
+    if(lastpopped) pd_vmess(lastpopped, gensym("loadbang"), "f", LB_LOAD);
     lastpopped = 0;
 }
 
-void pd_bang(t_pd *x)
-{
-    (*(*x)->c_bangmethod)(x);
-}
+void pd_bang(t_pd *x) { (*(*x)->c_bangmethod)(x); }
 
-void pd_float(t_pd *x, t_float f)
-{
-    (*(*x)->c_floatmethod)(x, f);
-}
+void pd_float(t_pd *x, t_float f) { (*(*x)->c_floatmethod)(x, f); }
 
-void pd_pointer(t_pd *x, t_gpointer *gp)
-{
-    (*(*x)->c_pointermethod)(x, gp);
-}
+void pd_pointer(t_pd *x, t_gpointer *gp) { (*(*x)->c_pointermethod)(x, gp); }
 
-void pd_symbol(t_pd *x, t_symbol *s)
-{
-    (*(*x)->c_symbolmethod)(x, s);
-}
+void pd_symbol(t_pd *x, t_symbol *s) { (*(*x)->c_symbolmethod)(x, s); }
 
 void pd_list(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 {
@@ -306,20 +296,19 @@ void pd_init(void)
 {
 #ifndef PDINSTANCE
     static int initted = 0;
-    if (initted)
-        return;
+    if(initted) return;
     initted = 1;
 #else
-    if (pd_instances)
-        return;
-    pd_instances = (t_pdinstance **)getbytes(sizeof(*pd_instances));
+    if(pd_instances) return;
+    pd_instances = (t_pdinstance **) getbytes(sizeof(*pd_instances));
     pd_instances[0] = &pd_maininstance;
     pd_ninstances = 1;
 #endif
     pd_init_systems();
 }
 
-EXTERN void pd_init_systems(void) {
+EXTERN void pd_init_systems(void)
+{
     mess_init();
     sys_lock();
     obj_init();
@@ -329,13 +318,10 @@ EXTERN void pd_init_systems(void) {
     sys_unlock();
 }
 
-EXTERN void pd_term_systems(void) {
+EXTERN void pd_term_systems(void)
+{
     sys_lock();
     sys_unlock();
 }
 
-EXTERN t_canvas *pd_getcanvaslist(void)
-{
-    return (pd_this->pd_canvaslist);
-}
-
+EXTERN t_canvas *pd_getcanvaslist(void) { return (pd_this->pd_canvaslist); }

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -155,7 +155,9 @@ void pd_bind(t_pd *x, t_symbol *s)
 void pd_unbind(t_pd *x, t_symbol *s)
 {
     if(s->s_thing == x)
+    {
         s->s_thing = 0;
+    }
     else if(s->s_thing && *s->s_thing == bindlist_class)
     {
         /* bindlists always have at least two elements... if the number
@@ -171,13 +173,17 @@ void pd_unbind(t_pd *x, t_symbol *s)
             freebytes(e, sizeof(t_bindelem));
         }
         else
+        {
             for(e = b->b_list; (e2 = e->e_next); e = e2)
+            {
                 if(e2->e_who == x)
                 {
                     e->e_next = e2->e_next;
                     freebytes(e2, sizeof(t_bindelem));
                     break;
                 }
+            }
+        }
         if(!b->b_list->e_next)
         {
             s->s_thing = b->b_list->e_who;
@@ -202,6 +208,7 @@ t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
         t_bindelem *e2;
         int warned = 0;
         for(e = b->b_list; e; e = e->e_next)
+        {
             if(*e->e_who == c)
             {
                 if(x && !warned)
@@ -211,6 +218,7 @@ t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
                 }
                 x = e->e_who;
             }
+        }
     }
     return x;
 }
@@ -252,7 +260,9 @@ void pd_pushsym(t_pd *x)
 void pd_popsym(t_pd *x)
 {
     if(!gstack_head || s__X.s_thing != x)
+    {
         bug("gstack_pop");
+    }
     else
     {
         t_gstack *headwas = gstack_head;

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -163,7 +163,8 @@ void pd_unbind(t_pd *x, t_symbol *s)
         straight to the remaining element. */
 
         t_bindlist *b = (t_bindlist *) s->s_thing;
-        t_bindelem *e, *e2;
+        t_bindelem *e;
+        t_bindelem *e2;
         if((e = b->b_list)->e_who == x)
         {
             b->b_list = e->e_next;
@@ -197,7 +198,8 @@ t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
     if(*s->s_thing == bindlist_class)
     {
         t_bindlist *b = (t_bindlist *) s->s_thing;
-        t_bindelem *e, *e2;
+        t_bindelem *e;
+        t_bindelem *e2;
         int warned = 0;
         for(e = b->b_list; e; e = e->e_next)
             if(*e->e_who == c)

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -1,18 +1,19 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #ifndef __m_pd_h_
 
 #if defined(_LANGUAGE_C_PLUS_PLUS) || defined(__cplusplus)
-extern "C" {
+extern "C"
+{
 #endif
 
 #define PD_MAJOR_VERSION 0
 #define PD_MINOR_VERSION 52
 #define PD_BUGFIX_VERSION 2
 #define PD_TEST_VERSION ""
-extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
+    extern int pd_compatibilitylevel; /* e.g., 43 for pd 0.43 compatibility */
 
 /* old name for "MSW" flag -- we have to take it for the sake of many old
 "nmakefiles" for externs, which will define NT and not MSW */
@@ -23,10 +24,10 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 /* These pragmas are only used for MSVC, not MinGW or Cygwin <hans@at.or.at> */
 #ifdef _MSC_VER
 /* #pragma warning( disable : 4091 ) */
-#pragma warning( disable : 4305 )  /* uncast const double to float */
-#pragma warning( disable : 4244 )  /* uncast float/int conversion etc. */
-#pragma warning( disable : 4101 )  /* unused automatic variables */
-#endif /* _MSC_VER */
+#pragma warning(disable : 4305) /* uncast const double to float */
+#pragma warning(disable : 4244) /* uncast float/int conversion etc. */
+#pragma warning(disable : 4101) /* unused automatic variables */
+#endif                          /* _MSC_VER */
 
     /* the external storage class is "extern" in UNIX; in MSW it's ugly. */
 #ifndef EXTERN
@@ -45,8 +46,8 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
     structure whose elements are defined elsewhere.  On very old MSVC versions,
     when compiling C (but not C++) code, you have to say "extern struct foo;".
     So we make a stupid macro: */
-#if defined(_MSC_VER) && !defined(_LANGUAGE_C_PLUS_PLUS) \
-    && !defined(__cplusplus) && (_MSC_VER < 1700)
+#if defined(_MSC_VER) && !defined(_LANGUAGE_C_PLUS_PLUS) && \
+    !defined(__cplusplus) && (_MSC_VER < 1700)
 #define EXTERN_STRUCT extern struct
 #else
 #define EXTERN_STRUCT struct
@@ -54,36 +55,38 @@ extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 
 /* Define some attributes, specific to the compiler */
 #if defined(__GNUC__)
-#define ATTRIBUTE_FORMAT_PRINTF(a, b) __attribute__ ((format (printf, a, b)))
+#define ATTRIBUTE_FORMAT_PRINTF(a, b) __attribute__((format(printf, a, b)))
 #else
 #define ATTRIBUTE_FORMAT_PRINTF(a, b)
 #endif
 
 #if !defined(_SIZE_T) && !defined(_SIZE_T_)
-#include <stddef.h>     /* just for size_t -- how lame! */
+#include <stddef.h> /* just for size_t -- how lame! */
 #endif
 
-/* Microsoft Visual Studio is not C99, but since VS2015 has included most C99 headers:
+/* Microsoft Visual Studio is not C99, but since VS2015 has included most C99
+   headers:
    https://docs.microsoft.com/en-us/previous-versions/hh409293(v=vs.140)#c-runtime-library
-   These definitions recreate stdint.h types, but only in pre-2015 Visual Studio: */
+   These definitions recreate stdint.h types, but only in pre-2015 Visual
+   Studio: */
 #if defined(_MSC_VER) && _MSC_VER < 1900
-typedef signed __int8     int8_t;
-typedef signed __int16    int16_t;
-typedef signed __int32    int32_t;
-typedef signed __int64    int64_t;
-typedef unsigned __int8   uint8_t;
-typedef unsigned __int16  uint16_t;
-typedef unsigned __int32  uint32_t;
-typedef unsigned __int64  uint64_t;
+    typedef signed __int8 int8_t;
+    typedef signed __int16 int16_t;
+    typedef signed __int32 int32_t;
+    typedef signed __int64 int64_t;
+    typedef unsigned __int8 uint8_t;
+    typedef unsigned __int16 uint16_t;
+    typedef unsigned __int32 uint32_t;
+    typedef unsigned __int64 uint64_t;
 #else
-# include <stdint.h>
+#include <stdint.h>
 #endif
 
 /* for FILE, needed by sys_fopen() and sys_fclose() only */
 #include <stdio.h>
 
-#define MAXPDSTRING 1000        /* use this for anything you want */
-#define MAXPDARG 5              /* max number of args we can typecheck today */
+#define MAXPDSTRING 1000 /* use this for anything you want */
+#define MAXPDARG 5       /* max number of args we can typecheck today */
 
 /* signed and unsigned integer types the size of a pointer:  */
 #if !defined(PD_LONGINTTYPE)
@@ -95,162 +98,164 @@ typedef unsigned __int64  uint64_t;
 #endif
 
 #if !defined(PD_FLOATSIZE)
-  /* normally, our floats (t_float, t_sample,...) are 32bit */
-# define PD_FLOATSIZE 32
+    /* normally, our floats (t_float, t_sample,...) are 32bit */
+#define PD_FLOATSIZE 32
 #endif
 
 #if PD_FLOATSIZE == 32
-# define PD_FLOATTYPE float
+#define PD_FLOATTYPE float
 /* an unsigned int of the same size as FLOATTYPE: */
-# define PD_FLOATUINTTYPE uint32_t
+#define PD_FLOATUINTTYPE uint32_t
 
 #elif PD_FLOATSIZE == 64
-# define PD_FLOATTYPE double
-# define PD_FLOATUINTTYPE uint64_t
+#define PD_FLOATTYPE double
+#define PD_FLOATUINTTYPE uint64_t
 #else
-# error invalid FLOATSIZE: must be 32 or 64
+#error invalid FLOATSIZE: must be 32 or 64
 #endif
 
-typedef PD_LONGINTTYPE t_int;       /* pointer-size integer */
-typedef PD_FLOATTYPE t_float;       /* a float type at most the same size */
-typedef PD_FLOATTYPE t_floatarg;    /* float type for function calls */
+    typedef PD_LONGINTTYPE t_int;    /* pointer-size integer */
+    typedef PD_FLOATTYPE t_float;    /* a float type at most the same size */
+    typedef PD_FLOATTYPE t_floatarg; /* float type for function calls */
 
-typedef struct _symbol
-{
-    const char *s_name;
-    struct _class **s_thing;
-    struct _symbol *s_next;
-} t_symbol;
-
-EXTERN_STRUCT _array;
-#define t_array struct _array       /* g_canvas.h */
-
-/* pointers to glist and array elements go through a "stub" which sticks
-around after the glist or array is freed.  The stub itself is deleted when
-both the glist/array is gone and the refcount is zero, ensuring that no
-gpointers are pointing here. */
-
-#define GP_NONE 0       /* the stub points nowhere (has been cut off) */
-#define GP_GLIST 1      /* the stub points to a glist element */
-#define GP_ARRAY 2      /* ... or array */
-
-typedef struct _gstub
-{
-    union
+    typedef struct _symbol
     {
-        struct _glist *gs_glist;    /* glist we're in */
-        struct _array *gs_array;    /* array we're in */
-    } gs_un;
-    int gs_which;                   /* GP_GLIST/GP_ARRAY */
-    int gs_refcount;                /* number of gpointers pointing here */
-} t_gstub;
+        const char *s_name;
+        struct _class **s_thing;
+        struct _symbol *s_next;
+    } t_symbol;
 
-typedef struct _gpointer           /* pointer to a gobj in a glist */
-{
-    union
+    EXTERN_STRUCT _array;
+#define t_array struct _array /* g_canvas.h */
+
+    /* pointers to glist and array elements go through a "stub" which sticks
+    around after the glist or array is freed.  The stub itself is deleted when
+    both the glist/array is gone and the refcount is zero, ensuring that no
+    gpointers are pointing here. */
+
+#define GP_NONE 0  /* the stub points nowhere (has been cut off) */
+#define GP_GLIST 1 /* the stub points to a glist element */
+#define GP_ARRAY 2 /* ... or array */
+
+    typedef struct _gstub
     {
-        struct _scalar *gp_scalar;  /* scalar we're in (if glist) */
-        union word *gp_w;           /* raw data (if array) */
-    } gp_un;
-    int gp_valid;                   /* number which must match gpointee */
-    t_gstub *gp_stub;               /* stub which points to glist/array */
-} t_gpointer;
+        union
+        {
+            struct _glist *gs_glist; /* glist we're in */
+            struct _array *gs_array; /* array we're in */
+        } gs_un;
 
-typedef union word
-{
-    t_float w_float;
-    t_symbol *w_symbol;
-    t_gpointer *w_gpointer;
-    t_array *w_array;
-    struct _binbuf *w_binbuf;
-    int w_index;
-} t_word;
+        int gs_which;    /* GP_GLIST/GP_ARRAY */
+        int gs_refcount; /* number of gpointers pointing here */
+    } t_gstub;
 
-typedef enum
-{
-    A_NULL,
-    A_FLOAT,
-    A_SYMBOL,
-    A_POINTER,
-    A_SEMI,
-    A_COMMA,
-    A_DEFFLOAT,
-    A_DEFSYM,
-    A_DOLLAR,
-    A_DOLLSYM,
-    A_GIMME,
-    A_CANT
-}  t_atomtype;
+    typedef struct _gpointer /* pointer to a gobj in a glist */
+    {
+        union
+        {
+            struct _scalar *gp_scalar; /* scalar we're in (if glist) */
+            union word *gp_w;          /* raw data (if array) */
+        } gp_un;
 
-#define A_DEFSYMBOL A_DEFSYM    /* better name for this */
+        int gp_valid;     /* number which must match gpointee */
+        t_gstub *gp_stub; /* stub which points to glist/array */
+    } t_gpointer;
 
-typedef struct _atom
-{
-    t_atomtype a_type;
-    union word a_w;
-} t_atom;
+    typedef union word
+    {
+        t_float w_float;
+        t_symbol *w_symbol;
+        t_gpointer *w_gpointer;
+        t_array *w_array;
+        struct _binbuf *w_binbuf;
+        int w_index;
+    } t_word;
 
-EXTERN_STRUCT _class;
+    typedef enum
+    {
+        A_NULL,
+        A_FLOAT,
+        A_SYMBOL,
+        A_POINTER,
+        A_SEMI,
+        A_COMMA,
+        A_DEFFLOAT,
+        A_DEFSYM,
+        A_DOLLAR,
+        A_DOLLSYM,
+        A_GIMME,
+        A_CANT
+    } t_atomtype;
+
+#define A_DEFSYMBOL A_DEFSYM /* better name for this */
+
+    typedef struct _atom
+    {
+        t_atomtype a_type;
+        union word a_w;
+    } t_atom;
+
+    EXTERN_STRUCT _class;
 #define t_class struct _class
 
-EXTERN_STRUCT _outlet;
+    EXTERN_STRUCT _outlet;
 #define t_outlet struct _outlet
 
-EXTERN_STRUCT _inlet;
+    EXTERN_STRUCT _inlet;
 #define t_inlet struct _inlet
 
-EXTERN_STRUCT _binbuf;
+    EXTERN_STRUCT _binbuf;
 #define t_binbuf struct _binbuf
 
-EXTERN_STRUCT _clock;
+    EXTERN_STRUCT _clock;
 #define t_clock struct _clock
 
-EXTERN_STRUCT _outconnect;
+    EXTERN_STRUCT _outconnect;
 #define t_outconnect struct _outconnect
 
-EXTERN_STRUCT _glist;
+    EXTERN_STRUCT _glist;
 #define t_glist struct _glist
-#define t_canvas struct _glist  /* LATER lose this */
+#define t_canvas struct _glist /* LATER lose this */
 
-EXTERN_STRUCT _template;
+    EXTERN_STRUCT _template;
 
-typedef t_class *t_pd;      /* pure datum: nothing but a class pointer */
+    typedef t_class *t_pd; /* pure datum: nothing but a class pointer */
 
-typedef struct _gobj        /* a graphical object */
-{
-    t_pd g_pd;              /* pure datum header (class) */
-    struct _gobj *g_next;   /* next in list */
-} t_gobj;
+    typedef struct _gobj /* a graphical object */
+    {
+        t_pd g_pd;            /* pure datum header (class) */
+        struct _gobj *g_next; /* next in list */
+    } t_gobj;
 
-typedef struct _scalar      /* a graphical object holding data */
-{
-    t_gobj sc_gobj;         /* header for graphical object */
-    t_symbol *sc_template;  /* template name (LATER replace with pointer) */
-    t_word sc_vec[1];       /* indeterminate-length array of words */
-} t_scalar;
+    typedef struct _scalar /* a graphical object holding data */
+    {
+        t_gobj sc_gobj;        /* header for graphical object */
+        t_symbol *sc_template; /* template name (LATER replace with pointer) */
+        t_word sc_vec[1];      /* indeterminate-length array of words */
+    } t_scalar;
 
-typedef struct _text        /* patchable object - graphical, with text */
-{
-    t_gobj te_g;                /* header for graphical object */
-    t_binbuf *te_binbuf;        /* holder for the text */
-    t_outlet *te_outlet;        /* linked list of outlets */
-    t_inlet *te_inlet;          /* linked list of inlets */
-    short te_xpix;              /* x&y location (within the toplevel) */
-    short te_ypix;
-    short te_width;             /* requested width in chars, 0 if auto */
-    unsigned int te_type:2;     /* from defs below */
-} t_text;
+    typedef struct _text /* patchable object - graphical, with text */
+    {
+        t_gobj te_g;         /* header for graphical object */
+        t_binbuf *te_binbuf; /* holder for the text */
+        t_outlet *te_outlet; /* linked list of outlets */
+        t_inlet *te_inlet;   /* linked list of inlets */
+        short te_xpix;       /* x&y location (within the toplevel) */
+        short te_ypix;
+        short te_width;           /* requested width in chars, 0 if auto */
+        unsigned int te_type : 2; /* from defs below */
+    } t_text;
 
-#define T_TEXT 0        /* just a textual comment */
-#define T_OBJECT 1      /* a MAX style patchable object */
-#define T_MESSAGE 2     /* a MAX type message */
-#define T_ATOM 3        /* a cell to display a number or symbol */
+#define T_TEXT 0    /* just a textual comment */
+#define T_OBJECT 1  /* a MAX style patchable object */
+#define T_MESSAGE 2 /* a MAX type message */
+#define T_ATOM 3    /* a cell to display a number or symbol */
 
 #define te_pd te_g.g_pd
 
-   /* t_object is synonym for t_text (LATER unify them) */
+    /* t_object is synonym for t_text (LATER unify them) */
 
-typedef struct _text t_object;
+    typedef struct _text t_object;
 
 #define ob_outlet te_outlet
 #define ob_inlet te_inlet
@@ -258,8 +263,8 @@ typedef struct _text t_object;
 #define ob_pd te_g.g_pd
 #define ob_g te_g
 
-typedef void (*t_method)(void);
-typedef void *(*t_newmethod)(void);
+    typedef void (*t_method)(void);
+    typedef void *(*t_newmethod)(void);
 
 /* in ARM 64 a varargs prototype generates a different function call sequence
 from a fixed one, so in that special case we make a more restrictive
@@ -267,201 +272,203 @@ definition for t_gotfn.  This will break some code in the "chaos" package
 in Pd extended.  (that code will run incorrectly anyhow so why not catch it
 at compile time anyhow.) */
 #if defined(__APPLE__) && defined(__aarch64__)
-typedef void (*t_gotfn)(void *x);
+    typedef void (*t_gotfn)(void *x);
 #else
 typedef void (*t_gotfn)(void *x, ...);
 #endif
 
-/* ---------------- pre-defined objects and symbols --------------*/
-EXTERN t_pd pd_objectmaker;     /* factory for creating "object" boxes */
-EXTERN t_pd pd_canvasmaker;     /* factory for creating canvases */
+    /* ---------------- pre-defined objects and symbols --------------*/
+    EXTERN t_pd pd_objectmaker; /* factory for creating "object" boxes */
+    EXTERN t_pd pd_canvasmaker; /* factory for creating canvases */
 
-/* --------- prototypes from the central message system ----------- */
-EXTERN void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv);
-EXTERN void pd_forwardmess(t_pd *x, int argc, t_atom *argv);
-EXTERN t_symbol *gensym(const char *s);
-EXTERN t_gotfn getfn(const t_pd *x, t_symbol *s);
-EXTERN t_gotfn zgetfn(const t_pd *x, t_symbol *s);
-EXTERN void nullfn(void);
-EXTERN void pd_vmess(t_pd *x, t_symbol *s, const char *fmt, ...);
+    /* --------- prototypes from the central message system ----------- */
+    EXTERN void pd_typedmess(t_pd *x, t_symbol *s, int argc, t_atom *argv);
+    EXTERN void pd_forwardmess(t_pd *x, int argc, t_atom *argv);
+    EXTERN t_symbol *gensym(const char *s);
+    EXTERN t_gotfn getfn(const t_pd *x, t_symbol *s);
+    EXTERN t_gotfn zgetfn(const t_pd *x, t_symbol *s);
+    EXTERN void nullfn(void);
+    EXTERN void pd_vmess(t_pd *x, t_symbol *s, const char *fmt, ...);
 
 /* the following macros are for sending non-type-checkable messages, i.e.,
 using function lookup but circumventing type checking on arguments.  Only
 use for internal messaging protected by A_CANT so that the message can't
 be generated at patch level. */
 #define mess0(x, s) ((*getfn((x), (s)))((x)))
-typedef void (*t_gotfn1)(void *x, void *arg1);
-#define mess1(x, s, a) ((*(t_gotfn1)getfn((x), (s)))((x), (a)))
-typedef void (*t_gotfn2)(void *x, void *arg1, void *arg2);
-#define mess2(x, s, a,b) ((*(t_gotfn2)getfn((x), (s)))((x), (a),(b)))
-typedef void (*t_gotfn3)(void *x, void *arg1, void *arg2, void *arg3);
-#define mess3(x, s, a,b,c) ((*(t_gotfn3)getfn((x), (s)))((x), (a),(b),(c)))
-typedef void (*t_gotfn4)(void *x,
-    void *arg1, void *arg2, void *arg3, void *arg4);
-#define mess4(x, s, a,b,c,d) \
-    ((*(t_gotfn4)getfn((x), (s)))((x), (a),(b),(c),(d)))
-typedef void (*t_gotfn5)(void *x,
-    void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
-#define mess5(x, s, a,b,c,d,e) \
-    ((*(t_gotfn5)getfn((x), (s)))((x), (a),(b),(c),(d),(e)))
+    typedef void (*t_gotfn1)(void *x, void *arg1);
+#define mess1(x, s, a) ((*(t_gotfn1) getfn((x), (s)))((x), (a)))
+    typedef void (*t_gotfn2)(void *x, void *arg1, void *arg2);
+#define mess2(x, s, a, b) ((*(t_gotfn2) getfn((x), (s)))((x), (a), (b)))
+    typedef void (*t_gotfn3)(void *x, void *arg1, void *arg2, void *arg3);
+#define mess3(x, s, a, b, c) ((*(t_gotfn3) getfn((x), (s)))((x), (a), (b), (c)))
+    typedef void (*t_gotfn4)(
+        void *x, void *arg1, void *arg2, void *arg3, void *arg4);
+#define mess4(x, s, a, b, c, d) \
+    ((*(t_gotfn4) getfn((x), (s)))((x), (a), (b), (c), (d)))
+    typedef void (*t_gotfn5)(
+        void *x, void *arg1, void *arg2, void *arg3, void *arg4, void *arg5);
+#define mess5(x, s, a, b, c, d, e) \
+    ((*(t_gotfn5) getfn((x), (s)))((x), (a), (b), (c), (d), (e)))
 
-EXTERN void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv);
-EXTERN t_pd *pd_newest(void);
+    EXTERN void obj_list(t_object *x, t_symbol *s, int argc, t_atom *argv);
+    EXTERN t_pd *pd_newest(void);
 
-/* --------------- memory management -------------------- */
-EXTERN void *getbytes(size_t nbytes);
-EXTERN void *getzbytes(size_t nbytes);
-EXTERN void *copybytes(const void *src, size_t nbytes);
-EXTERN void freebytes(void *x, size_t nbytes);
-EXTERN void *resizebytes(void *x, size_t oldsize, size_t newsize);
+    /* --------------- memory management -------------------- */
+    EXTERN void *getbytes(size_t nbytes);
+    EXTERN void *getzbytes(size_t nbytes);
+    EXTERN void *copybytes(const void *src, size_t nbytes);
+    EXTERN void freebytes(void *x, size_t nbytes);
+    EXTERN void *resizebytes(void *x, size_t oldsize, size_t newsize);
 
-/* -------------------- atoms ----------------------------- */
+    /* -------------------- atoms ----------------------------- */
 
 #define SETSEMI(atom) ((atom)->a_type = A_SEMI, (atom)->a_w.w_index = 0)
 #define SETCOMMA(atom) ((atom)->a_type = A_COMMA, (atom)->a_w.w_index = 0)
-#define SETPOINTER(atom, gp) ((atom)->a_type = A_POINTER, \
-    (atom)->a_w.w_gpointer = (gp))
+#define SETPOINTER(atom, gp) \
+    ((atom)->a_type = A_POINTER, (atom)->a_w.w_gpointer = (gp))
 #define SETFLOAT(atom, f) ((atom)->a_type = A_FLOAT, (atom)->a_w.w_float = (f))
-#define SETSYMBOL(atom, s) ((atom)->a_type = A_SYMBOL, \
-    (atom)->a_w.w_symbol = (s))
-#define SETDOLLAR(atom, n) ((atom)->a_type = A_DOLLAR, \
-    (atom)->a_w.w_index = (n))
-#define SETDOLLSYM(atom, s) ((atom)->a_type = A_DOLLSYM, \
-    (atom)->a_w.w_symbol= (s))
+#define SETSYMBOL(atom, s) \
+    ((atom)->a_type = A_SYMBOL, (atom)->a_w.w_symbol = (s))
+#define SETDOLLAR(atom, n) \
+    ((atom)->a_type = A_DOLLAR, (atom)->a_w.w_index = (n))
+#define SETDOLLSYM(atom, s) \
+    ((atom)->a_type = A_DOLLSYM, (atom)->a_w.w_symbol = (s))
 
-EXTERN t_float atom_getfloat(const t_atom *a);
-EXTERN t_int atom_getint(const t_atom *a);
-EXTERN t_symbol *atom_getsymbol(const t_atom *a);
-EXTERN t_symbol *atom_gensym(const t_atom *a);
-EXTERN t_float atom_getfloatarg(int which, int argc, const t_atom *argv);
-EXTERN t_int atom_getintarg(int which, int argc, const t_atom *argv);
-EXTERN t_symbol *atom_getsymbolarg(int which, int argc, const t_atom *argv);
+    EXTERN t_float atom_getfloat(const t_atom *a);
+    EXTERN t_int atom_getint(const t_atom *a);
+    EXTERN t_symbol *atom_getsymbol(const t_atom *a);
+    EXTERN t_symbol *atom_gensym(const t_atom *a);
+    EXTERN t_float atom_getfloatarg(int which, int argc, const t_atom *argv);
+    EXTERN t_int atom_getintarg(int which, int argc, const t_atom *argv);
+    EXTERN t_symbol *atom_getsymbolarg(int which, int argc, const t_atom *argv);
 
-EXTERN void atom_string(const t_atom *a, char *buf, unsigned int bufsize);
+    EXTERN void atom_string(const t_atom *a, char *buf, unsigned int bufsize);
 
-/* ------------------  binbufs --------------- */
+    /* ------------------  binbufs --------------- */
 
-EXTERN t_binbuf *binbuf_new(void);
-EXTERN void binbuf_free(t_binbuf *x);
-EXTERN t_binbuf *binbuf_duplicate(const t_binbuf *y);
+    EXTERN t_binbuf *binbuf_new(void);
+    EXTERN void binbuf_free(t_binbuf *x);
+    EXTERN t_binbuf *binbuf_duplicate(const t_binbuf *y);
 
-EXTERN void binbuf_text(t_binbuf *x, const char *text, size_t size);
-EXTERN void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp);
-EXTERN void binbuf_clear(t_binbuf *x);
-EXTERN void binbuf_add(t_binbuf *x, int argc, const t_atom *argv);
-EXTERN void binbuf_addv(t_binbuf *x, const char *fmt, ...);
-EXTERN void binbuf_addbinbuf(t_binbuf *x, const t_binbuf *y);
-EXTERN void binbuf_addsemi(t_binbuf *x);
-EXTERN void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv);
-EXTERN void binbuf_print(const t_binbuf *x);
-EXTERN int binbuf_getnatom(const t_binbuf *x);
-EXTERN t_atom *binbuf_getvec(const t_binbuf *x);
-EXTERN int binbuf_resize(t_binbuf *x, int newsize);
-EXTERN void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv);
-EXTERN int binbuf_read(t_binbuf *b, const char *filename, const char *dirname,
-    int crflag);
-EXTERN int binbuf_read_via_canvas(t_binbuf *b, const char *filename, const t_canvas *canvas,
-    int crflag);
-EXTERN int binbuf_read_via_path(t_binbuf *b, const char *filename, const char *dirname,
-    int crflag);
-EXTERN int binbuf_write(const t_binbuf *x, const char *filename, const char *dir,
-    int crflag);
-EXTERN void binbuf_evalfile(t_symbol *name, t_symbol *dir);
-EXTERN t_symbol *binbuf_realizedollsym(t_symbol *s, int ac, const t_atom *av,
-    int tonew);
+    EXTERN void binbuf_text(t_binbuf *x, const char *text, size_t size);
+    EXTERN void binbuf_gettext(const t_binbuf *x, char **bufp, int *lengthp);
+    EXTERN void binbuf_clear(t_binbuf *x);
+    EXTERN void binbuf_add(t_binbuf *x, int argc, const t_atom *argv);
+    EXTERN void binbuf_addv(t_binbuf *x, const char *fmt, ...);
+    EXTERN void binbuf_addbinbuf(t_binbuf *x, const t_binbuf *y);
+    EXTERN void binbuf_addsemi(t_binbuf *x);
+    EXTERN void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv);
+    EXTERN void binbuf_print(const t_binbuf *x);
+    EXTERN int binbuf_getnatom(const t_binbuf *x);
+    EXTERN t_atom *binbuf_getvec(const t_binbuf *x);
+    EXTERN int binbuf_resize(t_binbuf *x, int newsize);
+    EXTERN void binbuf_eval(
+        const t_binbuf *x, t_pd *target, int argc, const t_atom *argv);
+    EXTERN int binbuf_read(
+        t_binbuf *b, const char *filename, const char *dirname, int crflag);
+    EXTERN int binbuf_read_via_canvas(
+        t_binbuf *b, const char *filename, const t_canvas *canvas, int crflag);
+    EXTERN int binbuf_read_via_path(
+        t_binbuf *b, const char *filename, const char *dirname, int crflag);
+    EXTERN int binbuf_write(
+        const t_binbuf *x, const char *filename, const char *dir, int crflag);
+    EXTERN void binbuf_evalfile(t_symbol *name, t_symbol *dir);
+    EXTERN t_symbol *binbuf_realizedollsym(
+        t_symbol *s, int ac, const t_atom *av, int tonew);
 
-/* ------------------  clocks --------------- */
+    /* ------------------  clocks --------------- */
 
-EXTERN t_clock *clock_new(void *owner, t_method fn);
-EXTERN void clock_set(t_clock *x, double systime);
-EXTERN void clock_delay(t_clock *x, double delaytime);
-EXTERN void clock_unset(t_clock *x);
-EXTERN void clock_setunit(t_clock *x, double timeunit, int sampflag);
-EXTERN double clock_getlogicaltime(void);
-EXTERN double clock_getsystime(void); /* OBSOLETE; use clock_getlogicaltime() */
-EXTERN double clock_gettimesince(double prevsystime);
-EXTERN double clock_gettimesincewithunits(double prevsystime,
-    double units, int sampflag);
-EXTERN double clock_getsystimeafter(double delaytime);
-EXTERN void clock_free(t_clock *x);
+    EXTERN t_clock *clock_new(void *owner, t_method fn);
+    EXTERN void clock_set(t_clock *x, double systime);
+    EXTERN void clock_delay(t_clock *x, double delaytime);
+    EXTERN void clock_unset(t_clock *x);
+    EXTERN void clock_setunit(t_clock *x, double timeunit, int sampflag);
+    EXTERN double clock_getlogicaltime(void);
+    EXTERN double clock_getsystime(
+        void); /* OBSOLETE; use clock_getlogicaltime() */
+    EXTERN double clock_gettimesince(double prevsystime);
+    EXTERN double clock_gettimesincewithunits(
+        double prevsystime, double units, int sampflag);
+    EXTERN double clock_getsystimeafter(double delaytime);
+    EXTERN void clock_free(t_clock *x);
 
-/* ----------------- pure data ---------------- */
-EXTERN t_pd *pd_new(t_class *cls);
-EXTERN void pd_free(t_pd *x);
-EXTERN void pd_bind(t_pd *x, t_symbol *s);
-EXTERN void pd_unbind(t_pd *x, t_symbol *s);
-EXTERN t_pd *pd_findbyclass(t_symbol *s, const t_class *c);
-EXTERN void pd_pushsym(t_pd *x);
-EXTERN void pd_popsym(t_pd *x);
-EXTERN void pd_bang(t_pd *x);
-EXTERN void pd_pointer(t_pd *x, t_gpointer *gp);
-EXTERN void pd_float(t_pd *x, t_float f);
-EXTERN void pd_symbol(t_pd *x, t_symbol *s);
-EXTERN void pd_list(t_pd *x, t_symbol *s, int argc, t_atom *argv);
-EXTERN void pd_anything(t_pd *x, t_symbol *s, int argc, t_atom *argv);
+    /* ----------------- pure data ---------------- */
+    EXTERN t_pd *pd_new(t_class *cls);
+    EXTERN void pd_free(t_pd *x);
+    EXTERN void pd_bind(t_pd *x, t_symbol *s);
+    EXTERN void pd_unbind(t_pd *x, t_symbol *s);
+    EXTERN t_pd *pd_findbyclass(t_symbol *s, const t_class *c);
+    EXTERN void pd_pushsym(t_pd *x);
+    EXTERN void pd_popsym(t_pd *x);
+    EXTERN void pd_bang(t_pd *x);
+    EXTERN void pd_pointer(t_pd *x, t_gpointer *gp);
+    EXTERN void pd_float(t_pd *x, t_float f);
+    EXTERN void pd_symbol(t_pd *x, t_symbol *s);
+    EXTERN void pd_list(t_pd *x, t_symbol *s, int argc, t_atom *argv);
+    EXTERN void pd_anything(t_pd *x, t_symbol *s, int argc, t_atom *argv);
 #define pd_class(x) (*(x))
 
-/* ----------------- pointers ---------------- */
-EXTERN void gpointer_init(t_gpointer *gp);
-EXTERN void gpointer_copy(const t_gpointer *gpfrom, t_gpointer *gpto);
-EXTERN void gpointer_unset(t_gpointer *gp);
-EXTERN int gpointer_check(const t_gpointer *gp, int headok);
+    /* ----------------- pointers ---------------- */
+    EXTERN void gpointer_init(t_gpointer *gp);
+    EXTERN void gpointer_copy(const t_gpointer *gpfrom, t_gpointer *gpto);
+    EXTERN void gpointer_unset(t_gpointer *gp);
+    EXTERN int gpointer_check(const t_gpointer *gp, int headok);
 
-/* ----------------- patchable "objects" -------------- */
-EXTERN t_inlet *inlet_new(t_object *owner, t_pd *dest, t_symbol *s1,
-    t_symbol *s2);
-EXTERN t_inlet *pointerinlet_new(t_object *owner, t_gpointer *gp);
-EXTERN t_inlet *floatinlet_new(t_object *owner, t_float *fp);
-EXTERN t_inlet *symbolinlet_new(t_object *owner, t_symbol **sp);
-EXTERN t_inlet *signalinlet_new(t_object *owner, t_float f);
-EXTERN void inlet_free(t_inlet *x);
+    /* ----------------- patchable "objects" -------------- */
+    EXTERN t_inlet *inlet_new(
+        t_object *owner, t_pd *dest, t_symbol *s1, t_symbol *s2);
+    EXTERN t_inlet *pointerinlet_new(t_object *owner, t_gpointer *gp);
+    EXTERN t_inlet *floatinlet_new(t_object *owner, t_float *fp);
+    EXTERN t_inlet *symbolinlet_new(t_object *owner, t_symbol **sp);
+    EXTERN t_inlet *signalinlet_new(t_object *owner, t_float f);
+    EXTERN void inlet_free(t_inlet *x);
 
-EXTERN t_outlet *outlet_new(t_object *owner, t_symbol *s);
-EXTERN void outlet_bang(t_outlet *x);
-EXTERN void outlet_pointer(t_outlet *x, t_gpointer *gp);
-EXTERN void outlet_float(t_outlet *x, t_float f);
-EXTERN void outlet_symbol(t_outlet *x, t_symbol *s);
-EXTERN void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
-EXTERN void outlet_anything(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
-EXTERN t_symbol *outlet_getsymbol(t_outlet *x);
-EXTERN void outlet_free(t_outlet *x);
-EXTERN t_object *pd_checkobject(t_pd *x);
+    EXTERN t_outlet *outlet_new(t_object *owner, t_symbol *s);
+    EXTERN void outlet_bang(t_outlet *x);
+    EXTERN void outlet_pointer(t_outlet *x, t_gpointer *gp);
+    EXTERN void outlet_float(t_outlet *x, t_float f);
+    EXTERN void outlet_symbol(t_outlet *x, t_symbol *s);
+    EXTERN void outlet_list(t_outlet *x, t_symbol *s, int argc, t_atom *argv);
+    EXTERN void outlet_anything(
+        t_outlet *x, t_symbol *s, int argc, t_atom *argv);
+    EXTERN t_symbol *outlet_getsymbol(t_outlet *x);
+    EXTERN void outlet_free(t_outlet *x);
+    EXTERN t_object *pd_checkobject(t_pd *x);
 
+    /* -------------------- canvases -------------- */
 
-/* -------------------- canvases -------------- */
+    EXTERN void glob_setfilename(void *dummy, t_symbol *name, t_symbol *dir);
 
-EXTERN void glob_setfilename(void *dummy, t_symbol *name, t_symbol *dir);
+    EXTERN void canvas_setargs(int argc, const t_atom *argv);
+    EXTERN void canvas_getargs(int *argcp, t_atom **argvp);
+    EXTERN t_symbol *canvas_getcurrentdir(void);
+    EXTERN t_glist *canvas_getcurrent(void);
+    EXTERN void canvas_makefilename(
+        const t_glist *c, const char *file, char *result, int resultsize);
+    EXTERN t_symbol *canvas_getdir(const t_glist *x);
+    EXTERN char sys_font[];       /* default typeface set in s_main.c */
+    EXTERN char sys_fontweight[]; /* default font weight set in s_main.c */
+    EXTERN int sys_hostfontsize(int fontsize, int zoom);
+    EXTERN int sys_zoomfontwidth(int fontsize, int zoom, int worstcase);
+    EXTERN int sys_zoomfontheight(int fontsize, int zoom, int worstcase);
+    EXTERN int sys_fontwidth(int fontsize);
+    EXTERN int sys_fontheight(int fontsize);
+    EXTERN void canvas_dataproperties(t_glist *x, t_scalar *sc, t_binbuf *b);
+    EXTERN int canvas_open(const t_canvas *x, const char *name, const char *ext,
+        char *dirresult, char **nameresult, unsigned int size, int bin);
 
-EXTERN void canvas_setargs(int argc, const t_atom *argv);
-EXTERN void canvas_getargs(int *argcp, t_atom **argvp);
-EXTERN t_symbol *canvas_getcurrentdir(void);
-EXTERN t_glist *canvas_getcurrent(void);
-EXTERN void canvas_makefilename(const t_glist *c, const char *file,
-    char *result, int resultsize);
-EXTERN t_symbol *canvas_getdir(const t_glist *x);
-EXTERN char sys_font[]; /* default typeface set in s_main.c */
-EXTERN char sys_fontweight[]; /* default font weight set in s_main.c */
-EXTERN int sys_hostfontsize(int fontsize, int zoom);
-EXTERN int sys_zoomfontwidth(int fontsize, int zoom, int worstcase);
-EXTERN int sys_zoomfontheight(int fontsize, int zoom, int worstcase);
-EXTERN int sys_fontwidth(int fontsize);
-EXTERN int sys_fontheight(int fontsize);
-EXTERN void canvas_dataproperties(t_glist *x, t_scalar *sc, t_binbuf *b);
-EXTERN int canvas_open(const t_canvas *x, const char *name, const char *ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
+    /* ---------------- widget behaviors ---------------------- */
 
-/* ---------------- widget behaviors ---------------------- */
-
-EXTERN_STRUCT _widgetbehavior;
+    EXTERN_STRUCT _widgetbehavior;
 #define t_widgetbehavior struct _widgetbehavior
 
-EXTERN_STRUCT _parentwidgetbehavior;
+    EXTERN_STRUCT _parentwidgetbehavior;
 #define t_parentwidgetbehavior struct _parentwidgetbehavior
-EXTERN const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x);
+    EXTERN const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x);
 
-/* -------------------- classes -------------- */
+    /* -------------------- classes -------------- */
 
-#define CLASS_DEFAULT 0         /* flags for new classes below */
+#define CLASS_DEFAULT 0 /* flags for new classes below */
 #define CLASS_PD 1
 #define CLASS_GOBJ 2
 #define CLASS_PATCHABLE 3
@@ -469,269 +476,280 @@ EXTERN const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x);
 
 #define CLASS_TYPEMASK 3
 
-EXTERN t_class *class_new(t_symbol *name, t_newmethod newmethod,
-    t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
+    EXTERN t_class *class_new(t_symbol *name, t_newmethod newmethod,
+        t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
 
-EXTERN t_class *class_new64(t_symbol *name, t_newmethod newmethod,
-    t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
+    EXTERN t_class *class_new64(t_symbol *name, t_newmethod newmethod,
+        t_method freemethod, size_t size, int flags, t_atomtype arg1, ...);
 
-EXTERN void class_free(t_class *c);
+    EXTERN void class_free(t_class *c);
 
 #ifdef PDINSTANCE
-EXTERN t_class *class_getfirst(void);
+    EXTERN t_class *class_getfirst(void);
 #endif
 
-EXTERN void class_addcreator(t_newmethod newmethod, t_symbol *s,
-    t_atomtype type1, ...);
-EXTERN void class_addmethod(t_class *c, t_method fn, t_symbol *sel,
-    t_atomtype arg1, ...);
-EXTERN void class_addbang(t_class *c, t_method fn);
-EXTERN void class_addpointer(t_class *c, t_method fn);
-EXTERN void class_doaddfloat(t_class *c, t_method fn);
-EXTERN void class_addsymbol(t_class *c, t_method fn);
-EXTERN void class_addlist(t_class *c, t_method fn);
-EXTERN void class_addanything(t_class *c, t_method fn);
-EXTERN void class_sethelpsymbol(t_class *c, t_symbol *s);
-EXTERN void class_setwidget(t_class *c, const t_widgetbehavior *w);
-EXTERN void class_setparentwidget(t_class *c, const t_parentwidgetbehavior *w);
-EXTERN const char *class_getname(const t_class *c);
-EXTERN const char *class_gethelpname(const t_class *c);
-EXTERN const char *class_gethelpdir(const t_class *c);
-EXTERN void class_setdrawcommand(t_class *c);
-EXTERN int class_isdrawcommand(const t_class *c);
-EXTERN void class_domainsignalin(t_class *c, int onset);
-EXTERN void class_set_extern_dir(t_symbol *s);
+    EXTERN void class_addcreator(
+        t_newmethod newmethod, t_symbol *s, t_atomtype type1, ...);
+    EXTERN void class_addmethod(
+        t_class *c, t_method fn, t_symbol *sel, t_atomtype arg1, ...);
+    EXTERN void class_addbang(t_class *c, t_method fn);
+    EXTERN void class_addpointer(t_class *c, t_method fn);
+    EXTERN void class_doaddfloat(t_class *c, t_method fn);
+    EXTERN void class_addsymbol(t_class *c, t_method fn);
+    EXTERN void class_addlist(t_class *c, t_method fn);
+    EXTERN void class_addanything(t_class *c, t_method fn);
+    EXTERN void class_sethelpsymbol(t_class *c, t_symbol *s);
+    EXTERN void class_setwidget(t_class *c, const t_widgetbehavior *w);
+    EXTERN void class_setparentwidget(
+        t_class *c, const t_parentwidgetbehavior *w);
+    EXTERN const char *class_getname(const t_class *c);
+    EXTERN const char *class_gethelpname(const t_class *c);
+    EXTERN const char *class_gethelpdir(const t_class *c);
+    EXTERN void class_setdrawcommand(t_class *c);
+    EXTERN int class_isdrawcommand(const t_class *c);
+    EXTERN void class_domainsignalin(t_class *c, int onset);
+    EXTERN void class_set_extern_dir(t_symbol *s);
 #define CLASS_MAINSIGNALIN(c, type, field) \
-    class_domainsignalin(c, (char *)(&((type *)0)->field) - (char *)0)
+    class_domainsignalin(c, (char *) (&((type *) 0)->field) - (char *) 0)
 
-         /* prototype for functions to save Pd's to a binbuf */
-typedef void (*t_savefn)(t_gobj *x, t_binbuf *b);
-EXTERN void class_setsavefn(t_class *c, t_savefn f);
-EXTERN t_savefn class_getsavefn(const t_class *c);
-EXTERN void obj_saveformat(const t_object *x, t_binbuf *bb); /* add format to bb */
+    /* prototype for functions to save Pd's to a binbuf */
+    typedef void (*t_savefn)(t_gobj *x, t_binbuf *b);
+    EXTERN void class_setsavefn(t_class *c, t_savefn f);
+    EXTERN t_savefn class_getsavefn(const t_class *c);
+    EXTERN void obj_saveformat(
+        const t_object *x, t_binbuf *bb); /* add format to bb */
 
-        /* prototype for functions to open properties dialogs */
-typedef void (*t_propertiesfn)(t_gobj *x, struct _glist *glist);
-EXTERN void class_setpropertiesfn(t_class *c, t_propertiesfn f);
-EXTERN t_propertiesfn class_getpropertiesfn(const t_class *c);
+    /* prototype for functions to open properties dialogs */
+    typedef void (*t_propertiesfn)(t_gobj *x, struct _glist *glist);
+    EXTERN void class_setpropertiesfn(t_class *c, t_propertiesfn f);
+    EXTERN t_propertiesfn class_getpropertiesfn(const t_class *c);
 
-typedef void (*t_classfreefn)(t_class *);
-EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
+    typedef void (*t_classfreefn)(t_class *);
+    EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
 
 #ifndef PD_CLASS_DEF
-#define class_addbang(x, y) class_addbang((x), (t_method)(y))
-#define class_addpointer(x, y) class_addpointer((x), (t_method)(y))
-#define class_addfloat(x, y) class_doaddfloat((x), (t_method)(y))
-#define class_addsymbol(x, y) class_addsymbol((x), (t_method)(y))
-#define class_addlist(x, y) class_addlist((x), (t_method)(y))
-#define class_addanything(x, y) class_addanything((x), (t_method)(y))
+#define class_addbang(x, y) class_addbang((x), (t_method) (y))
+#define class_addpointer(x, y) class_addpointer((x), (t_method) (y))
+#define class_addfloat(x, y) class_doaddfloat((x), (t_method) (y))
+#define class_addsymbol(x, y) class_addsymbol((x), (t_method) (y))
+#define class_addlist(x, y) class_addlist((x), (t_method) (y))
+#define class_addanything(x, y) class_addanything((x), (t_method) (y))
 #endif
 
 #if PD_FLOATSIZE == 64
-# define class_new class_new64
+#define class_new class_new64
 #endif
 
-/* ------------   printing --------------------------------- */
+    /* ------------   printing --------------------------------- */
 
-EXTERN void post(const char *fmt, ...);
-EXTERN void startpost(const char *fmt, ...);
-EXTERN void poststring(const char *s);
-EXTERN void postfloat(t_floatarg f);
-EXTERN void postatom(int argc, const t_atom *argv);
-EXTERN void endpost(void);
+    EXTERN void post(const char *fmt, ...);
+    EXTERN void startpost(const char *fmt, ...);
+    EXTERN void poststring(const char *s);
+    EXTERN void postfloat(t_floatarg f);
+    EXTERN void postatom(int argc, const t_atom *argv);
+    EXTERN void endpost(void);
 
-EXTERN void bug(const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
-EXTERN void pd_error(const void *object, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+    EXTERN void bug(const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+    EXTERN void pd_error(const void *object, const char *fmt, ...)
+        ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
-/* for logpost(); does *not* work with verbose()! */
-typedef enum {
-    PD_CRITICAL = 0,
-    PD_ERROR,
-    PD_NORMAL,
-    PD_DEBUG,
-    PD_VERBOSE
-} t_loglevel;
+    /* for logpost(); does *not* work with verbose()! */
+    typedef enum
+    {
+        PD_CRITICAL = 0,
+        PD_ERROR,
+        PD_NORMAL,
+        PD_DEBUG,
+        PD_VERBOSE
+    } t_loglevel;
 
-EXTERN void logpost(const void *object, int level, const char *fmt, ...)
-    ATTRIBUTE_FORMAT_PRINTF(3, 4);
+    EXTERN void logpost(const void *object, int level, const char *fmt, ...)
+        ATTRIBUTE_FORMAT_PRINTF(3, 4);
 
-/* deprecated, use logpost() instead. */
-EXTERN void verbose(int level, const char *fmt, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+    /* deprecated, use logpost() instead. */
+    EXTERN void verbose(int level, const char *fmt, ...)
+        ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
+    /* ------------  system interface routines ------------------- */
+    EXTERN int sys_isabsolutepath(const char *dir);
+    EXTERN void sys_bashfilename(const char *from, char *to);
+    EXTERN void sys_unbashfilename(const char *from, char *to);
+    EXTERN int open_via_path(const char *dir, const char *name, const char *ext,
+        char *dirresult, char **nameresult, unsigned int size, int bin);
+    EXTERN int sched_geteventno(void);
+    EXTERN double sys_getrealtime(void);
+    EXTERN int (*sys_idlehook)(void); /* hook to add idle time computation */
 
-/* ------------  system interface routines ------------------- */
-EXTERN int sys_isabsolutepath(const char *dir);
-EXTERN void sys_bashfilename(const char *from, char *to);
-EXTERN void sys_unbashfilename(const char *from, char *to);
-EXTERN int open_via_path(const char *dir, const char *name, const char *ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin);
-EXTERN int sched_geteventno(void);
-EXTERN double sys_getrealtime(void);
-EXTERN int (*sys_idlehook)(void);   /* hook to add idle time computation */
+    /* Win32's open()/fopen() do not handle UTF-8 filenames so we need
+     * these internal versions that handle UTF-8 filenames the same across
+     * all platforms.  They are recommended for use in external
+     * objectclasses as well so they work with Unicode filenames on Windows */
+    EXTERN int sys_open(const char *path, int oflag, ...);
+    EXTERN int sys_close(int fd);
+    EXTERN FILE *sys_fopen(const char *filename, const char *mode);
+    EXTERN int sys_fclose(FILE *stream);
 
-/* Win32's open()/fopen() do not handle UTF-8 filenames so we need
- * these internal versions that handle UTF-8 filenames the same across
- * all platforms.  They are recommended for use in external
- * objectclasses as well so they work with Unicode filenames on Windows */
-EXTERN int sys_open(const char *path, int oflag, ...);
-EXTERN int sys_close(int fd);
-EXTERN FILE *sys_fopen(const char *filename, const char *mode);
-EXTERN int sys_fclose(FILE *stream);
+    /* ------------  threading ------------------- */
+    EXTERN void sys_lock(void);
+    EXTERN void sys_unlock(void);
+    EXTERN int sys_trylock(void);
 
-/* ------------  threading ------------------- */
-EXTERN void sys_lock(void);
-EXTERN void sys_unlock(void);
-EXTERN int sys_trylock(void);
+    /* --------------- signals ----------------------------------- */
 
+    typedef PD_FLOATTYPE t_sample;
 
-/* --------------- signals ----------------------------------- */
+    typedef union _sampleint_union
+    {
+        t_sample f;
+        PD_FLOATUINTTYPE i;
+    } t_sampleint_union;
 
-typedef PD_FLOATTYPE t_sample;
-typedef union _sampleint_union {
-  t_sample f;
-  PD_FLOATUINTTYPE i;
-} t_sampleint_union;
 #define MAXLOGSIG 32
 #define MAXSIGSIZE (1 << MAXLOGSIG)
 
-typedef struct _signal
-{
-    int s_n;            /* number of points in the array */
-    t_sample *s_vec;    /* the array */
-    t_float s_sr;         /* sample rate */
-    int s_refcount;     /* number of times used */
-    int s_isborrowed;   /* whether we're going to borrow our array */
-    struct _signal *s_borrowedfrom;     /* signal to borrow it from */
-    struct _signal *s_nextfree;         /* next in freelist */
-    struct _signal *s_nextused;         /* next in used list */
-    int s_vecsize;      /* allocated size of array in points */
-} t_signal;
+    typedef struct _signal
+    {
+        int s_n;          /* number of points in the array */
+        t_sample *s_vec;  /* the array */
+        t_float s_sr;     /* sample rate */
+        int s_refcount;   /* number of times used */
+        int s_isborrowed; /* whether we're going to borrow our array */
+        struct _signal *s_borrowedfrom; /* signal to borrow it from */
+        struct _signal *s_nextfree;     /* next in freelist */
+        struct _signal *s_nextused;     /* next in used list */
+        int s_vecsize;                  /* allocated size of array in points */
+    } t_signal;
 
-typedef t_int *(*t_perfroutine)(t_int *args);
+    typedef t_int *(*t_perfroutine)(t_int *args);
 
-EXTERN t_int *plus_perform(t_int *args);
-EXTERN t_int *zero_perform(t_int *args);
-EXTERN t_int *copy_perform(t_int *args);
+    EXTERN t_int *plus_perform(t_int *args);
+    EXTERN t_int *zero_perform(t_int *args);
+    EXTERN t_int *copy_perform(t_int *args);
 
-EXTERN void dsp_add_plus(t_sample *in1, t_sample *in2, t_sample *out, int n);
-EXTERN void dsp_add_copy(t_sample *in, t_sample *out, int n);
-EXTERN void dsp_add_scalarcopy(t_float *in, t_sample *out, int n);
-EXTERN void dsp_add_zero(t_sample *out, int n);
+    EXTERN void dsp_add_plus(
+        t_sample *in1, t_sample *in2, t_sample *out, int n);
+    EXTERN void dsp_add_copy(t_sample *in, t_sample *out, int n);
+    EXTERN void dsp_add_scalarcopy(t_float *in, t_sample *out, int n);
+    EXTERN void dsp_add_zero(t_sample *out, int n);
 
-EXTERN int sys_getblksize(void);
-EXTERN t_float sys_getsr(void);
-EXTERN int sys_get_inchannels(void);
-EXTERN int sys_get_outchannels(void);
+    EXTERN int sys_getblksize(void);
+    EXTERN t_float sys_getsr(void);
+    EXTERN int sys_get_inchannels(void);
+    EXTERN int sys_get_outchannels(void);
 
-EXTERN void dsp_add(t_perfroutine f, int n, ...);
-EXTERN void dsp_addv(t_perfroutine f, int n, t_int *vec);
-EXTERN void pd_fft(t_float *buf, int npoints, int inverse);
-EXTERN int ilog2(int n);
+    EXTERN void dsp_add(t_perfroutine f, int n, ...);
+    EXTERN void dsp_addv(t_perfroutine f, int n, t_int *vec);
+    EXTERN void pd_fft(t_float *buf, int npoints, int inverse);
+    EXTERN int ilog2(int n);
 
-EXTERN void mayer_fht(t_sample *fz, int n);
-EXTERN void mayer_fft(int n, t_sample *real, t_sample *imag);
-EXTERN void mayer_ifft(int n, t_sample *real, t_sample *imag);
-EXTERN void mayer_realfft(int n, t_sample *real);
-EXTERN void mayer_realifft(int n, t_sample *real);
+    EXTERN void mayer_fht(t_sample *fz, int n);
+    EXTERN void mayer_fft(int n, t_sample *real, t_sample *imag);
+    EXTERN void mayer_ifft(int n, t_sample *real, t_sample *imag);
+    EXTERN void mayer_realfft(int n, t_sample *real);
+    EXTERN void mayer_realifft(int n, t_sample *real);
 
-EXTERN float *cos_table;
+    EXTERN float *cos_table;
 #define LOGCOSTABSIZE 9
-#define COSTABSIZE (1<<LOGCOSTABSIZE)
+#define COSTABSIZE (1 << LOGCOSTABSIZE)
 
-EXTERN int canvas_suspend_dsp(void);
-EXTERN void canvas_resume_dsp(int oldstate);
-EXTERN void canvas_update_dsp(void);
-EXTERN int canvas_dspstate;
+    EXTERN int canvas_suspend_dsp(void);
+    EXTERN void canvas_resume_dsp(int oldstate);
+    EXTERN void canvas_update_dsp(void);
+    EXTERN int canvas_dspstate;
 
-/*   up/downsampling */
-typedef struct _resample
-{
-  int method;       /* up/downsampling method ID */
+    /*   up/downsampling */
+    typedef struct _resample
+    {
+        int method; /* up/downsampling method ID */
 
-  int downsample; /* downsampling factor */
-  int upsample;   /* upsampling factor */
+        int downsample; /* downsampling factor */
+        int upsample;   /* upsampling factor */
 
-  t_sample *s_vec;   /* here we hold the resampled data */
-  int      s_n;
+        t_sample *s_vec; /* here we hold the resampled data */
+        int s_n;
 
-  t_sample *coeffs;  /* coefficients for filtering... */
-  int      coefsize;
+        t_sample *coeffs; /* coefficients for filtering... */
+        int coefsize;
 
-  t_sample *buffer;  /* buffer for filtering */
-  int      bufsize;
-} t_resample;
+        t_sample *buffer; /* buffer for filtering */
+        int bufsize;
+    } t_resample;
 
-EXTERN void resample_init(t_resample *x);
-EXTERN void resample_free(t_resample *x);
+    EXTERN void resample_init(t_resample *x);
+    EXTERN void resample_free(t_resample *x);
 
-EXTERN void resample_dsp(t_resample *x, t_sample *in, int insize, t_sample *out, int outsize, int method);
-EXTERN void resamplefrom_dsp(t_resample *x, t_sample *in, int insize, int outsize, int method);
-EXTERN void resampleto_dsp(t_resample *x, t_sample *out, int insize, int outsize, int method);
+    EXTERN void resample_dsp(t_resample *x, t_sample *in, int insize,
+        t_sample *out, int outsize, int method);
+    EXTERN void resamplefrom_dsp(
+        t_resample *x, t_sample *in, int insize, int outsize, int method);
+    EXTERN void resampleto_dsp(
+        t_resample *x, t_sample *out, int insize, int outsize, int method);
 
-/* ----------------------- utility functions for signals -------------- */
-EXTERN t_float mtof(t_float);
-EXTERN t_float ftom(t_float);
-EXTERN t_float rmstodb(t_float);
-EXTERN t_float powtodb(t_float);
-EXTERN t_float dbtorms(t_float);
-EXTERN t_float dbtopow(t_float);
+    /* ----------------------- utility functions for signals -------------- */
+    EXTERN t_float mtof(t_float);
+    EXTERN t_float ftom(t_float);
+    EXTERN t_float rmstodb(t_float);
+    EXTERN t_float powtodb(t_float);
+    EXTERN t_float dbtorms(t_float);
+    EXTERN t_float dbtopow(t_float);
 
-EXTERN t_float q8_sqrt(t_float);
-EXTERN t_float q8_rsqrt(t_float);
+    EXTERN t_float q8_sqrt(t_float);
+    EXTERN t_float q8_rsqrt(t_float);
 #ifndef N32
-EXTERN t_float qsqrt(t_float);  /* old names kept for extern compatibility */
-EXTERN t_float qrsqrt(t_float);
+    EXTERN t_float qsqrt(t_float); /* old names kept for extern compatibility */
+    EXTERN t_float qrsqrt(t_float);
 #endif
 
-/* --------------------- data --------------------------------- */
+    /* --------------------- data --------------------------------- */
 
     /* graphical arrays */
-EXTERN_STRUCT _garray;
+    EXTERN_STRUCT _garray;
 #define t_garray struct _garray
 
-EXTERN t_class *garray_class;
-EXTERN int garray_getfloatarray(t_garray *x, int *size, t_float **vec);
-EXTERN int garray_getfloatwords(t_garray *x, int *size, t_word **vec);
-EXTERN void garray_redraw(t_garray *x);
-EXTERN int garray_npoints(t_garray *x);
-EXTERN char *garray_vec(t_garray *x);
-EXTERN void garray_resize(t_garray *x, t_floatarg f);  /* avoid; use this: */
-EXTERN void garray_resize_long(t_garray *x, long n);   /* better version */
-EXTERN void garray_usedindsp(t_garray *x);
-EXTERN void garray_setsaveit(t_garray *x, int saveit);
-EXTERN t_glist *garray_getglist(t_garray *x);
-EXTERN t_array *garray_getarray(t_garray *x);
-EXTERN t_class *scalar_class;
+    EXTERN t_class *garray_class;
+    EXTERN int garray_getfloatarray(t_garray *x, int *size, t_float **vec);
+    EXTERN int garray_getfloatwords(t_garray *x, int *size, t_word **vec);
+    EXTERN void garray_redraw(t_garray *x);
+    EXTERN int garray_npoints(t_garray *x);
+    EXTERN char *garray_vec(t_garray *x);
+    EXTERN void garray_resize(t_garray *x, t_floatarg f); /* avoid; use this: */
+    EXTERN void garray_resize_long(t_garray *x, long n);  /* better version */
+    EXTERN void garray_usedindsp(t_garray *x);
+    EXTERN void garray_setsaveit(t_garray *x, int saveit);
+    EXTERN t_glist *garray_getglist(t_garray *x);
+    EXTERN t_array *garray_getarray(t_garray *x);
+    EXTERN t_class *scalar_class;
 
-EXTERN t_float *value_get(t_symbol *s);
-EXTERN void value_release(t_symbol *s);
-EXTERN int value_getfloat(t_symbol *s, t_float *f);
-EXTERN int value_setfloat(t_symbol *s, t_float f);
+    EXTERN t_float *value_get(t_symbol *s);
+    EXTERN void value_release(t_symbol *s);
+    EXTERN int value_getfloat(t_symbol *s, t_float *f);
+    EXTERN int value_setfloat(t_symbol *s, t_float f);
 
-/* ------- GUI interface - functions to send strings to TK --------- */
-typedef void (*t_guicallbackfn)(t_gobj *client, t_glist *glist);
+    /* ------- GUI interface - functions to send strings to TK --------- */
+    typedef void (*t_guicallbackfn)(t_gobj *client, t_glist *glist);
 
-EXTERN void sys_vgui(const char *fmt, ...);
-EXTERN void sys_gui(const char *s);
-EXTERN void sys_pretendguibytes(int n);
-EXTERN void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f);
-EXTERN void sys_unqueuegui(void *client);
+    EXTERN void sys_vgui(const char *fmt, ...);
+    EXTERN void sys_gui(const char *s);
+    EXTERN void sys_pretendguibytes(int n);
+    EXTERN void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f);
+    EXTERN void sys_unqueuegui(void *client);
     /* dialog window creation and destruction */
-EXTERN void gfxstub_new(t_pd *owner, void *key, const char *cmd);
-EXTERN void gfxstub_deleteforkey(void *key);
+    EXTERN void gfxstub_new(t_pd *owner, void *key, const char *cmd);
+    EXTERN void gfxstub_deleteforkey(void *key);
 
-extern t_class *glob_pdobject;  /* object to send "pd" messages */
+    extern t_class *glob_pdobject; /* object to send "pd" messages */
 
-/*-------------  Max 0.26 compatibility --------------------*/
+    /*-------------  Max 0.26 compatibility --------------------*/
 
-/* the following reflects the new way classes are laid out, with the class
-   pointing to the messlist and not vice versa. Externs shouldn't feel it. */
-typedef t_class *t_externclass;
+    /* the following reflects the new way classes are laid out, with the class
+       pointing to the messlist and not vice versa. Externs shouldn't feel it.
+     */
+    typedef t_class *t_externclass;
 
-EXTERN void c_extern(t_externclass *cls, t_newmethod newroutine,
-    t_method freeroutine, t_symbol *name, size_t size, int tiny, \
-    t_atomtype arg1, ...);
-EXTERN void c_addmess(t_method fn, t_symbol *sel, t_atomtype arg1, ...);
+    EXTERN void c_extern(t_externclass *cls, t_newmethod newroutine,
+        t_method freeroutine, t_symbol *name, size_t size, int tiny,
+        t_atomtype arg1, ...);
+    EXTERN void c_addmess(t_method fn, t_symbol *sel, t_atomtype arg1, ...);
 
 #define t_getbytes getbytes
 #define t_freebytes freebytes
@@ -739,8 +757,9 @@ EXTERN void c_addmess(t_method fn, t_symbol *sel, t_atomtype arg1, ...);
 #define typedmess pd_typedmess
 #define vmess pd_vmess
 
-/* A definition to help gui objects straddle 0.34-0.35 changes.  If this is
-defined, there is a "te_xpix" field in objects, not a "te_xpos" as before: */
+    /* A definition to help gui objects straddle 0.34-0.35 changes.  If this is
+    defined, there is a "te_xpix" field in objects, not a "te_xpos" as before:
+  */
 
 #define PD_USE_TE_XPIX
 
@@ -749,131 +768,134 @@ defined, there is a "te_xpix" field in objects, not a "te_xpos" as before: */
 /* a test for NANs and denormals.  Should only be necessary on i386. */
 #if PD_FLOATSIZE == 32
 
-typedef  union
-{
-    t_float f;
-    unsigned int ui;
-}t_bigorsmall32;
+    typedef union
+    {
+        t_float f;
+        unsigned int ui;
+    } t_bigorsmall32;
 
-static inline int PD_BADFLOAT(t_float f)  /* malformed float */
-{
-    t_bigorsmall32 pun;
-    pun.f = f;
-    pun.ui &= 0x7f800000;
-    return((pun.ui == 0) | (pun.ui == 0x7f800000));
-}
+    static inline int PD_BADFLOAT(t_float f) /* malformed float */
+    {
+        t_bigorsmall32 pun;
+        pun.f = f;
+        pun.ui &= 0x7f800000;
+        return ((pun.ui == 0) | (pun.ui == 0x7f800000));
+    }
 
-static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-64,64) */
-{
-    t_bigorsmall32 pun;
-    pun.f = f;
-    return((pun.ui & 0x20000000) == ((pun.ui >> 1) & 0x20000000));
-}
+    static inline int PD_BIGORSMALL(t_float f) /* exponent outside (-64,64) */
+    {
+        t_bigorsmall32 pun;
+        pun.f = f;
+        return ((pun.ui & 0x20000000) == ((pun.ui >> 1) & 0x20000000));
+    }
 
 #elif PD_FLOATSIZE == 64
 
-typedef  union
-{
-    t_float f;
-    unsigned int ui[2];
-}t_bigorsmall64;
+    typedef union
+    {
+        t_float f;
+        unsigned int ui[2];
+    } t_bigorsmall64;
 
-static inline int PD_BADFLOAT(t_float f)  /* malformed double */
-{
-    t_bigorsmall64 pun;
-    pun.f = f;
-    pun.ui[1] &= 0x7ff00000;
-    return((pun.ui[1] == 0) | (pun.ui[1] == 0x7ff00000));
-}
+    static inline int PD_BADFLOAT(t_float f) /* malformed double */
+    {
+        t_bigorsmall64 pun;
+        pun.f = f;
+        pun.ui[1] &= 0x7ff00000;
+        return ((pun.ui[1] == 0) | (pun.ui[1] == 0x7ff00000));
+    }
 
-static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-512,512) */
-{
-    t_bigorsmall64 pun;
-    pun.f = f;
-    return((pun.ui[1] & 0x20000000) == ((pun.ui[1] >> 1) & 0x20000000));
-}
+    static inline int PD_BIGORSMALL(t_float f) /* exponent outside (-512,512) */
+    {
+        t_bigorsmall64 pun;
+        pun.f = f;
+        return ((pun.ui[1] & 0x20000000) == ((pun.ui[1] >> 1) & 0x20000000));
+    }
 
 #endif /* PD_FLOATSIZE */
-#else /* not INTEL or ARM */
+#else  /* not INTEL or ARM */
 #define PD_BADFLOAT(f) 0
 #define PD_BIGORSMALL(f) 0
 #endif
 
-#else   /* _MSC_VER */
+#else /* _MSC_VER */
 #if PD_FLOATSIZE == 32
-#define PD_BADFLOAT(f) ((((*(unsigned int*)&(f))&0x7f800000)==0) || \
-    (((*(unsigned int*)&(f))&0x7f800000)==0x7f800000))
+#define PD_BADFLOAT(f)                                 \
+    ((((*(unsigned int *) &(f)) & 0x7f800000) == 0) || \
+        (((*(unsigned int *) &(f)) & 0x7f800000) == 0x7f800000))
 /* more stringent test: anything not between 1e-19 and 1e19 in absolute val */
-#define PD_BIGORSMALL(f) ((((*(unsigned int*)&(f))&0x60000000)==0) || \
-    (((*(unsigned int*)&(f))&0x60000000)==0x60000000))
-#else   /* 64 bits... don't know what to do here */
+#define PD_BIGORSMALL(f)                               \
+    ((((*(unsigned int *) &(f)) & 0x60000000) == 0) || \
+        (((*(unsigned int *) &(f)) & 0x60000000) == 0x60000000))
+#else /* 64 bits... don't know what to do here */
 #define PD_BADFLOAT(f) (!(((f) >= 0) || ((f) <= 0)))
-#define PD_BIGORSMALL(f) ((f) > 1e150 || (f) <  -1e150 \
-    || (f) > -1e-150 && (f) < 1e-150 )
+#define PD_BIGORSMALL(f) \
+    ((f) > 1e150 || (f) < -1e150 || (f) > -1e-150 && (f) < 1e-150)
 #endif
 #endif /* _MSC_VER */
     /* get version number at run time */
-EXTERN void sys_getversion(int *major, int *minor, int *bugfix);
+    EXTERN void sys_getversion(int *major, int *minor, int *bugfix);
 
-EXTERN_STRUCT _instancemidi;
+    EXTERN_STRUCT _instancemidi;
 #define t_instancemidi struct _instancemidi
 
-EXTERN_STRUCT _instanceinter;
+    EXTERN_STRUCT _instanceinter;
 #define t_instanceinter struct _instanceinter
 
-EXTERN_STRUCT _instancecanvas;
+    EXTERN_STRUCT _instancecanvas;
 #define t_instancecanvas struct _instancecanvas
 
-EXTERN_STRUCT _instanceugen;
+    EXTERN_STRUCT _instanceugen;
 #define t_instanceugen struct _instanceugen
 
-EXTERN_STRUCT _instancestuff;
+    EXTERN_STRUCT _instancestuff;
 #define t_instancestuff struct _instancestuff
 
 #ifndef PDTHREADS
 #define PDTHREADS 1
 #endif
 
-struct _pdinstance
-{
-    double pd_systime;          /* global time in Pd ticks */
-    t_clock *pd_clock_setlist;  /* list of set clocks */
-    t_canvas *pd_canvaslist;    /* list of all root canvases */
-    struct _template *pd_templatelist;  /* list of all templates */
-    int pd_instanceno;          /* ordinal number of this instance */
-    t_symbol **pd_symhash;      /* symbol table hash table */
-    t_instancemidi *pd_midi;    /* private stuff for x_midi.c */
-    t_instanceinter *pd_inter;  /* private stuff for s_inter.c */
-    t_instanceugen *pd_ugen;    /* private stuff for d_ugen.c */
-    t_instancecanvas *pd_gui;   /* semi-private stuff in g_canvas.h */
-    t_instancestuff *pd_stuff;  /* semi-private stuff in s_stuff.h */
-    t_pd *pd_newest;            /* most recently created object */
+    struct _pdinstance
+    {
+        double pd_systime;                 /* global time in Pd ticks */
+        t_clock *pd_clock_setlist;         /* list of set clocks */
+        t_canvas *pd_canvaslist;           /* list of all root canvases */
+        struct _template *pd_templatelist; /* list of all templates */
+        int pd_instanceno;                 /* ordinal number of this instance */
+        t_symbol **pd_symhash;             /* symbol table hash table */
+        t_instancemidi *pd_midi;           /* private stuff for x_midi.c */
+        t_instanceinter *pd_inter;         /* private stuff for s_inter.c */
+        t_instanceugen *pd_ugen;           /* private stuff for d_ugen.c */
+        t_instancecanvas *pd_gui;  /* semi-private stuff in g_canvas.h */
+        t_instancestuff *pd_stuff; /* semi-private stuff in s_stuff.h */
+        t_pd *pd_newest;           /* most recently created object */
 #ifdef PDINSTANCE
-    t_symbol  pd_s_pointer;
-    t_symbol  pd_s_float;
-    t_symbol  pd_s_symbol;
-    t_symbol  pd_s_bang;
-    t_symbol  pd_s_list;
-    t_symbol  pd_s_anything;
-    t_symbol  pd_s_signal;
-    t_symbol  pd_s__N;
-    t_symbol  pd_s__X;
-    t_symbol  pd_s_x;
-    t_symbol  pd_s_y;
-    t_symbol  pd_s_;
+        t_symbol pd_s_pointer;
+        t_symbol pd_s_float;
+        t_symbol pd_s_symbol;
+        t_symbol pd_s_bang;
+        t_symbol pd_s_list;
+        t_symbol pd_s_anything;
+        t_symbol pd_s_signal;
+        t_symbol pd_s__N;
+        t_symbol pd_s__X;
+        t_symbol pd_s_x;
+        t_symbol pd_s_y;
+        t_symbol pd_s_;
 #endif
 #if PDTHREADS
-    int pd_islocked;
+        int pd_islocked;
 #endif
-};
+    };
+
 #define t_pdinstance struct _pdinstance
-EXTERN t_pdinstance pd_maininstance;
+    EXTERN t_pdinstance pd_maininstance;
 
 /* m_pd.c */
 #ifdef PDINSTANCE
-EXTERN t_pdinstance *pdinstance_new(void);
-EXTERN void pd_setinstance(t_pdinstance *x);
-EXTERN void pdinstance_free(t_pdinstance *x);
+    EXTERN t_pdinstance *pdinstance_new(void);
+    EXTERN void pd_setinstance(t_pdinstance *x);
+    EXTERN void pdinstance_free(t_pdinstance *x);
 #endif /* PDINSTANCE */
 
 #if defined(PDTHREADS) && defined(PDINSTANCE)
@@ -887,48 +909,48 @@ EXTERN void pdinstance_free(t_pdinstance *x);
 #endif
 
 #ifdef PDINSTANCE
-extern PERTHREAD t_pdinstance *pd_this;
-EXTERN t_pdinstance **pd_instances;
-EXTERN int pd_ninstances;
+    extern PERTHREAD t_pdinstance *pd_this;
+    EXTERN t_pdinstance **pd_instances;
+    EXTERN int pd_ninstances;
 #else
 #define pd_this (&pd_maininstance)
 #endif /* PDINSTANCE */
 
 #ifdef PDINSTANCE
-#define s_pointer   (pd_this->pd_s_pointer)
-#define s_float     (pd_this->pd_s_float)
-#define s_symbol    (pd_this->pd_s_symbol)
-#define s_bang      (pd_this->pd_s_bang)
-#define s_list      (pd_this->pd_s_list)
-#define s_anything  (pd_this->pd_s_anything)
-#define s_signal    (pd_this->pd_s_signal)
-#define s__N        (pd_this->pd_s__N)
-#define s__X        (pd_this->pd_s__X)
-#define s_x         (pd_this->pd_s_x)
-#define s_y         (pd_this->pd_s_y)
-#define s_          (pd_this->pd_s_)
+#define s_pointer (pd_this->pd_s_pointer)
+#define s_float (pd_this->pd_s_float)
+#define s_symbol (pd_this->pd_s_symbol)
+#define s_bang (pd_this->pd_s_bang)
+#define s_list (pd_this->pd_s_list)
+#define s_anything (pd_this->pd_s_anything)
+#define s_signal (pd_this->pd_s_signal)
+#define s__N (pd_this->pd_s__N)
+#define s__X (pd_this->pd_s__X)
+#define s_x (pd_this->pd_s_x)
+#define s_y (pd_this->pd_s_y)
+#define s_ (pd_this->pd_s_)
 #else
 EXTERN t_symbol s_pointer, s_float, s_symbol, s_bang, s_list, s_anything,
-  s_signal, s__N, s__X, s_x, s_y, s_;
+    s_signal, s__N, s__X, s_x, s_y, s_;
 #endif
 
-EXTERN t_canvas *pd_getcanvaslist(void);
-EXTERN int pd_getdspstate(void);
+    EXTERN t_canvas *pd_getcanvaslist(void);
+    EXTERN int pd_getdspstate(void);
 
-/* x_text.c */
-EXTERN t_binbuf *text_getbufbyname(t_symbol *s); /* get binbuf from text obj */
-EXTERN void text_notifybyname(t_symbol *s);      /* notify it was modified */
+    /* x_text.c */
+    EXTERN t_binbuf *text_getbufbyname(
+        t_symbol *s);                           /* get binbuf from text obj */
+    EXTERN void text_notifybyname(t_symbol *s); /* notify it was modified */
 
-/* g_undo.c */
-/* store two message-sets to be sent to the object's <s> method for 'undo'ing
- * resp. 'redo'ing the current state of an object.
- * this creates an internal copy of the atom-lists (so the caller is responsible
- * for freeing any dynamically allocated data)
- * this is a no-op if called during 'undo' (resp. 'redo').
- */
-EXTERN void pd_undo_set_objectstate(t_canvas*canvas, t_pd*x, t_symbol*s,
-                                    int undo_argc, t_atom*undo_argv,
-                                    int redo_argc, t_atom*redo_argv);
+    /* g_undo.c */
+    /* store two message-sets to be sent to the object's <s> method for
+     * 'undo'ing resp. 'redo'ing the current state of an object. this creates an
+     * internal copy of the atom-lists (so the caller is responsible for freeing
+     * any dynamically allocated data) this is a no-op if called during 'undo'
+     * (resp. 'redo').
+     */
+    EXTERN void pd_undo_set_objectstate(t_canvas *canvas, t_pd *x, t_symbol *s,
+        int undo_argc, t_atom *undo_argv, int redo_argc, t_atom *redo_argv);
 
 #if defined(_LANGUAGE_C_PLUS_PLUS) || defined(__cplusplus)
 }

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -160,9 +160,7 @@ double clock_gettimesincewithunits(
     if(sampflag)
         return ((pd_this->pd_systime - prevsystime) /
                 ((TIMEUNITPERSECOND / STUFF->st_dacsr) * units));
-    else
-        return (
-            (pd_this->pd_systime - prevsystime) / (TIMEUNITPERMSEC * units));
+    return ((pd_this->pd_systime - prevsystime) / (TIMEUNITPERMSEC * units));
 }
 
 /* what value the system clock will have after a delay */

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -59,7 +59,9 @@ void clock_unset(t_clock *x)
     if(x->c_settime >= 0)
     {
         if(x == pd_this->pd_clock_setlist)
+        {
             pd_this->pd_clock_setlist = x->c_next;
+        }
         else
         {
             t_clock *x2 = pd_this->pd_clock_setlist;
@@ -129,9 +131,13 @@ void clock_setunit(t_clock *x, double timeunit, int sampflag)
                                        : (x->c_unit * (TIMEUNITPERSECOND /
                                                           STUFF->st_dacsr))));
     if(sampflag)
+    {
         x->c_unit = -timeunit; /* negate to flag sample-based */
+    }
     else
+    {
         x->c_unit = timeunit * TIMEUNITPERMSEC;
+    }
     if(timeleft >= 0) /* reschedule if already set */
         clock_delay(x, timeleft);
 }
@@ -158,8 +164,10 @@ double clock_gettimesincewithunits(
     units == 1 and (sys_time - prevsystime) is an integer number of
     DSP ticks, the result will be exact. */
     if(sampflag)
+    {
         return ((pd_this->pd_systime - prevsystime) /
                 ((TIMEUNITPERSECOND / STUFF->st_dacsr) * units));
+    }
     return ((pd_this->pd_systime - prevsystime) / (TIMEUNITPERMSEC * units));
 }
 
@@ -431,9 +439,13 @@ int m_mainloop(void)
     while(sys_quit != SYS_QUIT_QUIT)
     {
         if(sched_useaudio == SCHED_AUDIO_CALLBACK)
+        {
             m_callbackscheduler();
+        }
         else
+        {
             m_pollingscheduler();
+        }
         if(sys_quit == SYS_QUIT_RESTART)
         {
             sys_quit = 0;

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -299,7 +299,8 @@ int (*sys_idlehook)(void);
 /* when audio is idle, see to GUI and other stuff */
 static int sched_idletask(void)
 {
-    static int sched_nextmeterpolltime, sched_nextpingtime;
+    static int sched_nextmeterpolltime;
+    static int sched_nextpingtime;
     int rtn = 0;
     sys_lock();
     if(sys_pollgui()) rtn = 1;

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  scheduling stuff  */
 
@@ -11,14 +11,14 @@
 #include <windows.h>
 #endif
 
-    /* LATER consider making this variable.  It's now the LCM of all sample
-    rates we expect to see: 32000, 44100, 48000, 88200, 96000. */
+/* LATER consider making this variable.  It's now the LCM of all sample
+rates we expect to see: 32000, 44100, 48000, 88200, 96000. */
 #define TIMEUNITPERMSEC (32. * 441.)
 #define TIMEUNITPERSECOND (TIMEUNITPERMSEC * 1000.)
 #define SYSTIMEPERTICK \
-    ((STUFF->st_schedblocksize/STUFF->st_dacsr) * TIMEUNITPERSECOND)
+    ((STUFF->st_schedblocksize / STUFF->st_dacsr) * TIMEUNITPERSECOND)
 #define APPROXTICKSPERSEC \
-    ((int)(STUFF->st_dacsr /(double)STUFF->st_schedblocksize))
+    ((int) (STUFF->st_dacsr / (double) STUFF->st_schedblocksize))
 
 #define SYS_QUIT_QUIT 1
 #define SYS_QUIT_RESTART 2
@@ -32,11 +32,11 @@ typedef void (*t_clockmethod)(void *client);
 
 struct _clock
 {
-    double c_settime;       /* in TIMEUNITS; <0 if unset */
+    double c_settime; /* in TIMEUNITS; <0 if unset */
     void *c_owner;
     t_clockmethod c_fn;
     struct _clock *c_next;
-    t_float c_unit;         /* >0 if in TIMEUNITS; <0 if in samples */
+    t_float c_unit; /* >0 if in TIMEUNITS; <0 if in samples */
 };
 
 #ifdef HAVE_UNISTD_H
@@ -45,10 +45,10 @@ struct _clock
 
 t_clock *clock_new(void *owner, t_method fn)
 {
-    t_clock *x = (t_clock *)getbytes(sizeof *x);
+    t_clock *x = (t_clock *) getbytes(sizeof *x);
     x->c_settime = -1;
     x->c_owner = owner;
-    x->c_fn = (t_clockmethod)fn;
+    x->c_fn = (t_clockmethod) fn;
     x->c_next = 0;
     x->c_unit = TIMEUNITPERMSEC;
     return (x);
@@ -56,35 +56,36 @@ t_clock *clock_new(void *owner, t_method fn)
 
 void clock_unset(t_clock *x)
 {
-    if (x->c_settime >= 0)
+    if(x->c_settime >= 0)
     {
-        if (x == pd_this->pd_clock_setlist)
+        if(x == pd_this->pd_clock_setlist)
             pd_this->pd_clock_setlist = x->c_next;
         else
         {
             t_clock *x2 = pd_this->pd_clock_setlist;
-            while (x2->c_next != x) x2 = x2->c_next;
+            while(x2->c_next != x)
+                x2 = x2->c_next;
             x2->c_next = x->c_next;
         }
         x->c_settime = -1;
     }
 }
 
-    /* set the clock to call back at an absolute system time */
+/* set the clock to call back at an absolute system time */
 void clock_set(t_clock *x, double setticks)
 {
-    if (setticks < pd_this->pd_systime) setticks = pd_this->pd_systime;
+    if(setticks < pd_this->pd_systime) setticks = pd_this->pd_systime;
     clock_unset(x);
     x->c_settime = setticks;
-    if (pd_this->pd_clock_setlist &&
+    if(pd_this->pd_clock_setlist &&
         pd_this->pd_clock_setlist->c_settime <= setticks)
     {
         t_clock *cbefore, *cafter;
-        for (cbefore = pd_this->pd_clock_setlist,
-            cafter = pd_this->pd_clock_setlist->c_next;
-                cbefore; cbefore = cafter, cafter = cbefore->c_next)
+        for(cbefore = pd_this->pd_clock_setlist,
+        cafter = pd_this->pd_clock_setlist->c_next;
+            cbefore; cbefore = cafter, cafter = cbefore->c_next)
         {
-            if (!cafter || cafter->c_settime > setticks)
+            if(!cafter || cafter->c_settime > setticks)
             {
                 cbefore->c_next = x;
                 x->c_next = cafter;
@@ -92,73 +93,79 @@ void clock_set(t_clock *x, double setticks)
             }
         }
     }
-    else x->c_next = pd_this->pd_clock_setlist, pd_this->pd_clock_setlist = x;
+    else
+        x->c_next = pd_this->pd_clock_setlist, pd_this->pd_clock_setlist = x;
 }
 
-    /* set the clock to call back after a delay in msec */
+/* set the clock to call back after a delay in msec */
 void clock_delay(t_clock *x, double delaytime)
 {
-    clock_set(x, (x->c_unit > 0 ?
-        pd_this->pd_systime + x->c_unit * delaytime :
-            pd_this->pd_systime -
-                (x->c_unit*(TIMEUNITPERSECOND/STUFF->st_dacsr)) * delaytime));
+    clock_set(
+        x, (x->c_unit > 0
+                   ? pd_this->pd_systime + x->c_unit * delaytime
+                   : pd_this->pd_systime -
+                         (x->c_unit * (TIMEUNITPERSECOND / STUFF->st_dacsr)) *
+                             delaytime));
 }
 
-    /* set the time unit in msec or (if 'samps' is set) in samples.  This
-    is flagged by setting c_unit negative.  If the clock is currently set,
-    recalculate the delay based on the new unit and reschedule */
+/* set the time unit in msec or (if 'samps' is set) in samples.  This
+is flagged by setting c_unit negative.  If the clock is currently set,
+recalculate the delay based on the new unit and reschedule */
 void clock_setunit(t_clock *x, double timeunit, int sampflag)
 {
     double timeleft;
-    if (timeunit <= 0)
-        timeunit = 1;
+    if(timeunit <= 0) timeunit = 1;
     /* if no change, return to avoid truncation errors recalculating delay */
-    if ((sampflag && (timeunit == -x->c_unit)) ||
+    if((sampflag && (timeunit == -x->c_unit)) ||
         (!sampflag && (timeunit == x->c_unit * TIMEUNITPERMSEC)))
-            return;
+        return;
 
-        /* figure out time left in the units we were in */
-    timeleft = (x->c_settime < 0 ? -1 :
-        (x->c_settime - pd_this->pd_systime)/((x->c_unit > 0)? x->c_unit :
-            (x->c_unit*(TIMEUNITPERSECOND/STUFF->st_dacsr))));
-    if (sampflag)
-        x->c_unit = -timeunit;  /* negate to flag sample-based */
-    else x->c_unit = timeunit * TIMEUNITPERMSEC;
-    if (timeleft >= 0)  /* reschedule if already set */
+    /* figure out time left in the units we were in */
+    timeleft =
+        (x->c_settime < 0
+                ? -1
+                : (x->c_settime - pd_this->pd_systime) /
+                      ((x->c_unit > 0) ? x->c_unit
+                                       : (x->c_unit * (TIMEUNITPERSECOND /
+                                                          STUFF->st_dacsr))));
+    if(sampflag)
+        x->c_unit = -timeunit; /* negate to flag sample-based */
+    else
+        x->c_unit = timeunit * TIMEUNITPERMSEC;
+    if(timeleft >= 0) /* reschedule if already set */
         clock_delay(x, timeleft);
 }
 
-    /* get current logical time.  We don't specify what units this is in;
-    use clock_gettimesince() to measure intervals from time of this call. */
-double clock_getlogicaltime(void)
-{
-    return (pd_this->pd_systime);
-}
+/* get current logical time.  We don't specify what units this is in;
+use clock_gettimesince() to measure intervals from time of this call. */
+double clock_getlogicaltime(void) { return (pd_this->pd_systime); }
 
-    /* OBSOLETE (misleading) function name kept for compatibility */
+/* OBSOLETE (misleading) function name kept for compatibility */
 double clock_getsystime(void) { return (pd_this->pd_systime); }
 
-    /* elapsed time in milliseconds since the given system time */
+/* elapsed time in milliseconds since the given system time */
 double clock_gettimesince(double prevsystime)
 {
-    return ((pd_this->pd_systime - prevsystime)/TIMEUNITPERMSEC);
+    return ((pd_this->pd_systime - prevsystime) / TIMEUNITPERMSEC);
 }
 
-    /* elapsed time in units, ala clock_setunit(), since given system time */
-double clock_gettimesincewithunits(double prevsystime,
-    double units, int sampflag)
+/* elapsed time in units, ala clock_setunit(), since given system time */
+double clock_gettimesincewithunits(
+    double prevsystime, double units, int sampflag)
 {
-            /* If in samples, divide TIMEUNITPERSECOND/sys_dacsr first (at
-            cost of an extra division) since it's probably an integer and if
-            units == 1 and (sys_time - prevsystime) is an integer number of
-            DSP ticks, the result will be exact. */
-    if (sampflag)
-        return ((pd_this->pd_systime - prevsystime)/
-            ((TIMEUNITPERSECOND/STUFF->st_dacsr)*units));
-    else return ((pd_this->pd_systime - prevsystime)/(TIMEUNITPERMSEC*units));
+    /* If in samples, divide TIMEUNITPERSECOND/sys_dacsr first (at
+    cost of an extra division) since it's probably an integer and if
+    units == 1 and (sys_time - prevsystime) is an integer number of
+    DSP ticks, the result will be exact. */
+    if(sampflag)
+        return ((pd_this->pd_systime - prevsystime) /
+                ((TIMEUNITPERSECOND / STUFF->st_dacsr) * units));
+    else
+        return (
+            (pd_this->pd_systime - prevsystime) / (TIMEUNITPERMSEC * units));
 }
 
-    /* what value the system clock will have after a delay */
+/* what value the system clock will have after a delay */
 double clock_getsystimeafter(double delaytime)
 {
     return (pd_this->pd_systime + TIMEUNITPERMSEC * delaytime);
@@ -170,10 +177,8 @@ void clock_free(t_clock *x)
     freebytes(x, sizeof *x);
 }
 
-
 void glob_audiostatus(void)
-{
-    /* rewrite me */
+{ /* rewrite me */
 }
 
 static int sched_diored;
@@ -181,12 +186,13 @@ static int sched_dioredtime;
 static int sched_meterson;
 static int sched_counter;
 
-static void sys_addhist(int n) {}   /* maybe revive this later for profiling */
+static void sys_addhist(int n) {} /* maybe revive this later for profiling */
+
 static void sys_clearhist(void) {}
 
 void sys_log_error(int type)
 {
-    if (type != ERR_NOTHING && !sched_diored &&
+    if(type != ERR_NOTHING && !sched_diored &&
         (sched_counter >= sched_dioredtime))
     {
         sys_vgui("pdtk_pd_dio 1\n");
@@ -195,8 +201,7 @@ void sys_log_error(int type)
     sched_dioredtime = sched_counter + APPROXTICKSPERSEC;
 }
 
-static int sched_lastinclip, sched_lastoutclip,
-    sched_lastindb, sched_lastoutdb;
+static int sched_lastinclip, sched_lastoutclip, sched_lastindb, sched_lastoutdb;
 
 void glob_watchdog(t_pd *dummy);
 
@@ -212,7 +217,7 @@ void dsp_tick(void);
 static int sched_useaudio = SCHED_AUDIO_NONE;
 static double sched_referencerealtime, sched_referencelogicaltime;
 
-void sched_reopenmeplease(void)   /* request from s_audio for deferred reopen */
+void sched_reopenmeplease(void) /* request from s_audio for deferred reopen */
 {
     sys_quit = SYS_QUIT_RESTART;
 }
@@ -220,57 +225,57 @@ void sched_reopenmeplease(void)   /* request from s_audio for deferred reopen */
 void sched_set_using_audio(int flag)
 {
     sched_useaudio = flag;
-    if (flag == SCHED_AUDIO_NONE)
+    if(flag == SCHED_AUDIO_NONE)
     {
         sched_referencerealtime = sys_getrealtime();
         sched_referencelogicaltime = clock_getlogicaltime();
     }
-        if (flag == SCHED_AUDIO_CALLBACK &&
-            sched_useaudio != SCHED_AUDIO_CALLBACK)
-                sys_quit = SYS_QUIT_RESTART;
-        if (flag != SCHED_AUDIO_CALLBACK &&
-            sched_useaudio == SCHED_AUDIO_CALLBACK)
-                post("sorry, can't turn off callbacks yet; restart Pd");
-                    /* not right yet! */
+    if(flag == SCHED_AUDIO_CALLBACK && sched_useaudio != SCHED_AUDIO_CALLBACK)
+        sys_quit = SYS_QUIT_RESTART;
+    if(flag != SCHED_AUDIO_CALLBACK && sched_useaudio == SCHED_AUDIO_CALLBACK)
+        post("sorry, can't turn off callbacks yet; restart Pd");
+    /* not right yet! */
 
     sys_vgui("pdtk_pd_audio %s\n", flag ? "on" : "off");
 }
 
-    /* take the scheduler forward one DSP tick, also handling clock timeouts */
+/* take the scheduler forward one DSP tick, also handling clock timeouts */
 void sched_tick(void)
 {
     double next_sys_time = pd_this->pd_systime + SYSTIMEPERTICK;
     int countdown = 5000;
-    while (pd_this->pd_clock_setlist &&
-        pd_this->pd_clock_setlist->c_settime < next_sys_time)
+    while(pd_this->pd_clock_setlist &&
+          pd_this->pd_clock_setlist->c_settime < next_sys_time)
     {
         t_clock *c = pd_this->pd_clock_setlist;
         pd_this->pd_systime = c->c_settime;
         clock_unset(pd_this->pd_clock_setlist);
         outlet_setstacklim();
         (*c->c_fn)(c->c_owner);
-        if (!countdown--)
+        if(!countdown--)
         {
             countdown = 5000;
-            (void)sys_pollgui();
+            (void) sys_pollgui();
         }
-        if (sys_quit)
-            return;
+        if(sys_quit) return;
     }
     pd_this->pd_systime = next_sys_time;
     dsp_tick();
     sched_counter++;
 }
 
-int sched_get_sleepgrain( void)
+int sched_get_sleepgrain(void)
 {
-    return (sys_sleepgrain > 0 ? sys_sleepgrain :
-        (sys_schedadvance/4 > 5000 ? 5000 : (sys_schedadvance/4 < 100 ? 100 :
-            sys_schedadvance/4)));
+    return (sys_sleepgrain > 0 ? sys_sleepgrain
+                               : (sys_schedadvance / 4 > 5000
+                                         ? 5000
+                                         : (sys_schedadvance / 4 < 100
+                                                   ? 100
+                                                   : sys_schedadvance / 4)));
 }
 
-    /* old stuff for extern binary compatibility -- remove someday */
-int *get_sys_sleepgrain(void) {return(&sys_sleepgrain);}
+/* old stuff for extern binary compatibility -- remove someday */
+int *get_sys_sleepgrain(void) { return (&sys_sleepgrain); }
 
 /*
 Here is Pd's "main loop."  This routine dispatches clock timeouts and DSP
@@ -286,39 +291,38 @@ the audio I/O system is still busy with previous transfers.
 void sys_pollmidiqueue(void);
 void sys_initmidiqueue(void);
 
- /* sys_idlehook is a hook the user can fill in to grab idle time.  Return
+/* sys_idlehook is a hook the user can fill in to grab idle time.  Return
 nonzero if you actually used the time; otherwise we're really really idle and
 will now sleep. */
 int (*sys_idlehook)(void);
 
-    /* when audio is idle, see to GUI and other stuff */
-static int sched_idletask( void)
+/* when audio is idle, see to GUI and other stuff */
+static int sched_idletask(void)
 {
     static int sched_nextmeterpolltime, sched_nextpingtime;
     int rtn = 0;
     sys_lock();
-    if (sys_pollgui())
-        rtn = 1;
+    if(sys_pollgui()) rtn = 1;
     sys_unlock();
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__)\
-                || defined(__GNU__)
-        /* if there's no GUI but we're running in "realtime", here is
-        where we arrange to ping the watchdog every 2 seconds.  (If there's
-        a GUI, it initiates the ping instead to be sure there's communication
-        back and forth.) */
-    if (!sys_havegui() && sys_hipriority && sched_counter > sched_nextpingtime)
+#if defined(__linux__) || defined(__FreeBSD__) || \
+    defined(__FreeBSD_kernel__) || defined(__GNU__)
+    /* if there's no GUI but we're running in "realtime", here is
+    where we arrange to ping the watchdog every 2 seconds.  (If there's
+    a GUI, it initiates the ping instead to be sure there's communication
+    back and forth.) */
+    if(!sys_havegui() && sys_hipriority && sched_counter > sched_nextpingtime)
     {
         glob_watchdog(0);
-            /* ping every 2 seconds */
+        /* ping every 2 seconds */
         sched_nextpingtime = sched_counter + 2 * APPROXTICKSPERSEC;
     }
 #endif
 
-        /* clear the "DIO error" warning 1 sec after it flashes */
-    if (sched_counter > sched_nextmeterpolltime)
+    /* clear the "DIO error" warning 1 sec after it flashes */
+    if(sched_counter > sched_nextmeterpolltime)
     {
-        if (sched_diored && (sched_counter - sched_dioredtime > 0))
+        if(sched_diored && (sched_counter - sched_dioredtime > 0))
         {
             sys_vgui("pdtk_pd_dio 0\n");
             sched_diored = 0;
@@ -332,16 +336,16 @@ static void m_pollingscheduler(void)
 {
     sys_lock();
     sys_initmidiqueue();
-    while (!sys_quit)   /* outer loop runs once per tick */
+    while(!sys_quit) /* outer loop runs once per tick */
     {
         sys_addhist(0);
         sched_tick();
         sys_addhist(1);
 
-            /* fast forward, in which the scheduler advances without waiting
-            for real time; for patches that alternate between interactive
-            and batch-like computations. */
-        if (sched_fastforward > 0)
+        /* fast forward, in which the scheduler advances without waiting
+        for real time; for patches that alternate between interactive
+        and batch-like computations. */
+        if(sched_fastforward > 0)
         {
             sched_fastforward -= SYSTIMEPERTICK;
             sched_referencerealtime = sys_getrealtime();
@@ -351,28 +355,30 @@ static void m_pollingscheduler(void)
         sys_pollgui();
         sys_pollmidiqueue();
         sys_addhist(2);
-        while (!sys_quit)   /* inner loop runs until it can transfer audio */
+        while(!sys_quit) /* inner loop runs until it can transfer audio */
         {
-            int timeforward; /* SENDDACS_YES if audio was transferred, SENDDACS_NO if not,
-                                or SENDDACS_SLEPT if yes but time elapsed during xfer */
+            int timeforward; /* SENDDACS_YES if audio was transferred,
+                                SENDDACS_NO if not, or SENDDACS_SLEPT if yes but
+                                time elapsed during xfer */
             sys_unlock();
-            if (sched_useaudio == SCHED_AUDIO_NONE)
+            if(sched_useaudio == SCHED_AUDIO_NONE)
             {
-                    /* no audio; use system clock */
-                double lateness = 1000. *
-                    (sys_getrealtime() - sched_referencerealtime) -
-                        clock_gettimesince(sched_referencelogicaltime);
-                if (lateness > 20000)   /* if 20" late, don't try to catch up */
+                /* no audio; use system clock */
+                double lateness =
+                    1000. * (sys_getrealtime() - sched_referencerealtime) -
+                    clock_gettimesince(sched_referencelogicaltime);
+                if(lateness > 20000) /* if 20" late, don't try to catch up */
                 {
                     sched_referencerealtime = sys_getrealtime();
                     sched_referencelogicaltime = pd_this->pd_systime;
                 }
                 timeforward = (lateness > 0 ? SENDDACS_YES : SENDDACS_NO);
             }
-            else timeforward = sys_send_dacs();
+            else
+                timeforward = sys_send_dacs();
             sys_addhist(3);
-                /* test for idle; if so, do graphics updates. */
-            if (timeforward != SENDDACS_YES && !sched_idletask() && !sys_nosleep)
+            /* test for idle; if so, do graphics updates. */
+            if(timeforward != SENDDACS_YES && !sched_idletask() && !sys_nosleep)
             {
                 /* if even that had nothing to do, sleep. */
                 sys_addhist(4);
@@ -380,8 +386,7 @@ static void m_pollingscheduler(void)
             }
             sys_addhist(5);
             sys_lock();
-            if (timeforward != SENDDACS_NO)
-                break;
+            if(timeforward != SENDDACS_NO) break;
         }
     }
     sys_unlock();
@@ -396,14 +401,14 @@ void sched_audio_callbackfn(void)
     sys_pollmidiqueue();
     sys_addhist(2);
     sys_unlock();
-    (void)sched_idletask();
+    (void) sched_idletask();
     sys_addhist(3);
 }
 
 static void m_callbackscheduler(void)
 {
     sys_initmidiqueue();
-    while (!sys_quit)
+    while(!sys_quit)
     {
         double timewas = pd_this->pd_systime;
 #ifdef _WIN32
@@ -411,29 +416,29 @@ static void m_callbackscheduler(void)
 #else
         sleep(1);
 #endif
-        if (pd_this->pd_systime == timewas)
+        if(pd_this->pd_systime == timewas)
         {
             sys_lock();
-            (void)sys_pollgui();
+            (void) sys_pollgui();
             sched_tick();
             sys_unlock();
         }
-        if (sys_idlehook)
-            sys_idlehook();
+        if(sys_idlehook) sys_idlehook();
     }
 }
 
 int m_mainloop(void)
 {
-    while (sys_quit != SYS_QUIT_QUIT)
+    while(sys_quit != SYS_QUIT_QUIT)
     {
-        if (sched_useaudio == SCHED_AUDIO_CALLBACK)
+        if(sched_useaudio == SCHED_AUDIO_CALLBACK)
             m_callbackscheduler();
-        else m_pollingscheduler();
-        if (sys_quit == SYS_QUIT_RESTART)
+        else
+            m_pollingscheduler();
+        if(sys_quit == SYS_QUIT_RESTART)
         {
             sys_quit = 0;
-            if (audio_isopen())
+            if(audio_isopen())
             {
                 sys_close_audio();
                 sys_reopen_audio();
@@ -445,12 +450,9 @@ int m_mainloop(void)
 
 int m_batchmain(void)
 {
-    while (sys_quit != SYS_QUIT_QUIT)
+    while(sys_quit != SYS_QUIT_QUIT)
         sched_tick();
     return (0);
 }
 
-void sys_exit(void)
-{
-    sys_quit = SYS_QUIT_QUIT;
-}
+void sys_exit(void) { sys_quit = SYS_QUIT_QUIT; }

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -179,7 +179,8 @@ called make_sane above */
 static void audio_compact_and_count_channels(
     int *ndev, int *devvec, int *chanvec, int *totalchans, int maxdev)
 {
-    int i, newndev;
+    int i;
+    int newndev;
     /* count total number of input and output channels */
     for(i = newndev = *totalchans = 0; i < *ndev; i++)
         if(chanvec[i] > 0)
@@ -232,8 +233,12 @@ dialog window.   */
 void sys_set_audio_settings(t_audiosettings *a)
 {
     int i;
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int indevs = 0, outdevs = 0, canmulti = 0, cancallback = 0;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int indevs = 0;
+    int outdevs = 0;
+    int canmulti = 0;
+    int cancallback = 0;
     sys_get_audio_devs(indevlist, &indevs, outdevlist, &outdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, a->a_api);
 
@@ -314,7 +319,8 @@ void sys_close_audio(void)
 void sys_init_audio(void)
 {
     t_audiosettings as;
-    int totalinchans, totaloutchans;
+    int totalinchans;
+    int totaloutchans;
     sys_get_audio_settings(&as);
     audio_compact_and_count_channels(&as.a_nindev, as.a_indevvec,
         as.a_chindevvec, &totalinchans, MAXAUDIOINDEV);
@@ -327,7 +333,9 @@ void sys_init_audio(void)
 void sys_reopen_audio(void)
 {
     t_audiosettings as;
-    int outcome = 0, totalinchans, totaloutchans;
+    int outcome = 0;
+    int totalinchans;
+    int totaloutchans;
     sys_get_audio_settings(&as);
     /* fprintf(stderr, "audio in ndev %d, dev %d; out ndev %d, dev %d\n",
         as.a_nindev, as.a_indevvec[0], as.a_noutdev, as.a_outdevvec[0]); */
@@ -579,9 +587,14 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
     char buf[MAXPDSTRING];
     t_audiosettings as;
     /* these are all the devices on your system: */
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
     char device[MAXPDSTRING];
-    int nindevs = 0, noutdevs = 0, canmulti = 0, cancallback = 0, i;
+    int nindevs = 0;
+    int noutdevs = 0;
+    int canmulti = 0;
+    int cancallback = 0;
+    int i;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
@@ -675,8 +688,13 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 
 void sys_listdevs(void)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i, canmulti = 0, cancallback = 0;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
+    int canmulti = 0;
+    int cancallback = 0;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
@@ -814,8 +832,13 @@ void sys_get_audio_apis(char *buf)
 
 int sys_audiodevnametonumber(int output, const char *name)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i, canmulti, cancallback;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
+    int canmulti;
+    int cancallback;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
@@ -855,8 +878,12 @@ int sys_audiodevnametonumber(int output, const char *name)
 
 void sys_audiodevnumbertoname(int output, int devno, char *name, int namesize)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, canmulti, cancallback;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int canmulti;
+    int cancallback;
     if(devno < 0)
     {
         *name = 0;

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2003, Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  machine-independent (well, mostly!) audio layer.  Stores and recalls
     audio settings from argparse routine and from dialog window.
@@ -33,22 +33,19 @@
 #define DEVDESCSIZE 128
 #define MAXBLOCKSIZE 2048
 
-    /* exported variables */
-int sys_schedadvance;   /* scheduler advance in microseconds */
+/* exported variables */
+int sys_schedadvance; /* scheduler advance in microseconds */
 
-static int sys_audioapiopened; /* what API is open, API_NONE if none */
-static int audio_callback_is_open;  /* true if we're open in callback mode */
+static int sys_audioapiopened;     /* what API is open, API_NONE if none */
+static int audio_callback_is_open; /* true if we're open in callback mode */
 
-    /* current parameters (if an API is open) or requested ones otherwise: */
+/* current parameters (if an API is open) or requested ones otherwise: */
 static t_audiosettings audio_nextsettings;
 
 void sched_audio_callbackfn(void);
 void sched_reopenmeplease(void);
 
-int audio_isopen(void)
-{
-    return (sys_audioapiopened > 0);
-}
+int audio_isopen(void) { return (sys_audioapiopened > 0); }
 
 static int audio_isfixedsr(int api)
 {
@@ -81,118 +78,117 @@ static int audio_getfixedblocksize(int api)
     return 0;
 }
 
-    /* inform rest of Pd of current channels and sample rate.  Do this when
-    opening audio device.  This is also called from alsamm but I think that
-    is no longer in use, so in principle this could be static. */
+/* inform rest of Pd of current channels and sample rate.  Do this when
+opening audio device.  This is also called from alsamm but I think that
+is no longer in use, so in principle this could be static. */
 
 void sys_setchsr(int chin, int chout, int sr)
 {
-    int inbytes = (chin ? chin : 2) *
-                (DEFDACBLKSIZE*sizeof(t_sample));
-    int outbytes = (chout ? chout : 2) *
-                (DEFDACBLKSIZE*sizeof(t_sample));
+    int inbytes = (chin ? chin : 2) * (DEFDACBLKSIZE * sizeof(t_sample));
+    int outbytes = (chout ? chout : 2) * (DEFDACBLKSIZE * sizeof(t_sample));
 
-    if (STUFF->st_soundin)
+    if(STUFF->st_soundin)
         freebytes(STUFF->st_soundin,
-            (STUFF->st_inchannels? STUFF->st_inchannels : 2) *
-                (DEFDACBLKSIZE*sizeof(t_sample)));
-    if (STUFF->st_soundout)
+            (STUFF->st_inchannels ? STUFF->st_inchannels : 2) *
+                (DEFDACBLKSIZE * sizeof(t_sample)));
+    if(STUFF->st_soundout)
         freebytes(STUFF->st_soundout,
-            (STUFF->st_outchannels? STUFF->st_outchannels : 2) *
-                (DEFDACBLKSIZE*sizeof(t_sample)));
+            (STUFF->st_outchannels ? STUFF->st_outchannels : 2) *
+                (DEFDACBLKSIZE * sizeof(t_sample)));
     STUFF->st_inchannels = chin;
     STUFF->st_outchannels = chout;
-    if (!audio_isfixedsr(sys_audioapiopened))
-        STUFF->st_dacsr = sr;
+    if(!audio_isfixedsr(sys_audioapiopened)) STUFF->st_dacsr = sr;
 
-    STUFF->st_soundin = (t_sample *)getbytes(inbytes);
+    STUFF->st_soundin = (t_sample *) getbytes(inbytes);
     memset(STUFF->st_soundin, 0, inbytes);
 
-    STUFF->st_soundout = (t_sample *)getbytes(outbytes);
+    STUFF->st_soundout = (t_sample *) getbytes(outbytes);
     memset(STUFF->st_soundout, 0, outbytes);
 
     logpost(NULL, PD_VERBOSE, "input channels = %d, output channels = %d",
-            STUFF->st_inchannels, STUFF->st_outchannels);
+        STUFF->st_inchannels, STUFF->st_outchannels);
     canvas_resume_dsp(canvas_suspend_dsp());
 }
 
-static void audio_make_sane(int *ndev, int *devvec,
-    int *nchan, int *chanvec, int maxdev)
+static void audio_make_sane(
+    int *ndev, int *devvec, int *nchan, int *chanvec, int maxdev)
 {
     int i;
-    if (*ndev == -1)
-    {           /* no input audio devices specified */
-        if (*nchan == -1)
+    if(*ndev == -1)
+    { /* no input audio devices specified */
+        if(*nchan == -1)
         {
-            if (*ndev >= 1)
+            if(*ndev >= 1)
             {
-                *nchan=1;
+                *nchan = 1;
                 chanvec[0] = SYS_DEFAULTCH;
                 *ndev = 1;
                 devvec[0] = DEFAULTAUDIODEV;
             }
-            else *ndev = *nchan = 0;
+            else
+                *ndev = *nchan = 0;
         }
         else
         {
-            for (i = 0; i < maxdev; i++)
+            for(i = 0; i < maxdev; i++)
                 devvec[i] = i;
             *ndev = *nchan;
         }
     }
     else
     {
-        if (*nchan == -1)
+        if(*nchan == -1)
         {
             *nchan = *ndev;
-            for (i = 0; i < *ndev; i++)
+            for(i = 0; i < *ndev; i++)
                 chanvec[i] = SYS_DEFAULTCH;
         }
-        else if (*nchan > *ndev)
+        else if(*nchan > *ndev)
         {
-            for (i = *ndev; i < *nchan; i++)
+            for(i = *ndev; i < *nchan; i++)
             {
-                if (i == 0)
+                if(i == 0)
                     devvec[0] = DEFAULTAUDIODEV;
-                else devvec[i] = devvec[i-1] + 1;
+                else
+                    devvec[i] = devvec[i - 1] + 1;
             }
             *ndev = *nchan;
         }
-        else if (*nchan < *ndev)
+        else if(*nchan < *ndev)
         {
-            for (i = *nchan; i < *ndev; i++)
+            for(i = *nchan; i < *ndev; i++)
             {
-                if (i == 0)
+                if(i == 0)
                     chanvec[0] = SYS_DEFAULTCH;
-                else chanvec[i] = chanvec[i-1];
+                else
+                    chanvec[i] = chanvec[i - 1];
             }
             *ndev = *nchan;
         }
     }
-    for (i = *ndev; i < maxdev; i++)
+    for(i = *ndev; i < maxdev; i++)
         devvec[i] = -1;
-    for (i = *nchan; i < maxdev; i++)
+    for(i = *nchan; i < maxdev; i++)
         chanvec[i] = 0;
-
 }
 
-    /* compact the list of audio devices by skipping those whose channel
-    counts are zero, and add up all channel counts.  Assumes you've already
-    called make_sane above */
+/* compact the list of audio devices by skipping those whose channel
+counts are zero, and add up all channel counts.  Assumes you've already
+called make_sane above */
 
-static void audio_compact_and_count_channels(int *ndev, int *devvec,
-    int *chanvec, int *totalchans, int maxdev)
+static void audio_compact_and_count_channels(
+    int *ndev, int *devvec, int *chanvec, int *totalchans, int maxdev)
 {
     int i, newndev;
-            /* count total number of input and output channels */
-    for (i = newndev = *totalchans = 0; i < *ndev; i++)
-        if (chanvec[i] > 0)
-    {
-        chanvec[newndev] = chanvec[i];
-        devvec[newndev] = devvec[i];
-        *totalchans += chanvec[i];
-        newndev++;
-    }
+    /* count total number of input and output channels */
+    for(i = newndev = *totalchans = 0; i < *ndev; i++)
+        if(chanvec[i] > 0)
+        {
+            chanvec[newndev] = chanvec[i];
+            devvec[newndev] = devvec[i];
+            *totalchans += chanvec[i];
+            newndev++;
+        }
     *ndev = newndev;
 }
 
@@ -202,15 +198,14 @@ static int initted = 0;
 
 void sys_get_audio_settings(t_audiosettings *a)
 {
-    if (!initted)
+    if(!initted)
     {
         audio_nextsettings.a_api = API_DEFAULT;
         audio_nextsettings.a_srate = DEFAULTSRATE;
         audio_nextsettings.a_nindev = audio_nextsettings.a_nchindev =
-            audio_nextsettings.a_noutdev = audio_nextsettings.a_nchoutdev
-                = 1;
-        audio_nextsettings.a_indevvec[0] =
-            audio_nextsettings.a_outdevvec[0] = DEFAULTAUDIODEV;
+            audio_nextsettings.a_noutdev = audio_nextsettings.a_nchoutdev = 1;
+        audio_nextsettings.a_indevvec[0] = audio_nextsettings.a_outdevvec[0] =
+            DEFAULTAUDIODEV;
         audio_nextsettings.a_chindevvec[0] =
             audio_nextsettings.a_choutdevvec[0] = SYS_DEFAULTCH;
         audio_nextsettings.a_advance = DEFAULTADVANCE;
@@ -218,43 +213,40 @@ void sys_get_audio_settings(t_audiosettings *a)
         initted = 1;
     }
     *a = audio_nextsettings;
-    if (audio_isfixedsr(a->a_api))
-        a->a_srate = STUFF->st_dacsr;
-    if (audio_isfixedblocksize(a->a_api))
+    if(audio_isfixedsr(a->a_api)) a->a_srate = STUFF->st_dacsr;
+    if(audio_isfixedblocksize(a->a_api))
         a->a_blocksize = audio_getfixedblocksize(a->a_api);
 }
 
-    /* Since the channel vector might be longer than the
-    audio device vector, or vice versa, we fill the shorter one
-    in to match the longer one.  Also, if both are empty, we fill in
-    one device (the default) and two channels. This function can leave number
-    of channels at zero which is appropriate for the dialog window but before
-    starting audio we also call audio_compact_and_count_channels below.*/
-    /* set audio device settings (after cleaning up the specified device and
-    channel vectors).  The audio devices are "zero based" (i.e. "0" means the
-    first one.)  We can later re-open audio and/or show the settings on a
-    dialog window.   */
+/* Since the channel vector might be longer than the
+audio device vector, or vice versa, we fill the shorter one
+in to match the longer one.  Also, if both are empty, we fill in
+one device (the default) and two channels. This function can leave number
+of channels at zero which is appropriate for the dialog window but before
+starting audio we also call audio_compact_and_count_channels below.*/
+/* set audio device settings (after cleaning up the specified device and
+channel vectors).  The audio devices are "zero based" (i.e. "0" means the
+first one.)  We can later re-open audio and/or show the settings on a
+dialog window.   */
 
 void sys_set_audio_settings(t_audiosettings *a)
 {
     int i;
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int indevs = 0, outdevs = 0, canmulti = 0, cancallback = 0;
     sys_get_audio_devs(indevlist, &indevs, outdevlist, &outdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, a->a_api);
 
-    if (a->a_srate < 1)
-        a->a_srate = DEFAULTSRATE;
-    if (a->a_advance < 0)
-        a->a_advance = DEFAULTADVANCE;
+    if(a->a_srate < 1) a->a_srate = DEFAULTSRATE;
+    if(a->a_advance < 0) a->a_advance = DEFAULTADVANCE;
     a->a_blocksize = 1 << ilog2(a->a_blocksize);
-    if (a->a_blocksize < DEFDACBLKSIZE || a->a_blocksize > MAXBLOCKSIZE)
+    if(a->a_blocksize < DEFDACBLKSIZE || a->a_blocksize > MAXBLOCKSIZE)
         a->a_blocksize = DEFDACBLKSIZE;
 
-    audio_make_sane(&a->a_noutdev, a->a_outdevvec,
-        &a->a_nchoutdev, a->a_choutdevvec, MAXAUDIOOUTDEV);
-    audio_make_sane(&a->a_nindev, a->a_indevvec,
-        &a->a_nchindev, a->a_chindevvec, MAXAUDIOINDEV);
+    audio_make_sane(&a->a_noutdev, a->a_outdevvec, &a->a_nchoutdev,
+        a->a_choutdevvec, MAXAUDIOOUTDEV);
+    audio_make_sane(&a->a_nindev, a->a_indevvec, &a->a_nchindev,
+        a->a_chindevvec, MAXAUDIOINDEV);
 
     sys_schedadvance = a->a_advance * 1000;
     audio_nextsettings = *a;
@@ -266,49 +258,48 @@ void sys_set_audio_settings(t_audiosettings *a)
 
 void sys_close_audio(void)
 {
-    if (sys_externalschedlib)
+    if(sys_externalschedlib)
     {
         return;
     }
-    if (!audio_isopen())
-        return;
+    if(!audio_isopen()) return;
 #ifdef USEAPI_PORTAUDIO
-    if (sys_audioapiopened == API_PORTAUDIO)
+    if(sys_audioapiopened == API_PORTAUDIO)
         pa_close_audio();
     else
 #endif
 #ifdef USEAPI_JACK
-    if (sys_audioapiopened == API_JACK)
+        if(sys_audioapiopened == API_JACK)
         jack_close_audio();
     else
 #endif
 #ifdef USEAPI_OSS
-    if (sys_audioapiopened == API_OSS)
+        if(sys_audioapiopened == API_OSS)
         oss_close_audio();
     else
 #endif
 #ifdef USEAPI_ALSA
-    if (sys_audioapiopened == API_ALSA)
+        if(sys_audioapiopened == API_ALSA)
         alsa_close_audio();
     else
 #endif
 #ifdef USEAPI_MMIO
-    if (sys_audioapiopened == API_MMIO)
+        if(sys_audioapiopened == API_MMIO)
         mmio_close_audio();
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-    if (sys_audioapiopened == API_AUDIOUNIT)
+        if(sys_audioapiopened == API_AUDIOUNIT)
         audiounit_close_audio();
     else
 #endif
 #ifdef USEAPI_ESD
-    if (sys_audioapiopened == API_ESD)
+        if(sys_audioapiopened == API_ESD)
         esd_close_audio();
     else
 #endif
 #ifdef USEAPI_DUMMY
-    if (sys_audioapiopened == API_DUMMY)
+        if(sys_audioapiopened == API_DUMMY)
         dummy_close_audio();
     else
 #endif
@@ -332,7 +323,7 @@ void sys_init_audio(void)
     sys_setchsr(totalinchans, totaloutchans, as.a_srate);
 }
 
-    /* open audio using currently requested parameters */
+/* open audio using currently requested parameters */
 void sys_reopen_audio(void)
 {
     t_audiosettings as;
@@ -345,91 +336,89 @@ void sys_reopen_audio(void)
     audio_compact_and_count_channels(&as.a_noutdev, as.a_outdevvec,
         as.a_choutdevvec, &totaloutchans, MAXAUDIOOUTDEV);
     sys_setchsr(totalinchans, totaloutchans, as.a_srate);
-    if (!as.a_nindev && !as.a_noutdev)
+    if(!as.a_nindev && !as.a_noutdev)
     {
         sched_set_using_audio(SCHED_AUDIO_NONE);
         return;
     }
 #ifdef USEAPI_PORTAUDIO
-    if (as.a_api == API_PORTAUDIO)
+    if(as.a_api == API_PORTAUDIO)
     {
         int blksize = (as.a_blocksize ? as.a_blocksize : 64);
-        int nbufs = (double)sys_schedadvance / 1000000. * as.a_srate / blksize;
-            /* make sure that the delay is not smaller than the hardware blocksize */
-        if (nbufs < 1)
+        int nbufs = (double) sys_schedadvance / 1000000. * as.a_srate / blksize;
+        /* make sure that the delay is not smaller than the hardware blocksize
+         */
+        if(nbufs < 1)
         {
-            int delay = ((double)sys_schedadvance / 1000.) + 0.5;
-            int limit = ceil(blksize * 1000. / (double)as.a_srate);
+            int delay = ((double) sys_schedadvance / 1000.) + 0.5;
+            int limit = ceil(blksize * 1000. / (double) as.a_srate);
             nbufs = 1;
-            post("warning: 'delay' setting (%d ms) too small for current blocksize "
+            post("warning: 'delay' setting (%d ms) too small for current "
+                 "blocksize "
                  "(%d samples); falling back to minimum value (%d ms)",
-                 delay, blksize, limit);
+                delay, blksize, limit);
         }
         outcome = pa_open_audio((as.a_nindev > 0 ? as.a_chindevvec[0] : 0),
-        (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0), as.a_srate,
+            (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0), as.a_srate,
             STUFF->st_soundin, STUFF->st_soundout, blksize, nbufs,
-             (as.a_nindev > 0 ? as.a_indevvec[0] : 0),
-              (as.a_noutdev > 0 ? as.a_outdevvec[0] : 0),
-               (as.a_callback ? sched_audio_callbackfn : 0));
+            (as.a_nindev > 0 ? as.a_indevvec[0] : 0),
+            (as.a_noutdev > 0 ? as.a_outdevvec[0] : 0),
+            (as.a_callback ? sched_audio_callbackfn : 0));
     }
     else
 #endif
 #ifdef USEAPI_JACK
-    if (as.a_api == API_JACK)
+        if(as.a_api == API_JACK)
         outcome = jack_open_audio((as.a_nindev > 0 ? as.a_chindevvec[0] : 0),
             (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0),
-                (as.a_callback ? sched_audio_callbackfn : 0));
+            (as.a_callback ? sched_audio_callbackfn : 0));
 
     else
 #endif
 #ifdef USEAPI_OSS
-    if (as.a_api == API_OSS)
-        outcome = oss_open_audio(as.a_nindev, as.a_indevvec,
-        as.a_nindev, as.a_chindevvec, as.a_noutdev, as.a_outdevvec,
-        as.a_noutdev, as.a_choutdevvec, as.a_srate,
-                as.a_blocksize);
+        if(as.a_api == API_OSS)
+        outcome = oss_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
+            as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
+            as.a_choutdevvec, as.a_srate, as.a_blocksize);
     else
 #endif
 #ifdef USEAPI_ALSA
-    if (as.a_api == API_ALSA)
-        outcome = alsa_open_audio(as.a_nindev, as.a_indevvec,
-            as.a_nindev, as.a_chindevvec, as.a_noutdev,
-            as.a_outdevvec, as.a_noutdev, as.a_choutdevvec, as.a_srate,
-                as.a_blocksize);
+        if(as.a_api == API_ALSA)
+        outcome = alsa_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
+            as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
+            as.a_choutdevvec, as.a_srate, as.a_blocksize);
     else
 #endif
 #ifdef USEAPI_MMIO
-    if (as.a_api == API_MMIO)
-        outcome = mmio_open_audio(as.a_nindev, as.a_indevvec,
-            as.a_nindev, as.a_chindevvec, as.a_noutdev,
-                as.a_outdevvec, as.a_noutdev, as.a_choutdevvec, as.a_srate,
-                as.a_blocksize);
+        if(as.a_api == API_MMIO)
+        outcome = mmio_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
+            as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
+            as.a_choutdevvec, as.a_srate, as.a_blocksize);
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-    if (as.a_api == API_AUDIOUNIT)
-        outcome = audiounit_open_audio(
-            (as.a_nindev > 0 ? as.a_chindev[0] : 0),
+        if(as.a_api == API_AUDIOUNIT)
+        outcome = audiounit_open_audio((as.a_nindev > 0 ? as.a_chindev[0] : 0),
             (as.a_nindev > 0 ? as.a_choutdev[0] : 0), as.a_srate);
     else
 #endif
 #ifdef USEAPI_ESD
-    if (as.a_api == API_ALSA)
-        outcome = esd_open_audio(as.a_nindev, as.a_indevvec,
-            as.a_nindev, as.a_chindevvec, as.a_noutdev,
-                as.a_outdevvec, as.a_noutdev, as.a_choutdevvec, as.a_srate);
+        if(as.a_api == API_ALSA)
+        outcome = esd_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
+            as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
+            as.a_choutdevvec, as.a_srate);
     else
 #endif
 #ifdef USEAPI_DUMMY
-    if (as.a_api == API_DUMMY)
-        outcome = dummy_open_audio(as.a_nindev, as.a_noutdev,
-            as.a_srate);
+        if(as.a_api == API_DUMMY)
+        outcome = dummy_open_audio(as.a_nindev, as.a_noutdev, as.a_srate);
     else
 #endif
-    if (as.a_api == API_NONE)
+        if(as.a_api == API_NONE)
         ;
-    else post("unknown audio API specified");
-    if (outcome)    /* failed */
+    else
+        post("unknown audio API specified");
+    if(outcome) /* failed */
     {
         sys_audioapiopened = API_NONE;
         sched_set_using_audio(SCHED_AUDIO_NONE);
@@ -442,94 +431,82 @@ void sys_reopen_audio(void)
             (as.a_callback ? SCHED_AUDIO_CALLBACK : SCHED_AUDIO_POLL));
         audio_callback_is_open = as.a_callback;
     }
-    sys_vgui("set pd_whichapi %d\n",  sys_audioapiopened);
+    sys_vgui("set pd_whichapi %d\n", sys_audioapiopened);
 }
 
 int sys_send_dacs(void)
 {
 #ifdef USEAPI_PORTAUDIO
-    if (sys_audioapiopened == API_PORTAUDIO)
+    if(sys_audioapiopened == API_PORTAUDIO)
         return (pa_send_dacs());
     else
 #endif
 #ifdef USEAPI_JACK
-      if (sys_audioapiopened == API_JACK)
+        if(sys_audioapiopened == API_JACK)
         return (jack_send_dacs());
     else
 #endif
 #ifdef USEAPI_OSS
-    if (sys_audioapiopened == API_OSS)
+        if(sys_audioapiopened == API_OSS)
         return (oss_send_dacs());
     else
 #endif
 #ifdef USEAPI_ALSA
-    if (sys_audioapiopened == API_ALSA)
+        if(sys_audioapiopened == API_ALSA)
         return (alsa_send_dacs());
     else
 #endif
 #ifdef USEAPI_MMIO
-    if (sys_audioapiopened == API_MMIO)
+        if(sys_audioapiopened == API_MMIO)
         return (mmio_send_dacs());
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-    if (sys_audioapiopened == API_AUDIOUNIT)
+        if(sys_audioapiopened == API_AUDIOUNIT)
         return (audiounit_send_dacs());
     else
 #endif
 #ifdef USEAPI_ESD
-    if (sys_audioapiopened == API_ESD)
+        if(sys_audioapiopened == API_ESD)
         return (esd_send_dacs());
     else
 #endif
 #ifdef USEAPI_DUMMY
-    if (sys_audioapiopened == API_DUMMY)
+        if(sys_audioapiopened == API_DUMMY)
         return (dummy_send_dacs());
     else
 #endif
-    post("unknown API");
+        post("unknown API");
     return (0);
 }
 
-t_float sys_getsr(void)
-{
-     return (STUFF->st_dacsr);
-}
+t_float sys_getsr(void) { return (STUFF->st_dacsr); }
 
-int sys_get_outchannels(void)
-{
-     return (STUFF->st_outchannels);
-}
+int sys_get_outchannels(void) { return (STUFF->st_outchannels); }
 
-int sys_get_inchannels(void)
-{
-     return (STUFF->st_inchannels);
-}
+int sys_get_inchannels(void) { return (STUFF->st_inchannels); }
 
 /* this could later be set by a preference but for now it seems OK to just
 keep jack audio open but close unused audio devices for any other API */
-int audio_shouldkeepopen(void)
-{
-    return (sys_audioapiopened == API_JACK);
-}
+int audio_shouldkeepopen(void) { return (sys_audioapiopened == API_JACK); }
 
-    /* get names of available audio devices for the specified API */
-void sys_get_audio_devs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti, int *cancallback,
-        int maxndev, int devdescsize, int api)
+/* get names of available audio devices for the specified API */
+void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int *cancallback, int maxndev,
+    int devdescsize, int api)
 {
-    *cancallback = 0;   /* may be overridden by specific API implementation */
+    *cancallback = 0; /* may be overridden by specific API implementation */
 #ifdef USEAPI_PORTAUDIO
-    if (api == API_PORTAUDIO)
+    if(api == API_PORTAUDIO)
     {
-        pa_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
-            maxndev, devdescsize);
+        pa_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti, maxndev,
+            devdescsize);
         *cancallback = 1;
     }
     else
 #endif
 #ifdef USEAPI_JACK
-    if (api == API_JACK)
+        if(api == API_JACK)
     {
         jack_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -538,15 +515,15 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     else
 #endif
 #ifdef USEAPI_OSS
-    if (api == API_OSS)
+        if(api == API_OSS)
     {
-        oss_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
-            maxndev, devdescsize);
+        oss_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti, maxndev,
+            devdescsize);
     }
     else
 #endif
 #ifdef USEAPI_ALSA
-    if (api == API_ALSA)
+        if(api == API_ALSA)
     {
         alsa_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -554,7 +531,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     else
 #endif
 #ifdef USEAPI_MMIO
-    if (api == API_MMIO)
+        if(api == API_MMIO)
     {
         mmio_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -562,21 +539,21 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-    if (api == API_AUDIOUNIT)
+        if(api == API_AUDIOUNIT)
     {
     }
     else
 #endif
 #ifdef USEAPI_ESD
-    if (api == API_ESD)
+        if(api == API_ESD)
     {
-        esd_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
-            maxndev, devdescsize);
+        esd_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti, maxndev,
+            devdescsize);
     }
     else
 #endif
 #ifdef USEAPI_DUMMY
-    if (api == API_DUMMY)
+        if(api == API_DUMMY)
     {
         dummy_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -584,70 +561,67 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     else
 #endif
     {
-            /* this shouldn't happen once all the above get filled in. */
+        /* this shouldn't happen once all the above get filled in. */
         int i;
         *nindevs = *noutdevs = 3;
-        for (i = 0; i < 3; i++)
+        for(i = 0; i < 3; i++)
         {
-            sprintf(indevlist + i * devdescsize, "input device #%d", i+1);
-            sprintf(outdevlist + i * devdescsize, "output device #%d", i+1);
+            sprintf(indevlist + i * devdescsize, "input device #%d", i + 1);
+            sprintf(outdevlist + i * devdescsize, "output device #%d", i + 1);
         }
         *canmulti = 0;
     }
 }
 
-    /* start an audio settings dialog window */
+/* start an audio settings dialog window */
 void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
 {
     char buf[MAXPDSTRING];
     t_audiosettings as;
-        /* these are all the devices on your system: */
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    /* these are all the devices on your system: */
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     char device[MAXPDSTRING];
     int nindevs = 0, noutdevs = 0, canmulti = 0, cancallback = 0, i;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
-         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
+        &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
 
     sys_gui("global audio_indevlist; set audio_indevlist {}\n");
-    for (i = 0; i < nindevs; i++)
+    for(i = 0; i < nindevs; i++)
         sys_vgui("lappend audio_indevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
+            pdgui_strnescape(
+                device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
 
     sys_gui("global audio_outdevlist; set audio_outdevlist {}\n");
-    for (i = 0; i < noutdevs; i++)
+    for(i = 0; i < noutdevs; i++)
         sys_vgui("lappend audio_outdevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+            pdgui_strnescape(
+                device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
 
     sys_get_audio_settings(&as);
 
-    if (as.a_nindev > 1 || as.a_noutdev > 1)
-        flongform = 1;
+    if(as.a_nindev > 1 || as.a_noutdev > 1) flongform = 1;
 
-        /* values that are fixed and must not be changed by the GUI are
-        prefixed with '!';  * the GUI will then display these values but
-        disable their widgets */
-    snprintf(buf, MAXPDSTRING,
-"pdtk_audio_dialog %%s \
+    /* values that are fixed and must not be changed by the GUI are
+    prefixed with '!';  * the GUI will then display these values but
+    disable their widgets */
+    snprintf(buf, MAXPDSTRING, "pdtk_audio_dialog %%s \
 %d %d %d %d %d %d %d %d \
 %d %d %d %d %d %d %d %d \
 %s%d %d %d %s%d %d %s%d\n",
-        as.a_indevvec[0], as.a_indevvec[1],
-            as.a_indevvec[2], as.a_indevvec[3],
-        as.a_chindevvec[0], as.a_chindevvec[1],
-            as.a_chindevvec[2], as.a_chindevvec[3],
-        as.a_outdevvec[0], as.a_outdevvec[1],
-            as.a_outdevvec[2], as.a_outdevvec[3],
-        as.a_choutdevvec[0], as.a_choutdevvec[1],
-            as.a_choutdevvec[2], as.a_choutdevvec[3],
-        audio_isfixedsr(as.a_api)?"!":"", as.a_srate, as.a_advance, canmulti,
-        cancallback?"":"!", as.a_callback,
-        (flongform != 0), audio_isfixedblocksize(as.a_api)?"!":"", as.a_blocksize);
+        as.a_indevvec[0], as.a_indevvec[1], as.a_indevvec[2], as.a_indevvec[3],
+        as.a_chindevvec[0], as.a_chindevvec[1], as.a_chindevvec[2],
+        as.a_chindevvec[3], as.a_outdevvec[0], as.a_outdevvec[1],
+        as.a_outdevvec[2], as.a_outdevvec[3], as.a_choutdevvec[0],
+        as.a_choutdevvec[1], as.a_choutdevvec[2], as.a_choutdevvec[3],
+        audio_isfixedsr(as.a_api) ? "!" : "", as.a_srate, as.a_advance,
+        canmulti, cancallback ? "" : "!", as.a_callback, (flongform != 0),
+        audio_isfixedblocksize(as.a_api) ? "!" : "", as.a_blocksize);
     gfxstub_deleteforkey(0);
-    gfxstub_new(&glob_pdobject, (void *)glob_audio_properties, buf);
+    gfxstub_new(&glob_pdobject, (void *) glob_audio_properties, buf);
 }
 
-    /* new values from dialog window */
+/* new values from dialog window */
 void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
@@ -658,26 +632,26 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     as.a_callback = atom_getfloatarg(18, argc, argv);
     as.a_blocksize = atom_getfloatarg(19, argc, argv);
 
-    for (i = 0; i < 4; i++)
+    for(i = 0; i < 4; i++)
     {
         as.a_indevvec[i] = atom_getfloatarg(i, argc, argv);
-        as.a_chindevvec[i] = atom_getfloatarg(i+4, argc, argv);
-        as.a_outdevvec[i] = atom_getfloatarg(i+8, argc, argv);
-        as.a_choutdevvec[i] = atom_getfloatarg(i+12, argc, argv);
+        as.a_chindevvec[i] = atom_getfloatarg(i + 4, argc, argv);
+        as.a_outdevvec[i] = atom_getfloatarg(i + 8, argc, argv);
+        as.a_choutdevvec[i] = atom_getfloatarg(i + 12, argc, argv);
     }
-        /* compact out any zeros and count nonzero entries */
-    for (i = 0, as.a_nindev = 0; i < 4; i++)
+    /* compact out any zeros and count nonzero entries */
+    for(i = 0, as.a_nindev = 0; i < 4; i++)
     {
-        if (as.a_chindevvec[i])
+        if(as.a_chindevvec[i])
         {
             as.a_indevvec[as.a_nindev] = as.a_indevvec[i];
             as.a_chindevvec[as.a_nindev] = as.a_chindevvec[i];
             as.a_nindev++;
         }
     }
-    for (i = 0, as.a_noutdev = 0; i < 4; i++)
+    for(i = 0, as.a_noutdev = 0; i < 4; i++)
     {
-        if (as.a_choutdevvec[i])
+        if(as.a_choutdevvec[i])
         {
             as.a_outdevvec[as.a_noutdev] = as.a_outdevvec[i];
             as.a_choutdevvec[as.a_noutdev] = as.a_choutdevvec[i];
@@ -686,47 +660,45 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     }
     as.a_nchindev = as.a_nindev;
     as.a_nchoutdev = as.a_noutdev;
-    if (as.a_callback < 0)
-        as.a_callback = 0;
-    as.a_blocksize = (1<<ilog2(as.a_blocksize));
-    if (as.a_blocksize < DEFDACBLKSIZE || as.a_blocksize > MAXBLOCKSIZE)
-            as.a_blocksize = DEFDACBLKSIZE;
+    if(as.a_callback < 0) as.a_callback = 0;
+    as.a_blocksize = (1 << ilog2(as.a_blocksize));
+    if(as.a_blocksize < DEFDACBLKSIZE || as.a_blocksize > MAXBLOCKSIZE)
+        as.a_blocksize = DEFDACBLKSIZE;
 
-    if (!audio_callback_is_open && !as.a_callback)
-        sys_close_audio();
+    if(!audio_callback_is_open && !as.a_callback) sys_close_audio();
     sys_set_audio_settings(&as);
-    if (!audio_callback_is_open && !as.a_callback)
+    if(!audio_callback_is_open && !as.a_callback)
         sys_reopen_audio();
-    else sched_reopenmeplease();
+    else
+        sched_reopenmeplease();
 }
 
 void sys_listdevs(void)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i, canmulti = 0, cancallback = 0;
 
-    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        &canmulti, &cancallback, MAXNDEV, DEVDESCSIZE,
-            audio_nextsettings.a_api);
-    if (!nindevs)
+    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
+        &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
+    if(!nindevs)
         post("no audio input devices found");
     else
     {
-            /* To agree with command line flags, normally start at 1 */
-            /* But microsoft "MMIO" device list starts at 0 (the "mapper"). */
-            /* (see also sys_mmio variable in s_main.c)  */
+        /* To agree with command line flags, normally start at 1 */
+        /* But microsoft "MMIO" device list starts at 0 (the "mapper"). */
+        /* (see also sys_mmio variable in s_main.c)  */
 
         post("audio input devices:");
-        for (i = 0; i < nindevs; i++)
+        for(i = 0; i < nindevs; i++)
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 indevlist + i * DEVDESCSIZE);
     }
-    if (!noutdevs)
+    if(!noutdevs)
         post("no audio output devices found");
     else
     {
         post("audio output devices:");
-        for (i = 0; i < noutdevs; i++)
+        for(i = 0; i < noutdevs; i++)
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 outdevlist + i * DEVDESCSIZE);
     }
@@ -737,21 +709,20 @@ void sys_listdevs(void)
 void glob_audio_setapi(void *dummy, t_floatarg f)
 {
     int newapi = f;
-    if (newapi)
+    if(newapi)
     {
-        if (newapi == audio_nextsettings.a_api)
+        if(newapi == audio_nextsettings.a_api)
         {
-            if (!audio_isopen() && audio_shouldkeepopen())
-                sys_reopen_audio();
+            if(!audio_isopen() && audio_shouldkeepopen()) sys_reopen_audio();
         }
         else
         {
             sys_close_audio();
             audio_nextsettings.a_api = newapi;
-                /* bash device params back to default */
+            /* bash device params back to default */
             audio_nextsettings.a_nindev = audio_nextsettings.a_nchindev =
-                audio_nextsettings.a_noutdev = audio_nextsettings.a_nchoutdev
-                    = 1;
+                audio_nextsettings.a_noutdev = audio_nextsettings.a_nchoutdev =
+                    1;
             audio_nextsettings.a_indevvec[0] =
                 audio_nextsettings.a_outdevvec[0] = DEFAULTAUDIODEV;
             audio_nextsettings.a_chindevvec[0] =
@@ -761,28 +732,27 @@ void glob_audio_setapi(void *dummy, t_floatarg f)
         }
         glob_audio_properties(0, 0);
     }
-    else if (audio_isopen())
+    else if(audio_isopen())
     {
         sys_close_audio();
     }
 }
 
-    /* start or stop the audio hardware */
+/* start or stop the audio hardware */
 void sys_set_audio_state(int onoff)
 {
-    if (onoff)  /* start */
+    if(onoff) /* start */
     {
-        if (!audio_isopen())
-            sys_reopen_audio();
+        if(!audio_isopen()) sys_reopen_audio();
     }
     else
     {
-        if (audio_isopen())
-            sys_close_audio();
+        if(audio_isopen()) sys_close_audio();
     }
 }
 
 #define MAXAPIENTRY 10
+
 typedef struct _apientry
 {
     char a_name[30];
@@ -809,7 +779,7 @@ static t_apientry audio_apilist[] = {
     {"portaudio", API_PORTAUDIO},
 #endif
 #endif
-#endif  /* USEAPI_PORTAUDIO */
+#endif /* USEAPI_PORTAUDIO */
 #ifdef USEAPI_JACK
     {"jack", API_JACK},
 #endif
@@ -817,7 +787,7 @@ static t_apientry audio_apilist[] = {
     {"Audiounit", API_AUDIOUNIT},
 #endif
 #ifdef USEAPI_ESD
-    {"ESD",  API_ESD},
+    {"ESD", API_ESD},
 #endif
 #ifdef USEAPI_DUMMY
     {"dummy", API_DUMMY},
@@ -827,14 +797,14 @@ static t_apientry audio_apilist[] = {
 void sys_get_audio_apis(char *buf)
 {
     unsigned int n;
-    if (sizeof(audio_apilist)/sizeof(t_apientry) < 2)
+    if(sizeof(audio_apilist) / sizeof(t_apientry) < 2)
         strcpy(buf, "{}");
     else
     {
         strcpy(buf, "{ ");
-        for (n = 0; n < sizeof(audio_apilist)/sizeof(t_apientry); n++)
-            sprintf(buf + strlen(buf), "{%s %d} ",
-                audio_apilist[n].a_name, audio_apilist[n].a_id);
+        for(n = 0; n < sizeof(audio_apilist) / sizeof(t_apientry); n++)
+            sprintf(buf + strlen(buf), "{%s %d} ", audio_apilist[n].a_name,
+                audio_apilist[n].a_id);
         strcat(buf, "}");
     }
 }
@@ -844,41 +814,36 @@ void sys_get_audio_apis(char *buf)
 
 int sys_audiodevnametonumber(int output, const char *name)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i, canmulti, cancallback;
 
-    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        &canmulti, &cancallback, MAXNDEV, DEVDESCSIZE,
-            audio_nextsettings.a_api);
+    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
+        &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
 
-    if (output)
+    if(output)
     {
-            /* try first for exact match */
-        for (i = 0; i < noutdevs; i++)
-            if (!strcmp(name, outdevlist + i * DEVDESCSIZE))
-                return (i);
-            /* failing that, a match up to end of shorter string */
-        for (i = 0; i < noutdevs; i++)
+        /* try first for exact match */
+        for(i = 0; i < noutdevs; i++)
+            if(!strcmp(name, outdevlist + i * DEVDESCSIZE)) return (i);
+        /* failing that, a match up to end of shorter string */
+        for(i = 0; i < noutdevs; i++)
         {
             unsigned long comp = strlen(name);
-            if (comp > strlen(outdevlist + i * DEVDESCSIZE))
+            if(comp > strlen(outdevlist + i * DEVDESCSIZE))
                 comp = strlen(outdevlist + i * DEVDESCSIZE);
-            if (!strncmp(name, outdevlist + i * DEVDESCSIZE, comp))
-                return (i);
+            if(!strncmp(name, outdevlist + i * DEVDESCSIZE, comp)) return (i);
         }
     }
     else
     {
-        for (i = 0; i < nindevs; i++)
-            if (!strcmp(name, indevlist + i * DEVDESCSIZE))
-                return (i);
-        for (i = 0; i < nindevs; i++)
+        for(i = 0; i < nindevs; i++)
+            if(!strcmp(name, indevlist + i * DEVDESCSIZE)) return (i);
+        for(i = 0; i < nindevs; i++)
         {
             unsigned long comp = strlen(name);
-            if (comp > strlen(indevlist + i * DEVDESCSIZE))
+            if(comp > strlen(indevlist + i * DEVDESCSIZE))
                 comp = strlen(indevlist + i * DEVDESCSIZE);
-            if (!strncmp(name, indevlist + i * DEVDESCSIZE, comp))
-                return (i);
+            if(!strncmp(name, indevlist + i * DEVDESCSIZE, comp)) return (i);
         }
     }
     return (-1);
@@ -890,20 +855,20 @@ int sys_audiodevnametonumber(int output, const char *name)
 
 void sys_audiodevnumbertoname(int output, int devno, char *name, int namesize)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, canmulti, cancallback;
-    if (devno < 0)
+    if(devno < 0)
     {
         *name = 0;
         return;
     }
-    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        &canmulti, &cancallback, MAXNDEV, DEVDESCSIZE,
-            audio_nextsettings.a_api);
-    if (output && (devno < noutdevs))
+    sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
+        &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
+    if(output && (devno < noutdevs))
         strncpy(name, outdevlist + devno * DEVDESCSIZE, namesize);
-    else if (!output && (devno < nindevs))
+    else if(!output && (devno < nindevs))
         strncpy(name, indevlist + devno * DEVDESCSIZE, namesize);
-    else *name = 0;
-    name[namesize-1] = 0;
+    else
+        *name = 0;
+    name[namesize - 1] = 0;
 }

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -482,9 +482,8 @@ int sys_send_dacs(void)
 #ifdef USEAPI_DUMMY
         if(sys_audioapiopened == API_DUMMY)
         return (dummy_send_dacs());
-    else
 #endif
-        post("unknown API");
+    post("unknown API");
     return (0);
 }
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -117,7 +117,6 @@ void sys_setchsr(int chin, int chout, int sr)
 static void audio_make_sane(
     int *ndev, int *devvec, int *nchan, int *chanvec, int maxdev)
 {
-    int i;
     if(*ndev == -1)
     { /* no input audio devices specified */
         if(*nchan == -1)
@@ -134,7 +133,7 @@ static void audio_make_sane(
         }
         else
         {
-            for(i = 0; i < maxdev; i++)
+            for(int i = 0; i < maxdev; i++)
                 devvec[i] = i;
             *ndev = *nchan;
         }
@@ -144,12 +143,12 @@ static void audio_make_sane(
         if(*nchan == -1)
         {
             *nchan = *ndev;
-            for(i = 0; i < *ndev; i++)
+            for(int i = 0; i < *ndev; i++)
                 chanvec[i] = SYS_DEFAULTCH;
         }
         else if(*nchan > *ndev)
         {
-            for(i = *ndev; i < *nchan; i++)
+            for(int i = *ndev; i < *nchan; i++)
             {
                 if(i == 0)
                 {
@@ -164,7 +163,7 @@ static void audio_make_sane(
         }
         else if(*nchan < *ndev)
         {
-            for(i = *nchan; i < *ndev; i++)
+            for(int i = *nchan; i < *ndev; i++)
             {
                 if(i == 0)
                 {
@@ -178,9 +177,9 @@ static void audio_make_sane(
             *ndev = *nchan;
         }
     }
-    for(i = *ndev; i < maxdev; i++)
+    for(int i = *ndev; i < maxdev; i++)
         devvec[i] = -1;
-    for(i = *nchan; i < maxdev; i++)
+    for(int i = *nchan; i < maxdev; i++)
         chanvec[i] = 0;
 }
 
@@ -603,9 +602,8 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
 #endif
     {
         /* this shouldn't happen once all the above get filled in. */
-        int i;
         *nindevs = *noutdevs = 3;
-        for(i = 0; i < 3; i++)
+        for(int i = 0; i < 3; i++)
         {
             sprintf(indevlist + i * devdescsize, "input device #%d", i + 1);
             sprintf(outdevlist + i * devdescsize, "output device #%d", i + 1);
@@ -627,13 +625,12 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
     int noutdevs = 0;
     int canmulti = 0;
     int cancallback = 0;
-    int i;
 
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
 
     sys_gui("global audio_indevlist; set audio_indevlist {}\n");
-    for(i = 0; i < nindevs; i++)
+    for(int i = 0; i < nindevs; i++)
     {
         sys_vgui("lappend audio_indevlist {%s}\n",
             pdgui_strnescape(
@@ -641,7 +638,7 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
     }
 
     sys_gui("global audio_outdevlist; set audio_outdevlist {}\n");
-    for(i = 0; i < noutdevs; i++)
+    for(int i = 0; i < noutdevs; i++)
     {
         sys_vgui("lappend audio_outdevlist {%s}\n",
             pdgui_strnescape(
@@ -733,7 +730,6 @@ void sys_listdevs(void)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
     int canmulti = 0;
     int cancallback = 0;
 
@@ -750,7 +746,7 @@ void sys_listdevs(void)
         /* (see also sys_mmio variable in s_main.c)  */
 
         post("audio input devices:");
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
         {
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 indevlist + i * DEVDESCSIZE);
@@ -763,7 +759,7 @@ void sys_listdevs(void)
     else
     {
         post("audio output devices:");
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
         {
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 outdevlist + i * DEVDESCSIZE);
@@ -889,7 +885,6 @@ int sys_audiodevnametonumber(int output, const char *name)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
     int canmulti;
     int cancallback;
 
@@ -899,10 +894,10 @@ int sys_audiodevnametonumber(int output, const char *name)
     if(output)
     {
         /* try first for exact match */
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
             if(!strcmp(name, outdevlist + i * DEVDESCSIZE)) return (i);
         /* failing that, a match up to end of shorter string */
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
         {
             unsigned long comp = strlen(name);
             if(comp > strlen(outdevlist + i * DEVDESCSIZE))
@@ -912,9 +907,9 @@ int sys_audiodevnametonumber(int output, const char *name)
     }
     else
     {
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
             if(!strcmp(name, indevlist + i * DEVDESCSIZE)) return (i);
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
         {
             unsigned long comp = strlen(name);
             if(comp > strlen(indevlist + i * DEVDESCSIZE))

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -88,13 +88,17 @@ void sys_setchsr(int chin, int chout, int sr)
     int outbytes = (chout ? chout : 2) * (DEFDACBLKSIZE * sizeof(t_sample));
 
     if(STUFF->st_soundin)
+    {
         freebytes(STUFF->st_soundin,
             (STUFF->st_inchannels ? STUFF->st_inchannels : 2) *
                 (DEFDACBLKSIZE * sizeof(t_sample)));
+    }
     if(STUFF->st_soundout)
+    {
         freebytes(STUFF->st_soundout,
             (STUFF->st_outchannels ? STUFF->st_outchannels : 2) *
                 (DEFDACBLKSIZE * sizeof(t_sample)));
+    }
     STUFF->st_inchannels = chin;
     STUFF->st_outchannels = chout;
     if(!audio_isfixedsr(sys_audioapiopened)) STUFF->st_dacsr = sr;
@@ -148,9 +152,13 @@ static void audio_make_sane(
             for(i = *ndev; i < *nchan; i++)
             {
                 if(i == 0)
+                {
                     devvec[0] = DEFAULTAUDIODEV;
+                }
                 else
+                {
                     devvec[i] = devvec[i - 1] + 1;
+                }
             }
             *ndev = *nchan;
         }
@@ -159,9 +167,13 @@ static void audio_make_sane(
             for(i = *nchan; i < *ndev; i++)
             {
                 if(i == 0)
+                {
                     chanvec[0] = SYS_DEFAULTCH;
+                }
                 else
+                {
                     chanvec[i] = chanvec[i - 1];
+                }
             }
             *ndev = *nchan;
         }
@@ -183,6 +195,7 @@ static void audio_compact_and_count_channels(
     int newndev;
     /* count total number of input and output channels */
     for(i = newndev = *totalchans = 0; i < *ndev; i++)
+    {
         if(chanvec[i] > 0)
         {
             chanvec[newndev] = chanvec[i];
@@ -190,6 +203,7 @@ static void audio_compact_and_count_channels(
             *totalchans += chanvec[i];
             newndev++;
         }
+    }
     *ndev = newndev;
 }
 
@@ -274,41 +288,44 @@ void sys_close_audio(void)
     else
 #endif
 #ifdef USEAPI_JACK
-        if(sys_audioapiopened == API_JACK)
+    if(sys_audioapiopened == API_JACK)
         jack_close_audio();
     else
 #endif
 #ifdef USEAPI_OSS
-        if(sys_audioapiopened == API_OSS)
+    if(sys_audioapiopened == API_OSS)
         oss_close_audio();
     else
 #endif
 #ifdef USEAPI_ALSA
-        if(sys_audioapiopened == API_ALSA)
+    if(sys_audioapiopened == API_ALSA)
         alsa_close_audio();
     else
 #endif
 #ifdef USEAPI_MMIO
-        if(sys_audioapiopened == API_MMIO)
+    if(sys_audioapiopened == API_MMIO)
         mmio_close_audio();
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-        if(sys_audioapiopened == API_AUDIOUNIT)
+    if(sys_audioapiopened == API_AUDIOUNIT)
         audiounit_close_audio();
     else
 #endif
 #ifdef USEAPI_ESD
-        if(sys_audioapiopened == API_ESD)
+    if(sys_audioapiopened == API_ESD)
         esd_close_audio();
     else
 #endif
 #ifdef USEAPI_DUMMY
-        if(sys_audioapiopened == API_DUMMY)
+    if(sys_audioapiopened == API_DUMMY)
         dummy_close_audio();
     else
 #endif
+    {
         post("sys_close_audio: unknown API %d", sys_audioapiopened);
+    }
+
     sys_audioapiopened = API_NONE;
     sched_set_using_audio(SCHED_AUDIO_NONE);
     audio_callback_is_open = 0;
@@ -376,56 +393,72 @@ void sys_reopen_audio(void)
     else
 #endif
 #ifdef USEAPI_JACK
-        if(as.a_api == API_JACK)
+    if(as.a_api == API_JACK)
+    {
         outcome = jack_open_audio((as.a_nindev > 0 ? as.a_chindevvec[0] : 0),
             (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0),
             (as.a_callback ? sched_audio_callbackfn : 0));
-
+    }
     else
 #endif
 #ifdef USEAPI_OSS
-        if(as.a_api == API_OSS)
+    if(as.a_api == API_OSS)
+    {
         outcome = oss_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
             as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
             as.a_choutdevvec, as.a_srate, as.a_blocksize);
+    }
     else
 #endif
 #ifdef USEAPI_ALSA
-        if(as.a_api == API_ALSA)
+    if(as.a_api == API_ALSA)
+    {
         outcome = alsa_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
             as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
             as.a_choutdevvec, as.a_srate, as.a_blocksize);
+    }
     else
 #endif
 #ifdef USEAPI_MMIO
-        if(as.a_api == API_MMIO)
+     if(as.a_api == API_MMIO)
+     {
         outcome = mmio_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
             as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
             as.a_choutdevvec, as.a_srate, as.a_blocksize);
+    }
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-        if(as.a_api == API_AUDIOUNIT)
+    if(as.a_api == API_AUDIOUNIT)
+    {
         outcome = audiounit_open_audio((as.a_nindev > 0 ? as.a_chindev[0] : 0),
             (as.a_nindev > 0 ? as.a_choutdev[0] : 0), as.a_srate);
+    }
     else
 #endif
 #ifdef USEAPI_ESD
-        if(as.a_api == API_ALSA)
+    if(as.a_api == API_ALSA)
+    {
         outcome = esd_open_audio(as.a_nindev, as.a_indevvec, as.a_nindev,
             as.a_chindevvec, as.a_noutdev, as.a_outdevvec, as.a_noutdev,
             as.a_choutdevvec, as.a_srate);
+    }
     else
 #endif
 #ifdef USEAPI_DUMMY
-        if(as.a_api == API_DUMMY)
+    if(as.a_api == API_DUMMY)
+    {
         outcome = dummy_open_audio(as.a_nindev, as.a_noutdev, as.a_srate);
+    }
     else
 #endif
-        if(as.a_api == API_NONE)
-        ;
+    if(as.a_api == API_NONE)
+    {;}
     else
+    {
         post("unknown audio API specified");
+    }
+
     if(outcome) /* failed */
     {
         sys_audioapiopened = API_NONE;
@@ -450,40 +483,41 @@ int sys_send_dacs(void)
     else
 #endif
 #ifdef USEAPI_JACK
-        if(sys_audioapiopened == API_JACK)
+    if(sys_audioapiopened == API_JACK)
         return (jack_send_dacs());
     else
 #endif
 #ifdef USEAPI_OSS
-        if(sys_audioapiopened == API_OSS)
+    if(sys_audioapiopened == API_OSS)
         return (oss_send_dacs());
     else
 #endif
 #ifdef USEAPI_ALSA
-        if(sys_audioapiopened == API_ALSA)
+    if(sys_audioapiopened == API_ALSA)
         return (alsa_send_dacs());
     else
 #endif
 #ifdef USEAPI_MMIO
-        if(sys_audioapiopened == API_MMIO)
+    if(sys_audioapiopened == API_MMIO)
         return (mmio_send_dacs());
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-        if(sys_audioapiopened == API_AUDIOUNIT)
+    if(sys_audioapiopened == API_AUDIOUNIT)
         return (audiounit_send_dacs());
     else
 #endif
 #ifdef USEAPI_ESD
-        if(sys_audioapiopened == API_ESD)
+    if(sys_audioapiopened == API_ESD)
         return (esd_send_dacs());
     else
 #endif
 #ifdef USEAPI_DUMMY
-        if(sys_audioapiopened == API_DUMMY)
+    if(sys_audioapiopened == API_DUMMY)
         return (dummy_send_dacs());
+    else
 #endif
-    post("unknown API");
+        post("unknown API");
     return (0);
 }
 
@@ -513,7 +547,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_JACK
-        if(api == API_JACK)
+    if(api == API_JACK)
     {
         jack_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -522,7 +556,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_OSS
-        if(api == API_OSS)
+    if(api == API_OSS)
     {
         oss_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti, maxndev,
             devdescsize);
@@ -530,7 +564,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_ALSA
-        if(api == API_ALSA)
+    if(api == API_ALSA)
     {
         alsa_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -538,7 +572,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_MMIO
-        if(api == API_MMIO)
+    if(api == API_MMIO)
     {
         mmio_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -546,13 +580,13 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_AUDIOUNIT
-        if(api == API_AUDIOUNIT)
+    if(api == API_AUDIOUNIT)
     {
     }
     else
 #endif
 #ifdef USEAPI_ESD
-        if(api == API_ESD)
+    if(api == API_ESD)
     {
         esd_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti, maxndev,
             devdescsize);
@@ -560,7 +594,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
     else
 #endif
 #ifdef USEAPI_DUMMY
-        if(api == API_DUMMY)
+    if(api == API_DUMMY)
     {
         dummy_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
@@ -600,15 +634,19 @@ void glob_audio_properties(t_pd *dummy, t_floatarg flongform)
 
     sys_gui("global audio_indevlist; set audio_indevlist {}\n");
     for(i = 0; i < nindevs; i++)
+    {
         sys_vgui("lappend audio_indevlist {%s}\n",
             pdgui_strnescape(
                 device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
+    }
 
     sys_gui("global audio_outdevlist; set audio_outdevlist {}\n");
     for(i = 0; i < noutdevs; i++)
+    {
         sys_vgui("lappend audio_outdevlist {%s}\n",
             pdgui_strnescape(
                 device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+    }
 
     sys_get_audio_settings(&as);
 
@@ -680,9 +718,13 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     if(!audio_callback_is_open && !as.a_callback) sys_close_audio();
     sys_set_audio_settings(&as);
     if(!audio_callback_is_open && !as.a_callback)
+    {
         sys_reopen_audio();
+    }
     else
+    {
         sched_reopenmeplease();
+    }
 }
 
 void sys_listdevs(void)
@@ -698,7 +740,9 @@ void sys_listdevs(void)
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
     if(!nindevs)
+    {
         post("no audio input devices found");
+    }
     else
     {
         /* To agree with command line flags, normally start at 1 */
@@ -707,17 +751,23 @@ void sys_listdevs(void)
 
         post("audio input devices:");
         for(i = 0; i < nindevs; i++)
+        {
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 indevlist + i * DEVDESCSIZE);
+        }
     }
     if(!noutdevs)
+    {
         post("no audio output devices found");
+    }
     else
     {
         post("audio output devices:");
         for(i = 0; i < noutdevs; i++)
+        {
             post("%d. %s", i + (audio_nextsettings.a_api != API_MMIO),
                 outdevlist + i * DEVDESCSIZE);
+        }
     }
     post("API number %d\n", audio_nextsettings.a_api);
     sys_listmididevs();
@@ -815,13 +865,17 @@ void sys_get_audio_apis(char *buf)
 {
     unsigned int n;
     if(sizeof(audio_apilist) / sizeof(t_apientry) < 2)
+    {
         strcpy(buf, "{}");
+    }
     else
     {
         strcpy(buf, "{ ");
         for(n = 0; n < sizeof(audio_apilist) / sizeof(t_apientry); n++)
+        {
             sprintf(buf + strlen(buf), "{%s %d} ", audio_apilist[n].a_name,
                 audio_apilist[n].a_id);
+        }
         strcat(buf, "}");
     }
 }
@@ -891,10 +945,16 @@ void sys_audiodevnumbertoname(int output, int devno, char *name, int namesize)
     sys_get_audio_devs(indevlist, &nindevs, outdevlist, &noutdevs, &canmulti,
         &cancallback, MAXNDEV, DEVDESCSIZE, audio_nextsettings.a_api);
     if(output && (devno < noutdevs))
+    {
         strncpy(name, outdevlist + devno * DEVDESCSIZE, namesize);
+    }
     else if(!output && (devno < nindevs))
+    {
         strncpy(name, indevlist + devno * DEVDESCSIZE, namesize);
+    }
     else
+    {
         *name = 0;
+    }
     name[namesize - 1] = 0;
 }

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -83,7 +83,8 @@ in s_audio_alsamm.c). */
 static int alsaio_canmmap(t_alsa_dev *dev)
 {
     snd_pcm_hw_params_t *hw_params;
-    int err1, err2;
+    int err1;
+    int err2;
 
     snd_pcm_hw_params_alloca(&hw_params);
 
@@ -113,7 +114,8 @@ static int alsaio_canmmap(t_alsa_dev *dev)
 static int alsaio_setup(t_alsa_dev *dev, int out, int *channels, int *rate,
     int nfrags, int frag_size)
 {
-    int bufsizeforthis, err;
+    int bufsizeforthis;
+    int err;
     snd_pcm_hw_params_t *hw_params;
     snd_pcm_sw_params_t *sw_params;
     unsigned int tmp_uint;
@@ -276,11 +278,17 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
     int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
     int *choutdev, int rate, int blocksize)
 {
-    int err, inchans = 0, outchans = 0, subunitdir;
+    int err;
+    int inchans = 0;
+    int outchans = 0;
+    int subunitdir;
     char devname[512];
     snd_output_t *out;
     int frag_size = (blocksize ? blocksize : ALSA_DEFFRAGSIZE);
-    int nfrags, i, iodev, dev2;
+    int nfrags;
+    int i;
+    int iodev;
+    int dev2;
 
     nfrags = sys_schedadvance * (float) rate / (1e6 * frag_size);
     /* save our belief as to ALSA's buffer size for later */
@@ -406,7 +414,8 @@ blewit:
 
 void alsa_close_audio(void)
 {
-    int err, iodev;
+    int err;
+    int iodev;
     if(alsa_usemmap)
     {
         alsamm_close_audio();
@@ -429,9 +438,20 @@ int alsa_send_dacs(void)
 {
     static double timenow;
     double timelast;
-    t_sample *fp, *fp1, *fp2;
-    int i, j, k, err, iodev, result, ch, goterror = 0, busy = 0;
-    int chansintogo, chansouttogo;
+    t_sample *fp;
+    t_sample *fp1;
+    t_sample *fp2;
+    int i;
+    int j;
+    int k;
+    int err;
+    int iodev;
+    int result;
+    int ch;
+    int goterror = 0;
+    int busy = 0;
+    int chansintogo;
+    int chansouttogo;
     unsigned int transfersize;
     if(alsa_usemmap) return (alsamm_send_dacs());
 
@@ -702,8 +722,13 @@ int alsa_send_dacs(void)
 
 void alsa_printstate(void)
 {
-    int i, result, iodev = 0;
-    snd_pcm_sframes_t indelay = 0, inavail = 0, outdelay = 0, outavail = 0;
+    int i;
+    int result;
+    int iodev = 0;
+    snd_pcm_sframes_t indelay = 0;
+    snd_pcm_sframes_t inavail = 0;
+    snd_pcm_sframes_t outdelay = 0;
+    snd_pcm_sframes_t outavail = 0;
     if(!alsa_nindev && !alsa_noutdev)
     {
         post("alsa_printstate: alsa not open");
@@ -731,7 +756,8 @@ void alsa_printstate(void)
 
 void alsa_putzeros(int iodev, int n)
 {
-    int i, result;
+    int i;
+    int result;
     memset(alsa_snd_buf, 0,
         alsa_outdev[iodev].a_sampwidth * DEFDACBLKSIZE *
             alsa_outdev[iodev].a_channels);
@@ -749,7 +775,8 @@ void alsa_putzeros(int iodev, int n)
 
 void alsa_getzeros(int iodev, int n)
 {
-    int i, result;
+    int i;
+    int result;
     for(i = 0; i < n; i++)
     {
         result = snd_pcm_readi(
@@ -765,8 +792,16 @@ void alsa_getzeros(int iodev, int n)
 /* call this only if both input and output are open */
 static void alsa_checkiosync(void)
 {
-    int i, result, giveup = 50, alreadylogged = 0, iodev = 0, err;
-    snd_pcm_sframes_t minphase, maxphase, thisphase, outdelay;
+    int i;
+    int result;
+    int giveup = 50;
+    int alreadylogged = 0;
+    int iodev = 0;
+    int err;
+    snd_pcm_sframes_t minphase;
+    snd_pcm_sframes_t maxphase;
+    snd_pcm_sframes_t thisphase;
+    snd_pcm_sframes_t outdelay;
     while(1)
     {
         if(giveup-- <= 0)
@@ -903,7 +938,8 @@ void alsa_adddev(const char *name)
 
 static void alsa_numbertoname(int devno, char *devname, int nchar)
 {
-    int ndev = 0, cardno = -1;
+    int ndev = 0;
+    int cardno = -1;
     while(!snd_card_next(&cardno) && cardno >= 0)
         ndev++;
     if(devno < 2 * ndev)
@@ -924,7 +960,10 @@ static void alsa_numbertoname(int devno, char *devname, int nchar)
 void alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
-    int ndev = 0, cardno = -1, i, j;
+    int ndev = 0;
+    int cardno = -1;
+    int i;
+    int j;
     *canmulti = 2; /* supports multiple devices */
     while(!snd_card_next(&cardno) && cardno >= 0)
     {

--- a/src/s_audio_alsa.c
+++ b/src/s_audio_alsa.c
@@ -800,12 +800,11 @@ void alsa_printstate(void)
 
 void alsa_putzeros(int iodev, int n)
 {
-    int i;
     int result;
     memset(alsa_snd_buf, 0,
         alsa_outdev[iodev].a_sampwidth * DEFDACBLKSIZE *
             alsa_outdev[iodev].a_channels);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         result = snd_pcm_writei(
             alsa_outdev[iodev].a_handle, alsa_snd_buf, DEFDACBLKSIZE);
@@ -819,9 +818,8 @@ void alsa_putzeros(int iodev, int n)
 
 void alsa_getzeros(int iodev, int n)
 {
-    int i;
     int result;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         result = snd_pcm_readi(
             alsa_indev[iodev].a_handle, alsa_snd_buf, DEFDACBLKSIZE);

--- a/src/s_audio_alsa.h
+++ b/src/s_audio_alsa.h
@@ -1,15 +1,14 @@
 /* Copyright (c) 1997- Guenter Geiger, Miller Puckette, Larry Troxler,
-* Winfried Ritsch, Karl MacMillan, and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
-
+ * Winfried Ritsch, Karl MacMillan, and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 typedef int16_t t_alsa_sample16;
 typedef int32_t t_alsa_sample32;
 #define ALSA_SAMPLEWIDTH_16 sizeof(t_alsa_sample16)
 #define ALSA_SAMPLEWIDTH_32 sizeof(t_alsa_sample32)
-#define ALSA_XFERSIZE16  (signed int)(sizeof(t_alsa_sample16) * DEFDACBLKSIZE)
-#define ALSA_XFERSIZE32  (signed int)(sizeof(t_alsa_sample32) * DEFDACBLKSIZE)
+#define ALSA_XFERSIZE16 (signed int) (sizeof(t_alsa_sample16) * DEFDACBLKSIZE)
+#define ALSA_XFERSIZE32 (signed int) (sizeof(t_alsa_sample32) * DEFDACBLKSIZE)
 #define ALSA_MAXDEV 4
 #define ALSA_JITTER 1024
 #define ALSA_EXTRABUFFER 2048

--- a/src/s_audio_alsamm.c
+++ b/src/s_audio_alsamm.c
@@ -856,7 +856,7 @@ static int xrun_recovery(snd_pcm_t *handle, int err)
 
         return 0;
     }
-    else if(err == -ESTRPIPE)
+    if(err == -ESTRPIPE)
     {
         while((err = snd_pcm_resume(handle)) == -EAGAIN)
             sleep(1); /* wait until the suspend flag is released */

--- a/src/s_audio_alsamm.c
+++ b/src/s_audio_alsamm.c
@@ -153,8 +153,7 @@ static int alsamm_xruns = 0;
 
 static void show_availist(void)
 {
-    int i;
-    for(i = 1; i < WATCH_PERIODS; i++)
+    for(int i = 1; i < WATCH_PERIODS; i++)
     {
         post("%2d:avail i=%7d %s o=%7d(%5d), offset i=%7d %s o=%7d, ptr i=%12p "
              "o=%12p, %d xruns ",
@@ -206,7 +205,6 @@ int alsamm_open_audio(int rate, int blocksize)
        alsa...
        ...we use periodsize and buffersize in frames */
 
-    int i;
     short *tmp_buf;
     unsigned int tmp_uint;
 
@@ -225,7 +223,7 @@ int alsamm_open_audio(int rate, int blocksize)
 #endif
 
     /* init some structures */
-    for(i = 0; i < ALSA_MAXDEV; i++)
+    for(int i = 0; i < ALSA_MAXDEV; i++)
     {
         alsa_indev[i].a_synced = alsa_outdev[i].a_synced = 0;
         alsa_indev[i].a_channels = alsa_outdev[i].a_channels =
@@ -270,7 +268,7 @@ int alsamm_open_audio(int rate, int blocksize)
 
     alsamm_periods = 0; /* no one wants periods setting from command line ;-) */
 
-    for(i = 0; i < alsa_noutdev; i++)
+    for(int i = 0; i < alsa_noutdev; i++)
     {
         /*   post("open audio out %d, of %lx, %d",i,&alsa_device[i],
                    alsa_outdev[i].a_handle); */
@@ -304,7 +302,7 @@ int alsamm_open_audio(int rate, int blocksize)
             alsa_outdev[i].a_channels, alsamm_buffertime);
     }
 
-    for(i = 0; i < alsa_nindev; i++)
+    for(int i = 0; i < alsa_nindev; i++)
     {
 
         if(sys_verbose) post("capture card %d:--------------------", i);
@@ -346,7 +344,7 @@ int alsamm_open_audio(int rate, int blocksize)
 
     /* check for linked handles of input for each output*/
 
-    for(i = 0; i < (alsa_noutdev < alsa_nindev ? alsa_noutdev : alsa_nindev);
+    for(int i = 0; i < (alsa_noutdev < alsa_nindev ? alsa_noutdev : alsa_nindev);
         i++)
     {
         t_alsa_dev *ad = &alsa_outdev[i];
@@ -376,10 +374,10 @@ int alsamm_open_audio(int rate, int blocksize)
 
     /* start alsa in open or better in send_dacs once ??? we will see */
 
-    for(i = 0; i < alsa_noutdev; i++)
+    for(int i = 0; i < alsa_noutdev; i++)
         snd_pcm_dump(alsa_outdev[i].a_handle, alsa_stdout);
 
-    for(i = 0; i < alsa_nindev; i++)
+    for(int i = 0; i < alsa_nindev; i++)
         snd_pcm_dump(alsa_indev[i].inhandle, alsa_stdout);
 
     fflush(stdout);
@@ -395,7 +393,6 @@ int alsamm_open_audio(int rate, int blocksize)
 
 void alsamm_close_audio(void)
 {
-    int i;
     int err;
 
 #ifdef ALSAMM_DEBUG
@@ -404,7 +401,7 @@ void alsamm_close_audio(void)
 
     alsamm_stop();
 
-    for(i = 0; i < alsa_noutdev; i++)
+    for(int i = 0; i < alsa_noutdev; i++)
     {
 
 #ifdef ALSAMM_DEBUG
@@ -430,7 +427,7 @@ void alsamm_close_audio(void)
         alsa_outdev[i].a_channels = 0;
     }
 
-    for(i = 0; i < alsa_nindev; i++)
+    for(int i = 0; i < alsa_nindev; i++)
     {
 
         err = snd_pcm_close(alsa_indev[i].a_handle);
@@ -1152,7 +1149,6 @@ int alsamm_send_dacs(void)
     t_sample *fpi;
     t_sample *fp1;
     t_sample *fp2;
-    int i;
     int err;
     int devno;
 
@@ -1321,7 +1317,7 @@ int alsamm_send_dacs(void)
                 osc(buf, oframes, (dac_send%1000 <
                 500)?-100.0:-10.0,440,&(indexes[chn]));
                 */
-
+                int i;
                 for(i = 0, fp2 = fp1 + chn * alsamm_transfersize; i < oframes;
                     i++, fp2++)
                 {
@@ -1443,7 +1439,7 @@ int alsamm_send_dacs(void)
             {
 
                 t_alsa_sample32 *buf = (t_alsa_sample32 *) dev->a_addr[chn];
-
+                int i;
                 for(i = 0, fp2 = fp1 + chn * alsamm_transfersize; i < iframes;
                     i++, fp2++)
                 {

--- a/src/s_audio_alsamm.c
+++ b/src/s_audio_alsamm.c
@@ -1,14 +1,13 @@
 /* Copyright (c) 1997-2003 Guenter Geiger, Miller Puckette, Larry Troxler,
-* Winfried Ritsch, Karl MacMillan, and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * Winfried Ritsch, Karl MacMillan, and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*
    this audiodriverinterface inputs and outputs audio data using
    the ALSA MMAP API available on linux.
-   this is optimized for hammerfall cards and does not make an attempt to be general
-   now, please adapt to your needs or let me know ...
-   constrains now:
+   this is optimized for hammerfall cards and does not make an attempt to be
+   general now, please adapt to your needs or let me know ... constrains now:
     - audio Card with ALSA-Driver > 1.0.3,
     - alsa-device (preferable hw) with MMAP NONINTERLEAVED SIGNED-32Bit features
     - up to 4 cards with has to be hardwaresynced
@@ -32,16 +31,16 @@
 #include "s_audio_alsa.h"
 
 /* needed for alsa 0.9 compatibility: */
-#if (SND_LIB_MAJOR < 1)
+#if(SND_LIB_MAJOR < 1)
 #define ALSAAPI9
 #endif
 /* sample type magic ...
-   Hammerfall/HDSP/DSPMADI cards always 32Bit where lower 8Bit not used (played) in AD/DA,
-   but can have some bits set (subchannel coding)
+   Hammerfall/HDSP/DSPMADI cards always 32Bit where lower 8Bit not used (played)
+   in AD/DA, but can have some bits set (subchannel coding)
 */
 /* sample type magic ...
-   Hammerfall/HDSP/DSPMADI cards always 32Bit where lower 8Bit not used (played) in AD/DA,
-   but can have some bits set (subchannel coding)
+   Hammerfall/HDSP/DSPMADI cards always 32Bit where lower 8Bit not used (played)
+   in AD/DA, but can have some bits set (subchannel coding)
 */
 
 #define ALSAMM_SAMPLEWIDTH_32 sizeof(t_alsa_sample32)
@@ -59,13 +58,13 @@
 
 /* 24 Bit are used so MAX Samplevalue not INT32_MAX ??? */
 #define F32MAX 0x7fffff00
-#define CLIP32(x) (((x)>F32MAX)?F32MAX:((x) < -F32MAX)?-F32MAX:(x))
+#define CLIP32(x) (((x) > F32MAX) ? F32MAX : ((x) < -F32MAX) ? -F32MAX : (x))
 
 #define ALSAMM_FORMAT SND_PCM_FORMAT_S32
 /*
    maximum of 4 devices
-   you can mix rme9632,hdsp9632 (18 chans) rme9652,hdsp9652 (26 chans), dsp-madi (64 chans)
-   if synced
+   you can mix rme9632,hdsp9632 (18 chans) rme9652,hdsp9652 (26 chans), dsp-madi
+   (64 chans) if synced
 */
 
 /* the concept is holding data for each device
@@ -96,13 +95,14 @@ static unsigned int alsamm_buffertime = 0;
 static unsigned int alsamm_buffersize = 0;
 static int alsamm_transfersize = DEFDACBLKSIZE;
 
-/* bad style: we assume all cards give the same answer at init so we make this vars global
-   to have a faster access in writing reading during send_dacs */
+/* bad style: we assume all cards give the same answer at init so we make this
+   vars global to have a faster access in writing reading during send_dacs */
 static snd_pcm_sframes_t alsamm_period_size;
 static unsigned int alsamm_periods;
 static snd_pcm_sframes_t alsamm_buffer_size;
 
-/* if more than this sleep detected, should be more than periodsize/samplerate ??? */
+/* if more than this sleep detected, should be more than periodsize/samplerate
+ * ??? */
 static double sleep_time;
 
 /* now we just sum all inputs/outputs of used cards to a global count
@@ -117,7 +117,8 @@ Note on why:
    normally hdsp and dspmadi can handle channel
    count from one to all since they can switch on/off
    the dma for them to reduce pci load, but this is only
-   implemented in alsa low level drivers for dspmadi now and maybe fixed for hdsp in future
+   implemented in alsa low level drivers for dspmadi now and maybe fixed for
+hdsp in future
 */
 
 static int alsamm_inchannels = 0;
@@ -127,644 +128,697 @@ static int alsamm_outchannels = 0;
 /*#define ALSAMM_DEBUG */
 #ifdef ALSAMM_DEBUG
 
- #define DEBUG(x) x
- #define DEBUG2(x) {x;}
+#define DEBUG(x) x
+#define DEBUG2(x) \
+    {             \
+        x;        \
+    }
 
- #define WATCH_PERIODS 90
+#define WATCH_PERIODS 90
 
- static int in_avail[WATCH_PERIODS];
- static  int out_avail[WATCH_PERIODS];
- static  int in_offset[WATCH_PERIODS];
- static  int out_offset[WATCH_PERIODS];
- static  int out_cm[WATCH_PERIODS];
- static  char *outaddr[WATCH_PERIODS];
- static  char *inaddr[WATCH_PERIODS];
- static  char *outaddr2[WATCH_PERIODS];
- static  char *inaddr2[WATCH_PERIODS];
- static  int xruns_watch[WATCH_PERIODS];
- static  int broken_opipe;
+static int in_avail[WATCH_PERIODS];
+static int out_avail[WATCH_PERIODS];
+static int in_offset[WATCH_PERIODS];
+static int out_offset[WATCH_PERIODS];
+static int out_cm[WATCH_PERIODS];
+static char *outaddr[WATCH_PERIODS];
+static char *inaddr[WATCH_PERIODS];
+static char *outaddr2[WATCH_PERIODS];
+static char *inaddr2[WATCH_PERIODS];
+static int xruns_watch[WATCH_PERIODS];
+static int broken_opipe;
 
- static int dac_send = 0;
- static int alsamm_xruns = 0;
+static int dac_send = 0;
+static int alsamm_xruns = 0;
 
 static void show_availist(void)
 {
-  int i;
-  for(i=1;i<WATCH_PERIODS;i++){
-    post("%2d:avail i=%7d %s o=%7d(%5d), offset i=%7d %s o=%7d, ptr i=%12p o=%12p, %d xruns ",
-         i,in_avail[i],(out_avail[i] != in_avail[i])? "!=" : "==" , out_avail[i],out_cm[i],
-         in_offset[i],(out_offset[i] != in_offset[i])? "!=" : "==" , out_offset[i],
-         inaddr[i], outaddr[i], xruns_watch[i]);
-  }
+    int i;
+    for(i = 1; i < WATCH_PERIODS; i++)
+    {
+        post("%2d:avail i=%7d %s o=%7d(%5d), offset i=%7d %s o=%7d, ptr i=%12p "
+             "o=%12p, %d xruns ",
+            i, in_avail[i],
+            (out_avail[i] != in_avail[i]) ? "!=" : "==", out_avail[i],
+            out_cm[i], in_offset[i],
+            (out_offset[i] != in_offset[i]) ? "!=" : "==", out_offset[i],
+            inaddr[i], outaddr[i], xruns_watch[i]);
+    }
 }
 #else
- #define DEBUG(x)
- #define DEBUG2(x) {}
+#define DEBUG(x)
+#define DEBUG2(x) \
+    {             \
+    }
 #endif
 
 /* protos */
 static char *alsamm_getdev(int nr);
 
-static int set_hwparams(snd_pcm_t *handle,
-                               snd_pcm_hw_params_t *params, int *chs);
-static int set_swparams(snd_pcm_t *handle,
-                               snd_pcm_sw_params_t *swparams, int playback);
+static int set_hwparams(
+    snd_pcm_t *handle, snd_pcm_hw_params_t *params, int *chs);
+static int set_swparams(
+    snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int playback);
 
 static int alsamm_start(void);
 static int alsamm_stop(void);
 
 /* for debugging attach output of alsa messages to stdout stream */
-snd_output_t* alsa_stdout;
+snd_output_t *alsa_stdout;
 
 static void check_error(int err, const char *why)
 {
-    if (err < 0)
-        pd_error(0, "%s: %s\n", why, snd_strerror(err));
+    if(err < 0) pd_error(0, "%s: %s\n", why, snd_strerror(err));
 }
 
 int alsamm_open_audio(int rate, int blocksize)
 {
-  int err;
-  char devname[80];
-  char *cardname;
-  snd_pcm_hw_params_t* hw_params;
-  snd_pcm_sw_params_t* sw_params;
+    int err;
+    char devname[80];
+    char *cardname;
+    snd_pcm_hw_params_t *hw_params;
+    snd_pcm_sw_params_t *sw_params;
 
+    /* fragsize is an old concept now use periods, used to be called fragments.
+     */
+    /* Be aware in ALSA periodsize can be in bytes, where buffersize is in
+       frames, but sometimes buffersize is in bytes and periods in frames, crazy
+       alsa...
+       ...we use periodsize and buffersize in frames */
 
-  /* fragsize is an old concept now use periods, used to be called fragments. */
-  /* Be aware in ALSA periodsize can be in bytes, where buffersize is in frames,
-     but sometimes buffersize is in bytes and periods in frames, crazy alsa...
-     ...we use periodsize and buffersize in frames */
+    int i;
+    short *tmp_buf;
+    unsigned int tmp_uint;
 
-  int i;
-  short* tmp_buf;
-  unsigned int tmp_uint;
+    snd_pcm_hw_params_alloca(&hw_params);
+    snd_pcm_sw_params_alloca(&sw_params);
 
-  snd_pcm_hw_params_alloca(&hw_params);
-  snd_pcm_sw_params_alloca(&sw_params);
-
-  /* see add_devname */
-  /* first have a look which cards we can get and
-     set up device infos for them */
+    /* see add_devname */
+    /* first have a look which cards we can get and
+       set up device infos for them */
 
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("naudioindev=%d,  nchindev=%d, naudiooutdev=%d, nchoutdev=%d,rate=%d",
-         naudioindev, nchindev,naudiooutdev, nchoutdev, rate);
+    if(sys_verbose)
+        post("naudioindev=%d,  nchindev=%d, naudiooutdev=%d, "
+             "nchoutdev=%d,rate=%d",
+            naudioindev, nchindev, naudiooutdev, nchoutdev, rate);
 #endif
 
-  /* init some structures */
-  for(i=0;i < ALSA_MAXDEV;i++){
-    alsa_indev[i].a_synced=alsa_outdev[i].a_synced=0;
-    alsa_indev[i].a_channels=alsa_outdev[i].a_channels=-1; /* query defaults */
-  }
-  alsamm_inchannels = 0;
-  alsamm_outchannels = 0;
+    /* init some structures */
+    for(i = 0; i < ALSA_MAXDEV; i++)
+    {
+        alsa_indev[i].a_synced = alsa_outdev[i].a_synced = 0;
+        alsa_indev[i].a_channels = alsa_outdev[i].a_channels =
+            -1; /* query defaults */
+    }
+    alsamm_inchannels = 0;
+    alsamm_outchannels = 0;
 
-  /* opening alsa debug channel */
-  err = snd_output_stdio_attach(&alsa_stdout, stdout, 0);
-  if (err < 0) {
-    check_error(err,"attaching alsa debug output to stdout failed");
-    /*    return; no so bad ... and never should happe */
-  }
+    /* opening alsa debug channel */
+    err = snd_output_stdio_attach(&alsa_stdout, stdout, 0);
+    if(err < 0)
+    {
+        check_error(err, "attaching alsa debug output to stdout failed");
+        /*    return; no so bad ... and never should happe */
+    }
 
+    /*
+       Weak failure prevention:
+       first card found (out then in) is used as a reference for parameter,
+       so this  set the globals and other cards hopefully don't change them
+    */
+    alsamm_sr = rate;
 
-  /*
-     Weak failure prevention:
-     first card found (out then in) is used as a reference for parameter,
-     so this  set the globals and other cards hopefully don't change them
-  */
-  alsamm_sr = rate;
+    /* set the asked buffer time (alsa buffertime in us)*/
+    alsamm_buffertime = alsamm_buffersize = 0;
+    if(blocksize == 0)
+        alsamm_buffertime = sys_schedadvance;
+    else
+        alsamm_buffersize = blocksize;
 
-  /* set the asked buffer time (alsa buffertime in us)*/
-  alsamm_buffertime = alsamm_buffersize = 0;
-  if(blocksize == 0)
-    alsamm_buffertime = sys_schedadvance;
-  else
-    alsamm_buffersize = blocksize;
+    if(sys_verbose)
+        post(
+            "syschedadvance=%d microseconds so buffertime max should be this=%d"
+            "or sys_blocksize=%d (samples) to use buffersize=%d",
+            sys_schedadvance, alsamm_buffertime, blocksize, alsamm_buffersize);
 
-  if(sys_verbose)
-    post("syschedadvance=%d microseconds so buffertime max should be this=%d"
-         "or sys_blocksize=%d (samples) to use buffersize=%d",
-         sys_schedadvance, alsamm_buffertime,
-         blocksize,alsamm_buffersize);
+    alsamm_periods = 0; /* no one wants periods setting from command line ;-) */
 
-  alsamm_periods = 0; /* no one wants periods setting from command line ;-) */
-
-  for(i=0;i<alsa_noutdev;i++)
-  {
+    for(i = 0; i < alsa_noutdev; i++)
+    {
         /*   post("open audio out %d, of %lx, %d",i,&alsa_device[i],
                    alsa_outdev[i].a_handle); */
-      if((err = set_hwparams(alsa_outdev[i].a_handle, hw_params,
-                             &(alsa_outdev[i].a_channels))) < 0)
+        if((err = set_hwparams(alsa_outdev[i].a_handle, hw_params,
+                &(alsa_outdev[i].a_channels))) < 0)
         {
-          check_error(err,"playback device hwparam_set error:");
-          continue;
+            check_error(err, "playback device hwparam_set error:");
+            continue;
         }
 
-      if((err = set_swparams(alsa_outdev[i].a_handle, sw_params,1)) < 0){
-        check_error(err,"playback device swparam_set error:");
-        continue;
-      }
+        if((err = set_swparams(alsa_outdev[i].a_handle, sw_params, 1)) < 0)
+        {
+            check_error(err, "playback device swparam_set error:");
+            continue;
+        }
 
-      alsamm_outchannels += alsa_outdev[i].a_channels;
+        alsamm_outchannels += alsa_outdev[i].a_channels;
 
-      alsa_outdev[i].a_addr =
-        (char **) malloc(sizeof(char *) *  alsa_outdev[i].a_channels);
+        alsa_outdev[i].a_addr =
+            (char **) malloc(sizeof(char *) * alsa_outdev[i].a_channels);
 
-      if(alsa_outdev[i].a_addr == NULL){
-        check_error(errno,"playback device outaddr allocation error:");
-        continue;
-      }
-      memset(alsa_outdev[i].a_addr, 0, sizeof(char*) * alsa_outdev[i].a_channels);
+        if(alsa_outdev[i].a_addr == NULL)
+        {
+            check_error(errno, "playback device outaddr allocation error:");
+            continue;
+        }
+        memset(alsa_outdev[i].a_addr, 0,
+            sizeof(char *) * alsa_outdev[i].a_channels);
 
-      post("playback device with %d channels and buffer_time %d us opened",
-           alsa_outdev[i].a_channels, alsamm_buffertime);
+        post("playback device with %d channels and buffer_time %d us opened",
+            alsa_outdev[i].a_channels, alsamm_buffertime);
     }
 
-
-  for(i=0;i<alsa_nindev;i++)
+    for(i = 0; i < alsa_nindev; i++)
     {
 
-      if(sys_verbose)
-        post("capture card %d:--------------------",i);
+        if(sys_verbose) post("capture card %d:--------------------", i);
 
-      if((err = set_hwparams(alsa_indev[i].a_handle, hw_params,
-                               &(alsa_indev[i].a_channels))) < 0)
+        if((err = set_hwparams(alsa_indev[i].a_handle, hw_params,
+                &(alsa_indev[i].a_channels))) < 0)
         {
-          check_error(err,"capture device hwparam_set error:");
-          continue;
+            check_error(err, "capture device hwparam_set error:");
+            continue;
         }
 
-      alsamm_inchannels += alsa_indev[i].a_channels;
+        alsamm_inchannels += alsa_indev[i].a_channels;
 
-      if((err = set_swparams(alsa_indev[i].a_handle,
-            sw_params,0)) < 0){
-        check_error(err,"capture device swparam_set error:");
-        continue;
-      }
+        if((err = set_swparams(alsa_indev[i].a_handle, sw_params, 0)) < 0)
+        {
+            check_error(err, "capture device swparam_set error:");
+            continue;
+        }
 
-      alsa_indev[i].a_addr =
-        (char **) malloc (sizeof(char*) *  alsa_indev[i].a_channels);
+        alsa_indev[i].a_addr =
+            (char **) malloc(sizeof(char *) * alsa_indev[i].a_channels);
 
-      if(alsa_indev[i].a_addr == NULL){
-        check_error(errno,"capture device inaddr allocation error:");
-        continue;
-      }
+        if(alsa_indev[i].a_addr == NULL)
+        {
+            check_error(errno, "capture device inaddr allocation error:");
+            continue;
+        }
 
-      memset(alsa_indev[i].a_addr, 0, sizeof(char*) * alsa_indev[i].a_channels);
+        memset(
+            alsa_indev[i].a_addr, 0, sizeof(char *) * alsa_indev[i].a_channels);
 
-      if(sys_verbose)
-        post("capture device with %d channels and buffertime %d us opened\n",
-             alsa_indev[i].a_channels,alsamm_buffertime);
-    }
-
-  /* check for linked handles of input for each output*/
-
-  for(i=0; i<(alsa_noutdev < alsa_nindev ? alsa_noutdev:alsa_nindev); i++){
-    t_alsa_dev *ad = &alsa_outdev[i];
-
-    if (alsa_outdev[i].a_devno == alsa_indev[i].a_devno){
-      if ((err = snd_pcm_link (alsa_indev[i].a_handle,
-                               alsa_outdev[i].a_handle)) == 0){
-        alsa_indev[i].a_synced = alsa_outdev[i].a_synced = 1;
         if(sys_verbose)
-          post("linking in and outs of card %d",i);
-      }
-      else
-        check_error(err,"could not link in and outs");
+            post(
+                "capture device with %d channels and buffertime %d us opened\n",
+                alsa_indev[i].a_channels, alsamm_buffertime);
     }
-  }
 
-  /* some globals */
-  sleep_time =  (float) alsamm_period_size/ (float) alsamm_sr;
+    /* check for linked handles of input for each output*/
 
+    for(i = 0; i < (alsa_noutdev < alsa_nindev ? alsa_noutdev : alsa_nindev);
+        i++)
+    {
+        t_alsa_dev *ad = &alsa_outdev[i];
+
+        if(alsa_outdev[i].a_devno == alsa_indev[i].a_devno)
+        {
+            if((err = snd_pcm_link(
+                    alsa_indev[i].a_handle, alsa_outdev[i].a_handle)) == 0)
+            {
+                alsa_indev[i].a_synced = alsa_outdev[i].a_synced = 1;
+                if(sys_verbose) post("linking in and outs of card %d", i);
+            }
+            else
+                check_error(err, "could not link in and outs");
+        }
+    }
+
+    /* some globals */
+    sleep_time = (float) alsamm_period_size / (float) alsamm_sr;
 
 #ifdef ALSAMM_DEBUG
-  /* start ---------------------------- */
-  if(sys_verbose)
-    post("open_audio: after dacsend=%d (xruns=%d)done",dac_send,alsamm_xruns);
-  alsamm_xruns = dac_send = 0; /* reset debug */
+    /* start ---------------------------- */
+    if(sys_verbose)
+        post("open_audio: after dacsend=%d (xruns=%d)done", dac_send,
+            alsamm_xruns);
+    alsamm_xruns = dac_send = 0; /* reset debug */
 
-  /* start alsa in open or better in send_dacs once ??? we will see */
+    /* start alsa in open or better in send_dacs once ??? we will see */
 
-  for(i=0;i<alsa_noutdev;i++)
-    snd_pcm_dump(alsa_outdev[i].a_handle, alsa_stdout);
+    for(i = 0; i < alsa_noutdev; i++)
+        snd_pcm_dump(alsa_outdev[i].a_handle, alsa_stdout);
 
-  for(i=0;i<alsa_nindev;i++)
-    snd_pcm_dump(alsa_indev[i].inhandle, alsa_stdout);
+    for(i = 0; i < alsa_nindev; i++)
+        snd_pcm_dump(alsa_indev[i].inhandle, alsa_stdout);
 
-  fflush(stdout);
+    fflush(stdout);
 #endif
 
-  sys_setchsr(alsamm_inchannels,  alsamm_outchannels, alsamm_sr);
+    sys_setchsr(alsamm_inchannels, alsamm_outchannels, alsamm_sr);
 
-  alsamm_start();
+    alsamm_start();
 
-  /* report success  */
-  return (0);
+    /* report success  */
+    return (0);
 }
-
 
 void alsamm_close_audio(void)
 {
-  int i,err;
-
+    int i, err;
 
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("closing devices");
+    if(sys_verbose) post("closing devices");
 #endif
 
-  alsamm_stop();
+    alsamm_stop();
 
-  for(i=0;i< alsa_noutdev;i++){
-
+    for(i = 0; i < alsa_noutdev; i++)
+    {
 
 #ifdef ALSAMM_DEBUG
-    if(sys_verbose)
-      post("unlink audio out %d, of %lx",i,used_outdevice[i]);
+        if(sys_verbose)
+            post("unlink audio out %d, of %lx", i, used_outdevice[i]);
 #endif
 
-    if(alsa_outdev[i].a_synced != 0){
-      if((err = snd_pcm_unlink(alsa_outdev[i].a_handle)) < 0)
-        check_error(err, "snd_pcm_unlink (output)");
-      alsa_outdev[i].a_synced = 0;
-     }
+        if(alsa_outdev[i].a_synced != 0)
+        {
+            if((err = snd_pcm_unlink(alsa_outdev[i].a_handle)) < 0)
+                check_error(err, "snd_pcm_unlink (output)");
+            alsa_outdev[i].a_synced = 0;
+        }
 
-    if((err = snd_pcm_close(alsa_outdev[i].a_handle)) <= 0)
-      check_error(err, "snd_pcm_close (output)");
+        if((err = snd_pcm_close(alsa_outdev[i].a_handle)) <= 0)
+            check_error(err, "snd_pcm_close (output)");
 
-    if(alsa_outdev[i].a_addr){
-      free(alsa_outdev[i].a_addr);
-      alsa_outdev[i].a_addr = NULL;
-    }
-    alsa_outdev[i].a_channels = 0;
-  }
-
-  for(i=0;i< alsa_nindev;i++){
-
-    err = snd_pcm_close(alsa_indev[i].a_handle);
-
-    if(sys_verbose)
-      check_error(err, "snd_pcm_close (input)");
-
-    if(alsa_indev[i].a_addr){
-      free(alsa_indev[i].a_addr);
-      alsa_indev[i].a_addr = NULL;
+        if(alsa_outdev[i].a_addr)
+        {
+            free(alsa_outdev[i].a_addr);
+            alsa_outdev[i].a_addr = NULL;
+        }
+        alsa_outdev[i].a_channels = 0;
     }
 
-    alsa_indev[i].a_channels = 0;
-  }
-  alsa_nindev = alsa_noutdev = 0;
+    for(i = 0; i < alsa_nindev; i++)
+    {
+
+        err = snd_pcm_close(alsa_indev[i].a_handle);
+
+        if(sys_verbose) check_error(err, "snd_pcm_close (input)");
+
+        if(alsa_indev[i].a_addr)
+        {
+            free(alsa_indev[i].a_addr);
+            alsa_indev[i].a_addr = NULL;
+        }
+
+        alsa_indev[i].a_channels = 0;
+    }
+    alsa_nindev = alsa_noutdev = 0;
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("close_audio: after dacsend=%d (xruns=%d)done",dac_send,alsamm_xruns);
-   alsamm_xruns = dac_send = 0;
+    if(sys_verbose)
+        post("close_audio: after dacsend=%d (xruns=%d)done", dac_send,
+            alsamm_xruns);
+    alsamm_xruns = dac_send = 0;
 #endif
 }
 
 /* ------- PCM INITS --------------------------------- */
-static int set_hwparams(snd_pcm_t *handle, snd_pcm_hw_params_t *params,int *chs)
+static int set_hwparams(
+    snd_pcm_t *handle, snd_pcm_hw_params_t *params, int *chs)
 {
 #ifndef ALSAAPI9
-  unsigned int rrate;
-  int err, dir;
-  int channels_allocated = 0;
+    unsigned int rrate;
+    int err, dir;
+    int channels_allocated = 0;
 
-  /* choose all parameters */
-  err = snd_pcm_hw_params_any(handle, params);
-  if (err < 0) {
-    check_error(err,"broken configuration: no configurations available");
-    return err;
-  }
-
-  /* set the nointerleaved read/write format */
-  err = snd_pcm_hw_params_set_access(handle, params,
-                                     SND_PCM_ACCESS_MMAP_NONINTERLEAVED);
-  if (err >= 0) {
-#ifdef ALSAMM_DEBUG
-    if(sys_verbose)
-      post("access type %s available","SND_PCM_ACCESS_MMAP_NONINTERLEAVED");
-#endif
-  }
-  else{
-    check_error(err,"no Accesstype SND_PCM_ACCESS_MMAP_NONINTERLEAVED");
-    return err;
-  }
-
-  /* set the sample format */
-  err = snd_pcm_hw_params_set_format(handle, params, ALSAMM_FORMAT);
-  if (err < 0) {
-    check_error(err,"sample format not available for playback");
-    return err;
-  }
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("setting format to %s",snd_pcm_format_name(ALSAMM_FORMAT));
-#endif
-
-  /* first check samplerate since channels numbers
-     are samplerate dependent (double speed) */
-  /* set the stream rate */
-
-  rrate = alsamm_sr;
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("samplerate request: %i Hz",rrate);
-#endif
-
-  dir=-1;
-  err = snd_pcm_hw_params_set_rate_near(handle, params, &rrate, &dir);
-  if (err < 0) {
-    check_error(err,"rate not available");
-    return err;
-  }
-
-  if (rrate != alsamm_sr) {
-    post("warning: rate %iHz doesn't match requested %iHz", rrate,alsamm_sr);
-    alsamm_sr = rrate;
-  }
-  else
-    if(sys_verbose)
-      post("samplerate is set to %iHz",alsamm_sr);
-
-  /* Info on channels */
-  {
-    int maxchs,minchs,channels = *chs;
-
-    if((err = snd_pcm_hw_params_get_channels_max(params,
-        (unsigned int *)&maxchs)) < 0){
-      check_error(err,"getting channels_max not available");
-      return err;
+    /* choose all parameters */
+    err = snd_pcm_hw_params_any(handle, params);
+    if(err < 0)
+    {
+        check_error(err, "broken configuration: no configurations available");
+        return err;
     }
-    if((err = snd_pcm_hw_params_get_channels_min(params,
-        (unsigned int *)&minchs)) < 0){
-      check_error(err,"getting channels_min not available");
-      return err;
+
+    /* set the nointerleaved read/write format */
+    err = snd_pcm_hw_params_set_access(
+        handle, params, SND_PCM_ACCESS_MMAP_NONINTERLEAVED);
+    if(err >= 0)
+    {
+#ifdef ALSAMM_DEBUG
+        if(sys_verbose)
+            post("access type %s available",
+                "SND_PCM_ACCESS_MMAP_NONINTERLEAVED");
+#endif
+    }
+    else
+    {
+        check_error(err, "no Accesstype SND_PCM_ACCESS_MMAP_NONINTERLEAVED");
+        return err;
+    }
+
+    /* set the sample format */
+    err = snd_pcm_hw_params_set_format(handle, params, ALSAMM_FORMAT);
+    if(err < 0)
+    {
+        check_error(err, "sample format not available for playback");
+        return err;
     }
 
 #ifdef ALSAMM_DEBUG
     if(sys_verbose)
-      post("getting channels: min=%d, max= %d for request=%d",minchs,maxchs,channels);
+        post("setting format to %s", snd_pcm_format_name(ALSAMM_FORMAT));
 #endif
-    if(channels < 0)channels=maxchs;
-    if(channels > maxchs)channels = maxchs;
-    if(channels < minchs)channels = minchs;
 
-    if(channels != *chs)
-      post("requested channels=%d but used=%d",*chs,channels);
+    /* first check samplerate since channels numbers
+       are samplerate dependent (double speed) */
+    /* set the stream rate */
 
-    *chs = channels;
+    rrate = alsamm_sr;
+
+#ifdef ALSAMM_DEBUG
+    if(sys_verbose) post("samplerate request: %i Hz", rrate);
+#endif
+
+    dir = -1;
+    err = snd_pcm_hw_params_set_rate_near(handle, params, &rrate, &dir);
+    if(err < 0)
+    {
+        check_error(err, "rate not available");
+        return err;
+    }
+
+    if(rrate != alsamm_sr)
+    {
+        post("warning: rate %iHz doesn't match requested %iHz", rrate,
+            alsamm_sr);
+        alsamm_sr = rrate;
+    }
+    else if(sys_verbose)
+        post("samplerate is set to %iHz", alsamm_sr);
+
+    /* Info on channels */
+    {
+        int maxchs, minchs, channels = *chs;
+
+        if((err = snd_pcm_hw_params_get_channels_max(
+                params, (unsigned int *) &maxchs)) < 0)
+        {
+            check_error(err, "getting channels_max not available");
+            return err;
+        }
+        if((err = snd_pcm_hw_params_get_channels_min(
+                params, (unsigned int *) &minchs)) < 0)
+        {
+            check_error(err, "getting channels_min not available");
+            return err;
+        }
+
+#ifdef ALSAMM_DEBUG
+        if(sys_verbose)
+            post("getting channels: min=%d, max= %d for request=%d", minchs,
+                maxchs, channels);
+#endif
+        if(channels < 0) channels = maxchs;
+        if(channels > maxchs) channels = maxchs;
+        if(channels < minchs) channels = minchs;
+
+        if(channels != *chs)
+            post("requested channels=%d but used=%d", *chs, channels);
+
+        *chs = channels;
+#ifdef ALSAMM_DEBUG
+        if(sys_verbose) post("trying to use channels: %d", channels);
+#endif
+    }
+
+    /* set the count of channels */
+    err = snd_pcm_hw_params_set_channels(handle, params, *chs);
+    if(err < 0)
+    {
+        check_error(err, "unable to set channels");
+        return err;
+    }
+
+    /* testing for channels */
+    if((err = snd_pcm_hw_params_get_channels(params, (unsigned int *) chs)) < 0)
+        check_error(err, "unable to get channels");
+#ifdef ALSAMM_DEBUG
+    else if(sys_verbose)
+        post("when setting channels count and got %d", *chs);
+#endif
+
+    /* if buffersize is set use this instead buffertime */
+    if(alsamm_buffersize > 0)
+    {
+
+#ifdef ALSAMM_DEBUG
+        if(sys_verbose)
+            post("hw_params: ask for max buffersize of %d samples",
+                (unsigned int) alsamm_buffersize);
+#endif
+
+        alsamm_buffer_size = alsamm_buffersize;
+
+        err = snd_pcm_hw_params_set_buffer_size_near(
+            handle, params, (unsigned long *) &alsamm_buffer_size);
+        if(err < 0)
+        {
+            check_error(err, "unable to set max buffer size");
+            return err;
+        }
+    }
+    else
+    {
+        if(alsamm_buffertime <= 0) /* should never happen, but use 20ms */
+            alsamm_buffertime = 20000;
+
+#ifdef ALSAMM_DEBUG
+        if(sys_verbose)
+            post("hw_params: ask for max buffertime of %d ms",
+                (unsigned int) (alsamm_buffertime * 0.001));
+#endif
+
+        err = snd_pcm_hw_params_set_buffer_time_near(
+            handle, params, &alsamm_buffertime, &dir);
+        if(err < 0)
+        {
+            check_error(err, "unable to set max buffer time");
+            return err;
+        }
+    }
+
+    err = snd_pcm_hw_params_get_buffer_time(
+        params, (unsigned int *) &alsamm_buffertime, &dir);
+    if(err < 0)
+    {
+        check_error(err, "unable to get buffer time");
+        return err;
+    }
+
 #ifdef ALSAMM_DEBUG
     if(sys_verbose)
-      post("trying to use channels: %d",channels);
-#endif
-  }
-
-  /* set the count of channels */
-  err = snd_pcm_hw_params_set_channels(handle, params, *chs);
-  if (err < 0) {
-    check_error(err,"unable to set channels");
-    return err;
-  }
-
-  /* testing for channels */
-  if((err = snd_pcm_hw_params_get_channels(params,(unsigned int *)chs)) < 0)
-    check_error(err,"unable to get channels");
-#ifdef ALSAMM_DEBUG
-  else
-    if(sys_verbose)
-      post("when setting channels count and got %d",*chs);
+        post("hw_params: got buffertime to %f ms",
+            (float) (alsamm_buffertime * 0.001));
 #endif
 
-  /* if buffersize is set use this instead buffertime */
-  if(alsamm_buffersize > 0){
+    err = snd_pcm_hw_params_get_buffer_size(
+        params, (unsigned long *) &alsamm_buffer_size);
+    if(err < 0)
+    {
+        check_error(err, "unable to get buffer size");
+        return err;
+    }
 
 #ifdef ALSAMM_DEBUG
     if(sys_verbose)
-      post("hw_params: ask for max buffersize of %d samples",
-           (unsigned int) alsamm_buffersize );
+        post("hw_params: got buffersize to %d samples",
+            (int) alsamm_buffer_size);
 #endif
 
-    alsamm_buffer_size = alsamm_buffersize;
-
-    err = snd_pcm_hw_params_set_buffer_size_near(handle, params,
-        (unsigned long *)&alsamm_buffer_size);
-    if (err < 0) {
-      check_error(err,"unable to set max buffer size");
-      return err;
+    err = snd_pcm_hw_params_get_period_size(
+        params, (unsigned long *) &alsamm_period_size, &dir);
+    if(err > 0)
+    {
+        check_error(err, "unable to get period size");
+        return err;
     }
-
-  }
-  else{
-    if(alsamm_buffertime <= 0) /* should never happen, but use 20ms */
-      alsamm_buffertime = 20000;
 
 #ifdef ALSAMM_DEBUG
-    if(sys_verbose)
-      post("hw_params: ask for max buffertime of %d ms",
-           (unsigned int) (alsamm_buffertime*0.001) );
+    if(sys_verbose) post("got period size of %d", (int) alsamm_period_size);
 #endif
+    {
+        unsigned int pmin, pmax;
 
-    err = snd_pcm_hw_params_set_buffer_time_near(handle, params,
-        &alsamm_buffertime, &dir);
-    if (err < 0) {
-      check_error(err,"unable to set max buffer time");
-      return err;
-    }
-  }
+        err = snd_pcm_hw_params_get_periods_min(params, &pmin, &dir);
+        if(err > 0)
+        {
+            check_error(err, "unable to get period size");
+            return err;
+        }
+        err = snd_pcm_hw_params_get_periods_min(params, &pmax, &dir);
+        if(err > 0)
+        {
+            check_error(err, "unable to get period size");
+            return err;
+        }
 
-  err = snd_pcm_hw_params_get_buffer_time(params,
-    (unsigned int *)&alsamm_buffertime, &dir);
-  if (err < 0) {
-    check_error(err,"unable to get buffer time");
-    return err;
-  }
+        /* use maximum of periods */
+        if(alsamm_periods <= 0) alsamm_periods = pmax;
+        alsamm_periods = (alsamm_periods > pmax) ? pmax : alsamm_periods;
+        alsamm_periods = (alsamm_periods < pmin) ? pmin : alsamm_periods;
 
+        err =
+            snd_pcm_hw_params_set_periods(handle, params, alsamm_periods, dir);
+        if(err > 0)
+        {
+            check_error(err, "unable to set periods");
+            return err;
+        }
+
+        err = snd_pcm_hw_params_get_periods(params, &pmin, &dir);
+        if(err > 0)
+        {
+            check_error(err, "unable to get periods");
+            return err;
+        }
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("hw_params: got buffertime to %f ms",
-         (float) (alsamm_buffertime*0.001));
+        if(sys_verbose)
+            post("got periods of %d, where periodsmin=%d, periodsmax=%d",
+                alsamm_periods, pmin, pmax);
 #endif
-
-  err = snd_pcm_hw_params_get_buffer_size(params,
-    (unsigned long *)&alsamm_buffer_size);
-  if (err < 0) {
-    check_error(err,"unable to get buffer size");
-    return err;
-  }
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("hw_params: got buffersize to %d samples",(int) alsamm_buffer_size);
-#endif
-
-  err = snd_pcm_hw_params_get_period_size(params,
-    (unsigned long *)&alsamm_period_size, &dir);
-  if (err > 0) {
-    check_error(err,"unable to get period size");
-    return err;
-  }
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("got period size of %d", (int) alsamm_period_size);
-#endif
-  {
-    unsigned int pmin,pmax;
-
-    err = snd_pcm_hw_params_get_periods_min(params, &pmin, &dir);
-    if (err > 0) {
-      check_error(err,"unable to get period size");
-      return err;
-    }
-    err = snd_pcm_hw_params_get_periods_min(params, &pmax, &dir);
-    if (err > 0) {
-      check_error(err,"unable to get period size");
-      return err;
     }
 
-    /* use maximum of periods */
-    if( alsamm_periods <= 0)
-      alsamm_periods = pmax;
-    alsamm_periods = (alsamm_periods > pmax)?pmax:alsamm_periods;
-    alsamm_periods = (alsamm_periods < pmin)?pmin:alsamm_periods;
-
-    err = snd_pcm_hw_params_set_periods(handle, params, alsamm_periods, dir);
-    if (err > 0) {
-      check_error(err,"unable to set periods");
-      return err;
+    /* write the parameters to device */
+    err = snd_pcm_hw_params(handle, params);
+    if(err < 0)
+    {
+        check_error(err, "unable to set hw params");
+        return err;
     }
-
-
-    err = snd_pcm_hw_params_get_periods(params, &pmin, &dir);
-    if (err > 0) {
-      check_error(err,"unable to get periods");
-      return err;
-    }
-#ifdef ALSAMM_DEBUG
-    if(sys_verbose)
-      post("got periods of %d, where periodsmin=%d, periodsmax=%d",
-           alsamm_periods,pmin,pmax);
-#endif
-  }
-
-  /* write the parameters to device */
-  err = snd_pcm_hw_params(handle, params);
-  if (err < 0) {
-    check_error(err,"unable to set hw params");
-    return err;
-  }
 #endif /* ALSAAPI9 */
-  return 0;
+    return 0;
 }
 
-static int set_swparams(snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int playback)
+static int set_swparams(
+    snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int playback)
 {
 #ifndef ALSAAPI9
-  int err;
-  snd_pcm_uframes_t ps,ops;
-  snd_pcm_uframes_t bs,obs;
+    int err;
+    snd_pcm_uframes_t ps, ops;
+    snd_pcm_uframes_t bs, obs;
 
-  /* get the current swparams */
-  err = snd_pcm_sw_params_current(handle, swparams);
-  if (err < 0) {
-    check_error(err,"unable to determine current swparams for playback");
-    return err;
-  }
-
-  /* AUTOSTART: start the transfer on each write/commit ??? */
-  snd_pcm_sw_params_get_start_threshold(swparams, &obs);
-
-  err = snd_pcm_sw_params_set_start_threshold(handle, swparams, 0U);
-  if (err < 0) {
-    check_error(err,"unable to set start threshold mode");
-    return err;
-  }
-
-  snd_pcm_sw_params_get_start_threshold(swparams, &bs);
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("sw_params: got start_thresh_hold= %d (was %d)",(int) bs,(int)obs);
-#endif
-
-  /* AUTOSTOP:  never stop the machine */
-
-  snd_pcm_sw_params_get_stop_threshold(swparams, &obs);
-
-  err = snd_pcm_sw_params_set_stop_threshold(handle, swparams, (snd_pcm_uframes_t)-1);
-  if (err < 0) {
-    check_error(err,"unable to set stop threshold mode");
-    return err;
-  }
-
-  snd_pcm_sw_params_get_stop_threshold(swparams, &bs);
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("sw_params: set stop_thresh_hold= %d (was %d)", (int) bs,(int)obs);
-#endif
-
-
-  /* AUTOSILENCE: silence if overrun.... */
-
-  snd_pcm_sw_params_get_silence_threshold (swparams, &ops);
-  if ((err = snd_pcm_sw_params_set_silence_threshold (handle, swparams, alsamm_period_size)) < 0) {
-    check_error (err,"cannot set silence threshold for");
-    return -1;
-  }
-  snd_pcm_sw_params_get_silence_threshold (swparams, &ps);
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("sw_params: set silence_threshold = %d (was %d)", (int) ps,(int)ops);
-#endif
-
-  snd_pcm_sw_params_get_silence_size (swparams, &ops);
-  if ((err = snd_pcm_sw_params_set_silence_size(handle, swparams, alsamm_period_size)) < 0) {
-    check_error (err,"cannot set silence size for");
-    return -1;
-  }
-  snd_pcm_sw_params_get_silence_size (swparams, &ps);
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("sw_params: set silence_size = %d (was %d)", (int) ps,(int)ops);
-#endif
-
-  /* AVAIL: allow the transfer when at least period_size samples can be processed */
-
-  snd_pcm_sw_params_get_avail_min(swparams, &ops);
-
-  err = snd_pcm_sw_params_set_avail_min(handle, swparams, alsamm_transfersize/2);
-  if (err < 0) {
-    check_error(err,"unable to set avail min");
-    return err;
+    /* get the current swparams */
+    err = snd_pcm_sw_params_current(handle, swparams);
+    if(err < 0)
+    {
+        check_error(err, "unable to determine current swparams for playback");
+        return err;
     }
 
-  snd_pcm_sw_params_get_avail_min(swparams, &ps);
+    /* AUTOSTART: start the transfer on each write/commit ??? */
+    snd_pcm_sw_params_get_start_threshold(swparams, &obs);
+
+    err = snd_pcm_sw_params_set_start_threshold(handle, swparams, 0U);
+    if(err < 0)
+    {
+        check_error(err, "unable to set start threshold mode");
+        return err;
+    }
+
+    snd_pcm_sw_params_get_start_threshold(swparams, &bs);
+
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("sw_params: set avail_min = %d (was  %d)", (int) ps, (int) ops);
+    if(sys_verbose)
+        post("sw_params: got start_thresh_hold= %d (was %d)", (int) bs,
+            (int) obs);
 #endif
 
-  /* write the parameters to the playback device */
+    /* AUTOSTOP:  never stop the machine */
 
-  err = snd_pcm_sw_params(handle, swparams);
-  if (err < 0) {
-    check_error(err,"unable to set sw params");
-    return err;
-  }
+    snd_pcm_sw_params_get_stop_threshold(swparams, &obs);
+
+    err = snd_pcm_sw_params_set_stop_threshold(
+        handle, swparams, (snd_pcm_uframes_t) -1);
+    if(err < 0)
+    {
+        check_error(err, "unable to set stop threshold mode");
+        return err;
+    }
+
+    snd_pcm_sw_params_get_stop_threshold(swparams, &bs);
+#ifdef ALSAMM_DEBUG
+    if(sys_verbose)
+        post("sw_params: set stop_thresh_hold= %d (was %d)", (int) bs,
+            (int) obs);
+#endif
+
+    /* AUTOSILENCE: silence if overrun.... */
+
+    snd_pcm_sw_params_get_silence_threshold(swparams, &ops);
+    if((err = snd_pcm_sw_params_set_silence_threshold(
+            handle, swparams, alsamm_period_size)) < 0)
+    {
+        check_error(err, "cannot set silence threshold for");
+        return -1;
+    }
+    snd_pcm_sw_params_get_silence_threshold(swparams, &ps);
+#ifdef ALSAMM_DEBUG
+    if(sys_verbose)
+        post("sw_params: set silence_threshold = %d (was %d)", (int) ps,
+            (int) ops);
+#endif
+
+    snd_pcm_sw_params_get_silence_size(swparams, &ops);
+    if((err = snd_pcm_sw_params_set_silence_size(
+            handle, swparams, alsamm_period_size)) < 0)
+    {
+        check_error(err, "cannot set silence size for");
+        return -1;
+    }
+    snd_pcm_sw_params_get_silence_size(swparams, &ps);
+#ifdef ALSAMM_DEBUG
+    if(sys_verbose)
+        post("sw_params: set silence_size = %d (was %d)", (int) ps, (int) ops);
+#endif
+
+    /* AVAIL: allow the transfer when at least period_size samples can be
+     * processed */
+
+    snd_pcm_sw_params_get_avail_min(swparams, &ops);
+
+    err = snd_pcm_sw_params_set_avail_min(
+        handle, swparams, alsamm_transfersize / 2);
+    if(err < 0)
+    {
+        check_error(err, "unable to set avail min");
+        return err;
+    }
+
+    snd_pcm_sw_params_get_avail_min(swparams, &ps);
+#ifdef ALSAMM_DEBUG
+    if(sys_verbose)
+        post("sw_params: set avail_min = %d (was  %d)", (int) ps, (int) ops);
+#endif
+
+    /* write the parameters to the playback device */
+
+    err = snd_pcm_sw_params(handle, swparams);
+    if(err < 0)
+    {
+        check_error(err, "unable to set sw params");
+        return err;
+    }
 
 #ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("set sw finished");
+    if(sys_verbose) post("set sw finished");
 #endif
 #else
-  post("alsa: need version 1.0 or above for mmap operation");
+    post("alsa: need version 1.0 or above for mmap operation");
 #endif /* ALSAAPI9 */
-  return 0;
+    return 0;
 }
 
 /* ALSA Transfer helps */
@@ -780,249 +834,269 @@ static int set_swparams(snd_pcm_t *handle, snd_pcm_sw_params_t *swparams, int pl
 static int xrun_recovery(snd_pcm_t *handle, int err)
 {
 #ifdef ALSAMM_DEBUG
-  alsamm_xruns++; /* count xruns */
+    alsamm_xruns++; /* count xruns */
 #endif
 
-  if (err == -EPIPE) {    /* under-run */
-    err = snd_pcm_prepare(handle);
-    if (err < 0)
-      check_error(err,"couldn't recover from underrun, prepare failed");
+    if(err == -EPIPE)
+    { /* under-run */
+        err = snd_pcm_prepare(handle);
+        if(err < 0)
+            check_error(err, "couldn't recover from underrun, prepare failed");
 
-    err = snd_pcm_start(handle);
-    if (err < 0)
-      check_error(err,"couldn't start when recovering from underrun");
+        err = snd_pcm_start(handle);
+        if(err < 0)
+            check_error(err, "couldn't start when recovering from underrun");
 
-    return 0;
-  } else if (err == -ESTRPIPE) {
-    while ((err = snd_pcm_resume(handle)) == -EAGAIN)
-      sleep(1);       /* wait until the suspend flag is released */
-    if (err < 0) {
-      err = snd_pcm_prepare(handle);
-      if (err < 0)
-        check_error(err,"couldn't recover from suspend, prepare failed");
-
-      err = snd_pcm_start(handle);
-      if (err < 0)
-        check_error(err,"couldn't start when recovering from underrun");
+        return 0;
     }
-    return 0;
-  }
+    else if(err == -ESTRPIPE)
+    {
+        while((err = snd_pcm_resume(handle)) == -EAGAIN)
+            sleep(1); /* wait until the suspend flag is released */
+        if(err < 0)
+        {
+            err = snd_pcm_prepare(handle);
+            if(err < 0)
+                check_error(
+                    err, "couldn't recover from suspend, prepare failed");
 
-  return err;
+            err = snd_pcm_start(handle);
+            if(err < 0)
+                check_error(
+                    err, "couldn't start when recovering from underrun");
+        }
+        return 0;
+    }
+
+    return err;
 }
 
 /* note that snd_pcm_avail has to be called before using this function */
 
-static int alsamm_get_channels(snd_pcm_t *dev,
-                               snd_pcm_uframes_t *avail,
-                               snd_pcm_uframes_t *offset,
-                               int nchns, char **addr)
+static int alsamm_get_channels(snd_pcm_t *dev, snd_pcm_uframes_t *avail,
+    snd_pcm_uframes_t *offset, int nchns, char **addr)
 {
-  int err = 0;
-  int chn;
-  const snd_pcm_channel_area_t *mm_areas;
+    int err = 0;
+    int chn;
+    const snd_pcm_channel_area_t *mm_areas;
 
+    if(nchns > 0 && avail != NULL && offset != NULL)
+    {
 
-  if (nchns > 0 && avail != NULL && offset != NULL) {
+        if((err = snd_pcm_mmap_begin(dev, &mm_areas, offset, avail)) < 0)
+        {
+            check_error(err, "setmems: begin_mmap failure ???");
+            return err;
+        }
 
-    if ((err = snd_pcm_mmap_begin(dev, &mm_areas, offset, avail)) < 0){
-      check_error(err,"setmems: begin_mmap failure ???");
-      return err;
+        for(chn = 0; chn < nchns; chn++)
+        {
+            const snd_pcm_channel_area_t *a = &mm_areas[chn];
+            addr[chn] = (char *) a->addr + ((a->first + a->step * *offset) / 8);
+        }
+
+        return err;
     }
 
-    for (chn = 0; chn < nchns; chn++) {
-      const snd_pcm_channel_area_t *a = &mm_areas[chn];
-      addr[chn] = (char *) a->addr + ((a->first + a->step * *offset) / 8);
-    }
-
-    return err;
-  }
-
-  return -1;
+    return -1;
 }
-
 
 static int alsamm_start()
 {
-  int err = 0;
-  int devno;
-  int chn,nchns;
+    int err = 0;
+    int devno;
+    int chn, nchns;
 
-  const snd_pcm_channel_area_t *mm_areas;
-
-#ifdef ALSAMM_DEBUG
-  if(sys_verbose)
-    post("start audio with %d out cards and %d incards",alsamm_outcards,alsamm_incards);
-#endif
-
-  /* first prepare for in/out */
-  for(devno = 0;devno < alsa_noutdev;devno++){
-
-    snd_pcm_uframes_t offset, avail;
-    t_alsa_dev *dev = &alsa_outdev[devno];
-
-    /* snd_pcm_prepare also in xrun, but cannot harm here */
-    if ((err = snd_pcm_prepare (dev->a_handle)) < 0) {
-      check_error (err,"outcard prepare error for playback");
-      return err;
-    }
-
-    offset = 0;
-    avail = snd_pcm_avail_update(dev->a_handle);
-
-    if (avail != (snd_pcm_uframes_t) alsamm_buffer_size) {
-      check_error (avail,"full buffer not available at start");
-    }
-
-    /* cleaning out mmap buffer before start */
+    const snd_pcm_channel_area_t *mm_areas;
 
 #ifdef ALSAMM_DEBUG
     if(sys_verbose)
-      post("start: set mems for avail=%d,offset=%d at buffersize=%d",
-           avail,offset,alsamm_buffer_size);
+        post("start audio with %d out cards and %d incards", alsamm_outcards,
+            alsamm_incards);
 #endif
 
-    if(avail > 0){
+    /* first prepare for in/out */
+    for(devno = 0; devno < alsa_noutdev; devno++)
+    {
 
-      int committed = 0;
+        snd_pcm_uframes_t offset, avail;
+        t_alsa_dev *dev = &alsa_outdev[devno];
 
-      if ((err = alsamm_get_channels(dev->a_handle, &avail, &offset,
-                                     dev->a_channels,dev->a_addr)) < 0) {
-        check_error(err,"setting initial out channelspointer failure ?");
-        continue;
-      }
+        /* snd_pcm_prepare also in xrun, but cannot harm here */
+        if((err = snd_pcm_prepare(dev->a_handle)) < 0)
+        {
+            check_error(err, "outcard prepare error for playback");
+            return err;
+        }
 
-      for (chn = 0; chn < dev->a_channels; chn++)
-        memset(dev->a_addr[chn],0,avail*ALSAMM_SAMPLEWIDTH_32);
+        offset = 0;
+        avail = snd_pcm_avail_update(dev->a_handle);
 
-      committed = snd_pcm_mmap_commit (dev->a_handle, offset, avail);
+        if(avail != (snd_pcm_uframes_t) alsamm_buffer_size)
+        {
+            check_error(avail, "full buffer not available at start");
+        }
 
-      avail = snd_pcm_avail_update(dev->a_handle);
+        /* cleaning out mmap buffer before start */
 
 #ifdef ALSAMM_DEBUG
-      if(sys_verbose)
-        post("start: now channels cleared, out with avail=%d, offset=%d, committed=%d",
-             avail,offset,committed);
+        if(sys_verbose)
+            post("start: set mems for avail=%d,offset=%d at buffersize=%d",
+                avail, offset, alsamm_buffer_size);
 #endif
-    }
-    /* now start, should be autostarted */
-    avail = snd_pcm_avail_update(dev->a_handle);
+
+        if(avail > 0)
+        {
+
+            int committed = 0;
+
+            if((err = alsamm_get_channels(dev->a_handle, &avail, &offset,
+                    dev->a_channels, dev->a_addr)) < 0)
+            {
+                check_error(
+                    err, "setting initial out channelspointer failure ?");
+                continue;
+            }
+
+            for(chn = 0; chn < dev->a_channels; chn++)
+                memset(dev->a_addr[chn], 0, avail * ALSAMM_SAMPLEWIDTH_32);
+
+            committed = snd_pcm_mmap_commit(dev->a_handle, offset, avail);
+
+            avail = snd_pcm_avail_update(dev->a_handle);
 
 #ifdef ALSAMM_DEBUG
-    if(sys_verbose)
-      post("start: finish start, out with avail=%d, offset=%d",avail,offset);
+            if(sys_verbose)
+                post("start: now channels cleared, out with avail=%d, "
+                     "offset=%d, committed=%d",
+                    avail, offset, committed);
 #endif
-
-    /* we have no autostart so anyway start*/
-    if ((err = snd_pcm_start (dev->a_handle)) < 0) {
-      check_error (err,"could not start playback");
-    }
-  }
-
-  for(devno = 0;devno < alsa_nindev;devno++){
-
-    snd_pcm_uframes_t ioffset, iavail;
-    t_alsa_dev *dev = &alsa_indev[devno];
-
-    /* if devices are synced then don't need to prepare
-       hopefully dma in areas already filled correct by the card */
-
-    if(dev->a_synced == 0){
-      if ((err = snd_pcm_prepare (dev->a_handle)) < 0) {
-        check_error (err,"incard prepare error for capture");
-        /*      return err;*/
-      }
-    }
-
-    ioffset = 0;
-    iavail = snd_pcm_avail_update (dev->a_handle);
-
-    /* cleaning out mmap buffer before start */
-#ifdef ALSAMM_DEBUG
-    post("start in: set in mems for avail=%d, offset=%d at buffersize=%d",
-         iavail,ioffset,alsamm_buffer_size);
-#endif
-
-    if (iavail > (snd_pcm_uframes_t) 0) {
+        }
+        /* now start, should be autostarted */
+        avail = snd_pcm_avail_update(dev->a_handle);
 
 #ifdef ALSAMM_DEBUG
-      post("empty buffer not available at start, since avail %d != %d buffersize",
-           iavail, alsamm_buffer_size);
+        if(sys_verbose)
+            post("start: finish start, out with avail=%d, offset=%d", avail,
+                offset);
 #endif
 
-      if ((err = alsamm_get_channels(dev->a_handle, &iavail, &ioffset,
-                                     dev->a_channels,dev->a_addr)) < 0) {
-        check_error(err,"getting in channelspointer failure ????");
-        continue;
-      }
-
-      snd_pcm_mmap_commit (dev->a_handle, ioffset, iavail);
-
-      iavail = snd_pcm_avail_update (dev->a_handle);
-#ifdef ALSAMM_DEBUG
-      post("start in now avail=%d",iavail);
-#endif
+        /* we have no autostart so anyway start*/
+        if((err = snd_pcm_start(dev->a_handle)) < 0)
+        {
+            check_error(err, "could not start playback");
+        }
     }
 
+    for(devno = 0; devno < alsa_nindev; devno++)
+    {
+
+        snd_pcm_uframes_t ioffset, iavail;
+        t_alsa_dev *dev = &alsa_indev[devno];
+
+        /* if devices are synced then don't need to prepare
+           hopefully dma in areas already filled correct by the card */
+
+        if(dev->a_synced == 0)
+        {
+            if((err = snd_pcm_prepare(dev->a_handle)) < 0)
+            {
+                check_error(err, "incard prepare error for capture");
+                /*      return err;*/
+            }
+        }
+
+        ioffset = 0;
+        iavail = snd_pcm_avail_update(dev->a_handle);
+
+        /* cleaning out mmap buffer before start */
 #ifdef ALSAMM_DEBUG
-     post("start: init inchannels with avail=%d, offset=%d",iavail,ioffset);
+        post("start in: set in mems for avail=%d, offset=%d at buffersize=%d",
+            iavail, ioffset, alsamm_buffer_size);
 #endif
 
-    /* if devices are synced then don't need to start */
-    /* start with autostart , but anyway start */
-    if(dev->a_synced == 0){
-      if ((err = snd_pcm_start (dev->a_handle)) < 0) {
-        check_error (err,"could not start capture");
-        continue;
-      }
+        if(iavail > (snd_pcm_uframes_t) 0)
+        {
+
+#ifdef ALSAMM_DEBUG
+            post("empty buffer not available at start, since avail %d != %d "
+                 "buffersize",
+                iavail, alsamm_buffer_size);
+#endif
+
+            if((err = alsamm_get_channels(dev->a_handle, &iavail, &ioffset,
+                    dev->a_channels, dev->a_addr)) < 0)
+            {
+                check_error(err, "getting in channelspointer failure ????");
+                continue;
+            }
+
+            snd_pcm_mmap_commit(dev->a_handle, ioffset, iavail);
+
+            iavail = snd_pcm_avail_update(dev->a_handle);
+#ifdef ALSAMM_DEBUG
+            post("start in now avail=%d", iavail);
+#endif
+        }
+
+#ifdef ALSAMM_DEBUG
+        post(
+            "start: init inchannels with avail=%d, offset=%d", iavail, ioffset);
+#endif
+
+        /* if devices are synced then don't need to start */
+        /* start with autostart , but anyway start */
+        if(dev->a_synced == 0)
+        {
+            if((err = snd_pcm_start(dev->a_handle)) < 0)
+            {
+                check_error(err, "could not start capture");
+                continue;
+            }
+        }
     }
 
-  }
-
-  return err;
+    return err;
 }
 
 static int alsamm_stop()
 {
-  int err = 0;
-  int devno;
+    int err = 0;
+    int devno;
 
-  /* first stop in... */
-  for(devno = 0;devno < alsa_nindev;devno++){
+    /* first stop in... */
+    for(devno = 0; devno < alsa_nindev; devno++)
+    {
 
-    t_alsa_dev *dev = &alsa_indev[devno];
+        t_alsa_dev *dev = &alsa_indev[devno];
 
-    if(sys_verbose)
-      post("stop in device %d",devno);
+        if(sys_verbose) post("stop in device %d", devno);
 
-    if ((err = snd_pcm_drop(dev->a_handle)) < 0) {
-      check_error (err,"channel flush for capture failed");
+        if((err = snd_pcm_drop(dev->a_handle)) < 0)
+        {
+            check_error(err, "channel flush for capture failed");
+        }
     }
 
-  }
+    /* then outs */
+    for(devno = 0; devno < alsa_noutdev; devno++)
+    {
 
-  /* then outs */
-  for(devno = 0;devno < alsa_noutdev;devno++){
+        t_alsa_dev *dev = &alsa_outdev[devno];
+        if(sys_verbose) post("stop out device %d", devno);
 
-
-    t_alsa_dev *dev = &alsa_outdev[devno];
-    if(sys_verbose)
-      post("stop out device %d",devno);
-
-    if ((err = snd_pcm_drop(dev->a_handle)) < 0) {
-      check_error (err,"channel flush for playback failed");
+        if((err = snd_pcm_drop(dev->a_handle)) < 0)
+        {
+            check_error(err, "channel flush for playback failed");
+        }
     }
-
-  }
 
 #ifdef ALSAMM_DEBUG
-  show_availist();
+    show_availist();
 #endif
 
-  return err;
+    return err;
 }
-
-
 
 /* ---------- ADC/DAC transfer in  the main loop ------- */
 
@@ -1049,317 +1123,352 @@ Problems to solve:
 int alsamm_send_dacs(void)
 {
 
-  static double timenow,timelast;
+    static double timenow, timelast;
 
-  t_sample *fpo, *fpi, *fp1, *fp2;
-  int i, err, devno;
+    t_sample *fpo, *fpi, *fp1, *fp2;
+    int i, err, devno;
 
-  const snd_pcm_channel_area_t *my_areas;
-  snd_pcm_sframes_t size;
-  snd_pcm_sframes_t commitres;
-  snd_pcm_state_t state;
-  snd_pcm_sframes_t ooffset, oavail;
-  snd_pcm_sframes_t ioffset, iavail;
+    const snd_pcm_channel_area_t *my_areas;
+    snd_pcm_sframes_t size;
+    snd_pcm_sframes_t commitres;
+    snd_pcm_state_t state;
+    snd_pcm_sframes_t ooffset, oavail;
+    snd_pcm_sframes_t ioffset, iavail;
 
-  /*
-     unused channels should be zeroed out on startup (open) and stay this
-  */
-  int inchannels = STUFF->st_inchannels;
-  int outchannels = STUFF->st_outchannels;
-
-  timelast = sys_getrealtime();
-
-#ifdef ALSAMM_DEBUG
-  if(dac_send++ < 0)
-    post("dac send called in %d, out %d, xrun %d",inchannels,outchannels, alsamm_xruns);
-
-  if(alsamm_xruns && (alsamm_xruns % 1000) == 0)
-    post("1000 xruns occurred");
-
-  if(dac_send < WATCH_PERIODS){
-    out_cm[dac_send] = -1;
-    in_avail[dac_send] = out_avail[dac_send] = -1;
-    in_offset[dac_send] = out_offset[dac_send] = -1;
-    outaddr[dac_send] = inaddr[dac_send] = NULL;
-    xruns_watch[dac_send] = alsamm_xruns;
-  }
-#endif
-
-  if (!inchannels && !outchannels)
-    {
-      return SENDDACS_NO;
-    }
-
-  /* here we should check if in and out samples are here.
-     but, the point is if out samples available also in sample should,
-     so we don't make a precheck of insamples here and let outsample check be the
-     the first of the first card.
-  */
-
-
-  /* OUTPUT Transfer */
-  fpo = STUFF->st_soundout;
-  for(devno = 0;devno < alsa_noutdev;devno++){
-
-    t_alsa_dev *dev = &alsa_outdev[devno];
-    snd_pcm_t *out = dev->a_handle;
-    int ochannels =dev->a_channels;
-
-
-
-    /* how much samples available ??? */
-    oavail = snd_pcm_avail_update(out);
-
-    /* only one reason i can think about,
-       the driver stopped and says broken pipe
-       so this should not happen if we have enough stopthreshhold
-       but if try to restart with next commit
+    /*
+       unused channels should be zeroed out on startup (open) and stay this
     */
-    if (oavail < 0) {
+    int inchannels = STUFF->st_inchannels;
+    int outchannels = STUFF->st_outchannels;
+
+    timelast = sys_getrealtime();
 
 #ifdef ALSAMM_DEBUG
-      broken_opipe++;
-#endif
-      err = xrun_recovery(out, -EPIPE);
-      if (err < 0) {
-        check_error(err,"otavail<0 recovery failed");
-        return SENDDACS_NO;
-      }
-      oavail = snd_pcm_avail_update(out);
-    }
+    if(dac_send++ < 0)
+        post("dac send called in %d, out %d, xrun %d", inchannels, outchannels,
+            alsamm_xruns);
 
-    /* check if we are late and have to (able to) catch up */
-    /* xruns will be ignored since you can't do anything since already happened */
-    state = snd_pcm_state(out);
-    if (state == SND_PCM_STATE_XRUN) {
-      err = xrun_recovery(out, -EPIPE);
-      if (err < 0) {
-        check_error(err,"DAC XRUN recovery failed");
-        return SENDDACS_NO;
-      }
-      oavail = snd_pcm_avail_update(out);
+    if(alsamm_xruns && (alsamm_xruns % 1000) == 0) post("1000 xruns occurred");
 
-    } else if (state == SND_PCM_STATE_SUSPENDED) {
-      err = xrun_recovery(out, -ESTRPIPE);
-      if (err < 0) {
-        check_error(err,"DAC SUSPEND recovery failed");
-        return SENDDACS_NO;
-      }
-      oavail = snd_pcm_avail_update(out);
-    }
-
-#ifdef ALSAMM_DEBUG
-    if(dac_send < WATCH_PERIODS){
-      out_avail[dac_send] = oavail;
+    if(dac_send < WATCH_PERIODS)
+    {
+        out_cm[dac_send] = -1;
+        in_avail[dac_send] = out_avail[dac_send] = -1;
+        in_offset[dac_send] = out_offset[dac_send] = -1;
+        outaddr[dac_send] = inaddr[dac_send] = NULL;
+        xruns_watch[dac_send] = alsamm_xruns;
     }
 #endif
 
-    /* we only transfer transfersize of bytes request,
-       this should only happen on first card otherwise we got a problem :-(()*/
-
-    if(oavail < alsamm_transfersize){
-      return SENDDACS_NO;
+    if(!inchannels && !outchannels)
+    {
+        return SENDDACS_NO;
     }
 
-    /* transfer now */
-    size = alsamm_transfersize;
-    fp1 = fpo;
-    ooffset = 0;
+    /* here we should check if in and out samples are here.
+       but, the point is if out samples available also in sample should,
+       so we don't make a precheck of insamples here and let outsample check be
+       the the first of the first card.
+    */
 
-    /* since this can go over a buffer boundary we maybe need two steps to
-       transfer (normally when buffersize is a multiple of transfersize
-       this should never happen) */
+    /* OUTPUT Transfer */
+    fpo = STUFF->st_soundout;
+    for(devno = 0; devno < alsa_noutdev; devno++)
+    {
 
-    while (size > 0) {
+        t_alsa_dev *dev = &alsa_outdev[devno];
+        snd_pcm_t *out = dev->a_handle;
+        int ochannels = dev->a_channels;
 
-      int chn;
-      snd_pcm_sframes_t oframes;
+        /* how much samples available ??? */
+        oavail = snd_pcm_avail_update(out);
 
-      oframes = size;
-
-      err =  alsamm_get_channels(out, (unsigned long *)&oframes,
-        (unsigned long *)&ooffset,ochannels,dev->a_addr);
-
-#ifdef ALSAMM_DEBUG
-      if(dac_send < WATCH_PERIODS){
-        out_offset[dac_send] = ooffset;
-        outaddr[dac_send] = (char *) dev->a_addr[0];
-      }
-#endif
-
-      if (err < 0){
-        if ((err = xrun_recovery(out, err)) < 0) {
-          check_error(err,"MMAP begins avail error");
-          break; /* next card please */
-        }
-      }
-
-      /* transfer into memory */
-      for (chn = 0; chn < ochannels; chn++) {
-
-        t_alsa_sample32 *buf = (t_alsa_sample32 *)dev->a_addr[chn];
-
-        /*
-        osc(buf, oframes, (dac_send%1000 < 500)?-100.0:-10.0,440,&(indexes[chn]));
+        /* only one reason i can think about,
+           the driver stopped and says broken pipe
+           so this should not happen if we have enough stopthreshhold
+           but if try to restart with next commit
         */
-
-        for (i = 0, fp2 = fp1 + chn*alsamm_transfersize; i < oframes; i++,fp2++)
-          {
-            t_sample s1 = *fp2 * F32MAX;
-            /* better but slower, better never clip ;-)
-               buf[i]= CLIP32(s1); */
-            buf[i]= ((int) s1 & 0xFFFFFF00);
-            *fp2 = 0.0;
-          }
-      }
-
-      commitres = snd_pcm_mmap_commit(out, ooffset, oframes);
-      if (commitres < 0 || commitres != oframes) {
-        if ((err = xrun_recovery(out, commitres >= 0 ? -EPIPE : commitres)) < 0) {
-          check_error(err,"MMAP commit error");
-          return SENDDACS_NO;
-        }
-      }
+        if(oavail < 0)
+        {
 
 #ifdef ALSAMM_DEBUG
-      if(dac_send < WATCH_PERIODS)
-        out_cm[dac_send] = oframes;
+            broken_opipe++;
 #endif
-
-      fp1 += oframes;
-      size -= oframes;
-    } /* while size */
-    fpo += ochannels*alsamm_transfersize;
-
-  }/* for devno */
-
-
-  fpi = STUFF->st_soundin; /* star first card first channel */
-
-  for(devno = 0;devno < alsa_nindev;devno++){
-
-    t_alsa_dev *dev = &alsa_indev[devno];
-    snd_pcm_t *in = dev->a_handle;
-    int ichannels = dev->a_channels;
-
-    iavail = snd_pcm_avail_update(in);
-
-    if (iavail < 0) {
-      err = xrun_recovery(in, iavail);
-      if (err < 0) {
-        check_error(err,"input avail update failed");
-        return SENDDACS_NO;
-      }
-      iavail=snd_pcm_avail_update(in);
-    }
-
-    state = snd_pcm_state(in);
-
-    if (state == SND_PCM_STATE_XRUN) {
-      err = xrun_recovery(in, -EPIPE);
-      if (err < 0) {
-        check_error(err,"ADC XRUN recovery failed");
-        return SENDDACS_NO;
-      }
-      iavail=snd_pcm_avail_update(in);
-
-    } else if (state == SND_PCM_STATE_SUSPENDED) {
-      err = xrun_recovery(in, -ESTRPIPE);
-      if (err < 0) {
-        check_error(err,"ADC SUSPEND recovery failed");
-        return SENDDACS_NO;
-      }
-      iavail=snd_pcm_avail_update(in);
-    }
-
-    /* only transfer full transfersize or nothing */
-    if(iavail < alsamm_transfersize){
-      return SENDDACS_NO;
-    }
-    size = alsamm_transfersize;
-    fp1 = fpi;
-    ioffset = 0;
-
-    /* since sysdata can go over a driver buffer boundary we maybe need two steps to
-       transfer (normally when buffersize is a multiple of transfersize
-       this should never happen) */
-
-    while(size > 0){
-      int chn;
-      snd_pcm_sframes_t iframes = size;
-
-      err =  alsamm_get_channels(in,
-        (unsigned long *)&iframes, (unsigned long *)&ioffset,ichannels,dev->a_addr);
-      if (err < 0){
-        if ((err = xrun_recovery(in, err)) < 0) {
-          check_error(err,"MMAP begins avail error");
-          return SENDDACS_NO;
+            err = xrun_recovery(out, -EPIPE);
+            if(err < 0)
+            {
+                check_error(err, "otavail<0 recovery failed");
+                return SENDDACS_NO;
+            }
+            oavail = snd_pcm_avail_update(out);
         }
-      }
+
+        /* check if we are late and have to (able to) catch up */
+        /* xruns will be ignored since you can't do anything since already
+         * happened */
+        state = snd_pcm_state(out);
+        if(state == SND_PCM_STATE_XRUN)
+        {
+            err = xrun_recovery(out, -EPIPE);
+            if(err < 0)
+            {
+                check_error(err, "DAC XRUN recovery failed");
+                return SENDDACS_NO;
+            }
+            oavail = snd_pcm_avail_update(out);
+        }
+        else if(state == SND_PCM_STATE_SUSPENDED)
+        {
+            err = xrun_recovery(out, -ESTRPIPE);
+            if(err < 0)
+            {
+                check_error(err, "DAC SUSPEND recovery failed");
+                return SENDDACS_NO;
+            }
+            oavail = snd_pcm_avail_update(out);
+        }
 
 #ifdef ALSAMM_DEBUG
-      if(dac_send < WATCH_PERIODS){
-        in_avail[dac_send] = iavail;
-        in_offset[dac_send] = ioffset;
-        inaddr[dac_send] = dev->a_addr[0];
-      }
-#endif
-      /* transfer into memory */
-
-      for (chn = 0; chn < ichannels; chn++) {
-
-        t_alsa_sample32 *buf = (t_alsa_sample32 *) dev->a_addr[chn];
-
-        for (i = 0, fp2 = fp1 + chn*alsamm_transfersize; i < iframes; i++,fp2++)
-          {
-            /* mask the lowest bits, since subchannels info can make zero samples nonzero */
-            *fp2 = (t_sample) ((t_alsa_sample32) (buf[i] & 0xFFFFFF00))
-              * (1.0 / (t_sample) INT32_MAX);
-          }
-      }
-
-      commitres = snd_pcm_mmap_commit(in, ioffset, iframes);
-      if (commitres < 0 || commitres != iframes) {
-        //post("please never");
-        if ((err = xrun_recovery(in, commitres >= 0 ? -EPIPE : commitres)) < 0) {
-          check_error(err,"MMAP synced in commit error");
-          return SENDDACS_NO;
+        if(dac_send < WATCH_PERIODS)
+        {
+            out_avail[dac_send] = oavail;
         }
-      }
-      fp1 += iframes;
-      size -= iframes;
-    }
-    fpi += ichannels*alsamm_transfersize;
-  } /* for out devno < alsamm_outcards*/
+#endif
 
+        /* we only transfer transfersize of bytes request,
+           this should only happen on first card otherwise we got a problem
+           :-(()*/
 
-  if ((timenow = sys_getrealtime()) > (timelast + sleep_time))
+        if(oavail < alsamm_transfersize)
+        {
+            return SENDDACS_NO;
+        }
+
+        /* transfer now */
+        size = alsamm_transfersize;
+        fp1 = fpo;
+        ooffset = 0;
+
+        /* since this can go over a buffer boundary we maybe need two steps to
+           transfer (normally when buffersize is a multiple of transfersize
+           this should never happen) */
+
+        while(size > 0)
+        {
+
+            int chn;
+            snd_pcm_sframes_t oframes;
+
+            oframes = size;
+
+            err = alsamm_get_channels(out, (unsigned long *) &oframes,
+                (unsigned long *) &ooffset, ochannels, dev->a_addr);
+
+#ifdef ALSAMM_DEBUG
+            if(dac_send < WATCH_PERIODS)
+            {
+                out_offset[dac_send] = ooffset;
+                outaddr[dac_send] = (char *) dev->a_addr[0];
+            }
+#endif
+
+            if(err < 0)
+            {
+                if((err = xrun_recovery(out, err)) < 0)
+                {
+                    check_error(err, "MMAP begins avail error");
+                    break; /* next card please */
+                }
+            }
+
+            /* transfer into memory */
+            for(chn = 0; chn < ochannels; chn++)
+            {
+
+                t_alsa_sample32 *buf = (t_alsa_sample32 *) dev->a_addr[chn];
+
+                /*
+                osc(buf, oframes, (dac_send%1000 <
+                500)?-100.0:-10.0,440,&(indexes[chn]));
+                */
+
+                for(i = 0, fp2 = fp1 + chn * alsamm_transfersize; i < oframes;
+                    i++, fp2++)
+                {
+                    t_sample s1 = *fp2 * F32MAX;
+                    /* better but slower, better never clip ;-)
+                       buf[i]= CLIP32(s1); */
+                    buf[i] = ((int) s1 & 0xFFFFFF00);
+                    *fp2 = 0.0;
+                }
+            }
+
+            commitres = snd_pcm_mmap_commit(out, ooffset, oframes);
+            if(commitres < 0 || commitres != oframes)
+            {
+                if((err = xrun_recovery(
+                        out, commitres >= 0 ? -EPIPE : commitres)) < 0)
+                {
+                    check_error(err, "MMAP commit error");
+                    return SENDDACS_NO;
+                }
+            }
+
+#ifdef ALSAMM_DEBUG
+            if(dac_send < WATCH_PERIODS) out_cm[dac_send] = oframes;
+#endif
+
+            fp1 += oframes;
+            size -= oframes;
+        } /* while size */
+        fpo += ochannels * alsamm_transfersize;
+
+    } /* for devno */
+
+    fpi = STUFF->st_soundin; /* star first card first channel */
+
+    for(devno = 0; devno < alsa_nindev; devno++)
+    {
+
+        t_alsa_dev *dev = &alsa_indev[devno];
+        snd_pcm_t *in = dev->a_handle;
+        int ichannels = dev->a_channels;
+
+        iavail = snd_pcm_avail_update(in);
+
+        if(iavail < 0)
+        {
+            err = xrun_recovery(in, iavail);
+            if(err < 0)
+            {
+                check_error(err, "input avail update failed");
+                return SENDDACS_NO;
+            }
+            iavail = snd_pcm_avail_update(in);
+        }
+
+        state = snd_pcm_state(in);
+
+        if(state == SND_PCM_STATE_XRUN)
+        {
+            err = xrun_recovery(in, -EPIPE);
+            if(err < 0)
+            {
+                check_error(err, "ADC XRUN recovery failed");
+                return SENDDACS_NO;
+            }
+            iavail = snd_pcm_avail_update(in);
+        }
+        else if(state == SND_PCM_STATE_SUSPENDED)
+        {
+            err = xrun_recovery(in, -ESTRPIPE);
+            if(err < 0)
+            {
+                check_error(err, "ADC SUSPEND recovery failed");
+                return SENDDACS_NO;
+            }
+            iavail = snd_pcm_avail_update(in);
+        }
+
+        /* only transfer full transfersize or nothing */
+        if(iavail < alsamm_transfersize)
+        {
+            return SENDDACS_NO;
+        }
+        size = alsamm_transfersize;
+        fp1 = fpi;
+        ioffset = 0;
+
+        /* since sysdata can go over a driver buffer boundary we maybe need two
+           steps to transfer (normally when buffersize is a multiple of
+           transfersize this should never happen) */
+
+        while(size > 0)
+        {
+            int chn;
+            snd_pcm_sframes_t iframes = size;
+
+            err = alsamm_get_channels(in, (unsigned long *) &iframes,
+                (unsigned long *) &ioffset, ichannels, dev->a_addr);
+            if(err < 0)
+            {
+                if((err = xrun_recovery(in, err)) < 0)
+                {
+                    check_error(err, "MMAP begins avail error");
+                    return SENDDACS_NO;
+                }
+            }
+
+#ifdef ALSAMM_DEBUG
+            if(dac_send < WATCH_PERIODS)
+            {
+                in_avail[dac_send] = iavail;
+                in_offset[dac_send] = ioffset;
+                inaddr[dac_send] = dev->a_addr[0];
+            }
+#endif
+            /* transfer into memory */
+
+            for(chn = 0; chn < ichannels; chn++)
+            {
+
+                t_alsa_sample32 *buf = (t_alsa_sample32 *) dev->a_addr[chn];
+
+                for(i = 0, fp2 = fp1 + chn * alsamm_transfersize; i < iframes;
+                    i++, fp2++)
+                {
+                    /* mask the lowest bits, since subchannels info can make
+                     * zero samples nonzero */
+                    *fp2 =
+                        (t_sample) ((t_alsa_sample32) (buf[i] & 0xFFFFFF00)) *
+                        (1.0 / (t_sample) INT32_MAX);
+                }
+            }
+
+            commitres = snd_pcm_mmap_commit(in, ioffset, iframes);
+            if(commitres < 0 || commitres != iframes)
+            {
+                // post("please never");
+                if((err = xrun_recovery(
+                        in, commitres >= 0 ? -EPIPE : commitres)) < 0)
+                {
+                    check_error(err, "MMAP synced in commit error");
+                    return SENDDACS_NO;
+                }
+            }
+            fp1 += iframes;
+            size -= iframes;
+        }
+        fpi += ichannels * alsamm_transfersize;
+    } /* for out devno < alsamm_outcards*/
+
+    if((timenow = sys_getrealtime()) > (timelast + sleep_time))
     {
 
 #ifdef ALSAMM_DEBUG
-      if(dac_send < 10 && sys_verbose)
-        post("slept %f > %f + %f (=%f)",
-             timenow,timelast,sleep_time,(timelast + sleep_time));
+        if(dac_send < 10 && sys_verbose)
+            post("slept %f > %f + %f (=%f)", timenow, timelast, sleep_time,
+                (timelast + sleep_time));
 #endif
-      return (SENDDACS_SLEPT);
+        return (SENDDACS_SLEPT);
     }
 
-  return SENDDACS_YES;
+    return SENDDACS_YES;
 }
-
 
 /* extra debug info */
 
 void alsamm_showstat(snd_pcm_t *handle)
 {
-  int err;
-  snd_pcm_status_t *status;
-  snd_output_t *output = NULL;
+    int err;
+    snd_pcm_status_t *status;
+    snd_output_t *output = NULL;
 
-  snd_pcm_status_alloca(&status);
-  if ((err = snd_pcm_status(handle, status)) < 0) {
-    check_error(err, "get stream status error");
-    return;
-  }
-  snd_pcm_status_dump(status, alsa_stdout);
+    snd_pcm_status_alloca(&status);
+    if((err = snd_pcm_status(handle, status)) < 0)
+    {
+        check_error(err, "get stream status error");
+        return;
+    }
+    snd_pcm_status_dump(status, alsa_stdout);
 }

--- a/src/s_audio_alsamm.c
+++ b/src/s_audio_alsamm.c
@@ -252,15 +252,21 @@ int alsamm_open_audio(int rate, int blocksize)
     /* set the asked buffer time (alsa buffertime in us)*/
     alsamm_buffertime = alsamm_buffersize = 0;
     if(blocksize == 0)
+    {
         alsamm_buffertime = sys_schedadvance;
+    }
     else
+    {
         alsamm_buffersize = blocksize;
+    }
 
     if(sys_verbose)
+    {
         post(
             "syschedadvance=%d microseconds so buffertime max should be this=%d"
             "or sys_blocksize=%d (samples) to use buffersize=%d",
             sys_schedadvance, alsamm_buffertime, blocksize, alsamm_buffersize);
+    }
 
     alsamm_periods = 0; /* no one wants periods setting from command line ;-) */
 
@@ -331,9 +337,11 @@ int alsamm_open_audio(int rate, int blocksize)
             alsa_indev[i].a_addr, 0, sizeof(char *) * alsa_indev[i].a_channels);
 
         if(sys_verbose)
+        {
             post(
                 "capture device with %d channels and buffertime %d us opened\n",
                 alsa_indev[i].a_channels, alsamm_buffertime);
+        }
     }
 
     /* check for linked handles of input for each output*/
@@ -864,13 +872,17 @@ static int xrun_recovery(snd_pcm_t *handle, int err)
         {
             err = snd_pcm_prepare(handle);
             if(err < 0)
+            {
                 check_error(
                     err, "couldn't recover from suspend, prepare failed");
+            }
 
             err = snd_pcm_start(handle);
             if(err < 0)
+            {
                 check_error(
                     err, "couldn't start when recovering from underrun");
+            }
         }
         return 0;
     }

--- a/src/s_audio_alsamm.c
+++ b/src/s_audio_alsamm.c
@@ -387,7 +387,8 @@ int alsamm_open_audio(int rate, int blocksize)
 
 void alsamm_close_audio(void)
 {
-    int i, err;
+    int i;
+    int err;
 
 #ifdef ALSAMM_DEBUG
     if(sys_verbose) post("closing devices");
@@ -451,7 +452,8 @@ static int set_hwparams(
 {
 #ifndef ALSAAPI9
     unsigned int rrate;
-    int err, dir;
+    int err;
+    int dir;
     int channels_allocated = 0;
 
     /* choose all parameters */
@@ -521,7 +523,9 @@ static int set_hwparams(
 
     /* Info on channels */
     {
-        int maxchs, minchs, channels = *chs;
+        int maxchs;
+        int minchs;
+        int channels = *chs;
 
         if((err = snd_pcm_hw_params_get_channels_max(
                 params, (unsigned int *) &maxchs)) < 0)
@@ -650,7 +654,8 @@ static int set_hwparams(
     if(sys_verbose) post("got period size of %d", (int) alsamm_period_size);
 #endif
     {
-        unsigned int pmin, pmax;
+        unsigned int pmin;
+        unsigned int pmax;
 
         err = snd_pcm_hw_params_get_periods_min(params, &pmin, &dir);
         if(err > 0)
@@ -707,8 +712,10 @@ static int set_swparams(
 {
 #ifndef ALSAAPI9
     int err;
-    snd_pcm_uframes_t ps, ops;
-    snd_pcm_uframes_t bs, obs;
+    snd_pcm_uframes_t ps;
+    snd_pcm_uframes_t ops;
+    snd_pcm_uframes_t bs;
+    snd_pcm_uframes_t obs;
 
     /* get the current swparams */
     err = snd_pcm_sw_params_current(handle, swparams);
@@ -905,7 +912,8 @@ static int alsamm_start()
 {
     int err = 0;
     int devno;
-    int chn, nchns;
+    int chn;
+    int nchns;
 
     const snd_pcm_channel_area_t *mm_areas;
 
@@ -919,7 +927,8 @@ static int alsamm_start()
     for(devno = 0; devno < alsa_noutdev; devno++)
     {
 
-        snd_pcm_uframes_t offset, avail;
+        snd_pcm_uframes_t offset;
+        snd_pcm_uframes_t avail;
         t_alsa_dev *dev = &alsa_outdev[devno];
 
         /* snd_pcm_prepare also in xrun, but cannot harm here */
@@ -991,7 +1000,8 @@ static int alsamm_start()
     for(devno = 0; devno < alsa_nindev; devno++)
     {
 
-        snd_pcm_uframes_t ioffset, iavail;
+        snd_pcm_uframes_t ioffset;
+        snd_pcm_uframes_t iavail;
         t_alsa_dev *dev = &alsa_indev[devno];
 
         /* if devices are synced then don't need to prepare
@@ -1123,17 +1133,25 @@ Problems to solve:
 int alsamm_send_dacs(void)
 {
 
-    static double timenow, timelast;
+    static double timenow;
+    static double timelast;
 
-    t_sample *fpo, *fpi, *fp1, *fp2;
-    int i, err, devno;
+    t_sample *fpo;
+    t_sample *fpi;
+    t_sample *fp1;
+    t_sample *fp2;
+    int i;
+    int err;
+    int devno;
 
     const snd_pcm_channel_area_t *my_areas;
     snd_pcm_sframes_t size;
     snd_pcm_sframes_t commitres;
     snd_pcm_state_t state;
-    snd_pcm_sframes_t ooffset, oavail;
-    snd_pcm_sframes_t ioffset, iavail;
+    snd_pcm_sframes_t ooffset;
+    snd_pcm_sframes_t oavail;
+    snd_pcm_sframes_t ioffset;
+    snd_pcm_sframes_t iavail;
 
     /*
        unused channels should be zeroed out on startup (open) and stay this

--- a/src/s_audio_audiounit.c
+++ b/src/s_audio_audiounit.c
@@ -2,7 +2,8 @@
 /* ------------- routines for Apple AudioUnit in AudioToolbox -------------- */
 #ifdef USEAPI_AUDIOUNIT
 
-/* this is currently a placeholder file while we decide which one of three implementations of this API we use */
+/* this is currently a placeholder file while we decide which one of three
+ * implementations of this API we use */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,23 +15,14 @@
 pthread_mutex_t audiounit_mutex;
 pthread_cond_t audiounit_sem;
 
-int audiounit_open_audio(int inchans, int outchans, int rate)
-{
-    return 0;
-}
+int audiounit_open_audio(int inchans, int outchans, int rate) { return 0; }
 
-void audiounit_close_audio(void)
-{
-}
+void audiounit_close_audio(void) {}
 
-int audiounit_send_dacs(void)
-{
-    return 0;
-}
+int audiounit_send_dacs(void) { return 0; }
 
-void audiounit_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize)
+void audiounit_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
     post("device getting not implemented for AudioUnit yet\n");
 }

--- a/src/s_audio_dummy.c
+++ b/src/s_audio_dummy.c
@@ -9,29 +9,24 @@
 
 #include <stdio.h>
 
-int dummy_open_audio(int nin, int nout, int sr) {
-  return 0;
-}
+int dummy_open_audio(int nin, int nout, int sr) { return 0; }
 
-int dummy_close_audio(void) {
-  return 0;
-}
+int dummy_close_audio(void) { return 0; }
 
-int dummy_send_dacs(void) {
-  return 0;
-}
+int dummy_send_dacs(void) { return 0; }
 
 void dummy_getdevs(char *indevlist, int *nindevs, char *outdevlist,
-    int *noutdevs, int *canmulti, int maxndev, int devdescsize) {
-  sprintf(indevlist, "NONE");
-  sprintf(outdevlist, "NONE");
-  *nindevs = *noutdevs = 1;
-  *canmulti = 0;
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize)
+{
+    sprintf(indevlist, "NONE");
+    sprintf(outdevlist, "NONE");
+    *nindevs = *noutdevs = 1;
+    *canmulti = 0;
 }
 
-void dummy_listdevs(void) {
-  // do nothing
+void dummy_listdevs(void)
+{
+    // do nothing
 }
 
 #endif
-

--- a/src/s_audio_esd.c
+++ b/src/s_audio_esd.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2006 Guenter Geiger,
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #ifdef USEAPI_ESD
 
@@ -21,9 +21,8 @@ static int esd_channels_out;
 static int esd_socket_in;
 static int esd_channels_in;
 
-
-int esd_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
-    int noutdev, int *outdev, int nchout, int *chout, int rate)
+int esd_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
+    int *outdev, int nchout, int *chout, int rate)
 {
 
     esd_format_t format = ESD_BITS16 | ESD_STEREO | ESD_STREAM | ESD_PLAY;
@@ -36,81 +35,94 @@ int esd_open_audio(int nindev,  int *indev,  int nchin,  int *chin,
 
     rate = sys_dacsr = ESD_DEFAULT_RATE;
 
-    if (*chout == 2) {
-      esd_socket_out = esd_play_stream_fallback(format, ESD_DEFAULT_RATE, NULL, "pd");
-      if (esd_socket_out <= 0) {
-        fprintf (stderr, "Error at esd open: %d\n", esd_socket_out);
-        esd_channels_out = *chout = 0;
-        return 0;
-      }
-      esd_channels_out = *chout = 2;
+    if(*chout == 2)
+    {
+        esd_socket_out =
+            esd_play_stream_fallback(format, ESD_DEFAULT_RATE, NULL, "pd");
+        if(esd_socket_out <= 0)
+        {
+            fprintf(stderr, "Error at esd open: %d\n", esd_socket_out);
+            esd_channels_out = *chout = 0;
+            return 0;
+        }
+        esd_channels_out = *chout = 2;
     }
 
-    if (*chin == 2) {
-      esd_socket_in = esd_record_stream_fallback(format, ESD_DEFAULT_RATE, NULL, "pd-in");
-      if (esd_socket_in <= 0) {
-        fprintf (stderr, "Error at esd open: %d\n", esd_socket_in);
-        esd_channels_in = *chin = 0;
-        return 0;
-      }
-      esd_channels_in = *chin = 2;
+    if(*chin == 2)
+    {
+        esd_socket_in =
+            esd_record_stream_fallback(format, ESD_DEFAULT_RATE, NULL, "pd-in");
+        if(esd_socket_in <= 0)
+        {
+            fprintf(stderr, "Error at esd open: %d\n", esd_socket_in);
+            esd_channels_in = *chin = 0;
+            return 0;
+        }
+        esd_channels_in = *chin = 2;
     }
     return (0);
 }
 
 void esd_close_audio(void)
 {
-  close(esd_socket_out);
-  close(esd_socket_in);
+    close(esd_socket_out);
+    close(esd_socket_in);
 }
-
 
 #define DEFDACBLKSIZE 64
 #define MAXCHANS 2
 
-static short buf[DEFDACBLKSIZE*MAXCHANS];
+static short buf[DEFDACBLKSIZE * MAXCHANS];
 
 int esd_send_dacs(void)
 {
-  t_sample* fp1,*fp2;
-  short* sp;
-  int i,j;
+    t_sample *fp1, *fp2;
+    short *sp;
+    int i, j;
 
-  /* Do input */
+    /* Do input */
 
-  if (esd_channels_in) {
-    read(esd_socket_in,buf,DEFDACBLKSIZE*esd_channels_out*2);
-    for (i = DEFDACBLKSIZE,  fp1 = sys_soundin,
-                 sp = (short *)buf; i--; fp1++, sp += esd_channels_in) {
-      for (j=0, fp2 = fp1; j<esd_channels_in; j++, fp2 += DEFDACBLKSIZE)
+    if(esd_channels_in)
+    {
+        read(esd_socket_in, buf, DEFDACBLKSIZE * esd_channels_out * 2);
+        for(i = DEFDACBLKSIZE, fp1 = sys_soundin, sp = (short *) buf; i--;
+            fp1++, sp += esd_channels_in)
         {
-          int s = INVSCALE16(sp[j]);
-          *fp2 = s;
-        }
-    }
-  }
-
-  /* Do output */
-
-  if (esd_channels_out) {
-    for (i = DEFDACBLKSIZE,  fp1 = sys_soundout,
-         sp = (short *)buf; i--; fp1++, sp += esd_channels_out) {
-      for (j=0, fp2 = fp1; j<esd_channels_out; j++, fp2 += DEFDACBLKSIZE)
-        {
-          int s = SCALE16(*fp2);
-          if (s > 32767) s = 32767;
-          else if (s < -32767) s = -32767;
-          sp[j] = s;
+            for(j = 0, fp2 = fp1; j < esd_channels_in;
+                j++, fp2 += DEFDACBLKSIZE)
+            {
+                int s = INVSCALE16(sp[j]);
+                *fp2 = s;
+            }
         }
     }
 
-    write(esd_socket_out,buf,DEFDACBLKSIZE*esd_channels_out*2);
-  }
+    /* Do output */
 
-  memset(sys_soundin,0,DEFDACBLKSIZE*esd_channels_out*2);
-  memset(sys_soundout,0,DEFDACBLKSIZE*esd_channels_out*4);
+    if(esd_channels_out)
+    {
+        for(i = DEFDACBLKSIZE, fp1 = sys_soundout, sp = (short *) buf; i--;
+            fp1++, sp += esd_channels_out)
+        {
+            for(j = 0, fp2 = fp1; j < esd_channels_out;
+                j++, fp2 += DEFDACBLKSIZE)
+            {
+                int s = SCALE16(*fp2);
+                if(s > 32767)
+                    s = 32767;
+                else if(s < -32767)
+                    s = -32767;
+                sp[j] = s;
+            }
+        }
 
-  return (SENDDACS_YES);
+        write(esd_socket_out, buf, DEFDACBLKSIZE * esd_channels_out * 2);
+    }
+
+    memset(sys_soundin, 0, DEFDACBLKSIZE * esd_channels_out * 2);
+    memset(sys_soundout, 0, DEFDACBLKSIZE * esd_channels_out * 4);
+
+    return (SENDDACS_YES);
 }
 
 void esd_listdevs(void)
@@ -118,12 +130,11 @@ void esd_listdevs(void)
     post("device listing not implemented for ESD yet\n");
 }
 
-void esd_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize)
+void esd_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
+    int *canmulti, int maxndev, int devdescsize)
 {
     int i, ndev;
-    *canmulti = 1;  /* supports multiple devices */
+    *canmulti = 1; /* supports multiple devices */
     sprintf(indevlist, "ESD device");
     sprintf(outdevlist, "ESD device");
     *nindevs = *noutdevs = 1;

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 2003, Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  Audio back-end for connecting with the JACK audio interconnect system.
-*/
+ */
 
 #ifdef USEAPI_JACK
 
@@ -21,7 +21,7 @@
 #include <regex.h>
 
 #define MAX_CLIENTS 100
-#define MAX_JACK_PORTS 128  /* higher values seem to give bad xrun problems */
+#define MAX_JACK_PORTS 128 /* higher values seem to give bad xrun problems */
 #define BUF_JACK 4096
 /* taken from the PipeWire libjack implementation: the larger of the
  * `JACK_CLIENT_NAME_SIZE` definitions I could find in the wild. */
@@ -33,7 +33,7 @@ static int jack_started = 0;
 static jack_port_t *input_port[MAX_JACK_PORTS];
 static jack_port_t *output_port[MAX_JACK_PORTS];
 static jack_client_t *jack_client = NULL;
-static char * desired_client_name = NULL;
+static char *desired_client_name = NULL;
 char *jack_client_names[MAX_CLIENTS];
 static int jack_dio_error;
 static t_audiocallback jack_callback;
@@ -48,65 +48,64 @@ static PA_VOLATILE sys_ringbuf jack_inring;
 
 /* #define TESTCANSLEEP */
 
-    /* callback routine for non-callback client... throw samples into
-        and read them out of a FIFO.  Since we don't know at compile time
-        how many samples jack will treat us to, we interleave them in the
-        two FIFos.  So we have to mux/demux them both here and up at the
-        user level in jack_send_dacs(). */
+/* callback routine for non-callback client... throw samples into
+    and read them out of a FIFO.  Since we don't know at compile time
+    how many samples jack will treat us to, we interleave them in the
+    two FIFos.  So we have to mux/demux them both here and up at the
+    user level in jack_send_dacs(). */
 static int jack_polling_callback(jack_nframes_t nframes, void *unused)
 {
     unsigned long infiforoom = sys_ringbuf_getwriteavailable(&jack_inring),
-        outfiforoom = sys_ringbuf_getreadavailable(&jack_outring);
-    t_sample *muxbuffer =  (t_sample *)alloca(sizeof (t_sample) * nframes *
-        (STUFF->st_inchannels > STUFF->st_outchannels ?
-            STUFF->st_inchannels : STUFF->st_outchannels));
+                  outfiforoom = sys_ringbuf_getreadavailable(&jack_outring);
+    t_sample *muxbuffer = (t_sample *) alloca(
+        sizeof(t_sample) * nframes *
+        (STUFF->st_inchannels > STUFF->st_outchannels ? STUFF->st_inchannels
+                                                      : STUFF->st_outchannels));
     int j;
     jack_default_audio_sample_t *jp;
 
-        /* even though the FIFO is lock-free we have to lock here
-        to prevent a race condition in the waiting thread between
-        the FIFO and the pthread_cond_wait() call. */
+    /* even though the FIFO is lock-free we have to lock here
+    to prevent a race condition in the waiting thread between
+    the FIFO and the pthread_cond_wait() call. */
     pthread_mutex_lock(&jack_mutex);
-    if (infiforoom < nframes * STUFF->st_inchannels * sizeof(t_sample) ||
+    if(infiforoom < nframes * STUFF->st_inchannels * sizeof(t_sample) ||
         outfiforoom < nframes * STUFF->st_outchannels * sizeof(t_sample))
     {
         /* data late: output zeros, drop inputs, and leave FIFos untouched */
-        if (jack_started)
-            jack_dio_error = 1;
-        for (j = 0; j < STUFF->st_outchannels; j++)
+        if(jack_started) jack_dio_error = 1;
+        for(j = 0; j < STUFF->st_outchannels; j++)
         {
-            if ((jp = jack_port_get_buffer(output_port[j], nframes)))
-                memset(jp, 0, sizeof (jack_default_audio_sample_t) * nframes);
+            if((jp = jack_port_get_buffer(output_port[j], nframes)))
+                memset(jp, 0, sizeof(jack_default_audio_sample_t) * nframes);
         }
     }
     else
     {
         t_sample *fp, *fp2;
         int ch;
-        if (STUFF->st_inchannels)
+        if(STUFF->st_inchannels)
         {
-            for (fp = muxbuffer, ch = 0; ch < STUFF->st_inchannels; ch++, fp++)
+            for(fp = muxbuffer, ch = 0; ch < STUFF->st_inchannels; ch++, fp++)
             {
                 jp = jack_port_get_buffer(input_port[ch], nframes);
-                for (j = 0, fp2 = fp; j < (int)nframes;
+                for(j = 0, fp2 = fp; j < (int) nframes;
                     j++, fp2 += STUFF->st_inchannels)
-                        *fp2 = jp[j];
+                    *fp2 = jp[j];
             }
             sys_ringbuf_write(&jack_inring, muxbuffer,
-                nframes * STUFF->st_inchannels * sizeof(t_sample),
-                    jack_inbuf);
+                nframes * STUFF->st_inchannels * sizeof(t_sample), jack_inbuf);
         }
-        if (STUFF->st_outchannels)
+        if(STUFF->st_outchannels)
         {
             sys_ringbuf_read(&jack_outring, muxbuffer,
                 nframes * STUFF->st_outchannels * sizeof(t_sample),
-                    jack_outbuf);
-            for (fp = muxbuffer, ch = 0; ch < STUFF->st_outchannels; ch++, fp++)
+                jack_outbuf);
+            for(fp = muxbuffer, ch = 0; ch < STUFF->st_outchannels; ch++, fp++)
             {
                 jp = jack_port_get_buffer(output_port[ch], nframes);
-                for (j = 0, fp2 = fp; j < (int)nframes;
+                for(j = 0, fp2 = fp; j < (int) nframes;
                     j++, fp2 += STUFF->st_outchannels)
-                        jp[j] = *fp2;
+                    jp[j] = *fp2;
             }
         }
     }
@@ -120,56 +119,55 @@ static int callbackprocess(jack_nframes_t nframes, void *arg)
     int chan, j, k;
     unsigned int n;
     jack_default_audio_sample_t *out[MAX_JACK_PORTS], *in[MAX_JACK_PORTS], *jp;
-    if (nframes % DEFDACBLKSIZE)
+    if(nframes % DEFDACBLKSIZE)
     {
         fprintf(stderr, "jack: nframes %d not a multiple of blocksize %d\n",
             nframes, DEFDACBLKSIZE);
         nframes -= (nframes % DEFDACBLKSIZE);
     }
-    for (chan = 0; chan < STUFF->st_inchannels; chan++)
+    for(chan = 0; chan < STUFF->st_inchannels; chan++)
         in[chan] = jack_port_get_buffer(input_port[chan], nframes);
-    for (chan = 0; chan < STUFF->st_outchannels; chan++)
+    for(chan = 0; chan < STUFF->st_outchannels; chan++)
         out[chan] = jack_port_get_buffer(output_port[chan], nframes);
-    for (n = 0; n < nframes; n += DEFDACBLKSIZE)
+    for(n = 0; n < nframes; n += DEFDACBLKSIZE)
     {
         t_sample *fp;
-        for (chan = 0; chan < STUFF->st_inchannels; chan++)
-            if (in[chan])
-        {
-            for (fp = STUFF->st_soundin + chan*DEFDACBLKSIZE,
-                jp = in[chan] + n, j=0; j < DEFDACBLKSIZE; j++)
+        for(chan = 0; chan < STUFF->st_inchannels; chan++)
+            if(in[chan])
+            {
+                for(fp = STUFF->st_soundin + chan * DEFDACBLKSIZE,
+                jp = in[chan] + n, j = 0;
+                    j < DEFDACBLKSIZE; j++)
                     *fp++ = *jp++;
-        }
-        for (chan = 0; chan < STUFF->st_outchannels; chan++)
+            }
+        for(chan = 0; chan < STUFF->st_outchannels; chan++)
         {
-            for (fp = STUFF->st_soundout + chan*DEFDACBLKSIZE,
-                j = 0; j < DEFDACBLKSIZE; j++)
-                    *fp++ = 0;
+            for(fp = STUFF->st_soundout + chan * DEFDACBLKSIZE, j = 0;
+                j < DEFDACBLKSIZE; j++)
+                *fp++ = 0;
         }
         (*jack_callback)();
-        for (chan = 0; chan < STUFF->st_outchannels; chan++)
-            if (out[chan])
-        {
-            for (fp = STUFF->st_soundout + chan*DEFDACBLKSIZE, jp = out[chan] + n,
-                j=0; j < DEFDACBLKSIZE; j++)
+        for(chan = 0; chan < STUFF->st_outchannels; chan++)
+            if(out[chan])
+            {
+                for(fp = STUFF->st_soundout + chan * DEFDACBLKSIZE,
+                jp = out[chan] + n, j = 0;
+                    j < DEFDACBLKSIZE; j++)
                     *jp++ = *fp++;
-        }
+            }
     }
     return 0;
 }
 
-static int
-jack_srate (jack_nframes_t srate, void *arg)
+static int jack_srate(jack_nframes_t srate, void *arg)
 {
     const t_float oldrate = STUFF->st_dacsr;
     STUFF->st_dacsr = srate;
-    if (oldrate != STUFF->st_dacsr)
-        canvas_update_dsp();
+    if(oldrate != STUFF->st_dacsr) canvas_update_dsp();
     return 0;
 }
 
-static int
-jack_bsize (jack_nframes_t bufsize, void *arg)
+static int jack_bsize(jack_nframes_t bufsize, void *arg)
 {
     jack_blocksize = bufsize;
     return 0;
@@ -177,91 +175,93 @@ jack_bsize (jack_nframes_t bufsize, void *arg)
 
 void glob_audio_setapi(void *dummy, t_floatarg f);
 
-static void
-jack_shutdown (void *arg)
+static void jack_shutdown(void *arg)
 {
-  pd_error(0, "JACK: server shut down");
+    pd_error(0, "JACK: server shut down");
 
-  jack_deactivate (jack_client);
-  jack_client = NULL;
-  jack_blocksize = 0;
+    jack_deactivate(jack_client);
+    jack_client = NULL;
+    jack_blocksize = 0;
 
-  glob_audio_setapi(NULL, API_NONE); // set pd_whichapi 0
+    glob_audio_setapi(NULL, API_NONE); // set pd_whichapi 0
 }
 
-static int jack_xrun(void* arg) {
-  jack_dio_error = 1;
-  return 0;
+static int jack_xrun(void *arg)
+{
+    jack_dio_error = 1;
+    return 0;
 }
 
-
-static char** jack_get_clients(void)
+static char **jack_get_clients(void)
 {
     const char **jack_ports;
-    int tmp_client_name_size = jack_client_name_size ? jack_client_name_size() : CLIENT_NAME_SIZE_FALLBACK;
-    char* tmp_client_name = (char*)getbytes(tmp_client_name_size);
-    int i,j;
+    int tmp_client_name_size = jack_client_name_size
+                                   ? jack_client_name_size()
+                                   : CLIENT_NAME_SIZE_FALLBACK;
+    char *tmp_client_name = (char *) getbytes(tmp_client_name_size);
+    int i, j;
     int num_clients = 0;
     regex_t port_regex;
-    jack_ports = jack_get_ports( jack_client, "", "", 0 );
-    regcomp( &port_regex, "^[^:]*", REG_EXTENDED );
+    jack_ports = jack_get_ports(jack_client, "", "", 0);
+    regcomp(&port_regex, "^[^:]*", REG_EXTENDED);
 
     jack_client_names[0] = NULL;
 
     /* Build a list of clients from the list of ports */
-    for( i = 0; jack_ports[i] != NULL; i++ )
+    for(i = 0; jack_ports[i] != NULL; i++)
     {
         int client_seen;
         regmatch_t match_info;
 
-        if(num_clients>=MAX_CLIENTS)break;
-
+        if(num_clients >= MAX_CLIENTS) break;
 
         /* extract the client name from the port name, using a regex
          * that parses the clientname:portname syntax */
-        regexec( &port_regex, jack_ports[i], 1, &match_info, 0 );
-        memcpy( tmp_client_name, &jack_ports[i][match_info.rm_so],
-                match_info.rm_eo - match_info.rm_so );
-        tmp_client_name[ match_info.rm_eo - match_info.rm_so ] = '\0';
+        regexec(&port_regex, jack_ports[i], 1, &match_info, 0);
+        memcpy(tmp_client_name, &jack_ports[i][match_info.rm_so],
+            match_info.rm_eo - match_info.rm_so);
+        tmp_client_name[match_info.rm_eo - match_info.rm_so] = '\0';
 
         /* do we know about this port's client yet? */
         client_seen = 0;
 
-        for( j = 0; j < num_clients; j++ )
-            if( strcmp( tmp_client_name, jack_client_names[j] ) == 0 )
+        for(j = 0; j < num_clients; j++)
+            if(strcmp(tmp_client_name, jack_client_names[j]) == 0)
                 client_seen = 1;
 
-        if( client_seen == 0 )
+        if(client_seen == 0)
         {
-            jack_client_names[num_clients] = (char*)getbytes(strlen(tmp_client_name) + 1);
+            jack_client_names[num_clients] =
+                (char *) getbytes(strlen(tmp_client_name) + 1);
 
             /* The alsa_pcm client should go in spot 0.  If this
              * is the alsa_pcm client AND we are NOT about to put
              * it in spot 0 put it in spot 0 and move whatever
              * was already in spot 0 to the end. */
 
-            if( strcmp( "alsa_pcm", tmp_client_name ) == 0 && num_clients > 0 )
+            if(strcmp("alsa_pcm", tmp_client_name) == 0 && num_clients > 0)
             {
-              char* tmp;
+                char *tmp;
                 /* alsa_pcm goes in spot 0 */
-              tmp = jack_client_names[ num_clients ];
-              jack_client_names[ num_clients ] = jack_client_names[0];
-              jack_client_names[0] = tmp;
-              strcpy( jack_client_names[0], tmp_client_name);
+                tmp = jack_client_names[num_clients];
+                jack_client_names[num_clients] = jack_client_names[0];
+                jack_client_names[0] = tmp;
+                strcpy(jack_client_names[0], tmp_client_name);
             }
             else
             {
                 /* put the new client at the end of the client list */
-                strcpy( jack_client_names[ num_clients ], tmp_client_name );
+                strcpy(jack_client_names[num_clients], tmp_client_name);
             }
             num_clients++;
         }
     }
 
-    /*    for (i=0;i<num_clients;i++) post("client: %s",jack_client_names[i]); */
+    /*    for (i=0;i<num_clients;i++) post("client: %s",jack_client_names[i]);
+     */
 
-    freebytes( tmp_client_name, tmp_client_name_size );
-    free( jack_ports );
+    freebytes(tmp_client_name, tmp_client_name_size);
+    free(jack_ports);
     return jack_client_names;
 }
 
@@ -270,46 +270,46 @@ static char** jack_get_clients(void)
  *
  */
 
-static int jack_connect_ports(char* client)
+static int jack_connect_ports(char *client)
 {
-    char  regex_pattern[100]; /* its always the same, ... */
+    char regex_pattern[100]; /* its always the same, ... */
     int i;
     const char **jack_ports;
 
-    if (strlen(client) > 96)  return -1;
+    if(strlen(client) > 96) return -1;
 
-    sprintf( regex_pattern, "%s:.*", client );
+    sprintf(regex_pattern, "%s:.*", client);
 
-    jack_ports = jack_get_ports( jack_client, regex_pattern,
-                                 NULL, JackPortIsOutput);
-    if (jack_ports)
+    jack_ports =
+        jack_get_ports(jack_client, regex_pattern, NULL, JackPortIsOutput);
+    if(jack_ports)
     {
-        for (i=0;jack_ports[i] != NULL && i < STUFF->st_inchannels;i++)
-            if (jack_connect (jack_client, jack_ports[i],
-               jack_port_name (input_port[i])))
-                  pd_error(0, "JACK: cannot connect input ports %s -> %s",
-                      jack_ports[i],jack_port_name (input_port[i]));
+        for(i = 0; jack_ports[i] != NULL && i < STUFF->st_inchannels; i++)
+            if(jack_connect(
+                   jack_client, jack_ports[i], jack_port_name(input_port[i])))
+                pd_error(0, "JACK: cannot connect input ports %s -> %s",
+                    jack_ports[i], jack_port_name(input_port[i]));
         free(jack_ports);
     }
-    jack_ports = jack_get_ports( jack_client, regex_pattern,
-                                 NULL, JackPortIsInput);
-    if (jack_ports)
+    jack_ports =
+        jack_get_ports(jack_client, regex_pattern, NULL, JackPortIsInput);
+    if(jack_ports)
     {
-        for (i=0;jack_ports[i] != NULL && i < STUFF->st_outchannels;i++)
-          if (jack_connect (jack_client, jack_port_name (output_port[i]),
-            jack_ports[i]))
-              pd_error(0,  "JACK: cannot connect output ports %s -> %s",
-                jack_port_name (output_port[i]),jack_ports[i]);
+        for(i = 0; jack_ports[i] != NULL && i < STUFF->st_outchannels; i++)
+            if(jack_connect(
+                   jack_client, jack_port_name(output_port[i]), jack_ports[i]))
+                pd_error(0, "JACK: cannot connect output ports %s -> %s",
+                    jack_port_name(output_port[i]), jack_ports[i]);
 
         free(jack_ports);
     }
     return 0;
 }
 
-
-static void pd_jack_error_callback(const char *desc) {
-  pd_error(0, "JACKerror: %s", desc);
-  return;
+static void pd_jack_error_callback(const char *desc)
+{
+    pd_error(0, "JACKerror: %s", desc);
+    return;
 }
 
 int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
@@ -321,25 +321,26 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     int client_iterator = 0;
     jack_status_t status;
 
-    if (!jack_client_open)
+    if(!jack_client_open)
     {
         pd_error(0, "Can't open Jack (it seems not to be installed)");
         return 1;
     }
-    if (jack_client)
-        jack_close_audio();
+    if(jack_client) jack_close_audio();
 
     jack_dio_error = 0;
 
-    if ((inchans == 0) && (outchans == 0)) return 0;
+    if((inchans == 0) && (outchans == 0)) return 0;
 
-    if (outchans > MAX_JACK_PORTS) {
+    if(outchans > MAX_JACK_PORTS)
+    {
         pd_error(0, "JACK: %d output ports not supported, setting to %d",
             outchans, MAX_JACK_PORTS);
         outchans = MAX_JACK_PORTS;
     }
 
-    if (inchans > MAX_JACK_PORTS) {
+    if(inchans > MAX_JACK_PORTS)
+    {
         pd_error(0, "JACK: %d input ports not supported, setting to %d",
             inchans, MAX_JACK_PORTS);
         inchans = MAX_JACK_PORTS;
@@ -349,19 +350,20 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
         jack_client_open() will start uone up by default.  It's not clear
         whether or not this is desirable; see long Pd list thread started by
         yvan volochine, June 2013) */
-    if (!desired_client_name || !strlen(desired_client_name))
+    if(!desired_client_name || !strlen(desired_client_name))
         jack_client_name("pure_data");
-    jack_client = jack_client_open (desired_client_name, JackNoStartServer,
-      &status, NULL);
-    if (status & JackFailure) {
+    jack_client =
+        jack_client_open(desired_client_name, JackNoStartServer, &status, NULL);
+    if(status & JackFailure)
+    {
         pd_error(0, "JACK: couldn't connect to server, is JACK running?");
         logpost(NULL, PD_VERBOSE, "JACK: returned status is: %d", status);
-        jack_client=NULL;
+        jack_client = NULL;
         /* jack spits out enough messages already, do not warn */
         STUFF->st_inchannels = STUFF->st_outchannels = 0;
         return 1;
     }
-    if (status & JackNameNotUnique)
+    if(status & JackNameNotUnique)
         jack_client_name(jack_get_client_name(jack_client));
     logpost(NULL, PD_VERBOSE, "JACK: registered as '%s'", desired_client_name);
 
@@ -373,119 +375,123 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     /* set JACK callback functions */
 
     jack_callback = callback;
-    jack_set_process_callback(jack_client,
-        (callback? callbackprocess : jack_polling_callback), 0);
+    jack_set_process_callback(
+        jack_client, (callback ? callbackprocess : jack_polling_callback), 0);
 
-    jack_set_error_function (pd_jack_error_callback);
+    jack_set_error_function(pd_jack_error_callback);
 
 #ifdef JACK_XRUN
-    jack_set_xrun_callback (jack_client, jack_xrun, NULL);
+    jack_set_xrun_callback(jack_client, jack_xrun, NULL);
 #endif
 
     /* tell the JACK server to call `jack_srate()' whenever
        the sample rate of the system changes.
     */
 
-    jack_set_sample_rate_callback (jack_client, jack_srate, 0);
+    jack_set_sample_rate_callback(jack_client, jack_srate, 0);
 
     /* tell the JACK server to call `jack_bsize()' whenever
        the buffer size of the system changes.
     */
 
-    jack_set_buffer_size_callback (jack_client, jack_bsize, 0);
+    jack_set_buffer_size_callback(jack_client, jack_bsize, 0);
 
     /* tell the JACK server to call `jack_shutdown()' if
        it ever shuts down, either entirely, or if it
        just decides to stop calling us.
     */
 
-    jack_on_shutdown (jack_client, jack_shutdown, 0);
+    jack_on_shutdown(jack_client, jack_shutdown, 0);
 
-    for (j=0; j<STUFF->st_inchannels; j++)
-         input_port[j]=NULL;
-    for (j=0; j<STUFF->st_outchannels; j++)
-         output_port[j] = NULL;
+    for(j = 0; j < STUFF->st_inchannels; j++)
+        input_port[j] = NULL;
+    for(j = 0; j < STUFF->st_outchannels; j++)
+        output_port[j] = NULL;
 
-    /* display the current sample rate & block size. once the client is activated
-       (see below), you should rely on your own sample rate
-       callback (see above) for this value.
+    /* display the current sample rate & block size. once the client is
+       activated (see below), you should rely on your own sample rate callback
+       (see above) for this value.
     */
 
-    STUFF->st_dacsr = jack_get_sample_rate (jack_client);
-    jack_blocksize = jack_get_buffer_size (jack_client);
-    advance_samples = sys_schedadvance * (double)STUFF->st_dacsr / 1.e6;
+    STUFF->st_dacsr = jack_get_sample_rate(jack_client);
+    jack_blocksize = jack_get_buffer_size(jack_client);
+    advance_samples = sys_schedadvance * (double) STUFF->st_dacsr / 1.e6;
     advance_samples -= (advance_samples % DEFDACBLKSIZE);
-        /* make sure that the delay is not smaller than the Jack blocksize! */
-    if (advance_samples < jack_blocksize)
+    /* make sure that the delay is not smaller than the Jack blocksize! */
+    if(advance_samples < jack_blocksize)
     {
-        int delay = ((double)sys_schedadvance / 1000.) + 0.5;
-        int limit = ceil(jack_blocksize * 1000. / (double)STUFF->st_dacsr);
+        int delay = ((double) sys_schedadvance / 1000.) + 0.5;
+        int limit = ceil(jack_blocksize * 1000. / (double) STUFF->st_dacsr);
         advance_samples = jack_blocksize;
         post("warning: 'delay' setting (%d ms) too small for current blocksize "
              "(%d samples); falling back to minimum value (%d ms)",
-             delay, jack_blocksize, limit);
+            delay, jack_blocksize, limit);
     }
 
     /* create the ports */
 
-    for (j = 0; j < inchans; j++)
+    for(j = 0; j < inchans; j++)
     {
-        sprintf(port_name, "input_%d", j+1);
-        if (!input_port[j]) input_port[j] = jack_port_register (jack_client,
-            port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
-        if (!input_port[j])
+        sprintf(port_name, "input_%d", j + 1);
+        if(!input_port[j])
+            input_port[j] = jack_port_register(jack_client, port_name,
+                JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+        if(!input_port[j])
         {
-          pd_error(0, "JACK: can only register %d input ports (of %d requested)",
-            j, inchans);
-          STUFF->st_inchannels = inchans = j;
-          break;
+            pd_error(0,
+                "JACK: can only register %d input ports (of %d requested)", j,
+                inchans);
+            STUFF->st_inchannels = inchans = j;
+            break;
         }
     }
 
-    for (j = 0; j < outchans; j++)
+    for(j = 0; j < outchans; j++)
     {
-        sprintf(port_name, "output_%d", j+1);
-        if (!output_port[j]) output_port[j] = jack_port_register (jack_client,
-            port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-        if (!output_port[j])
+        sprintf(port_name, "output_%d", j + 1);
+        if(!output_port[j])
+            output_port[j] = jack_port_register(jack_client, port_name,
+                JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+        if(!output_port[j])
         {
-          pd_error(0, "JACK: can only register %d output ports (of %d requested)",
-            j, outchans);
-          STUFF->st_outchannels = outchans = j;
-          break;
+            pd_error(0,
+                "JACK: can only register %d output ports (of %d requested)", j,
+                outchans);
+            STUFF->st_outchannels = outchans = j;
+            break;
         }
     }
 
-        /* create ring buffers (if not callback) */
+    /* create ring buffers (if not callback) */
 
-    if (!callback && STUFF->st_inchannels)
+    if(!callback && STUFF->st_inchannels)
     {
-        jack_inbuf = malloc(sizeof(t_sample) * STUFF->st_inchannels
-            * advance_samples);
+        jack_inbuf =
+            malloc(sizeof(t_sample) * STUFF->st_inchannels * advance_samples);
         sys_ringbuf_init(&jack_inring,
             sizeof(t_sample) * STUFF->st_inchannels * advance_samples,
-                jack_inbuf,
-                    sizeof(t_sample) * STUFF->st_inchannels * advance_samples);
+            jack_inbuf,
+            sizeof(t_sample) * STUFF->st_inchannels * advance_samples);
     }
-    if (!callback && STUFF->st_outchannels)
+    if(!callback && STUFF->st_outchannels)
     {
-        jack_outbuf = malloc(sizeof(t_sample) * STUFF->st_outchannels
-             * advance_samples);
+        jack_outbuf =
+            malloc(sizeof(t_sample) * STUFF->st_outchannels * advance_samples);
         sys_ringbuf_init(&jack_outring,
             sizeof(t_sample) * STUFF->st_outchannels * advance_samples,
-                jack_outbuf, 0);
+            jack_outbuf, 0);
     }
 
     /* tell the JACK server that we are ready to roll */
 
-    if (jack_activate (jack_client))
+    if(jack_activate(jack_client))
     {
         pd_error(0, "cannot activate client");
         STUFF->st_inchannels = STUFF->st_outchannels = 0;
         return 1;
     }
 
-    if (jack_client_names[0] && jack_should_autoconnect)
+    if(jack_client_names[0] && jack_should_autoconnect)
         jack_connect_ports(jack_client_names[0]);
 
     pthread_mutex_init(&jack_mutex, NULL);
@@ -496,22 +502,21 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
 
 void jack_close_audio(void)
 {
-    if (jack_client){
-        jack_deactivate (jack_client);
+    if(jack_client)
+    {
+        jack_deactivate(jack_client);
         jack_client_close(jack_client);
         jack_client = 0;
     }
-    if (jack_inbuf)
-        free(jack_inbuf), jack_inbuf = 0;
-    if (jack_outbuf)
-        free(jack_outbuf), jack_outbuf = 0;
+    if(jack_inbuf) free(jack_inbuf), jack_inbuf = 0;
+    if(jack_outbuf) free(jack_outbuf), jack_outbuf = 0;
 
     jack_started = 0;
     jack_blocksize = 0;
 
-        /* this should never be necessary since jack_close_audio() should
-        only be called form the main thread.  Still, it doesn't hurt
-        anything. */
+    /* this should never be necessary since jack_close_audio() should
+    only be called form the main thread.  Still, it doesn't hurt
+    anything. */
     pthread_cond_broadcast(&jack_sem);
 
     pthread_cond_destroy(&jack_sem);
@@ -525,79 +530,80 @@ int jack_send_dacs(void)
     t_sample *fp, *fp2, *jp;
     int j, ch;
     double timenow, timeref = sys_getrealtime();
-    if (!STUFF->st_inchannels && !STUFF->st_outchannels) return (SENDDACS_NO);
+    if(!STUFF->st_inchannels && !STUFF->st_outchannels) return (SENDDACS_NO);
 
 #ifdef TESTCANSLEEP
     pthread_mutex_lock(&jack_mutex);
-    while (jack_client &&
+    while(
+        jack_client &&
         (sys_ringbuf_getreadavailable(&jack_inring) <
-            (long)(STUFF->st_inchannels * DEFDACBLKSIZE*sizeof(t_sample))) &&
+            (long) (STUFF->st_inchannels * DEFDACBLKSIZE * sizeof(t_sample))) &&
         (sys_ringbuf_getwriteavailable(&jack_outring) <
-            (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(t_sample))))
-                pthread_cond_wait(&jack_sem,&jack_mutex);
+            (long) (STUFF->st_outchannels * DEFDACBLKSIZE * sizeof(t_sample))))
+        pthread_cond_wait(&jack_sem, &jack_mutex);
     pthread_mutex_unlock(&jack_mutex);
-    if (!jack_client)
-        return SENDDACS_NO;
+    if(!jack_client) return SENDDACS_NO;
 #else
-    if (!jack_client ||
+    if(!jack_client ||
         (sys_ringbuf_getreadavailable(&jack_inring) <
-            (long)(STUFF->st_inchannels * DEFDACBLKSIZE*sizeof(t_sample))) ||
+            (long) (STUFF->st_inchannels * DEFDACBLKSIZE * sizeof(t_sample))) ||
         (sys_ringbuf_getwriteavailable(&jack_outring) <
-            (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(t_sample))))
-                return (SENDDACS_NO);
+            (long) (STUFF->st_outchannels * DEFDACBLKSIZE * sizeof(t_sample))))
+        return (SENDDACS_NO);
 #endif
-    if (jack_dio_error)
+    if(jack_dio_error)
     {
         sys_log_error(ERR_RESYNC);
         jack_dio_error = 0;
     }
     jack_started = 1;
 
-    muxbuffer =  (t_sample *)alloca(sizeof (t_sample) * DEFDACBLKSIZE *
-        (STUFF->st_inchannels > STUFF->st_outchannels ?
-            STUFF->st_inchannels : STUFF->st_outchannels));
-    if (STUFF->st_inchannels)
+    muxbuffer = (t_sample *) alloca(
+        sizeof(t_sample) * DEFDACBLKSIZE *
+        (STUFF->st_inchannels > STUFF->st_outchannels ? STUFF->st_inchannels
+                                                      : STUFF->st_outchannels));
+    if(STUFF->st_inchannels)
     {
         sys_ringbuf_read(&jack_inring, muxbuffer,
             DEFDACBLKSIZE * STUFF->st_inchannels * sizeof(t_sample),
-                jack_inbuf);
-        for (fp = muxbuffer, ch = 0; ch < STUFF->st_inchannels; ch++, fp++)
+            jack_inbuf);
+        for(fp = muxbuffer, ch = 0; ch < STUFF->st_inchannels; ch++, fp++)
         {
             jp = STUFF->st_soundin + ch * DEFDACBLKSIZE;
-            for (j = 0, fp2 = fp; j < DEFDACBLKSIZE;
+            for(j = 0, fp2 = fp; j < DEFDACBLKSIZE;
                 j++, fp2 += STUFF->st_inchannels)
-                    jp[j] = *fp2;
+                jp[j] = *fp2;
         }
     }
-    if (STUFF->st_outchannels)
+    if(STUFF->st_outchannels)
     {
-        for (fp = muxbuffer, ch = 0; ch < STUFF->st_outchannels; ch++, fp++)
+        for(fp = muxbuffer, ch = 0; ch < STUFF->st_outchannels; ch++, fp++)
         {
             jp = STUFF->st_soundout + ch * DEFDACBLKSIZE;
-            for (j = 0, fp2 = fp; j < DEFDACBLKSIZE;
+            for(j = 0, fp2 = fp; j < DEFDACBLKSIZE;
                 j++, fp2 += STUFF->st_outchannels)
-                    *fp2 = jp[j];
+                *fp2 = jp[j];
         }
         sys_ringbuf_write(&jack_outring, muxbuffer,
             DEFDACBLKSIZE * STUFF->st_outchannels * sizeof(t_sample),
-                jack_outbuf);
+            jack_outbuf);
     }
     memset(STUFF->st_soundout, 0,
-        DEFDACBLKSIZE*sizeof(t_sample) * STUFF->st_outchannels);
-            /* fprintf(stderr, "%g ", sys_getrealtime() - timeref); */
-    if ((timenow = sys_getrealtime()) - timeref > 0.0002)
+        DEFDACBLKSIZE * sizeof(t_sample) * STUFF->st_outchannels);
+    /* fprintf(stderr, "%g ", sys_getrealtime() - timeref); */
+    if((timenow = sys_getrealtime()) - timeref > 0.0002)
         return (SENDDACS_SLEPT);
-    else return (SENDDACS_YES);
+    else
+        return (SENDDACS_YES);
 }
 
-void jack_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize)
+void jack_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
     int i, ndev;
-    *canmulti = 0;  /* supports multiple devices */
+    *canmulti = 0; /* supports multiple devices */
     ndev = 1;
-    for (i = 0; i < ndev; i++)
+    for(i = 0; i < ndev; i++)
     {
         sprintf(indevlist + i * devdescsize, "JACK");
         sprintf(outdevlist + i * devdescsize, "JACK");
@@ -610,26 +616,22 @@ void jack_listdevs(void)
     post("device listing not implemented for jack yet\n");
 }
 
-void jack_autoconnect(int v)
-{
-    jack_should_autoconnect = v;
-}
+void jack_autoconnect(int v) { jack_should_autoconnect = v; }
 
 void jack_client_name(const char *name)
 {
-    if (desired_client_name) {
+    if(desired_client_name)
+    {
         free(desired_client_name);
         desired_client_name = NULL;
     }
-    if (name) {
-        desired_client_name = (char*)getbytes(strlen(name) + 1);
+    if(name)
+    {
+        desired_client_name = (char *) getbytes(strlen(name) + 1);
         strcpy(desired_client_name, name);
     }
 }
 
-int jack_get_blocksize(void)
-{
-    return jack_blocksize;
-}
+int jack_get_blocksize(void) { return jack_blocksize; }
 
 #endif /* JACK */

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -208,7 +208,7 @@ static char **jack_get_clients(void)
     jack_client_names[0] = NULL;
 
     /* Build a list of clients from the list of ports */
-    for(i = 0; jack_ports[i] != NULL; i++)
+    for(int i = 0; jack_ports[i] != NULL; i++)
     {
         int client_seen;
         regmatch_t match_info;
@@ -273,8 +273,7 @@ static char **jack_get_clients(void)
 static int jack_connect_ports(char *client)
 {
     char regex_pattern[100]; /* its always the same, ... */
-    int i;
-    const char **jack_ports;
+    zconst char **jack_ports;
 
     if(strlen(client) > 96) return -1;
 
@@ -284,7 +283,7 @@ static int jack_connect_ports(char *client)
         jack_get_ports(jack_client, regex_pattern, NULL, JackPortIsOutput);
     if(jack_ports)
     {
-        for(i = 0; jack_ports[i] != NULL && i < STUFF->st_inchannels; i++)
+        for(int i = 0; jack_ports[i] != NULL && i < STUFF->st_inchannels; i++)
             if(jack_connect(
                    jack_client, jack_ports[i], jack_port_name(input_port[i])))
                 pd_error(0, "JACK: cannot connect input ports %s -> %s",
@@ -295,7 +294,7 @@ static int jack_connect_ports(char *client)
         jack_get_ports(jack_client, regex_pattern, NULL, JackPortIsInput);
     if(jack_ports)
     {
-        for(i = 0; jack_ports[i] != NULL && i < STUFF->st_outchannels; i++)
+        for(int i = 0; jack_ports[i] != NULL && i < STUFF->st_outchannels; i++)
             if(jack_connect(
                    jack_client, jack_port_name(output_port[i]), jack_ports[i]))
                 pd_error(0, "JACK: cannot connect output ports %s -> %s",
@@ -600,10 +599,10 @@ int jack_send_dacs(void)
 void jack_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
-    int i, ndev;
+    int ndev;
     *canmulti = 0; /* supports multiple devices */
     ndev = 1;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
     {
         sprintf(indevlist + i * devdescsize, "JACK");
         sprintf(outdevlist + i * devdescsize, "JACK");

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -73,7 +73,9 @@ static void mmio_allocbufs(
     t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs, int blocksize, int setdone)
 {
     short *sp;
-    int i, devno, bufno;
+    int i;
+    int devno;
+    int bufno;
     for(devno = 0; devno < ndevs; devno++)
         for(bufno = 0; bufno < nbufs; bufno++)
         {
@@ -124,7 +126,9 @@ static void mmio_allocbufs(
 static void mmio_freebufs(t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs)
 {
     short *sp;
-    int i, devno, bufno;
+    int i;
+    int devno;
+    int bufno;
     for(devno = 0; devno < ndevs; devno++)
         for(bufno = 0; bufno < nbufs; bufno++)
         {
@@ -145,9 +149,11 @@ static UINT nt_whichdac = WAVE_MAPPER, nt_whichadc = WAVE_MAPPER;
 int mmio_do_open_audio(void)
 {
     PCMWAVEFORMAT form;
-    int i, j;
+    int i;
+    int j;
     UINT mmresult;
-    int nad, nda;
+    int nad;
+    int nda;
     logpost(NULL, PD_VERBOSE, "%d devices in, %d devices out", nt_nwavein,
         nt_nwaveout);
 
@@ -224,7 +230,8 @@ int mmio_do_open_audio(void)
 void mmio_close_audio(void)
 {
     int errcode;
-    int nda, nad;
+    int nda;
+    int nad;
     logpost(NULL, PD_VERBOSE, "closing audio...");
 
     for(nda = 0; nda < nt_nwaveout; nda++) /*if (nt_nwaveout) wini */
@@ -403,7 +410,9 @@ static void nt_noresync(void) { nt_resync_cancelled = 1; }
 static void nt_resyncaudio(void)
 {
     UINT mmresult;
-    int nad, nda, count;
+    int nad;
+    int nda;
+    int count;
     if(nt_resync_cancelled) return;
     /* for each open input device, eat all buffers which are marked
         ready.  The next one will thus be "busy".  */
@@ -490,16 +499,22 @@ int mmio_send_dacs(void)
     HMMIO hmmio;
     UINT mmresult;
     HANDLE hFormat;
-    int i, j;
-    short *sp1, *sp2;
-    t_sample *fp1, *fp2;
-    int nextfill, doxfer = 0;
-    int nda, nad;
+    int i;
+    int j;
+    short *sp1;
+    short *sp2;
+    t_sample *fp1;
+    t_sample *fp2;
+    int nextfill;
+    int doxfer = 0;
+    int nda;
+    int nad;
     if(!nt_nwavein && !nt_nwaveout) return (0);
 
     if(nt_meters)
     {
-        int i, n;
+        int i;
+        int n;
         t_sample maxsamp;
         for(i = 0, n = 2 * nt_nwavein * DEFDACBLKSIZE, maxsamp = nt_inmax;
             i < n; i++)
@@ -762,7 +777,9 @@ void mmio_listdevs(void)
 void mmio_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
-    int wRtn, ndev, i;
+    int wRtn;
+    int ndev;
+    int i;
     char utf8device[MAXPDSTRING];
 
     *canmulti = 2; /* supports multiple devices */

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* modified 2/98 by Winfried Ritsch to deal with up to 4 synchronized
 "wave" devices, which is how ADAT boards appear to the WAVE API. */
@@ -21,39 +21,39 @@ static void nt_noresync(void);
 
 static void postflags(void);
 
-#define NAPORTS 16   /* wini hack for multiple ADDA devices  */
+#define NAPORTS 16 /* wini hack for multiple ADDA devices  */
 #define CHANNELS_PER_DEVICE 2
 #define DEFAULTCHANS 2
 #define SAMPSIZE 2
 
 #define DEFREALDACBLKSIZE (4 * DEFDACBLKSIZE) /* larger underlying bufsize */
 
-#define MAXBUFFER 100   /* number of buffers in use at maximum advance */
-#define DEFBUFFER 30    /* default is about 30x6 = 180 msec! */
+#define MAXBUFFER 100 /* number of buffers in use at maximum advance */
+#define DEFBUFFER 30  /* default is about 30x6 = 180 msec! */
 static int nt_naudiobuffer = DEFBUFFER;
 
 static int nt_whichapi = API_MMIO;
-static int nt_meters;        /* true if we're metering */
-static t_sample nt_inmax;       /* max input amplitude */
-static t_sample nt_outmax;      /* max output amplitude */
-static int nt_nwavein, nt_nwaveout;     /* number of WAVE devices in and out */
+static int nt_meters;               /* true if we're metering */
+static t_sample nt_inmax;           /* max input amplitude */
+static t_sample nt_outmax;          /* max output amplitude */
+static int nt_nwavein, nt_nwaveout; /* number of WAVE devices in and out */
 int nt_blocksize;
 
 typedef struct _sbuf
 {
     HANDLE hData;
-    HPSTR  lpData;      // pointer to waveform data memory
+    HPSTR lpData; // pointer to waveform data memory
     HANDLE hWaveHdr;
-    WAVEHDR   *lpWaveHdr;   // pointer to header structure
+    WAVEHDR *lpWaveHdr; // pointer to header structure
 } t_sbuf;
 
-t_sbuf ntsnd_outvec[NAPORTS][MAXBUFFER];    /* circular buffer array */
-HWAVEOUT ntsnd_outdev[NAPORTS];             /* output device */
-static int ntsnd_outphase[NAPORTS];         /* index of next buffer to send */
+t_sbuf ntsnd_outvec[NAPORTS][MAXBUFFER]; /* circular buffer array */
+HWAVEOUT ntsnd_outdev[NAPORTS];          /* output device */
+static int ntsnd_outphase[NAPORTS];      /* index of next buffer to send */
 
-t_sbuf ntsnd_invec[NAPORTS][MAXBUFFER];     /* circular buffer array */
-HWAVEIN ntsnd_indev[NAPORTS];               /* input device */
-static int ntsnd_inphase[NAPORTS];          /* index of next buffer to read */
+t_sbuf ntsnd_invec[NAPORTS][MAXBUFFER]; /* circular buffer array */
+HWAVEIN ntsnd_indev[NAPORTS];           /* input device */
+static int ntsnd_inphase[NAPORTS];      /* index of next buffer to read */
 
 static void nt_waveinerror(char *s, int err)
 {
@@ -69,152 +69,151 @@ static void nt_waveouterror(char *s, int err)
     fprintf(stderr, s, t);
 }
 
-static void mmio_allocbufs(t_sbuf bp[][MAXBUFFER],
-    int ndevs, int nbufs, int blocksize, int setdone)
+static void mmio_allocbufs(
+    t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs, int blocksize, int setdone)
 {
     short *sp;
     int i, devno, bufno;
-    for (devno = 0; devno < ndevs; devno++)
-        for (bufno = 0; bufno < nbufs; bufno++)
-    {
-        WAVEHDR *wh;
+    for(devno = 0; devno < ndevs; devno++)
+        for(bufno = 0; bufno < nbufs; bufno++)
+        {
+            WAVEHDR *wh;
 
-        /*
-         * Allocate and lock memory for the waveform data. The memory
-         * for waveform data must be globally allocated with
-         * GMEM_MOVEABLE and GMEM_SHARE flags.
-         */
+            /*
+             * Allocate and lock memory for the waveform data. The memory
+             * for waveform data must be globally allocated with
+             * GMEM_MOVEABLE and GMEM_SHARE flags.
+             */
 
-        if (!(bp[devno][bufno].hData =
-            GlobalAlloc(GMEM_MOVEABLE | GMEM_SHARE,
-                (DWORD) (CHANNELS_PER_DEVICE * SAMPSIZE * blocksize))))
-                    fprintf(stderr, "alloc 1 failed\n");
+            if(!(bp[devno][bufno].hData = GlobalAlloc(
+                     GMEM_MOVEABLE | GMEM_SHARE,
+                     (DWORD) (CHANNELS_PER_DEVICE * SAMPSIZE * blocksize))))
+                fprintf(stderr, "alloc 1 failed\n");
 
-        if (!(bp[devno][bufno].lpData =
-            (HPSTR) GlobalLock(bp[devno][bufno].hData)))
+            if(!(bp[devno][bufno].lpData =
+                       (HPSTR) GlobalLock(bp[devno][bufno].hData)))
                 printf("lock 1 failed\n");
 
-        /*  Allocate and lock memory for the header.  */
+            /*  Allocate and lock memory for the header.  */
 
-        if (!(bp[devno][bufno].hWaveHdr =
-            GlobalAlloc(GMEM_MOVEABLE | GMEM_SHARE, (DWORD) sizeof(WAVEHDR))))
+            if(!(bp[devno][bufno].hWaveHdr = GlobalAlloc(
+                     GMEM_MOVEABLE | GMEM_SHARE, (DWORD) sizeof(WAVEHDR))))
                 printf("alloc 2 failed\n");
 
-        if (!(wh = bp[devno][bufno].lpWaveHdr =
-            (WAVEHDR *) GlobalLock(bp[devno][bufno].hWaveHdr)))
+            if(!(wh = bp[devno][bufno].lpWaveHdr =
+                       (WAVEHDR *) GlobalLock(bp[devno][bufno].hWaveHdr)))
                 printf("lock 2 failed\n");
 
-        for (i = CHANNELS_PER_DEVICE * blocksize,
-            sp = (short *)bp[devno][bufno].lpData; i--; )
+            for(i = CHANNELS_PER_DEVICE * blocksize,
+            sp = (short *) bp[devno][bufno].lpData;
+                i--;)
                 *sp++ = 0;
 
-        wh->lpData = bp[devno][bufno].lpData;
-        wh->dwBufferLength =
-            (CHANNELS_PER_DEVICE * SAMPSIZE * blocksize);
-        wh->dwFlags = 0;
-        wh->dwLoops = 0L;
-        wh->lpNext = 0;
-        wh->reserved = 0;
-            /* optionally (for writing) set DONE flag as if we had queued them */
-        if (setdone)
-            wh->dwFlags = WHDR_DONE;
-    }
+            wh->lpData = bp[devno][bufno].lpData;
+            wh->dwBufferLength = (CHANNELS_PER_DEVICE * SAMPSIZE * blocksize);
+            wh->dwFlags = 0;
+            wh->dwLoops = 0L;
+            wh->lpNext = 0;
+            wh->reserved = 0;
+            /* optionally (for writing) set DONE flag as if we had queued them
+             */
+            if(setdone) wh->dwFlags = WHDR_DONE;
+        }
 }
 
-static void mmio_freebufs(t_sbuf bp[][MAXBUFFER],
-    int ndevs, int nbufs)
+static void mmio_freebufs(t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs)
 {
     short *sp;
     int i, devno, bufno;
-    for (devno = 0; devno < ndevs; devno++)
-        for (bufno = 0; bufno < nbufs; bufno++)
-    {
-        /* unlock and free memory for the waveform data.  */
+    for(devno = 0; devno < ndevs; devno++)
+        for(bufno = 0; bufno < nbufs; bufno++)
+        {
+            /* unlock and free memory for the waveform data.  */
 
-        GlobalUnlock(bp[devno][bufno].lpData);
-        GlobalFree(bp[devno][bufno].hData);
+            GlobalUnlock(bp[devno][bufno].lpData);
+            GlobalFree(bp[devno][bufno].hData);
 
-        /*  unlock and free memory for the header.  */
+            /*  unlock and free memory for the header.  */
 
-        GlobalUnlock(bp[devno][bufno].lpWaveHdr);
-        GlobalFree(bp[devno][bufno].hWaveHdr);
-    }
+            GlobalUnlock(bp[devno][bufno].lpWaveHdr);
+            GlobalFree(bp[devno][bufno].hWaveHdr);
+        }
 }
 
 static UINT nt_whichdac = WAVE_MAPPER, nt_whichadc = WAVE_MAPPER;
 
 int mmio_do_open_audio(void)
 {
-    PCMWAVEFORMAT  form;
+    PCMWAVEFORMAT form;
     int i, j;
     UINT mmresult;
     int nad, nda;
-    logpost(NULL, PD_VERBOSE, "%d devices in, %d devices out",
-            nt_nwavein, nt_nwaveout);
+    logpost(NULL, PD_VERBOSE, "%d devices in, %d devices out", nt_nwavein,
+        nt_nwaveout);
 
     form.wf.wFormatTag = WAVE_FORMAT_PCM;
     form.wf.nChannels = CHANNELS_PER_DEVICE;
     form.wf.nSamplesPerSec = STUFF->st_dacsr;
-    form.wf.nAvgBytesPerSec = STUFF->st_dacsr * (CHANNELS_PER_DEVICE * SAMPSIZE);
+    form.wf.nAvgBytesPerSec =
+        STUFF->st_dacsr * (CHANNELS_PER_DEVICE * SAMPSIZE);
     form.wf.nBlockAlign = CHANNELS_PER_DEVICE * SAMPSIZE;
     form.wBitsPerSample = 8 * SAMPSIZE;
 
-    if (nt_nwavein <= 1 && nt_nwaveout <= 1)
-        nt_noresync();
+    if(nt_nwavein <= 1 && nt_nwaveout <= 1) nt_noresync();
 
     mmio_allocbufs(ntsnd_invec, nt_nwavein, nt_naudiobuffer, nt_blocksize, 0);
     mmio_allocbufs(ntsnd_outvec, nt_nwaveout, nt_naudiobuffer, nt_blocksize, 1);
 
-    for (nad = 0; nad < nt_nwavein; nad++)
+    for(nad = 0; nad < nt_nwavein; nad++)
     {
         /* Open waveform device(s), successively numbered, for input */
 
-        mmresult = waveInOpen(&ntsnd_indev[nad], nt_whichadc+nad,
-                (WAVEFORMATEX *)(&form), 0L, 0L, CALLBACK_NULL);
+        mmresult = waveInOpen(&ntsnd_indev[nad], nt_whichadc + nad,
+            (WAVEFORMATEX *) (&form), 0L, 0L, CALLBACK_NULL);
 
-        if (sys_verbose)
+        if(sys_verbose)
             fprintf(stderr, "opened adc device %d with return %d\n",
-                nt_whichadc+nad,mmresult);
+                nt_whichadc + nad, mmresult);
 
-        if (mmresult != MMSYSERR_NOERROR)
+        if(mmresult != MMSYSERR_NOERROR)
         {
             nt_waveinerror("waveInOpen: %s\n", mmresult);
             nt_nwavein = nad; /* nt_nwavein = 0 wini */
         }
         else
         {
-            for (i = 0; i < nt_naudiobuffer; i++)
+            for(i = 0; i < nt_naudiobuffer; i++)
             {
                 mmresult = waveInPrepareHeader(ntsnd_indev[nad],
                     ntsnd_invec[nad][i].lpWaveHdr, sizeof(WAVEHDR));
-                if (mmresult != MMSYSERR_NOERROR)
+                if(mmresult != MMSYSERR_NOERROR)
                     nt_waveinerror("waveinprepareheader: %s\n", mmresult);
                 mmresult = waveInAddBuffer(ntsnd_indev[nad],
                     ntsnd_invec[nad][i].lpWaveHdr, sizeof(WAVEHDR));
-                if (mmresult != MMSYSERR_NOERROR)
+                if(mmresult != MMSYSERR_NOERROR)
                     nt_waveinerror("waveInAddBuffer: %s\n", mmresult);
             }
         }
     }
-        /* quickly start them all together */
-    for (nad = 0; nad < nt_nwavein; nad++)
+    /* quickly start them all together */
+    for(nad = 0; nad < nt_nwavein; nad++)
         waveInStart(ntsnd_indev[nad]);
 
-    for (nda = 0; nda < nt_nwaveout; nda++)
+    for(nda = 0; nda < nt_nwaveout; nda++)
     {
         /* Open waveform device(s), successively numbered, for output */
 
         mmresult = waveOutOpen(&ntsnd_outdev[nda], nt_whichdac + nda,
-            (WAVEFORMATEX *)(&form), 0L, 0L, CALLBACK_NULL);
+            (WAVEFORMATEX *) (&form), 0L, 0L, CALLBACK_NULL);
 
-        if (sys_verbose)
-            fprintf(stderr,"opened dac device %d, with return %d\n",
-                nt_whichdac +nda, mmresult);
+        if(sys_verbose)
+            fprintf(stderr, "opened dac device %d, with return %d\n",
+                nt_whichdac + nda, mmresult);
 
-        if (mmresult != MMSYSERR_NOERROR)
+        if(mmresult != MMSYSERR_NOERROR)
         {
-            fprintf(stderr,"Wave out open device %d + %d\n",nt_whichdac,nda);
-            nt_waveouterror("waveOutOpen device: %s\n",  mmresult);
+            fprintf(stderr, "Wave out open device %d + %d\n", nt_whichdac, nda);
+            nt_waveouterror("waveOutOpen device: %s\n", mmresult);
             nt_nwaveout = nda;
         }
     }
@@ -228,23 +227,23 @@ void mmio_close_audio(void)
     int nda, nad;
     logpost(NULL, PD_VERBOSE, "closing audio...");
 
-    for (nda=0; nda < nt_nwaveout; nda++) /*if (nt_nwaveout) wini */
+    for(nda = 0; nda < nt_nwaveout; nda++) /*if (nt_nwaveout) wini */
     {
-       errcode = waveOutReset(ntsnd_outdev[nda]);
-       if (errcode != MMSYSERR_NOERROR)
-           printf("error resetting output %d: %d\n", nda, errcode);
-       errcode = waveOutClose(ntsnd_outdev[nda]);
-       if (errcode != MMSYSERR_NOERROR)
-           printf("error closing output %d: %d\n",nda , errcode);
+        errcode = waveOutReset(ntsnd_outdev[nda]);
+        if(errcode != MMSYSERR_NOERROR)
+            printf("error resetting output %d: %d\n", nda, errcode);
+        errcode = waveOutClose(ntsnd_outdev[nda]);
+        if(errcode != MMSYSERR_NOERROR)
+            printf("error closing output %d: %d\n", nda, errcode);
     }
 
-    for(nad=0; nad < nt_nwavein;nad++) /* if (nt_nwavein) wini */
+    for(nad = 0; nad < nt_nwavein; nad++) /* if (nt_nwavein) wini */
     {
         errcode = waveInReset(ntsnd_indev[nad]);
-        if (errcode != MMSYSERR_NOERROR)
+        if(errcode != MMSYSERR_NOERROR)
             printf("error resetting input: %d\n", errcode);
         errcode = waveInClose(ntsnd_indev[nad]);
-        if (errcode != MMSYSERR_NOERROR)
+        if(errcode != MMSYSERR_NOERROR)
             printf("error closing input: %d\n", errcode);
     }
     mmio_freebufs(ntsnd_invec, nt_nwavein, nt_naudiobuffer);
@@ -253,42 +252,42 @@ void mmio_close_audio(void)
     logpost(NULL, PD_VERBOSE, "done closing audio...");
 }
 
-
-#define ADCJITTER 10    /* We tolerate X buffers of jitter by default */
+#define ADCJITTER 10 /* We tolerate X buffers of jitter by default */
 #define DACJITTER 10
 
 static int nt_adcjitterbufsallowed = ADCJITTER;
 static int nt_dacjitterbufsallowed = DACJITTER;
 
-    /* ------------- MIDI time stamping from audio clock ------------ */
+/* ------------- MIDI time stamping from audio clock ------------ */
 
 #ifdef MIDI_TIMESTAMP
 
 static double nt_hibuftime;
 static double initsystime = -1;
 
-    /* call this whenever we reset audio */
+/* call this whenever we reset audio */
 static void nt_resetmidisync(void)
 {
     initsystime = clock_getsystime();
     nt_hibuftime = sys_getrealtime();
 }
 
-    /* call this whenever we're idled waiting for audio to be ready.
-    The routine maintains a high and low water point for the difference
-    between real and DAC time. */
+/* call this whenever we're idled waiting for audio to be ready.
+The routine maintains a high and low water point for the difference
+between real and DAC time. */
 
 static void nt_midisync(void)
 {
     double jittersec, diff;
 
-    if (initsystime == -1) nt_resetmidisync();
-    jittersec = (nt_dacjitterbufsallowed > nt_adcjitterbufsallowed ?
-        nt_dacjitterbufsallowed : nt_adcjitterbufsallowed)
-            * nt_blocksize / STUFF->st_getsr();
+    if(initsystime == -1) nt_resetmidisync();
+    jittersec = (nt_dacjitterbufsallowed > nt_adcjitterbufsallowed
+                        ? nt_dacjitterbufsallowed
+                        : nt_adcjitterbufsallowed) *
+                nt_blocksize / STUFF->st_getsr();
     diff = sys_getrealtime() - 0.001 * clock_gettimesince(initsystime);
-    if (diff > nt_hibuftime) nt_hibuftime = diff;
-    if (diff < nt_hibuftime - jittersec)
+    if(diff > nt_hibuftime) nt_hibuftime = diff;
+    if(diff < nt_hibuftime - jittersec)
     {
         post("jitter excess %d %f", dac, diff);
         nt_resetmidisync();
@@ -302,15 +301,14 @@ static double nt_midigettimefor(LARGE_INTEGER timestamp)
             timeGetSystemTime() call in the MIDI callback routine below. */
     return (nt_tixtotime(timestamp) - nt_hibuftime);
 }
-#endif      /* MIDI_TIMESTAMP */
-
+#endif /* MIDI_TIMESTAMP */
 
 static int nt_fill = 0;
-#define WRAPFWD(x) ((x) >= nt_naudiobuffer ? (x) - nt_naudiobuffer: (x))
-#define WRAPBACK(x) ((x) < 0 ? (x) + nt_naudiobuffer: (x))
+#define WRAPFWD(x) ((x) >= nt_naudiobuffer ? (x) -nt_naudiobuffer : (x))
+#define WRAPBACK(x) ((x) < 0 ? (x) + nt_naudiobuffer : (x))
 #define MAXRESYNC 500
 
-#if 0       /* this is used for debugging */
+#if 0  /* this is used for debugging */
 static void nt_printaudiostatus(void)
 {
     int nad, nda;
@@ -400,70 +398,65 @@ reason the sync testing below gives false positives. */
 
 static int nt_resync_cancelled;
 
-static void nt_noresync(void)
-{
-    nt_resync_cancelled = 1;
-}
+static void nt_noresync(void) { nt_resync_cancelled = 1; }
 
 static void nt_resyncaudio(void)
 {
     UINT mmresult;
     int nad, nda, count;
-    if (nt_resync_cancelled)
-        return;
-        /* for each open input device, eat all buffers which are marked
-            ready.  The next one will thus be "busy".  */
+    if(nt_resync_cancelled) return;
+    /* for each open input device, eat all buffers which are marked
+        ready.  The next one will thus be "busy".  */
     post("resyncing audio");
-    for (nad = 0; nad < nt_nwavein; nad++)
+    for(nad = 0; nad < nt_nwavein; nad++)
     {
         int phase = ntsnd_inphase[nad];
-        for (count = 0; count < MAXRESYNC; count++)
+        for(count = 0; count < MAXRESYNC; count++)
         {
             WAVEHDR *inwavehdr = ntsnd_invec[nad][phase].lpWaveHdr;
-            if (!(inwavehdr->dwFlags & WHDR_DONE)) break;
-            if (inwavehdr->dwFlags & WHDR_PREPARED)
-                waveInUnprepareHeader(ntsnd_indev[nad],
-                    inwavehdr, sizeof(WAVEHDR));
+            if(!(inwavehdr->dwFlags & WHDR_DONE)) break;
+            if(inwavehdr->dwFlags & WHDR_PREPARED)
+                waveInUnprepareHeader(
+                    ntsnd_indev[nad], inwavehdr, sizeof(WAVEHDR));
             inwavehdr->dwFlags = 0L;
             waveInPrepareHeader(ntsnd_indev[nad], inwavehdr, sizeof(WAVEHDR));
-            mmresult = waveInAddBuffer(ntsnd_indev[nad], inwavehdr,
-                sizeof(WAVEHDR));
-            if (mmresult != MMSYSERR_NOERROR)
+            mmresult =
+                waveInAddBuffer(ntsnd_indev[nad], inwavehdr, sizeof(WAVEHDR));
+            if(mmresult != MMSYSERR_NOERROR)
                 nt_waveinerror("waveInAddBuffer: %s\n", mmresult);
             ntsnd_inphase[nad] = phase = WRAPFWD(phase + 1);
         }
-        if (count == MAXRESYNC) post("resync error 1");
+        if(count == MAXRESYNC) post("resync error 1");
     }
-        /* Each output buffer which is "ready" is filled with zeros and
-        queued. */
-    for (nda = 0; nda < nt_nwaveout; nda++)
+    /* Each output buffer which is "ready" is filled with zeros and
+    queued. */
+    for(nda = 0; nda < nt_nwaveout; nda++)
     {
         int phase = ntsnd_outphase[nda];
-        for (count = 0; count < MAXRESYNC; count++)
+        for(count = 0; count < MAXRESYNC; count++)
         {
             WAVEHDR *outwavehdr = ntsnd_outvec[nda][phase].lpWaveHdr;
-            if (!(outwavehdr->dwFlags & WHDR_DONE)) break;
-            if (outwavehdr->dwFlags & WHDR_PREPARED)
-                waveOutUnprepareHeader(ntsnd_outdev[nda],
-                    outwavehdr, sizeof(WAVEHDR));
+            if(!(outwavehdr->dwFlags & WHDR_DONE)) break;
+            if(outwavehdr->dwFlags & WHDR_PREPARED)
+                waveOutUnprepareHeader(
+                    ntsnd_outdev[nda], outwavehdr, sizeof(WAVEHDR));
             outwavehdr->dwFlags = 0L;
-            memset((char *)(ntsnd_outvec[nda][phase].lpData),
-                0, (CHANNELS_PER_DEVICE * SAMPSIZE * nt_blocksize));
-            waveOutPrepareHeader(ntsnd_outdev[nda], outwavehdr,
-                sizeof(WAVEHDR));
-            mmresult = waveOutWrite(ntsnd_outdev[nda], outwavehdr,
-                sizeof(WAVEHDR));
-            if (mmresult != MMSYSERR_NOERROR)
+            memset((char *) (ntsnd_outvec[nda][phase].lpData), 0,
+                (CHANNELS_PER_DEVICE * SAMPSIZE * nt_blocksize));
+            waveOutPrepareHeader(
+                ntsnd_outdev[nda], outwavehdr, sizeof(WAVEHDR));
+            mmresult =
+                waveOutWrite(ntsnd_outdev[nda], outwavehdr, sizeof(WAVEHDR));
+            if(mmresult != MMSYSERR_NOERROR)
                 nt_waveouterror("waveOutAddBuffer: %s\n", mmresult);
             ntsnd_outphase[nda] = phase = WRAPFWD(phase + 1);
         }
-        if (count == MAXRESYNC) post("resync error 2");
+        if(count == MAXRESYNC) post("resync error 2");
     }
 
 #ifdef MIDI_TIMESTAMP
     nt_resetmidisync();
 #endif
-
 }
 
 #define LATE 0
@@ -502,150 +495,153 @@ int mmio_send_dacs(void)
     t_sample *fp1, *fp2;
     int nextfill, doxfer = 0;
     int nda, nad;
-    if (!nt_nwavein && !nt_nwaveout) return (0);
+    if(!nt_nwavein && !nt_nwaveout) return (0);
 
-
-    if (nt_meters)
+    if(nt_meters)
     {
         int i, n;
         t_sample maxsamp;
-        for (i = 0, n = 2 * nt_nwavein * DEFDACBLKSIZE, maxsamp = nt_inmax;
+        for(i = 0, n = 2 * nt_nwavein * DEFDACBLKSIZE, maxsamp = nt_inmax;
             i < n; i++)
         {
             t_sample f = STUFF->st_soundin[i];
-            if (f > maxsamp) maxsamp = f;
-            else if (-f > maxsamp) maxsamp = -f;
+            if(f > maxsamp)
+                maxsamp = f;
+            else if(-f > maxsamp)
+                maxsamp = -f;
         }
         nt_inmax = maxsamp;
-        for (i = 0, n = 2 * nt_nwaveout * DEFDACBLKSIZE, maxsamp = nt_outmax;
+        for(i = 0, n = 2 * nt_nwaveout * DEFDACBLKSIZE, maxsamp = nt_outmax;
             i < n; i++)
         {
             t_sample f = STUFF->st_soundout[i];
-            if (f > maxsamp) maxsamp = f;
-            else if (-f > maxsamp) maxsamp = -f;
+            if(f > maxsamp)
+                maxsamp = f;
+            else if(-f > maxsamp)
+                maxsamp = -f;
         }
         nt_outmax = maxsamp;
     }
 
-        /* the "fill pointer" nt_fill controls where in the next
-        I/O buffers we will write and/or read.  If it's zero, we
-        first check whether the buffers are marked "done". */
+    /* the "fill pointer" nt_fill controls where in the next
+    I/O buffers we will write and/or read.  If it's zero, we
+    first check whether the buffers are marked "done". */
 
-    if (!nt_fill)
+    if(!nt_fill)
     {
-        for (nad = 0; nad < nt_nwavein; nad++)
+        for(nad = 0; nad < nt_nwavein; nad++)
         {
             int phase = ntsnd_inphase[nad];
             WAVEHDR *inwavehdr = ntsnd_invec[nad][phase].lpWaveHdr;
-            if (!(inwavehdr->dwFlags & WHDR_DONE)) goto idle;
+            if(!(inwavehdr->dwFlags & WHDR_DONE)) goto idle;
         }
-        for (nda = 0; nda < nt_nwaveout; nda++)
-        {
-            int phase = ntsnd_outphase[nda];
-            WAVEHDR *outwavehdr =
-                ntsnd_outvec[nda][phase].lpWaveHdr;
-            if (!(outwavehdr->dwFlags & WHDR_DONE)) goto idle;
-        }
-        for (nad = 0; nad < nt_nwavein; nad++)
-        {
-            int phase = ntsnd_inphase[nad];
-            WAVEHDR *inwavehdr =
-                ntsnd_invec[nad][phase].lpWaveHdr;
-            if (inwavehdr->dwFlags & WHDR_PREPARED)
-                waveInUnprepareHeader(ntsnd_indev[nad],
-                    inwavehdr, sizeof(WAVEHDR));
-        }
-        for (nda = 0; nda < nt_nwaveout; nda++)
+        for(nda = 0; nda < nt_nwaveout; nda++)
         {
             int phase = ntsnd_outphase[nda];
             WAVEHDR *outwavehdr = ntsnd_outvec[nda][phase].lpWaveHdr;
-            if (outwavehdr->dwFlags & WHDR_PREPARED)
-                waveOutUnprepareHeader(ntsnd_outdev[nda],
-                    outwavehdr, sizeof(WAVEHDR));
+            if(!(outwavehdr->dwFlags & WHDR_DONE)) goto idle;
+        }
+        for(nad = 0; nad < nt_nwavein; nad++)
+        {
+            int phase = ntsnd_inphase[nad];
+            WAVEHDR *inwavehdr = ntsnd_invec[nad][phase].lpWaveHdr;
+            if(inwavehdr->dwFlags & WHDR_PREPARED)
+                waveInUnprepareHeader(
+                    ntsnd_indev[nad], inwavehdr, sizeof(WAVEHDR));
+        }
+        for(nda = 0; nda < nt_nwaveout; nda++)
+        {
+            int phase = ntsnd_outphase[nda];
+            WAVEHDR *outwavehdr = ntsnd_outvec[nda][phase].lpWaveHdr;
+            if(outwavehdr->dwFlags & WHDR_PREPARED)
+                waveOutUnprepareHeader(
+                    ntsnd_outdev[nda], outwavehdr, sizeof(WAVEHDR));
         }
     }
 
-        /* Convert audio output to fixed-point and put it in the output
-        buffer. */
-    for (nda = 0, fp1 = STUFF->st_soundout; nda < nt_nwaveout; nda++)
+    /* Convert audio output to fixed-point and put it in the output
+    buffer. */
+    for(nda = 0, fp1 = STUFF->st_soundout; nda < nt_nwaveout; nda++)
     {
         int phase = ntsnd_outphase[nda];
 
-        for (i = 0, sp1 = (short *)(ntsnd_outvec[nda][phase].lpData) +
-            CHANNELS_PER_DEVICE * nt_fill;
-                i < 2; i++, fp1 += DEFDACBLKSIZE, sp1++)
+        for(i = 0, sp1 = (short *) (ntsnd_outvec[nda][phase].lpData) +
+                         CHANNELS_PER_DEVICE * nt_fill;
+            i < 2; i++, fp1 += DEFDACBLKSIZE, sp1++)
         {
-            for (j = 0, fp2 = fp1, sp2 = sp1; j < DEFDACBLKSIZE;
+            for(j = 0, fp2 = fp1, sp2 = sp1; j < DEFDACBLKSIZE;
                 j++, fp2++, sp2 += CHANNELS_PER_DEVICE)
             {
                 int x1 = 32767.f * *fp2;
-                if (x1 > 32767) x1 = 32767;
-                else if (x1 < -32767) x1 = -32767;
+                if(x1 > 32767)
+                    x1 = 32767;
+                else if(x1 < -32767)
+                    x1 = -32767;
                 *sp2 = x1;
             }
         }
     }
     memset(STUFF->st_soundout, 0,
-        (DEFDACBLKSIZE *sizeof(t_sample)*CHANNELS_PER_DEVICE)*nt_nwaveout);
+        (DEFDACBLKSIZE * sizeof(t_sample) * CHANNELS_PER_DEVICE) * nt_nwaveout);
 
-        /* vice versa for the input buffer */
+    /* vice versa for the input buffer */
 
-    for (nad = 0, fp1 = STUFF->st_soundin; nad < nt_nwavein; nad++)
+    for(nad = 0, fp1 = STUFF->st_soundin; nad < nt_nwavein; nad++)
     {
         int phase = ntsnd_inphase[nad];
 
-        for (i = 0, sp1 = (short *)(ntsnd_invec[nad][phase].lpData) +
-            CHANNELS_PER_DEVICE * nt_fill;
-                i < 2; i++, fp1 += DEFDACBLKSIZE, sp1++)
+        for(i = 0, sp1 = (short *) (ntsnd_invec[nad][phase].lpData) +
+                         CHANNELS_PER_DEVICE * nt_fill;
+            i < 2; i++, fp1 += DEFDACBLKSIZE, sp1++)
         {
-            for (j = 0, fp2 = fp1, sp2 = sp1; j < DEFDACBLKSIZE;
+            for(j = 0, fp2 = fp1, sp2 = sp1; j < DEFDACBLKSIZE;
                 j++, fp2++, sp2 += CHANNELS_PER_DEVICE)
             {
-                *fp2 = ((t_sample)(1./32767.)) * (t_sample)(*sp2);
+                *fp2 = ((t_sample) (1. / 32767.)) * (t_sample) (*sp2);
             }
         }
     }
 
     nt_fill = nt_fill + DEFDACBLKSIZE;
-    if (nt_fill == nt_blocksize)
+    if(nt_fill == nt_blocksize)
     {
         nt_fill = 0;
 
-        for (nad = 0; nad < nt_nwavein; nad++)
+        for(nad = 0; nad < nt_nwavein; nad++)
         {
             int phase = ntsnd_inphase[nad];
             HWAVEIN device = ntsnd_indev[nad];
             WAVEHDR *inwavehdr = ntsnd_invec[nad][phase].lpWaveHdr;
             waveInPrepareHeader(device, inwavehdr, sizeof(WAVEHDR));
             mmresult = waveInAddBuffer(device, inwavehdr, sizeof(WAVEHDR));
-            if (mmresult != MMSYSERR_NOERROR)
+            if(mmresult != MMSYSERR_NOERROR)
                 nt_waveinerror("waveInAddBuffer: %s\n", mmresult);
             ntsnd_inphase[nad] = WRAPFWD(phase + 1);
         }
-        for (nda = 0; nda < nt_nwaveout; nda++)
+        for(nda = 0; nda < nt_nwaveout; nda++)
         {
             int phase = ntsnd_outphase[nda];
             HWAVEOUT device = ntsnd_outdev[nda];
             WAVEHDR *outwavehdr = ntsnd_outvec[nda][phase].lpWaveHdr;
             waveOutPrepareHeader(device, outwavehdr, sizeof(WAVEHDR));
             mmresult = waveOutWrite(device, outwavehdr, sizeof(WAVEHDR));
-            if (mmresult != MMSYSERR_NOERROR)
+            if(mmresult != MMSYSERR_NOERROR)
                 nt_waveouterror("waveOutWrite: %s\n", mmresult);
             ntsnd_outphase[nda] = WRAPFWD(phase + 1);
         }
 
-            /* check for DAC underflow or ADC overflow. */
-        for (nad = 0; nad < nt_nwavein; nad++)
+        /* check for DAC underflow or ADC overflow. */
+        for(nad = 0; nad < nt_nwavein; nad++)
         {
             int phase = WRAPBACK(ntsnd_inphase[nad] - 2);
             WAVEHDR *inwavehdr = ntsnd_invec[nad][phase].lpWaveHdr;
-            if (inwavehdr->dwFlags & WHDR_DONE) goto late;
+            if(inwavehdr->dwFlags & WHDR_DONE) goto late;
         }
-        for (nda = 0; nda < nt_nwaveout; nda++)
+        for(nda = 0; nda < nt_nwaveout; nda++)
         {
             int phase = WRAPBACK(ntsnd_outphase[nda] - 2);
             WAVEHDR *outwavehdr = ntsnd_outvec[nda][phase].lpWaveHdr;
-            if (outwavehdr->dwFlags & WHDR_DONE) goto late;
+            if(outwavehdr->dwFlags & WHDR_DONE) goto late;
         }
     }
     return (1);
@@ -661,27 +657,27 @@ idle:
     /* If more than nt_adcjitterbufsallowed ADC buffers are ready
     on any input device, resynchronize */
 
-    for (nad = 0; nad < nt_nwavein; nad++)
+    for(nad = 0; nad < nt_nwavein; nad++)
     {
         int phase = ntsnd_inphase[nad];
         WAVEHDR *inwavehdr =
-            ntsnd_invec[nad]
-                [WRAPFWD(phase + nt_adcjitterbufsallowed)].lpWaveHdr;
-        if (inwavehdr->dwFlags & WHDR_DONE)
+            ntsnd_invec[nad][WRAPFWD(phase + nt_adcjitterbufsallowed)]
+                .lpWaveHdr;
+        if(inwavehdr->dwFlags & WHDR_DONE)
         {
             nt_resyncaudio();
             return (0);
         }
     }
 
-        /* test dac sync the same way */
-    for (nda = 0; nda < nt_nwaveout; nda++)
+    /* test dac sync the same way */
+    for(nda = 0; nda < nt_nwaveout; nda++)
     {
         int phase = ntsnd_outphase[nda];
         WAVEHDR *outwavehdr =
-            ntsnd_outvec[nda]
-                [WRAPFWD(phase + nt_dacjitterbufsallowed)].lpWaveHdr;
-        if (outwavehdr->dwFlags & WHDR_DONE)
+            ntsnd_outvec[nda][WRAPFWD(phase + nt_dacjitterbufsallowed)]
+                .lpWaveHdr;
+        if(outwavehdr->dwFlags & WHDR_DONE)
         {
             nt_resyncaudio();
             return (0);
@@ -695,45 +691,42 @@ idle:
 
 /* ------------------- public routines -------------------------- */
 
-int mmio_open_audio(int naudioindev, int *audioindev,
-    int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,
-    int nchoutdev, int *choutdev, int rate, int blocksize)
+int mmio_open_audio(int naudioindev, int *audioindev, int nchindev,
+    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
+    int *choutdev, int rate, int blocksize)
 {
     int nbuf;
 
     logpost(NULL, PD_VERBOSE, "opening audio...");
     nt_blocksize = (blocksize ? blocksize : DEFREALDACBLKSIZE);
-    nbuf = (double)sys_schedadvance / 1000000. * rate / nt_blocksize;
-    if (nbuf >= MAXBUFFER)
+    nbuf = (double) sys_schedadvance / 1000000. * rate / nt_blocksize;
+    if(nbuf >= MAXBUFFER)
     {
         fprintf(stderr, "pd: audio buffering maxed out to %d\n",
-            (int)(MAXBUFFER * ((nt_blocksize * 1000.)/44100.)));
+            (int) (MAXBUFFER * ((nt_blocksize * 1000.) / 44100.)));
         nbuf = MAXBUFFER;
     }
-    else if (nbuf < 4) nbuf = 4;
+    else if(nbuf < 4)
+        nbuf = 4;
     /* fprintf(stderr, "%d audio buffers\n", nbuf); */
     nt_naudiobuffer = nbuf;
-    if (nt_adcjitterbufsallowed > nbuf - 2)
-        nt_adcjitterbufsallowed = nbuf - 2;
-    if (nt_dacjitterbufsallowed > nbuf - 2)
-        nt_dacjitterbufsallowed = nbuf - 2;
+    if(nt_adcjitterbufsallowed > nbuf - 2) nt_adcjitterbufsallowed = nbuf - 2;
+    if(nt_dacjitterbufsallowed > nbuf - 2) nt_dacjitterbufsallowed = nbuf - 2;
 
     nt_nwavein = STUFF->st_inchannels / 2;
     nt_nwaveout = STUFF->st_outchannels / 2;
-    nt_whichadc = (naudioindev < 1 ?
-        (nt_nwavein > 1 ? WAVE_MAPPER : -1) : audioindev[0]);
-    nt_whichdac = (naudiooutdev < 1 ?
-        (nt_nwaveout > 1 ? WAVE_MAPPER : -1) : audiooutdev[0]);
-    if (naudiooutdev > 1 || naudioindev > 1)
- post("separate audio device choice not supported; using sequential devices.");
+    nt_whichadc =
+        (naudioindev < 1 ? (nt_nwavein > 1 ? WAVE_MAPPER : -1) : audioindev[0]);
+    nt_whichdac = (naudiooutdev < 1 ? (nt_nwaveout > 1 ? WAVE_MAPPER : -1)
+                                    : audiooutdev[0]);
+    if(naudiooutdev > 1 || naudioindev > 1)
+        post("separate audio device choice not supported; using sequential "
+             "devices.");
     return (mmio_do_open_audio());
     logpost(NULL, PD_VERBOSE, "done opening audio...");
 }
 
-
-void mmio_reportidle(void)
-{
-}
+void mmio_reportidle(void) {}
 
 #if 0
 /* list the audio and MIDI device names */
@@ -766,41 +759,36 @@ void mmio_listdevs(void)
 }
 #endif
 
-void mmio_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize)
+void mmio_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize)
 {
-    int  wRtn, ndev, i;
+    int wRtn, ndev, i;
     char utf8device[MAXPDSTRING];
 
-    *canmulti = 2;  /* supports multiple devices */
+    *canmulti = 2; /* supports multiple devices */
     ndev = waveInGetNumDevs();
-    if (ndev > maxndev)
-        ndev = maxndev;
+    if(ndev > maxndev) ndev = maxndev;
     *nindevs = ndev;
-    for (i = 0; i < ndev; i++)
+    for(i = 0; i < ndev; i++)
     {
         WAVEINCAPS wicap;
         wRtn = waveInGetDevCaps(i, (LPWAVEINCAPS) &wicap, sizeof(wicap));
-        if (!wRtn)
-            u8_nativetoutf8(utf8device, MAXPDSTRING, wicap.szPname, -1);
+        if(!wRtn) u8_nativetoutf8(utf8device, MAXPDSTRING, wicap.szPname, -1);
         _snprintf(indevlist + i * devdescsize, devdescsize, "%s",
             (wRtn ? "???" : utf8device));
-        indevlist[(i+1) * devdescsize - 1] = 0;
+        indevlist[(i + 1) * devdescsize - 1] = 0;
     }
 
     ndev = waveOutGetNumDevs();
-    if (ndev > maxndev)
-        ndev = maxndev;
+    if(ndev > maxndev) ndev = maxndev;
     *noutdevs = ndev;
-    for (i = 0; i < ndev; i++)
+    for(i = 0; i < ndev; i++)
     {
         WAVEOUTCAPS wocap;
         wRtn = waveOutGetDevCaps(i, (LPWAVEOUTCAPS) &wocap, sizeof(wocap));
-        if (!wRtn)
-            u8_nativetoutf8(utf8device, MAXPDSTRING, wocap.szPname, -1);
-        _snprintf(outdevlist + i * devdescsize,  devdescsize, "%s",
+        if(!wRtn) u8_nativetoutf8(utf8device, MAXPDSTRING, wocap.szPname, -1);
+        _snprintf(outdevlist + i * devdescsize, devdescsize, "%s",
             (wRtn ? "???" : utf8device));
-        outdevlist[(i+1) * devdescsize - 1] = 0;
+        outdevlist[(i + 1) * devdescsize - 1] = 0;
     }
 }

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -77,6 +77,7 @@ static void mmio_allocbufs(
     int devno;
     int bufno;
     for(devno = 0; devno < ndevs; devno++)
+    {
         for(bufno = 0; bufno < nbufs; bufno++)
         {
             WAVEHDR *wh;
@@ -121,6 +122,7 @@ static void mmio_allocbufs(
              */
             if(setdone) wh->dwFlags = WHDR_DONE;
         }
+    }
 }
 
 static void mmio_freebufs(t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs)
@@ -130,6 +132,7 @@ static void mmio_freebufs(t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs)
     int devno;
     int bufno;
     for(devno = 0; devno < ndevs; devno++)
+    {
         for(bufno = 0; bufno < nbufs; bufno++)
         {
             /* unlock and free memory for the waveform data.  */
@@ -142,6 +145,7 @@ static void mmio_freebufs(t_sbuf bp[][MAXBUFFER], int ndevs, int nbufs)
             GlobalUnlock(bp[devno][bufno].lpWaveHdr);
             GlobalFree(bp[devno][bufno].hWaveHdr);
         }
+    }
 }
 
 static UINT nt_whichdac = WAVE_MAPPER, nt_whichadc = WAVE_MAPPER;
@@ -521,9 +525,13 @@ int mmio_send_dacs(void)
         {
             t_sample f = STUFF->st_soundin[i];
             if(f > maxsamp)
+            {
                 maxsamp = f;
+            }
             else if(-f > maxsamp)
+            {
                 maxsamp = -f;
+            }
         }
         nt_inmax = maxsamp;
         for(i = 0, n = 2 * nt_nwaveout * DEFDACBLKSIZE, maxsamp = nt_outmax;
@@ -531,9 +539,13 @@ int mmio_send_dacs(void)
         {
             t_sample f = STUFF->st_soundout[i];
             if(f > maxsamp)
+            {
                 maxsamp = f;
+            }
             else if(-f > maxsamp)
+            {
                 maxsamp = -f;
+            }
         }
         nt_outmax = maxsamp;
     }
@@ -589,9 +601,13 @@ int mmio_send_dacs(void)
             {
                 int x1 = 32767.f * *fp2;
                 if(x1 > 32767)
+                {
                     x1 = 32767;
+                }
                 else if(x1 < -32767)
+                {
                     x1 = -32767;
+                }
                 *sp2 = x1;
             }
         }
@@ -735,8 +751,10 @@ int mmio_open_audio(int naudioindev, int *audioindev, int nchindev,
     nt_whichdac = (naudiooutdev < 1 ? (nt_nwaveout > 1 ? WAVE_MAPPER : -1)
                                     : audiooutdev[0]);
     if(naudiooutdev > 1 || naudioindev > 1)
+    {
         post("separate audio device choice not supported; using sequential "
              "devices.");
+    }
     return (mmio_do_open_audio());
     logpost(NULL, PD_VERBOSE, "done opening audio...");
 }

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -153,8 +153,6 @@ static UINT nt_whichdac = WAVE_MAPPER, nt_whichadc = WAVE_MAPPER;
 int mmio_do_open_audio(void)
 {
     PCMWAVEFORMAT form;
-    int i;
-    int j;
     UINT mmresult;
     int nad;
     int nda;
@@ -192,7 +190,7 @@ int mmio_do_open_audio(void)
         }
         else
         {
-            for(i = 0; i < nt_naudiobuffer; i++)
+            for(int i = 0; i < nt_naudiobuffer; i++)
             {
                 mmresult = waveInPrepareHeader(ntsnd_indev[nad],
                     ntsnd_invec[nad][i].lpWaveHdr, sizeof(WAVEHDR));
@@ -797,14 +795,13 @@ void mmio_getdevs(char *indevlist, int *nindevs, char *outdevlist,
 {
     int wRtn;
     int ndev;
-    int i;
     char utf8device[MAXPDSTRING];
 
     *canmulti = 2; /* supports multiple devices */
     ndev = waveInGetNumDevs();
     if(ndev > maxndev) ndev = maxndev;
     *nindevs = ndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
     {
         WAVEINCAPS wicap;
         wRtn = waveInGetDevCaps(i, (LPWAVEINCAPS) &wicap, sizeof(wicap));
@@ -817,7 +814,7 @@ void mmio_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     ndev = waveOutGetNumDevs();
     if(ndev > maxndev) ndev = maxndev;
     *noutdevs = ndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
     {
         WAVEOUTCAPS wocap;
         wRtn = waveOutGetDevCaps(i, (LPWAVEOUTCAPS) &wocap, sizeof(wocap));

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -285,7 +285,6 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
     int inchannels = 0;
     int outchannels = 0;
     int n;
-    int i;
     int fd;
     int flags;
     char buf[OSS_MAXSAMPLEWIDTH * DEFDACBLKSIZE * OSS_MAXCHPERDEV];
@@ -297,7 +296,7 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
 
     linux_nindevs = linux_noutdevs = 0;
     /* mark devices unopened */
-    for(i = 0; i < OSS_MAXDEV; i++)
+    for(int i = 0; i < OSS_MAXDEV; i++)
         linux_adcs[i].d_fd = linux_dacs[i].d_fd = -1;
 
     /* open output devices */
@@ -494,7 +493,7 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
         if(sys_verbose) fprintf(stderr, "...done.\n");
     }
     /* now go and fill all the output buffers. */
-    for(i = 0; i < linux_noutdevs; i++)
+    for(int i = 0; i < linux_noutdevs; i++)
     {
         int j;
         memset(buf, 0,
@@ -515,11 +514,10 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
 
 void oss_close_audio(void)
 {
-    int i;
-    for(i = 0; i < linux_nindevs; i++)
+    for(int i = 0; i < linux_nindevs; i++)
         close(linux_adcs[i].d_fd);
 
-    for(i = 0; i < linux_noutdevs; i++)
+    for(int i = 0; i < linux_noutdevs; i++)
         close(linux_dacs[i].d_fd);
 
     linux_nindevs = linux_noutdevs = 0;
@@ -627,7 +625,7 @@ static void oss_doresync(void)
             if(!zeroed)
             {
                 unsigned int i;
-                for(i = 0; i < OSS_XFERSAMPS(linux_dacs[dev].d_nchannels); i++)
+                for(int i = 0; i < OSS_XFERSAMPS(linux_dacs[dev].d_nchannels); i++)
                     buf[i] = 0;
                 zeroed = 1;
             }
@@ -861,12 +859,11 @@ int oss_send_dacs(void)
 void oss_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
     int *canmulti, int maxdev, int devdescsize)
 {
-    int i;
     int ndev;
     oss_init();
     *canmulti = 2; /* supports multiple devices */
     if((ndev = oss_ndev) > maxdev) ndev = maxdev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
     {
         sprintf(indevlist + i * devdescsize, "OSS device #%d", i + 1);
         sprintf(outdevlist + i * devdescsize, "OSS device #%d", i + 1);

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -144,17 +144,25 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
     param = wantformat;
 
     if(ioctl(fd, SNDCTL_DSP_SETFMT, &param) == -1)
+    {
         fprintf(stderr, "OSS: Could not set DSP format\n");
+    }
     else if(wantformat != param)
+    {
         fprintf(
             stderr, "OSS: DSP format: wanted %d, got %d\n", wantformat, param);
+    }
 
     /* sample rate */
     orig = param = srate;
     if(ioctl(fd, SNDCTL_DSP_SPEED, &param) == -1)
+    {
         fprintf(stderr, "OSS: Could not set sampling rate for device\n");
+    }
     else if(orig != param)
+    {
         fprintf(stderr, "OSS: sampling rate: wanted %d, got %d\n", orig, param);
+    }
     oss_advance_samples = sys_schedadvance * (srate) / 1000000.;
     if(oss_advance_samples < DEFDACBLKSIZE) oss_advance_samples = DEFDACBLKSIZE;
 
@@ -179,8 +187,10 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
         logfragsize = ilog2(fragbytes);
 
         if(fragbytes != (1 << logfragsize))
+        {
             post("warning: OSS takes only power of 2 blocksize; using %d",
                 (1 << logfragsize) / (dev->d_bytespersamp * nchannels));
+        }
         logpost(NULL, PD_VERBOSE, "setting nfrags = %d, fragsize %d\n",
             nfragment, fragbytes);
 
@@ -217,10 +227,12 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
         if(defect > 0)
         {
             if(sys_verbose || defect > (dev->d_bufsize >> 2))
+            {
                 fprintf(stderr,
                     "OSS: requested audio buffer size %d limited to %d\n",
                     oss_advance_samples * (dev->d_bytespersamp * nchannels),
                     dev->d_bufsize);
+            }
             oss_advance_samples = (dev->d_bufsize - OSS_XFERSAMPS(nchannels)) /
                                   (dev->d_bytespersamp * nchannels);
         }
@@ -253,9 +265,13 @@ whynot:
     {
         int save = param;
         if(ioctl(fd, SNDCTL_DSP_CHANNELS, &param) == -1)
+        {
             pd_error(0, "OSS: SNDCTL_DSP_CHANNELS failed %s", devname);
+        }
         else if(param == save)
+        {
             return (param);
+        }
         param = save - 1;
     }
 
@@ -319,9 +335,13 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
                 if(fcntl(fd, F_SETFD, 1) < 0)
                     post("couldn't set close-on-exec flag on audio");
                 if((flags = fcntl(fd, F_GETFL)) < 0)
+                {
                     post("couldn't get audio device flags");
+                }
                 else if(fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
+                {
                     post("couldn't set audio device flags");
+                }
                 logpost(NULL, PD_VERBOSE, "opened %s for reading and writing\n",
                     oss_devnames[thisdevice]);
                 linux_adcs[inindex].d_fd = fd;
@@ -340,15 +360,21 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
             if(fcntl(fd, F_SETFD, 1) < 0)
                 post("couldn't set close-on-exec flag on audio");
             if((flags = fcntl(fd, F_GETFL)) < 0)
+            {
                 post("couldn't get audio device flags");
+            }
             else if(fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
+            {
                 post("couldn't set audio device flags");
+            }
             logpost(NULL, PD_VERBOSE, "opened %s for writing only\n",
                 oss_devnames[thisdevice]);
         }
         if(ioctl(fd, SNDCTL_DSP_GETCAPS, &capabilities) == -1)
+        {
             pd_error(0, "OSS: SNDCTL_DSP_GETCAPS failed %s",
                 oss_devnames[thisdevice]);
+        }
 
         gotchans = oss_setchannels(fd,
             (wantchannels > OSS_MAXCHPERDEV) ? OSS_MAXCHPERDEV : wantchannels,
@@ -413,9 +439,13 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
             if(fcntl(fd, F_SETFD, 1) < 0)
                 post("couldn't set close-on-exec flag on audio");
             if((flags = fcntl(fd, F_GETFL)) < 0)
+            {
                 post("couldn't get audio device flags");
+            }
             else if(fcntl(fd, F_SETFL, flags & (~O_NDELAY)) < 0)
+            {
                 post("couldn't set audio device flags");
+            }
             logpost(NULL, PD_VERBOSE, "opened %s for reading only\n",
                 oss_devnames[thisdevice]);
         }
@@ -471,9 +501,11 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
             linux_dacs[i].d_bytespersamp * linux_dacs[i].d_nchannels *
                 DEFDACBLKSIZE);
         for(j = 0; j < oss_advance_samples / DEFDACBLKSIZE; j++)
+        {
             write(linux_dacs[i].d_fd, buf,
                 linux_dacs[i].d_bytespersamp * linux_dacs[i].d_nchannels *
                     DEFDACBLKSIZE);
+        }
     }
     sys_setalarm(0);
     STUFF->st_inchannels = inchannels;
@@ -518,8 +550,10 @@ static void oss_calcspace(void)
     for(dev = 0; dev < linux_nindevs; dev++)
     {
         if(ioctl(linux_adcs[dev].d_fd, SNDCTL_DSP_GETISPACE, &ainfo) < 0)
+        {
             fprintf(stderr, "OSS: ioctl on input device %d, fd %d failed", dev,
                 linux_adcs[dev].d_fd);
+        }
         linux_adcs[dev].d_space = ainfo.bytes;
     }
 }
@@ -560,6 +594,7 @@ static void oss_doresync(void)
                     linux_adcs[dev].d_bytespersamp));
         }
         else
+        {
             while(linux_adcs[dev].d_space >
                   OSS_XFERSIZE(linux_adcs[dev].d_nchannels,
                       linux_adcs[dev].d_bytespersamp))
@@ -577,6 +612,7 @@ static void oss_doresync(void)
                 }
                 linux_adcs[dev].d_space = ainfo.bytes;
             }
+        }
     }
 
     /* 2. if any output devices are behind, feed them zeros to catch them
@@ -656,16 +692,20 @@ int oss_send_dacs(void)
         oss_calcspace();
 
         for(dev = 0; dev < linux_noutdevs; dev++)
+        {
             if(linux_dacs[dev].d_dropcount ||
                 (linux_dacs[dev].d_bufsize - linux_dacs[dev].d_space >
                     oss_advance_samples * linux_dacs[dev].d_bytespersamp *
                         linux_dacs[dev].d_nchannels))
                 idle = 1;
+        }
         for(dev = 0; dev < linux_nindevs; dev++)
+        {
             if(linux_adcs[dev].d_space <
                 OSS_XFERSIZE(linux_adcs[dev].d_nchannels,
                     linux_adcs[dev].d_bytespersamp))
                 idle = 1;
+        }
     }
 
     if(idle && !oss_blockmode)
@@ -677,6 +717,7 @@ int oss_send_dacs(void)
         There should be an error flag we could check instead; look for this
         someday... */
         for(dev = 0; dev < linux_nindevs; dev++)
+        {
             if(linux_adcs[dev].d_space == 0)
             {
                 audio_buf_info ainfo;
@@ -689,6 +730,7 @@ int oss_send_dacs(void)
                 oss_doresync();
                 return (SENDDACS_NO);
             }
+        }
         /* check for slippage between devices, either because
         data got lost in the driver from a previous late condition, or
         because the devices aren't synced.  When we're idle, no
@@ -697,17 +739,21 @@ int oss_send_dacs(void)
         */
 
         for(dev = 0; dev < linux_noutdevs; dev++)
+        {
             if(!linux_dacs[dev].d_dropcount &&
                 (linux_dacs[dev].d_bufsize - linux_dacs[dev].d_space <
                     (oss_advance_samples - 2) *
                         (linux_dacs[dev].d_bytespersamp *
                             linux_dacs[dev].d_nchannels)))
                 goto badsync;
+        }
         for(dev = 0; dev < linux_nindevs; dev++)
+        {
             if(linux_adcs[dev].d_space >
                 3 * OSS_XFERSIZE(linux_adcs[dev].d_nchannels,
                         linux_adcs[dev].d_bytespersamp))
                 goto badsync;
+        }
 
         /* return zero to tell the scheduler we're idle. */
         return (SENDDACS_NO);
@@ -724,7 +770,9 @@ int oss_send_dacs(void)
     {
         int nchannels = linux_dacs[dev].d_nchannels;
         if(linux_dacs[dev].d_dropcount)
+        {
             linux_dacs[dev].d_dropcount--;
+        }
         else
         {
             if(linux_dacs[dev].d_bytespersamp == 2)
@@ -739,9 +787,13 @@ int oss_send_dacs(void)
                     {
                         int s = *fp2 * 32767.;
                         if(s > 32767)
+                        {
                             s = 32767;
+                        }
                         else if(s < -32767)
+                        {
                             s = -32767;
+                        }
                         sp[j] = s;
                     }
                 }
@@ -751,9 +803,13 @@ int oss_send_dacs(void)
             if((timenow = sys_getrealtime()) - timeref > 0.002)
             {
                 if(!oss_blockmode)
+                {
                     sys_log_error(ERR_DACSLEPT);
+                }
                 else
+                {
                     rtnval = SENDDACS_SLEPT;
+                }
             }
             timeref = timenow;
         }
@@ -773,9 +829,13 @@ int oss_send_dacs(void)
         if((timenow = sys_getrealtime()) - timeref > 0.002)
         {
             if(!oss_blockmode)
+            {
                 sys_log_error(ERR_ADCSLEPT);
+            }
             else
+            {
                 rtnval = SENDDACS_SLEPT;
+            }
         }
         timeref = timenow;
 
@@ -787,8 +847,10 @@ int oss_send_dacs(void)
                 i--; fp1++, sp += nchannels)
             {
                 for(j = 0; j < nchannels; j++)
+                {
                     fp1[j * DEFDACBLKSIZE] =
                         (t_sample) sp[j] * (t_sample) 3.051850e-05;
+                }
             }
         }
         thischan += nchannels;

--- a/src/s_audio_oss.c
+++ b/src/s_audio_oss.c
@@ -90,7 +90,8 @@ static char oss_devnames[OSS_MAXDEV][20];
 /* find out how many OSS devices we have and get their names  */
 static void oss_init(void)
 {
-    int fd, devno;
+    int fd;
+    int devno;
     struct stat statbuf;
     char namebuf[80];
 
@@ -126,7 +127,11 @@ int oss_reset(int fd)
 void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
     int suggestedblocksize)
 {
-    int orig, param, nblk, fd = dev->d_fd, wantformat;
+    int orig;
+    int param;
+    int nblk;
+    int fd = dev->d_fd;
+    int wantformat;
     int nchannels = dev->d_nchannels;
     int advwas = sys_schedadvance;
 
@@ -155,7 +160,9 @@ void oss_configure(t_oss_dev *dev, int srate, int dac, int skipblocksize,
 
     if(oss_blockmode && !skipblocksize)
     {
-        int fragbytes, logfragsize, nfragment;
+        int fragbytes;
+        int logfragsize;
+        int nfragment;
         /* setting fragment count and size.  */
         linux_fragsize = suggestedblocksize;
         if(!linux_fragsize)
@@ -259,8 +266,12 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
     int *outdev, int nchout, int *chout, int rate, int blocksize)
 {
     int capabilities = 0;
-    int inchannels = 0, outchannels = 0;
-    int n, i, fd, flags;
+    int inchannels = 0;
+    int outchannels = 0;
+    int n;
+    int i;
+    int fd;
+    int flags;
     char buf[OSS_MAXSAMPLEWIDTH * DEFDACBLKSIZE * OSS_MAXCHPERDEV];
     int num_devs = 0;
     int wantmore = 0;
@@ -279,7 +290,9 @@ int oss_open_audio(int nindev, int *indev, int nchin, int *chin, int noutdev,
 
     for(n = 0; n < noutdev; n++)
     {
-        int gotchans, j, inindex = -1;
+        int gotchans;
+        int j;
+        int inindex = -1;
         int thisdevice = (outdev[n] >= 0 ? outdev[n] : 0);
         int wantchannels = (nchout > n) ? chout[n] : wantmore;
         fd = -1;
@@ -530,7 +543,9 @@ in audio output and/or input. */
 
 static void oss_doresync(void)
 {
-    int dev, zeroed = 0, wantsize;
+    int dev;
+    int zeroed = 0;
+    int wantsize;
     char buf[OSS_MAXSAMPLEWIDTH * DEFDACBLKSIZE * OSS_MAXCHPERDEV];
     audio_buf_info ainfo;
 
@@ -614,16 +629,21 @@ static void oss_doresync(void)
 
 int oss_send_dacs(void)
 {
-    t_sample *fp1, *fp2;
+    t_sample *fp1;
+    t_sample *fp2;
     long fill;
-    int i, j, dev, rtnval = SENDDACS_YES;
+    int i;
+    int j;
+    int dev;
+    int rtnval = SENDDACS_YES;
     char buf[OSS_MAXSAMPLEWIDTH * DEFDACBLKSIZE * OSS_MAXCHPERDEV];
     t_oss_int16 *sp;
     t_oss_int32 *lp;
     /* the maximum number of samples we should have in the ADC buffer */
     int idle = 0;
     int thischan;
-    double timeref, timenow;
+    double timeref;
+    double timenow;
 
     if(!linux_nindevs && !linux_noutdevs) return (SENDDACS_NO);
 
@@ -779,7 +799,8 @@ int oss_send_dacs(void)
 void oss_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
     int *canmulti, int maxdev, int devdescsize)
 {
-    int i, ndev;
+    int i;
+    int ndev;
     oss_init();
     *canmulti = 2; /* supports multiple devices */
     if((ndev = oss_ndev) > maxdev) ndev = maxdev;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -716,7 +716,6 @@ static char *pdi2devname(const PaDeviceInfo *pdi, char *buf, size_t bufsize)
 void pa_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
     int *canmulti, int maxndev, int devdescsize)
 {
-    int i;
     int nin = 0;
     int nout = 0;
     int ndev;
@@ -724,7 +723,7 @@ void pa_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
 
     pa_init();
     ndev = Pa_GetDeviceCount();
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
     {
         char utf8device[MAXPDSTRING];
         const PaDeviceInfo *pdi = Pa_GetDeviceInfo(i);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -157,12 +157,16 @@ static int pa_lowlevel_callback(const void *inputBuffer, void *outputBuffer,
             fbuf = ((float *) inputBuffer) + n * pa_inchans;
             soundiop = pa_soundin;
             for(i = 0, fp2 = fbuf; i < pa_inchans; i++, fp2++)
+            {
                 for(j = 0, fp3 = fp2; j < DEFDACBLKSIZE; j++, fp3 += pa_inchans)
                     *soundiop++ = (t_sample) *fp3;
+            }
         }
         else
+        {
             memset((void *) pa_soundin, 0,
                 DEFDACBLKSIZE * pa_inchans * sizeof(t_sample));
+        }
         memset((void *) pa_soundout, 0,
             DEFDACBLKSIZE * pa_outchans * sizeof(t_sample));
         (*pa_callback)();
@@ -171,9 +175,11 @@ static int pa_lowlevel_callback(const void *inputBuffer, void *outputBuffer,
             fbuf = ((float *) outputBuffer) + n * pa_outchans;
             soundiop = pa_soundout;
             for(i = 0, fp2 = fbuf; i < pa_outchans; i++, fp2++)
+            {
                 for(j = 0, fp3 = fp2; j < DEFDACBLKSIZE;
                     j++, fp3 += pa_outchans)
                     *fp3 = (float) *soundiop++;
+            }
         }
     }
     return 0;
@@ -209,15 +215,23 @@ static int pa_fifo_callback(const void *inputBuffer, void *outputBuffer,
     if((unsigned) fiforoom >= nframes * pa_outchans * sizeof(float))
     {
         if(outputBuffer)
+        {
             sys_ringbuf_read(&pa_outring, outputBuffer,
                 nframes * pa_outchans * sizeof(float), pa_outbuf);
+        }
         else if(pa_outchans)
+        {
             post("audio error: no outputBuffer but output channels");
+        }
         if(inputBuffer)
+        {
             sys_ringbuf_write(&pa_inring, inputBuffer,
                 nframes * pa_inchans * sizeof(float), pa_inbuf);
+        }
         else if(pa_inchans)
+        {
             post("audio error: no inputBuffer but input channels");
+        }
     }
     else
     { /* PD could not keep up; generate zeros */
@@ -559,9 +573,11 @@ int pa_send_dacs(void)
     {
         for(j = 0, fp = STUFF->st_soundout, fp2 = conversionbuf;
             j < STUFF->st_outchannels; j++, fp2++)
+        {
             for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
                 k++, fp++, fp3 += STUFF->st_outchannels)
                 *fp3 = *fp;
+        }
         sys_ringbuf_write(&pa_outring, conversionbuf,
             STUFF->st_outchannels * (DEFDACBLKSIZE * sizeof(float)), pa_outbuf);
     }
@@ -602,9 +618,11 @@ int pa_send_dacs(void)
             STUFF->st_inchannels * (DEFDACBLKSIZE * sizeof(float)), pa_inbuf);
         for(j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
             j < STUFF->st_inchannels; j++, fp2++)
+        {
             for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
                 k++, fp++, fp3 += STUFF->st_inchannels)
                 *fp = *fp3;
+        }
     }
 
 #else  /* FAKEBLOCKING */
@@ -661,7 +679,9 @@ int pa_send_dacs(void)
         pd_error(0, "trying to reopen audio device");
         sys_reopen_audio(); /* try to reopen it */
         if(audio_isopen())
+        {
             pd_error(0, "successfully reopened audio device");
+        }
         else
         {
             pd_error(0, "audio device not responding - closing audio");

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2001 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* this file calls Ross Bencina's and Phil Burk's Portaudio package.  It's
     the main way in for Mac OS and, with Michael Casey's help, also into
@@ -34,16 +34,16 @@
 #define snprintf _snprintf
 #endif
 
-#ifndef _WIN32          /* for the "dup2" workaround -- do we still need it? */
+#ifndef _WIN32 /* for the "dup2" workaround -- do we still need it? */
 #include <unistd.h>
 #endif
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #if 1
@@ -53,12 +53,12 @@
 /* define this to enable thread signaling instead of polling */
 // #define THREADSIGNAL
 
-    /* LATER try to figure out how to handle default devices in portaudio;
-    the way s_audio.c handles them isn't going to work here. */
+/* LATER try to figure out how to handle default devices in portaudio;
+the way s_audio.c handles them isn't going to work here. */
 
-    /* public interface declared in m_imp.h */
+/* public interface declared in m_imp.h */
 
-    /* implementation */
+/* implementation */
 static PaStream *pa_stream;
 static int pa_inchans, pa_outchans;
 static t_sample *pa_soundin, *pa_soundout;
@@ -89,20 +89,20 @@ static PA_VOLATILE sys_ringbuf pa_inring;
 static pthread_mutex_t pa_mutex;
 static pthread_cond_t pa_sem;
 #else /* THREADSIGNAL */
-#if defined (FAKEBLOCKING) && defined(_WIN32)
-#include <windows.h>    /* for Sleep() */
+#if defined(FAKEBLOCKING) && defined(_WIN32)
+#include <windows.h> /* for Sleep() */
 #endif
 /* max time (in ms) before trying to reopen the device */
 #ifndef POLL_TIMEOUT
 #define POLL_TIMEOUT 2000
 #endif
 #endif /* THREADSIGNAL */
-#endif  /* FAKEBLOCKING */
+#endif /* FAKEBLOCKING */
 
-static void pa_init(void)        /* Initialize PortAudio  */
+static void pa_init(void) /* Initialize PortAudio  */
 {
     static int initialized;
-    if (!initialized)
+    if(!initialized)
     {
 #ifdef __APPLE__
         /* for some reason, on the Mac Pa_Initialize() closes file descriptor
@@ -114,7 +114,7 @@ static void pa_init(void)        /* Initialize PortAudio  */
         int err = Pa_Initialize();
         close(1);
         close(another);
-        if (newfd >= 0)
+        if(newfd >= 0)
         {
             fflush(stdout);
             dup2(newfd, 1);
@@ -124,8 +124,7 @@ static void pa_init(void)        /* Initialize PortAudio  */
         int err = Pa_Initialize();
 #endif
 
-
-        if ( err != paNoError )
+        if(err != paNoError)
         {
             post("error#%d opening audio: %s", err, Pa_GetErrorText(err));
             return;
@@ -134,63 +133,61 @@ static void pa_init(void)        /* Initialize PortAudio  */
     }
 }
 
-static int pa_lowlevel_callback(const void *inputBuffer,
-    void *outputBuffer, unsigned long nframes,
-    const PaStreamCallbackTimeInfo *outTime, PaStreamCallbackFlags myflags,
-    void *userData)
+static int pa_lowlevel_callback(const void *inputBuffer, void *outputBuffer,
+    unsigned long nframes, const PaStreamCallbackTimeInfo *outTime,
+    PaStreamCallbackFlags myflags, void *userData)
 {
     int i;
     unsigned int n, j;
     float *fbuf, *fp2, *fp3;
     t_sample *soundiop;
-    if (nframes % DEFDACBLKSIZE)
+    if(nframes % DEFDACBLKSIZE)
     {
         post("warning: audio nframes %ld not a multiple of blocksize %d",
-            nframes, (int)DEFDACBLKSIZE);
+            nframes, (int) DEFDACBLKSIZE);
         nframes -= (nframes % DEFDACBLKSIZE);
     }
-    for (n = 0; n < nframes; n += DEFDACBLKSIZE)
+    for(n = 0; n < nframes; n += DEFDACBLKSIZE)
     {
-        if (inputBuffer != NULL)
+        if(inputBuffer != NULL)
         {
-            fbuf = ((float *)inputBuffer) + n*pa_inchans;
+            fbuf = ((float *) inputBuffer) + n * pa_inchans;
             soundiop = pa_soundin;
-            for (i = 0, fp2 = fbuf; i < pa_inchans; i++, fp2++)
-                    for (j = 0, fp3 = fp2; j < DEFDACBLKSIZE;
-                        j++, fp3 += pa_inchans)
-                            *soundiop++ = (t_sample)*fp3;
+            for(i = 0, fp2 = fbuf; i < pa_inchans; i++, fp2++)
+                for(j = 0, fp3 = fp2; j < DEFDACBLKSIZE; j++, fp3 += pa_inchans)
+                    *soundiop++ = (t_sample) *fp3;
         }
-        else memset((void *)pa_soundin, 0,
-            DEFDACBLKSIZE * pa_inchans * sizeof(t_sample));
-        memset((void *)pa_soundout, 0,
+        else
+            memset((void *) pa_soundin, 0,
+                DEFDACBLKSIZE * pa_inchans * sizeof(t_sample));
+        memset((void *) pa_soundout, 0,
             DEFDACBLKSIZE * pa_outchans * sizeof(t_sample));
         (*pa_callback)();
-        if (outputBuffer != NULL)
+        if(outputBuffer != NULL)
         {
-            fbuf = ((float *)outputBuffer) + n*pa_outchans;
+            fbuf = ((float *) outputBuffer) + n * pa_outchans;
             soundiop = pa_soundout;
-            for (i = 0, fp2 = fbuf; i < pa_outchans; i++, fp2++)
-                for (j = 0, fp3 = fp2; j < DEFDACBLKSIZE;
+            for(i = 0, fp2 = fbuf; i < pa_outchans; i++, fp2++)
+                for(j = 0, fp3 = fp2; j < DEFDACBLKSIZE;
                     j++, fp3 += pa_outchans)
-                        *fp3 = (float)*soundiop++;
+                    *fp3 = (float) *soundiop++;
         }
     }
     return 0;
 }
 
 #ifdef FAKEBLOCKING
-    /* callback for "non-callback" case in which we actually open portaudio
-    in callback mode but fake "blocking mode". We communicate with the
-    main thread via FIFO.  First read the audio output FIFO (which
-    we sync on, not waiting for it but supplying zeros to the audio output if
-    there aren't enough samples in the FIFO when we are called), then write
-    to the audio input FIFO.  The main thread will wait for the input fifo.
-    We can either throw it a pthreads condition or just allow the main thread
-    to poll for us; so far polling seems to work better. */
-static int pa_fifo_callback(const void *inputBuffer,
-    void *outputBuffer, unsigned long nframes,
-    const PaStreamCallbackTimeInfo *outTime, PaStreamCallbackFlags myflags,
-    void *userData)
+/* callback for "non-callback" case in which we actually open portaudio
+in callback mode but fake "blocking mode". We communicate with the
+main thread via FIFO.  First read the audio output FIFO (which
+we sync on, not waiting for it but supplying zeros to the audio output if
+there aren't enough samples in the FIFO when we are called), then write
+to the audio input FIFO.  The main thread will wait for the input fifo.
+We can either throw it a pthreads condition or just allow the main thread
+to poll for us; so far polling seems to work better. */
+static int pa_fifo_callback(const void *inputBuffer, void *outputBuffer,
+    unsigned long nframes, const PaStreamCallbackTimeInfo *outTime,
+    PaStreamCallbackFlags myflags, void *userData)
 {
     /* callback routine for non-callback client... throw samples into
             and read them out of a FIFO */
@@ -199,37 +196,36 @@ static int pa_fifo_callback(const void *inputBuffer,
     float *fbuf;
 
 #if CHECKFIFOS
-    if (pa_inchans * sys_ringbuf_getreadavailable(&pa_outring) !=
+    if(pa_inchans * sys_ringbuf_getreadavailable(&pa_outring) !=
         pa_outchans * sys_ringbuf_getwriteavailable(&pa_inring))
-            post("warning: in and out rings unequal (%d, %d)",
-                sys_ringbuf_getreadavailable(&pa_outring),
-                 sys_ringbuf_getwriteavailable(&pa_inring));
+        post("warning: in and out rings unequal (%d, %d)",
+            sys_ringbuf_getreadavailable(&pa_outring),
+            sys_ringbuf_getwriteavailable(&pa_inring));
 #endif
     fiforoom = sys_ringbuf_getreadavailable(&pa_outring);
-    if ((unsigned)fiforoom >= nframes*pa_outchans*sizeof(float))
+    if((unsigned) fiforoom >= nframes * pa_outchans * sizeof(float))
     {
-        if (outputBuffer)
+        if(outputBuffer)
             sys_ringbuf_read(&pa_outring, outputBuffer,
-                nframes*pa_outchans*sizeof(float), pa_outbuf);
-        else if (pa_outchans)
+                nframes * pa_outchans * sizeof(float), pa_outbuf);
+        else if(pa_outchans)
             post("audio error: no outputBuffer but output channels");
-        if (inputBuffer)
+        if(inputBuffer)
             sys_ringbuf_write(&pa_inring, inputBuffer,
-                nframes*pa_inchans*sizeof(float), pa_inbuf);
-        else if (pa_inchans)
+                nframes * pa_inchans * sizeof(float), pa_inbuf);
+        else if(pa_inchans)
             post("audio error: no inputBuffer but input channels");
     }
     else
-    {        /* PD could not keep up; generate zeros */
-        if (pa_started)
-            pa_dio_error = 1;
-        if (outputBuffer)
+    { /* PD could not keep up; generate zeros */
+        if(pa_started) pa_dio_error = 1;
+        if(outputBuffer)
         {
-            for (ch = 0; ch < pa_outchans; ch++)
+            for(ch = 0; ch < pa_outchans; ch++)
             {
                 unsigned long frame;
-                fbuf = ((float *)outputBuffer) + ch;
-                for (frame = 0; frame < nframes; frame++, fbuf += pa_outchans)
+                fbuf = ((float *) outputBuffer) + ch;
+                for(frame = 0; frame < nframes; frame++, fbuf += pa_outchans)
                     *fbuf = 0;
             }
         }
@@ -244,12 +240,13 @@ static int pa_fifo_callback(const void *inputBuffer,
 #endif /* FAKEBLOCKING */
 
 PaError pa_open_callback(double sampleRate, int inchannels, int outchannels,
-    int framesperbuf, int nbuffers, int indeviceno, int outdeviceno, PaStreamCallback *callbackfn)
+    int framesperbuf, int nbuffers, int indeviceno, int outdeviceno,
+    PaStreamCallback *callbackfn)
 {
-    long   bytesPerSample;
+    long bytesPerSample;
     PaError err;
     PaStreamParameters instreamparams, outstreamparams;
-    PaStreamParameters*p_instreamparams=0, *p_outstreamparams=0;
+    PaStreamParameters *p_instreamparams = 0, *p_outstreamparams = 0;
 
     /* fprintf(stderr, "nchan %d, flags %d, bufs %d, framesperbuf %d\n",
             nchannels, flags, nbuffers, framesperbuf); */
@@ -268,75 +265,67 @@ PaError pa_open_callback(double sampleRate, int inchannels, int outchannels,
     instreamparams.suggestedLatency = outstreamparams.suggestedLatency = 0;
 #else
     instreamparams.suggestedLatency = outstreamparams.suggestedLatency =
-        nbuffers*framesperbuf/sampleRate;
+        nbuffers * framesperbuf / sampleRate;
 #endif /* FAKEBLOCKING */
 
-    if( inchannels>0 && indeviceno >= 0)
-        p_instreamparams=&instreamparams;
-    if( outchannels>0 && outdeviceno >= 0)
-        p_outstreamparams=&outstreamparams;
+    if(inchannels > 0 && indeviceno >= 0) p_instreamparams = &instreamparams;
+    if(outchannels > 0 && outdeviceno >= 0)
+        p_outstreamparams = &outstreamparams;
 
-    err=Pa_IsFormatSupported(p_instreamparams, p_outstreamparams, sampleRate);
+    err = Pa_IsFormatSupported(p_instreamparams, p_outstreamparams, sampleRate);
 
-    if (paFormatIsSupported != err)
+    if(paFormatIsSupported != err)
     {
-        /* check whether we have to change the numbers of channel and/or samplerate */
-        const PaDeviceInfo* info = 0;
-        double inRate=0, outRate=0;
+        /* check whether we have to change the numbers of channel and/or
+         * samplerate */
+        const PaDeviceInfo *info = 0;
+        double inRate = 0, outRate = 0;
 
-        if (inchannels>0)
+        if(inchannels > 0)
         {
-            if (NULL != (info = Pa_GetDeviceInfo( instreamparams.device )))
+            if(NULL != (info = Pa_GetDeviceInfo(instreamparams.device)))
             {
-              inRate=info->defaultSampleRate;
+                inRate = info->defaultSampleRate;
 
-              if(info->maxInputChannels<inchannels)
-                instreamparams.channelCount=info->maxInputChannels;
+                if(info->maxInputChannels < inchannels)
+                    instreamparams.channelCount = info->maxInputChannels;
             }
         }
 
-        if (outchannels>0)
+        if(outchannels > 0)
         {
-            if (NULL != (info = Pa_GetDeviceInfo( outstreamparams.device )))
+            if(NULL != (info = Pa_GetDeviceInfo(outstreamparams.device)))
             {
-              outRate=info->defaultSampleRate;
+                outRate = info->defaultSampleRate;
 
-              if(info->maxOutputChannels<outchannels)
-                outstreamparams.channelCount=info->maxOutputChannels;
+                if(info->maxOutputChannels < outchannels)
+                    outstreamparams.channelCount = info->maxOutputChannels;
             }
         }
 
-        if (err == paInvalidSampleRate)
+        if(err == paInvalidSampleRate)
         {
-            sampleRate=outRate;
+            sampleRate = outRate;
         }
 
-        err=Pa_IsFormatSupported(p_instreamparams, p_outstreamparams,
-            sampleRate);
-        if (paFormatIsSupported != err)
-        goto error;
+        err = Pa_IsFormatSupported(
+            p_instreamparams, p_outstreamparams, sampleRate);
+        if(paFormatIsSupported != err) goto error;
     }
-    err = Pa_OpenStream(
-              &pa_stream,
-              p_instreamparams,
-              p_outstreamparams,
-              sampleRate,
-              framesperbuf,
-              paNoFlag,      /* portaudio will clip for us */
-              callbackfn,
-              0);
-    if (err != paNoError)
-        goto error;
+    err = Pa_OpenStream(&pa_stream, p_instreamparams, p_outstreamparams,
+        sampleRate, framesperbuf, paNoFlag, /* portaudio will clip for us */
+        callbackfn, 0);
+    if(err != paNoError) goto error;
 
     err = Pa_StartStream(pa_stream);
-    if (err != paNoError)
+    if(err != paNoError)
     {
         post("error opening failed; closing audio stream: %s",
             Pa_GetErrorText(err));
         pa_close_audio();
         goto error;
     }
-    STUFF->st_dacsr=sampleRate;
+    STUFF->st_dacsr = sampleRate;
     return paNoError;
 error:
     pa_stream = NULL;
@@ -344,8 +333,8 @@ error:
 }
 
 int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
-    t_sample *soundout, int framesperbuf, int nbuffers,
-    int indeviceno, int outdeviceno, t_audiocallback callbackfn)
+    t_sample *soundout, int framesperbuf, int nbuffers, int indeviceno,
+    int outdeviceno, t_audiocallback callbackfn)
 {
     PaError err;
     int j, devno, pa_indev = -1, pa_outdev = -1;
@@ -353,22 +342,22 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     pa_callback = callbackfn;
     /* fprintf(stderr, "open callback %d\n", (callbackfn != 0)); */
     pa_init();
-    /* post("in %d out %d rate %d device %d", inchans, outchans, rate, deviceno); */
+    /* post("in %d out %d rate %d device %d", inchans, outchans, rate,
+     * deviceno); */
 
-    if (pa_stream)
-        pa_close_audio();
+    if(pa_stream) pa_close_audio();
 
-    if (inchans > 0)
+    if(inchans > 0)
     {
-        for (j = 0, devno = 0; j < Pa_GetDeviceCount(); j++)
+        for(j = 0, devno = 0; j < Pa_GetDeviceCount(); j++)
         {
             const PaDeviceInfo *info = Pa_GetDeviceInfo(j);
-            if (info->maxInputChannels > 0)
+            if(info->maxInputChannels > 0)
             {
-                if (devno == indeviceno)
+                if(devno == indeviceno)
                 {
-                    if (inchans > info->maxInputChannels)
-                      inchans = info->maxInputChannels;
+                    if(inchans > info->maxInputChannels)
+                        inchans = info->maxInputChannels;
 
                     pa_indev = j;
                     break;
@@ -378,17 +367,17 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         }
     }
 
-    if (outchans > 0)
+    if(outchans > 0)
     {
-        for (j = 0, devno = 0; j < Pa_GetDeviceCount(); j++)
+        for(j = 0, devno = 0; j < Pa_GetDeviceCount(); j++)
         {
             const PaDeviceInfo *info = Pa_GetDeviceInfo(j);
-            if (info->maxOutputChannels > 0)
+            if(info->maxOutputChannels > 0)
             {
-                if (devno == outdeviceno)
+                if(devno == outdeviceno)
                 {
-                    if (outchans > info->maxOutputChannels)
-                      outchans = info->maxOutputChannels;
+                    if(outchans > info->maxOutputChannels)
+                        outchans = info->maxOutputChannels;
 
                     pa_outdev = j;
                     break;
@@ -398,14 +387,15 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         }
     }
 
-    if (inchans > 0 && pa_indev == -1)
-        inchans = 0;
-    if (outchans > 0 && pa_outdev == -1)
-        outchans = 0;
+    if(inchans > 0 && pa_indev == -1) inchans = 0;
+    if(outchans > 0 && pa_outdev == -1) outchans = 0;
 
-    logpost(NULL, PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
-    logpost(NULL, PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);
-    logpost(NULL, PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
+    logpost(
+        NULL, PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
+    logpost(
+        NULL, PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);
+    logpost(
+        NULL, PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
     logpost(NULL, PD_VERBOSE, "rate %d", rate);
 
     pa_inchans = STUFF->st_inchannels = inchans;
@@ -414,73 +404,72 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     pa_soundout = soundout;
 
 #ifdef FAKEBLOCKING
-    if (pa_inbuf)
-        free((char *)pa_inbuf), pa_inbuf = 0;
-    if (pa_outbuf)
-        free((char *)pa_outbuf), pa_outbuf = 0;
+    if(pa_inbuf) free((char *) pa_inbuf), pa_inbuf = 0;
+    if(pa_outbuf) free((char *) pa_outbuf), pa_outbuf = 0;
 #ifdef THREADSIGNAL
     pthread_mutex_init(&pa_mutex, 0);
     pthread_cond_init(&pa_sem, 0);
 #endif
 #endif
 
-    if (! inchans && !outchans)
-        return (0);
+    if(!inchans && !outchans) return (0);
 
-    if (callbackfn)
+    if(callbackfn)
     {
         pa_callback = callbackfn;
-        err = pa_open_callback(rate, inchans, outchans,
-            framesperbuf, nbuffers, pa_indev, pa_outdev, pa_lowlevel_callback);
+        err = pa_open_callback(rate, inchans, outchans, framesperbuf, nbuffers,
+            pa_indev, pa_outdev, pa_lowlevel_callback);
     }
     else
     {
 #ifdef FAKEBLOCKING
-        if (pa_inchans)
+        if(pa_inchans)
         {
-            pa_inbuf = malloc(nbuffers*framesperbuf*pa_inchans*sizeof(float));
+            pa_inbuf =
+                malloc(nbuffers * framesperbuf * pa_inchans * sizeof(float));
             sys_ringbuf_init(&pa_inring,
-                nbuffers*framesperbuf*pa_inchans*sizeof(float), pa_inbuf,
-                    nbuffers*framesperbuf*pa_inchans*sizeof(float));
+                nbuffers * framesperbuf * pa_inchans * sizeof(float), pa_inbuf,
+                nbuffers * framesperbuf * pa_inchans * sizeof(float));
         }
-        if (pa_outchans)
+        if(pa_outchans)
         {
-            pa_outbuf = malloc(nbuffers*framesperbuf*pa_outchans*sizeof(float));
+            pa_outbuf =
+                malloc(nbuffers * framesperbuf * pa_outchans * sizeof(float));
             sys_ringbuf_init(&pa_outring,
-                nbuffers*framesperbuf*pa_outchans*sizeof(float), pa_outbuf, 0);
+                nbuffers * framesperbuf * pa_outchans * sizeof(float),
+                pa_outbuf, 0);
         }
-        err = pa_open_callback(rate, inchans, outchans,
-            framesperbuf, nbuffers, pa_indev, pa_outdev, pa_fifo_callback);
+        err = pa_open_callback(rate, inchans, outchans, framesperbuf, nbuffers,
+            pa_indev, pa_outdev, pa_fifo_callback);
 #else
-        err = pa_open_callback(rate, inchans, outchans,
-            framesperbuf, nbuffers, pa_indev, pa_outdev, 0);
+        err = pa_open_callback(rate, inchans, outchans, framesperbuf, nbuffers,
+            pa_indev, pa_outdev, 0);
 #endif
     }
     pa_started = 0;
     pa_nbuffers = nbuffers;
-    if ( err != paNoError )
+    if(err != paNoError)
     {
         pd_error(0, "error opening audio: %s", Pa_GetErrorText(err));
         /* Pa_Terminate(); */
         return (1);
     }
-    else logpost(NULL, PD_VERBOSE, "... opened OK.");
+    else
+        logpost(NULL, PD_VERBOSE, "... opened OK.");
     return (0);
 }
 
 void pa_close_audio(void)
 {
-    if (pa_stream)
+    if(pa_stream)
     {
         Pa_AbortStream(pa_stream);
         Pa_CloseStream(pa_stream);
     }
     pa_stream = 0;
 #ifdef FAKEBLOCKING
-    if (pa_inbuf)
-        free((char *)pa_inbuf), pa_inbuf = 0;
-    if (pa_outbuf)
-        free((char *)pa_outbuf), pa_outbuf = 0;
+    if(pa_inbuf) free((char *) pa_inbuf), pa_inbuf = 0;
+    if(pa_outbuf) free((char *) pa_outbuf), pa_outbuf = 0;
 #ifdef THREADSIGNAL
     pthread_mutex_destroy(&pa_mutex);
     pthread_cond_destroy(&pa_sem);
@@ -494,7 +483,7 @@ int pa_send_dacs(void)
     float *fp2, *fp3;
     float *conversionbuf;
     int j, k;
-    int rtnval =  SENDDACS_YES;
+    int rtnval = SENDDACS_YES;
     int locked = 0;
     double timebefore;
 #ifdef FAKEBLOCKING
@@ -504,50 +493,52 @@ int pa_send_dacs(void)
 #ifdef _WIN32
     struct __timeb64 tb;
     _ftime64(&tb);
-    timeout = (double)tb.time + tb.millitm * 0.001;
+    timeout = (double) tb.time + tb.millitm * 0.001;
 #else
     struct timeval now;
     gettimeofday(&now, 0);
-    timeout = (double)now.tv_sec + (1./1000000.) * now.tv_usec;
+    timeout = (double) now.tv_sec + (1. / 1000000.) * now.tv_usec;
 #endif
     timeout += THREADSIGNAL_TIMEOUT * 0.001;
-    ts.tv_sec = (long long)timeout;
-    ts.tv_nsec = (timeout - (double)ts.tv_sec) * 1e9;
+    ts.tv_sec = (long long) timeout;
+    ts.tv_nsec = (timeout - (double) ts.tv_sec) * 1e9;
 #else
 #endif /* THREADSIGNAL */
 #endif /* FAKEBLOCKING */
     timebefore = sys_getrealtime();
 
-    if ((!STUFF->st_inchannels && !STUFF->st_outchannels) || !pa_stream)
+    if((!STUFF->st_inchannels && !STUFF->st_outchannels) || !pa_stream)
         return (SENDDACS_NO);
-    conversionbuf = (float *)alloca((STUFF->st_inchannels > STUFF->st_outchannels?
-        STUFF->st_inchannels:STUFF->st_outchannels) * DEFDACBLKSIZE * sizeof(float));
+    conversionbuf = (float *) alloca(
+        (STUFF->st_inchannels > STUFF->st_outchannels ? STUFF->st_inchannels
+                                                      : STUFF->st_outchannels) *
+        DEFDACBLKSIZE * sizeof(float));
 
 #ifdef FAKEBLOCKING
-    if (!STUFF->st_inchannels)    /* if no input channels sync on output */
+    if(!STUFF->st_inchannels) /* if no input channels sync on output */
     {
 #ifdef THREADSIGNAL
         pthread_mutex_lock(&pa_mutex);
 #endif
-        while (sys_ringbuf_getwriteavailable(&pa_outring) <
-            (long)(STUFF->st_outchannels * DEFDACBLKSIZE * sizeof(float)))
+        while(sys_ringbuf_getwriteavailable(&pa_outring) <
+              (long) (STUFF->st_outchannels * DEFDACBLKSIZE * sizeof(float)))
         {
             rtnval = SENDDACS_SLEPT;
 #ifdef THREADSIGNAL
-            if (pthread_cond_timedwait(&pa_sem, &pa_mutex, &ts) == ETIMEDOUT)
+            if(pthread_cond_timedwait(&pa_sem, &pa_mutex, &ts) == ETIMEDOUT)
             {
                 locked = 1;
                 break;
             }
 #else
-            if (Pa_IsStreamActive(&pa_stream) < 0 &&
+            if(Pa_IsStreamActive(&pa_stream) < 0 &&
                 (sys_getrealtime() - timebefore) > (POLL_TIMEOUT * 0.001))
             {
                 locked = 1;
                 break;
             }
             sys_microsleep();
-            if (!pa_stream)     /* sys_microsleep() may have closed device */
+            if(!pa_stream) /* sys_microsleep() may have closed device */
                 return SENDDACS_NO;
 #endif /* THREADSIGNAL */
         }
@@ -555,41 +546,41 @@ int pa_send_dacs(void)
         pthread_mutex_unlock(&pa_mutex);
 #endif
     }
-        /* write output */
-    if (STUFF->st_outchannels && !locked)
+    /* write output */
+    if(STUFF->st_outchannels && !locked)
     {
-        for (j = 0, fp = STUFF->st_soundout, fp2 = conversionbuf;
+        for(j = 0, fp = STUFF->st_soundout, fp2 = conversionbuf;
             j < STUFF->st_outchannels; j++, fp2++)
-                for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
-                    k++, fp++, fp3 += STUFF->st_outchannels)
-                        *fp3 = *fp;
+            for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
+                k++, fp++, fp3 += STUFF->st_outchannels)
+                *fp3 = *fp;
         sys_ringbuf_write(&pa_outring, conversionbuf,
-            STUFF->st_outchannels*(DEFDACBLKSIZE*sizeof(float)), pa_outbuf);
+            STUFF->st_outchannels * (DEFDACBLKSIZE * sizeof(float)), pa_outbuf);
     }
-    if (STUFF->st_inchannels)    /* if there is input sync on it */
+    if(STUFF->st_inchannels) /* if there is input sync on it */
     {
 #ifdef THREADSIGNAL
         pthread_mutex_lock(&pa_mutex);
 #endif
-        while (sys_ringbuf_getreadavailable(&pa_inring) <
-            (long)(STUFF->st_inchannels * DEFDACBLKSIZE * sizeof(float)))
+        while(sys_ringbuf_getreadavailable(&pa_inring) <
+              (long) (STUFF->st_inchannels * DEFDACBLKSIZE * sizeof(float)))
         {
             rtnval = SENDDACS_SLEPT;
 #ifdef THREADSIGNAL
-            if (pthread_cond_timedwait(&pa_sem, &pa_mutex, &ts) == ETIMEDOUT)
+            if(pthread_cond_timedwait(&pa_sem, &pa_mutex, &ts) == ETIMEDOUT)
             {
                 locked = 1;
                 break;
             }
 #else
-            if (Pa_IsStreamActive(&pa_stream) < 0 &&
+            if(Pa_IsStreamActive(&pa_stream) < 0 &&
                 (sys_getrealtime() - timebefore) > (POLL_TIMEOUT * 0.001))
             {
                 locked = 1;
                 break;
             }
             sys_microsleep();
-            if (!pa_stream)     /* sys_microsleep() may have closed device */
+            if(!pa_stream) /* sys_microsleep() may have closed device */
                 return SENDDACS_NO;
 #endif /* THREADSIGNAL */
         }
@@ -597,50 +588,48 @@ int pa_send_dacs(void)
         pthread_mutex_unlock(&pa_mutex);
 #endif
     }
-    if (STUFF->st_inchannels && !locked)
+    if(STUFF->st_inchannels && !locked)
     {
         sys_ringbuf_read(&pa_inring, conversionbuf,
-            STUFF->st_inchannels*(DEFDACBLKSIZE*sizeof(float)), pa_inbuf);
-        for (j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
+            STUFF->st_inchannels * (DEFDACBLKSIZE * sizeof(float)), pa_inbuf);
+        for(j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
             j < STUFF->st_inchannels; j++, fp2++)
-                for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
-                    k++, fp++, fp3 += STUFF->st_inchannels)
-                        *fp = *fp3;
+            for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
+                k++, fp++, fp3 += STUFF->st_inchannels)
+                *fp = *fp3;
     }
 
-#else /* FAKEBLOCKING */
-        /* write output */
-    if (STUFF->st_outchannels)
+#else  /* FAKEBLOCKING */
+    /* write output */
+    if(STUFF->st_outchannels)
     {
-        if (!pa_started)
+        if(!pa_started)
         {
             memset(conversionbuf, 0,
                 STUFF->st_outchannels * DEFDACBLKSIZE * sizeof(float));
-            for (j = 0; j < pa_nbuffers-1; j++)
+            for(j = 0; j < pa_nbuffers - 1; j++)
                 Pa_WriteStream(pa_stream, conversionbuf, DEFDACBLKSIZE);
         }
-        for (j = 0, fp = STUFF->st_soundout, fp2 = conversionbuf;
+        for(j = 0, fp = STUFF->st_soundout, fp2 = conversionbuf;
             j < STUFF->st_outchannels; j++, fp2++)
-                for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
-                    k++, fp++, fp3 += STUFF->st_outchannels)
-                        *fp3 = *fp;
-        if (Pa_WriteStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
-            if (Pa_IsStreamActive(&pa_stream) < 0)
-                locked = 1;
+            for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
+                k++, fp++, fp3 += STUFF->st_outchannels)
+                *fp3 = *fp;
+        if(Pa_WriteStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
+            if(Pa_IsStreamActive(&pa_stream) < 0) locked = 1;
     }
 
-    if (STUFF->st_inchannels)
+    if(STUFF->st_inchannels)
     {
-        if (Pa_ReadStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
-            if (Pa_IsStreamActive(&pa_stream) < 0)
-                locked = 1;
-        for (j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
+        if(Pa_ReadStream(pa_stream, conversionbuf, DEFDACBLKSIZE) != paNoError)
+            if(Pa_IsStreamActive(&pa_stream) < 0) locked = 1;
+        for(j = 0, fp = STUFF->st_soundin, fp2 = conversionbuf;
             j < STUFF->st_inchannels; j++, fp2++)
-                for (k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
-                    k++, fp++, fp3 += STUFF->st_inchannels)
-                        *fp = *fp3;
+            for(k = 0, fp3 = fp2; k < DEFDACBLKSIZE;
+                k++, fp++, fp3 += STUFF->st_inchannels)
+                *fp = *fp3;
     }
-    if (sys_getrealtime() - timebefore > 0.002)
+    if(sys_getrealtime() - timebefore > 0.002)
     {
         rtnval = SENDDACS_SLEPT;
     }
@@ -648,80 +637,78 @@ int pa_send_dacs(void)
     pa_started = 1;
 
     memset(STUFF->st_soundout, 0,
-        DEFDACBLKSIZE*sizeof(t_sample)*STUFF->st_outchannels);
-    if (locked)
+        DEFDACBLKSIZE * sizeof(t_sample) * STUFF->st_outchannels);
+    if(locked)
     {
         PaError err = Pa_IsStreamActive(&pa_stream);
         pd_error(0, "error %d: %s", err, Pa_GetErrorText(err));
         sys_close_audio();
-        #ifdef __APPLE__
-            /* TODO: the portaudio coreaudio implementation doesn't handle
-               re-connection, so suggest restarting */
+#ifdef __APPLE__
+        /* TODO: the portaudio coreaudio implementation doesn't handle
+           re-connection, so suggest restarting */
+        pd_error(0, "audio device not responding - closing audio");
+        pd_error(0, "you may need to save and restart pd");
+#else
+        /* portaudio seems to handle this better on windows and linux */
+        pd_error(0, "trying to reopen audio device");
+        sys_reopen_audio(); /* try to reopen it */
+        if(audio_isopen())
+            pd_error(0, "successfully reopened audio device");
+        else
+        {
             pd_error(0, "audio device not responding - closing audio");
-            pd_error(0, "you may need to save and restart pd");
-        #else
-            /* portaudio seems to handle this better on windows and linux */
-            pd_error(0, "trying to reopen audio device");
-            sys_reopen_audio(); /* try to reopen it */
-            if (audio_isopen())
-                pd_error(0, "successfully reopened audio device");
-            else
-            {
-                pd_error(0, "audio device not responding - closing audio");
-                pd_error(0, "reconnect and reselect it in the settings (or toggle DSP)");
-            }
-        #endif
+            pd_error(
+                0, "reconnect and reselect it in the settings (or toggle DSP)");
+        }
+#endif
         return SENDDACS_NO;
     }
-    else return (rtnval);
+    else
+        return (rtnval);
 }
 
-static char*pdi2devname(const PaDeviceInfo*pdi, char*buf, size_t bufsize) {
+static char *pdi2devname(const PaDeviceInfo *pdi, char *buf, size_t bufsize)
+{
     const PaHostApiInfo *api = 0;
     char utf8device[MAXPDSTRING];
     utf8device[0] = 0;
 
-    if(!pdi)
-        return 0;
+    if(!pdi) return 0;
 
     api = Pa_GetHostApiInfo(pdi->hostApi);
     if(api)
-        snprintf(utf8device, MAXPDSTRING, "%s: %s",
-            api->name, pdi->name);
+        snprintf(utf8device, MAXPDSTRING, "%s: %s", api->name, pdi->name);
     else
-        snprintf(utf8device, MAXPDSTRING, "%s",
-            pdi->name);
+        snprintf(utf8device, MAXPDSTRING, "%s", pdi->name);
 
     u8_nativetoutf8(buf, bufsize, utf8device, MAXPDSTRING);
     return buf;
 }
 
-    /* scanning for devices */
-void pa_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize)
+/* scanning for devices */
+void pa_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
+    int *canmulti, int maxndev, int devdescsize)
 {
     int i, nin = 0, nout = 0, ndev;
-    *canmulti = 1;  /* one dev each for input and output */
+    *canmulti = 1; /* one dev each for input and output */
 
     pa_init();
     ndev = Pa_GetDeviceCount();
-    for (i = 0; i < ndev; i++)
+    for(i = 0; i < ndev; i++)
     {
         char utf8device[MAXPDSTRING];
         const PaDeviceInfo *pdi = Pa_GetDeviceInfo(i);
-        char*devname = pdi2devname(pdi, utf8device, MAXPDSTRING);
-        if (pdi->maxInputChannels > 0 && nin < maxndev)
+        char *devname = pdi2devname(pdi, utf8device, MAXPDSTRING);
+        if(pdi->maxInputChannels > 0 && nin < maxndev)
         {
-                /* LATER figure out how to get API name correctly */
-            snprintf(indevlist + nin * devdescsize, devdescsize,
-                "%s", devname);
+            /* LATER figure out how to get API name correctly */
+            snprintf(indevlist + nin * devdescsize, devdescsize, "%s", devname);
             nin++;
         }
-        if (pdi->maxOutputChannels > 0 && nout < maxndev)
+        if(pdi->maxOutputChannels > 0 && nout < maxndev)
         {
-            snprintf(outdevlist + nout * devdescsize, devdescsize,
-                "%s", devname);
+            snprintf(
+                outdevlist + nout * devdescsize, devdescsize, "%s", devname);
             nout++;
         }
     }

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -461,8 +461,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
         /* Pa_Terminate(); */
         return (1);
     }
-    else
-        logpost(NULL, PD_VERBOSE, "... opened OK.");
+    logpost(NULL, PD_VERBOSE, "... opened OK.");
     return (0);
 }
 
@@ -672,8 +671,7 @@ int pa_send_dacs(void)
 #endif
         return SENDDACS_NO;
     }
-    else
-        return (rtnval);
+    return (rtnval);
 }
 
 static char *pdi2devname(const PaDeviceInfo *pdi, char *buf, size_t bufsize)

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -138,8 +138,11 @@ static int pa_lowlevel_callback(const void *inputBuffer, void *outputBuffer,
     PaStreamCallbackFlags myflags, void *userData)
 {
     int i;
-    unsigned int n, j;
-    float *fbuf, *fp2, *fp3;
+    unsigned int n;
+    unsigned int j;
+    float *fbuf;
+    float *fp2;
+    float *fp3;
     t_sample *soundiop;
     if(nframes % DEFDACBLKSIZE)
     {
@@ -279,7 +282,8 @@ PaError pa_open_callback(double sampleRate, int inchannels, int outchannels,
         /* check whether we have to change the numbers of channel and/or
          * samplerate */
         const PaDeviceInfo *info = 0;
-        double inRate = 0, outRate = 0;
+        double inRate = 0;
+        double outRate = 0;
 
         if(inchannels > 0)
         {
@@ -337,7 +341,10 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     int outdeviceno, t_audiocallback callbackfn)
 {
     PaError err;
-    int j, devno, pa_indev = -1, pa_outdev = -1;
+    int j;
+    int devno;
+    int pa_indev = -1;
+    int pa_outdev = -1;
 
     pa_callback = callbackfn;
     /* fprintf(stderr, "open callback %d\n", (callbackfn != 0)); */
@@ -480,9 +487,11 @@ void pa_close_audio(void)
 int pa_send_dacs(void)
 {
     t_sample *fp;
-    float *fp2, *fp3;
+    float *fp2;
+    float *fp3;
     float *conversionbuf;
-    int j, k;
+    int j;
+    int k;
     int rtnval = SENDDACS_YES;
     int locked = 0;
     double timebefore;
@@ -689,7 +698,10 @@ static char *pdi2devname(const PaDeviceInfo *pdi, char *buf, size_t bufsize)
 void pa_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
     int *canmulti, int maxndev, int devdescsize)
 {
-    int i, nin = 0, nout = 0, ndev;
+    int i;
+    int nin = 0;
+    int nout = 0;
+    int ndev;
     *canmulti = 1; /* one dev each for input and output */
 
     pa_init();

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -212,8 +212,11 @@ static long sys_ringbuf_AdvanceReadIndex(
 long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
     long numBytes, PA_VOLATILE char *buffer)
 {
-    long size1, size2, numWritten;
-    PA_VOLATILE void *data1, *data2;
+    long size1;
+    long size2;
+    long numWritten;
+    PA_VOLATILE void *data1;
+    void *data2;
     numWritten = sys_ringbuf_GetWriteRegions(
         rbuf, numBytes, &data1, &size1, &data2, &size2, buffer);
     if(size2 > 0)
@@ -236,8 +239,11 @@ long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
 long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
     PA_VOLATILE char *buffer)
 {
-    long size1, size2, numRead;
-    PA_VOLATILE void *data1, *data2;
+    long size1;
+    long size2;
+    long numRead;
+    PA_VOLATILE void *data1;
+    void *data2;
     numRead = sys_ringbuf_GetReadRegions(
         rbuf, numBytes, &data1, &size1, &data2, &size2, buffer);
     if(size2 > 0)

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -44,19 +44,19 @@
 #include <string.h>
 
 /* Clear buffer. Should only be called when buffer is NOT being read. */
-static void sys_ringbuf_Flush(PA_VOLATILE sys_ringbuf *rbuf,
-    PA_VOLATILE void *dataPtr, long nfill);
+static void sys_ringbuf_Flush(
+    PA_VOLATILE sys_ringbuf *rbuf, PA_VOLATILE void *dataPtr, long nfill);
 
 /* Get address of region(s) to which we can write data.
 ** If the region is contiguous, size2 will be zero.
 ** If non-contiguous, size2 will be the size of second region.
 ** Returns room available to be written or numBytes, whichever is smaller.
 */
-static long sys_ringbuf_GetWriteRegions(PA_VOLATILE  sys_ringbuf *rbuf,
+static long sys_ringbuf_GetWriteRegions(PA_VOLATILE sys_ringbuf *rbuf,
     long numBytes, PA_VOLATILE void **dataPtr1, long *sizePtr1,
     PA_VOLATILE void **dataPtr2, long *sizePtr2, PA_VOLATILE char *buffer);
-static long sys_ringbuf_AdvanceWriteIndex(PA_VOLATILE sys_ringbuf *rbuf,
-    long numBytes);
+static long sys_ringbuf_AdvanceWriteIndex(
+    PA_VOLATILE sys_ringbuf *rbuf, long numBytes);
 
 /* Get address of region(s) from which we can read data.
 ** If the region is contiguous, size2 will be zero.
@@ -67,8 +67,8 @@ static long sys_ringbuf_GetReadRegions(PA_VOLATILE sys_ringbuf *rbuf,
     long numBytes, PA_VOLATILE void **dataPtr1, long *sizePtr1,
     PA_VOLATILE void **dataPtr2, long *sizePtr2, PA_VOLATILE char *buffer);
 
-static long sys_ringbuf_AdvanceReadIndex(PA_VOLATILE sys_ringbuf *rbuf,
-    long numBytes );
+static long sys_ringbuf_AdvanceReadIndex(
+    PA_VOLATILE sys_ringbuf *rbuf, long numBytes);
 
 /***************************************************************************
  * Initialize FIFO.
@@ -77,38 +77,39 @@ long sys_ringbuf_init(PA_VOLATILE sys_ringbuf *rbuf, long numBytes,
     PA_VOLATILE char *dataPtr, long nfill)
 {
     rbuf->bufferSize = numBytes;
-    sys_ringbuf_Flush(rbuf, dataPtr,  nfill);
+    sys_ringbuf_Flush(rbuf, dataPtr, nfill);
     return 0;
 }
+
 /***************************************************************************
 ** Return number of bytes available for reading. */
 long sys_ringbuf_getreadavailable(PA_VOLATILE sys_ringbuf *rbuf)
 {
     long ret = rbuf->writeIndex - rbuf->readIndex;
-    if (ret < 0)
-        ret += 2 * rbuf->bufferSize;
-    if (ret < 0 || ret > rbuf->bufferSize)
-        fprintf(stderr,
-            "consistency check failed: sys_ringbuf_getreadavailable\n");
-    return ( ret );
+    if(ret < 0) ret += 2 * rbuf->bufferSize;
+    if(ret < 0 || ret > rbuf->bufferSize)
+        fprintf(
+            stderr, "consistency check failed: sys_ringbuf_getreadavailable\n");
+    return (ret);
 }
+
 /***************************************************************************
 ** Return number of bytes available for writing. */
 long sys_ringbuf_getwriteavailable(PA_VOLATILE sys_ringbuf *rbuf)
 {
-    return ( rbuf->bufferSize - sys_ringbuf_getreadavailable(rbuf));
+    return (rbuf->bufferSize - sys_ringbuf_getreadavailable(rbuf));
 }
 
 /***************************************************************************
 ** Clear buffer. Should only be called when buffer is NOT being read. */
-static void sys_ringbuf_Flush(PA_VOLATILE sys_ringbuf *rbuf,
-    PA_VOLATILE void *dataPtr, long nfill)
+static void sys_ringbuf_Flush(
+    PA_VOLATILE sys_ringbuf *rbuf, PA_VOLATILE void *dataPtr, long nfill)
 {
     PA_VOLATILE char *s;
     long n;
     rbuf->readIndex = 0;
     rbuf->writeIndex = nfill;
-    for (n = nfill, s = dataPtr; n--; s++)
+    for(n = nfill, s = dataPtr; n--; s++)
         *s = 0;
 }
 
@@ -118,67 +119,18 @@ static void sys_ringbuf_Flush(PA_VOLATILE sys_ringbuf *rbuf,
 ** If non-contiguous, size2 will be the size of second region.
 ** Returns room available to be written or numBytes, whichever is smaller.
 */
-static long sys_ringbuf_GetWriteRegions(PA_VOLATILE  sys_ringbuf *rbuf,
+static long sys_ringbuf_GetWriteRegions(PA_VOLATILE sys_ringbuf *rbuf,
     long numBytes, PA_VOLATILE void **dataPtr1, long *sizePtr1,
     PA_VOLATILE void **dataPtr2, long *sizePtr2, PA_VOLATILE char *buffer)
 {
-    long   index;
-    long   available = sys_ringbuf_getwriteavailable( rbuf );
-    if( numBytes > available ) numBytes = available;
+    long index;
+    long available = sys_ringbuf_getwriteavailable(rbuf);
+    if(numBytes > available) numBytes = available;
     /* Check to see if write is not contiguous. */
     index = rbuf->writeIndex;
-    while (index >= rbuf->bufferSize)
+    while(index >= rbuf->bufferSize)
         index -= rbuf->bufferSize;
-    if( (index + numBytes) > rbuf->bufferSize )
-    {
-        /* Write data in two blocks that wrap the buffer. */
-        long   firstHalf = rbuf->bufferSize - index;
-        *dataPtr1 = &buffer[index];
-        *sizePtr1 = firstHalf;
-        *dataPtr2 = &buffer[0];
-        *sizePtr2 = numBytes - firstHalf;
-    }
-    else
-    {
-        *dataPtr1 = &buffer[index];
-        *sizePtr1 = numBytes;
-        *dataPtr2 = NULL;
-        *sizePtr2 = 0;
-    }
-    return numBytes;
-}
-
-
-/***************************************************************************
-*/
-static long sys_ringbuf_AdvanceWriteIndex(PA_VOLATILE sys_ringbuf *rbuf,
-    long numBytes)
-{
-    long ret = (rbuf->writeIndex + numBytes);
-    if ( ret >= 2 * rbuf->bufferSize)
-        ret -= 2 * rbuf->bufferSize;    /* check for end of buffer */
-    return rbuf->writeIndex = ret;
-}
-
-/***************************************************************************
-** Get address of region(s) from which we can read data.
-** If the region is contiguous, size2 will be zero.
-** If non-contiguous, size2 will be the size of second region.
-** Returns room available to be written or numBytes, whichever is smaller.
-*/
-static long sys_ringbuf_GetReadRegions(PA_VOLATILE sys_ringbuf *rbuf,
-    long numBytes, PA_VOLATILE void **dataPtr1, long *sizePtr1,
-    PA_VOLATILE void **dataPtr2, long *sizePtr2, PA_VOLATILE char *buffer)
-{
-    long   index;
-    long   available = sys_ringbuf_getreadavailable( rbuf );
-    if( numBytes > available ) numBytes = available;
-    /* Check to see if read is not contiguous. */
-    index = rbuf->readIndex;
-    while (index >= rbuf->bufferSize)
-        index -= rbuf->bufferSize;
-
-    if( (index + numBytes) > rbuf->bufferSize )
+    if((index + numBytes) > rbuf->bufferSize)
     {
         /* Write data in two blocks that wrap the buffer. */
         long firstHalf = rbuf->bufferSize - index;
@@ -196,14 +148,62 @@ static long sys_ringbuf_GetReadRegions(PA_VOLATILE sys_ringbuf *rbuf,
     }
     return numBytes;
 }
+
 /***************************************************************************
+ */
+static long sys_ringbuf_AdvanceWriteIndex(
+    PA_VOLATILE sys_ringbuf *rbuf, long numBytes)
+{
+    long ret = (rbuf->writeIndex + numBytes);
+    if(ret >= 2 * rbuf->bufferSize)
+        ret -= 2 * rbuf->bufferSize; /* check for end of buffer */
+    return rbuf->writeIndex = ret;
+}
+
+/***************************************************************************
+** Get address of region(s) from which we can read data.
+** If the region is contiguous, size2 will be zero.
+** If non-contiguous, size2 will be the size of second region.
+** Returns room available to be written or numBytes, whichever is smaller.
 */
-static long sys_ringbuf_AdvanceReadIndex(PA_VOLATILE sys_ringbuf *rbuf,
-    long numBytes)
+static long sys_ringbuf_GetReadRegions(PA_VOLATILE sys_ringbuf *rbuf,
+    long numBytes, PA_VOLATILE void **dataPtr1, long *sizePtr1,
+    PA_VOLATILE void **dataPtr2, long *sizePtr2, PA_VOLATILE char *buffer)
+{
+    long index;
+    long available = sys_ringbuf_getreadavailable(rbuf);
+    if(numBytes > available) numBytes = available;
+    /* Check to see if read is not contiguous. */
+    index = rbuf->readIndex;
+    while(index >= rbuf->bufferSize)
+        index -= rbuf->bufferSize;
+
+    if((index + numBytes) > rbuf->bufferSize)
+    {
+        /* Write data in two blocks that wrap the buffer. */
+        long firstHalf = rbuf->bufferSize - index;
+        *dataPtr1 = &buffer[index];
+        *sizePtr1 = firstHalf;
+        *dataPtr2 = &buffer[0];
+        *sizePtr2 = numBytes - firstHalf;
+    }
+    else
+    {
+        *dataPtr1 = &buffer[index];
+        *sizePtr1 = numBytes;
+        *dataPtr2 = NULL;
+        *sizePtr2 = 0;
+    }
+    return numBytes;
+}
+
+/***************************************************************************
+ */
+static long sys_ringbuf_AdvanceReadIndex(
+    PA_VOLATILE sys_ringbuf *rbuf, long numBytes)
 {
     long ret = (rbuf->readIndex + numBytes);
-    if( ret >= 2 * rbuf->bufferSize)
-        ret -= 2 * rbuf->bufferSize;
+    if(ret >= 2 * rbuf->bufferSize) ret -= 2 * rbuf->bufferSize;
     return rbuf->readIndex = ret;
 }
 
@@ -214,20 +214,20 @@ long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
 {
     long size1, size2, numWritten;
     PA_VOLATILE void *data1, *data2;
-    numWritten = sys_ringbuf_GetWriteRegions( rbuf, numBytes, &data1, &size1,
-        &data2, &size2, buffer);
-    if( size2 > 0 )
+    numWritten = sys_ringbuf_GetWriteRegions(
+        rbuf, numBytes, &data1, &size1, &data2, &size2, buffer);
+    if(size2 > 0)
     {
 
-        memcpy((void *)data1, data, size1 );
-        data = ((char *)data) + size1;
-        memcpy((void *)data2, data, size2 );
+        memcpy((void *) data1, data, size1);
+        data = ((char *) data) + size1;
+        memcpy((void *) data2, data, size2);
     }
     else
     {
-        memcpy((void *)data1, data, size1 );
+        memcpy((void *) data1, data, size1);
     }
-    sys_ringbuf_AdvanceWriteIndex( rbuf, numWritten );
+    sys_ringbuf_AdvanceWriteIndex(rbuf, numWritten);
     return numWritten;
 }
 
@@ -238,18 +238,18 @@ long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
 {
     long size1, size2, numRead;
     PA_VOLATILE void *data1, *data2;
-    numRead = sys_ringbuf_GetReadRegions( rbuf, numBytes, &data1, &size1,
-        &data2, &size2, buffer);
-    if( size2 > 0 )
+    numRead = sys_ringbuf_GetReadRegions(
+        rbuf, numBytes, &data1, &size1, &data2, &size2, buffer);
+    if(size2 > 0)
     {
-        memcpy(data, (void *)data1, size1 );
-        data = ((char *)data) + size1;
-        memcpy(data, (void *)data2, size2 );
+        memcpy(data, (void *) data1, size1);
+        data = ((char *) data) + size1;
+        memcpy(data, (void *) data2, size2);
     }
     else
     {
-        memcpy( data, (void *)data1, size1 );
+        memcpy(data, (void *) data1, size1);
     }
-    sys_ringbuf_AdvanceReadIndex( rbuf, numRead );
+    sys_ringbuf_AdvanceReadIndex(rbuf, numRead);
     return numRead;
 }

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -88,8 +88,10 @@ long sys_ringbuf_getreadavailable(PA_VOLATILE sys_ringbuf *rbuf)
     long ret = rbuf->writeIndex - rbuf->readIndex;
     if(ret < 0) ret += 2 * rbuf->bufferSize;
     if(ret < 0 || ret > rbuf->bufferSize)
+    {
         fprintf(
             stderr, "consistency check failed: sys_ringbuf_getreadavailable\n");
+    }
     return (ret);
 }
 

--- a/src/s_audio_paring.h
+++ b/src/s_audio_paring.h
@@ -44,30 +44,31 @@ extern "C"
 another one writes to the same ring buffer, define this as 'volatile' : */
 #define PA_VOLATILE
 
-typedef struct
-{
-    long   bufferSize;              /* Number of bytes in FIFO.
-                                        Set by sys_ringbuf_init */
-    PA_VOLATILE long   writeIndex; /* Index of next writable byte.
-                                        Set by sys_ringbuf_AdvanceWriteIndex */
-    PA_VOLATILE long   readIndex;  /* Index of next readable byte.
-                                        Set by sys_ringbuf_AdvanceReadIndex */
-} sys_ringbuf;
+    typedef struct
+    {
+        long bufferSize; /* Number of bytes in FIFO.
+                             Set by sys_ringbuf_init */
+        PA_VOLATILE long
+            writeIndex;             /* Index of next writable byte.
+                                         Set by sys_ringbuf_AdvanceWriteIndex */
+        PA_VOLATILE long readIndex; /* Index of next readable byte.
+                                         Set by sys_ringbuf_AdvanceReadIndex */
+    } sys_ringbuf;
 
-/* Initialize Ring Buffer. */
-long sys_ringbuf_init(PA_VOLATILE sys_ringbuf *rbuf, long numBytes,
-    PA_VOLATILE char *dataPtr, long nfill);
+    /* Initialize Ring Buffer. */
+    long sys_ringbuf_init(PA_VOLATILE sys_ringbuf *rbuf, long numBytes,
+        PA_VOLATILE char *dataPtr, long nfill);
 
-/* Return number of bytes available for writing. */
-long sys_ringbuf_getwriteavailable(PA_VOLATILE sys_ringbuf *rbuf);
-/* Return number of bytes available for read. */
-long sys_ringbuf_getreadavailable(PA_VOLATILE sys_ringbuf *rbuf);
-/* Return bytes written. */
-long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
-    long numBytes, PA_VOLATILE char *buffer);
-/* Return bytes read. */
-long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
-    PA_VOLATILE char *buffer);
+    /* Return number of bytes available for writing. */
+    long sys_ringbuf_getwriteavailable(PA_VOLATILE sys_ringbuf *rbuf);
+    /* Return number of bytes available for read. */
+    long sys_ringbuf_getreadavailable(PA_VOLATILE sys_ringbuf *rbuf);
+    /* Return bytes written. */
+    long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
+        long numBytes, PA_VOLATILE char *buffer);
+    /* Return bytes read. */
+    long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data,
+        long numBytes, PA_VOLATILE char *buffer);
 
 #ifdef __cplusplus
 }

--- a/src/s_entry.c
+++ b/src/s_entry.c
@@ -11,11 +11,12 @@ int sys_main(int argc, char **argv);
 #include <windows.h>
 #include <stdio.h>
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
-    LPSTR lpCmdLine, int nCmdShow)
+int WINAPI WinMain(
+    HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-    __try {
-        sys_main(__argc,__argv);
+    __try
+    {
+        sys_main(__argc, __argv);
     }
     __finally
     {
@@ -24,11 +25,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     return (0);
 }
 
-#else /* not _MSC_VER ... */
-int main(int argc, char **argv)
-{
-    return (sys_main(argc, argv));
-}
+#else  /* not _MSC_VER ... */
+int main(int argc, char **argv) { return (sys_main(argc, argv)); }
 #endif /* _MSC_VER */
-
-

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -80,7 +80,9 @@ static void sys_initloadpreferences_file(const char *filename)
 
 static int sys_getpreference_file(const char *key, char *value, int size)
 {
-    char searchfor[80], *where, *whereend;
+    char searchfor[80];
+    char *where;
+    char *whereend;
     if(!sys_prefbuf) return (0);
     sprintf(searchfor, "\n%s:", key);
     where = strstr(sys_prefbuf, searchfor);
@@ -470,8 +472,10 @@ static void sys_putpreference(const char *key, const char *value)
 
 static void sys_initloadpreferences(void)
 {
-    char filenamebuf[MAXPDSTRING], *homedir = getenv("HOME");
-    int fd, length;
+    char filenamebuf[MAXPDSTRING];
+    char *homedir = getenv("HOME");
+    int fd;
+    int length;
     char user_prefs_file[MAXPDSTRING]; /* user prefs file */
     /* default prefs embedded in the package */
     char default_prefs_file[MAXPDSTRING];
@@ -500,7 +504,8 @@ static void sys_doneloadpreferences(void) { sys_doneloadpreferences_file(); }
 
 static void sys_initsavepreferences(void)
 {
-    char filenamebuf[MAXPDSTRING], *homedir = getenv("HOME");
+    char filenamebuf[MAXPDSTRING];
+    char *homedir = getenv("HOME");
     FILE *fp;
 
     if(!homedir) return;
@@ -521,10 +526,16 @@ static void sys_donesavepreferences(void) { sys_donesavepreferences_file(); }
 void sys_loadpreferences(const char *filename, int startingup)
 {
     t_audiosettings as;
-    int nmidiindev, midiindev[MAXMIDIINDEV];
-    int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
-    int midiapi, nolib, maxi, i;
-    char prefbuf[MAXPDSTRING], keybuf[80];
+    int nmidiindev;
+    int midiindev[MAXMIDIINDEV];
+    int nmidioutdev;
+    int midioutdev[MAXMIDIOUTDEV];
+    int midiapi;
+    int nolib;
+    int maxi;
+    int i;
+    char prefbuf[MAXPDSTRING];
+    char keybuf[80];
     sys_get_audio_settings(&as);
 
     if(*filename)
@@ -700,9 +711,12 @@ void sys_savepreferences(const char *filename)
 {
     t_audiosettings as;
     int i;
-    char buf1[MAXPDSTRING], buf2[MAXPDSTRING];
-    int nmidiindev, midiindev[MAXMIDIINDEV];
-    int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
+    char buf1[MAXPDSTRING];
+    char buf2[MAXPDSTRING];
+    int nmidiindev;
+    int midiindev[MAXMIDIINDEV];
+    int nmidioutdev;
+    int midioutdev[MAXMIDIOUTDEV];
 
     if(filename && *filename)
         sys_initsavepreferences_file(filename);

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -539,7 +539,6 @@ void sys_loadpreferences(const char *filename, int startingup)
     int midiapi;
     int nolib;
     int maxi;
-    int i;
     char prefbuf[MAXPDSTRING];
     char keybuf[80];
     sys_get_audio_settings(&as);
@@ -696,7 +695,7 @@ void sys_loadpreferences(const char *filename, int startingup)
     {
         maxi = 0x7fffffff;
     }
-    for(i = 0; i < maxi; i++)
+    for(int i = 0; i < maxi; i++)
     {
         sprintf(keybuf, "path%d", i + 1);
         if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
@@ -717,7 +716,7 @@ void sys_loadpreferences(const char *filename, int startingup)
     {
         maxi = 0x7fffffff;
     }
-    for(i = 0; i < maxi; i++)
+    for(int i = 0; i < maxi; i++)
     {
         sprintf(keybuf, "loadlib%d", i + 1);
         if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
@@ -774,7 +773,7 @@ void sys_savepreferences(const char *filename)
     sprintf(buf1, "%d", as.a_api);
     sys_putpreference("audioapi", buf1);
     sys_putpreference("noaudioin", (as.a_nindev <= 0 ? "True" : "False"));
-    for(i = 0; i < as.a_nindev; i++)
+    for(int i = 0; i < as.a_nindev; i++)
     {
         sprintf(buf1, "audioindev%d", i + 1);
         sprintf(buf2, "%d %d", as.a_indevvec[i], as.a_chindevvec[i]);
@@ -785,7 +784,7 @@ void sys_savepreferences(const char *filename)
         sys_putpreference(buf1, buf2);
     }
     sys_putpreference("noaudioout", (as.a_noutdev <= 0 ? "True" : "False"));
-    for(i = 0; i < as.a_noutdev; i++)
+    for(int i = 0; i < as.a_noutdev; i++)
     {
         sprintf(buf1, "audiooutdev%d", i + 1);
         sprintf(buf2, "%d %d", as.a_outdevvec[i], as.a_choutdevvec[i]);
@@ -814,7 +813,7 @@ void sys_savepreferences(const char *filename)
 
     sys_get_midi_params(&nmidiindev, midiindev, &nmidioutdev, midioutdev);
     sys_putpreference("nomidiin", (nmidiindev <= 0 ? "True" : "False"));
-    for(i = 0; i < nmidiindev; i++)
+    for(int i = 0; i < nmidiindev; i++)
     {
         sprintf(buf1, "midiindev%d", i + 1);
         sprintf(buf2, "%d", midiindev[i]);
@@ -825,7 +824,7 @@ void sys_savepreferences(const char *filename)
         sys_putpreference(buf1, buf2);
     }
     sys_putpreference("nomidiout", (nmidioutdev <= 0 ? "True" : "False"));
-    for(i = 0; i < nmidioutdev; i++)
+    for(int i = 0; i < nmidioutdev; i++)
     {
         sprintf(buf1, "midioutdev%d", i + 1);
         sprintf(buf2, "%d", midioutdev[i]);
@@ -837,7 +836,7 @@ void sys_savepreferences(const char *filename)
     }
     /* file search path */
 
-    for(i = 0; 1; i++)
+    for(int i = 0; 1; i++)
     {
         const char *pathelem = namelist_get(STUFF->st_searchpath, i);
         if(!pathelem) break;
@@ -852,7 +851,7 @@ void sys_savepreferences(const char *filename)
     sys_putpreference("verbose", buf1);
 
     /* startup */
-    for(i = 0; 1; i++)
+    for(int i = 0; 1; i++)
     {
         const char *pathelem = namelist_get(STUFF->st_externlist, i);
         if(!pathelem) break;

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2004 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*
  * this file implements a mechanism for storing and retrieving preferences.
@@ -29,7 +29,7 @@
 #include <tchar.h>
 #include <io.h>
 #endif
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
+#ifdef _MSC_VER /* This is only for Microsoft's compiler, not cygwin, e.g. */
 #define snprintf _snprintf
 #endif
 #ifdef __APPLE__ /* needed for plist handling */
@@ -46,36 +46,34 @@ static void sys_initloadpreferences_file(const char *filename)
 {
     int fd;
     long length;
-    if ((fd = open(filename, 0)) < 0)
+    if((fd = open(filename, 0)) < 0)
     {
-        if (sys_verbose)
-            perror(filename);
+        if(sys_verbose) perror(filename);
         return;
     }
     length = lseek(fd, 0, 2);
-    if (length < 0)
+    if(length < 0)
     {
-        if (sys_verbose)
-            perror(filename);
+        if(sys_verbose) perror(filename);
         close(fd);
         return;
     }
     lseek(fd, 0, 0);
-    if (!(sys_prefbuf = malloc(length + 2)))
+    if(!(sys_prefbuf = malloc(length + 2)))
     {
         pd_error(0, "couldn't allocate memory for preferences buffer");
         close(fd);
         return;
     }
     sys_prefbuf[0] = '\n';
-    if (read(fd, sys_prefbuf+1, length) < length)
+    if(read(fd, sys_prefbuf + 1, length) < length)
     {
         perror(filename);
         sys_prefbuf[0] = 0;
         close(fd);
         return;
     }
-    sys_prefbuf[length+1] = 0;
+    sys_prefbuf[length + 1] = 0;
     close(fd);
     logpost(NULL, PD_VERBOSE, "success reading preferences from: %s", filename);
 }
@@ -83,48 +81,41 @@ static void sys_initloadpreferences_file(const char *filename)
 static int sys_getpreference_file(const char *key, char *value, int size)
 {
     char searchfor[80], *where, *whereend;
-    if (!sys_prefbuf)
-        return (0);
+    if(!sys_prefbuf) return (0);
     sprintf(searchfor, "\n%s:", key);
     where = strstr(sys_prefbuf, searchfor);
-    if (!where)
-        return (0);
+    if(!where) return (0);
     where += strlen(searchfor);
-    while (*where == ' ' || *where == '\t')
+    while(*where == ' ' || *where == '\t')
         where++;
-    for (whereend = where; *whereend && *whereend != '\n'; whereend++)
+    for(whereend = where; *whereend && *whereend != '\n'; whereend++)
         ;
-    if (*whereend == '\n')
-        whereend--;
-    if (whereend > where + size - 1)
-        whereend = where + size - 1;
-    strncpy(value, where, whereend+1-where);
-    value[whereend+1-where] = 0;
+    if(*whereend == '\n') whereend--;
+    if(whereend > where + size - 1) whereend = where + size - 1;
+    strncpy(value, where, whereend + 1 - where);
+    value[whereend + 1 - where] = 0;
     return (1);
 }
 
 static void sys_doneloadpreferences_file(void)
 {
-    if (sys_prefbuf)
-        free(sys_prefbuf);
+    if(sys_prefbuf) free(sys_prefbuf);
 }
 
 static void sys_initsavepreferences_file(const char *filename)
 {
-    if ((sys_prefsavefp = fopen(filename, "w")) == NULL)
+    if((sys_prefsavefp = fopen(filename, "w")) == NULL)
         pd_error(0, "%s: %s", filename, strerror(errno));
 }
 
 static void sys_putpreference_file(const char *key, const char *value)
 {
-    if (sys_prefsavefp)
-        fprintf(sys_prefsavefp, "%s: %s\n",
-            key, value);
+    if(sys_prefsavefp) fprintf(sys_prefsavefp, "%s: %s\n", key, value);
 }
 
 static void sys_donesavepreferences_file(void)
 {
-    if (sys_prefsavefp)
+    if(sys_prefsavefp)
     {
         fclose(sys_prefsavefp);
         sys_prefsavefp = 0;
@@ -147,7 +138,7 @@ static int preferences_getloadpath(char *dst, size_t size)
         sys_libdir->s_name);
     snprintf(user_prefs, MAXPDSTRING,
         "%s/Library/Preferences/org.puredata.pd.plist", homedir);
-    if (stat(user_prefs, &statbuf) == 0)
+    if(stat(user_prefs, &statbuf) == 0)
     {
         strncpy(dst, user_prefs, size);
         return 0;
@@ -177,7 +168,7 @@ static void sys_initloadpreferences(void)
     CFErrorRef err = NULL;
     CFPropertyListRef plist = NULL;
 
-    if (sys_prefbuf || sys_prefdict)
+    if(sys_prefbuf || sys_prefdict)
     {
         bug("sys_initloadpreferences");
         return;
@@ -190,12 +181,13 @@ static void sys_initloadpreferences(void)
     fileURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path,
         kCFURLPOSIXPathStyle, false); // false -> not a directory
     stream = CFReadStreamCreateWithFile(kCFAllocatorDefault, fileURL);
-    if (!stream || !CFReadStreamOpen(stream)) goto cleanup;
+    if(!stream || !CFReadStreamOpen(stream)) goto cleanup;
 
     // read plist
-    plist = CFPropertyListCreateWithStream(kCFAllocatorDefault, stream, 0,
-        kCFPropertyListImmutable, NULL, &err);
-    if (!plist) {
+    plist = CFPropertyListCreateWithStream(
+        kCFAllocatorDefault, stream, 0, kCFPropertyListImmutable, NULL, &err);
+    if(!plist)
+    {
         CFStringRef errString = CFErrorCopyDescription(err);
         pd_error(0, "couldn't read preferences plist: %s",
             CFStringGetCStringPtr(errString, kCFStringEncodingUTF8));
@@ -203,25 +195,35 @@ static void sys_initloadpreferences(void)
         goto cleanup;
     }
     CFRetain(plist);
-    sys_prefdict = (CFMutableDictionaryRef)plist;
+    sys_prefdict = (CFMutableDictionaryRef) plist;
 
 cleanup:
-    if (stream) {
-        if (CFReadStreamGetStatus(stream) == kCFStreamStatusOpen) {
+    if(stream)
+    {
+        if(CFReadStreamGetStatus(stream) == kCFStreamStatusOpen)
+        {
             CFReadStreamClose(stream);
         }
         CFRelease(stream);
     }
-    if (fileURL) {CFRelease(fileURL);}
-    if (path) {CFRelease(path);}
-    if (err) {CFRelease(err);}
+    if(fileURL)
+    {
+        CFRelease(fileURL);
+    }
+    if(path)
+    {
+        CFRelease(path);
+    }
+    if(err)
+    {
+        CFRelease(err);
+    }
 }
 
 static void sys_doneloadpreferences(void)
 {
-    if (sys_prefbuf)
-        sys_doneloadpreferences_file();
-    if (sys_prefdict)
+    if(sys_prefbuf) sys_doneloadpreferences_file();
+    if(sys_prefdict)
     {
         CFRelease(sys_prefdict);
         sys_prefdict = NULL;
@@ -230,7 +232,7 @@ static void sys_doneloadpreferences(void)
 
 static void sys_initsavepreferences(void)
 {
-    if (sys_prefsavefp)
+    if(sys_prefsavefp)
     {
         bug("sys_initsavepreferences");
         return;
@@ -248,15 +250,14 @@ static void sys_donesavepreferences(void)
     CFErrorRef err = NULL;
     CFDataRef data = NULL;
 
-    if (sys_prefsavefp)
-        sys_donesavepreferences_file();
-    if (!sys_prefdict) return;
+    if(sys_prefsavefp) sys_donesavepreferences_file();
+    if(!sys_prefdict) return;
 
     // convert dict to plist data
     data = CFPropertyListCreateData(kCFAllocatorDefault,
-                                    (CFPropertyListRef)sys_prefdict,
-                                    kCFPropertyListBinaryFormat_v1_0, 0, &err);
-    if (!data)
+        (CFPropertyListRef) sys_prefdict, kCFPropertyListBinaryFormat_v1_0, 0,
+        &err);
+    if(!data)
     {
         CFStringRef errString = CFErrorCopyDescription(err);
         pd_error(0, "couldn't write preferences plist: %s",
@@ -272,111 +273,127 @@ static void sys_donesavepreferences(void)
     fileURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, path,
         kCFURLPOSIXPathStyle, false); // false -> not a directory
     stream = CFWriteStreamCreateWithFile(kCFAllocatorDefault, fileURL);
-    if (!stream || !CFWriteStreamOpen(stream)) goto cleanup;
+    if(!stream || !CFWriteStreamOpen(stream)) goto cleanup;
 
     // write plist
-    if (CFWriteStreamWrite(stream, CFDataGetBytePtr(data),
-                                   CFDataGetLength(data)) < 0) {
+    if(CFWriteStreamWrite(
+           stream, CFDataGetBytePtr(data), CFDataGetLength(data)) < 0)
+    {
         pd_error(0, "couldn't write preferences plist");
         goto cleanup;
     }
 
 cleanup:
-    if (sys_prefdict)
+    if(sys_prefdict)
     {
         CFRelease(sys_prefdict);
         sys_prefdict = NULL;
     }
-    if (data) {CFRelease(data);}
-    if (stream) {
-        if(CFWriteStreamGetStatus(stream) == kCFStreamStatusOpen) {
+    if(data)
+    {
+        CFRelease(data);
+    }
+    if(stream)
+    {
+        if(CFWriteStreamGetStatus(stream) == kCFStreamStatusOpen)
+        {
             CFWriteStreamClose(stream);
         }
         CFRelease(stream);
     }
-    if (fileURL) {CFRelease(fileURL);}
-    if (path) {CFRelease(path);}
-    if (err) {CFRelease(err);}
+    if(fileURL)
+    {
+        CFRelease(fileURL);
+    }
+    if(path)
+    {
+        CFRelease(path);
+    }
+    if(err)
+    {
+        CFRelease(err);
+    }
 }
 
 static int sys_getpreference(const char *key, char *value, int size)
 {
-    if (sys_prefbuf)
-        return (sys_getpreference_file(key, value, size));
-    if (sys_prefdict) {
+    if(sys_prefbuf) return (sys_getpreference_file(key, value, size));
+    if(sys_prefdict)
+    {
         /* read from loaded plist dict */
-        CFStringRef k = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault,
-            key, kCFStringEncodingUTF8, kCFAllocatorNull);
+        CFStringRef k = CFStringCreateWithCStringNoCopy(
+            kCFAllocatorDefault, key, kCFStringEncodingUTF8, kCFAllocatorNull);
         void *v = NULL;
         int ret = 0;
-        if (CFDictionaryGetValueIfPresent(sys_prefdict, k,
-                                          (const void **)&v)) {
-            ret = CFStringGetCString((CFStringRef)v, value, size,
-                                     kCFStringEncodingUTF8);
+        if(CFDictionaryGetValueIfPresent(sys_prefdict, k, (const void **) &v))
+        {
+            ret = CFStringGetCString(
+                (CFStringRef) v, value, size, kCFStringEncodingUTF8);
 #if 0
             if (ret) fprintf(stderr, "plist read %s = %s\n", key, value);
 #endif
-            if (v) CFRelease(v);
+            if(v) CFRelease(v);
         }
         CFRelease(k);
         return (ret);
     }
-    else {
+    else
+    {
         /* fallback to defaults command */
         char cmdbuf[256];
         int nread = 0, nleft = size;
         char path[MAXPDSTRING];
         int embedded = preferences_getloadpath(path, MAXPDSTRING);
-        if (embedded)
-            snprintf(cmdbuf, 256, "defaults read %s %s 2> /dev/null\n",
-                path, key);
+        if(embedded)
+            snprintf(
+                cmdbuf, 256, "defaults read %s %s 2> /dev/null\n", path, key);
         else
-            snprintf(cmdbuf, 256, "defaults read org.puredata.pd %s 2> /dev/null\n",
-                key);
+            snprintf(cmdbuf, 256,
+                "defaults read org.puredata.pd %s 2> /dev/null\n", key);
         FILE *fp = popen(cmdbuf, "r");
-        while (nread < size)
+        while(nread < size)
         {
-            int newread = fread(value+nread, 1, size-nread, fp);
-            if (newread <= 0)
-                break;
+            int newread = fread(value + nread, 1, size - nread, fp);
+            if(newread <= 0) break;
             nread += newread;
         }
         pclose(fp);
-        if (nread < 1)
-            return (0);
-        if (nread >= size)
-            nread = size-1;
+        if(nread < 1) return (0);
+        if(nread >= size) nread = size - 1;
         value[nread] = 0;
-        if (value[nread-1] == '\n')     /* remove newline character at end */
-            value[nread-1] = 0;
+        if(value[nread - 1] == '\n') /* remove newline character at end */
+            value[nread - 1] = 0;
         return (1);
     }
 }
 
 static void sys_putpreference(const char *key, const char *value)
 {
-    if (sys_prefsavefp)
+    if(sys_prefsavefp)
     {
         sys_putpreference_file(key, value);
         return;
     }
-    if (sys_prefdict) {
-        CFStringRef k = CFStringCreateWithCString(kCFAllocatorDefault, key,
-                                                  kCFStringEncodingUTF8);
-        CFStringRef v = CFStringCreateWithCString(kCFAllocatorDefault, value,
-                                                  kCFStringEncodingUTF8);
-        CFDictionarySetValue((CFMutableDictionaryRef)sys_prefdict, k, v);
+    if(sys_prefdict)
+    {
+        CFStringRef k = CFStringCreateWithCString(
+            kCFAllocatorDefault, key, kCFStringEncodingUTF8);
+        CFStringRef v = CFStringCreateWithCString(
+            kCFAllocatorDefault, value, kCFStringEncodingUTF8);
+        CFDictionarySetValue((CFMutableDictionaryRef) sys_prefdict, k, v);
         CFRelease(k);
         CFRelease(v);
 #if 0
         fprintf(stderr, "plist write %s = %s\n", key, value);
 #endif
     }
-    else {
+    else
+    {
         /* fallback to defaults command */
         char cmdbuf[MAXPDSTRING];
         snprintf(cmdbuf, MAXPDSTRING,
-            "defaults write org.puredata.pd %s \"%s\" 2> /dev/null\n", key, value);
+            "defaults write org.puredata.pd %s \"%s\" 2> /dev/null\n", key,
+            value);
         system(cmdbuf);
     }
 }
@@ -386,42 +403,37 @@ static void sys_putpreference(const char *key, const char *value)
 
 static void sys_initloadpreferences(void)
 {
-    if (sys_prefbuf)
-        bug("sys_initloadpreferences");
+    if(sys_prefbuf) bug("sys_initloadpreferences");
 }
 
 static void sys_doneloadpreferences(void)
 {
-    if (sys_prefbuf)
-        sys_doneloadpreferences_file();
+    if(sys_prefbuf) sys_doneloadpreferences_file();
 }
 
 static void sys_initsavepreferences(void)
 {
-    if (sys_prefsavefp)
-        bug("sys_initsavepreferences");
+    if(sys_prefsavefp) bug("sys_initsavepreferences");
 }
 
 static void sys_donesavepreferences(void)
 {
-    if (sys_prefsavefp)
-        sys_donesavepreferences_file();
+    if(sys_prefsavefp) sys_donesavepreferences_file();
 }
 
 static int sys_getpreference(const char *key, char *value, int size)
 {
-    if (sys_prefbuf)
+    if(sys_prefbuf)
         return (sys_getpreference_file(key, value, size));
     else
     {
         HKEY hkey;
         DWORD bigsize = size;
-        LONG err = RegOpenKeyEx(HKEY_CURRENT_USER,
-            "Software\\Pure-Data", 0,  KEY_QUERY_VALUE, &hkey);
-        if (err != ERROR_SUCCESS)
-            return (0);
+        LONG err = RegOpenKeyEx(HKEY_CURRENT_USER, "Software\\Pure-Data", 0,
+            KEY_QUERY_VALUE, &hkey);
+        if(err != ERROR_SUCCESS) return (0);
         err = RegQueryValueEx(hkey, key, 0, 0, value, &bigsize);
-        if (err != ERROR_SUCCESS)
+        if(err != ERROR_SUCCESS)
         {
             RegCloseKey(hkey);
             return (0);
@@ -433,21 +445,21 @@ static int sys_getpreference(const char *key, char *value, int size)
 
 static void sys_putpreference(const char *key, const char *value)
 {
-    if (sys_prefsavefp)
+    if(sys_prefsavefp)
         sys_putpreference_file(key, value);
     else
     {
         HKEY hkey;
-        LONG err = RegCreateKeyEx(HKEY_CURRENT_USER,
-            "Software\\Pure-Data", 0, NULL, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE,
-            NULL, &hkey, NULL);
-        if (err != ERROR_SUCCESS)
+        LONG err = RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Pure-Data", 0,
+            NULL, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE, NULL, &hkey, NULL);
+        if(err != ERROR_SUCCESS)
         {
             pd_error(0, "unable to create registry entry: %s\n", key);
             return;
         }
-        err = RegSetValueEx(hkey, key, 0, REG_EXPAND_SZ, value, strlen(value)+1);
-        if (err != ERROR_SUCCESS)
+        err = RegSetValueEx(
+            hkey, key, 0, REG_EXPAND_SZ, value, strlen(value) + 1);
+        if(err != ERROR_SUCCESS)
             pd_error(0, "unable to set registry entry: %s\n", key);
         RegCloseKey(hkey);
     }
@@ -461,7 +473,7 @@ static void sys_initloadpreferences(void)
     char filenamebuf[MAXPDSTRING], *homedir = getenv("HOME");
     int fd, length;
     char user_prefs_file[MAXPDSTRING]; /* user prefs file */
-        /* default prefs embedded in the package */
+    /* default prefs embedded in the package */
     char default_prefs_file[MAXPDSTRING];
     struct stat statbuf;
 
@@ -469,12 +481,13 @@ static void sys_initloadpreferences(void)
         sys_libdir->s_name);
     snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
         (homedir ? homedir : "."));
-    if (stat(user_prefs_file, &statbuf) == 0)
+    if(stat(user_prefs_file, &statbuf) == 0)
         strncpy(filenamebuf, user_prefs_file, MAXPDSTRING);
-    else if (stat(default_prefs_file, &statbuf) == 0)
+    else if(stat(default_prefs_file, &statbuf) == 0)
         strncpy(filenamebuf, default_prefs_file, MAXPDSTRING);
-    else return;
-    filenamebuf[MAXPDSTRING-1] = 0;
+    else
+        return;
+    filenamebuf[MAXPDSTRING - 1] = 0;
     sys_initloadpreferences_file(filenamebuf);
 }
 
@@ -483,21 +496,16 @@ static int sys_getpreference(const char *key, char *value, int size)
     return (sys_getpreference_file(key, value, size));
 }
 
-static void sys_doneloadpreferences(void)
-{
-    sys_doneloadpreferences_file();
-}
+static void sys_doneloadpreferences(void) { sys_doneloadpreferences_file(); }
 
 static void sys_initsavepreferences(void)
 {
-    char filenamebuf[MAXPDSTRING],
-        *homedir = getenv("HOME");
+    char filenamebuf[MAXPDSTRING], *homedir = getenv("HOME");
     FILE *fp;
 
-    if (!homedir)
-        return;
+    if(!homedir) return;
     snprintf(filenamebuf, MAXPDSTRING, "%s/.pdsettings", homedir);
-    filenamebuf[MAXPDSTRING-1] = 0;
+    filenamebuf[MAXPDSTRING - 1] = 0;
     sys_initsavepreferences_file(filenamebuf);
 }
 
@@ -506,10 +514,7 @@ static void sys_putpreference(const char *key, const char *value)
     sys_putpreference_file(key, value);
 }
 
-static void sys_donesavepreferences(void)
-{
-    sys_donesavepreferences_file();
-}
+static void sys_donesavepreferences(void) { sys_donesavepreferences_file(); }
 
 #endif
 
@@ -522,169 +527,162 @@ void sys_loadpreferences(const char *filename, int startingup)
     char prefbuf[MAXPDSTRING], keybuf[80];
     sys_get_audio_settings(&as);
 
-    if (*filename)
+    if(*filename)
         sys_initloadpreferences_file(filename);
-    else sys_initloadpreferences();
-        /* load audio preferences */
-    if (!sys_externalschedlib
-        && sys_getpreference("audioapi", prefbuf, MAXPDSTRING)
-        && sscanf(prefbuf, "%d", &as.a_api) < 1)
-            as.a_api = -1;
-            /* JMZ/MB: brackets for initializing */
-    if (sys_getpreference("noaudioin", prefbuf, MAXPDSTRING) &&
+    else
+        sys_initloadpreferences();
+    /* load audio preferences */
+    if(!sys_externalschedlib &&
+        sys_getpreference("audioapi", prefbuf, MAXPDSTRING) &&
+        sscanf(prefbuf, "%d", &as.a_api) < 1)
+        as.a_api = -1;
+    /* JMZ/MB: brackets for initializing */
+    if(sys_getpreference("noaudioin", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
-            as.a_nindev = 0;
+        as.a_nindev = 0;
     else
     {
-        for (as.a_nindev = 0; as.a_nindev < MAXAUDIOINDEV; as.a_nindev++)
+        for(as.a_nindev = 0; as.a_nindev < MAXAUDIOINDEV; as.a_nindev++)
         {
-                /* first try to find a name - if that matches an existing
-                device use it.  Otherwise fall back to device number. */
+            /* first try to find a name - if that matches an existing
+            device use it.  Otherwise fall back to device number. */
             int devn;
-                /* read in device number and channel count */
-            sprintf(keybuf, "audioindev%d", as.a_nindev+1);
-            if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
+            /* read in device number and channel count */
+            sprintf(keybuf, "audioindev%d", as.a_nindev + 1);
+            if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
+            if(sscanf(prefbuf, "%d %d", &as.a_indevvec[as.a_nindev],
+                   &as.a_chindevvec[as.a_nindev]) < 2)
                 break;
-            if (sscanf(prefbuf, "%d %d",
-                &as.a_indevvec[as.a_nindev], &as.a_chindevvec[as.a_nindev]) < 2)
-                    break;
-                /* possibly override device number if the device name was
-                also saved and if it matches one we have now */
-            sprintf(keybuf, "audioindevname%d", as.a_nindev+1);
-            if (sys_getpreference(keybuf, prefbuf, MAXPDSTRING)
-                && (devn = sys_audiodevnametonumber(0, prefbuf)) >= 0)
-                    as.a_indevvec[as.a_nindev] = devn;
+            /* possibly override device number if the device name was
+            also saved and if it matches one we have now */
+            sprintf(keybuf, "audioindevname%d", as.a_nindev + 1);
+            if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
+                (devn = sys_audiodevnametonumber(0, prefbuf)) >= 0)
+                as.a_indevvec[as.a_nindev] = devn;
             as.a_nindev++;
         }
-            /* if no preferences at all, set -1 for default behavior */
-        if (as.a_nindev == 0)
-            as.a_nindev = -1;
+        /* if no preferences at all, set -1 for default behavior */
+        if(as.a_nindev == 0) as.a_nindev = -1;
     }
-        /* JMZ/MB: brackets for initializing */
-    if (sys_getpreference("noaudioout", prefbuf, MAXPDSTRING) &&
+    /* JMZ/MB: brackets for initializing */
+    if(sys_getpreference("noaudioout", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
-            as.a_noutdev = 0;
+        as.a_noutdev = 0;
     else
     {
-        for (as.a_noutdev = 0; as.a_noutdev < MAXAUDIOOUTDEV; as.a_noutdev++)
+        for(as.a_noutdev = 0; as.a_noutdev < MAXAUDIOOUTDEV; as.a_noutdev++)
         {
             int devn;
-            sprintf(keybuf, "audiooutdev%d", as.a_noutdev+1);
-            if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
+            sprintf(keybuf, "audiooutdev%d", as.a_noutdev + 1);
+            if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
+            if(sscanf(prefbuf, "%d %d", &as.a_outdevvec[as.a_noutdev],
+                   &as.a_choutdevvec[as.a_noutdev]) < 2)
                 break;
-            if (sscanf(prefbuf, "%d %d",
-                &as.a_outdevvec[as.a_noutdev],
-                    &as.a_choutdevvec[as.a_noutdev]) < 2)
-                        break;
-            sprintf(keybuf, "audiooutdevname%d", as.a_noutdev+1);
-            if (sys_getpreference(keybuf, prefbuf, MAXPDSTRING)
-                && (devn = sys_audiodevnametonumber(1, prefbuf)) >= 0)
-                    as.a_outdevvec[as.a_noutdev] = devn;
+            sprintf(keybuf, "audiooutdevname%d", as.a_noutdev + 1);
+            if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
+                (devn = sys_audiodevnametonumber(1, prefbuf)) >= 0)
+                as.a_outdevvec[as.a_noutdev] = devn;
             as.a_noutdev++;
         }
-        if (as.a_noutdev == 0)
-            as.a_noutdev = -1;
+        if(as.a_noutdev == 0) as.a_noutdev = -1;
     }
-    if (sys_getpreference("rate", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("rate", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_srate);
-    if (sys_getpreference("audiobuf", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("audiobuf", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_advance);
-    if (sys_getpreference("callback", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("callback", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_callback);
-    if (sys_getpreference("audioblocksize", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("audioblocksize", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_blocksize);
 #ifndef _WIN32
-    else if (sys_getpreference("blocksize", prefbuf, MAXPDSTRING))
+    else if(sys_getpreference("blocksize", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_blocksize);
 #endif
     sys_set_audio_settings(&as);
 
-        /* load MIDI preferences */
-    if (sys_getpreference("midiapi", prefbuf, MAXPDSTRING)
-        && sscanf(prefbuf, "%d", &midiapi) > 0)
-            sys_set_midi_api(midiapi);
-        /* JMZ/MB: brackets for initializing */
-    if (sys_getpreference("nomidiin", prefbuf, MAXPDSTRING) &&
+    /* load MIDI preferences */
+    if(sys_getpreference("midiapi", prefbuf, MAXPDSTRING) &&
+        sscanf(prefbuf, "%d", &midiapi) > 0)
+        sys_set_midi_api(midiapi);
+    /* JMZ/MB: brackets for initializing */
+    if(sys_getpreference("nomidiin", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
-            nmidiindev = 0;
-    else for (nmidiindev = 0; nmidiindev < MAXMIDIINDEV; nmidiindev++)
-    {
+        nmidiindev = 0;
+    else
+        for(nmidiindev = 0; nmidiindev < MAXMIDIINDEV; nmidiindev++)
+        {
             /* first try to find a name - if that matches an existing device
             use it.  Otherwise fall back to device number. */
-        int devn;
-        sprintf(keybuf, "midiindevname%d", nmidiindev+1);
-        if (sys_getpreference(keybuf, prefbuf, MAXPDSTRING)
-            && (devn = sys_mididevnametonumber(0, prefbuf)) >= 0)
+            int devn;
+            sprintf(keybuf, "midiindevname%d", nmidiindev + 1);
+            if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
+                (devn = sys_mididevnametonumber(0, prefbuf)) >= 0)
                 midiindev[nmidiindev] = devn;
-        else
-        {
-            sprintf(keybuf, "midiindev%d", nmidiindev+1);
-            if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
-                break;
-            if (sscanf(prefbuf, "%d", &midiindev[nmidiindev]) < 1)
-                break;
+            else
+            {
+                sprintf(keybuf, "midiindev%d", nmidiindev + 1);
+                if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
+                if(sscanf(prefbuf, "%d", &midiindev[nmidiindev]) < 1) break;
+            }
         }
-    }
-        /* JMZ/MB: brackets for initializing */
-    if (sys_getpreference("nomidiout", prefbuf, MAXPDSTRING) &&
+    /* JMZ/MB: brackets for initializing */
+    if(sys_getpreference("nomidiout", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
-            nmidioutdev = 0;
-    else for (nmidioutdev = 0; nmidioutdev < MAXMIDIOUTDEV; nmidioutdev++)
-    {
-        int devn;
-        sprintf(keybuf, "midioutdevname%d", nmidioutdev+1);
-        if (sys_getpreference(keybuf, prefbuf, MAXPDSTRING)
-            && (devn = sys_mididevnametonumber(1, prefbuf)) >= 0)
-                midioutdev[nmidioutdev] = devn;
-        else
+        nmidioutdev = 0;
+    else
+        for(nmidioutdev = 0; nmidioutdev < MAXMIDIOUTDEV; nmidioutdev++)
         {
-            sprintf(keybuf, "midioutdev%d", nmidioutdev+1);
-            if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
-                break;
-            if (sscanf(prefbuf, "%d", &midioutdev[nmidioutdev]) < 1)
-                break;
+            int devn;
+            sprintf(keybuf, "midioutdevname%d", nmidioutdev + 1);
+            if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
+                (devn = sys_mididevnametonumber(1, prefbuf)) >= 0)
+                midioutdev[nmidioutdev] = devn;
+            else
+            {
+                sprintf(keybuf, "midioutdev%d", nmidioutdev + 1);
+                if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
+                if(sscanf(prefbuf, "%d", &midioutdev[nmidioutdev]) < 1) break;
+            }
         }
-    }
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 0);
 
-        /* search path */
-    if (sys_getpreference("npath", prefbuf, MAXPDSTRING))
+    /* search path */
+    if(sys_getpreference("npath", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &maxi);
-    else maxi = 0x7fffffff;
-    for (i = 0; i < maxi; i++)
+    else
+        maxi = 0x7fffffff;
+    for(i = 0; i < maxi; i++)
     {
-        sprintf(keybuf, "path%d", i+1);
-        if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
-            break;
+        sprintf(keybuf, "path%d", i + 1);
+        if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
         STUFF->st_searchpath =
             namelist_append_files(STUFF->st_searchpath, prefbuf);
     }
-    if (sys_getpreference("standardpath", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("standardpath", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_usestdpath);
-    if (sys_getpreference("verbose", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("verbose", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_verbose);
 
-        /* startup settings */
-    if (sys_getpreference("nloadlib", prefbuf, MAXPDSTRING))
+    /* startup settings */
+    if(sys_getpreference("nloadlib", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &maxi);
-    else maxi = 0x7fffffff;
-    for (i = 0; i<maxi; i++)
+    else
+        maxi = 0x7fffffff;
+    for(i = 0; i < maxi; i++)
     {
-        sprintf(keybuf, "loadlib%d", i+1);
-        if (!sys_getpreference(keybuf, prefbuf, MAXPDSTRING))
-            break;
-        STUFF->st_externlist = namelist_append_files(STUFF->st_externlist, prefbuf);
+        sprintf(keybuf, "loadlib%d", i + 1);
+        if(!sys_getpreference(keybuf, prefbuf, MAXPDSTRING)) break;
+        STUFF->st_externlist =
+            namelist_append_files(STUFF->st_externlist, prefbuf);
     }
-    if (sys_getpreference("defeatrt", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("defeatrt", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_defeatrt);
-    if (sys_getpreference("flags", prefbuf, MAXPDSTRING) &&
-        strcmp(prefbuf, "."))
+    if(sys_getpreference("flags", prefbuf, MAXPDSTRING) && strcmp(prefbuf, "."))
     {
         sys_flags = gensym(prefbuf);
-        if (startingup)
-            sys_doflags();
+        if(startingup) sys_doflags();
     }
-    if (sys_defeatrt)
+    if(sys_defeatrt)
         sys_hipriority = 0;
     else
 #if defined(ANDROID)
@@ -692,7 +690,7 @@ void sys_loadpreferences(const char *filename, int startingup)
 #else
         sys_hipriority = 1;
 #endif
-    if (sys_getpreference("zoom", prefbuf, MAXPDSTRING))
+    if(sys_getpreference("zoom", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_zoom_open);
 
     sys_doneloadpreferences();
@@ -706,38 +704,37 @@ void sys_savepreferences(const char *filename)
     int nmidiindev, midiindev[MAXMIDIINDEV];
     int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
 
-    if (filename && *filename)
+    if(filename && *filename)
         sys_initsavepreferences_file(filename);
-    else sys_initsavepreferences();
-        /* audio settings */
+    else
+        sys_initsavepreferences();
+    /* audio settings */
     sys_get_audio_settings(&as);
 
     sprintf(buf1, "%d", as.a_api);
     sys_putpreference("audioapi", buf1);
-    sys_putpreference("noaudioin", (as.a_nindev <= 0 ? "True":"False"));
-    for (i = 0; i < as.a_nindev; i++)
+    sys_putpreference("noaudioin", (as.a_nindev <= 0 ? "True" : "False"));
+    for(i = 0; i < as.a_nindev; i++)
     {
-        sprintf(buf1, "audioindev%d", i+1);
+        sprintf(buf1, "audioindev%d", i + 1);
         sprintf(buf2, "%d %d", as.a_indevvec[i], as.a_chindevvec[i]);
         sys_putpreference(buf1, buf2);
-        sprintf(buf1, "audioindevname%d", i+1);
+        sprintf(buf1, "audioindevname%d", i + 1);
         sys_audiodevnumbertoname(0, as.a_indevvec[i], buf2, MAXPDSTRING);
-        if (! *buf2)
-            strcat(buf2, "?");
+        if(!*buf2) strcat(buf2, "?");
         sys_putpreference(buf1, buf2);
     }
-    sys_putpreference("noaudioout", (as.a_noutdev <= 0 ? "True":"False"));
-    for (i = 0; i < as.a_noutdev; i++)
+    sys_putpreference("noaudioout", (as.a_noutdev <= 0 ? "True" : "False"));
+    for(i = 0; i < as.a_noutdev; i++)
     {
-        sprintf(buf1, "audiooutdev%d", i+1);
+        sprintf(buf1, "audiooutdev%d", i + 1);
         sprintf(buf2, "%d %d", as.a_outdevvec[i], as.a_choutdevvec[i]);
         sys_putpreference(buf1, buf2);
-        sprintf(buf1, "audiooutdevname%d", i+1);
+        sprintf(buf1, "audiooutdevname%d", i + 1);
         sys_audiodevnumbertoname(1, as.a_outdevvec[i], buf2, MAXPDSTRING);
-        if (! *buf2)
-            strcat(buf2, "?");
+        if(!*buf2) strcat(buf2, "?");
         sys_putpreference(buf1, buf2);
-   }
+    }
 
     sprintf(buf1, "%d", as.a_advance);
     sys_putpreference("audiobuf", buf1);
@@ -751,43 +748,40 @@ void sys_savepreferences(const char *filename)
     sprintf(buf1, "%d", as.a_blocksize);
     sys_putpreference("audioblocksize", buf1);
 
-        /* MIDI settings */
+    /* MIDI settings */
     sprintf(buf1, "%d", sys_midiapi);
     sys_putpreference("midiapi", buf1);
 
     sys_get_midi_params(&nmidiindev, midiindev, &nmidioutdev, midioutdev);
     sys_putpreference("nomidiin", (nmidiindev <= 0 ? "True" : "False"));
-    for (i = 0; i < nmidiindev; i++)
+    for(i = 0; i < nmidiindev; i++)
     {
-        sprintf(buf1, "midiindev%d", i+1);
+        sprintf(buf1, "midiindev%d", i + 1);
         sprintf(buf2, "%d", midiindev[i]);
         sys_putpreference(buf1, buf2);
-        sprintf(buf1, "midiindevname%d", i+1);
+        sprintf(buf1, "midiindevname%d", i + 1);
         sys_mididevnumbertoname(0, midiindev[i], buf2, MAXPDSTRING);
-        if (! *buf2)
-            strcat(buf2, "?");
+        if(!*buf2) strcat(buf2, "?");
         sys_putpreference(buf1, buf2);
     }
     sys_putpreference("nomidiout", (nmidioutdev <= 0 ? "True" : "False"));
-    for (i = 0; i < nmidioutdev; i++)
+    for(i = 0; i < nmidioutdev; i++)
     {
-        sprintf(buf1, "midioutdev%d", i+1);
+        sprintf(buf1, "midioutdev%d", i + 1);
         sprintf(buf2, "%d", midioutdev[i]);
         sys_putpreference(buf1, buf2);
-        sprintf(buf1, "midioutdevname%d", i+1);
+        sprintf(buf1, "midioutdevname%d", i + 1);
         sys_mididevnumbertoname(1, midioutdev[i], buf2, MAXPDSTRING);
-        if (! *buf2)
-            strcat(buf2, "?");
+        if(!*buf2) strcat(buf2, "?");
         sys_putpreference(buf1, buf2);
     }
-        /* file search path */
+    /* file search path */
 
-    for (i = 0; 1; i++)
+    for(i = 0; 1; i++)
     {
         const char *pathelem = namelist_get(STUFF->st_searchpath, i);
-        if (!pathelem)
-            break;
-        sprintf(buf1, "path%d", i+1);
+        if(!pathelem) break;
+        sprintf(buf1, "path%d", i + 1);
         sys_putpreference(buf1, pathelem);
     }
     sprintf(buf1, "%d", i);
@@ -797,22 +791,20 @@ void sys_savepreferences(const char *filename)
     sprintf(buf1, "%d", sys_verbose);
     sys_putpreference("verbose", buf1);
 
-        /* startup */
-    for (i = 0; 1; i++)
+    /* startup */
+    for(i = 0; 1; i++)
     {
         const char *pathelem = namelist_get(STUFF->st_externlist, i);
-        if (!pathelem)
-            break;
-        sprintf(buf1, "loadlib%d", i+1);
+        if(!pathelem) break;
+        sprintf(buf1, "loadlib%d", i + 1);
         sys_putpreference(buf1, pathelem);
     }
     sprintf(buf1, "%d", i);
     sys_putpreference("nloadlib", buf1);
     sprintf(buf1, "%d", sys_defeatrt);
     sys_putpreference("defeatrt", buf1);
-    sys_putpreference("flags",
-        (sys_flags ? sys_flags->s_name : ""));
-        /* misc */
+    sys_putpreference("flags", (sys_flags ? sys_flags->s_name : ""));
+    /* misc */
     sprintf(buf1, "%d", sys_zoom_open);
     sys_putpreference("zoom", buf1);
     sys_putpreference("loading", "no");
@@ -820,7 +812,7 @@ void sys_savepreferences(const char *filename)
     sys_donesavepreferences();
 }
 
-    /* calls from GUI to load/save from/to a file */
+/* calls from GUI to load/save from/to a file */
 void glob_loadpreferences(t_pd *dummy, t_symbol *filesym)
 {
     sys_loadpreferences(filesym->s_name, 0);
@@ -843,37 +835,44 @@ void glob_forgetpreferences(t_pd *dummy)
     struct stat statbuf;
     snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
         (homedir ? homedir : "."));
-    user_prefs_file[MAXPDSTRING-1] = 0;
-    if (stat(user_prefs_file, &statbuf) != 0) {
+    user_prefs_file[MAXPDSTRING - 1] = 0;
+    if(stat(user_prefs_file, &statbuf) != 0)
+    {
         post("no Pd settings to clear");
-    } else if (!unlink(user_prefs_file)) {
+    }
+    else if(!unlink(user_prefs_file))
+    {
         post("removed %s file", user_prefs_file);
-    } else {
+    }
+    else
+    {
         post("couldn't delete %s file: %s", user_prefs_file, strerror(errno));
     }
-#endif  /* !defined(_WIN32) && !defined(__APPLE__) */
+#endif /* !defined(_WIN32) && !defined(__APPLE__) */
 #ifdef __APPLE__
     char cmdbuf[MAXPDSTRING];
     int warn = 1;
-    if (!sys_getpreference("audioapi", cmdbuf, MAXPDSTRING))
+    if(!sys_getpreference("audioapi", cmdbuf, MAXPDSTRING))
         post("no Pd settings to clear"), warn = 0;
-            /* do it anyhow, why not... */
-    snprintf(cmdbuf, MAXPDSTRING,
-        "defaults delete org.puredata.pd 2> /dev/null\n");
-    if (system(cmdbuf) && warn)
+    /* do it anyhow, why not... */
+    snprintf(
+        cmdbuf, MAXPDSTRING, "defaults delete org.puredata.pd 2> /dev/null\n");
+    if(system(cmdbuf) && warn)
         post("failed to erase Pd settings");
-    else if(warn) post("erased Pd settings");
+    else if(warn)
+        post("erased Pd settings");
 #endif /* __APPLE__ */
 #ifdef _WIN32
     HKEY hkey;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-        "Software", 0,  KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS)
-            post("no Pd settings to erase");
+    if(RegOpenKeyEx(HKEY_CURRENT_USER, "Software", 0, KEY_QUERY_VALUE, &hkey) !=
+        ERROR_SUCCESS)
+        post("no Pd settings to erase");
     else
     {
-        if (RegDeleteKey(hkey, "Pure-Data") != ERROR_SUCCESS)
+        if(RegDeleteKey(hkey, "Pure-Data") != ERROR_SUCCESS)
             post("no Pd settings to erase");
-        else post("erased Pd settings");
+        else
+            post("erased Pd settings");
         RegCloseKey(hkey);
     }
 #endif /* _WIN32 */
@@ -882,7 +881,7 @@ void glob_forgetpreferences(t_pd *dummy)
 int sys_oktoloadfiles(int done)
 {
 #if defined(_WIN32) || defined(__APPLE__)
-    if (done)
+    if(done)
     {
         sys_putpreference("loading", "no");
         return (1);
@@ -890,11 +889,11 @@ int sys_oktoloadfiles(int done)
     else
     {
         char prefbuf[MAXPDSTRING];
-        if (sys_getpreference("loading", prefbuf, MAXPDSTRING) &&
+        if(sys_getpreference("loading", prefbuf, MAXPDSTRING) &&
             strcmp(prefbuf, "no"))
         {
-            post(
-    "skipping loading preferences... Pd seems to have crashed on startup");
+            post("skipping loading preferences... Pd seems to have crashed on "
+                 "startup");
             post("(re-save preferences to reinstate them)");
             return (0);
         }

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -486,11 +486,17 @@ static void sys_initloadpreferences(void)
     snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
         (homedir ? homedir : "."));
     if(stat(user_prefs_file, &statbuf) == 0)
+    {
         strncpy(filenamebuf, user_prefs_file, MAXPDSTRING);
+    }
     else if(stat(default_prefs_file, &statbuf) == 0)
+    {
         strncpy(filenamebuf, default_prefs_file, MAXPDSTRING);
+    }
     else
+    {
         return;
+    }
     filenamebuf[MAXPDSTRING - 1] = 0;
     sys_initloadpreferences_file(filenamebuf);
 }
@@ -539,9 +545,13 @@ void sys_loadpreferences(const char *filename, int startingup)
     sys_get_audio_settings(&as);
 
     if(*filename)
+    {
         sys_initloadpreferences_file(filename);
+    }
     else
+    {
         sys_initloadpreferences();
+    }
     /* load audio preferences */
     if(!sys_externalschedlib &&
         sys_getpreference("audioapi", prefbuf, MAXPDSTRING) &&
@@ -550,7 +560,9 @@ void sys_loadpreferences(const char *filename, int startingup)
     /* JMZ/MB: brackets for initializing */
     if(sys_getpreference("noaudioin", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
+    {
         as.a_nindev = 0;
+    }
     else
     {
         for(as.a_nindev = 0; as.a_nindev < MAXAUDIOINDEV; as.a_nindev++)
@@ -578,7 +590,9 @@ void sys_loadpreferences(const char *filename, int startingup)
     /* JMZ/MB: brackets for initializing */
     if(sys_getpreference("noaudioout", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
+    {
         as.a_noutdev = 0;
+    }
     else
     {
         for(as.a_noutdev = 0; as.a_noutdev < MAXAUDIOOUTDEV; as.a_noutdev++)
@@ -604,10 +618,14 @@ void sys_loadpreferences(const char *filename, int startingup)
     if(sys_getpreference("callback", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &as.a_callback);
     if(sys_getpreference("audioblocksize", prefbuf, MAXPDSTRING))
+    {
         sscanf(prefbuf, "%d", &as.a_blocksize);
 #ifndef _WIN32
+    }
     else if(sys_getpreference("blocksize", prefbuf, MAXPDSTRING))
+    {
         sscanf(prefbuf, "%d", &as.a_blocksize);
+    }
 #endif
     sys_set_audio_settings(&as);
 
@@ -618,8 +636,11 @@ void sys_loadpreferences(const char *filename, int startingup)
     /* JMZ/MB: brackets for initializing */
     if(sys_getpreference("nomidiin", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
+    {
         nmidiindev = 0;
+    }
     else
+    {
         for(nmidiindev = 0; nmidiindev < MAXMIDIINDEV; nmidiindev++)
         {
             /* first try to find a name - if that matches an existing device
@@ -628,7 +649,9 @@ void sys_loadpreferences(const char *filename, int startingup)
             sprintf(keybuf, "midiindevname%d", nmidiindev + 1);
             if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
                 (devn = sys_mididevnametonumber(0, prefbuf)) >= 0)
+            {
                 midiindev[nmidiindev] = devn;
+            }
             else
             {
                 sprintf(keybuf, "midiindev%d", nmidiindev + 1);
@@ -636,18 +659,24 @@ void sys_loadpreferences(const char *filename, int startingup)
                 if(sscanf(prefbuf, "%d", &midiindev[nmidiindev]) < 1) break;
             }
         }
+    }
     /* JMZ/MB: brackets for initializing */
     if(sys_getpreference("nomidiout", prefbuf, MAXPDSTRING) &&
         (!strcmp(prefbuf, ".") || !strcmp(prefbuf, "True")))
+    {
         nmidioutdev = 0;
+    }
     else
+    {
         for(nmidioutdev = 0; nmidioutdev < MAXMIDIOUTDEV; nmidioutdev++)
         {
             int devn;
             sprintf(keybuf, "midioutdevname%d", nmidioutdev + 1);
             if(sys_getpreference(keybuf, prefbuf, MAXPDSTRING) &&
                 (devn = sys_mididevnametonumber(1, prefbuf)) >= 0)
+            {
                 midioutdev[nmidioutdev] = devn;
+            }
             else
             {
                 sprintf(keybuf, "midioutdev%d", nmidioutdev + 1);
@@ -655,13 +684,18 @@ void sys_loadpreferences(const char *filename, int startingup)
                 if(sscanf(prefbuf, "%d", &midioutdev[nmidioutdev]) < 1) break;
             }
         }
+    }
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 0);
 
     /* search path */
     if(sys_getpreference("npath", prefbuf, MAXPDSTRING))
+    {
         sscanf(prefbuf, "%d", &maxi);
+    }
     else
+    {
         maxi = 0x7fffffff;
+    }
     for(i = 0; i < maxi; i++)
     {
         sprintf(keybuf, "path%d", i + 1);
@@ -676,9 +710,13 @@ void sys_loadpreferences(const char *filename, int startingup)
 
     /* startup settings */
     if(sys_getpreference("nloadlib", prefbuf, MAXPDSTRING))
+    {
         sscanf(prefbuf, "%d", &maxi);
+    }
     else
+    {
         maxi = 0x7fffffff;
+    }
     for(i = 0; i < maxi; i++)
     {
         sprintf(keybuf, "loadlib%d", i + 1);
@@ -694,18 +732,22 @@ void sys_loadpreferences(const char *filename, int startingup)
         if(startingup) sys_doflags();
     }
     if(sys_defeatrt)
+    {
         sys_hipriority = 0;
+    }
     else
+    {
 #if defined(ANDROID)
         sys_hipriority = 0;
 #else
         sys_hipriority = 1;
+    }
 #endif
     if(sys_getpreference("zoom", prefbuf, MAXPDSTRING))
         sscanf(prefbuf, "%d", &sys_zoom_open);
 
     sys_doneloadpreferences();
-}
+    }
 
 void sys_savepreferences(const char *filename)
 {
@@ -719,9 +761,13 @@ void sys_savepreferences(const char *filename)
     int midioutdev[MAXMIDIOUTDEV];
 
     if(filename && *filename)
+    {
         sys_initsavepreferences_file(filename);
+    }
     else
+    {
         sys_initsavepreferences();
+    }
     /* audio settings */
     sys_get_audio_settings(&as);
 

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* Pd side of the Pd/Pd-gui interface.  Also, some system interface routines
 that didn't really belong anywhere. */
@@ -8,7 +8,7 @@ that didn't really belong anywhere. */
 #include "m_pd.h"
 #include "s_stuff.h"
 #include "m_imp.h"
-#include "g_canvas.h"   /* for GUI queueing stuff */
+#include "g_canvas.h" /* for GUI queueing stuff */
 #include "s_net.h"
 #include <errno.h>
 #ifndef _WIN32
@@ -48,8 +48,8 @@ that didn't really belong anywhere. */
 
 #define INTER (pd_this->pd_inter)
 
-#define DEBUG_MESSUP 1      /* messages up from pd to pd-gui */
-#define DEBUG_MESSDOWN 2    /* messages down from pd-gui to pd */
+#define DEBUG_MESSUP 1   /* messages up from pd to pd-gui */
+#define DEBUG_MESSDOWN 2 /* messages down from pd-gui to pd */
 
 #ifndef PDBINDIR
 #define PDBINDIR "bin/"
@@ -60,14 +60,14 @@ that didn't really belong anywhere. */
 #endif
 
 #ifndef WISH
-# if defined _WIN32
-#  define WISH "wish85.exe"
-# elif defined __APPLE__
-   // leave undefined to use dummy search path, otherwise
-   // this should be a full path to wish on mac
+#if defined _WIN32
+#define WISH "wish85.exe"
+#elif defined __APPLE__
+// leave undefined to use dummy search path, otherwise
+// this should be a full path to wish on mac
 #else
-#  define WISH "wish"
-# endif
+#define WISH "wish"
+#endif
 #endif
 
 #define LOCALHOST "localhost"
@@ -120,7 +120,7 @@ struct _instanceinter
     int i_guisize;
     int i_waitingforping;
     int i_bytessincelastping;
-    int i_fdschanged;   /* flag to break fdpoll loop if fd list changes */
+    int i_fdschanged; /* flag to break fdpoll loop if fd list changes */
 
 #ifdef _WIN32
     LARGE_INTEGER i_inittime;
@@ -150,10 +150,10 @@ static void sys_initntclock(void)
     LARGE_INTEGER f1;
     LARGE_INTEGER now;
     QueryPerformanceCounter(&now);
-    if (!QueryPerformanceFrequency(&f1))
+    if(!QueryPerformanceFrequency(&f1))
     {
-          fprintf(stderr, "pd: QueryPerformanceFrequency failed\n");
-          f1.QuadPart = 1;
+        fprintf(stderr, "pd: QueryPerformanceFrequency failed\n");
+        f1.QuadPart = 1;
     }
     INTER->i_freq = f1.QuadPart;
     INTER->i_inittime = now;
@@ -173,23 +173,23 @@ double nt_tixtotime(LARGE_INTEGER *dumbass)
 #endif
 #endif /* _WIN32 */
 
-    /* get "real time" in seconds; take the
-    first time we get called as a reference time of zero. */
+/* get "real time" in seconds; take the
+first time we get called as a reference time of zero. */
 double sys_getrealtime(void)
 {
 #ifndef _WIN32
     static struct timeval then;
     struct timeval now;
     gettimeofday(&now, 0);
-    if (then.tv_sec == 0 && then.tv_usec == 0) then = now;
+    if(then.tv_sec == 0 && then.tv_usec == 0) then = now;
     return ((now.tv_sec - then.tv_sec) +
-        (1./1000000.) * (now.tv_usec - then.tv_usec));
+            (1. / 1000000.) * (now.tv_usec - then.tv_usec));
 #else
     LARGE_INTEGER now;
     QueryPerformanceCounter(&now);
-    if (INTER->i_freq == 0) sys_initntclock();
-    return (((double)(now.QuadPart -
-        INTER->i_inittime.QuadPart)) / INTER->i_freq);
+    if(INTER->i_freq == 0) sys_initntclock();
+    return (
+        ((double) (now.QuadPart - INTER->i_inittime.QuadPart)) / INTER->i_freq);
 #endif
 }
 
@@ -204,36 +204,32 @@ static int sys_domicrosleep(int microsec)
     t_fdpoll *fp;
     timeout.tv_sec = 0;
     timeout.tv_usec = 0;
-    if (INTER->i_nfdpoll)
+    if(INTER->i_nfdpoll)
     {
         fd_set readset, writeset, exceptset;
         FD_ZERO(&writeset);
         FD_ZERO(&readset);
         FD_ZERO(&exceptset);
-        for (fp = INTER->i_fdpoll,
-            i = INTER->i_nfdpoll; i--; fp++)
-                FD_SET(fp->fdp_fd, &readset);
-        if(select(INTER->i_maxfd+1,
-                  &readset, &writeset, &exceptset, &timeout) < 0)
-          perror("microsleep select");
+        for(fp = INTER->i_fdpoll, i = INTER->i_nfdpoll; i--; fp++)
+            FD_SET(fp->fdp_fd, &readset);
+        if(select(INTER->i_maxfd + 1, &readset, &writeset, &exceptset,
+               &timeout) < 0)
+            perror("microsleep select");
         INTER->i_fdschanged = 0;
-        for (i = 0; i < INTER->i_nfdpoll &&
-            !INTER->i_fdschanged; i++)
-                if (FD_ISSET(INTER->i_fdpoll[i].fdp_fd, &readset))
-        {
-            (*INTER->i_fdpoll[i].fdp_fn)
-                (INTER->i_fdpoll[i].fdp_ptr,
-                    INTER->i_fdpoll[i].fdp_fd);
-            didsomething = 1;
-        }
-        if (didsomething)
-            return (1);
+        for(i = 0; i < INTER->i_nfdpoll && !INTER->i_fdschanged; i++)
+            if(FD_ISSET(INTER->i_fdpoll[i].fdp_fd, &readset))
+            {
+                (*INTER->i_fdpoll[i].fdp_fn)(
+                    INTER->i_fdpoll[i].fdp_ptr, INTER->i_fdpoll[i].fdp_fd);
+                didsomething = 1;
+            }
+        if(didsomething) return (1);
     }
-    if (microsec)
+    if(microsec)
     {
         sys_unlock();
 #ifdef _WIN32
-        Sleep(microsec/1000);
+        Sleep(microsec / 1000);
 #else
         usleep(microsec);
 #endif
@@ -242,9 +238,9 @@ static int sys_domicrosleep(int microsec)
     return (0);
 }
 
-    /* sleep (but if any incoming or to-gui sending to do, do that instead.)
-    Call with the PD instance lock UNSET - we set it here. */
-void sys_microsleep( void)
+/* sleep (but if any incoming or to-gui sending to do, do that instead.)
+Call with the PD instance lock UNSET - we set it here. */
+void sys_microsleep(void)
 {
     sys_lock();
     sys_domicrosleep(sched_get_sleepgrain());
@@ -258,23 +254,23 @@ static void sys_signal(int signo, sig_t sigfun)
     action.sa_flags = 0;
     action.sa_handler = sigfun;
     memset(&action.sa_mask, 0, sizeof(action.sa_mask));
-#if 0  /* GG says: don't use that */
+#if 0 /* GG says: don't use that */
     action.sa_restorer = 0;
 #endif
-    if (sigaction(signo, &action, 0) < 0)
-        perror("sigaction");
+    if(sigaction(signo, &action, 0) < 0) perror("sigaction");
 }
 
 static void sys_exithandler(int n)
 {
     static int trouble = 0;
-    if (!trouble)
+    if(!trouble)
     {
         trouble = 1;
         fprintf(stderr, "Pd: signal %d\n", n);
         sys_bail(1);
     }
-    else _exit(1);
+    else
+        _exit(1);
 }
 
 static void sys_alarmhandler(int n)
@@ -293,7 +289,7 @@ static void sys_huphandler(int n)
 void sys_setalarm(int microsec)
 {
     struct itimerval gonzo;
-    int sec = (int)(microsec/1000000);
+    int sec = (int) (microsec / 1000000);
     microsec %= 1000000;
 #if 0
     fprintf(stderr, "timer %d:%d\n", sec, microsec);
@@ -302,31 +298,32 @@ void sys_setalarm(int microsec)
     gonzo.it_interval.tv_usec = 0;
     gonzo.it_value.tv_sec = sec;
     gonzo.it_value.tv_usec = microsec;
-    if (microsec)
+    if(microsec)
         sys_signal(SIGALRM, sys_alarmhandler);
-    else sys_signal(SIGALRM, SIG_IGN);
+    else
+        sys_signal(SIGALRM, SIG_IGN);
     setitimer(ITIMER_REAL, &gonzo, 0);
 }
 
 #endif /* NOT _WIN32 && NOT __CYGWIN__ */
 
-    /* on startup, set various signal handlers */
+/* on startup, set various signal handlers */
 void sys_setsignalhandlers(void)
 {
 #if !defined(_WIN32) && !defined(__CYGWIN__)
     signal(SIGHUP, sys_huphandler);
     signal(SIGINT, sys_exithandler);
     signal(SIGQUIT, sys_exithandler);
-# ifdef SIGIOT
+#ifdef SIGIOT
     signal(SIGIOT, sys_exithandler);
-# endif
+#endif
     signal(SIGFPE, SIG_IGN);
     /* signal(SIGILL, sys_exithandler);
     signal(SIGBUS, sys_exithandler);
     signal(SIGSEGV, sys_exithandler); */
     signal(SIGPIPE, SIG_IGN);
     signal(SIGALRM, SIG_IGN);
-#if 0  /* GG says: don't use that */
+#if 0 /* GG says: don't use that */
     signal(SIGSTKFLT, sys_exithandler);
 #endif
 #endif /* NOT _WIN32 && NOT __CYGWIN__ */
@@ -355,35 +352,39 @@ void sys_set_priority(int mode)
     p3 = (mode == MODE_WATCHDOG ? p2 - 5 : (mode == MODE_RT ? p2 - 7 : 0));
 #endif
     par.sched_priority = p3;
-    if (sched_setscheduler(0,
-        (mode == MODE_NRT ? SCHED_OTHER : SCHED_FIFO), &par) < 0)
+    if(sched_setscheduler(
+           0, (mode == MODE_NRT ? SCHED_OTHER : SCHED_FIFO), &par) < 0)
     {
-        if (mode == MODE_WATCHDOG)
+        if(mode == MODE_WATCHDOG)
             fprintf(stderr, "priority %d scheduling failed.\n", p3);
-        else post("priority %d scheduling failed; running at normal priority",
+        else
+            post("priority %d scheduling failed; running at normal priority",
                 p3);
     }
     else
     {
-        if (mode == MODE_RT)
+        if(mode == MODE_RT)
             logpost(NULL, PD_VERBOSE, "priority %d scheduling enabled.\n", p3);
-        else logpost(NULL, PD_VERBOSE, "running at normal (non-real-time) priority.\n");
+        else
+            logpost(NULL, PD_VERBOSE,
+                "running at normal (non-real-time) priority.\n");
     }
 #endif
 
 #if !defined(USEAPI_JACK)
-    if (mode != MODE_NRT)
+    if(mode != MODE_NRT)
     {
-            /* tb: force memlock to physical memory { */
+        /* tb: force memlock to physical memory { */
         struct rlimit mlock_limit;
-        mlock_limit.rlim_cur=0;
-        mlock_limit.rlim_max=0;
-        setrlimit(RLIMIT_MEMLOCK,&mlock_limit);
-            /* } tb */
-        if (mlockall(MCL_FUTURE) != -1 && sys_verbose)
+        mlock_limit.rlim_cur = 0;
+        mlock_limit.rlim_max = 0;
+        setrlimit(RLIMIT_MEMLOCK, &mlock_limit);
+        /* } tb */
+        if(mlockall(MCL_FUTURE) != -1 && sys_verbose)
             fprintf(stderr, "memory locking enabled.\n");
     }
-    else munlockall();
+    else
+        munlockall();
 #endif
 }
 
@@ -393,8 +394,7 @@ void sys_set_priority(int mode)
 
 unsigned char *sys_getrecvbuf(unsigned int *size)
 {
-    if (size)
-        *size = NET_MAXPACKETSIZE;
+    if(size) *size = NET_MAXPACKETSIZE;
     return INTER->i_recvbuf;
 }
 
@@ -413,15 +413,14 @@ void sys_addpollfn(int fd, t_fdpollfn fn, void *ptr)
     sys_init_fdpoll();
     nfd = INTER->i_nfdpoll;
     size = nfd * sizeof(t_fdpoll);
-    INTER->i_fdpoll = (t_fdpoll *)t_resizebytes(
+    INTER->i_fdpoll = (t_fdpoll *) t_resizebytes(
         INTER->i_fdpoll, size, size + sizeof(t_fdpoll));
     fp = INTER->i_fdpoll + nfd;
     fp->fdp_fd = fd;
     fp->fdp_fn = fn;
     fp->fdp_ptr = ptr;
     INTER->i_nfdpoll = nfd + 1;
-    if (fd >= INTER->i_maxfd)
-        INTER->i_maxfd = fd + 1;
+    if(fd >= INTER->i_maxfd) INTER->i_maxfd = fd + 1;
     INTER->i_fdschanged = 1;
 }
 
@@ -431,16 +430,16 @@ void sys_rmpollfn(int fd)
     int i, size = nfd * sizeof(t_fdpoll);
     t_fdpoll *fp;
     INTER->i_fdschanged = 1;
-    for (i = nfd, fp = INTER->i_fdpoll; i--; fp++)
+    for(i = nfd, fp = INTER->i_fdpoll; i--; fp++)
     {
-        if (fp->fdp_fd == fd)
+        if(fp->fdp_fd == fd)
         {
-            while (i--)
+            while(i--)
             {
                 fp[0] = fp[1];
                 fp++;
             }
-            INTER->i_fdpoll = (t_fdpoll *)t_resizebytes(
+            INTER->i_fdpoll = (t_fdpoll *) t_resizebytes(
                 INTER->i_fdpoll, size, size - sizeof(t_fdpoll));
             INTER->i_nfdpoll = nfd - 1;
             return;
@@ -449,15 +448,15 @@ void sys_rmpollfn(int fd)
     post("warning: %d removed from poll list but not found", fd);
 }
 
-    /* Size of the buffer used for parsing FUDI messages
-    received over TCP. Must be a power of two!
-    LATER make this settable per socketreceiver instance */
+/* Size of the buffer used for parsing FUDI messages
+received over TCP. Must be a power of two!
+LATER make this settable per socketreceiver instance */
 #define INBUFSIZE 4096
 
 t_socketreceiver *socketreceiver_new(void *owner, t_socketnotifier notifier,
     t_socketreceivefn socketreceivefn, int udp)
 {
-    t_socketreceiver *x = (t_socketreceiver *)getbytes(sizeof(*x));
+    t_socketreceiver *x = (t_socketreceiver *) getbytes(sizeof(*x));
     x->sr_inhead = x->sr_intail = 0;
     x->sr_owner = owner;
     x->sr_notifier = notifier;
@@ -465,10 +464,9 @@ t_socketreceiver *socketreceiver_new(void *owner, t_socketnotifier notifier,
     x->sr_udp = udp;
     x->sr_fromaddr = NULL;
     x->sr_fromaddrfn = NULL;
-    if (!udp)
+    if(!udp)
     {
-        if (!(x->sr_inbuf = malloc(INBUFSIZE)))
-            bug("t_socketreceiver");
+        if(!(x->sr_inbuf = malloc(INBUFSIZE))) bug("t_socketreceiver");
     }
     else
         x->sr_inbuf = NULL;
@@ -477,14 +475,13 @@ t_socketreceiver *socketreceiver_new(void *owner, t_socketnotifier notifier,
 
 void socketreceiver_free(t_socketreceiver *x)
 {
-    if (x->sr_inbuf)
-        free(x->sr_inbuf);
-    if (x->sr_fromaddr) free(x->sr_fromaddr);
+    if(x->sr_inbuf) free(x->sr_inbuf);
+    if(x->sr_fromaddr) free(x->sr_fromaddr);
     freebytes(x, sizeof(*x));
 }
 
-    /* this is in a separately called subroutine so that the buffer isn't
-    sitting on the stack while the messages are getting passed. */
+/* this is in a separately called subroutine so that the buffer isn't
+sitting on the stack while the messages are getting passed. */
 static int socketreceiver_doread(t_socketreceiver *x)
 {
     char messbuf[INBUFSIZE], *bp = messbuf;
@@ -492,30 +489,30 @@ static int socketreceiver_doread(t_socketreceiver *x)
     int inhead = x->sr_inhead;
     int intail = x->sr_intail;
     char *inbuf = x->sr_inbuf;
-    for (indx = intail; first || (indx != inhead);
-        first = 0, (indx = (indx+1)&(INBUFSIZE-1)))
+    for(indx = intail; first || (indx != inhead);
+        first = 0, (indx = (indx + 1) & (INBUFSIZE - 1)))
     {
-            /* if we hit a semi that isn't preceded by a \, it's a message
-            boundary. LATER we should deal with the possibility that the
-            preceding \ might itself be escaped! */
+        /* if we hit a semi that isn't preceded by a \, it's a message
+        boundary. LATER we should deal with the possibility that the
+        preceding \ might itself be escaped! */
         char c = *bp++ = inbuf[indx];
-        if (c == ';' && (!indx || inbuf[indx-1] != '\\'))
+        if(c == ';' && (!indx || inbuf[indx - 1] != '\\'))
         {
-            intail = (indx+1)&(INBUFSIZE-1);
+            intail = (indx + 1) & (INBUFSIZE - 1);
             binbuf_text(INTER->i_inbinbuf, messbuf, bp - messbuf);
-            if (sys_debuglevel & DEBUG_MESSDOWN)
+            if(sys_debuglevel & DEBUG_MESSDOWN)
             {
-                size_t bufsize = (bp>messbuf)?(bp-messbuf):0;
-        #ifdef _WIN32
-            #ifdef _MSC_VER
-                fwprintf(stderr, L"<< %.*S\n", (int)bufsize, messbuf);
-            #else
-                fwprintf(stderr, L"<< %.*s\n", (int)bufsize, messbuf);
-            #endif
+                size_t bufsize = (bp > messbuf) ? (bp - messbuf) : 0;
+#ifdef _WIN32
+#ifdef _MSC_VER
+                fwprintf(stderr, L"<< %.*S\n", (int) bufsize, messbuf);
+#else
+                fwprintf(stderr, L"<< %.*s\n", (int) bufsize, messbuf);
+#endif
                 fflush(stderr);
-        #else
-                fprintf(stderr, "<< %.*s\n", (int)bufsize, messbuf);
-        #endif
+#else
+                fprintf(stderr, "<< %.*s\n", (int) bufsize, messbuf);
+#endif
             }
             x->sr_inhead = inhead;
             x->sr_intail = intail;
@@ -527,21 +524,22 @@ static int socketreceiver_doread(t_socketreceiver *x)
 
 static void socketreceiver_getudp(t_socketreceiver *x, int fd)
 {
-    char *buf = (char *)sys_getrecvbuf(0);
+    char *buf = (char *) sys_getrecvbuf(0);
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
     int ret, readbytes = 0;
-    while (1)
+    while(1)
     {
-        ret = (int)recvfrom(fd, buf, NET_MAXPACKETSIZE-1, 0,
-            (struct sockaddr *)x->sr_fromaddr, (x->sr_fromaddr ? &fromaddrlen : 0));
-        if (ret < 0)
+        ret = (int) recvfrom(fd, buf, NET_MAXPACKETSIZE - 1, 0,
+            (struct sockaddr *) x->sr_fromaddr,
+            (x->sr_fromaddr ? &fromaddrlen : 0));
+        if(ret < 0)
         {
-                /* socket_errno_udp() ignores some error codes */
-            if (socket_errno_udp())
+            /* socket_errno_udp() ignores some error codes */
+            if(socket_errno_udp())
             {
                 sys_sockerror("recv (udp)");
-                    /* only notify and shutdown a UDP sender! */
-                if (x->sr_notifier)
+                /* only notify and shutdown a UDP sender! */
+                if(x->sr_notifier)
                 {
                     (*x->sr_notifier)(x->sr_owner, fd);
                     sys_rmpollfn(fd);
@@ -550,63 +548,62 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
             }
             return;
         }
-        else if (ret > 0)
+        else if(ret > 0)
         {
-                /* handle too large UDP packets */
-            if (ret > NET_MAXPACKETSIZE-1)
+            /* handle too large UDP packets */
+            if(ret > NET_MAXPACKETSIZE - 1)
             {
-                post("warning: incoming UDP packet truncated from %d to %d bytes.",
-                    ret, NET_MAXPACKETSIZE-1);
-                ret = NET_MAXPACKETSIZE-1;
+                post("warning: incoming UDP packet truncated from %d to %d "
+                     "bytes.",
+                    ret, NET_MAXPACKETSIZE - 1);
+                ret = NET_MAXPACKETSIZE - 1;
             }
             buf[ret] = 0;
-    #if 0
+#if 0
             post("%s", buf);
-    #endif
-            if (buf[ret-1] != '\n')
+#endif
+            if(buf[ret - 1] != '\n')
             {
-    #if 0
+#if 0
                 pd_error(0, "dropped bad buffer %s\n", buf);
-    #endif
+#endif
             }
             else
             {
                 char *semi = strchr(buf, ';');
-                if (semi)
-                    *semi = 0;
-                if (x->sr_fromaddrfn)
-                    (*x->sr_fromaddrfn)(x->sr_owner, (const void *)x->sr_fromaddr);
+                if(semi) *semi = 0;
+                if(x->sr_fromaddrfn)
+                    (*x->sr_fromaddrfn)(
+                        x->sr_owner, (const void *) x->sr_fromaddr);
                 binbuf_text(INTER->i_inbinbuf, buf, strlen(buf));
                 outlet_setstacklim();
-                if (x->sr_socketreceivefn)
-                    (*x->sr_socketreceivefn)(x->sr_owner,
-                        INTER->i_inbinbuf);
-                else bug("socketreceiver_getudp");
+                if(x->sr_socketreceivefn)
+                    (*x->sr_socketreceivefn)(x->sr_owner, INTER->i_inbinbuf);
+                else
+                    bug("socketreceiver_getudp");
             }
             readbytes += ret;
             /* throttle */
-            if (readbytes >= NET_MAXPACKETSIZE)
-                return;
+            if(readbytes >= NET_MAXPACKETSIZE) return;
             /* check for pending UDP packets */
-            if (socket_bytes_available(fd) <= 0)
-                return;
+            if(socket_bytes_available(fd) <= 0) return;
         }
     }
 }
 
 void socketreceiver_read(t_socketreceiver *x, int fd)
 {
-    if (x->sr_udp)   /* UDP ("datagram") socket protocol */
+    if(x->sr_udp) /* UDP ("datagram") socket protocol */
         socketreceiver_getudp(x, fd);
-    else  /* TCP ("streaming") socket protocol */
+    else /* TCP ("streaming") socket protocol */
     {
         char *semi;
         int readto =
-            (x->sr_inhead >= x->sr_intail ? INBUFSIZE : x->sr_intail-1);
+            (x->sr_inhead >= x->sr_intail ? INBUFSIZE : x->sr_intail - 1);
         int ret;
 
-            /* the input buffer might be full. If so, drop the whole thing */
-        if (readto == x->sr_inhead)
+        /* the input buffer might be full. If so, drop the whole thing */
+        if(readto == x->sr_inhead)
         {
             fprintf(stderr, "pd: dropped message from gui\n");
             x->sr_inhead = x->sr_intail = 0;
@@ -614,15 +611,14 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
         }
         else
         {
-            ret = (int)recv(fd, x->sr_inbuf + x->sr_inhead,
-                readto - x->sr_inhead, 0);
-            if (ret <= 0)
+            ret = (int) recv(
+                fd, x->sr_inbuf + x->sr_inhead, readto - x->sr_inhead, 0);
+            if(ret <= 0)
             {
-                if (ret < 0)
-                    sys_sockerror("recv (tcp)");
-                if (x == INTER->i_socketreceiver)
+                if(ret < 0) sys_sockerror("recv (tcp)");
+                if(x == INTER->i_socketreceiver)
                 {
-                    if (pd_this == &pd_maininstance)
+                    if(pd_this == &pd_maininstance)
                     {
                         fprintf(stderr, "read from GUI socket: %s; stopping\n",
                             strerror(errno));
@@ -637,8 +633,7 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
                 }
                 else
                 {
-                    if (x->sr_notifier)
-                        (*x->sr_notifier)(x->sr_owner, fd);
+                    if(x->sr_notifier) (*x->sr_notifier)(x->sr_owner, fd);
                     sys_rmpollfn(fd);
                     sys_closesocket(fd);
                 }
@@ -646,72 +641,68 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
             else
             {
                 x->sr_inhead += ret;
-                if (x->sr_inhead >= INBUFSIZE) x->sr_inhead = 0;
-                while (socketreceiver_doread(x))
+                if(x->sr_inhead >= INBUFSIZE) x->sr_inhead = 0;
+                while(socketreceiver_doread(x))
                 {
-                    if (x->sr_fromaddrfn)
+                    if(x->sr_fromaddrfn)
                     {
                         socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
-                        if(!getpeername(fd,
-                                        (struct sockaddr *)x->sr_fromaddr,
-                                        &fromaddrlen))
-                            (*x->sr_fromaddrfn)(x->sr_owner,
-                                (const void *)x->sr_fromaddr);
+                        if(!getpeername(fd, (struct sockaddr *) x->sr_fromaddr,
+                               &fromaddrlen))
+                            (*x->sr_fromaddrfn)(
+                                x->sr_owner, (const void *) x->sr_fromaddr);
                     }
                     outlet_setstacklim();
-                    if (x->sr_socketreceivefn)
-                        (*x->sr_socketreceivefn)(x->sr_owner,
-                            INTER->i_inbinbuf);
-                    else binbuf_eval(INTER->i_inbinbuf, 0, 0, 0);
-                    if (x->sr_inhead == x->sr_intail)
-                        break;
+                    if(x->sr_socketreceivefn)
+                        (*x->sr_socketreceivefn)(
+                            x->sr_owner, INTER->i_inbinbuf);
+                    else
+                        binbuf_eval(INTER->i_inbinbuf, 0, 0, 0);
+                    if(x->sr_inhead == x->sr_intail) break;
                 }
             }
         }
     }
 }
 
-void socketreceiver_set_fromaddrfn(t_socketreceiver *x,
-    t_socketfromaddrfn fromaddrfn)
+void socketreceiver_set_fromaddrfn(
+    t_socketreceiver *x, t_socketfromaddrfn fromaddrfn)
 {
     x->sr_fromaddrfn = fromaddrfn;
-    if (fromaddrfn)
+    if(fromaddrfn)
     {
-        if (!x->sr_fromaddr)
+        if(!x->sr_fromaddr)
             x->sr_fromaddr = malloc(sizeof(struct sockaddr_storage));
     }
-    else if (x->sr_fromaddr)
+    else if(x->sr_fromaddr)
     {
         free(x->sr_fromaddr);
         x->sr_fromaddr = NULL;
     }
 }
 
-void sys_closesocket(int sockfd)
-{
-    socket_close(sockfd);
-}
+void sys_closesocket(int sockfd) { socket_close(sockfd); }
 
 /* ---------------------- sending messages to the GUI ------------------ */
 #define GUI_ALLOCCHUNK 8192
-#define GUI_UPDATESLICE 512 /* how much we try to do in one idle period */
+#define GUI_UPDATESLICE 512   /* how much we try to do in one idle period */
 #define GUI_BYTESPERPING 1024 /* how much we send up per ping */
 
 static void sys_trytogetmoreguibuf(int newsize)
 {
-        /* newsize can be negative if it overflows (at 0x7FFFFFFF)
-         * which only happens if we push a huge amount of data to the GUI,
-         * such as printing a billion numbers
-         *
-         * we could fix this by using size_t (or ssize_t), but this will
-         * possibly lead to memory exhaustion.
-         * as the overflow happens at 2GB which is rather large anyhow,
-         * but most machines will still be able to handle this without swapping
-         * and crashing, we just use the 2GB limit to trigger a synchronous write.
-	 * also note that on the Tcl/Tk side, the maximum size of a buffer is 2GB,
-	 * so there's a nice analogy here.
-         */
-    char *newbuf = (newsize>=0)?realloc(INTER->i_guibuf, newsize):0;
+    /* newsize can be negative if it overflows (at 0x7FFFFFFF)
+     * which only happens if we push a huge amount of data to the GUI,
+     * such as printing a billion numbers
+     *
+     * we could fix this by using size_t (or ssize_t), but this will
+     * possibly lead to memory exhaustion.
+     * as the overflow happens at 2GB which is rather large anyhow,
+     * but most machines will still be able to handle this without swapping
+     * and crashing, we just use the 2GB limit to trigger a synchronous write.
+     * also note that on the Tcl/Tk side, the maximum size of a buffer is 2GB,
+     * so there's a nice analogy here.
+     */
+    char *newbuf = (newsize >= 0) ? realloc(INTER->i_guibuf, newsize) : 0;
 #if 0
     static int sizewas;
     if (newsize > 70000 && sizewas < 70000)
@@ -727,20 +718,18 @@ static void sys_trytogetmoreguibuf(int newsize)
         newsize, INTER->i_guihead, INTER->i_guitail);
 #endif
 
-        /* if realloc fails, make a last-ditch attempt to stay alive by
-        synchronously writing out the existing contents.  LATER test
-        this by intentionally setting newbuf to zero */
-    if (!newbuf)
+    /* if realloc fails, make a last-ditch attempt to stay alive by
+    synchronously writing out the existing contents.  LATER test
+    this by intentionally setting newbuf to zero */
+    if(!newbuf)
     {
         int bytestowrite = INTER->i_guihead - INTER->i_guitail;
         int written = 0;
-        while (1)
+        while(1)
         {
-            int res = (int)send(
-                INTER->i_guisock,
-                INTER->i_guibuf + INTER->i_guitail + written,
-                bytestowrite, 0);
-            if (res < 0)
+            int res = (int) send(INTER->i_guisock,
+                INTER->i_guibuf + INTER->i_guitail + written, bytestowrite, 0);
+            if(res < 0)
             {
                 perror("pd output pipe");
                 sys_bail(1);
@@ -748,8 +737,7 @@ static void sys_trytogetmoreguibuf(int newsize)
             else
             {
                 written += res;
-                if (written >= bytestowrite)
-                    break;
+                if(written >= bytestowrite) break;
             }
         }
         INTER->i_guihead = INTER->i_guitail = 0;
@@ -761,21 +749,17 @@ static void sys_trytogetmoreguibuf(int newsize)
     }
 }
 
-int sys_havegui(void)
-{
-    return (INTER->i_havegui);
-}
+int sys_havegui(void) { return (INTER->i_havegui); }
 
 void sys_vgui(const char *fmt, ...)
 {
     int msglen, bytesleft, headwas, nwrote;
     va_list ap;
 
-    if (!sys_havegui())
-        return;
-    if (!INTER->i_guibuf)
+    if(!sys_havegui()) return;
+    if(!INTER->i_guibuf)
     {
-        if (!(INTER->i_guibuf = malloc(GUI_ALLOCCHUNK)))
+        if(!(INTER->i_guibuf = malloc(GUI_ALLOCCHUNK)))
         {
             fprintf(stderr, "Pd: couldn't allocate GUI buffer\n");
             sys_bail(1);
@@ -783,49 +767,44 @@ void sys_vgui(const char *fmt, ...)
         INTER->i_guisize = GUI_ALLOCCHUNK;
         INTER->i_guihead = INTER->i_guitail = 0;
     }
-    if (INTER->i_guihead > INTER->i_guisize - (GUI_ALLOCCHUNK/2)) {
-            sys_trytogetmoreguibuf(INTER->i_guisize + GUI_ALLOCCHUNK);
+    if(INTER->i_guihead > INTER->i_guisize - (GUI_ALLOCCHUNK / 2))
+    {
+        sys_trytogetmoreguibuf(INTER->i_guisize + GUI_ALLOCCHUNK);
     }
     va_start(ap, fmt);
-    msglen = vsnprintf(
-        INTER->i_guibuf  + INTER->i_guihead,
-        INTER->i_guisize - INTER->i_guihead,
-        fmt, ap);
+    msglen = vsnprintf(INTER->i_guibuf + INTER->i_guihead,
+        INTER->i_guisize - INTER->i_guihead, fmt, ap);
     va_end(ap);
     if(msglen < 0)
     {
-        fprintf(stderr,
-            "Pd: buffer space wasn't sufficient for long GUI string\n");
+        fprintf(
+            stderr, "Pd: buffer space wasn't sufficient for long GUI string\n");
         return;
     }
-    if (msglen >= INTER->i_guisize - INTER->i_guihead)
+    if(msglen >= INTER->i_guisize - INTER->i_guihead)
     {
-        int msglen2, newsize =
-            INTER->i_guisize
-            + 1
-            + (msglen > GUI_ALLOCCHUNK ? msglen : GUI_ALLOCCHUNK);
+        int msglen2,
+            newsize = INTER->i_guisize + 1 +
+                      (msglen > GUI_ALLOCCHUNK ? msglen : GUI_ALLOCCHUNK);
         sys_trytogetmoreguibuf(newsize);
 
         va_start(ap, fmt);
-        msglen2 = vsnprintf(
-            INTER->i_guibuf  + INTER->i_guihead,
-            INTER->i_guisize - INTER->i_guihead,
-            fmt, ap);
+        msglen2 = vsnprintf(INTER->i_guibuf + INTER->i_guihead,
+            INTER->i_guisize - INTER->i_guihead, fmt, ap);
         va_end(ap);
-        if (msglen2 != msglen)
-            bug("sys_vgui");
-        if (msglen >= INTER->i_guisize - INTER->i_guihead)
-            msglen  = INTER->i_guisize - INTER->i_guihead;
+        if(msglen2 != msglen) bug("sys_vgui");
+        if(msglen >= INTER->i_guisize - INTER->i_guihead)
+            msglen = INTER->i_guisize - INTER->i_guihead;
     }
-    if (sys_debuglevel & DEBUG_MESSUP)
+    if(sys_debuglevel & DEBUG_MESSUP)
     {
         const char *mess = INTER->i_guibuf + INTER->i_guihead;
 #ifdef _WIN32
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         fwprintf(stderr, L">> %S", mess);
-    #else
+#else
         fwprintf(stderr, L">> %s", mess);
-    #endif
+#endif
         fflush(stderr);
 #else
         fprintf(stderr, ">> %s", mess);
@@ -835,42 +814,35 @@ void sys_vgui(const char *fmt, ...)
     INTER->i_bytessincelastping += msglen;
 }
 
-void sys_gui(const char *s)
-{
-    sys_vgui("%s", s);
-}
+void sys_gui(const char *s) { sys_vgui("%s", s); }
 
 static int sys_flushtogui(void)
 {
-    int writesize = INTER->i_guihead - INTER->i_guitail,
-        nwrote = 0;
-    if (writesize > 0)
-        nwrote = (int)send(
-            INTER->i_guisock,
-            INTER->i_guibuf + INTER->i_guitail,
-            writesize, 0);
+    int writesize = INTER->i_guihead - INTER->i_guitail, nwrote = 0;
+    if(writesize > 0)
+        nwrote = (int) send(
+            INTER->i_guisock, INTER->i_guibuf + INTER->i_guitail, writesize, 0);
 
 #if 0
     if (writesize)
         fprintf(stderr, "wrote %d of %d\n", nwrote, writesize);
 #endif
 
-    if (nwrote < 0)
+    if(nwrote < 0)
     {
         perror("pd-to-gui socket");
         sys_bail(1);
     }
-    else if (!nwrote)
+    else if(!nwrote)
         return (0);
-    else if (nwrote >= INTER->i_guihead - INTER->i_guitail)
+    else if(nwrote >= INTER->i_guihead - INTER->i_guitail)
         INTER->i_guihead = INTER->i_guitail = 0;
-    else if (nwrote)
+    else if(nwrote)
     {
         INTER->i_guitail += nwrote;
-        if (INTER->i_guitail > (INTER->i_guisize >> 2))
+        if(INTER->i_guitail > (INTER->i_guisize >> 2))
         {
-            memmove(INTER->i_guibuf,
-                INTER->i_guibuf  + INTER->i_guitail,
+            memmove(INTER->i_guibuf, INTER->i_guibuf + INTER->i_guitail,
                 INTER->i_guihead - INTER->i_guitail);
             INTER->i_guihead = INTER->i_guihead - INTER->i_guitail;
             INTER->i_guitail = 0;
@@ -879,82 +851,68 @@ static int sys_flushtogui(void)
     return (1);
 }
 
-void glob_ping(t_pd *dummy)
-{
-    INTER->i_waitingforping = 0;
-}
+void glob_ping(t_pd *dummy) { INTER->i_waitingforping = 0; }
 
 static int sys_flushqueue(void)
 {
     int wherestop = INTER->i_bytessincelastping + GUI_UPDATESLICE;
-    if (wherestop + (GUI_UPDATESLICE >> 1) > GUI_BYTESPERPING)
+    if(wherestop + (GUI_UPDATESLICE >> 1) > GUI_BYTESPERPING)
         wherestop = 0x7fffffff;
-    if (INTER->i_waitingforping)
-        return (0);
-    if (!INTER->i_guiqueuehead)
-        return (0);
-    while (1)
+    if(INTER->i_waitingforping) return (0);
+    if(!INTER->i_guiqueuehead) return (0);
+    while(1)
     {
-        if (INTER->i_bytessincelastping >= GUI_BYTESPERPING)
+        if(INTER->i_bytessincelastping >= GUI_BYTESPERPING)
         {
             sys_gui("pdtk_ping\n");
             INTER->i_bytessincelastping = 0;
             INTER->i_waitingforping = 1;
             return (1);
         }
-        if (INTER->i_guiqueuehead)
+        if(INTER->i_guiqueuehead)
         {
             t_guiqueue *headwas = INTER->i_guiqueuehead;
             INTER->i_guiqueuehead = headwas->gq_next;
             (*headwas->gq_fn)(headwas->gq_client, headwas->gq_glist);
             t_freebytes(headwas, sizeof(*headwas));
-            if (INTER->i_bytessincelastping >= wherestop)
-                break;
+            if(INTER->i_bytessincelastping >= wherestop) break;
         }
-        else break;
+        else
+            break;
     }
     sys_flushtogui();
     return (1);
 }
 
-    /* flush output buffer and update queue to gui in small time slices */
+/* flush output buffer and update queue to gui in small time slices */
 static int sys_poll_togui(void) /* returns 1 if did anything */
 {
-    if (!sys_havegui())
-        return (0);
-        /* in case there is stuff still in the buffer, try to flush it. */
+    if(!sys_havegui()) return (0);
+    /* in case there is stuff still in the buffer, try to flush it. */
     sys_flushtogui();
-        /* if the flush wasn't complete, wait. */
-    if (INTER->i_guihead > INTER->i_guitail)
-        return (0);
+    /* if the flush wasn't complete, wait. */
+    if(INTER->i_guihead > INTER->i_guitail) return (0);
 
-        /* check for queued updates */
-    if (sys_flushqueue())
-        return (1);
+    /* check for queued updates */
+    if(sys_flushqueue()) return (1);
 
     return (0);
 }
 
-    /* if some GUI object is having to do heavy computations, it can tell
-    us to back off from doing more updates by faking a big one itself. */
-void sys_pretendguibytes(int n)
-{
-    INTER->i_bytessincelastping += n;
-}
+/* if some GUI object is having to do heavy computations, it can tell
+us to back off from doing more updates by faking a big one itself. */
+void sys_pretendguibytes(int n) { INTER->i_bytessincelastping += n; }
 
 void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
 {
     t_guiqueue **gqnextptr, *gq;
-    if (!INTER->i_guiqueuehead)
+    if(!INTER->i_guiqueuehead)
         gqnextptr = &INTER->i_guiqueuehead;
     else
     {
-        for (gq = INTER->i_guiqueuehead; gq->gq_next;
-            gq = gq->gq_next)
-                if (gq->gq_client == client)
-                    return;
-        if (gq->gq_client == client)
-            return;
+        for(gq = INTER->i_guiqueuehead; gq->gq_next; gq = gq->gq_next)
+            if(gq->gq_client == client) return;
+        if(gq->gq_client == client) return;
         gqnextptr = &gq->gq_next;
     }
     gq = t_getbytes(sizeof(*gq));
@@ -969,16 +927,15 @@ void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
 void sys_unqueuegui(void *client)
 {
     t_guiqueue *gq, *gq2;
-    while (INTER->i_guiqueuehead && INTER->i_guiqueuehead->gq_client == client)
+    while(INTER->i_guiqueuehead && INTER->i_guiqueuehead->gq_client == client)
     {
         gq = INTER->i_guiqueuehead;
         INTER->i_guiqueuehead = INTER->i_guiqueuehead->gq_next;
         t_freebytes(gq, sizeof(*gq));
     }
-    if (!INTER->i_guiqueuehead)
-        return;
-    for (gq = INTER->i_guiqueuehead; (gq2 = gq->gq_next); gq = gq2)
-        if (gq2->gq_client == client)
+    if(!INTER->i_guiqueuehead) return;
+    for(gq = INTER->i_guiqueuehead; (gq2 = gq->gq_next); gq = gq2)
+        if(gq2->gq_client == client)
         {
             gq->gq_next = gq2->gq_next;
             t_freebytes(gq2, sizeof(*gq2));
@@ -986,28 +943,26 @@ void sys_unqueuegui(void *client)
         }
 }
 
-    /* poll for any incoming packets, or for GUI updates to send.  call with
-    the PD instance lock set. */
+/* poll for any incoming packets, or for GUI updates to send.  call with
+the PD instance lock set. */
 int sys_pollgui(void)
 {
     static double lasttime = 0;
     double now = 0;
     int didsomething = sys_domicrosleep(0);
-    if (!didsomething || (now = sys_getrealtime()) > lasttime + 0.5)
+    if(!didsomething || (now = sys_getrealtime()) > lasttime + 0.5)
     {
         didsomething |= sys_poll_togui();
-        if (now)
-            lasttime = now;
+        if(now) lasttime = now;
     }
     return (didsomething);
 }
 
 void sys_init_fdpoll(void)
 {
-    if (INTER->i_fdpoll)
-        return;
+    if(INTER->i_fdpoll) return;
     /* create an empty FD poll list */
-    INTER->i_fdpoll = (t_fdpoll *)t_getbytes(0);
+    INTER->i_fdpoll = (t_fdpoll *) t_getbytes(0);
     INTER->i_nfdpoll = 0;
     INTER->i_inbinbuf = binbuf_new();
 }
@@ -1019,7 +974,7 @@ static int sys_watchfd;
 #if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 void glob_watchdog(t_pd *dummy)
 {
-    if (write(sys_watchfd, "\n", 1) < 1)
+    if(write(sys_watchfd, "\n", 1) < 1)
     {
         fprintf(stderr, "pd: watchdog process died\n");
         sys_bail(1);
@@ -1029,7 +984,7 @@ void glob_watchdog(t_pd *dummy)
 
 static void sys_init_deken(void)
 {
-    const char*os =
+    const char *os =
 #if defined __linux__
         "Linux"
 #elif defined __APPLE__
@@ -1043,42 +998,42 @@ static void sys_init_deken(void)
 #elif defined _WIN32
         "Windows"
 #else
-# if defined(__GNUC__)
-#  warning unknown OS
-# endif
+#if defined(__GNUC__)
+#warning unknown OS
+#endif
         0
 #endif
         ;
-    const char*machine =
-#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || defined(_M_AMD64)
+    const char *machine =
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
+    defined(_M_AMD64)
         "amd64"
-#elif defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86)
+#elif defined(__i386__) || defined(__i486__) || defined(__i586__) || \
+    defined(__i686__) || defined(_M_IX86)
         "i386"
 #elif defined(__ppc__)
         "ppc"
 #elif defined(__aarch64__)
         "arm64"
-#elif defined (__ARM_ARCH)
+#elif defined(__ARM_ARCH)
         "armv" stringify(__ARM_ARCH)
-# if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__)
-#  if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-        "b"
-#  endif
-# endif
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+            "b"
+#endif
+#endif
 #else
-# if defined(__GNUC__)
-#  warning unknown architecture
-# endif
+#if defined(__GNUC__)
+#warning unknown architecture
+#endif
         0
 #endif
         ;
 
-        /* only send the arch info, if we are sure about it... */
-    if (os && machine)
-        sys_vgui("::deken::set_platform %s %s %d %d\n",
-                 os, machine,
-                 8 * sizeof(char*),
-                 8 * sizeof(t_float));
+    /* only send the arch info, if we are sure about it... */
+    if(os && machine)
+        sys_vgui("::deken::set_platform %s %s %d %d\n", os, machine,
+            8 * sizeof(char *), 8 * sizeof(t_float));
 }
 
 static int sys_do_startgui(const char *libdir)
@@ -1095,29 +1050,26 @@ static int sys_do_startgui(const char *libdir)
 
     sys_init_fdpoll();
 
-    if (sys_guisetportnumber)  /* GUI exists and sent us a port number */
+    if(sys_guisetportnumber) /* GUI exists and sent us a port number */
     {
         int status;
 #ifdef __APPLE__
-            /* guisock might be 1 or 2, which will have offensive results
-            if somebody writes to stdout or stderr - so we just open a few
-            files to try to fill fds 0 through 2.  (I tried using dup()
-            instead, which would seem the logical way to do this, but couldn't
-            get it to work.) */
+        /* guisock might be 1 or 2, which will have offensive results
+        if somebody writes to stdout or stderr - so we just open a few
+        files to try to fill fds 0 through 2.  (I tried using dup()
+        instead, which would seem the logical way to do this, but couldn't
+        get it to work.) */
         int burnfd1 = open("/dev/null", 0), burnfd2 = open("/dev/null", 0),
             burnfd3 = open("/dev/null", 0);
-        if (burnfd1 > 2)
-            close(burnfd1);
-        if (burnfd2 > 2)
-            close(burnfd2);
-        if (burnfd3 > 2)
-            close(burnfd3);
+        if(burnfd1 > 2) close(burnfd1);
+        if(burnfd2 > 2) close(burnfd2);
+        if(burnfd3 > 2) close(burnfd3);
 #endif
 
         /* get addrinfo list using hostname & port */
-        status = addrinfo_get_list(&ailist,
-            LOCALHOST, sys_guisetportnumber, SOCK_STREAM);
-        if (status != 0)
+        status = addrinfo_get_list(
+            &ailist, LOCALHOST, sys_guisetportnumber, SOCK_STREAM);
+        if(status != 0)
         {
             fprintf(stderr,
                 "localhost not found (inet protocol not installed?)\n%s (%d)",
@@ -1130,18 +1082,17 @@ static int sys_do_startgui(const char *libdir)
 
         /* We don't know in advance whether the GUI uses IPv4 or IPv6,
            so we try both and pick the one which works. */
-        for (ai = ailist; ai != NULL; ai = ai->ai_next)
+        for(ai = ailist; ai != NULL; ai = ai->ai_next)
         {
             /* create a socket */
             sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-            if (sockfd < 0)
-                continue;
-        #if 1
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(sockfd < 0) continue;
+#if 1
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 fprintf(stderr, "setsockopt (TCP_NODELAY) failed");
-        #endif
+#endif
             /* try to connect */
-            if (socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen, 10.f) < 0)
+            if(socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen, 10.f) < 0)
             {
                 sys_closesocket(sockfd);
                 sockfd = -1;
@@ -1153,7 +1104,7 @@ static int sys_do_startgui(const char *libdir)
         freeaddrinfo(ailist);
 
         /* confirm that we could connect */
-        if (sockfd < 0)
+        if(sockfd < 0)
         {
             sys_sockerror("connecting stream socket");
             return (1);
@@ -1161,46 +1112,48 @@ static int sys_do_startgui(const char *libdir)
 
         INTER->i_guisock = sockfd;
     }
-    else    /* default behavior: start up the GUI ourselves. */
+    else /* default behavior: start up the GUI ourselves. */
     {
         struct sockaddr_storage addr;
         int status;
 #ifdef _WIN32
-        char scriptbuf[MAXPDSTRING+30], wishbuf[MAXPDSTRING+30], portbuf[80];
+        char scriptbuf[MAXPDSTRING + 30], wishbuf[MAXPDSTRING + 30],
+            portbuf[80];
         int spawnret;
 #else
-        char cmdbuf[4*MAXPDSTRING];
+        char cmdbuf[4 * MAXPDSTRING];
         const char *guicmd;
 #endif
         /* get addrinfo list using hostname (get random port from OS) */
         status = addrinfo_get_list(&ailist, LOCALHOST, 0, SOCK_STREAM);
-        if (status != 0)
+        if(status != 0)
         {
             fprintf(stderr,
                 "localhost not found (inet protocol not installed?)\n%s (%d)",
                 gai_strerror(status), status);
             return (1);
         }
-        /* we prefer the IPv4 addresses because the GUI might not be IPv6 capable. */
+        /* we prefer the IPv4 addresses because the GUI might not be IPv6
+         * capable. */
         addrinfo_sort_list(&ailist, addrinfo_ipv4_first);
         /* try each addr until we find one that works */
-        for (ai = ailist; ai != NULL; ai = ai->ai_next)
+        for(ai = ailist; ai != NULL; ai = ai->ai_next)
         {
             sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-            if (sockfd < 0)
-                continue;
-        #if 1
-            /* ask OS to allow another process to reopen this port after we close it */
-            if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
+            if(sockfd < 0) continue;
+#if 1
+            /* ask OS to allow another process to reopen this port after we
+             * close it */
+            if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
                 fprintf(stderr, "setsockopt (SO_REUSEADDR) failed\n");
-        #endif
-        #if 1
+#endif
+#if 1
             /* stream (TCP) sockets are set NODELAY */
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 fprintf(stderr, "setsockopt (TCP_NODELAY) failed");
-        #endif
+#endif
             /* name the socket */
-            if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
+            if(bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
             {
                 socket_close(sockfd);
                 sockfd = -1;
@@ -1213,17 +1166,17 @@ static int sys_do_startgui(const char *libdir)
         freeaddrinfo(ailist);
 
         /* confirm that socket/bind worked */
-        if (sockfd < 0)
+        if(sockfd < 0)
         {
             sys_sockerror("bind");
             return (1);
         }
         /* get the actual port number */
         portno = socket_get_port(sockfd);
-        if (sys_verbose) fprintf(stderr, "port %d\n", portno);
+        if(sys_verbose) fprintf(stderr, "port %d\n", portno);
 
 #ifndef _WIN32
-        if (sys_guicmd)
+        if(sys_guicmd)
             guicmd = sys_guicmd;
         else
         {
@@ -1234,19 +1187,22 @@ static int sys_do_startgui(const char *libdir)
             char *homedir = getenv("HOME");
             char embed_glob[FILENAME_MAX];
             char home_filename[FILENAME_MAX];
-            char *wish_paths[11] = {
- "(custom wish not defined)",
- "(did not find a home directory)",
- "/Applications/Utilities/Wish.app/Contents/MacOS/Wish",
- "/Applications/Utilities/Wish Shell.app/Contents/MacOS/Wish Shell",
- "/Applications/Wish.app/Contents/MacOS/Wish",
- "/Applications/Wish Shell.app/Contents/MacOS/Wish Shell",
- "/Library/Frameworks/Tk.framework/Resources/Wish.app/Contents/MacOS/Wish",
- "/Library/Frameworks/Tk.framework/Resources/Wish Shell.app/Contents/MacOS/Wish Shell",
- "/System/Library/Frameworks/Tk.framework/Resources/Wish.app/Contents/MacOS/Wish",
- "/System/Library/Frameworks/Tk.framework/Resources/Wish Shell.app/Contents/MacOS/Wish Shell",
- "/usr/bin/wish"
-            };
+            char *wish_paths[11] = {"(custom wish not defined)",
+                "(did not find a home directory)",
+                "/Applications/Utilities/Wish.app/Contents/MacOS/Wish",
+                "/Applications/Utilities/Wish Shell.app/Contents/MacOS/Wish "
+                "Shell",
+                "/Applications/Wish.app/Contents/MacOS/Wish",
+                "/Applications/Wish Shell.app/Contents/MacOS/Wish Shell",
+                "/Library/Frameworks/Tk.framework/Resources/Wish.app/Contents/"
+                "MacOS/Wish",
+                "/Library/Frameworks/Tk.framework/Resources/Wish "
+                "Shell.app/Contents/MacOS/Wish Shell",
+                "/System/Library/Frameworks/Tk.framework/Resources/Wish.app/"
+                "Contents/MacOS/Wish",
+                "/System/Library/Frameworks/Tk.framework/Resources/Wish "
+                "Shell.app/Contents/MacOS/Wish Shell",
+                "/usr/bin/wish"};
             /* this glob is needed so the Wish executable can have the same
              * filename as the Pd.app, i.e. 'Pd-0.42-3.app' should have a Wish
              * executable called 'Pd-0.42-3.app/Contents/MacOS/Pd-0.42-3' */
@@ -1258,87 +1214,87 @@ static int sys_do_startgui(const char *libdir)
              * find ../Resources/Scripts/AppMain.tcl, then Wish doesn't want
              * to receive the pd-gui.tcl as an argument.  Otherwise it needs
              * to know how to find pd-gui.tcl */
-            if (glob_buffer.gl_pathc > 0)
+            if(glob_buffer.gl_pathc > 0)
                 sprintf(cmdbuf, "\"%s\" %d\n", glob_buffer.gl_pathv[0], portno);
             else
             {
-                int wish_paths_count = sizeof(wish_paths)/sizeof(*wish_paths);
-                #ifdef WISH
-                    wish_paths[0] = WISH;
-                #endif
+                int wish_paths_count = sizeof(wish_paths) / sizeof(*wish_paths);
+#ifdef WISH
+                wish_paths[0] = WISH;
+#endif
                 sprintf(home_filename,
-                        "%s/Applications/Wish.app/Contents/MacOS/Wish",homedir);
+                    "%s/Applications/Wish.app/Contents/MacOS/Wish", homedir);
                 wish_paths[1] = home_filename;
-                for(i=0; i<wish_paths_count; i++)
+                for(i = 0; i < wish_paths_count; i++)
                 {
-                    if (sys_verbose)
-                        fprintf(stderr, "Trying Wish at \"%s\"\n",
-                            wish_paths[i]);
-                    if (stat(wish_paths[i], &statbuf) >= 0)
-                        break;
+                    if(sys_verbose)
+                        fprintf(
+                            stderr, "Trying Wish at \"%s\"\n", wish_paths[i]);
+                    if(stat(wish_paths[i], &statbuf) >= 0) break;
                 }
-                if(i>=wish_paths_count)
+                if(i >= wish_paths_count)
                 {
                     fprintf(stderr, "sys_startgui couldn't find tcl/tk\n");
                     sys_closesocket(sockfd);
                     return (1);
                 }
                 sprintf(cmdbuf, "\"%s\" \"%s/%spd-gui.tcl\" %d\n",
-                        wish_paths[i], libdir, PDGUIDIR, portno);
+                    wish_paths[i], libdir, PDGUIDIR, portno);
             }
-#else /* __APPLE__ */
+#else  /* __APPLE__ */
             /* sprintf the wish command with needed environment variables.
             For some reason the wish script fails if HOME isn't defined so
             if necessary we put that in here too. */
             sprintf(cmdbuf,
-  "TCL_LIBRARY=\"%s/lib/tcl/library\" TK_LIBRARY=\"%s/lib/tk/library\"%s \
+                "TCL_LIBRARY=\"%s/lib/tcl/library\" TK_LIBRARY=\"%s/lib/tk/library\"%s \
   " WISH " \"%s/" PDGUIDIR "/pd-gui.tcl\" %d\n",
-                 libdir, libdir, (getenv("HOME") ? "" : " HOME=/tmp"),
-                    libdir, portno);
+                libdir, libdir, (getenv("HOME") ? "" : " HOME=/tmp"), libdir,
+                portno);
 #endif /* __APPLE__ */
             guicmd = cmdbuf;
         }
-        if (sys_verbose)
-            fprintf(stderr, "%s", guicmd);
+        if(sys_verbose) fprintf(stderr, "%s", guicmd);
 
         childpid = fork();
-        if (childpid < 0)
+        if(childpid < 0)
         {
-            if (errno) perror("sys_startgui");
-            else fprintf(stderr, "sys_startgui failed\n");
+            if(errno)
+                perror("sys_startgui");
+            else
+                fprintf(stderr, "sys_startgui failed\n");
             sys_closesocket(sockfd);
             return (1);
         }
-        else if (!childpid)                     /* we're the child */
+        else if(!childpid) /* we're the child */
         {
-            sys_closesocket(sockfd);     /* child doesn't listen */
+            sys_closesocket(sockfd); /* child doesn't listen */
 #if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
-            sys_set_priority(MODE_NRT);  /* child runs non-real-time */
+            sys_set_priority(MODE_NRT); /* child runs non-real-time */
 #endif
 #ifndef __APPLE__
-// TODO this seems unneeded on any platform hans@eds.org
-                /* the wish process in Unix will make a wish shell and
-                    read/write standard in and out unless we close the
-                    file descriptors.  Somehow this doesn't make the MAC OSX
-                        version of Wish happy...*/
-            if (pipe(stdinpipe) < 0)
+            // TODO this seems unneeded on any platform hans@eds.org
+            /* the wish process in Unix will make a wish shell and
+                read/write standard in and out unless we close the
+                file descriptors.  Somehow this doesn't make the MAC OSX
+                    version of Wish happy...*/
+            if(pipe(stdinpipe) < 0)
                 sys_sockerror("pipe");
             else
             {
-                if (stdinpipe[0] != 0)
+                if(stdinpipe[0] != 0)
                 {
-                    close (0);
+                    close(0);
                     dup2(stdinpipe[0], 0);
                     close(stdinpipe[0]);
                 }
             }
 #endif /* NOT __APPLE__ */
-            execl("/bin/sh", "sh", "-c", guicmd, (char*)0);
+            execl("/bin/sh", "sh", "-c", guicmd, (char *) 0);
             perror("pd: exec");
             fprintf(stderr, "Perhaps tcl and tk aren't yet installed?\n");
             _exit(1);
-       }
-#else /* NOT _WIN32 */
+        }
+#else  /* NOT _WIN32 */
         /* fprintf(stderr, "%s\n", libdir); */
 
         strcpy(scriptbuf, "\"");
@@ -1353,16 +1309,15 @@ static int sys_do_startgui(const char *libdir)
         sys_bashfilename(wishbuf, wishbuf);
 
         spawnret = _spawnl(P_NOWAIT, wishbuf, WISH, scriptbuf, portbuf, NULL);
-        if (spawnret < 0)
+        if(spawnret < 0)
         {
             perror("spawnl");
             fprintf(stderr, "%s: couldn't load TCL\n", wishbuf);
             return (1);
         }
 #endif /* NOT _WIN32 */
-        if (sys_verbose)
-            fprintf(stderr, "Waiting for connection request... \n");
-        if (listen(sockfd, 5) < 0)
+        if(sys_verbose) fprintf(stderr, "Waiting for connection request... \n");
+        if(listen(sockfd, 5) < 0)
         {
             sys_sockerror("listen");
             sys_closesocket(sockfd);
@@ -1373,44 +1328,39 @@ static int sys_do_startgui(const char *libdir)
 
         sys_closesocket(sockfd);
 
-        if (INTER->i_guisock < 0)
+        if(INTER->i_guisock < 0)
         {
             sys_sockerror("accept");
             return (1);
         }
-        if (sys_verbose)
-            fprintf(stderr, "... connected\n");
+        if(sys_verbose) fprintf(stderr, "... connected\n");
         INTER->i_guihead = INTER->i_guitail = 0;
     }
 
     INTER->i_socketreceiver = socketreceiver_new(0, 0, 0, 0);
-    sys_addpollfn(INTER->i_guisock,
-        (t_fdpollfn)socketreceiver_read,
-            INTER->i_socketreceiver);
+    sys_addpollfn(INTER->i_guisock, (t_fdpollfn) socketreceiver_read,
+        INTER->i_socketreceiver);
 
-            /* here is where we start the pinging. */
+    /* here is where we start the pinging. */
 #if defined(__linux__) || defined(__FreeBSD_kernel__)
-    if (sys_hipriority)
-        sys_gui("pdtk_watchdog\n");
+    if(sys_hipriority) sys_gui("pdtk_watchdog\n");
 #endif
     sys_get_audio_apis(apibuf);
     sys_get_midi_apis(apibuf2);
-    sys_set_searchpath();     /* tell GUI about path and startup flags */
+    sys_set_searchpath(); /* tell GUI about path and startup flags */
     sys_set_temppath();
     sys_set_extrapath();
     sys_set_startup();
-                       /* ... and about font, medio APIS, etc */
-    sys_vgui("pdtk_pd_startup %d %d %d {%s} %s %s {%s} %s\n",
-             PD_MAJOR_VERSION, PD_MINOR_VERSION,
-             PD_BUGFIX_VERSION, PD_TEST_VERSION,
-             apibuf, apibuf2,
-             pdgui_strnescape(quotebuf, MAXPDSTRING, sys_font, 0),
-             sys_fontweight);
+    /* ... and about font, medio APIS, etc */
+    sys_vgui("pdtk_pd_startup %d %d %d {%s} %s %s {%s} %s\n", PD_MAJOR_VERSION,
+        PD_MINOR_VERSION, PD_BUGFIX_VERSION, PD_TEST_VERSION, apibuf, apibuf2,
+        pdgui_strnescape(quotebuf, MAXPDSTRING, sys_font, 0), sys_fontweight);
     sys_vgui("set zoom_open %d\n", sys_zoom_open == 2);
 
     sys_init_deken();
 
-    do {
+    do
+    {
         t_audiosettings as;
         sys_get_audio_settings(&as);
         sys_vgui("set pd_whichapi %d\n", as.a_api);
@@ -1422,95 +1372,97 @@ void sys_setrealtime(const char *libdir)
 {
     char cmdbuf[MAXPDSTRING];
 #if defined(__linux__) || defined(__FreeBSD_kernel__)
-        /*  promote this process's priority, if we can and want to.
-        If sys_hipriority not specified (-1), we assume real-time was wanted.
-        Starting in Linux 2.6 one can permit real-time operation of Pd by]
-        putting lines like:
-                @audio - rtprio 99
-                @audio - memlock unlimited
-        in the system limits file, perhaps /etc/limits.conf or
-        /etc/security/limits.conf, and calling Pd from a user in group audio. */
-    if (sys_hipriority == -1)
-        sys_hipriority = 1;
+    /*  promote this process's priority, if we can and want to.
+    If sys_hipriority not specified (-1), we assume real-time was wanted.
+    Starting in Linux 2.6 one can permit real-time operation of Pd by]
+    putting lines like:
+            @audio - rtprio 99
+            @audio - memlock unlimited
+    in the system limits file, perhaps /etc/limits.conf or
+    /etc/security/limits.conf, and calling Pd from a user in group audio. */
+    if(sys_hipriority == -1) sys_hipriority = 1;
 
     snprintf(cmdbuf, MAXPDSTRING, "%s/bin/pd-watchdog", libdir);
-    cmdbuf[MAXPDSTRING-1] = 0;
-    if (sys_hipriority)
+    cmdbuf[MAXPDSTRING - 1] = 0;
+    if(sys_hipriority)
     {
         struct stat statbuf;
-        if (stat(cmdbuf, &statbuf) < 0)
+        if(stat(cmdbuf, &statbuf) < 0)
         {
             fprintf(stderr,
-              "disabling real-time priority due to missing pd-watchdog (%s)\n",
+                "disabling real-time priority due to missing pd-watchdog "
+                "(%s)\n",
                 cmdbuf);
             sys_hipriority = 0;
         }
     }
-    if (sys_hipriority)
+    if(sys_hipriority)
     {
         int pipe9[2], watchpid;
-            /* To prevent lockup, we fork off a watchdog process with
-            higher real-time priority than ours.  The GUI has to send
-            a stream of ping messages to the watchdog THROUGH the Pd
-            process which has to pick them up from the GUI and forward
-            them.  If any of these things aren't happening the watchdog
-            starts sending "stop" and "cont" signals to the Pd process
-            to make it timeshare with the rest of the system.  (Version
-            0.33P2 : if there's no GUI, the watchdog pinging is done
-            from the scheduler idle routine in this process instead.) */
+        /* To prevent lockup, we fork off a watchdog process with
+        higher real-time priority than ours.  The GUI has to send
+        a stream of ping messages to the watchdog THROUGH the Pd
+        process which has to pick them up from the GUI and forward
+        them.  If any of these things aren't happening the watchdog
+        starts sending "stop" and "cont" signals to the Pd process
+        to make it timeshare with the rest of the system.  (Version
+        0.33P2 : if there's no GUI, the watchdog pinging is done
+        from the scheduler idle routine in this process instead.) */
 
-        if (pipe(pipe9) < 0)
+        if(pipe(pipe9) < 0)
         {
             sys_sockerror("pipe");
             return;
         }
         watchpid = fork();
-        if (watchpid < 0)
+        if(watchpid < 0)
         {
-            if (errno)
+            if(errno)
                 perror("sys_setpriority");
-            else fprintf(stderr, "sys_setpriority failed\n");
+            else
+                fprintf(stderr, "sys_setpriority failed\n");
             return;
         }
-        else if (!watchpid)             /* we're the child */
+        else if(!watchpid) /* we're the child */
         {
             sys_set_priority(MODE_WATCHDOG);
-            if (pipe9[1] != 0)
+            if(pipe9[1] != 0)
             {
                 dup2(pipe9[0], 0);
                 close(pipe9[0]);
             }
             close(pipe9[1]);
 
-            if (sys_verbose) fprintf(stderr, "%s\n", cmdbuf);
-            execl(cmdbuf, cmdbuf, (char*)0);
+            if(sys_verbose) fprintf(stderr, "%s\n", cmdbuf);
+            execl(cmdbuf, cmdbuf, (char *) 0);
             perror("pd: exec");
             _exit(1);
         }
-        else                            /* we're the parent */
+        else /* we're the parent */
         {
             sys_set_priority(MODE_RT);
             close(pipe9[0]);
-                /* set close-on-exec so that watchdog will see an EOF when we
-                close our copy - otherwise it might hang waiting for some
-                stupid child process (as seems to happen if jackd auto-starts
-                for us.) */
+            /* set close-on-exec so that watchdog will see an EOF when we
+            close our copy - otherwise it might hang waiting for some
+            stupid child process (as seems to happen if jackd auto-starts
+            for us.) */
             if(fcntl(pipe9[1], F_SETFD, FD_CLOEXEC) < 0)
-              perror("close-on-exec");
+                perror("close-on-exec");
             sys_watchfd = pipe9[1];
-                /* We also have to start the ping loop in the GUI;
-                this is done later when the socket is open. */
+            /* We also have to start the ping loop in the GUI;
+            this is done later when the socket is open. */
         }
     }
-    else logpost(NULL, PD_VERBOSE, "not setting real-time priority");
+    else
+        logpost(NULL, PD_VERBOSE, "not setting real-time priority");
 #endif /* __linux__ */
 
 #ifdef _WIN32
-    if (!SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS))
+    if(!SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS))
         fprintf(stderr, "pd: couldn't set high priority class\n");
 #endif
 #ifdef __APPLE__
-    if (sys_hipriority)
+    if(sys_hipriority)
     {
         struct sched_param param;
         int policy = SCHED_RR;
@@ -1518,8 +1470,7 @@ void sys_setrealtime(const char *libdir)
         param.sched_priority = 80; /* adjust 0 : 100 */
 
         err = pthread_setschedparam(pthread_self(), policy, &param);
-        if (err)
-            post("warning: high priority scheduling failed");
+        if(err) post("warning: high priority scheduling failed");
     }
 #endif /* __APPLE__ */
 }
@@ -1530,12 +1481,12 @@ LATER try to save dirty documents even in the bad case. */
 void sys_bail(int n)
 {
     static int reentered = 0;
-    if (!reentered)
+    if(!reentered)
     {
         reentered = 1;
 #if !defined(__linux__) && !defined(__FreeBSD_kernel__) && !defined(__GNU__)
-            /* sys_close_audio() hangs if you're in a signal? */
-        fprintf(stderr ,"gui socket %d - \n", INTER->i_guisock);
+        /* sys_close_audio() hangs if you're in a signal? */
+        fprintf(stderr, "gui socket %d - \n", INTER->i_guisock);
         fprintf(stderr, "closing audio...\n");
         sys_close_audio();
         fprintf(stderr, "closing MIDI...\n");
@@ -1544,38 +1495,36 @@ void sys_bail(int n)
 #endif
         exit(n);
     }
-    else _exit(1);
+    else
+        _exit(1);
 }
 
 extern void sys_exit(void);
 
 void glob_exit(void *dummy, t_float status)
 {
-        /* sys_exit() sets the sys_quit flag, so all loops end */
+    /* sys_exit() sets the sys_quit flag, so all loops end */
     sys_exit();
     sys_close_audio();
     sys_close_midi();
-    if (sys_havegui())
+    if(sys_havegui())
     {
         sys_closesocket(INTER->i_guisock);
         sys_rmpollfn(INTER->i_guisock);
     }
-    exit((int)status);
-}
-void glob_quit(void *dummy)
-{
-    glob_exit(dummy, 0);
+    exit((int) status);
 }
 
-    /* recursively descend to all canvases and send them "vis" messages
-    if they believe they're visible, to make it really so. */
+void glob_quit(void *dummy) { glob_exit(dummy, 0); }
+
+/* recursively descend to all canvases and send them "vis" messages
+if they believe they're visible, to make it really so. */
 static void glist_maybevis(t_glist *gl)
 {
     t_gobj *g;
-    for (g = gl->gl_list; g; g = g->g_next)
-        if (pd_class(&g->g_pd) == canvas_class)
-            glist_maybevis((t_glist *)g);
-    if (gl->gl_havewindow)
+    for(g = gl->gl_list; g; g = g->g_next)
+        if(pd_class(&g->g_pd) == canvas_class) glist_maybevis((t_glist *) g);
+    if(gl->gl_havewindow)
     {
         canvas_vis(gl, 0);
         canvas_vis(gl, 1);
@@ -1585,33 +1534,32 @@ static void glist_maybevis(t_glist *gl)
 int sys_startgui(const char *libdir)
 {
     t_canvas *x;
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
         canvas_vis(x, 0);
     INTER->i_havegui = 1;
     INTER->i_guihead = INTER->i_guitail = 0;
-    if (sys_do_startgui(libdir))
-        return (-1);
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
-        if (strcmp(x->gl_name->s_name, "_float_template") &&
+    if(sys_do_startgui(libdir)) return (-1);
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
+        if(strcmp(x->gl_name->s_name, "_float_template") &&
             strcmp(x->gl_name->s_name, "_float_array_template") &&
-                strcmp(x->gl_name->s_name, "_text_template"))
-    {
-        glist_maybevis(x);
-        canvas_vis(x, 1);
-    }
+            strcmp(x->gl_name->s_name, "_text_template"))
+        {
+            glist_maybevis(x);
+            canvas_vis(x, 1);
+        }
     return (0);
 }
 
- /* more work needed here - for some reason we can't restart the gui after
- shutting it down this way.  I think the second 'init' message never makes
- it because the to-gui buffer isn't re-initialized. */
+/* more work needed here - for some reason we can't restart the gui after
+shutting it down this way.  I think the second 'init' message never makes
+it because the to-gui buffer isn't re-initialized. */
 void sys_stopgui(void)
 {
     t_canvas *x;
-    for (x = pd_getcanvaslist(); x; x = x->gl_next)
+    for(x = pd_getcanvaslist(); x; x = x->gl_next)
         canvas_vis(x, 0);
     sys_vgui("%s", "exit\n");
-    if (INTER->i_guisock >= 0)
+    if(INTER->i_guisock >= 0)
     {
         sys_closesocket(INTER->i_guisock);
         sys_rmpollfn(INTER->i_guisock);
@@ -1637,7 +1585,7 @@ void s_inter_newpdinstance(void)
 
 void s_inter_free(t_instanceinter *inter)
 {
-    if (inter->i_fdpoll)
+    if(inter->i_fdpoll)
     {
         binbuf_free(inter->i_inbinbuf);
         inter->i_inbinbuf = 0;
@@ -1651,15 +1599,12 @@ void s_inter_free(t_instanceinter *inter)
     freebytes(inter, sizeof(*inter));
 }
 
-void s_inter_freepdinstance(void)
-{
-    s_inter_free(INTER);
-}
+void s_inter_freepdinstance(void) { s_inter_free(INTER); }
 
 #if PDTHREADS
 #ifdef PDINSTANCE
 static pthread_rwlock_t sys_rwlock = PTHREAD_RWLOCK_INITIALIZER;
-#else /* PDINSTANCE */
+#else  /* PDINSTANCE */
 static pthread_mutex_t sys_mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif /* PDINSTANCE */
 #endif /* PDTHREADS */
@@ -1677,8 +1622,7 @@ write-lock to be available. */
 void pd_globallock(void)
 {
 #ifdef PDINSTANCE
-    if (!pd_this->pd_islocked)
-        bug("pd_globallock");
+    if(!pd_this->pd_islocked) bug("pd_globallock");
     pthread_rwlock_unlock(&sys_rwlock);
     pthread_rwlock_wrlock(&sys_rwlock);
 #endif /* PDINSTANCE */
@@ -1721,9 +1665,9 @@ int sys_trylock(void)
 {
 #ifdef PDINSTANCE
     int ret;
-    if (!(ret = pthread_mutex_trylock(&INTER->i_mutex)))
+    if(!(ret = pthread_mutex_trylock(&INTER->i_mutex)))
     {
-        if (!(ret = pthread_rwlock_tryrdlock(&sys_rwlock)))
+        if(!(ret = pthread_rwlock_tryrdlock(&sys_rwlock)))
             return (0);
         else
         {
@@ -1731,7 +1675,8 @@ int sys_trylock(void)
             return (ret);
         }
     }
-    else return (ret);
+    else
+        return (ret);
 #else
     return pthread_mutex_trylock(&sys_mutex);
 #endif
@@ -1741,22 +1686,25 @@ int sys_trylock(void)
 
 #ifdef TEST_LOCKING /* run standalone Pd with this to find deadlocks */
 static int amlocked;
+
 void sys_lock(void)
 {
-    if (amlocked) bug("duplicate lock");
+    if(amlocked) bug("duplicate lock");
     amlocked = 1;
 }
 
 void sys_unlock(void)
 {
-    if (!amlocked) bug("duplicate unlock");
+    if(!amlocked) bug("duplicate unlock");
     amlocked = 0;
 }
 #else
 void sys_lock(void) {}
+
 void sys_unlock(void) {}
 #endif
 void pd_globallock(void) {}
+
 void pd_globalunlock(void) {}
 
 #endif /* PDTHREADS */

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -200,13 +200,16 @@ sleep. */
 static int sys_domicrosleep(int microsec)
 {
     struct timeval timeout;
-    int i, didsomething = 0;
+    int i;
+    int didsomething = 0;
     t_fdpoll *fp;
     timeout.tv_sec = 0;
     timeout.tv_usec = 0;
     if(INTER->i_nfdpoll)
     {
-        fd_set readset, writeset, exceptset;
+        fd_set readset;
+        fd_set writeset;
+        fd_set exceptset;
         FD_ZERO(&writeset);
         FD_ZERO(&readset);
         FD_ZERO(&exceptset);
@@ -343,7 +346,9 @@ void sys_set_priority(int mode)
 {
 #ifdef _POSIX_PRIORITY_SCHEDULING
     struct sched_param par;
-    int p1, p2, p3;
+    int p1;
+    int p2;
+    int p3;
     p1 = sched_get_priority_min(SCHED_FIFO);
     p2 = sched_get_priority_max(SCHED_FIFO);
 #ifdef USEAPI_JACK
@@ -408,7 +413,8 @@ void sys_sockerror(const char *s)
 
 void sys_addpollfn(int fd, t_fdpollfn fn, void *ptr)
 {
-    int nfd, size;
+    int nfd;
+    int size;
     t_fdpoll *fp;
     sys_init_fdpoll();
     nfd = INTER->i_nfdpoll;
@@ -427,7 +433,8 @@ void sys_addpollfn(int fd, t_fdpollfn fn, void *ptr)
 void sys_rmpollfn(int fd)
 {
     int nfd = INTER->i_nfdpoll;
-    int i, size = nfd * sizeof(t_fdpoll);
+    int i;
+    int size = nfd * sizeof(t_fdpoll);
     t_fdpoll *fp;
     INTER->i_fdschanged = 1;
     for(i = nfd, fp = INTER->i_fdpoll; i--; fp++)
@@ -484,8 +491,10 @@ void socketreceiver_free(t_socketreceiver *x)
 sitting on the stack while the messages are getting passed. */
 static int socketreceiver_doread(t_socketreceiver *x)
 {
-    char messbuf[INBUFSIZE], *bp = messbuf;
-    int indx, first = 1;
+    char messbuf[INBUFSIZE];
+    char *bp = messbuf;
+    int indx;
+    int first = 1;
     int inhead = x->sr_inhead;
     int intail = x->sr_intail;
     char *inbuf = x->sr_inbuf;
@@ -526,7 +535,8 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
 {
     char *buf = (char *) sys_getrecvbuf(0);
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
-    int ret, readbytes = 0;
+    int ret;
+    int readbytes = 0;
     while(1)
     {
         ret = (int) recvfrom(fd, buf, NET_MAXPACKETSIZE - 1, 0,
@@ -753,7 +763,10 @@ int sys_havegui(void) { return (INTER->i_havegui); }
 
 void sys_vgui(const char *fmt, ...)
 {
-    int msglen, bytesleft, headwas, nwrote;
+    int msglen;
+    int bytesleft;
+    int headwas;
+    int nwrote;
     va_list ap;
 
     if(!sys_havegui()) return;
@@ -783,8 +796,8 @@ void sys_vgui(const char *fmt, ...)
     }
     if(msglen >= INTER->i_guisize - INTER->i_guihead)
     {
-        int msglen2,
-            newsize = INTER->i_guisize + 1 +
+        int msglen2;
+        int newsize = INTER->i_guisize + 1 +
                       (msglen > GUI_ALLOCCHUNK ? msglen : GUI_ALLOCCHUNK);
         sys_trytogetmoreguibuf(newsize);
 
@@ -818,7 +831,8 @@ void sys_gui(const char *s) { sys_vgui("%s", s); }
 
 static int sys_flushtogui(void)
 {
-    int writesize = INTER->i_guihead - INTER->i_guitail, nwrote = 0;
+    int writesize = INTER->i_guihead - INTER->i_guitail;
+    int nwrote = 0;
     if(writesize > 0)
         nwrote = (int) send(
             INTER->i_guisock, INTER->i_guibuf + INTER->i_guitail, writesize, 0);
@@ -905,7 +919,8 @@ void sys_pretendguibytes(int n) { INTER->i_bytessincelastping += n; }
 
 void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
 {
-    t_guiqueue **gqnextptr, *gq;
+    t_guiqueue **gqnextptr;
+    t_guiqueue *gq;
     if(!INTER->i_guiqueuehead)
         gqnextptr = &INTER->i_guiqueuehead;
     else
@@ -926,7 +941,8 @@ void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
 
 void sys_unqueuegui(void *client)
 {
-    t_guiqueue *gq, *gq2;
+    t_guiqueue *gq;
+    t_guiqueue *gq2;
     while(INTER->i_guiqueuehead && INTER->i_guiqueuehead->gq_client == client)
     {
         gq = INTER->i_guiqueuehead;
@@ -1039,8 +1055,10 @@ static void sys_init_deken(void)
 static int sys_do_startgui(const char *libdir)
 {
     char quotebuf[MAXPDSTRING];
-    char apibuf[256], apibuf2[256];
-    struct addrinfo *ailist = NULL, *ai;
+    char apibuf[256];
+    char apibuf2[256];
+    struct addrinfo *ailist = NULL;
+    struct addrinfo *ai;
     int sockfd = -1;
     int portno = -1;
 #ifndef _WIN32
@@ -1398,7 +1416,8 @@ void sys_setrealtime(const char *libdir)
     }
     if(sys_hipriority)
     {
-        int pipe9[2], watchpid;
+        int pipe9[2];
+        int watchpid;
         /* To prevent lockup, we fork off a watchdog process with
         higher real-time priority than ours.  The GUI has to send
         a stream of ping messages to the watchdog THROUGH the Pd

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -220,12 +220,14 @@ static int sys_domicrosleep(int microsec)
             perror("microsleep select");
         INTER->i_fdschanged = 0;
         for(i = 0; i < INTER->i_nfdpoll && !INTER->i_fdschanged; i++)
+        {
             if(FD_ISSET(INTER->i_fdpoll[i].fdp_fd, &readset))
             {
                 (*INTER->i_fdpoll[i].fdp_fn)(
                     INTER->i_fdpoll[i].fdp_ptr, INTER->i_fdpoll[i].fdp_fd);
                 didsomething = 1;
             }
+        }
         if(didsomething) return (1);
     }
     if(microsec)
@@ -302,9 +304,13 @@ void sys_setalarm(int microsec)
     gonzo.it_value.tv_sec = sec;
     gonzo.it_value.tv_usec = microsec;
     if(microsec)
+    {
         sys_signal(SIGALRM, sys_alarmhandler);
+    }
     else
+    {
         sys_signal(SIGALRM, SIG_IGN);
+    }
     setitimer(ITIMER_REAL, &gonzo, 0);
 }
 
@@ -361,18 +367,26 @@ void sys_set_priority(int mode)
            0, (mode == MODE_NRT ? SCHED_OTHER : SCHED_FIFO), &par) < 0)
     {
         if(mode == MODE_WATCHDOG)
+        {
             fprintf(stderr, "priority %d scheduling failed.\n", p3);
+        }
         else
+        {
             post("priority %d scheduling failed; running at normal priority",
                 p3);
+        }
     }
     else
     {
         if(mode == MODE_RT)
+        {
             logpost(NULL, PD_VERBOSE, "priority %d scheduling enabled.\n", p3);
+        }
         else
+        {
             logpost(NULL, PD_VERBOSE,
                 "running at normal (non-real-time) priority.\n");
+        }
     }
 #endif
 
@@ -583,14 +597,20 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
                 char *semi = strchr(buf, ';');
                 if(semi) *semi = 0;
                 if(x->sr_fromaddrfn)
+                {
                     (*x->sr_fromaddrfn)(
                         x->sr_owner, (const void *) x->sr_fromaddr);
+                }
                 binbuf_text(INTER->i_inbinbuf, buf, strlen(buf));
                 outlet_setstacklim();
                 if(x->sr_socketreceivefn)
+                {
                     (*x->sr_socketreceivefn)(x->sr_owner, INTER->i_inbinbuf);
+                }
                 else
+                {
                     bug("socketreceiver_getudp");
+                }
             }
             readbytes += ret;
             /* throttle */
@@ -603,8 +623,10 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
 
 void socketreceiver_read(t_socketreceiver *x, int fd)
 {
-    if(x->sr_udp) /* UDP ("datagram") socket protocol */
+    if(x->sr_udp)
+    { /* UDP ("datagram") socket protocol */
         socketreceiver_getudp(x, fd);
+    }
     else /* TCP ("streaming") socket protocol */
     {
         char *semi;
@@ -659,15 +681,21 @@ void socketreceiver_read(t_socketreceiver *x, int fd)
                         socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
                         if(!getpeername(fd, (struct sockaddr *) x->sr_fromaddr,
                                &fromaddrlen))
+                        {
                             (*x->sr_fromaddrfn)(
                                 x->sr_owner, (const void *) x->sr_fromaddr);
+                        }
                     }
                     outlet_setstacklim();
                     if(x->sr_socketreceivefn)
+                    {
                         (*x->sr_socketreceivefn)(
                             x->sr_owner, INTER->i_inbinbuf);
+                    }
                     else
+                    {
                         binbuf_eval(INTER->i_inbinbuf, 0, 0, 0);
+                    }
                     if(x->sr_inhead == x->sr_intail) break;
                 }
             }
@@ -834,8 +862,10 @@ static int sys_flushtogui(void)
     int writesize = INTER->i_guihead - INTER->i_guitail;
     int nwrote = 0;
     if(writesize > 0)
+    {
         nwrote = (int) send(
             INTER->i_guisock, INTER->i_guibuf + INTER->i_guitail, writesize, 0);
+    }
 
 #if 0
     if (writesize)
@@ -848,9 +878,13 @@ static int sys_flushtogui(void)
         sys_bail(1);
     }
     else if(!nwrote)
+    {
         return (0);
+    }
     else if(nwrote >= INTER->i_guihead - INTER->i_guitail)
+    {
         INTER->i_guihead = INTER->i_guitail = 0;
+    }
     else if(nwrote)
     {
         INTER->i_guitail += nwrote;
@@ -922,7 +956,9 @@ void sys_queuegui(void *client, t_glist *glist, t_guicallbackfn f)
     t_guiqueue **gqnextptr;
     t_guiqueue *gq;
     if(!INTER->i_guiqueuehead)
+    {
         gqnextptr = &INTER->i_guiqueuehead;
+    }
     else
     {
         for(gq = INTER->i_guiqueuehead; gq->gq_next; gq = gq->gq_next)
@@ -951,12 +987,14 @@ void sys_unqueuegui(void *client)
     }
     if(!INTER->i_guiqueuehead) return;
     for(gq = INTER->i_guiqueuehead; (gq2 = gq->gq_next); gq = gq2)
+    {
         if(gq2->gq_client == client)
         {
             gq->gq_next = gq2->gq_next;
             t_freebytes(gq2, sizeof(*gq2));
             break;
         }
+    }
 }
 
 /* poll for any incoming packets, or for GUI updates to send.  call with
@@ -1048,8 +1086,10 @@ static void sys_init_deken(void)
 
     /* only send the arch info, if we are sure about it... */
     if(os && machine)
+    {
         sys_vgui("::deken::set_platform %s %s %d %d\n", os, machine,
             8 * sizeof(char *), 8 * sizeof(t_float));
+    }
 }
 
 static int sys_do_startgui(const char *libdir)
@@ -1195,7 +1235,9 @@ static int sys_do_startgui(const char *libdir)
 
 #ifndef _WIN32
         if(sys_guicmd)
+        {
             guicmd = sys_guicmd;
+        }
         else
         {
 #ifdef __APPLE__
@@ -1277,9 +1319,13 @@ static int sys_do_startgui(const char *libdir)
         if(childpid < 0)
         {
             if(errno)
+            {
                 perror("sys_startgui");
+            }
             else
+            {
                 fprintf(stderr, "sys_startgui failed\n");
+            }
             sys_closesocket(sockfd);
             return (1);
         }
@@ -1296,7 +1342,9 @@ static int sys_do_startgui(const char *libdir)
                 file descriptors.  Somehow this doesn't make the MAC OSX
                     version of Wish happy...*/
             if(pipe(stdinpipe) < 0)
+            {
                 sys_sockerror("pipe");
+            }
             else
             {
                 if(stdinpipe[0] != 0)
@@ -1437,9 +1485,13 @@ void sys_setrealtime(const char *libdir)
         if(watchpid < 0)
         {
             if(errno)
+            {
                 perror("sys_setpriority");
+            }
             else
+            {
                 fprintf(stderr, "sys_setpriority failed\n");
+            }
             return;
         }
         if(!watchpid) /* we're the child */
@@ -1559,6 +1611,7 @@ int sys_startgui(const char *libdir)
     INTER->i_guihead = INTER->i_guitail = 0;
     if(sys_do_startgui(libdir)) return (-1);
     for(x = pd_getcanvaslist(); x; x = x->gl_next)
+    {
         if(strcmp(x->gl_name->s_name, "_float_template") &&
             strcmp(x->gl_name->s_name, "_float_array_template") &&
             strcmp(x->gl_name->s_name, "_text_template"))
@@ -1566,6 +1619,7 @@ int sys_startgui(const char *libdir)
             glist_maybevis(x);
             canvas_vis(x, 1);
         }
+    }
     return (0);
 }
 

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -200,13 +200,13 @@ sleep. */
 static int sys_domicrosleep(int microsec)
 {
     struct timeval timeout;
-    int i;
     int didsomething = 0;
     t_fdpoll *fp;
     timeout.tv_sec = 0;
     timeout.tv_usec = 0;
     if(INTER->i_nfdpoll)
     {
+        int i;
         fd_set readset;
         fd_set writeset;
         fd_set exceptset;

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -558,7 +558,7 @@ static void socketreceiver_getudp(t_socketreceiver *x, int fd)
             }
             return;
         }
-        else if(ret > 0)
+        if(ret > 0)
         {
             /* handle too large UDP packets */
             if(ret > NET_MAXPACKETSIZE - 1)
@@ -1283,7 +1283,7 @@ static int sys_do_startgui(const char *libdir)
             sys_closesocket(sockfd);
             return (1);
         }
-        else if(!childpid) /* we're the child */
+        if(!childpid) /* we're the child */
         {
             sys_closesocket(sockfd); /* child doesn't listen */
 #if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
@@ -1442,7 +1442,7 @@ void sys_setrealtime(const char *libdir)
                 fprintf(stderr, "sys_setpriority failed\n");
             return;
         }
-        else if(!watchpid) /* we're the child */
+        if(!watchpid) /* we're the child */
         {
             sys_set_priority(MODE_WATCHDOG);
             if(pipe9[1] != 0)

--- a/src/s_libpdmidi.c
+++ b/src/s_libpdmidi.c
@@ -16,59 +16,84 @@
 
 #define CHANNEL ((CLAMP12BIT(port) << 4) | CLAMP4BIT(channel))
 
-void outmidi_noteon(int port, int channel, int pitch, int velo) {
-  if (libpd_noteonhook)
-    libpd_noteonhook(CHANNEL, CLAMP7BIT(pitch), CLAMP7BIT(velo));
+void outmidi_noteon(int port, int channel, int pitch, int velo)
+{
+    if(libpd_noteonhook)
+        libpd_noteonhook(CHANNEL, CLAMP7BIT(pitch), CLAMP7BIT(velo));
 }
 
-void outmidi_controlchange(int port, int channel, int ctl, int value) {
-  if (libpd_controlchangehook)
-    libpd_controlchangehook(CHANNEL, CLAMP7BIT(ctl), CLAMP7BIT(value));
+void outmidi_controlchange(int port, int channel, int ctl, int value)
+{
+    if(libpd_controlchangehook)
+        libpd_controlchangehook(CHANNEL, CLAMP7BIT(ctl), CLAMP7BIT(value));
 }
 
-void outmidi_programchange(int port, int channel, int value) {
-  if (libpd_programchangehook)
-    libpd_programchangehook(CHANNEL, CLAMP7BIT(value));
+void outmidi_programchange(int port, int channel, int value)
+{
+    if(libpd_programchangehook)
+        libpd_programchangehook(CHANNEL, CLAMP7BIT(value));
 }
 
-void outmidi_pitchbend(int port, int channel, int value) {
-  if (libpd_pitchbendhook)
-    libpd_pitchbendhook(CHANNEL, CLAMP14BIT(value) - 8192); // remove offset
+void outmidi_pitchbend(int port, int channel, int value)
+{
+    if(libpd_pitchbendhook)
+        libpd_pitchbendhook(CHANNEL, CLAMP14BIT(value) - 8192); // remove offset
 }
 
-void outmidi_aftertouch(int port, int channel, int value) {
-  if (libpd_aftertouchhook)
-    libpd_aftertouchhook(CHANNEL, CLAMP7BIT(value));
+void outmidi_aftertouch(int port, int channel, int value)
+{
+    if(libpd_aftertouchhook) libpd_aftertouchhook(CHANNEL, CLAMP7BIT(value));
 }
 
-void outmidi_polyaftertouch(int port, int channel, int pitch, int value) {
-  if (libpd_polyaftertouchhook)
-    libpd_polyaftertouchhook(CHANNEL, CLAMP7BIT(pitch), CLAMP7BIT(value));
+void outmidi_polyaftertouch(int port, int channel, int pitch, int value)
+{
+    if(libpd_polyaftertouchhook)
+        libpd_polyaftertouchhook(CHANNEL, CLAMP7BIT(pitch), CLAMP7BIT(value));
 }
 
-void outmidi_byte(int port, int value) {
-  if (libpd_midibytehook)
-    libpd_midibytehook(CLAMP12BIT(port), CLAMP8BIT(value));
+void outmidi_byte(int port, int value)
+{
+    if(libpd_midibytehook)
+        libpd_midibytehook(CLAMP12BIT(port), CLAMP8BIT(value));
 }
 
 /* tell Pd GUI that our list of MIDI APIs is empty */
 #include <string.h>
-void sys_get_midi_apis(char *buf) {strcpy(buf, "{}");}
+
+void sys_get_midi_apis(char *buf) { strcpy(buf, "{}"); }
 
 // the rest is not relevant to libpd
 void sys_listmididevs(void) {}
-void sys_get_midi_params(int *pnmidiindev, int *pmidiindev,
-    int *pnmidioutdev, int *pmidioutdev) {*pnmidiindev = *pnmidioutdev = 0;}
-void sys_open_midi(int nmidiindev, int *midiindev,
-    int nmidioutdev, int *midioutdev, int enable) {}
+
+void sys_get_midi_params(
+    int *pnmidiindev, int *pmidiindev, int *pnmidioutdev, int *pmidioutdev)
+{
+    *pnmidiindev = *pnmidioutdev = 0;
+}
+
+void sys_open_midi(int nmidiindev, int *midiindev, int nmidioutdev,
+    int *midioutdev, int enable)
+{
+}
+
 void sys_close_midi() {}
+
 void sys_reopen_midi(void) {}
+
 void sys_initmidiqueue(void) {}
+
 void sys_pollmidiqueue(void) {}
+
 void glob_midi_setapi(void *dummy, t_floatarg f) {}
+
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform) {}
+
 void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv) {}
+
 int sys_mididevnametonumber(int output, const char *name) { return 0; }
+
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize) {}
+
 void sys_set_midi_api(int api) {}
+
 int sys_midiapi;

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -130,9 +130,13 @@ static int sys_do_load_lib(
     if(!path) return (0);
 
     if((classname = strrchr(objectname, '/')))
+    {
         classname++;
+    }
     else
+    {
         classname = objectname;
+    }
     for(i = 0, cnameptr = classname; i < MAXPDSTRING - 7 && *cnameptr;
         cnameptr++)
     {
@@ -295,7 +299,9 @@ void sys_register_loader(loader_t loader)
         if(q->loader == loader) /* already loaded - nothing to do */
             return;
         if(q->next)
+        {
             q = q->next;
+        }
         else
         {
             q->next = (loader_queue_t *) getbytes(sizeof(loader_queue_t));
@@ -355,10 +361,11 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
         sys_loadlib_iter(dirbuf, &data);
     }
     data.classname = classname;
-    if(!data.ok && !sys_isabsolutepath(
-                       classname)) /* don't iterate if classname is absolute */
+    if(!data.ok && !sys_isabsolutepath(classname))
+    { /* don't iterate if classname is absolute */
         canvas_path_iterate(
             canvas, (t_canvas_path_iterator) sys_loadlib_iter, &data);
+    }
 
     /* if loaders failed so far, we try a last time without a PATH
      * let the loaders search wherever they want */
@@ -460,9 +467,13 @@ static t_pd *do_create_abstraction(t_symbol *s, int argc, t_atom *argv)
 
             binbuf_evalfile(gensym(nameptr), gensym(dirbuf));
             if(s__X.s_thing && was != s__X.s_thing)
+            {
                 canvas_popabstraction((t_canvas *) (s__X.s_thing));
+            }
             else
+            {
                 s__X.s_thing = was;
+            }
             canvas_setargs(0, 0);
             return (pd_this->pd_newest);
         }

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #if defined(HAVE_LIBDL) || defined(__FreeBSD__)
 #include <dlfcn.h>
@@ -22,7 +22,7 @@
 #include "s_stuff.h"
 #include <stdio.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
+#ifdef _MSC_VER /* This is only for Microsoft's compiler, not cygwin, e.g. */
 #define snprintf _snprintf
 #define stat _stat
 #endif
@@ -38,50 +38,43 @@ darwin, or microsoft, followed by a more specific string, either "fat" for
 a fat binary or an indication of the instruction set. */
 
 #if defined(__x86_64__) || defined(_M_X64)
-# define ARCHEXT "amd64"
+#define ARCHEXT "amd64"
 #elif defined(__i386__) || defined(_M_IX86)
-# define ARCHEXT "i386"
+#define ARCHEXT "i386"
 #elif defined(__arm__)
-# define ARCHEXT "arm"
+#define ARCHEXT "arm"
 #elif defined(__aarch64__)
-# define ARCHEXT "arm64"
+#define ARCHEXT "arm64"
 #elif defined(__ppc__)
-# define ARCHEXT "ppc"
+#define ARCHEXT "ppc"
 #endif
 
 #ifdef ARCHEXT
-#define ARCHDLLEXT(prefix) prefix ARCHEXT ,
+#define ARCHDLLEXT(prefix) prefix ARCHEXT,
 #else
 #define ARCHDLLEXT(prefix)
 #endif
 
-
-static const char*sys_dllextent[] = {
-#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || defined(__FreeBSD__)
+static const char *sys_dllextent[] = {
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__) || \
+    defined(__FreeBSD__)
     ARCHDLLEXT(".l_")
 #if defined(__x86_64__) || defined(_M_X64)
-    ".l_ia64",      /* incorrect but probably in wide use */
+        ".l_ia64", /* incorrect but probably in wide use */
 #endif
-    ".pd_linux",
-    ".so",
+    ".pd_linux", ".so",
 #elif defined(__APPLE__)
-    ".d_fat",
-    ARCHDLLEXT(".d_")
-    ".pd_darwin",
-    ".so",
+    ".d_fat", ARCHDLLEXT(".d_") ".pd_darwin", ".so",
 #elif defined(__OPENBSD__)
-    ARCHDLLEXT(".o_")
-    ".pd_openbsd",
-    ".so",
+    ARCHDLLEXT(".o_") ".pd_openbsd", ".so",
 #elif defined(_WIN32) || defined(__CYGWIN__)
-    ARCHDLLEXT(".m_")
-    ".dll",
+    ARCHDLLEXT(".m_") ".dll",
 #else
     ".so",
 #endif
     0};
 
-    /* maintain list of loaded modules to avoid repeating loads */
+/* maintain list of loaded modules to avoid repeating loads */
 typedef struct _loadedlist
 {
     struct _loadedlist *ll_next;
@@ -89,20 +82,20 @@ typedef struct _loadedlist
 } t_loadlist;
 
 static t_loadlist *sys_loaded;
+
 int sys_onloadlist(const char *classname) /* return true if already loaded */
 {
     t_symbol *s = gensym(classname);
     t_loadlist *ll;
-    for (ll = sys_loaded; ll; ll = ll->ll_next)
-        if (ll->ll_name == s)
-            return (1);
+    for(ll = sys_loaded; ll; ll = ll->ll_next)
+        if(ll->ll_name == s) return (1);
     return (0);
 }
 
-     /* add to list of loaded modules */
+/* add to list of loaded modules */
 void sys_putonloadlist(const char *classname)
 {
-    t_loadlist *ll = (t_loadlist *)getbytes(sizeof(*ll));
+    t_loadlist *ll = (t_loadlist *) getbytes(sizeof(*ll));
     ll->ll_name = gensym(classname);
     ll->ll_next = sys_loaded;
     sys_loaded = ll;
@@ -111,14 +104,15 @@ void sys_putonloadlist(const char *classname)
 
 void class_set_extern_dir(t_symbol *s);
 
-static int sys_do_load_abs(t_canvas *canvas, const char *objectname,
-    const char *path);
-static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
-    const char *path)
+static int sys_do_load_abs(
+    t_canvas *canvas, const char *objectname, const char *path);
+
+static int sys_do_load_lib(
+    t_canvas *canvas, const char *objectname, const char *path)
 {
     char symname[MAXPDSTRING], filename[MAXPDSTRING], dirbuf[MAXPDSTRING],
         *nameptr;
-    const char**dllextent;
+    const char **dllextent;
     const char *classname, *cnameptr;
     void *dlobj;
     t_xxx makeout = NULL;
@@ -126,89 +120,92 @@ static int sys_do_load_lib(t_canvas *canvas, const char *objectname,
 #ifdef _WIN32
     HINSTANCE ntdll;
 #endif
-        /* NULL-path is only used as a last resort,
-           but we have already tried all paths */
-    if(!path)return (0);
+    /* NULL-path is only used as a last resort,
+       but we have already tried all paths */
+    if(!path) return (0);
 
-    if ((classname = strrchr(objectname, '/')))
+    if((classname = strrchr(objectname, '/')))
         classname++;
-    else classname = objectname;
-    for (i = 0, cnameptr = classname; i < MAXPDSTRING-7 && *cnameptr;
+    else
+        classname = objectname;
+    for(i = 0, cnameptr = classname; i < MAXPDSTRING - 7 && *cnameptr;
         cnameptr++)
     {
         char c = *cnameptr;
-        if ((c>='0' && c<='9') || (c>='A' && c<='Z')||
-           (c>='a' && c<='z' )|| c == '_')
+        if((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+            (c >= 'a' && c <= 'z') || c == '_')
         {
             symname[i] = c;
             i++;
         }
-            /* trailing tilde becomes "_tilde" */
-        else if (c == '~' && cnameptr[1] == 0)
+        /* trailing tilde becomes "_tilde" */
+        else if(c == '~' && cnameptr[1] == 0)
         {
-            strcpy(symname+i, "_tilde");
-            i += strlen(symname+i);
+            strcpy(symname + i, "_tilde");
+            i += strlen(symname + i);
         }
         else /* anything you can't put in a C symbol is sprintf'ed in hex */
         {
-            sprintf(symname+i, "0x%02x", c);
-            i += strlen(symname+i);
+            sprintf(symname + i, "0x%02x", c);
+            i += strlen(symname + i);
             hexmunge = 1;
         }
     }
     symname[i] = 0;
-    if (hexmunge)
+    if(hexmunge)
     {
-        memmove(symname+6, symname, strlen(symname)+1);
+        memmove(symname + 6, symname, strlen(symname) + 1);
         strncpy(symname, "setup_", 6);
     }
-    else strcat(symname, "_setup");
+    else
+        strcat(symname, "_setup");
 
 #if 0
     fprintf(stderr, "lib: %s\n", classname);
 #endif
-        /* try looking in the path for (objectname).(sys_dllextent) ... */
-    for(dllextent=sys_dllextent; *dllextent; dllextent++)
+    /* try looking in the path for (objectname).(sys_dllextent) ... */
+    for(dllextent = sys_dllextent; *dllextent; dllextent++)
     {
-        if ((fd = sys_trytoopenone(path, objectname, *dllextent,
-            dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
-                goto gotone;
+        if((fd = sys_trytoopenone(path, objectname, *dllextent, dirbuf,
+                &nameptr, MAXPDSTRING, 1)) >= 0)
+            goto gotone;
     }
-        /* next try (objectname)/(classname).(sys_dllextent) ... */
+    /* next try (objectname)/(classname).(sys_dllextent) ... */
     strncpy(filename, objectname, MAXPDSTRING);
-    filename[MAXPDSTRING-2] = 0;
+    filename[MAXPDSTRING - 2] = 0;
     strcat(filename, "/");
-    strncat(filename, classname, MAXPDSTRING-strlen(filename));
-    filename[MAXPDSTRING-1] = 0;
-    for(dllextent=sys_dllextent; *dllextent; dllextent++)
+    strncat(filename, classname, MAXPDSTRING - strlen(filename));
+    filename[MAXPDSTRING - 1] = 0;
+    for(dllextent = sys_dllextent; *dllextent; dllextent++)
     {
-        if ((fd = sys_trytoopenone(path, filename, *dllextent,
-            dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
-                goto gotone;
+        if((fd = sys_trytoopenone(path, filename, *dllextent, dirbuf, &nameptr,
+                MAXPDSTRING, 1)) >= 0)
+            goto gotone;
     }
 #ifdef ANDROID
     /* Android libs have a 'lib' prefix, '.so' suffix and don't allow ~ */
     char libname[MAXPDSTRING] = "lib";
     strncat(libname, objectname, MAXPDSTRING - 4);
     int len = strlen(libname);
-    if (libname[len-1] == '~' && len < MAXPDSTRING - 6) {
-        strcpy(libname+len-1, "_tilde");
+    if(libname[len - 1] == '~' && len < MAXPDSTRING - 6)
+    {
+        strcpy(libname + len - 1, "_tilde");
     }
-    if ((fd = sys_trytoopenone(path, libname, ".so",
-        dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
-            goto gotone;
+    if((fd = sys_trytoopenone(
+            path, libname, ".so", dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
+        goto gotone;
 #endif
     return (0);
 gotone:
     close(fd);
     class_set_extern_dir(gensym(dirbuf));
 
-        /* rebuild the absolute pathname */
+    /* rebuild the absolute pathname */
     strncpy(filename, dirbuf, MAXPDSTRING);
-    filename[MAXPDSTRING-2] = 0;
+    filename[MAXPDSTRING - 2] = 0;
     strcat(filename, "/");
-    strncat(filename, nameptr, MAXPDSTRING-strlen(filename));
-    filename[MAXPDSTRING-1] = 0;
+    strncat(filename, nameptr, MAXPDSTRING - strlen(filename));
+    filename[MAXPDSTRING - 1] = 0;
 
 #ifdef _WIN32
     {
@@ -222,48 +219,49 @@ gotone:
         strncpy(dirname, filename, MAXPDSTRING);
         s = strrchr(dirname, '\\');
         basename = s;
-        if (s && *s)
-          *s = '\0';
-        if (!SetDllDirectory(dirname))
-           pd_error(0, "could not set '%s' as DllDirectory(), '%s' might not load.",
-                 dirname, basename);
+        if(s && *s) *s = '\0';
+        if(!SetDllDirectory(dirname))
+            pd_error(0,
+                "could not set '%s' as DllDirectory(), '%s' might not load.",
+                dirname, basename);
         /* now load the DLL for the external */
         ntdll = LoadLibrary(filename);
-        if (!ntdll)
+        if(!ntdll)
         {
             wchar_t wbuf[MAXPDSTRING];
             char buf[MAXPDSTRING];
             DWORD count, err = GetLastError();
-            count = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                0, err, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, MAXPDSTRING, NULL);
-            if (!count || !WideCharToMultiByte(CP_UTF8, 0, wbuf, count+1, buf, MAXPDSTRING, 0, 0))
+            count = FormatMessageW(
+                FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0,
+                err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf,
+                MAXPDSTRING, NULL);
+            if(!count || !WideCharToMultiByte(CP_UTF8, 0, wbuf, count + 1, buf,
+                             MAXPDSTRING, 0, 0))
                 *buf = '\0';
             pd_error(0, "%s: %s (%d)", filename, buf, err);
             class_set_extern_dir(&s_);
             return (0);
         }
-        makeout = (t_xxx)GetProcAddress(ntdll, symname);
-        if (!makeout)
-             makeout = (t_xxx)GetProcAddress(ntdll, "setup");
+        makeout = (t_xxx) GetProcAddress(ntdll, symname);
+        if(!makeout) makeout = (t_xxx) GetProcAddress(ntdll, "setup");
         SetDllDirectory(NULL); /* reset DLL dir to nothing */
     }
 #elif defined(HAVE_LIBDL) || defined(__FreeBSD__)
     dlobj = dlopen(filename, RTLD_NOW | RTLD_GLOBAL);
-    if (!dlobj)
+    if(!dlobj)
     {
         pd_error(0, "%s: %s", filename, dlerror());
         class_set_extern_dir(&s_);
         return (0);
     }
-    makeout = (t_xxx)dlsym(dlobj,  symname);
-    if(!makeout)
-        makeout = (t_xxx)dlsym(dlobj,  "setup");
+    makeout = (t_xxx) dlsym(dlobj, symname);
+    if(!makeout) makeout = (t_xxx) dlsym(dlobj, "setup");
 #else
 #warning "No dynamic loading mechanism specified, \
 libdl or WIN32 required for loading externals!"
 #endif
 
-    if (!makeout)
+    if(!makeout)
     {
         pd_error(0, "load_object: Symbol \"%s\" not found", symname);
         class_set_extern_dir(&s_);
@@ -274,9 +272,9 @@ libdl or WIN32 required for loading externals!"
     return (1);
 }
 
-
 /* linked list of loaders */
-typedef struct loader_queue {
+typedef struct loader_queue
+{
     loader_t loader;
     struct loader_queue *next;
 } loader_queue_t;
@@ -287,15 +285,15 @@ static loader_queue_t loaders = {sys_do_load_lib, NULL};
 void sys_register_loader(loader_t loader)
 {
     loader_queue_t *q = &loaders;
-    while (1)
+    while(1)
     {
-        if (q->loader == loader)    /* already loaded - nothing to do */
+        if(q->loader == loader) /* already loaded - nothing to do */
             return;
-        else if (q->next)
+        else if(q->next)
             q = q->next;
         else
         {
-            q->next = (loader_queue_t *)getbytes(sizeof(loader_queue_t));
+            q->next = (loader_queue_t *) getbytes(sizeof(loader_queue_t));
             q->next->loader = loader;
             q->next->next = NULL;
             break;
@@ -318,11 +316,9 @@ int sys_loadlib_iter(const char *path, struct _loadlib_data *data)
     int ok = 0;
     loader_queue_t *q;
     for(q = &loaders; q; q = q->next)
-        if ((ok = q->loader(data->canvas, data->classname, path)))
-            break;
+        if((ok = q->loader(data->canvas, data->classname, path))) break;
     /* if all loaders failed, try to load as abstraction */
-    if (!ok)
-        ok = sys_do_load_abs(data->canvas, data->classname, path);
+    if(!ok) ok = sys_do_load_abs(data->canvas, data->classname, path);
     data->ok = ok;
     return (ok == 0);
 }
@@ -334,94 +330,89 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
     data.canvas = canvas;
     data.ok = 0;
 
-    if (sys_onloadlist(classname))
+    if(sys_onloadlist(classname))
         return (1); /* if lib is already loaded, dismiss. */
 
-        /* if classname is absolute, try this first */
-    if (sys_isabsolutepath(classname))
+    /* if classname is absolute, try this first */
+    if(sys_isabsolutepath(classname))
     {
-            /* this is just copied from sys_open_absolute()
-               LATER avoid code duplication */
+        /* this is just copied from sys_open_absolute()
+           LATER avoid code duplication */
         char dirbuf[MAXPDSTRING], *z = strrchr(classname, '/');
         int dirlen;
-        if (!z)
-            return (0);
-        dirlen = (int)(z - classname);
-        if (dirlen > MAXPDSTRING-1)
-            dirlen = MAXPDSTRING-1;
+        if(!z) return (0);
+        dirlen = (int) (z - classname);
+        if(dirlen > MAXPDSTRING - 1) dirlen = MAXPDSTRING - 1;
         strncpy(dirbuf, classname, dirlen);
         dirbuf[dirlen] = 0;
-        data.classname=classname+(dirlen+1);
+        data.classname = classname + (dirlen + 1);
         sys_loadlib_iter(dirbuf, &data);
     }
     data.classname = classname;
-    if(!data.ok && !sys_isabsolutepath(classname)) /* don't iterate if classname is absolute */
-        canvas_path_iterate(canvas, (t_canvas_path_iterator)sys_loadlib_iter,
-            &data);
+    if(!data.ok && !sys_isabsolutepath(
+                       classname)) /* don't iterate if classname is absolute */
+        canvas_path_iterate(
+            canvas, (t_canvas_path_iterator) sys_loadlib_iter, &data);
 
     /* if loaders failed so far, we try a last time without a PATH
      * let the loaders search wherever they want */
-    if (!data.ok)
-        sys_loadlib_iter(0, &data);
+    if(!data.ok) sys_loadlib_iter(0, &data);
 
-    if(data.ok)
-      sys_putonloadlist(classname);
-
+    if(data.ok) sys_putonloadlist(classname);
 
     canvas_resume_dsp(dspstate);
     return data.ok;
 }
 
-int sys_run_scheduler(const char *externalschedlibname,
-    const char *sys_extraflagsstring)
+int sys_run_scheduler(
+    const char *externalschedlibname, const char *sys_extraflagsstring)
 {
     typedef int (*t_externalschedlibmain)(const char *);
     t_externalschedlibmain externalmainfunc;
     char filename[MAXPDSTRING];
-    const char**dllextent;
-    for(dllextent=sys_dllextent; *dllextent; dllextent++)
+    const char **dllextent;
+    for(dllextent = sys_dllextent; *dllextent; dllextent++)
     {
         struct stat statbuf;
         snprintf(filename, sizeof(filename), "%s%s", externalschedlibname,
             *dllextent);
         sys_bashfilename(filename, filename);
-        if(!stat(filename, &statbuf))
-            break;
+        if(!stat(filename, &statbuf)) break;
     }
 
 #ifdef _WIN32
     {
         HINSTANCE ntdll = LoadLibrary(filename);
-        if (!ntdll)
+        if(!ntdll)
         {
             fprintf(stderr, "%s: couldn't load external scheduler\n", filename);
             pd_error(0, "%s: couldn't load external scheduler", filename);
             return (1);
         }
         externalmainfunc =
-            (t_externalschedlibmain)GetProcAddress(ntdll, "pd_extern_sched");
-        if (!externalmainfunc)
+            (t_externalschedlibmain) GetProcAddress(ntdll, "pd_extern_sched");
+        if(!externalmainfunc)
             externalmainfunc =
-                (t_externalschedlibmain)GetProcAddress(ntdll, "main");
+                (t_externalschedlibmain) GetProcAddress(ntdll, "main");
     }
 #elif defined HAVE_LIBDL
     {
         void *dlobj;
         dlobj = dlopen(filename, RTLD_NOW | RTLD_GLOBAL);
-        if (!dlobj)
+        if(!dlobj)
         {
             pd_error(0, "%s: %s", filename, dlerror());
             fprintf(stderr, "dlopen failed for %s: %s\n", filename, dlerror());
             return (1);
         }
-        externalmainfunc = (t_externalschedlibmain)dlsym(dlobj,
-            "pd_extern_sched");
+        externalmainfunc =
+            (t_externalschedlibmain) dlsym(dlobj, "pd_extern_sched");
     }
 #else
     return (0);
 #endif
-    if (externalmainfunc)
-        return((*externalmainfunc)(sys_extraflagsstring));
+    if(externalmainfunc)
+        return ((*externalmainfunc)(sys_extraflagsstring));
     else
     {
         fprintf(stderr, "%s: couldn't find pd_extern_sched() or main()\n",
@@ -430,85 +421,86 @@ int sys_run_scheduler(const char *externalschedlibname,
     }
 }
 
-
 /* abstraction loading */
 void canvas_popabstraction(t_canvas *x);
 int pd_setloadingabstraction(t_symbol *sym);
 
-static t_pd *do_create_abstraction(t_symbol*s, int argc, t_atom *argv)
+static t_pd *do_create_abstraction(t_symbol *s, int argc, t_atom *argv)
 {
     /*
      * TODO: check if the there is a binbuf cached for <canvas::symbol>
         and use that instead.  We'll have to invalidate the cache once we
         are done (either with a clock_delay(0) or something else)
      */
-    if (!pd_setloadingabstraction(s))
+    if(!pd_setloadingabstraction(s))
     {
         const char *objectname = s->s_name;
         char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
-        t_glist *glist = (t_glist *)canvas_getcurrent();
-        t_canvas *canvas = (t_canvas*)glist_getcanvas(glist);
+        t_glist *glist = (t_glist *) canvas_getcurrent();
+        t_canvas *canvas = (t_canvas *) glist_getcanvas(glist);
         int fd = -1;
 
         t_pd *was = s__X.s_thing;
         snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
-        if ((fd = canvas_open(canvas, objectname, ".pd",
-                  dirbuf, &nameptr, MAXPDSTRING, 0)) >= 0 ||
-            (fd = canvas_open(canvas, objectname, ".pat",
-                  dirbuf, &nameptr, MAXPDSTRING, 0)) >= 0 ||
-            (fd = canvas_open(canvas, classslashclass, ".pd",
-                  dirbuf, &nameptr, MAXPDSTRING, 0)) >= 0)
+        if((fd = canvas_open(canvas, objectname, ".pd", dirbuf, &nameptr,
+                MAXPDSTRING, 0)) >= 0 ||
+            (fd = canvas_open(canvas, objectname, ".pat", dirbuf, &nameptr,
+                 MAXPDSTRING, 0)) >= 0 ||
+            (fd = canvas_open(canvas, classslashclass, ".pd", dirbuf, &nameptr,
+                 MAXPDSTRING, 0)) >= 0)
         {
             close(fd);
             canvas_setargs(argc, argv);
 
             binbuf_evalfile(gensym(nameptr), gensym(dirbuf));
-            if (s__X.s_thing && was != s__X.s_thing)
-                canvas_popabstraction((t_canvas *)(s__X.s_thing));
-            else s__X.s_thing = was;
+            if(s__X.s_thing && was != s__X.s_thing)
+                canvas_popabstraction((t_canvas *) (s__X.s_thing));
+            else
+                s__X.s_thing = was;
             canvas_setargs(0, 0);
             return (pd_this->pd_newest);
         }
-            /* otherwise we couldn't do it; just return 0 */
+        /* otherwise we couldn't do it; just return 0 */
     }
-    else pd_error(0, "%s: can't load abstraction within itself\n", s->s_name);
+    else
+        pd_error(0, "%s: can't load abstraction within itself\n", s->s_name);
     pd_this->pd_newest = 0;
     return (0);
 }
 
 /* search for abstraction; register a creator if found */
-static int sys_do_load_abs(t_canvas *canvas, const char *objectname,
-    const char *path)
+static int sys_do_load_abs(
+    t_canvas *canvas, const char *objectname, const char *path)
 {
     int fd;
-    static t_gobj*abstraction_classes = 0;
+    static t_gobj *abstraction_classes = 0;
     char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
-        /* NULL-path is only used as a last resort,
-           but we have already tried all paths */
-    if (!path) return (0);
+    /* NULL-path is only used as a last resort,
+       but we have already tried all paths */
+    if(!path) return (0);
 
     snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
-    if ((fd = sys_trytoopenone(path, objectname, ".pd",
-              dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0 ||
-        (fd = sys_trytoopenone(path, objectname, ".pat",
-              dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0 ||
-        (fd = sys_trytoopenone(path, classslashclass, ".pd",
-              dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0)
+    if((fd = sys_trytoopenone(
+            path, objectname, ".pd", dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0 ||
+        (fd = sys_trytoopenone(path, objectname, ".pat", dirbuf, &nameptr,
+             MAXPDSTRING, 1)) >= 0 ||
+        (fd = sys_trytoopenone(path, classslashclass, ".pd", dirbuf, &nameptr,
+             MAXPDSTRING, 1)) >= 0)
     {
-        t_class*c=0;
+        t_class *c = 0;
         close(fd);
-            /* found an abstraction, now register it as a new pseudo-class */
+        /* found an abstraction, now register it as a new pseudo-class */
         class_set_extern_dir(gensym(dirbuf));
-        if((c=class_new(gensym(objectname),
-                        (t_newmethod)do_create_abstraction, 0,
-                        0, 0, A_GIMME, 0)))
+        if((c = class_new(gensym(objectname),
+                (t_newmethod) do_create_abstraction, 0, 0, 0, A_GIMME, 0)))
         {
-                /* store away the newly created class, maybe we will need it one day */
-            t_gobj*absclass=0;
-            absclass=t_getbytes(sizeof(*absclass));
-            absclass->g_pd=c;
-            absclass->g_next=abstraction_classes;
-            abstraction_classes=absclass;
+            /* store away the newly created class, maybe we will need it one day
+             */
+            t_gobj *absclass = 0;
+            absclass = t_getbytes(sizeof(*absclass));
+            absclass->g_pd = c;
+            absclass->g_next = abstraction_classes;
+            abstraction_classes = absclass;
         }
         class_set_extern_dir(&s_);
 

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -110,13 +110,18 @@ static int sys_do_load_abs(
 static int sys_do_load_lib(
     t_canvas *canvas, const char *objectname, const char *path)
 {
-    char symname[MAXPDSTRING], filename[MAXPDSTRING], dirbuf[MAXPDSTRING],
-        *nameptr;
+    char symname[MAXPDSTRING];
+    char filename[MAXPDSTRING];
+    char dirbuf[MAXPDSTRING];
+    char *nameptr;
     const char **dllextent;
-    const char *classname, *cnameptr;
+    const char *classname;
+    const char *cnameptr;
     void *dlobj;
     t_xxx makeout = NULL;
-    int i, hexmunge = 0, fd;
+    int i;
+    int hexmunge = 0;
+    int fd;
 #ifdef _WIN32
     HINSTANCE ntdll;
 #endif
@@ -338,7 +343,8 @@ int sys_load_lib(t_canvas *canvas, const char *classname)
     {
         /* this is just copied from sys_open_absolute()
            LATER avoid code duplication */
-        char dirbuf[MAXPDSTRING], *z = strrchr(classname, '/');
+        char dirbuf[MAXPDSTRING];
+        char *z = strrchr(classname, '/');
         int dirlen;
         if(!z) return (0);
         dirlen = (int) (z - classname);
@@ -435,7 +441,9 @@ static t_pd *do_create_abstraction(t_symbol *s, int argc, t_atom *argv)
     if(!pd_setloadingabstraction(s))
     {
         const char *objectname = s->s_name;
-        char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
+        char dirbuf[MAXPDSTRING];
+        char classslashclass[MAXPDSTRING];
+        char *nameptr;
         t_glist *glist = (t_glist *) canvas_getcurrent();
         t_canvas *canvas = (t_canvas *) glist_getcanvas(glist);
         int fd = -1;
@@ -474,7 +482,9 @@ static int sys_do_load_abs(
 {
     int fd;
     static t_gobj *abstraction_classes = 0;
-    char dirbuf[MAXPDSTRING], classslashclass[MAXPDSTRING], *nameptr;
+    char dirbuf[MAXPDSTRING];
+    char classslashclass[MAXPDSTRING];
+    char *nameptr;
     /* NULL-path is only used as a last resort,
        but we have already tried all paths */
     if(!path) return (0);

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -294,7 +294,7 @@ void sys_register_loader(loader_t loader)
     {
         if(q->loader == loader) /* already loaded - nothing to do */
             return;
-        else if(q->next)
+        if(q->next)
             q = q->next;
         else
         {
@@ -419,12 +419,10 @@ int sys_run_scheduler(
 #endif
     if(externalmainfunc)
         return ((*externalmainfunc)(sys_extraflagsstring));
-    else
-    {
-        fprintf(stderr, "%s: couldn't find pd_extern_sched() or main()\n",
-            filename);
-        return (0);
-    }
+
+    fprintf(
+        stderr, "%s: couldn't find pd_extern_sched() or main()\n", filename);
+    return (0);
 }
 
 /* abstraction loading */

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -392,7 +392,7 @@ int sys_main(int argc, const char **argv)
     if(sys_externalschedlib)
         return (
             sys_run_scheduler(sys_externalschedlibname, sys_extraflagsstring));
-    else if(sys_batch)
+    if(sys_batch)
         return (m_batchmain());
     else
     {
@@ -554,15 +554,13 @@ static int sys_parsedevlist(int *np, int *vecp, int max, const char *str)
     {
         if(!*str)
             break;
-        else
-        {
-            char *endp;
-            vecp[n] = (int) strtol(str, &endp, 10);
-            if(endp == str) break;
-            n++;
-            if(!*endp) break;
-            str = endp + 1;
-        }
+
+        char *endp;
+        vecp[n] = (int) strtol(str, &endp, 10);
+        if(endp == str) break;
+        n++;
+        if(!*endp) break;
+        str = endp + 1;
     }
     return (*np = n);
 }

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -230,14 +230,12 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     const char *cwd = atom_getsymbolarg(0, argc, argv)->s_name;
     t_namelist *nl;
-    unsigned int i;
     int did_fontwarning = 0;
-    int j;
     sys_oldtclversion = atom_getfloatarg(1, argc, argv);
     if(argc != 2 + 3 * NZOOM * NFONT) bug("glob_initfromgui");
-    for(j = 0; j < NZOOM; j++)
+    for(int j = 0; j < NZOOM; j++)
     {
-        for(i = 0; i < NFONT; i++)
+        for(unsigned int i = 0; i < NFONT; i++)
         {
             int size = atom_getfloatarg(3 * (i + j * NFONT) + 2, argc, argv);
             int width = atom_getfloatarg(3 * (i + j * NFONT) + 3, argc, argv);
@@ -305,7 +303,6 @@ static void sys_fakefromgui(void)
     /* fake the GUI's message giving cwd and font sizes in case
     we aren't starting the gui. */
     t_atom zz[NDEFAULTFONT + 2];
-    int i;
     char buf[MAXPDSTRING];
 #ifdef _WIN32
     if(GetCurrentDirectory(MAXPDSTRING, buf) == 0) strcpy(buf, ".");
@@ -314,7 +311,7 @@ static void sys_fakefromgui(void)
 #endif
     SETSYMBOL(zz, gensym(buf));
     SETFLOAT(zz + 1, 0);
-    for(i = 0; i < (int) NDEFAULTFONT; i++)
+    for(int i = 0; i < (int) NDEFAULTFONT; i++)
         SETFLOAT(zz + i + 2, defaultfontshit[i]);
     glob_initfromgui(0, 0, 2 + NDEFAULTFONT, zz);
     clock_free(sys_fakefromguiclk);
@@ -566,8 +563,7 @@ static char *(usagemessage[]) = {
 
 static void sys_printusage(void)
 {
-    unsigned int i;
-    for(i = 0; i < sizeof(usagemessage) / sizeof(*usagemessage); i++)
+    for(unsigned int i = 0; i < sizeof(usagemessage) / sizeof(*usagemessage); i++)
     {
         fprintf(stderr, "%s", usagemessage[i]);
         fflush(stderr);
@@ -1536,7 +1532,6 @@ from command-line arguments */
 static void sys_afterargparse(void)
 {
     char sbuf[MAXPDSTRING];
-    int i;
     t_audiosettings as;
     int nmidiindev = 0;
     int midiindev[MAXMIDIINDEV];
@@ -1553,9 +1548,9 @@ static void sys_afterargparse(void)
     strcat(sbuf, "/doc/5.reference");
     STUFF->st_helppath = namelist_append_files(STUFF->st_helppath, sbuf);
 
-    for(i = 0; i < sys_nmidiin; i++)
+    for(int i = 0; i < sys_nmidiin; i++)
         sys_midiindevlist[i]--;
-    for(i = 0; i < sys_nmidiout; i++)
+    for(int i = 0; i < sys_nmidiout; i++)
         sys_midioutdevlist[i]--;
 
     if(sys_listplease) sys_listdevs();
@@ -1564,13 +1559,13 @@ static void sys_afterargparse(void)
     if(sys_nmidiin >= 0)
     {
         nmidiindev = sys_nmidiin;
-        for(i = 0; i < nmidiindev; i++)
+        for(int i = 0; i < nmidiindev; i++)
             midiindev[i] = sys_midiindevlist[i];
     }
     if(sys_nmidiout >= 0)
     {
         nmidioutdev = sys_nmidiout;
-        for(i = 0; i < nmidioutdev; i++)
+        for(int i = 0; i < nmidioutdev; i++)
             midioutdev[i] = sys_midioutdevlist[i];
     }
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 0);
@@ -1617,7 +1612,6 @@ t_symbol *sys_decodedialog(t_symbol *s)
 {
     char buf[MAXPDSTRING];
     const char *sp = s->s_name;
-    int i;
     if(*sp != '+')
     {
         bug("sys_decodedialog: %s", sp);
@@ -1626,6 +1620,7 @@ t_symbol *sys_decodedialog(t_symbol *s)
     {
         sp++;
     }
+    int i;
     for(i = 0; i < MAXPDSTRING - 1; i++, sp++)
     {
         if(!sp[0]) break;
@@ -1713,12 +1708,11 @@ void glob_start_path_dialog(t_pd *dummy)
 /* new values from dialog window */
 void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     namelist_free(STUFF->st_searchpath);
     STUFF->st_searchpath = 0;
     sys_usestdpath = atom_getfloatarg(0, argc, argv);
     sys_verbose = atom_getfloatarg(1, argc, argv);
-    for(i = 0; i < argc - 2; i++)
+    for(int i = 0; i < argc - 2; i++)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
         if(*s->s_name)
@@ -1783,12 +1777,11 @@ void glob_start_startup_dialog(t_pd *dummy)
 /* new values from dialog window */
 void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     namelist_free(STUFF->st_externlist);
     STUFF->st_externlist = 0;
     sys_defeatrt = atom_getfloatarg(0, argc, argv);
     sys_flags = sys_decodedialog(atom_getsymbolarg(1, argc, argv));
-    for(i = 0; i < argc - 2; i++)
+    for(int i = 0; i < argc - 2; i++)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
         if(*s->s_name)

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -165,9 +165,13 @@ int sys_zoomfontwidth(int fontsize, int zoomarg, int worstcase)
     int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg));
     int ret;
     if(worstcase)
+    {
         ret = zoom * sys_fontspec[sys_findfont(fontsize)].fi_width;
+    }
     else
+    {
         ret = sys_gotfonts[zoom - 1][sys_findfont(fontsize)].fi_width;
+    }
     return (ret < 1 ? 1 : ret);
 }
 
@@ -176,9 +180,13 @@ int sys_zoomfontheight(int fontsize, int zoomarg, int worstcase)
     int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg));
     int ret;
     if(worstcase)
+    {
         ret = (zoom * sys_fontspec[sys_findfont(fontsize)].fi_height);
+    }
     else
+    {
         ret = sys_gotfonts[zoom - 1][sys_findfont(fontsize)].fi_height;
+    }
     return (ret < 1 ? 1 : ret);
 }
 
@@ -228,6 +236,7 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     sys_oldtclversion = atom_getfloatarg(1, argc, argv);
     if(argc != 2 + 3 * NZOOM * NFONT) bug("glob_initfromgui");
     for(j = 0; j < NZOOM; j++)
+    {
         for(i = 0; i < NFONT; i++)
         {
             int size = atom_getfloatarg(3 * (i + j * NFONT) + 2, argc, argv);
@@ -254,12 +263,15 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
                     sys_gotfonts[j][i].fi_height);
 #endif
         }
+    }
     /* load dynamic libraries specified with "-lib" args */
     if(sys_oktoloadfiles(0))
     {
         for(nl = STUFF->st_externlist; nl; nl = nl->nl_next)
+        {
             if(!sys_load_lib(0, nl->nl_string))
                 post("%s: can't load library", nl->nl_string);
+        }
         sys_oktoloadfiles(1);
     }
     /* open patches specifies with "-open" args */
@@ -353,13 +365,19 @@ int sys_main(int argc, const char **argv)
     {
         /* for prefs override */
         if(!strcmp(argv[i], "-noprefs"))
+        {
             noprefs = 1;
+        }
         else if(!strcmp(argv[i], "-prefsfile") && i < argc - 1)
+        {
             prefsfile = argv[i + 1];
         /* for external scheduler (to ignore audio api in sys_loadpreferences)
          */
+        }
         else if(!strcmp(argv[i], "-schedlib") && i < argc - 1)
+        {
             sys_externalschedlib = 1;
+        }
         else if(!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help"))
         {
             sys_printusage();
@@ -371,8 +389,10 @@ int sys_main(int argc, const char **argv)
     if(sys_argparse(argc - 1, argv + 1))   /* parse cmd line args */
         return (1);
     if(sys_verbose || sys_version)
+    {
         fprintf(stderr, "%s compiled %s %s\n", pd_version, pd_compiletime,
             pd_compiledate);
+    }
     if(sys_verbose)
         fprintf(stderr, "float precision = %lu bits\n", sizeof(t_float) * 8);
     if(sys_version) /* if we were just asked our version, exit here. */
@@ -383,17 +403,25 @@ int sys_main(int argc, const char **argv)
     sys_setsignalhandlers();
     sys_afterargparse(); /* post-argparse settings */
     if(sys_dontstartgui)
+    {
         clock_set(
             (sys_fakefromguiclk = clock_new(0, (t_method) sys_fakefromgui)), 0);
-    else if(sys_startgui(sys_libdir->s_name)) /* start the gui */
+    }
+    else if(sys_startgui(sys_libdir->s_name))
+    { /* start the gui */
         return (1);
+    }
     if(sys_hipriority)
         sys_setrealtime(sys_libdir->s_name); /* set desired process priority */
     if(sys_externalschedlib)
+    {
         return (
             sys_run_scheduler(sys_externalschedlibname, sys_extraflagsstring));
+    }
     if(sys_batch)
+    {
         return (m_batchmain());
+    }
     else
     {
         /* open audio and MIDI */
@@ -993,14 +1021,20 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_audiodevnametonumber(0, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find audio input device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     as.a_indevvec[as.a_nindev++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of audio devices limited to %d\n",
                     MAXAUDIOINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1013,14 +1047,20 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_audiodevnametonumber(1, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find audio output device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     as.a_outdevvec[as.a_noutdev++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of audio devices limited to %d\n",
                     MAXAUDIOINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1034,20 +1074,30 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_audiodevnametonumber(0, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find audio input device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     as.a_indevvec[as.a_nindev++] = devn + 1;
+                }
                 devn = sys_audiodevnametonumber(1, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find audio output device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     as.a_outdevvec[as.a_noutdev++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of audio devices limited to %d",
                     MAXAUDIOINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1111,14 +1161,20 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_mididevnametonumber(0, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find MIDI input device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     sys_midiindevlist[sys_nmidiin++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of MIDI devices limited to %d\n",
                     MAXMIDIINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1131,14 +1187,20 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_mididevnametonumber(1, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     sys_midioutdevlist[sys_nmidiout++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of MIDI devices limited to %d\n",
                     MAXMIDIINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1152,20 +1214,30 @@ int sys_argparse(int argc, const char **argv)
             {
                 int devn = sys_mididevnametonumber(1, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     sys_midioutdevlist[sys_nmidiin++] = devn + 1;
+                }
                 devn = sys_mididevnametonumber(1, argv[1]);
                 if(devn < 0)
+                {
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
+                }
                 else
+                {
                     sys_midioutdevlist[sys_nmidiout++] = devn + 1;
+                }
             }
             else
+            {
                 fprintf(stderr, "number of MIDI devices limited to %d",
                     MAXMIDIINDEV);
+            }
             argc -= 2;
             argv += 2;
         }
@@ -1425,10 +1497,14 @@ int sys_argparse(int argc, const char **argv)
             argc--;
             argv++;
         }
-        else if(!strcmp(*argv, "-noprefs")) /* did this earlier */
+        else if(!strcmp(*argv, "-noprefs"))
+        { /* did this earlier */
             argc--, argv++;
-        else if(!strcmp(*argv, "-prefsfile") && argc > 1) /* this too */
+        }
+        else if(!strcmp(*argv, "-prefsfile") && argc > 1)
+        { /* this too */
             argc -= 2, argv += 2;
+        }
         else
         {
         usage:
@@ -1543,26 +1619,42 @@ t_symbol *sys_decodedialog(t_symbol *s)
     const char *sp = s->s_name;
     int i;
     if(*sp != '+')
+    {
         bug("sys_decodedialog: %s", sp);
+    }
     else
+    {
         sp++;
+    }
     for(i = 0; i < MAXPDSTRING - 1; i++, sp++)
     {
         if(!sp[0]) break;
         if(sp[0] == '+')
         {
             if(sp[1] == '_')
+            {
                 buf[i] = ' ', sp++;
+            }
             else if(sp[1] == '+')
+            {
                 buf[i] = '+', sp++;
+            }
             else if(sp[1] == 'c')
+            {
                 buf[i] = ',', sp++;
+            }
             else if(sp[1] == 's')
+            {
                 buf[i] = ';', sp++;
+            }
             else if(sp[1] == 'd')
+            {
                 buf[i] = '$', sp++;
+            }
             else
+            {
                 buf[i] = sp[0];
+            }
         }
         else
             buf[i] = sp[0];
@@ -1630,8 +1722,10 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
         if(*s->s_name)
+        {
             STUFF->st_searchpath =
                 namelist_append_files(STUFF->st_searchpath, s->s_name);
+        }
     }
 }
 
@@ -1645,11 +1739,15 @@ void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit)
     if(*s->s_name)
     {
         if(saveflag < 0)
+        {
             STUFF->st_temppath =
                 namelist_append_files(STUFF->st_temppath, s->s_name);
+        }
         else
+        {
             STUFF->st_searchpath =
                 namelist_append_files(STUFF->st_searchpath, s->s_name);
+        }
         if(saveit > 0) sys_savepreferences(0);
     }
 }
@@ -1694,8 +1792,10 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     {
         t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
         if(*s->s_name)
+        {
             STUFF->st_externlist =
                 namelist_append_files(STUFF->st_externlist, s->s_name);
+        }
     }
 }
 
@@ -1843,9 +1943,13 @@ int string2args(const char *cmd, int *retArgc, const char ***retArgv)
 
     if(retArgc) *retArgc = argCount;
     if(retArgv)
+    {
         *retArgv = argTable;
+    }
     else
+    {
         free(argTable);
+    }
     return argCount;
 
 ouch:

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -162,7 +162,8 @@ int sys_hostfontsize(int fontsize, int zoom)
 
 int sys_zoomfontwidth(int fontsize, int zoomarg, int worstcase)
 {
-    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
+    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg));
+    int ret;
     if(worstcase)
         ret = zoom * sys_fontspec[sys_findfont(fontsize)].fi_width;
     else
@@ -172,7 +173,8 @@ int sys_zoomfontwidth(int fontsize, int zoomarg, int worstcase)
 
 int sys_zoomfontheight(int fontsize, int zoomarg, int worstcase)
 {
-    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
+    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg));
+    int ret;
     if(worstcase)
         ret = (zoom * sys_fontspec[sys_findfont(fontsize)].fi_height);
     else
@@ -195,7 +197,8 @@ int sys_defaultfont;
 
 static void openit(const char *dirname, const char *filename)
 {
-    char dirbuf[MAXPDSTRING], *nameptr;
+    char dirbuf[MAXPDSTRING];
+    char *nameptr;
     int fd =
         open_via_path(dirname, filename, "", dirbuf, &nameptr, MAXPDSTRING, 0);
     if(fd >= 0)
@@ -311,7 +314,8 @@ static void sys_printusage(void);
 /* this is called from main() in s_entry.c */
 int sys_main(int argc, const char **argv)
 {
-    int i, noprefs;
+    int i;
+    int noprefs;
     const char *prefsfile = "";
     sys_externalschedlib = 0;
     sys_extraflags = 0;
@@ -579,7 +583,8 @@ invocation for Pd, or if that fails, by consulting the variable
 INSTALL_PREFIX.  In MSW, we don't try to use INSTALL_PREFIX. */
 void sys_findprogdir(const char *progname)
 {
-    char sbuf[MAXPDSTRING], sbuf2[MAXPDSTRING];
+    char sbuf[MAXPDSTRING];
+    char sbuf2[MAXPDSTRING];
     char *lastslash;
 #ifndef _WIN32
     struct stat statbuf;
@@ -1459,8 +1464,10 @@ static void sys_afterargparse(void)
     char sbuf[MAXPDSTRING];
     int i;
     t_audiosettings as;
-    int nmidiindev = 0, midiindev[MAXMIDIINDEV];
-    int nmidioutdev = 0, midioutdev[MAXMIDIOUTDEV];
+    int nmidiindev = 0;
+    int midiindev[MAXMIDIINDEV];
+    int nmidioutdev = 0;
+    int midioutdev[MAXMIDIOUTDEV];
     /* add "extra" library to path */
     strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING - 30);
     sbuf[MAXPDSTRING - 30] = 0;
@@ -1705,9 +1712,12 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 int string2args(const char *cmd, int *retArgc, const char ***retArgv)
 {
     int errCode = 1;
-    int len = strlen(cmd), argCount = 0;
-    char strings[MAXPDSTRING], *cp;
-    const char **argTable = 0, **newArgTable;
+    int len = strlen(cmd);
+    int argCount = 0;
+    char strings[MAXPDSTRING];
+    char *cp;
+    const char **argTable = 0;
+    const char **newArgTable;
 
     if(retArgc) *retArgc = 0;
     if(retArgv) *retArgv = NULL;
@@ -1730,7 +1740,8 @@ int string2args(const char *cmd, int *retArgc, const char ***retArgv)
     while(*cp)
     {
         const char *cpIn = cp;
-        char *cpOut = cp, *argument;
+        char *cpOut = cp;
+        char *argument;
         int quote = '\0';
 
         /*

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 #include "m_imp.h"
@@ -21,15 +21,15 @@
 #include <windows.h>
 #include <winbase.h>
 #endif
-#ifdef _MSC_VER  /* This is only for Microsoft's compiler, not cygwin, e.g. */
+#ifdef _MSC_VER /* This is only for Microsoft's compiler, not cygwin, e.g. */
 #define snprintf _snprintf
 #endif
 
 #define stringify(s) str(s)
 #define str(s) #s
 
-char *pd_version = "Pd-" stringify(PD_MAJOR_VERSION) "." \
-stringify(PD_MINOR_VERSION) "." stringify(PD_BUGFIX_VERSION) "\
+char *pd_version = "Pd-" stringify(PD_MAJOR_VERSION) "." stringify(
+    PD_MINOR_VERSION) "." stringify(PD_BUGFIX_VERSION) "\
  (" stringify(PD_TEST_VERSION) ")";
 
 char pd_compiletime[] = __TIME__;
@@ -53,18 +53,18 @@ int sys_debuglevel;
 int sys_verbose;
 int sys_noloadbang;
 static int sys_dontstartgui;
-int sys_hipriority = -1;    /* -1 = not specified; 0 = no; 1 = yes */
-int sys_guisetportnumber;   /* if started from the GUI, this is the port # */
-int sys_nosleep = 0;  /* skip all "sleep" calls and spin instead */
-int sys_defeatrt;       /* flag to cancel real-time */
-t_symbol *sys_flags;    /* more command-line flags */
+int sys_hipriority = -1;  /* -1 = not specified; 0 = no; 1 = yes */
+int sys_guisetportnumber; /* if started from the GUI, this is the port # */
+int sys_nosleep = 0;      /* skip all "sleep" calls and spin instead */
+int sys_defeatrt;         /* flag to cancel real-time */
+t_symbol *sys_flags;      /* more command-line flags */
 
 const char *sys_guicmd;
 t_symbol *sys_libdir;
 static t_namelist *sys_openlist;
 static t_namelist *sys_messagelist;
 static int sys_version;
-int sys_oldtclversion;      /* hack to warn g_rtext.c about old text sel */
+int sys_oldtclversion; /* hack to warn g_rtext.c about old text sel */
 
 int sys_nmidiout = -1;
 int sys_nmidiin = -1;
@@ -86,18 +86,25 @@ char sys_externalschedlibname[MAXPDSTRING];
 static int sys_batch;
 int sys_extraflags;
 char sys_extraflagsstring[MAXPDSTRING];
-int sys_run_scheduler(const char *externalschedlibname,
-    const char *sys_extraflagsstring);
-int sys_noautopatch;    /* temporary hack to defeat new 0.42 editing */
+int sys_run_scheduler(
+    const char *externalschedlibname, const char *sys_extraflagsstring);
+int sys_noautopatch; /* temporary hack to defeat new 0.42 editing */
 
 t_sample *get_sys_soundout() { return STUFF->st_soundout; }
+
 t_sample *get_sys_soundin() { return STUFF->st_soundin; }
+
 double *get_sys_time_per_dsp_tick() { return &STUFF->st_time_per_dsp_tick; }
+
 int *get_sys_schedblocksize() { return &STUFF->st_schedblocksize; }
+
 double *get_sys_time() { return &pd_this->pd_systime; }
+
 t_float *get_sys_dacsr() { return &STUFF->st_dacsr; }
+
 int *get_sys_schedadvance() { return &sys_schedadvance; }
-t_namelist *sys_searchpath;  /* so old versions of GEM might compile */
+
+t_namelist *sys_searchpath; /* so old versions of GEM might compile */
 
 typedef struct _fontinfo
 {
@@ -106,13 +113,12 @@ typedef struct _fontinfo
     int fi_height;
 } t_fontinfo;
 
-    /* these give the nominal point size and maximum height of the characters
-    in the six fonts.  */
+/* these give the nominal point size and maximum height of the characters
+in the six fonts.  */
 
-static t_fontinfo sys_fontspec[] = {
-    {8, 5, 11}, {10, 6, 13}, {12, 7, 16},
+static t_fontinfo sys_fontspec[] = {{8, 5, 11}, {10, 6, 13}, {12, 7, 16},
     {16, 10, 19}, {24, 14, 29}, {36, 22, 44}};
-#define NFONT (sizeof(sys_fontspec)/sizeof(*sys_fontspec))
+#define NFONT (sizeof(sys_fontspec) / sizeof(*sys_fontspec))
 #define NZOOM 2
 static t_fontinfo sys_gotfonts[NZOOM][NFONT];
 
@@ -138,9 +144,9 @@ static int sys_findfont(int fontsize)
 {
     unsigned int i;
     t_fontinfo *fi;
-    for (i = 0, fi = sys_fontspec; i < (NFONT-1); i++, fi++)
-        if (fontsize < fi[1].fi_pointsize) return (i);
-    return ((NFONT-1));
+    for(i = 0, fi = sys_fontspec; i < (NFONT - 1); i++, fi++)
+        if(fontsize < fi[1].fi_pointsize) return (i);
+    return ((NFONT - 1));
 }
 
 int sys_nearestfontsize(int fontsize)
@@ -151,24 +157,26 @@ int sys_nearestfontsize(int fontsize)
 int sys_hostfontsize(int fontsize, int zoom)
 {
     zoom = (zoom < 1 ? 1 : (zoom > NZOOM ? NZOOM : zoom));
-    return (sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_pointsize);
+    return (sys_gotfonts[zoom - 1][sys_findfont(fontsize)].fi_pointsize);
 }
 
 int sys_zoomfontwidth(int fontsize, int zoomarg, int worstcase)
 {
     int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
-    if (worstcase)
+    if(worstcase)
         ret = zoom * sys_fontspec[sys_findfont(fontsize)].fi_width;
-    else ret = sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_width;
+    else
+        ret = sys_gotfonts[zoom - 1][sys_findfont(fontsize)].fi_width;
     return (ret < 1 ? 1 : ret);
 }
 
 int sys_zoomfontheight(int fontsize, int zoomarg, int worstcase)
 {
     int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
-    if (worstcase)
+    if(worstcase)
         ret = (zoom * sys_fontspec[sys_findfont(fontsize)].fi_height);
-    else ret = sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_height;
+    else
+        ret = sys_gotfonts[zoom - 1][sys_findfont(fontsize)].fi_height;
     return (ret < 1 ? 1 : ret);
 }
 
@@ -188,11 +196,11 @@ int sys_defaultfont;
 static void openit(const char *dirname, const char *filename)
 {
     char dirbuf[MAXPDSTRING], *nameptr;
-    int fd = open_via_path(dirname, filename, "", dirbuf, &nameptr,
-        MAXPDSTRING, 0);
-    if (fd >= 0)
+    int fd =
+        open_via_path(dirname, filename, "", dirbuf, &nameptr, MAXPDSTRING, 0);
+    if(fd >= 0)
     {
-        close (fd);
+        close(fd);
         glob_evalfile(0, gensym(nameptr), gensym(dirbuf));
     }
     else
@@ -215,49 +223,49 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     int did_fontwarning = 0;
     int j;
     sys_oldtclversion = atom_getfloatarg(1, argc, argv);
-    if (argc != 2 + 3 * NZOOM * NFONT)
-        bug("glob_initfromgui");
-    for (j = 0; j < NZOOM; j++)
-        for (i = 0; i < NFONT; i++)
-    {
-        int size   = atom_getfloatarg(3 * (i + j * NFONT) + 2, argc, argv);
-        int width  = atom_getfloatarg(3 * (i + j * NFONT) + 3, argc, argv);
-        int height = atom_getfloatarg(3 * (i + j * NFONT) + 4, argc, argv);
-        if (!(size && width && height))
+    if(argc != 2 + 3 * NZOOM * NFONT) bug("glob_initfromgui");
+    for(j = 0; j < NZOOM; j++)
+        for(i = 0; i < NFONT; i++)
         {
-            size   = (j+1)*sys_fontspec[i].fi_pointsize;
-            width  = (j+1)*sys_fontspec[i].fi_width;
-            height = (j+1)*sys_fontspec[i].fi_height;
-            if (!did_fontwarning)
+            int size = atom_getfloatarg(3 * (i + j * NFONT) + 2, argc, argv);
+            int width = atom_getfloatarg(3 * (i + j * NFONT) + 3, argc, argv);
+            int height = atom_getfloatarg(3 * (i + j * NFONT) + 4, argc, argv);
+            if(!(size && width && height))
             {
-                logpost(NULL, PD_VERBOSE, "ignoring invalid font-metrics from GUI");
-                did_fontwarning = 1;
+                size = (j + 1) * sys_fontspec[i].fi_pointsize;
+                width = (j + 1) * sys_fontspec[i].fi_width;
+                height = (j + 1) * sys_fontspec[i].fi_height;
+                if(!did_fontwarning)
+                {
+                    logpost(NULL, PD_VERBOSE,
+                        "ignoring invalid font-metrics from GUI");
+                    did_fontwarning = 1;
+                }
             }
-        }
-        sys_gotfonts[j][i].fi_pointsize = size;
-        sys_gotfonts[j][i].fi_width = width;
-        sys_gotfonts[j][i].fi_height = height;
+            sys_gotfonts[j][i].fi_pointsize = size;
+            sys_gotfonts[j][i].fi_width = width;
+            sys_gotfonts[j][i].fi_height = height;
 #if 0
             fprintf(stderr, "font (%d %d %d)\n",
                 sys_gotfonts[j][i].fi_pointsize, sys_gotfonts[j][i].fi_width,
                     sys_gotfonts[j][i].fi_height);
 #endif
-    }
-        /* load dynamic libraries specified with "-lib" args */
-    if (sys_oktoloadfiles(0))
+        }
+    /* load dynamic libraries specified with "-lib" args */
+    if(sys_oktoloadfiles(0))
     {
-        for  (nl = STUFF->st_externlist; nl; nl = nl->nl_next)
-            if (!sys_load_lib(0, nl->nl_string))
+        for(nl = STUFF->st_externlist; nl; nl = nl->nl_next)
+            if(!sys_load_lib(0, nl->nl_string))
                 post("%s: can't load library", nl->nl_string);
         sys_oktoloadfiles(1);
     }
-        /* open patches specifies with "-open" args */
-    for  (nl = sys_openlist; nl; nl = nl->nl_next)
+    /* open patches specifies with "-open" args */
+    for(nl = sys_openlist; nl; nl = nl->nl_next)
         openit(cwd, nl->nl_string);
     namelist_free(sys_openlist);
     sys_openlist = 0;
-        /* send messages specified with "-send" args */
-    for  (nl = sys_messagelist; nl; nl = nl->nl_next)
+    /* send messages specified with "-send" args */
+    for(nl = sys_messagelist; nl; nl = nl->nl_next)
     {
         t_binbuf *b = binbuf_new();
         binbuf_text(b, nl->nl_string, strlen(nl->nl_string));
@@ -269,33 +277,31 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
 }
 
 // font char metric triples: pointsize width(pixels) height(pixels)
-static int defaultfontshit[] = {
-  8,  5, 11,  10,  6, 13,  12,  7, 16,  16, 10, 19,  24, 14, 29,  36, 22, 44,
- 16, 10, 22,  20, 12, 26,  24, 14, 32,  32, 20, 38,  48, 28, 58,  72, 44, 88
-}; // normal & zoomed (2x)
-#define NDEFAULTFONT (sizeof(defaultfontshit)/sizeof(*defaultfontshit))
+static int defaultfontshit[] = {8, 5, 11, 10, 6, 13, 12, 7, 16, 16, 10, 19, 24,
+    14, 29, 36, 22, 44, 16, 10, 22, 20, 12, 26, 24, 14, 32, 32, 20, 38, 48, 28,
+    58, 72, 44, 88}; // normal & zoomed (2x)
+#define NDEFAULTFONT (sizeof(defaultfontshit) / sizeof(*defaultfontshit))
 
 static t_clock *sys_fakefromguiclk;
 int socket_init(void);
+
 static void sys_fakefromgui(void)
 {
-        /* fake the GUI's message giving cwd and font sizes in case
-        we aren't starting the gui. */
-    t_atom zz[NDEFAULTFONT+2];
+    /* fake the GUI's message giving cwd and font sizes in case
+    we aren't starting the gui. */
+    t_atom zz[NDEFAULTFONT + 2];
     int i;
     char buf[MAXPDSTRING];
 #ifdef _WIN32
-    if (GetCurrentDirectory(MAXPDSTRING, buf) == 0)
-        strcpy(buf, ".");
+    if(GetCurrentDirectory(MAXPDSTRING, buf) == 0) strcpy(buf, ".");
 #else
-    if (!getcwd(buf, MAXPDSTRING))
-        strcpy(buf, ".");
+    if(!getcwd(buf, MAXPDSTRING)) strcpy(buf, ".");
 #endif
     SETSYMBOL(zz, gensym(buf));
-    SETFLOAT(zz+1, 0);
-    for (i = 0; i < (int)NDEFAULTFONT; i++)
-        SETFLOAT(zz+i+2, defaultfontshit[i]);
-    glob_initfromgui(0, 0, 2+NDEFAULTFONT, zz);
+    SETFLOAT(zz + 1, 0);
+    for(i = 0; i < (int) NDEFAULTFONT; i++)
+        SETFLOAT(zz + i + 2, defaultfontshit[i]);
+    glob_initfromgui(0, 0, 2 + NDEFAULTFONT, zz);
     clock_free(sys_fakefromguiclk);
 }
 
@@ -315,233 +321,242 @@ int sys_main(int argc, const char **argv)
     /* use Win32 "binary" mode by default since we don't want the
      * translation that Win32 does by default */
 #ifdef _WIN32
-# ifdef _MSC_VER /* MS Visual Studio */
-    _set_fmode( _O_BINARY );
-# else  /* MinGW */
+#ifdef _MSC_VER /* MS Visual Studio */
+    _set_fmode(_O_BINARY);
+#else /* MinGW */
     {
 #ifndef _fmode
         extern int _fmode;
 #endif
         _fmode = _O_BINARY;
     }
-# endif /* _MSC_VER */
-#endif  /* _WIN32 */
+#endif /* _MSC_VER */
+#endif /* _WIN32 */
 #ifndef _WIN32
     /* long ago Pd used setuid to promote itself to real-time priority.
     Just in case anyone's installation script still makes it setuid, we
     complain to stderr and lose setuid here. */
-    if (getuid() != geteuid())
+    if(getuid() != geteuid())
     {
         fprintf(stderr, "warning: canceling setuid privilege\n");
         setuid(getuid());
     }
-#endif  /* _WIN32 */
-    if (socket_init())
-        sys_sockerror("socket_init()");
-    pd_init();                                  /* start the message system */
-    sys_findprogdir(argv[0]);                   /* set sys_progname, guipath */
-    for (i = noprefs = 0; i < argc; i++)    /* prescan ... */
+#endif /* _WIN32 */
+    if(socket_init()) sys_sockerror("socket_init()");
+    pd_init();                          /* start the message system */
+    sys_findprogdir(argv[0]);           /* set sys_progname, guipath */
+    for(i = noprefs = 0; i < argc; i++) /* prescan ... */
     {
         /* for prefs override */
-        if (!strcmp(argv[i], "-noprefs"))
+        if(!strcmp(argv[i], "-noprefs"))
             noprefs = 1;
-        else if (!strcmp(argv[i], "-prefsfile") && i < argc-1)
-            prefsfile = argv[i+1];
-        /* for external scheduler (to ignore audio api in sys_loadpreferences) */
-        else if (!strcmp(argv[i], "-schedlib") && i < argc-1)
+        else if(!strcmp(argv[i], "-prefsfile") && i < argc - 1)
+            prefsfile = argv[i + 1];
+        /* for external scheduler (to ignore audio api in sys_loadpreferences)
+         */
+        else if(!strcmp(argv[i], "-schedlib") && i < argc - 1)
             sys_externalschedlib = 1;
-        else if (!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help"))
+        else if(!strcmp(argv[i], "-h") || !strcmp(argv[i], "-help"))
         {
             sys_printusage();
             return (1);
         }
     }
-    if (!noprefs)       /* load preferences before parsing args to allow ... */
-        sys_loadpreferences(prefsfile, 1);  /* args to override prefs */
-    if (sys_argparse(argc-1, argv+1))           /* parse cmd line args */
+    if(!noprefs) /* load preferences before parsing args to allow ... */
+        sys_loadpreferences(prefsfile, 1); /* args to override prefs */
+    if(sys_argparse(argc - 1, argv + 1))   /* parse cmd line args */
         return (1);
-    if (sys_verbose || sys_version) fprintf(stderr, "%s compiled %s %s\n",
-        pd_version, pd_compiletime, pd_compiledate);
-    if (sys_verbose)
-        fprintf(stderr, "float precision = %lu bits\n", sizeof(t_float)*8);
-    if (sys_version)    /* if we were just asked our version, exit here. */
+    if(sys_verbose || sys_version)
+        fprintf(stderr, "%s compiled %s %s\n", pd_version, pd_compiletime,
+            pd_compiledate);
+    if(sys_verbose)
+        fprintf(stderr, "float precision = %lu bits\n", sizeof(t_float) * 8);
+    if(sys_version) /* if we were just asked our version, exit here. */
     {
         fflush(stderr);
         return (0);
     }
     sys_setsignalhandlers();
-    sys_afterargparse();                    /* post-argparse settings */
-    if (sys_dontstartgui)
-        clock_set((sys_fakefromguiclk =
-            clock_new(0, (t_method)sys_fakefromgui)), 0);
-    else if (sys_startgui(sys_libdir->s_name)) /* start the gui */
+    sys_afterargparse(); /* post-argparse settings */
+    if(sys_dontstartgui)
+        clock_set(
+            (sys_fakefromguiclk = clock_new(0, (t_method) sys_fakefromgui)), 0);
+    else if(sys_startgui(sys_libdir->s_name)) /* start the gui */
         return (1);
-    if (sys_hipriority)
+    if(sys_hipriority)
         sys_setrealtime(sys_libdir->s_name); /* set desired process priority */
-    if (sys_externalschedlib)
-        return (sys_run_scheduler(sys_externalschedlibname,
-            sys_extraflagsstring));
-    else if (sys_batch)
+    if(sys_externalschedlib)
+        return (
+            sys_run_scheduler(sys_externalschedlibname, sys_extraflagsstring));
+    else if(sys_batch)
         return (m_batchmain());
     else
     {
-            /* open audio and MIDI */
+        /* open audio and MIDI */
         sys_reopen_midi();
-        if (audio_shouldkeepopen())
-            sys_reopen_audio();
-            /* run scheduler until it quits */
+        if(audio_shouldkeepopen()) sys_reopen_audio();
+        /* run scheduler until it quits */
         return (m_mainloop());
     }
 }
 
 static char *(usagemessage[]) = {
-"usage: pd [-flags] [file]...\n",
-"\naudio configuration flags:\n",
-"-r <n>           -- specify sample rate\n",
-"-audioindev ...  -- audio in devices; e.g., \"1,3\" for first and third\n",
-"-audiooutdev ... -- audio out devices (same)\n",
-"-audiodev ...    -- specify input and output together\n",
-"-audioaddindev   -- add an audio input device by name\n",
-"-audioaddoutdev  -- add an audio output device by name\n",
-"-audioadddev     -- add an audio input and output device by name\n",
-"-inchannels ...  -- audio input channels (by device, like \"2\" or \"16,8\")\n",
-"-outchannels ... -- number of audio out channels (same)\n",
-"-channels ...    -- specify both input and output channels\n",
-"-audiobuf <n>    -- specify size of audio buffer in msec\n",
-"-blocksize <n>   -- specify audio I/O block size in sample frames\n",
-"-sleepgrain <n>  -- specify number of milliseconds to sleep when idle\n",
-"-nodac           -- suppress audio output\n",
-"-noadc           -- suppress audio input\n",
-"-noaudio         -- suppress audio input and output (-nosound is synonym) \n",
-"-callback        -- use callbacks if possible\n",
-"-nocallback      -- use polling-mode (true by default)\n",
-"-listdev         -- list audio and MIDI devices\n",
+    "usage: pd [-flags] [file]...\n",
+    "\naudio configuration flags:\n",
+    "-r <n>           -- specify sample rate\n",
+    "-audioindev ...  -- audio in devices; e.g., \"1,3\" for first and third\n",
+    "-audiooutdev ... -- audio out devices (same)\n",
+    "-audiodev ...    -- specify input and output together\n",
+    "-audioaddindev   -- add an audio input device by name\n",
+    "-audioaddoutdev  -- add an audio output device by name\n",
+    "-audioadddev     -- add an audio input and output device by name\n",
+    "-inchannels ...  -- audio input channels (by device, like \"2\" or "
+    "\"16,8\")\n",
+    "-outchannels ... -- number of audio out channels (same)\n",
+    "-channels ...    -- specify both input and output channels\n",
+    "-audiobuf <n>    -- specify size of audio buffer in msec\n",
+    "-blocksize <n>   -- specify audio I/O block size in sample frames\n",
+    "-sleepgrain <n>  -- specify number of milliseconds to sleep when idle\n",
+    "-nodac           -- suppress audio output\n",
+    "-noadc           -- suppress audio input\n",
+    "-noaudio         -- suppress audio input and output (-nosound is synonym) "
+    "\n",
+    "-callback        -- use callbacks if possible\n",
+    "-nocallback      -- use polling-mode (true by default)\n",
+    "-listdev         -- list audio and MIDI devices\n",
 
 #ifdef USEAPI_OSS
-"-oss             -- use OSS audio API\n",
+    "-oss             -- use OSS audio API\n",
 #endif
 
 #ifdef USEAPI_ALSA
-"-alsa            -- use ALSA audio API\n",
-"-alsaadd <name>  -- add an ALSA device name to list\n",
+    "-alsa            -- use ALSA audio API\n",
+    "-alsaadd <name>  -- add an ALSA device name to list\n",
 #endif
 
 #ifdef USEAPI_JACK
-"-jack            -- use JACK audio API\n",
-"-jackname <name> -- a name for your JACK client\n",
-"-nojackconnect   -- do not automatically connect pd to the JACK graph\n",
-"-jackconnect     -- automatically connect pd to the JACK graph [default]\n",
+    "-jack            -- use JACK audio API\n",
+    "-jackname <name> -- a name for your JACK client\n",
+    "-nojackconnect   -- do not automatically connect pd to the JACK graph\n",
+    "-jackconnect     -- automatically connect pd to the JACK graph "
+    "[default]\n",
 
 #endif
 
 #ifdef USEAPI_PORTAUDIO
 #ifdef _WIN32
-"-asio            -- use ASIO audio driver (via Portaudio)\n",
-"-pa              -- synonym for -asio\n",
+    "-asio            -- use ASIO audio driver (via Portaudio)\n",
+    "-pa              -- synonym for -asio\n",
 #else
-"-pa              -- use Portaudio API\n",
+    "-pa              -- use Portaudio API\n",
 #endif
 #endif
 
 #ifdef USEAPI_MMIO
-"-mmio            -- use MMIO audio API (default for Windows)\n",
+    "-mmio            -- use MMIO audio API (default for Windows)\n",
 #endif
 
 #ifdef USEAPI_AUDIOUNIT
-"-audiounit       -- use Apple AudioUnit API\n",
+    "-audiounit       -- use Apple AudioUnit API\n",
 #endif
 
 #ifdef USEAPI_ESD
-"-esd             -- use Enlightenment Sound Daemon (ESD) API\n",
+    "-esd             -- use Enlightenment Sound Daemon (ESD) API\n",
 #endif
 
-"      (default audio API for this platform:  ", API_DEFSTRING, ")\n\n",
+    "      (default audio API for this platform:  ",
+    API_DEFSTRING,
+    ")\n\n",
 
-"\nMIDI configuration flags:\n",
-"-midiindev ...   -- midi in device list; e.g., \"1,3\" for first and third\n",
-"-midioutdev ...  -- midi out device list, same format\n",
-"-mididev ...     -- specify -midioutdev and -midiindev together\n",
-"-midiaddindev    -- add a MIDI input device by name\n",
-"-midiaddoutdev   -- add a MIDI output device by name\n",
-"-midiadddev      -- add a MIDI input and output device by name\n",
-"-nomidiin        -- suppress MIDI input\n",
-"-nomidiout       -- suppress MIDI output\n",
-"-nomidi          -- suppress MIDI input and output\n",
+    "\nMIDI configuration flags:\n",
+    "-midiindev ...   -- midi in device list; e.g., \"1,3\" for first and "
+    "third\n",
+    "-midioutdev ...  -- midi out device list, same format\n",
+    "-mididev ...     -- specify -midioutdev and -midiindev together\n",
+    "-midiaddindev    -- add a MIDI input device by name\n",
+    "-midiaddoutdev   -- add a MIDI output device by name\n",
+    "-midiadddev      -- add a MIDI input and output device by name\n",
+    "-nomidiin        -- suppress MIDI input\n",
+    "-nomidiout       -- suppress MIDI output\n",
+    "-nomidi          -- suppress MIDI input and output\n",
 #ifdef USEAPI_OSS
-"-ossmidi         -- use OSS midi API\n",
+    "-ossmidi         -- use OSS midi API\n",
 #endif
 #ifdef USEAPI_ALSA
-"-alsamidi        -- use ALSA midi API\n",
+    "-alsamidi        -- use ALSA midi API\n",
 #endif
 
-
-"\nother flags:\n",
-"-path <path>     -- add to file search path\n",
-"-nostdpath       -- don't search standard (\"extra\") directory\n",
-"-stdpath         -- search standard directory (true by default)\n",
-"-helppath <path> -- add to help file search path\n",
-"-open <file>     -- open file(s) on startup\n",
-"-lib <file>      -- load object library(s) (omit file extensions)\n",
-"-font-size <n>      -- specify default font size in points\n",
-"-font-face <name>   -- specify default font\n",
-"-font-weight <name> -- specify default font weight (normal or bold)\n",
-"-verbose         -- extra printout on startup and when searching for files\n",
-"-noverbose       -- no extra printout\n",
-"-version         -- don't run Pd; just print out which version it is \n",
-"-d <n>           -- specify debug level for inspecting the GUI communication\n",
-"-loadbang        -- do not suppress all loadbangs (true by default)\n",
-"-noloadbang      -- suppress all loadbangs\n",
-"-stderr          -- send printout to standard error instead of GUI\n",
-"-nostderr        -- send printout to GUI (true by default)\n",
-"-gui             -- start GUI (true by default)\n",
-"-nogui           -- suppress starting the GUI\n",
-"-guiport <n>     -- connect to pre-existing GUI over port <n>\n",
-"-guicmd \"cmd...\" -- start alternative GUI program (e.g., remote via ssh)\n",
-"-send \"msg...\"   -- send a message at startup, after patches are loaded\n",
-"-prefs           -- load preferences on startup (true by default)\n",
-"-noprefs         -- suppress loading preferences on startup\n",
-"-prefsfile <file>  -- load preferences from a file\n",
+    "\nother flags:\n",
+    "-path <path>     -- add to file search path\n",
+    "-nostdpath       -- don't search standard (\"extra\") directory\n",
+    "-stdpath         -- search standard directory (true by default)\n",
+    "-helppath <path> -- add to help file search path\n",
+    "-open <file>     -- open file(s) on startup\n",
+    "-lib <file>      -- load object library(s) (omit file extensions)\n",
+    "-font-size <n>      -- specify default font size in points\n",
+    "-font-face <name>   -- specify default font\n",
+    "-font-weight <name> -- specify default font weight (normal or bold)\n",
+    "-verbose         -- extra printout on startup and when searching for "
+    "files\n",
+    "-noverbose       -- no extra printout\n",
+    "-version         -- don't run Pd; just print out which version it is \n",
+    "-d <n>           -- specify debug level for inspecting the GUI "
+    "communication\n",
+    "-loadbang        -- do not suppress all loadbangs (true by default)\n",
+    "-noloadbang      -- suppress all loadbangs\n",
+    "-stderr          -- send printout to standard error instead of GUI\n",
+    "-nostderr        -- send printout to GUI (true by default)\n",
+    "-gui             -- start GUI (true by default)\n",
+    "-nogui           -- suppress starting the GUI\n",
+    "-guiport <n>     -- connect to pre-existing GUI over port <n>\n",
+    "-guicmd \"cmd...\" -- start alternative GUI program (e.g., remote via "
+    "ssh)\n",
+    "-send \"msg...\"   -- send a message at startup, after patches are "
+    "loaded\n",
+    "-prefs           -- load preferences on startup (true by default)\n",
+    "-noprefs         -- suppress loading preferences on startup\n",
+    "-prefsfile <file>  -- load preferences from a file\n",
 #ifdef HAVE_UNISTD_H
-"-rt or -realtime -- use real-time priority\n",
-"-nrt             -- don't use real-time priority\n",
+    "-rt or -realtime -- use real-time priority\n",
+    "-nrt             -- don't use real-time priority\n",
 #endif
-"-sleep           -- sleep when idle, don't spin (true by default)\n",
-"-nosleep         -- spin, don't sleep (may lower latency on multi-CPUs)\n",
-"-schedlib <file> -- plug in external scheduler (omit file extensions)\n",
-"-extraflags <s>  -- string argument to send schedlib\n",
-"-batch           -- run off-line as a batch process\n",
-"-nobatch         -- run interactively (true by default)\n",
-"-autopatch       -- enable auto-patching to new objects (true by default)\n",
-"-noautopatch     -- defeat auto-patching\n",
-"-compatibility <f> -- set back-compatibility to version <f>\n",
+    "-sleep           -- sleep when idle, don't spin (true by default)\n",
+    "-nosleep         -- spin, don't sleep (may lower latency on multi-CPUs)\n",
+    "-schedlib <file> -- plug in external scheduler (omit file extensions)\n",
+    "-extraflags <s>  -- string argument to send schedlib\n",
+    "-batch           -- run off-line as a batch process\n",
+    "-nobatch         -- run interactively (true by default)\n",
+    "-autopatch       -- enable auto-patching to new objects (true by "
+    "default)\n",
+    "-noautopatch     -- defeat auto-patching\n",
+    "-compatibility <f> -- set back-compatibility to version <f>\n",
 };
 
 static void sys_printusage(void)
 {
     unsigned int i;
-    for (i = 0; i < sizeof(usagemessage)/sizeof(*usagemessage); i++)
+    for(i = 0; i < sizeof(usagemessage) / sizeof(*usagemessage); i++)
     {
         fprintf(stderr, "%s", usagemessage[i]);
         fflush(stderr);
     }
 }
 
-    /* parse a comma-separated numeric list, returning the number found */
+/* parse a comma-separated numeric list, returning the number found */
 static int sys_parsedevlist(int *np, int *vecp, int max, const char *str)
 {
     int n = 0;
-    while (n < max)
+    while(n < max)
     {
-        if (! *str) break;
+        if(!*str)
+            break;
         else
         {
             char *endp;
-            vecp[n] = (int)strtol(str, &endp, 10);
-            if (endp == str)
-                break;
+            vecp[n] = (int) strtol(str, &endp, 10);
+            if(endp == str) break;
             n++;
-            if (! *endp)
-                break;
+            if(!*endp) break;
             str = endp + 1;
         }
     }
@@ -551,17 +566,17 @@ static int sys_parsedevlist(int *np, int *vecp, int max, const char *str)
 static int sys_getmultidevchannels(int n, int *devlist)
 {
     int sum = 0;
-    if (n<0)return(-1);
-    if (n==0)return 0;
-    while(n--)sum+=*devlist++;
+    if(n < 0) return (-1);
+    if(n == 0) return 0;
+    while(n--)
+        sum += *devlist++;
     return sum;
 }
 
-
-    /* this routine tries to figure out where to find the auxiliary files
-    Pd will need to run.  This is either done by looking at the command line
-    invocation for Pd, or if that fails, by consulting the variable
-    INSTALL_PREFIX.  In MSW, we don't try to use INSTALL_PREFIX. */
+/* this routine tries to figure out where to find the auxiliary files
+Pd will need to run.  This is either done by looking at the command line
+invocation for Pd, or if that fails, by consulting the variable
+INSTALL_PREFIX.  In MSW, we don't try to use INSTALL_PREFIX. */
 void sys_findprogdir(const char *progname)
 {
     char sbuf[MAXPDSTRING], sbuf2[MAXPDSTRING];
@@ -573,69 +588,70 @@ void sys_findprogdir(const char *progname)
     /* find out by what string Pd was invoked; put answer in "sbuf". */
 #ifdef _WIN32
     GetModuleFileName(NULL, sbuf2, sizeof(sbuf2));
-    sbuf2[MAXPDSTRING-1] = 0;
+    sbuf2[MAXPDSTRING - 1] = 0;
     sys_unbashfilename(sbuf2, sbuf);
 #else
     strncpy(sbuf, progname, MAXPDSTRING);
-    sbuf[MAXPDSTRING-1] = 0;
+    sbuf[MAXPDSTRING - 1] = 0;
 #endif /* _WIN32 */
     lastslash = strrchr(sbuf, '/');
-    if (lastslash)
+    if(lastslash)
     {
-            /* bash last slash to zero so that sbuf is directory pd was in,
-                e.g., ~/pd/bin */
+        /* bash last slash to zero so that sbuf is directory pd was in,
+            e.g., ~/pd/bin */
         *lastslash = 0;
-            /* go back to the parent from there, e.g., ~/pd */
+        /* go back to the parent from there, e.g., ~/pd */
         lastslash = strrchr(sbuf, '/');
-        if (lastslash)
+        if(lastslash)
         {
-            strncpy(sbuf2, sbuf, lastslash-sbuf);
-            sbuf2[lastslash-sbuf] = 0;
+            strncpy(sbuf2, sbuf, lastslash - sbuf);
+            sbuf2[lastslash - sbuf] = 0;
         }
-        else strcpy(sbuf2, "..");
+        else
+            strcpy(sbuf2, "..");
     }
     else
     {
-            /* no slashes found.  Try INSTALL_PREFIX. */
+        /* no slashes found.  Try INSTALL_PREFIX. */
 #ifdef INSTALL_PREFIX
         strcpy(sbuf2, INSTALL_PREFIX);
 #else
         strcpy(sbuf2, ".");
 #endif
     }
-        /* now we believe sbuf2 holds the parent directory of the directory
-        pd was found in.  We now want to infer the "lib" directory and the
-        "gui" directory.  In "simple" unix installations, the layout is
-            .../bin/pd
-            .../bin/pd-watchdog (etc)
-            .../bin/pd-gui.tcl
-            .../doc
-        and in "complicated" unix installations, it's:
-            .../bin/pd
-            .../lib/pd/bin/pd-watchdog
-            .../lib/pd/bin/pd-gui.tcl
-            .../lib/pd/doc
-        To decide which, we stat .../lib/pd; if that exists, we assume it's
-        the complicated layout.  In MSW, it's the "simple" layout, but
-        "wish" is found in bin:
-            .../bin/pd
-            .../bin/wish80.exe
-            .../doc
-        */
+    /* now we believe sbuf2 holds the parent directory of the directory
+    pd was found in.  We now want to infer the "lib" directory and the
+    "gui" directory.  In "simple" unix installations, the layout is
+        .../bin/pd
+        .../bin/pd-watchdog (etc)
+        .../bin/pd-gui.tcl
+        .../doc
+    and in "complicated" unix installations, it's:
+        .../bin/pd
+        .../lib/pd/bin/pd-watchdog
+        .../lib/pd/bin/pd-gui.tcl
+        .../lib/pd/doc
+    To decide which, we stat .../lib/pd; if that exists, we assume it's
+    the complicated layout.  In MSW, it's the "simple" layout, but
+    "wish" is found in bin:
+        .../bin/pd
+        .../bin/wish80.exe
+        .../doc
+    */
 #ifdef _WIN32
     sys_libdir = gensym(sbuf2);
 #else
-    strncpy(sbuf, sbuf2, MAXPDSTRING-30);
-    sbuf[MAXPDSTRING-30] = 0;
+    strncpy(sbuf, sbuf2, MAXPDSTRING - 30);
+    sbuf[MAXPDSTRING - 30] = 0;
     strcat(sbuf, "/lib/pd");
-    if (stat(sbuf, &statbuf) >= 0)
+    if(stat(sbuf, &statbuf) >= 0)
     {
-            /* complicated layout: lib dir is the one we just stat-ed above */
+        /* complicated layout: lib dir is the one we just stat-ed above */
         sys_libdir = gensym(sbuf);
     }
     else
     {
-            /* simple layout: lib dir is the parent */
+        /* simple layout: lib dir is the parent */
         sys_libdir = gensym(sbuf2);
     }
 #endif
@@ -650,626 +666,682 @@ static int sys_mmio = 0;
 int sys_argparse(int argc, const char **argv)
 {
     t_audiosettings as;
-            /* get the current audio parameters.  These are set
-            by the preferences mechanism (sys_loadpreferences()) or
-            else are the default.  Overwrite them with any results
-            of argument parsing, and store them again. */
+    /* get the current audio parameters.  These are set
+    by the preferences mechanism (sys_loadpreferences()) or
+    else are the default.  Overwrite them with any results
+    of argument parsing, and store them again. */
     sys_get_audio_settings(&as);
-    while ((argc > 0) && **argv == '-')
+    while((argc > 0) && **argv == '-')
     {
-                /* audio flags */
-        if (!strcmp(*argv, "-r") && argc > 1 &&
+        /* audio flags */
+        if(!strcmp(*argv, "-r") && argc > 1 &&
             sscanf(argv[1], "%d", &as.a_srate) >= 1)
         {
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-inchannels"))
+        else if(!strcmp(*argv, "-inchannels"))
         {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_nchindev,
-                    as.a_chindevvec, MAXAUDIOINDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(*argv, "-outchannels"))
-        {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_nchoutdev,
-                    as.a_choutdevvec, MAXAUDIOINDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(*argv, "-channels"))
-        {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_nchindev,
-                    as.a_chindevvec, MAXAUDIOINDEV, argv[1]) ||
-                !sys_parsedevlist(&as.a_nchoutdev,
-                    as.a_choutdevvec, MAXAUDIOINDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(*argv, "-soundbuf") || (!strcmp(*argv, "-audiobuf")))
-        {
-            if (argc < 2)
+            if(argc < 2 || !sys_parsedevlist(&as.a_nchindev, as.a_chindevvec,
+                               MAXAUDIOINDEV, argv[1]))
                 goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if(!strcmp(*argv, "-outchannels"))
+        {
+            if(argc < 2 || !sys_parsedevlist(&as.a_nchoutdev, as.a_choutdevvec,
+                               MAXAUDIOINDEV, argv[1]))
+                goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if(!strcmp(*argv, "-channels"))
+        {
+            if(argc < 2 ||
+                !sys_parsedevlist(
+                    &as.a_nchindev, as.a_chindevvec, MAXAUDIOINDEV, argv[1]) ||
+                !sys_parsedevlist(
+                    &as.a_nchoutdev, as.a_choutdevvec, MAXAUDIOINDEV, argv[1]))
+                goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if(!strcmp(*argv, "-soundbuf") || (!strcmp(*argv, "-audiobuf")))
+        {
+            if(argc < 2) goto usage;
 
             as.a_advance = atoi(argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-callback"))
+        else if(!strcmp(*argv, "-callback"))
         {
             as.a_callback = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nocallback"))
+        else if(!strcmp(*argv, "-nocallback"))
         {
             as.a_callback = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-blocksize"))
+        else if(!strcmp(*argv, "-blocksize"))
         {
             as.a_blocksize = atoi(argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-sleepgrain"))
+        else if(!strcmp(*argv, "-sleepgrain"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
             sys_sleepgrain = 1000 * atof(argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-nodac"))
+        else if(!strcmp(*argv, "-nodac"))
         {
             as.a_noutdev = as.a_nchoutdev = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-noadc"))
+        else if(!strcmp(*argv, "-noadc"))
         {
             as.a_nindev = as.a_nchindev = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nosound") || !strcmp(*argv, "-noaudio"))
+        else if(!strcmp(*argv, "-nosound") || !strcmp(*argv, "-noaudio"))
         {
-            as.a_noutdev = as.a_nchoutdev =  as.a_nindev = as.a_nchindev = 0;
-            argc--; argv++;
+            as.a_noutdev = as.a_nchoutdev = as.a_nindev = as.a_nchindev = 0;
+            argc--;
+            argv++;
         }
 #ifdef USEAPI_OSS
-        else if (!strcmp(*argv, "-oss"))
+        else if(!strcmp(*argv, "-oss"))
         {
             as.a_api = API_OSS;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-ossmidi"))
+        else if(!strcmp(*argv, "-ossmidi"))
         {
             sys_set_midi_api(API_OSS);
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if ((!strcmp(*argv, "-oss")) || (!strcmp(*argv, "-ossmidi")))
+        else if((!strcmp(*argv, "-oss")) || (!strcmp(*argv, "-ossmidi")))
         {
-            fprintf(stderr, "Pd compiled without OSS-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without OSS-support, ignoring '%s' flag\n", *argv);
+            argc--;
+            argv++;
         }
 #endif
 #ifdef USEAPI_ALSA
-        else if (!strcmp(*argv, "-alsa"))
+        else if(!strcmp(*argv, "-alsa"))
         {
             as.a_api = API_ALSA;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-alsaadd"))
+        else if(!strcmp(*argv, "-alsaadd"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
             as.a_api = API_ALSA;
             alsa_adddev(argv[1]);
-            argc -= 2; argv +=2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-alsamidi"))
+        else if(!strcmp(*argv, "-alsamidi"))
         {
             sys_set_midi_api(API_ALSA);
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if ((!strcmp(*argv, "-alsa")) || (!strcmp(*argv, "-alsamidi")))
+        else if((!strcmp(*argv, "-alsa")) || (!strcmp(*argv, "-alsamidi")))
         {
-            fprintf(stderr, "Pd compiled without ALSA-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without ALSA-support, ignoring '%s' flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-alsaadd"))
+        else if(!strcmp(*argv, "-alsaadd"))
         {
-            if (argc < 2)
-                goto usage;
-            fprintf(stderr, "Pd compiled without ALSA-support, ignoring '%s' flag\n", *argv);
-            argc -= 2; argv +=2;
+            if(argc < 2) goto usage;
+            fprintf(stderr,
+                "Pd compiled without ALSA-support, ignoring '%s' flag\n",
+                *argv);
+            argc -= 2;
+            argv += 2;
         }
 #endif
 #ifdef USEAPI_JACK
-        else if (!strcmp(*argv, "-jack"))
+        else if(!strcmp(*argv, "-jack"))
         {
             as.a_api = API_JACK;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nojackconnect"))
+        else if(!strcmp(*argv, "-nojackconnect"))
         {
             as.a_api = API_JACK;
             jack_autoconnect(0);
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-jackconnect"))
+        else if(!strcmp(*argv, "-jackconnect"))
         {
             as.a_api = API_JACK;
             jack_autoconnect(1);
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-jackname"))
+        else if(!strcmp(*argv, "-jackname"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
             as.a_api = API_JACK;
             jack_client_name(argv[1]);
-            argc -= 2; argv +=2;
+            argc -= 2;
+            argv += 2;
         }
 #else
-        else if ((!strcmp(*argv, "-jack"))
-            || (!strcmp(*argv, "-jackconnect"))
-            || (!strcmp(*argv, "-nojackconnect")))
+        else if((!strcmp(*argv, "-jack")) || (!strcmp(*argv, "-jackconnect")) ||
+                (!strcmp(*argv, "-nojackconnect")))
         {
-            fprintf(stderr, "Pd compiled without JACK-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without JACK-support, ignoring '%s' flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-jackname"))
+        else if(!strcmp(*argv, "-jackname"))
         {
-            if (argc < 2)
-                goto usage;
-            fprintf(stderr, "Pd compiled without JACK-support, ignoring '%s' flag\n", *argv);
-            argc -= 2; argv +=2;
+            if(argc < 2) goto usage;
+            fprintf(stderr,
+                "Pd compiled without JACK-support, ignoring '%s' flag\n",
+                *argv);
+            argc -= 2;
+            argv += 2;
         }
 #endif
 #ifdef USEAPI_PORTAUDIO
-        else if (!strcmp(*argv, "-pa") || !strcmp(*argv, "-portaudio")
-            || !strcmp(*argv, "-asio"))
+        else if(!strcmp(*argv, "-pa") || !strcmp(*argv, "-portaudio") ||
+                !strcmp(*argv, "-asio"))
         {
             as.a_api = API_PORTAUDIO;
             sys_mmio = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if ((!strcmp(*argv, "-pa")) || (!strcmp(*argv, "-portaudio")))
+        else if((!strcmp(*argv, "-pa")) || (!strcmp(*argv, "-portaudio")))
         {
-            fprintf(stderr, "Pd compiled without PortAudio-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without PortAudio-support, ignoring '%s' flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-asio"))
+        else if(!strcmp(*argv, "-asio"))
         {
-            fprintf(stderr, "Pd compiled without ASIO-support, ignoring '%s' flag\n", *argv);
-            argc -= 2; argv +=2;
+            fprintf(stderr,
+                "Pd compiled without ASIO-support, ignoring '%s' flag\n",
+                *argv);
+            argc -= 2;
+            argv += 2;
         }
 #endif
 #ifdef USEAPI_MMIO
-        else if (!strcmp(*argv, "-mmio"))
+        else if(!strcmp(*argv, "-mmio"))
         {
             as.a_api = API_MMIO;
             sys_mmio = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if (!strcmp(*argv, "-mmio"))
+        else if(!strcmp(*argv, "-mmio"))
         {
-            fprintf(stderr, "Pd compiled without MMIO-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without MMIO-support, ignoring '%s' flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
 #endif
 #ifdef USEAPI_AUDIOUNIT
-        else if (!strcmp(*argv, "-audiounit"))
+        else if(!strcmp(*argv, "-audiounit"))
         {
             as.a_api = API_AUDIOUNIT;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if (!strcmp(*argv, "-audiounit"))
+        else if(!strcmp(*argv, "-audiounit"))
         {
-            fprintf(stderr, "Pd compiled without AudioUnit-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without AudioUnit-support, ignoring '%s' flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
 #endif
 #ifdef USEAPI_ESD
-        else if (!strcmp(*argv, "-esd"))
+        else if(!strcmp(*argv, "-esd"))
         {
             as.a_api = API_ESD;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if (!strcmp(*argv, "-esd"))
+        else if(!strcmp(*argv, "-esd"))
         {
-            fprintf(stderr, "Pd compiled without ESD-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without ESD-support, ignoring '%s' flag\n", *argv);
+            argc--;
+            argv++;
         }
 #endif
-        else if (!strcmp(*argv, "-listdev"))
+        else if(!strcmp(*argv, "-listdev"))
         {
             sys_listplease = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-soundindev") ||
-            !strcmp(*argv, "-audioindev"))
+        else if(!strcmp(*argv, "-soundindev") || !strcmp(*argv, "-audioindev"))
         {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_nindev, as.a_indevvec,
-                    MAXAUDIOINDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(*argv, "-soundoutdev") ||
-            !strcmp(*argv, "-audiooutdev"))
-        {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_noutdev, as.a_outdevvec,
-                    MAXAUDIOOUTDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if ((!strcmp(*argv, "-sounddev") || !strcmp(*argv, "-audiodev")))
-        {
-            if (argc < 2 ||
-                !sys_parsedevlist(&as.a_nindev, as.a_indevvec,
-                    MAXAUDIOINDEV, argv[1]) ||
-                !sys_parsedevlist(&as.a_noutdev, as.a_outdevvec,
-                    MAXAUDIOOUTDEV, argv[1]))
-                        goto usage;
-            argc -= 2; argv += 2;
-        }
-        else if (!strcmp(*argv, "-audioaddindev"))
-        {
-            if (argc < 2)
+            if(argc < 2 || !sys_parsedevlist(&as.a_nindev, as.a_indevvec,
+                               MAXAUDIOINDEV, argv[1]))
                 goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if(!strcmp(*argv, "-soundoutdev") ||
+                !strcmp(*argv, "-audiooutdev"))
+        {
+            if(argc < 2 || !sys_parsedevlist(&as.a_noutdev, as.a_outdevvec,
+                               MAXAUDIOOUTDEV, argv[1]))
+                goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if((!strcmp(*argv, "-sounddev") || !strcmp(*argv, "-audiodev")))
+        {
+            if(argc < 2 ||
+                !sys_parsedevlist(
+                    &as.a_nindev, as.a_indevvec, MAXAUDIOINDEV, argv[1]) ||
+                !sys_parsedevlist(
+                    &as.a_noutdev, as.a_outdevvec, MAXAUDIOOUTDEV, argv[1]))
+                goto usage;
+            argc -= 2;
+            argv += 2;
+        }
+        else if(!strcmp(*argv, "-audioaddindev"))
+        {
+            if(argc < 2) goto usage;
 
-            if (as.a_nindev < 0)
-                as.a_nindev = 0;
-            if (as.a_nindev < MAXAUDIOINDEV)
+            if(as.a_nindev < 0) as.a_nindev = 0;
+            if(as.a_nindev < MAXAUDIOINDEV)
             {
                 int devn = sys_audiodevnametonumber(0, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find audio input device: %s\n",
                         argv[1]);
-                else as.a_indevvec[as.a_nindev++] = devn + 1;
+                else
+                    as.a_indevvec[as.a_nindev++] = devn + 1;
             }
-            else fprintf(stderr, "number of audio devices limited to %d\n",
-                MAXAUDIOINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of audio devices limited to %d\n",
+                    MAXAUDIOINDEV);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-audioaddoutdev"))
+        else if(!strcmp(*argv, "-audioaddoutdev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (as.a_noutdev < 0)
-                as.a_noutdev = 0;
-            if (as.a_noutdev < MAXAUDIOINDEV)
+            if(as.a_noutdev < 0) as.a_noutdev = 0;
+            if(as.a_noutdev < MAXAUDIOINDEV)
             {
                 int devn = sys_audiodevnametonumber(1, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find audio output device: %s\n",
                         argv[1]);
-                else as.a_outdevvec[as.a_noutdev++] = devn + 1;
+                else
+                    as.a_outdevvec[as.a_noutdev++] = devn + 1;
             }
-            else fprintf(stderr, "number of audio devices limited to %d\n",
-                MAXAUDIOINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of audio devices limited to %d\n",
+                    MAXAUDIOINDEV);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-audioadddev"))
+        else if(!strcmp(*argv, "-audioadddev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (as.a_nindev < 0)
-                as.a_nindev = 0;
-            if (as.a_noutdev < 0)
-                as.a_noutdev = 0;
-            if (as.a_nindev < MAXAUDIOINDEV && as.a_noutdev < MAXAUDIOINDEV)
+            if(as.a_nindev < 0) as.a_nindev = 0;
+            if(as.a_noutdev < 0) as.a_noutdev = 0;
+            if(as.a_nindev < MAXAUDIOINDEV && as.a_noutdev < MAXAUDIOINDEV)
             {
                 int devn = sys_audiodevnametonumber(0, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find audio input device: %s\n",
                         argv[1]);
-                else as.a_indevvec[as.a_nindev++] = devn + 1;
+                else
+                    as.a_indevvec[as.a_nindev++] = devn + 1;
                 devn = sys_audiodevnametonumber(1, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find audio output device: %s\n",
                         argv[1]);
-                else as.a_outdevvec[as.a_noutdev++] = devn + 1;
+                else
+                    as.a_outdevvec[as.a_noutdev++] = devn + 1;
             }
-            else fprintf(stderr, "number of audio devices limited to %d",
-                MAXAUDIOINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of audio devices limited to %d",
+                    MAXAUDIOINDEV);
+            argc -= 2;
+            argv += 2;
         }
-                /* MIDI flags */
-        else if (!strcmp(*argv, "-nomidiin"))
+        /* MIDI flags */
+        else if(!strcmp(*argv, "-nomidiin"))
         {
             sys_nmidiin = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nomidiout"))
+        else if(!strcmp(*argv, "-nomidiout"))
         {
             sys_nmidiout = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nomidi"))
+        else if(!strcmp(*argv, "-nomidi"))
         {
             sys_nmidiin = sys_nmidiout = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-midiindev"))
+        else if(!strcmp(*argv, "-midiindev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            sys_parsedevlist(&sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV,
-                argv[1]);
-            if (!sys_nmidiin)
-                goto usage;
-            argc -= 2; argv += 2;
+            sys_parsedevlist(
+                &sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV, argv[1]);
+            if(!sys_nmidiin) goto usage;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-midioutdev"))
+        else if(!strcmp(*argv, "-midioutdev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            sys_parsedevlist(&sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV,
-                argv[1]);
-            if (!sys_nmidiout)
-                goto usage;
-            argc -= 2; argv += 2;
+            sys_parsedevlist(
+                &sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV, argv[1]);
+            if(!sys_nmidiout) goto usage;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-mididev"))
+        else if(!strcmp(*argv, "-mididev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            sys_parsedevlist(&sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV,
-                argv[1]);
-            sys_parsedevlist(&sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV,
-                argv[1]);
-            if (!sys_nmidiout)
-                goto usage;
-            argc -= 2; argv += 2;
+            sys_parsedevlist(
+                &sys_nmidiin, sys_midiindevlist, MAXMIDIINDEV, argv[1]);
+            sys_parsedevlist(
+                &sys_nmidiout, sys_midioutdevlist, MAXMIDIOUTDEV, argv[1]);
+            if(!sys_nmidiout) goto usage;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-midiaddindev"))
+        else if(!strcmp(*argv, "-midiaddindev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (sys_nmidiin < 0)
-                sys_nmidiin = 0;
-            if (sys_nmidiin < MAXMIDIINDEV)
+            if(sys_nmidiin < 0) sys_nmidiin = 0;
+            if(sys_nmidiin < MAXMIDIINDEV)
             {
                 int devn = sys_mididevnametonumber(0, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find MIDI input device: %s\n",
                         argv[1]);
-                else sys_midiindevlist[sys_nmidiin++] = devn + 1;
+                else
+                    sys_midiindevlist[sys_nmidiin++] = devn + 1;
             }
-            else fprintf(stderr, "number of MIDI devices limited to %d\n",
-                MAXMIDIINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of MIDI devices limited to %d\n",
+                    MAXMIDIINDEV);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-midiaddoutdev"))
+        else if(!strcmp(*argv, "-midiaddoutdev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (sys_nmidiout < 0)
-                sys_nmidiout = 0;
-            if (sys_nmidiout < MAXMIDIINDEV)
+            if(sys_nmidiout < 0) sys_nmidiout = 0;
+            if(sys_nmidiout < MAXMIDIINDEV)
             {
                 int devn = sys_mididevnametonumber(1, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
-                else sys_midioutdevlist[sys_nmidiout++] = devn + 1;
+                else
+                    sys_midioutdevlist[sys_nmidiout++] = devn + 1;
             }
-            else fprintf(stderr, "number of MIDI devices limited to %d\n",
-                MAXMIDIINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of MIDI devices limited to %d\n",
+                    MAXMIDIINDEV);
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-midiadddev"))
+        else if(!strcmp(*argv, "-midiadddev"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (sys_nmidiin < 0)
-                sys_nmidiin = 0;
-            if (sys_nmidiout < 0)
-                sys_nmidiout = 0;
-            if (sys_nmidiin < MAXMIDIINDEV && sys_nmidiout < MAXMIDIINDEV)
+            if(sys_nmidiin < 0) sys_nmidiin = 0;
+            if(sys_nmidiout < 0) sys_nmidiout = 0;
+            if(sys_nmidiin < MAXMIDIINDEV && sys_nmidiout < MAXMIDIINDEV)
             {
                 int devn = sys_mididevnametonumber(1, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
-                else sys_midioutdevlist[sys_nmidiin++] = devn + 1;
+                else
+                    sys_midioutdevlist[sys_nmidiin++] = devn + 1;
                 devn = sys_mididevnametonumber(1, argv[1]);
-                if (devn < 0)
+                if(devn < 0)
                     fprintf(stderr, "Couldn't find MIDI output device: %s\n",
                         argv[1]);
-                else sys_midioutdevlist[sys_nmidiout++] = devn + 1;
+                else
+                    sys_midioutdevlist[sys_nmidiout++] = devn + 1;
             }
-            else fprintf(stderr, "number of MIDI devices limited to %d",
-                MAXMIDIINDEV);
-            argc -= 2; argv += 2;
+            else
+                fprintf(stderr, "number of MIDI devices limited to %d",
+                    MAXMIDIINDEV);
+            argc -= 2;
+            argv += 2;
         }
-                /* other flags */
-        else if (!strcmp(*argv, "-path"))
+        /* other flags */
+        else if(!strcmp(*argv, "-path"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
             STUFF->st_temppath =
                 namelist_append_files(STUFF->st_temppath, argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-nostdpath"))
+        else if(!strcmp(*argv, "-nostdpath"))
         {
             sys_usestdpath = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-stdpath"))
+        else if(!strcmp(*argv, "-stdpath"))
         {
             sys_usestdpath = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-helppath"))
+        else if(!strcmp(*argv, "-helppath"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
             STUFF->st_helppath =
                 namelist_append_files(STUFF->st_helppath, argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-open"))
+        else if(!strcmp(*argv, "-open"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_openlist = namelist_append_files(sys_openlist, argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-lib"))
+        else if(!strcmp(*argv, "-lib"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             STUFF->st_externlist =
                 namelist_append_files(STUFF->st_externlist, argv[1]);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if ((!strcmp(*argv, "-font-size") || !strcmp(*argv, "-font")))
+        else if((!strcmp(*argv, "-font-size") || !strcmp(*argv, "-font")))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_defaultfont = sys_nearestfontsize(atoi(argv[1]));
             argc -= 2;
             argv += 2;
         }
-        else if ((!strcmp(*argv, "-font-face") || !strcmp(*argv, "-typeface")))
+        else if((!strcmp(*argv, "-font-face") || !strcmp(*argv, "-typeface")))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            strncpy(sys_font,*(argv+1),sizeof(sys_font)-1);
-            sys_font[sizeof(sys_font)-1] = 0;
+            strncpy(sys_font, *(argv + 1), sizeof(sys_font) - 1);
+            sys_font[sizeof(sys_font) - 1] = 0;
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-font-weight"))
+        else if(!strcmp(*argv, "-font-weight"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            strncpy(sys_fontweight,*(argv+1),sizeof(sys_fontweight)-1);
-            sys_fontweight[sizeof(sys_fontweight)-1] = 0;
+            strncpy(sys_fontweight, *(argv + 1), sizeof(sys_fontweight) - 1);
+            sys_fontweight[sizeof(sys_fontweight) - 1] = 0;
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-verbose"))
+        else if(!strcmp(*argv, "-verbose"))
         {
             sys_verbose++;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-noverbose"))
+        else if(!strcmp(*argv, "-noverbose"))
         {
-            sys_verbose=0;
-            argc--; argv++;
+            sys_verbose = 0;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-version"))
+        else if(!strcmp(*argv, "-version"))
         {
             sys_version = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-d") && argc > 1 &&
-            sscanf(argv[1], "%d", &sys_debuglevel) >= 1)
+        else if(!strcmp(*argv, "-d") && argc > 1 &&
+                sscanf(argv[1], "%d", &sys_debuglevel) >= 1)
         {
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-loadbang"))
+        else if(!strcmp(*argv, "-loadbang"))
         {
             sys_noloadbang = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-noloadbang"))
+        else if(!strcmp(*argv, "-noloadbang"))
         {
             sys_noloadbang = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-gui"))
+        else if(!strcmp(*argv, "-gui"))
         {
             sys_dontstartgui = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nogui"))
+        else if(!strcmp(*argv, "-nogui"))
         {
             sys_dontstartgui = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-guiport") && argc > 1 &&
-            sscanf(argv[1], "%d", &sys_guisetportnumber) >= 1)
+        else if(!strcmp(*argv, "-guiport") && argc > 1 &&
+                sscanf(argv[1], "%d", &sys_guisetportnumber) >= 1)
         {
             argc -= 2;
             argv += 2;
         }
-        else if (!strcmp(*argv, "-nostderr"))
+        else if(!strcmp(*argv, "-nostderr"))
         {
             sys_printtostderr = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-stderr"))
+        else if(!strcmp(*argv, "-stderr"))
         {
             sys_printtostderr = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-guicmd"))
+        else if(!strcmp(*argv, "-guicmd"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_guicmd = argv[1];
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-send"))
+        else if(!strcmp(*argv, "-send"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_messagelist = namelist_append(sys_messagelist, argv[1], 1);
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(*argv, "-schedlib"))
+        else if(!strcmp(*argv, "-schedlib"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_externalschedlib = 1;
             strncpy(sys_externalschedlibname, argv[1],
                 sizeof(sys_externalschedlibname) - 1);
-#ifndef  __APPLE__
-                /* no audio I/O please, unless overwritten by later args.
-                This is to circumvent a problem running pd~ subprocesses
-                with -nogui; they would open an audio device before pdsched.c
-                could set the API to nothing.  For some reason though, on
-                MACOSX this causes Pd to switch to JACK so we just give up
-                and suppress the workaround there. */
+#ifndef __APPLE__
+            /* no audio I/O please, unless overwritten by later args.
+            This is to circumvent a problem running pd~ subprocesses
+            with -nogui; they would open an audio device before pdsched.c
+            could set the API to nothing.  For some reason though, on
+            MACOSX this causes Pd to switch to JACK so we just give up
+            and suppress the workaround there. */
             as.a_api = 0;
 #endif
             argv += 2;
             argc -= 2;
         }
-        else if (!strcmp(*argv, "-extraflags"))
+        else if(!strcmp(*argv, "-extraflags"))
         {
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
             sys_extraflags = 1;
             strncpy(sys_extraflagsstring, argv[1],
@@ -1277,72 +1349,83 @@ int sys_argparse(int argc, const char **argv)
             argv += 2;
             argc -= 2;
         }
-        else if (!strcmp(*argv, "-batch"))
+        else if(!strcmp(*argv, "-batch"))
         {
             sys_batch = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nobatch"))
+        else if(!strcmp(*argv, "-nobatch"))
         {
             sys_batch = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-autopatch"))
+        else if(!strcmp(*argv, "-autopatch"))
         {
             sys_noautopatch = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-noautopatch"))
+        else if(!strcmp(*argv, "-noautopatch"))
         {
             sys_noautopatch = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-compatibility"))
+        else if(!strcmp(*argv, "-compatibility"))
         {
             float f;
-            if (argc < 2)
-                goto usage;
+            if(argc < 2) goto usage;
 
-            if (sscanf(argv[1], "%f", &f) < 1)
-                goto usage;
+            if(sscanf(argv[1], "%f", &f) < 1) goto usage;
             pd_compatibilitylevel = 0.5 + 100. * f; /* e.g., 2.44 --> 244 */
             argv += 2;
             argc -= 2;
         }
 #ifdef HAVE_UNISTD_H
-        else if (!strcmp(*argv, "-rt") || !strcmp(*argv, "-realtime"))
+        else if(!strcmp(*argv, "-rt") || !strcmp(*argv, "-realtime"))
         {
             sys_hipriority = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort") || !strcmp(*argv, "-norealtime"))
+        else if(!strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort") ||
+                !strcmp(*argv, "-norealtime"))
         {
             sys_hipriority = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
 #else
-        else if (!strcmp(*argv, "-rt") || !strcmp(*argv, "-realtime")
-                 || !strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort")
-                 || !strcmp(*argv, "-norealtime"))
+        else if(!strcmp(*argv, "-rt") || !strcmp(*argv, "-realtime") ||
+                !strcmp(*argv, "-nrt") || !strcmp(*argv, "-nort") ||
+                !strcmp(*argv, "-norealtime"))
         {
-            fprintf(stderr, "Pd compiled without realtime priority-support, ignoring '%s' flag\n", *argv);
-            argc--; argv++;
+            fprintf(stderr,
+                "Pd compiled without realtime priority-support, ignoring '%s' "
+                "flag\n",
+                *argv);
+            argc--;
+            argv++;
         }
 #endif
-        else if (!strcmp(*argv, "-sleep"))
+        else if(!strcmp(*argv, "-sleep"))
         {
             sys_nosleep = 0;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-nosleep"))
+        else if(!strcmp(*argv, "-nosleep"))
         {
             sys_nosleep = 1;
-            argc--; argv++;
+            argc--;
+            argv++;
         }
-        else if (!strcmp(*argv, "-noprefs")) /* did this earlier */
+        else if(!strcmp(*argv, "-noprefs")) /* did this earlier */
             argc--, argv++;
-        else if (!strcmp(*argv, "-prefsfile") && argc > 1) /* this too */
-            argc -= 2, argv +=2;
+        else if(!strcmp(*argv, "-prefsfile") && argc > 1) /* this too */
+            argc -= 2, argv += 2;
         else
         {
         usage:
@@ -1350,34 +1433,27 @@ int sys_argparse(int argc, const char **argv)
             return (1);
         }
     }
-    if (sys_batch)
-        sys_dontstartgui = 1;
-    if (sys_dontstartgui)
-        sys_printtostderr = 1;
+    if(sys_batch) sys_dontstartgui = 1;
+    if(sys_dontstartgui) sys_printtostderr = 1;
 #ifdef _WIN32
-    if (sys_printtostderr)
-        /* we need to tell Windows to output UTF-8 */
+    if(sys_printtostderr) /* we need to tell Windows to output UTF-8 */
         SetConsoleOutputCP(CP_UTF8);
 #endif
-    if (!sys_defaultfont)
-        sys_defaultfont = DEFAULTFONT;
-    for (; argc > 0; argc--, argv++)
+    if(!sys_defaultfont) sys_defaultfont = DEFAULTFONT;
+    for(; argc > 0; argc--, argv++)
         sys_openlist = namelist_append_files(sys_openlist, *argv);
 
     sys_set_audio_settings(&as);
     return (0);
 }
 
-int sys_getblksize(void)
-{
-    return (DEFDACBLKSIZE);
-}
+int sys_getblksize(void) { return (DEFDACBLKSIZE); }
 
 void sys_init_audio(void);
 
-    /* stuff to do, once, after calling sys_argparse() -- which may itself
-    be called more than once (first from "settings, second from .pdrc, then
-    from command-line arguments */
+/* stuff to do, once, after calling sys_argparse() -- which may itself
+be called more than once (first from "settings, second from .pdrc, then
+from command-line arguments */
 static void sys_afterargparse(void)
 {
     char sbuf[MAXPDSTRING];
@@ -1385,36 +1461,35 @@ static void sys_afterargparse(void)
     t_audiosettings as;
     int nmidiindev = 0, midiindev[MAXMIDIINDEV];
     int nmidioutdev = 0, midioutdev[MAXMIDIOUTDEV];
-            /* add "extra" library to path */
-    strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING-30);
-    sbuf[MAXPDSTRING-30] = 0;
+    /* add "extra" library to path */
+    strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING - 30);
+    sbuf[MAXPDSTRING - 30] = 0;
     strcat(sbuf, "/extra");
     sys_setextrapath(sbuf);
-            /* add "doc/5.reference" library to helppath */
-    strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING-30);
-    sbuf[MAXPDSTRING-30] = 0;
+    /* add "doc/5.reference" library to helppath */
+    strncpy(sbuf, sys_libdir->s_name, MAXPDSTRING - 30);
+    sbuf[MAXPDSTRING - 30] = 0;
     strcat(sbuf, "/doc/5.reference");
     STUFF->st_helppath = namelist_append_files(STUFF->st_helppath, sbuf);
 
-    for (i = 0; i < sys_nmidiin; i++)
+    for(i = 0; i < sys_nmidiin; i++)
         sys_midiindevlist[i]--;
-    for (i = 0; i < sys_nmidiout; i++)
+    for(i = 0; i < sys_nmidiout; i++)
         sys_midioutdevlist[i]--;
 
-    if (sys_listplease)
-        sys_listdevs();
+    if(sys_listplease) sys_listdevs();
 
     sys_get_midi_params(&nmidiindev, midiindev, &nmidioutdev, midioutdev);
-    if (sys_nmidiin >= 0)
+    if(sys_nmidiin >= 0)
     {
         nmidiindev = sys_nmidiin;
-        for (i = 0; i < nmidiindev; i++)
+        for(i = 0; i < nmidiindev; i++)
             midiindev[i] = sys_midiindevlist[i];
     }
-    if (sys_nmidiout >= 0)
+    if(sys_nmidiout >= 0)
     {
         nmidioutdev = sys_nmidiout;
-        for (i = 0; i < nmidioutdev; i++)
+        for(i = 0; i < nmidioutdev; i++)
             midioutdev[i] = sys_midioutdevlist[i];
     }
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 0);
@@ -1422,39 +1497,36 @@ static void sys_afterargparse(void)
     sys_init_audio();
 }
 
-static void sys_addreferencepath(void)
-{
-    char sbuf[MAXPDSTRING];
-}
+static void sys_addreferencepath(void) { char sbuf[MAXPDSTRING]; }
 
 int sys_argparse(int argc, const char **argv);
-static int string2args(const char * cmd, int * retArgc, const char *** retArgv);
+static int string2args(const char *cmd, int *retArgc, const char ***retArgv);
 
 void sys_doflags(void)
 {
-    int rcargc=0;
-    const char**rcargv = NULL;
+    int rcargc = 0;
+    const char **rcargv = NULL;
     int len;
     int rcode = 0;
-    if (!sys_flags)
-        sys_flags = &s_;
-    len = (int)strlen(sys_flags->s_name);
-    if (len > MAXPDSTRING)
+    if(!sys_flags) sys_flags = &s_;
+    len = (int) strlen(sys_flags->s_name);
+    if(len > MAXPDSTRING)
     {
         pd_error(0, "flags: %s: too long", sys_flags->s_name);
         return;
     }
     rcode = string2args(sys_flags->s_name, &rcargc, &rcargv);
-    if(rcode < 0) {
+    if(rcode < 0)
+    {
         pd_error(0, "error#%d while parsing flags", rcode);
         return;
     }
 
-    if (sys_argparse(rcargc, rcargv))
+    if(sys_argparse(rcargc, rcargv))
         pd_error(0, "error parsing startup arguments");
 
-    for(len=0; len<rcargc; len++)
-        free((void*)rcargv[len]);
+    for(len = 0; len < rcargc; len++)
+        free((void *) rcargv[len]);
     free(rcargv);
 }
 
@@ -1465,80 +1537,83 @@ t_symbol *sys_decodedialog(t_symbol *s)
     char buf[MAXPDSTRING];
     const char *sp = s->s_name;
     int i;
-    if (*sp != '+')
+    if(*sp != '+')
         bug("sys_decodedialog: %s", sp);
-    else sp++;
-    for (i = 0; i < MAXPDSTRING-1; i++, sp++)
+    else
+        sp++;
+    for(i = 0; i < MAXPDSTRING - 1; i++, sp++)
     {
-        if (!sp[0])
-            break;
-        if (sp[0] == '+')
+        if(!sp[0]) break;
+        if(sp[0] == '+')
         {
-            if (sp[1] == '_')
+            if(sp[1] == '_')
                 buf[i] = ' ', sp++;
-            else if (sp[1] == '+')
+            else if(sp[1] == '+')
                 buf[i] = '+', sp++;
-            else if (sp[1] == 'c')
+            else if(sp[1] == 'c')
                 buf[i] = ',', sp++;
-            else if (sp[1] == 's')
+            else if(sp[1] == 's')
                 buf[i] = ';', sp++;
-            else if (sp[1] == 'd')
+            else if(sp[1] == 'd')
                 buf[i] = '$', sp++;
-            else buf[i] = sp[0];
+            else
+                buf[i] = sp[0];
         }
-        else buf[i] = sp[0];
+        else
+            buf[i] = sp[0];
     }
     buf[i] = 0;
     return (gensym(buf));
 }
 
-    /* send the user-specified search path to pd-gui */
+/* send the user-specified search path to pd-gui */
 void sys_set_searchpath(void)
 {
     int i;
     t_namelist *nl;
 
     sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_searchpath, i = 0; nl; nl = nl->nl_next, i++)
+    for(nl = STUFF->st_searchpath, i = 0; nl; nl = nl->nl_next, i++)
         sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
     sys_gui("set ::sys_searchpath $::tmp_path\n");
 }
 
-    /* send the temp paths from the commandline to pd-gui */
+/* send the temp paths from the commandline to pd-gui */
 void sys_set_temppath(void)
 {
     int i;
     t_namelist *nl;
 
     sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_temppath, i = 0; nl; nl = nl->nl_next, i++)
+    for(nl = STUFF->st_temppath, i = 0; nl; nl = nl->nl_next, i++)
         sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
     sys_gui("set ::sys_temppath $::tmp_path\n");
 }
 
-    /* send the hard-coded search path to pd-gui */
+/* send the hard-coded search path to pd-gui */
 void sys_set_extrapath(void)
 {
     int i;
     t_namelist *nl;
 
     sys_gui("set ::tmp_path {}\n");
-    for (nl = STUFF->st_staticpath, i = 0; nl; nl = nl->nl_next, i++)
+    for(nl = STUFF->st_staticpath, i = 0; nl; nl = nl->nl_next, i++)
         sys_vgui("lappend ::tmp_path {%s}\n", nl->nl_string);
     sys_gui("set ::sys_staticpath $::tmp_path\n");
 }
 
-    /* start a search path dialog window */
+/* start a search path dialog window */
 void glob_start_path_dialog(t_pd *dummy)
 {
-     char buf[MAXPDSTRING];
+    char buf[MAXPDSTRING];
 
     sys_set_searchpath();
-    snprintf(buf, MAXPDSTRING-1, "pdtk_path_dialog %%s %d %d\n", sys_usestdpath, sys_verbose);
-    gfxstub_new(&glob_pdobject, (void *)glob_start_path_dialog, buf);
+    snprintf(buf, MAXPDSTRING - 1, "pdtk_path_dialog %%s %d %d\n",
+        sys_usestdpath, sys_verbose);
+    gfxstub_new(&glob_pdobject, (void *) glob_start_path_dialog, buf);
 }
 
-    /* new values from dialog window */
+/* new values from dialog window */
 void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
@@ -1546,36 +1621,35 @@ void glob_path_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     STUFF->st_searchpath = 0;
     sys_usestdpath = atom_getfloatarg(0, argc, argv);
     sys_verbose = atom_getfloatarg(1, argc, argv);
-    for (i = 0; i < argc-2; i++)
+    for(i = 0; i < argc - 2; i++)
     {
-        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
-        if (*s->s_name)
+        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
+        if(*s->s_name)
             STUFF->st_searchpath =
                 namelist_append_files(STUFF->st_searchpath, s->s_name);
     }
 }
 
-    /* add one item to search path (intended for use by Deken plugin).
-    if "saveit" is > 0, this also saves all settings,
-    if "saveit" is < 0, the path is only added temporarily */
+/* add one item to search path (intended for use by Deken plugin).
+if "saveit" is > 0, this also saves all settings,
+if "saveit" is < 0, the path is only added temporarily */
 void glob_addtopath(t_pd *dummy, t_symbol *path, t_float saveit)
 {
-    int saveflag = (int)saveit;
+    int saveflag = (int) saveit;
     t_symbol *s = sys_decodedialog(path);
-    if (*s->s_name)
+    if(*s->s_name)
     {
-        if (saveflag < 0)
+        if(saveflag < 0)
             STUFF->st_temppath =
                 namelist_append_files(STUFF->st_temppath, s->s_name);
         else
             STUFF->st_searchpath =
                 namelist_append_files(STUFF->st_searchpath, s->s_name);
-        if (saveit > 0)
-            sys_savepreferences(0);
+        if(saveit > 0) sys_savepreferences(0);
     }
 }
 
-    /* set the global list vars for startup libraries and flags */
+/* set the global list vars for startup libraries and flags */
 void sys_set_startup(void)
 {
     int i;
@@ -1583,24 +1657,27 @@ void sys_set_startup(void)
     char obuf[MAXPDSTRING];
 
     sys_vgui("set ::startup_flags [subst -nocommands {%s}]\n",
-        (sys_flags? pdgui_strnescape(obuf, MAXPDSTRING, sys_flags->s_name, 0) : ""));
+        (sys_flags ? pdgui_strnescape(obuf, MAXPDSTRING, sys_flags->s_name, 0)
+                   : ""));
     sys_gui("set ::startup_libraries {}\n");
-    for (nl = STUFF->st_externlist, i = 0; nl; nl = nl->nl_next, i++)
+    for(nl = STUFF->st_externlist, i = 0; nl; nl = nl->nl_next, i++)
         sys_vgui("lappend ::startup_libraries {%s}\n", nl->nl_string);
 }
 
-    /* start a startup dialog window */
+/* start a startup dialog window */
 void glob_start_startup_dialog(t_pd *dummy)
 {
     char buf[MAXPDSTRING];
     char obuf[MAXPDSTRING];
     sys_set_startup();
-    snprintf(buf, MAXPDSTRING-1, "pdtk_startup_dialog %%s %d {%s}\n", sys_defeatrt,
-        (sys_flags? pdgui_strnescape(obuf, MAXPDSTRING, sys_flags->s_name, 0) : ""));
-    gfxstub_new(&glob_pdobject, (void *)glob_start_startup_dialog, buf);
+    snprintf(buf, MAXPDSTRING - 1, "pdtk_startup_dialog %%s %d {%s}\n",
+        sys_defeatrt,
+        (sys_flags ? pdgui_strnescape(obuf, MAXPDSTRING, sys_flags->s_name, 0)
+                   : ""));
+    gfxstub_new(&glob_pdobject, (void *) glob_start_startup_dialog, buf);
 }
 
-    /* new values from dialog window */
+/* new values from dialog window */
 void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
@@ -1608,24 +1685,24 @@ void glob_startup_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     STUFF->st_externlist = 0;
     sys_defeatrt = atom_getfloatarg(0, argc, argv);
     sys_flags = sys_decodedialog(atom_getsymbolarg(1, argc, argv));
-    for (i = 0; i < argc-2; i++)
+    for(i = 0; i < argc - 2; i++)
     {
-        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i+2, argc, argv));
-        if (*s->s_name)
+        t_symbol *s = sys_decodedialog(atom_getsymbolarg(i + 2, argc, argv));
+        if(*s->s_name)
             STUFF->st_externlist =
                 namelist_append_files(STUFF->st_externlist, s->s_name);
     }
 }
 
-
 /*
- * the following string2args function is based on from sash-3.8 (the StandAlone SHell)
- * Copyright (c) 2014 by David I. Bell
- * Permission is granted to use, distribute, or modify this source,
- * provided that this copyright notice remains intact.
+ * the following string2args function is based on from sash-3.8 (the StandAlone
+ * SHell) Copyright (c) 2014 by David I. Bell Permission is granted to use,
+ * distribute, or modify this source, provided that this copyright notice
+ * remains intact.
  */
-#define	isBlank(ch)	(((ch) == ' ') || ((ch) == '\t'))
-int string2args(const char * cmd, int * retArgc, const char *** retArgv)
+#define isBlank(ch) (((ch) == ' ') || ((ch) == '\t'))
+
+int string2args(const char *cmd, int *retArgc, const char ***retArgv)
 {
     int errCode = 1;
     int len = strlen(cmd), argCount = 0;
@@ -1635,97 +1712,123 @@ int string2args(const char * cmd, int * retArgc, const char *** retArgv)
     if(retArgc) *retArgc = 0;
     if(retArgv) *retArgv = NULL;
 
-        /*
-         * Copy the command string into a buffer that we can modify,
-         * reallocating it if necessary.
-         */
-    if(len >= MAXPDSTRING) {
-        errCode = 1; goto ouch;
+    /*
+     * Copy the command string into a buffer that we can modify,
+     * reallocating it if necessary.
+     */
+    if(len >= MAXPDSTRING)
+    {
+        errCode = 1;
+        goto ouch;
     }
     memset(strings, 0, MAXPDSTRING);
     memcpy(strings, cmd, len);
     cp = strings;
 
-        /* Keep parsing the command string as long as there are any arguments left. */
-    while (*cp) {
+    /* Keep parsing the command string as long as there are any arguments left.
+     */
+    while(*cp)
+    {
         const char *cpIn = cp;
         char *cpOut = cp, *argument;
         int quote = '\0';
 
-            /*
-             * Loop over the string collecting the next argument while
-             * looking for quoted strings or quoted characters.
-             */
-        while (*cp) {
+        /*
+         * Loop over the string collecting the next argument while
+         * looking for quoted strings or quoted characters.
+         */
+        while(*cp)
+        {
             int ch = *cp++;
 
-                /* If we are not in a quote and we see a blank then this argument is done. */
-            if (isBlank(ch) && (quote == '\0'))
-                break;
+            /* If we are not in a quote and we see a blank then this argument is
+             * done. */
+            if(isBlank(ch) && (quote == '\0')) break;
 
-                /* If we see a backslash then accept the next character no matter what it is. */
-            if (ch == '\\') {
+            /* If we see a backslash then accept the next character no matter
+             * what it is. */
+            if(ch == '\\')
+            {
                 ch = *cp++;
-                if (ch == '\0') { /* but only if there is a next char */
-                    errCode = 10; goto ouch;
+                if(ch == '\0')
+                { /* but only if there is a next char */
+                    errCode = 10;
+                    goto ouch;
                 }
                 *cpOut++ = ch;
                 continue;
             }
 
-                /* If we were in a quote and we saw the same quote character again then the quote is done. */
-            if (ch == quote) {
+            /* If we were in a quote and we saw the same quote character again
+             * then the quote is done. */
+            if(ch == quote)
+            {
                 quote = '\0';
                 continue;
             }
 
-                /* If we weren't in a quote and we see either type of quote character,
-                 * then remember that we are now inside of a quote. */
-            if ((quote == '\0') && ((ch == '\'') || (ch == '"')))  {
+            /* If we weren't in a quote and we see either type of quote
+             * character, then remember that we are now inside of a quote. */
+            if((quote == '\0') && ((ch == '\'') || (ch == '"')))
+            {
                 quote = ch;
                 continue;
             }
 
-                /* Store the character. */
+            /* Store the character. */
             *cpOut++ = ch;
         }
 
-        if (quote) { /* Unmatched quote character */
-            errCode = 11; goto ouch;
+        if(quote)
+        { /* Unmatched quote character */
+            errCode = 11;
+            goto ouch;
         }
 
-            /*
-             * Null terminate the argument if it had shrunk, and then
-             * skip over all blanks to the next argument, nulling them
-             * out too.
-             */
-        if (cp != cpOut)
-            *cpOut = '\0';
-        while (isBlank(*cp))
+        /*
+         * Null terminate the argument if it had shrunk, and then
+         * skip over all blanks to the next argument, nulling them
+         * out too.
+         */
+        if(cp != cpOut) *cpOut = '\0';
+        while(isBlank(*cp))
             *cp++ = '\0';
 
-        if (!(argument = calloc(1+cpOut-cpIn, 1))) {
-            errCode = 22; goto ouch;
+        if(!(argument = calloc(1 + cpOut - cpIn, 1)))
+        {
+            errCode = 22;
+            goto ouch;
         }
-        memcpy(argument, cpIn, cpOut-cpIn);
+        memcpy(argument, cpIn, cpOut - cpIn);
 
-            /* Now reallocate the argument table to hold the argument, add add it. */
-        if (!(newArgTable = (const char **) realloc(argTable, (sizeof(const char *) * (argCount + 1))))) {
+        /* Now reallocate the argument table to hold the argument, add add it.
+         */
+        if(!(newArgTable = (const char **) realloc(
+                 argTable, (sizeof(const char *) * (argCount + 1)))))
+        {
             free(argument);
-            errCode= 23; goto ouch;
-        } else argTable = newArgTable;
+            errCode = 23;
+            goto ouch;
+        }
+        else
+            argTable = newArgTable;
 
         argTable[argCount] = argument;
 
         argCount++;
     }
 
-        /*
-         * Null terminate the argument list and return it.
-         */
-    if (!(newArgTable = (const char **) realloc(argTable, (sizeof(const char *) * (argCount + 1))))) {
-        errCode = 23; goto ouch;
-    } else argTable = newArgTable;
+    /*
+     * Null terminate the argument list and return it.
+     */
+    if(!(newArgTable = (const char **) realloc(
+             argTable, (sizeof(const char *) * (argCount + 1)))))
+    {
+        errCode = 23;
+        goto ouch;
+    }
+    else
+        argTable = newArgTable;
 
     argTable[argCount] = NULL;
 
@@ -1736,7 +1839,7 @@ int string2args(const char * cmd, int * retArgc, const char *** retArgv)
         free(argTable);
     return argCount;
 
- ouch:
+ouch:
     free(argTable);
     return -errCode;
 }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -318,9 +318,10 @@ void inmidi_polyaftertouch(int portno, int channel, int pitch, int value);
 
 static void sys_dispatchnextmidiin(void)
 {
-    static t_midiparser parser[MAXMIDIINDEV], *parserp;
-    int portno = midi_inqueue[midi_intail].q_portno,
-        byte = midi_inqueue[midi_intail].q_byte1;
+    static t_midiparser parser[MAXMIDIINDEV];
+    static t_midiparser *parserp;
+    int portno = midi_inqueue[midi_intail].q_portno;
+    int byte = midi_inqueue[midi_intail].q_byte1;
     if(!midi_inqueue[midi_intail].q_onebyte) bug("sys_dispatchnextmidiin");
     if(portno < 0 || portno >= MAXMIDIINDEV) bug("sys_dispatchnextmidiin 2");
     parserp = parser + portno;
@@ -368,7 +369,10 @@ static void sys_dispatchnextmidiin(void)
         }
         else
         {
-            int status, chan, byte1, gotbyte1;
+            int status;
+            int chan;
+            int byte1;
+            int gotbyte1;
             /* data byte */
             inmidi_byte(portno, byte);
             status = (parserp->mp_status >= MIDI_SYSEX
@@ -564,7 +568,8 @@ void sys_get_midi_apis(char *buf)
 void sys_get_midi_params(
     int *pnmidiindev, int *pmidiindev, int *pnmidioutdev, int *pmidioutdev)
 {
-    int i, devn;
+    int i;
+    int devn;
     *pnmidiindev = midi_nmidiindev;
     for(i = 0; i < midi_nmidiindev; i++)
     {
@@ -632,16 +637,21 @@ void sys_open_midi(int nmidiindev, int *midiindev, int nmidioutdev,
 /* open midi using whatever parameters were last used */
 void sys_reopen_midi(void)
 {
-    int nmidiindev, midiindev[MAXMIDIINDEV];
-    int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
+    int nmidiindev;
+    int midiindev[MAXMIDIINDEV];
+    int nmidioutdev;
+    int midioutdev[MAXMIDIOUTDEV];
     sys_get_midi_params(&nmidiindev, midiindev, &nmidioutdev, midioutdev);
     sys_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev, 1);
 }
 
 void sys_listmididevs(void)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
 
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
@@ -715,16 +725,35 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 {
     char buf[1024 + 2 * MAXNDEV * (DEVDESCSIZE + 4)];
     /* these are the devices you're using: */
-    int nindev, midiindev[MAXMIDIINDEV];
-    int noutdev, midioutdev[MAXMIDIOUTDEV];
-    int midiindev1, midiindev2, midiindev3, midiindev4, midiindev5, midiindev6,
-        midiindev7, midiindev8, midiindev9, midioutdev1, midioutdev2,
-        midioutdev3, midioutdev4, midioutdev5, midioutdev6, midioutdev7,
-        midioutdev8, midioutdev9;
+    int nindev;
+    int midiindev[MAXMIDIINDEV];
+    int noutdev;
+    int midioutdev[MAXMIDIOUTDEV];
+    int midiindev1;
+    int midiindev2;
+    int midiindev3;
+    int midiindev4;
+    int midiindev5;
+    int midiindev6;
+    int midiindev7;
+    int midiindev8;
+    int midiindev9;
+    int midioutdev1;
+    int midioutdev2;
+    int midioutdev3;
+    int midioutdev4;
+    int midioutdev5;
+    int midioutdev6;
+    int midioutdev7;
+    int midioutdev8;
+    int midioutdev9;
 
     /* these are all the devices on your system: */
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
     char device[MAXPDSTRING];
 
     sys_get_midi_devs(
@@ -790,11 +819,17 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 /* new values from dialog window */
 void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int nmidiindev, midiindev[MAXMIDIINDEV];
-    int nmidioutdev, midioutdev[MAXMIDIOUTDEV];
-    int i, nindev, noutdev;
-    int newmidiindev[9], newmidioutdev[9];
-    int alsadevin, alsadevout;
+    int nmidiindev;
+    int midiindev[MAXMIDIINDEV];
+    int nmidioutdev;
+    int midioutdev[MAXMIDIOUTDEV];
+    int i;
+    int nindev;
+    int noutdev;
+    int newmidiindev[9];
+    int newmidioutdev[9];
+    int alsadevin;
+    int alsadevout;
 
     for(i = 0; i < 9; i++)
     {
@@ -868,8 +903,11 @@ void sys_get_midi_devs(char *indevlist, int *nindevs, char *outdevlist,
 'output' parameter is true, otherwise input device).  Negative on failure. */
 int sys_mididevnametonumber(int output, const char *name)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
 
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
@@ -907,8 +945,11 @@ int sys_mididevnametonumber(int output, const char *name)
 'output' parameter is true, otherwise input device). Empty string on failure. */
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize)
 {
-    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
-    int nindevs = 0, noutdevs = 0, i;
+    char indevlist[MAXNDEV * DEVDESCSIZE];
+    char outdevlist[MAXNDEV * DEVDESCSIZE];
+    int nindevs = 0;
+    int noutdevs = 0;
+    int i;
     if(devno < 0)
     {
         *name = 0;

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* Clock functions (which should move, but where?) and MIDI queueing */
 
@@ -25,33 +25,33 @@
 #include <signal.h>
 
 /* channel voice messages */     /* dec, # */
-#define MIDI_NOTEOFF        0x80 /* 128, 2 */
-#define MIDI_NOTEON         0x90 /* 144, 2 */
+#define MIDI_NOTEOFF 0x80        /* 128, 2 */
+#define MIDI_NOTEON 0x90         /* 144, 2 */
 #define MIDI_POLYAFTERTOUCH 0xa0 /* 160, 2 (aka key pressure) */
-#define MIDI_CONTROLCHANGE  0xb0 /* 176, 2 */
-#define MIDI_PROGRAMCHANGE  0xc0 /* 192, 1 */
-#define MIDI_AFTERTOUCH     0xd0 /* 208, 1 (aka channel pressure) */
-#define MIDI_PITCHBEND      0xe0 /* 224, 2 */
+#define MIDI_CONTROLCHANGE 0xb0  /* 176, 2 */
+#define MIDI_PROGRAMCHANGE 0xc0  /* 192, 1 */
+#define MIDI_AFTERTOUCH 0xd0     /* 208, 1 (aka channel pressure) */
+#define MIDI_PITCHBEND 0xe0      /* 224, 2 */
 
 /* system common messages */
-#define MIDI_SYSEX          0xf0 /* 240, N (until MIDI_SYSEXEND) */
-#define MIDI_TIMECODE       0xf1 /* 241, 1 */
-#define MIDI_SONGPOS        0xf2 /* 242, 2 */
-#define MIDI_SONGSELECT     0xf3 /* 243, 1 */
-#define MIDI_RESERVED1      0xf4 /* 244, ? */
-#define MIDI_RESERVED2      0xf5 /* 245, ? */
-#define MIDI_TUNEREQUEST    0xf6 /* 246, 0 */
-#define MIDI_SYSEXEND       0xf7 /* 247, 0 */
+#define MIDI_SYSEX 0xf0       /* 240, N (until MIDI_SYSEXEND) */
+#define MIDI_TIMECODE 0xf1    /* 241, 1 */
+#define MIDI_SONGPOS 0xf2     /* 242, 2 */
+#define MIDI_SONGSELECT 0xf3  /* 243, 1 */
+#define MIDI_RESERVED1 0xf4   /* 244, ? */
+#define MIDI_RESERVED2 0xf5   /* 245, ? */
+#define MIDI_TUNEREQUEST 0xf6 /* 246, 0 */
+#define MIDI_SYSEXEND 0xf7    /* 247, 0 */
 
 /* realtime messages */
-#define MIDI_CLOCK          0xf8 /* 248, 0 */
+#define MIDI_CLOCK 0xf8 /* 248, 0 */
 //      MIDI_RESERVED3      0xf9 /* 249, ? */
-#define MIDI_START          0xfa /* 250, 0 */
-#define MIDI_CONTINUE       0xfb /* 251, 0 */
-#define MIDI_STOP           0xfc /* 252, 0 */
+#define MIDI_START 0xfa    /* 250, 0 */
+#define MIDI_CONTINUE 0xfb /* 251, 0 */
+#define MIDI_STOP 0xfc     /* 252, 0 */
 //      MIDI_RESERVED4      0xfd /* 253, ? */
-#define MIDI_ACTIVESENSING  0xfe /* 254, 0 */
-#define MIDI_SYSTEMRESET    0xff /* 255, 0 */
+#define MIDI_ACTIVESENSING 0xfe /* 254, 0 */
+#define MIDI_SYSTEMRESET 0xff   /* 255, 0 */
 
 typedef struct _midiqelem
 {
@@ -72,11 +72,10 @@ int midi_inhead, midi_intail;
 static double sys_midiinittime;
 #define API_DEFAULTMIDI 0
 
-#if (defined USEAPI_ALSA) && (defined USEAPI_MIDIDUMMY)
-        /* if the only available MIDI-backend is ALSA, choose that */
-# define FORCEAPI_ALSA
+#if(defined USEAPI_ALSA) && (defined USEAPI_MIDIDUMMY)
+/* if the only available MIDI-backend is ALSA, choose that */
+#define FORCEAPI_ALSA
 #endif
-
 
 int sys_midiapi =
 #ifdef FORCEAPI_ALSA
@@ -86,10 +85,10 @@ int sys_midiapi =
 #endif
     ;
 
-    /* this is our current estimate for at what "system" real time the
-    current logical time's output should occur. */
+/* this is our current estimate for at what "system" real time the
+current logical time's output should occur. */
 static double sys_dactimeminusrealtime;
-    /* same for input, should be scheduler advance earlier. */
+/* same for input, should be scheduler advance earlier. */
 static double sys_adctimeminusrealtime;
 
 static double sys_newdactimeminusrealtime = -1e20;
@@ -102,22 +101,20 @@ void sys_initmidiqueue(void)
     sys_dactimeminusrealtime = sys_adctimeminusrealtime = 0;
 }
 
-    /* this is called from the OS dependent code from time to time when we
-    think we know the delay (outbuftime) in seconds, at which the last-output
-    audio sample will go out the door. */
+/* this is called from the OS dependent code from time to time when we
+think we know the delay (outbuftime) in seconds, at which the last-output
+audio sample will go out the door. */
 static void sys_setmiditimediff(double inbuftime, double outbuftime)
 {
-    double dactimeminusrealtime =
-        .001 * clock_gettimesince(sys_midiinittime)
-            - outbuftime - sys_getrealtime();
-    double adctimeminusrealtime =
-        .001 * clock_gettimesince(sys_midiinittime)
-            + inbuftime - sys_getrealtime();
-    if (dactimeminusrealtime > sys_newdactimeminusrealtime)
+    double dactimeminusrealtime = .001 * clock_gettimesince(sys_midiinittime) -
+                                  outbuftime - sys_getrealtime();
+    double adctimeminusrealtime = .001 * clock_gettimesince(sys_midiinittime) +
+                                  inbuftime - sys_getrealtime();
+    if(dactimeminusrealtime > sys_newdactimeminusrealtime)
         sys_newdactimeminusrealtime = dactimeminusrealtime;
-    if (adctimeminusrealtime > sys_newadctimeminusrealtime)
+    if(adctimeminusrealtime > sys_newadctimeminusrealtime)
         sys_newadctimeminusrealtime = adctimeminusrealtime;
-    if (sys_getrealtime() > sys_whenupdate)
+    if(sys_getrealtime() > sys_whenupdate)
     {
         sys_dactimeminusrealtime = sys_newdactimeminusrealtime;
         sys_adctimeminusrealtime = sys_newadctimeminusrealtime;
@@ -127,9 +124,9 @@ static void sys_setmiditimediff(double inbuftime, double outbuftime)
     }
 }
 
-    /* return the logical time of the DAC sample we believe is currently
-    going out, based on how much "system time" has elapsed since the
-    last time sys_setmiditimediff got called. */
+/* return the logical time of the DAC sample we believe is currently
+going out, based on how much "system time" has elapsed since the
+last time sys_setmiditimediff got called. */
 static double sys_getmidioutrealtime(void)
 {
     return (sys_getrealtime() + sys_dactimeminusrealtime);
@@ -144,24 +141,26 @@ static void sys_putnext(void)
 {
     int portno = midi_outqueue[midi_outtail].q_portno;
 #ifdef USEAPI_ALSA
-    if (sys_midiapi == API_ALSA)
-      {
-        if (midi_outqueue[midi_outtail].q_onebyte)
-          sys_alsa_putmidibyte(portno, midi_outqueue[midi_outtail].q_byte1);
-        else sys_alsa_putmidimess(portno, midi_outqueue[midi_outtail].q_byte1,
-                             midi_outqueue[midi_outtail].q_byte2,
-                             midi_outqueue[midi_outtail].q_byte3);
-      }
+    if(sys_midiapi == API_ALSA)
+    {
+        if(midi_outqueue[midi_outtail].q_onebyte)
+            sys_alsa_putmidibyte(portno, midi_outqueue[midi_outtail].q_byte1);
+        else
+            sys_alsa_putmidimess(portno, midi_outqueue[midi_outtail].q_byte1,
+                midi_outqueue[midi_outtail].q_byte2,
+                midi_outqueue[midi_outtail].q_byte3);
+    }
     else
 #endif /* ALSA */
-      {
-        if (midi_outqueue[midi_outtail].q_onebyte)
-          sys_putmidibyte(portno, midi_outqueue[midi_outtail].q_byte1);
-        else sys_putmidimess(portno, midi_outqueue[midi_outtail].q_byte1,
-                             midi_outqueue[midi_outtail].q_byte2,
-                             midi_outqueue[midi_outtail].q_byte3);
-      }
-    midi_outtail  = (midi_outtail + 1 == MIDIQSIZE ? 0 : midi_outtail + 1);
+    {
+        if(midi_outqueue[midi_outtail].q_onebyte)
+            sys_putmidibyte(portno, midi_outqueue[midi_outtail].q_byte1);
+        else
+            sys_putmidimess(portno, midi_outqueue[midi_outtail].q_byte1,
+                midi_outqueue[midi_outtail].q_byte2,
+                midi_outqueue[midi_outtail].q_byte3);
+    }
+    midi_outtail = (midi_outtail + 1 == MIDIQSIZE ? 0 : midi_outtail + 1);
 }
 
 /*  #define TEST_DEJITTER */
@@ -173,24 +172,24 @@ void sys_pollmidioutqueue(void)
 #endif
     double midirealtime = sys_getmidioutrealtime();
 #ifdef TEST_DEJITTER
-    if (midi_outhead == midi_outtail)
-        db = 0;
+    if(midi_outhead == midi_outtail) db = 0;
 #endif
-    while (midi_outhead != midi_outtail)
+    while(midi_outhead != midi_outtail)
     {
 #ifdef TEST_DEJITTER
-        if (!db)
+        if(!db)
         {
             post("out: del %f, midiRT %f logicaltime %f, RT %f dacminusRT %f",
                 (midi_outqueue[midi_outtail].q_time - midirealtime),
-                    midirealtime, .001 * clock_gettimesince(sys_midiinittime),
-                        sys_getrealtime(), sys_dactimeminusrealtime);
+                midirealtime, .001 * clock_gettimesince(sys_midiinittime),
+                sys_getrealtime(), sys_dactimeminusrealtime);
             db = 1;
         }
 #endif
-        if (midi_outqueue[midi_outtail].q_time <= midirealtime)
+        if(midi_outqueue[midi_outtail].q_time <= midirealtime)
             sys_putnext();
-        else break;
+        else
+            break;
     }
 }
 
@@ -199,12 +198,10 @@ void sys_pollmidioutqueue(void)
 static void sys_queuemidimess(int portno, int onebyte, int a, int b, int c)
 {
     t_midiqelem *midiqelem;
-    int newhead = midi_outhead +1;
-    if (newhead == MIDIQSIZE)
-        newhead = 0;
-            /* if FIFO is full flush an element to make room */
-    if (newhead == midi_outtail)
-        sys_putnext();
+    int newhead = midi_outhead + 1;
+    if(newhead == MIDIQSIZE) newhead = 0;
+    /* if FIFO is full flush an element to make room */
+    if(newhead == midi_outtail) sys_putnext();
     midi_outqueue[midi_outhead].q_portno = portno;
     midi_outqueue[midi_outhead].q_onebyte = onebyte;
     midi_outqueue[midi_outhead].q_byte1 = a;
@@ -218,67 +215,85 @@ static void sys_queuemidimess(int portno, int onebyte, int a, int b, int c)
 
 void outmidi_noteon(int portno, int channel, int pitch, int velo)
 {
-    if (pitch < 0) pitch = 0;
-    else if (pitch > 127) pitch = 127;
-    if (velo < 0) velo = 0;
-    else if (velo > 127) velo = 127;
+    if(pitch < 0)
+        pitch = 0;
+    else if(pitch > 127)
+        pitch = 127;
+    if(velo < 0)
+        velo = 0;
+    else if(velo > 127)
+        velo = 127;
     sys_queuemidimess(portno, 0, MIDI_NOTEON + (channel & 0xf), pitch, velo);
 }
 
 void outmidi_controlchange(int portno, int channel, int ctl, int value)
 {
-    if (ctl < 0) ctl = 0;
-    else if (ctl > 127) ctl = 127;
-    if (value < 0) value = 0;
-    else if (value > 127) value = 127;
-    sys_queuemidimess(portno, 0, MIDI_CONTROLCHANGE + (channel & 0xf),
-        ctl, value);
+    if(ctl < 0)
+        ctl = 0;
+    else if(ctl > 127)
+        ctl = 127;
+    if(value < 0)
+        value = 0;
+    else if(value > 127)
+        value = 127;
+    sys_queuemidimess(
+        portno, 0, MIDI_CONTROLCHANGE + (channel & 0xf), ctl, value);
 }
 
 void outmidi_programchange(int portno, int channel, int value)
 {
-    if (value < 0) value = 0;
-    else if (value > 127) value = 127;
-    sys_queuemidimess(portno, 0,
-        MIDI_PROGRAMCHANGE + (channel & 0xf), value, 0);
+    if(value < 0)
+        value = 0;
+    else if(value > 127)
+        value = 127;
+    sys_queuemidimess(
+        portno, 0, MIDI_PROGRAMCHANGE + (channel & 0xf), value, 0);
 }
 
 void outmidi_pitchbend(int portno, int channel, int value)
 {
-    if (value < 0) value = 0;
-    else if (value > 16383) value = 16383;
+    if(value < 0)
+        value = 0;
+    else if(value > 16383)
+        value = 16383;
     sys_queuemidimess(portno, 0, MIDI_PITCHBEND + (channel & 0xf),
-        (value & 127), ((value>>7) & 127));
+        (value & 127), ((value >> 7) & 127));
 }
 
 void outmidi_aftertouch(int portno, int channel, int value)
 {
-    if (value < 0) value = 0;
-    else if (value > 127) value = 127;
+    if(value < 0)
+        value = 0;
+    else if(value > 127)
+        value = 127;
     sys_queuemidimess(portno, 0, MIDI_AFTERTOUCH + (channel & 0xf), value, 0);
 }
 
 void outmidi_polyaftertouch(int portno, int channel, int pitch, int value)
 {
-    if (pitch < 0) pitch = 0;
-    else if (pitch > 127) pitch = 127;
-    if (value < 0) value = 0;
-    else if (value > 127) value = 127;
-    sys_queuemidimess(portno, 0, MIDI_POLYAFTERTOUCH + (channel & 0xf),
-        pitch, value);
+    if(pitch < 0)
+        pitch = 0;
+    else if(pitch > 127)
+        pitch = 127;
+    if(value < 0)
+        value = 0;
+    else if(value > 127)
+        value = 127;
+    sys_queuemidimess(
+        portno, 0, MIDI_POLYAFTERTOUCH + (channel & 0xf), pitch, value);
 }
 
 void outmidi_byte(int portno, int value)
 {
 #ifdef USEAPI_ALSA
-  if (sys_midiapi == API_ALSA)
+    if(sys_midiapi == API_ALSA)
     {
-      sys_alsa_putmidibyte(portno, value);
+        sys_alsa_putmidibyte(portno, value);
     }
-  else
+    else
 #endif
     {
-      sys_putmidibyte(portno, value);
+        sys_putmidibyte(portno, value);
     }
 }
 
@@ -290,7 +305,7 @@ typedef struct midiparser
     int mp_byte1;    /* second data byte */
 } t_midiparser;
 
-    /* functions in x_midi.c */
+/* functions in x_midi.c */
 void inmidi_realtimein(int portno, int cmd);
 void inmidi_byte(int portno, int byte);
 void inmidi_sysex(int portno, int byte);
@@ -306,37 +321,35 @@ static void sys_dispatchnextmidiin(void)
     static t_midiparser parser[MAXMIDIINDEV], *parserp;
     int portno = midi_inqueue[midi_intail].q_portno,
         byte = midi_inqueue[midi_intail].q_byte1;
-    if (!midi_inqueue[midi_intail].q_onebyte)
-        bug("sys_dispatchnextmidiin");
-    if (portno < 0 || portno >= MAXMIDIINDEV)
-        bug("sys_dispatchnextmidiin 2");
+    if(!midi_inqueue[midi_intail].q_onebyte) bug("sys_dispatchnextmidiin");
+    if(portno < 0 || portno >= MAXMIDIINDEV) bug("sys_dispatchnextmidiin 2");
     parserp = parser + portno;
     outlet_setstacklim();
 
-    if (byte >= MIDI_CLOCK)
+    if(byte >= MIDI_CLOCK)
     {
         /* realtime message */
         inmidi_realtimein(portno, byte);
     }
     else
     {
-        if (byte & 0x80)
+        if(byte & 0x80)
         {
             /* status byte */
             inmidi_byte(portno, byte);
-            if (byte == MIDI_TUNEREQUEST || byte == MIDI_RESERVED1 ||
+            if(byte == MIDI_TUNEREQUEST || byte == MIDI_RESERVED1 ||
                 byte == MIDI_RESERVED2)
             {
                 /* system messages clear running status,
                    rest are handled in the data byte section below */
                 parserp->mp_status = 0;
             }
-            else if (byte == MIDI_SYSEX)
+            else if(byte == MIDI_SYSEX)
             {
                 inmidi_sysex(portno, byte);
                 parserp->mp_status = byte;
             }
-            else if (byte == MIDI_SYSEXEND)
+            else if(byte == MIDI_SYSEXEND)
             {
                 inmidi_sysex(portno, byte);
                 parserp->mp_status = 0;
@@ -348,7 +361,7 @@ static void sys_dispatchnextmidiin(void)
             }
             parserp->mp_gotbyte1 = 0;
         }
-        else if (parserp->mp_status < MIDI_NOTEOFF)
+        else if(parserp->mp_status < MIDI_NOTEOFF)
         {
             /* running status w/out prev status byte or other invalid message */
             pd_error(0, "dropping unexpected MIDI byte %02X", byte);
@@ -358,36 +371,41 @@ static void sys_dispatchnextmidiin(void)
             int status, chan, byte1, gotbyte1;
             /* data byte */
             inmidi_byte(portno, byte);
-            status = (parserp->mp_status >= MIDI_SYSEX ?
-                parserp->mp_status : (parserp->mp_status & 0xf0));
+            status = (parserp->mp_status >= MIDI_SYSEX
+                          ? parserp->mp_status
+                          : (parserp->mp_status & 0xf0));
             chan = (parserp->mp_status & 0x0f);
             byte1 = parserp->mp_byte1;
             gotbyte1 = parserp->mp_gotbyte1;
-            switch (status)
+            switch(status)
             {
                 case MIDI_NOTEOFF:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         inmidi_noteon(portno, chan, byte1, 0),
                             parserp->mp_gotbyte1 = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_NOTEON:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         inmidi_noteon(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_POLYAFTERTOUCH:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         inmidi_polyaftertouch(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_CONTROLCHANGE:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         inmidi_controlchange(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_PROGRAMCHANGE:
                     inmidi_programchange(portno, chan, byte);
@@ -396,10 +414,11 @@ static void sys_dispatchnextmidiin(void)
                     inmidi_aftertouch(portno, chan, byte);
                     break;
                 case MIDI_PITCHBEND:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         inmidi_pitchbend(portno, chan, ((byte << 7) + byte1)),
                             parserp->mp_gotbyte1 = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_SYSEX:
                     inmidi_sysex(portno, byte);
@@ -411,9 +430,10 @@ static void sys_dispatchnextmidiin(void)
                     parserp->mp_status = 0;
                     break;
                 case MIDI_SONGPOS:
-                    if (gotbyte1)
+                    if(gotbyte1)
                         parserp->mp_gotbyte1 = 0, parserp->mp_status = 0;
-                    else parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    else
+                        parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
                     break;
                 case MIDI_SONGSELECT:
                     parserp->mp_status = 0;
@@ -431,17 +451,16 @@ void sys_pollmidiinqueue(void)
 #endif
     double logicaltime = .001 * clock_gettimesince(sys_midiinittime);
 #ifdef TEST_DEJITTER
-    if (midi_inhead == midi_intail)
-        db = 0;
+    if(midi_inhead == midi_intail) db = 0;
 #endif
-    while (midi_inhead != midi_intail)
+    while(midi_inhead != midi_intail)
     {
 #ifdef TEST_DEJITTER
-        if (!db)
+        if(!db)
         {
             post("in del %f, logicaltime %f, RT %f adcminusRT %f",
-                (midi_inqueue[midi_intail].q_time - logicaltime),
-                    logicaltime, sys_getrealtime(), sys_adctimeminusrealtime);
+                (midi_inqueue[midi_intail].q_time - logicaltime), logicaltime,
+                sys_getrealtime(), sys_adctimeminusrealtime);
             db = 1;
         }
 #endif
@@ -450,7 +469,7 @@ void sys_pollmidiinqueue(void)
             post("late %f",
                 1000 * (logicaltime - midi_inqueue[midi_intail].q_time));
 #endif
-        if (midi_inqueue[midi_intail].q_time <= logicaltime)
+        if(midi_inqueue[midi_intail].q_time <= logicaltime)
         {
 #if 0
             post("diff %f",
@@ -458,24 +477,24 @@ void sys_pollmidiinqueue(void)
 #endif
             sys_dispatchnextmidiin();
         }
-        else break;
+        else
+            break;
     }
 }
 
-    /* this should be called from the system dependent MIDI code when a byte
-    comes in, as a result of our calling sys_poll_midi.  We stick it on a
-    timetag queue and dispatch it at the appropriate logical time. */
+/* this should be called from the system dependent MIDI code when a byte
+comes in, as a result of our calling sys_poll_midi.  We stick it on a
+timetag queue and dispatch it at the appropriate logical time. */
 void sys_midibytein(int portno, int byte)
 {
     static int warned = 0;
     t_midiqelem *midiqelem;
-    int newhead = midi_inhead +1;
-    if (newhead == MIDIQSIZE)
-        newhead = 0;
-            /* if FIFO is full flush an element to make room */
-    if (newhead == midi_intail)
+    int newhead = midi_inhead + 1;
+    if(newhead == MIDIQSIZE) newhead = 0;
+    /* if FIFO is full flush an element to make room */
+    if(newhead == midi_intail)
     {
-        if (!warned)
+        if(!warned)
         {
             post("warning: MIDI timing FIFO overflowed");
             warned = 1;
@@ -494,11 +513,11 @@ void sys_pollmidiqueue(void)
 {
     sys_setmiditimediff(0, 1e-6 * sys_schedadvance);
 #ifdef USEAPI_ALSA
-      if (sys_midiapi == API_ALSA)
+    if(sys_midiapi == API_ALSA)
         sys_alsa_poll_midi();
-      else
-#endif /* ALSA */
-    sys_poll_midi();    /* OS dependent poll for MIDI input */
+    else
+#endif                   /* ALSA */
+        sys_poll_midi(); /* OS dependent poll for MIDI input */
     sys_pollmidioutqueue();
     sys_pollmidiinqueue();
 }
@@ -508,8 +527,7 @@ void sys_pollmidiqueue(void)
 #define MAXNDEV 128
 #define DEVDESCSIZE 1024
 
-#define DEVONSET 1  /* To agree with command line flags, normally start at 1 */
-
+#define DEVONSET 1 /* To agree with command line flags, normally start at 1 */
 
 #ifdef USEAPI_ALSA
 void midi_alsa_init(void);
@@ -518,7 +536,7 @@ void midi_alsa_init(void);
 void midi_oss_init(void);
 #endif
 
-    /* last requested parameters */
+/* last requested parameters */
 static int midi_nmidiindev;
 static int midi_midiindev[MAXMIDIINDEV];
 static char midi_indevnames[MAXMIDIINDEV * DEVDESCSIZE];
@@ -531,64 +549,66 @@ void sys_get_midi_apis(char *buf)
     int n = 0;
     strcpy(buf, "{ ");
 #ifdef USEAPI_OSS
-    sprintf(buf + strlen(buf), "{OSS-MIDI %d} ", API_DEFAULTMIDI); n++;
+    sprintf(buf + strlen(buf), "{OSS-MIDI %d} ", API_DEFAULTMIDI);
+    n++;
 #endif
 #ifdef USEAPI_ALSA
-    sprintf(buf + strlen(buf), "{ALSA-MIDI %d} ", API_ALSA); n++;
+    sprintf(buf + strlen(buf), "{ALSA-MIDI %d} ", API_ALSA);
+    n++;
 #endif
     strcat(buf, "}");
-        /* then again, if only one API (or none) we don't offer any choice. */
-    if (n < 2)
-        strcpy(buf, "{}");
+    /* then again, if only one API (or none) we don't offer any choice. */
+    if(n < 2) strcpy(buf, "{}");
 }
 
-void sys_get_midi_params(int *pnmidiindev, int *pmidiindev,
-    int *pnmidioutdev, int *pmidioutdev)
+void sys_get_midi_params(
+    int *pnmidiindev, int *pmidiindev, int *pnmidioutdev, int *pmidioutdev)
 {
     int i, devn;
     *pnmidiindev = midi_nmidiindev;
-    for (i = 0; i < midi_nmidiindev; i++)
+    for(i = 0; i < midi_nmidiindev; i++)
     {
-        if ((devn = sys_mididevnametonumber(0,
-            &midi_indevnames[i * DEVDESCSIZE])) >= 0)
-                pmidiindev[i] = devn;
-        else pmidiindev[i] = midi_midiindev[i];
+        if((devn = sys_mididevnametonumber(
+                0, &midi_indevnames[i * DEVDESCSIZE])) >= 0)
+            pmidiindev[i] = devn;
+        else
+            pmidiindev[i] = midi_midiindev[i];
     }
     *pnmidioutdev = midi_nmidioutdev;
-    for (i = 0; i < midi_nmidioutdev; i++)
+    for(i = 0; i < midi_nmidioutdev; i++)
     {
-        if ((devn = sys_mididevnametonumber(1,
-            &midi_outdevnames[i * DEVDESCSIZE])) >= 0)
-                pmidioutdev[i] = devn;
-        else pmidioutdev[i] = midi_midioutdev[i];
+        if((devn = sys_mididevnametonumber(
+                1, &midi_outdevnames[i * DEVDESCSIZE])) >= 0)
+            pmidioutdev[i] = devn;
+        else
+            pmidioutdev[i] = midi_midioutdev[i];
     }
 }
 
 static void sys_save_midi_params(
-    int nmidiindev, int *midiindev,
-    int nmidioutdev, int *midioutdev)
+    int nmidiindev, int *midiindev, int nmidioutdev, int *midioutdev)
 {
     int i;
     midi_nmidiindev = nmidiindev;
-    for (i = 0; i < nmidiindev; i++)
+    for(i = 0; i < nmidiindev; i++)
     {
         midi_midiindev[i] = midiindev[i];
-        sys_mididevnumbertoname(0, midiindev[i],
-            &midi_indevnames[i * DEVDESCSIZE], DEVDESCSIZE);
+        sys_mididevnumbertoname(
+            0, midiindev[i], &midi_indevnames[i * DEVDESCSIZE], DEVDESCSIZE);
     }
     midi_nmidioutdev = nmidioutdev;
-    for (i = 0; i < nmidioutdev; i++)
+    for(i = 0; i < nmidioutdev; i++)
     {
         midi_midioutdev[i] = midioutdev[i];
-        sys_mididevnumbertoname(1, midioutdev[i],
-            &midi_outdevnames[i * DEVDESCSIZE], DEVDESCSIZE);
+        sys_mididevnumbertoname(
+            1, midioutdev[i], &midi_outdevnames[i * DEVDESCSIZE], DEVDESCSIZE);
     }
 }
 
-void sys_open_midi(int nmidiindev, int *midiindev,
-    int nmidioutdev, int *midioutdev, int enable)
+void sys_open_midi(int nmidiindev, int *midiindev, int nmidioutdev,
+    int *midioutdev, int enable)
 {
-    if (enable)
+    if(enable)
     {
 #ifdef USEAPI_ALSA
         midi_alsa_init();
@@ -597,20 +617,19 @@ void sys_open_midi(int nmidiindev, int *midiindev,
         midi_oss_init();
 #endif
 #ifdef USEAPI_ALSA
-        if (sys_midiapi == API_ALSA)
-            sys_alsa_do_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev);
+        if(sys_midiapi == API_ALSA)
+            sys_alsa_do_open_midi(
+                nmidiindev, midiindev, nmidioutdev, midioutdev);
         else
 #endif /* ALSA */
             sys_do_open_midi(nmidiindev, midiindev, nmidioutdev, midioutdev);
     }
-    sys_save_midi_params(nmidiindev, midiindev,
-        nmidioutdev, midioutdev);
+    sys_save_midi_params(nmidiindev, midiindev, nmidioutdev, midioutdev);
 
     sys_vgui("set pd_whichmidiapi %d\n", sys_midiapi);
-
 }
 
-    /* open midi using whatever parameters were last used */
+/* open midi using whatever parameters were last used */
 void sys_reopen_midi(void)
 {
     int nmidiindev, midiindev[MAXMIDIINDEV];
@@ -621,42 +640,45 @@ void sys_reopen_midi(void)
 
 void sys_listmididevs(void)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i;
 
-    sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        MAXNDEV, DEVDESCSIZE);
+    sys_get_midi_devs(
+        indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
 
-    if (!nindevs)
+    if(!nindevs)
         post("no MIDI input devices found");
     else
     {
         post("MIDI input devices:");
-        for (i = 0; i < nindevs; i++)
-            post("%d. %s", i+1, indevlist + i * DEVDESCSIZE);
+        for(i = 0; i < nindevs; i++)
+            post("%d. %s", i + 1, indevlist + i * DEVDESCSIZE);
     }
-    if (!noutdevs)
+    if(!noutdevs)
         post("no MIDI output devices found");
     else
     {
         post("MIDI output devices:");
-        for (i = 0; i < noutdevs; i++)
-            post("%d. %s", i+DEVONSET, outdevlist + i * DEVDESCSIZE);
+        for(i = 0; i < noutdevs; i++)
+            post("%d. %s", i + DEVONSET, outdevlist + i * DEVDESCSIZE);
     }
 }
 
 void sys_set_midi_api(int which)
 {
-    switch (which) {
+    switch(which)
+    {
 #ifdef USEAPI_ALSA
-    case(API_ALSA): break;
+        case(API_ALSA):
+            break;
 #endif
 #ifndef FORCEAPI_ALSA
-    case(API_DEFAULTMIDI): break;
+        case(API_DEFAULTMIDI):
+            break;
 #endif
-    default:
-        logpost(NULL, PD_VERBOSE, "ignoring unknown MIDI API %d", which);
-        return;
+        default:
+            logpost(NULL, PD_VERBOSE, "ignoring unknown MIDI API %d", which);
+            return;
     }
 
     sys_midiapi = which;
@@ -669,14 +691,14 @@ void midi_alsa_setndevs(int in, int out);
 void glob_midi_setapi(void *dummy, t_floatarg f)
 {
     int newapi = f;
-    if (newapi != sys_midiapi)
+    if(newapi != sys_midiapi)
     {
 #ifdef USEAPI_ALSA
-        if (sys_midiapi == API_ALSA)
+        if(sys_midiapi == API_ALSA)
             sys_alsa_close_midi();
         else
 #endif
-              sys_close_midi();
+            sys_close_midi();
         sys_midiapi = newapi;
         sys_reopen_midi();
     }
@@ -688,87 +710,84 @@ void glob_midi_setapi(void *dummy, t_floatarg f)
 
 extern t_class *glob_pdobject;
 
-    /* start an midi settings dialog window */
+/* start an midi settings dialog window */
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 {
-    char buf[1024 + 2 * MAXNDEV*(DEVDESCSIZE+4)];
-        /* these are the devices you're using: */
+    char buf[1024 + 2 * MAXNDEV * (DEVDESCSIZE + 4)];
+    /* these are the devices you're using: */
     int nindev, midiindev[MAXMIDIINDEV];
     int noutdev, midioutdev[MAXMIDIOUTDEV];
-    int midiindev1, midiindev2, midiindev3, midiindev4, midiindev5,
-        midiindev6, midiindev7, midiindev8, midiindev9,
-        midioutdev1, midioutdev2, midioutdev3, midioutdev4, midioutdev5,
-        midioutdev6, midioutdev7, midioutdev8, midioutdev9;
+    int midiindev1, midiindev2, midiindev3, midiindev4, midiindev5, midiindev6,
+        midiindev7, midiindev8, midiindev9, midioutdev1, midioutdev2,
+        midioutdev3, midioutdev4, midioutdev5, midioutdev6, midioutdev7,
+        midioutdev8, midioutdev9;
 
-        /* these are all the devices on your system: */
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    /* these are all the devices on your system: */
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i;
     char device[MAXPDSTRING];
 
-    sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        MAXNDEV, DEVDESCSIZE);
+    sys_get_midi_devs(
+        indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
 
     sys_gui("global midi_indevlist; set midi_indevlist {none}\n");
-    for (i = 0; i < nindevs; i++)
+    for(i = 0; i < nindevs; i++)
         sys_vgui("lappend midi_indevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
+            pdgui_strnescape(
+                device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
 
     sys_gui("global midi_outdevlist; set midi_outdevlist {none}\n");
-    for (i = 0; i < noutdevs; i++)
+    for(i = 0; i < noutdevs; i++)
         sys_vgui("lappend midi_outdevlist {%s}\n",
-            pdgui_strnescape(device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+            pdgui_strnescape(
+                device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
 
     sys_get_midi_params(&nindev, midiindev, &noutdev, midioutdev);
 
-    if (nindev > 1 || noutdev > 1)
-        flongform = 1;
+    if(nindev > 1 || noutdev > 1) flongform = 1;
 
-    midiindev1 = (nindev > 0 &&  midiindev[0]>= 0 ? midiindev[0]+1 : 0);
-    midiindev2 = (nindev > 1 &&  midiindev[1]>= 0 ? midiindev[1]+1 : 0);
-    midiindev3 = (nindev > 2 &&  midiindev[2]>= 0 ? midiindev[2]+1 : 0);
-    midiindev4 = (nindev > 3 &&  midiindev[3]>= 0 ? midiindev[3]+1 : 0);
-    midiindev5 = (nindev > 4 &&  midiindev[4]>= 0 ? midiindev[4]+1 : 0);
-    midiindev6 = (nindev > 5 &&  midiindev[5]>= 0 ? midiindev[5]+1 : 0);
-    midiindev7 = (nindev > 6 &&  midiindev[6]>= 0 ? midiindev[6]+1 : 0);
-    midiindev8 = (nindev > 7 &&  midiindev[7]>= 0 ? midiindev[7]+1 : 0);
-    midiindev9 = (nindev > 8 &&  midiindev[8]>= 0 ? midiindev[8]+1 : 0);
-    midioutdev1 = (noutdev > 0 && midioutdev[0]>= 0 ? midioutdev[0]+1 : 0);
-    midioutdev2 = (noutdev > 1 && midioutdev[1]>= 0 ? midioutdev[1]+1 : 0);
-    midioutdev3 = (noutdev > 2 && midioutdev[2]>= 0 ? midioutdev[2]+1 : 0);
-    midioutdev4 = (noutdev > 3 && midioutdev[3]>= 0 ? midioutdev[3]+1 : 0);
-    midioutdev5 = (noutdev > 4 && midioutdev[4]>= 0 ? midioutdev[4]+1 : 0);
-    midioutdev6 = (noutdev > 5 && midioutdev[5]>= 0 ? midioutdev[5]+1 : 0);
-    midioutdev7 = (noutdev > 6 && midioutdev[6]>= 0 ? midioutdev[6]+1 : 0);
-    midioutdev8 = (noutdev > 7 && midioutdev[7]>= 0 ? midioutdev[7]+1 : 0);
-    midioutdev9 = (noutdev > 8 && midioutdev[8]>= 0 ? midioutdev[8]+1 : 0);
+    midiindev1 = (nindev > 0 && midiindev[0] >= 0 ? midiindev[0] + 1 : 0);
+    midiindev2 = (nindev > 1 && midiindev[1] >= 0 ? midiindev[1] + 1 : 0);
+    midiindev3 = (nindev > 2 && midiindev[2] >= 0 ? midiindev[2] + 1 : 0);
+    midiindev4 = (nindev > 3 && midiindev[3] >= 0 ? midiindev[3] + 1 : 0);
+    midiindev5 = (nindev > 4 && midiindev[4] >= 0 ? midiindev[4] + 1 : 0);
+    midiindev6 = (nindev > 5 && midiindev[5] >= 0 ? midiindev[5] + 1 : 0);
+    midiindev7 = (nindev > 6 && midiindev[6] >= 0 ? midiindev[6] + 1 : 0);
+    midiindev8 = (nindev > 7 && midiindev[7] >= 0 ? midiindev[7] + 1 : 0);
+    midiindev9 = (nindev > 8 && midiindev[8] >= 0 ? midiindev[8] + 1 : 0);
+    midioutdev1 = (noutdev > 0 && midioutdev[0] >= 0 ? midioutdev[0] + 1 : 0);
+    midioutdev2 = (noutdev > 1 && midioutdev[1] >= 0 ? midioutdev[1] + 1 : 0);
+    midioutdev3 = (noutdev > 2 && midioutdev[2] >= 0 ? midioutdev[2] + 1 : 0);
+    midioutdev4 = (noutdev > 3 && midioutdev[3] >= 0 ? midioutdev[3] + 1 : 0);
+    midioutdev5 = (noutdev > 4 && midioutdev[4] >= 0 ? midioutdev[4] + 1 : 0);
+    midioutdev6 = (noutdev > 5 && midioutdev[5] >= 0 ? midioutdev[5] + 1 : 0);
+    midioutdev7 = (noutdev > 6 && midioutdev[6] >= 0 ? midioutdev[6] + 1 : 0);
+    midioutdev8 = (noutdev > 7 && midioutdev[7] >= 0 ? midioutdev[7] + 1 : 0);
+    midioutdev9 = (noutdev > 8 && midioutdev[8] >= 0 ? midioutdev[8] + 1 : 0);
 
 #ifdef USEAPI_ALSA
-      if (sys_midiapi == API_ALSA)
-    sprintf(buf,
-"pdtk_alsa_midi_dialog %%s \
+    if(sys_midiapi == API_ALSA)
+        sprintf(buf, "pdtk_alsa_midi_dialog %%s \
 %d %d %d %d %d %d %d %d \
 %d 1\n",
-        midiindev1, midiindev2, midiindev3, midiindev4,
-        midioutdev1, midioutdev2, midioutdev3, midioutdev4,
-        (flongform != 0));
-      else
+            midiindev1, midiindev2, midiindev3, midiindev4, midioutdev1,
+            midioutdev2, midioutdev3, midioutdev4, (flongform != 0));
+    else
 #endif
-    sprintf(buf,
-"pdtk_midi_dialog %%s \
+        sprintf(buf, "pdtk_midi_dialog %%s \
 %d %d %d %d %d %d %d %d %d \
 %d %d %d %d %d %d %d %d %d \
 %d\n",
-        midiindev1, midiindev2, midiindev3, midiindev4, midiindev5,
-        midiindev6, midiindev7, midiindev8, midiindev9,
-        midioutdev1, midioutdev2, midioutdev3, midioutdev4, midioutdev5,
-        midioutdev6, midioutdev7, midioutdev8, midioutdev9,
-        (flongform != 0));
+            midiindev1, midiindev2, midiindev3, midiindev4, midiindev5,
+            midiindev6, midiindev7, midiindev8, midiindev9, midioutdev1,
+            midioutdev2, midioutdev3, midioutdev4, midioutdev5, midioutdev6,
+            midioutdev7, midioutdev8, midioutdev9, (flongform != 0));
 
     gfxstub_deleteforkey(0);
-    gfxstub_new(&glob_pdobject, (void *)glob_midi_properties, buf);
+    gfxstub_new(&glob_pdobject, (void *) glob_midi_properties, buf);
 }
 
-    /* new values from dialog window */
+/* new values from dialog window */
 void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     int nmidiindev, midiindev[MAXMIDIINDEV];
@@ -777,49 +796,48 @@ void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     int newmidiindev[9], newmidioutdev[9];
     int alsadevin, alsadevout;
 
-    for (i = 0; i < 9; i++)
+    for(i = 0; i < 9; i++)
     {
         newmidiindev[i] = atom_getfloatarg(i, argc, argv);
-        newmidioutdev[i] = atom_getfloatarg(i+9, argc, argv);
+        newmidioutdev[i] = atom_getfloatarg(i + 9, argc, argv);
     }
 
-    for (i = 0, nindev = 0; i < 9; i++)
+    for(i = 0, nindev = 0; i < 9; i++)
     {
-        if (newmidiindev[i] > 0)
+        if(newmidiindev[i] > 0)
         {
-            newmidiindev[nindev] = newmidiindev[i]-1;
+            newmidiindev[nindev] = newmidiindev[i] - 1;
             nindev++;
         }
     }
-    for (i = 0, noutdev = 0; i < 9; i++)
+    for(i = 0, noutdev = 0; i < 9; i++)
     {
-        if (newmidioutdev[i] > 0)
+        if(newmidioutdev[i] > 0)
         {
-            newmidioutdev[noutdev] = newmidioutdev[i]-1;
+            newmidioutdev[noutdev] = newmidioutdev[i] - 1;
             noutdev++;
         }
     }
     alsadevin = atom_getfloatarg(18, argc, argv);
     alsadevout = atom_getfloatarg(19, argc, argv);
 #ifdef USEAPI_ALSA
-            /* invent a story so that saving/recalling "settings" will
-            be able to restore the number of devices.  ALSA MIDI handling
-            uses its own set of variables.  LATER figure out how to get
-            this to work coherently */
-    if (sys_midiapi == API_ALSA)
+    /* invent a story so that saving/recalling "settings" will
+    be able to restore the number of devices.  ALSA MIDI handling
+    uses its own set of variables.  LATER figure out how to get
+    this to work coherently */
+    if(sys_midiapi == API_ALSA)
     {
         nindev = alsadevin;
         noutdev = alsadevout;
-        for (i = 0; i < nindev; i++)
+        for(i = 0; i < nindev; i++)
             newmidiindev[i] = i;
-        for (i = 0; i < noutdev; i++)
+        for(i = 0; i < noutdev; i++)
             newmidioutdev[i] = i;
     }
 #endif
-    sys_save_midi_params(nindev, newmidiindev,
-        noutdev, newmidioutdev);
+    sys_save_midi_params(nindev, newmidiindev, noutdev, newmidioutdev);
 #ifdef USEAPI_ALSA
-    if (sys_midiapi == API_ALSA)
+    if(sys_midiapi == API_ALSA)
     {
         sys_alsa_close_midi();
         sys_open_midi(alsadevin, newmidiindev, alsadevout, newmidioutdev, 1);
@@ -830,61 +848,56 @@ void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
         sys_close_midi();
         sys_open_midi(nindev, newmidiindev, noutdev, newmidioutdev, 1);
     }
-
 }
 
-void sys_get_midi_devs(char *indevlist, int *nindevs,
-                       char *outdevlist, int *noutdevs,
-                       int maxndevs, int devdescsize)
+void sys_get_midi_devs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndevs, int devdescsize)
 {
 
 #ifdef USEAPI_ALSA
-  if (sys_midiapi == API_ALSA)
-    midi_alsa_getdevs(indevlist, nindevs, outdevlist, noutdevs,
-                      maxndevs, devdescsize);
-  else
+    if(sys_midiapi == API_ALSA)
+        midi_alsa_getdevs(
+            indevlist, nindevs, outdevlist, noutdevs, maxndevs, devdescsize);
+    else
 #endif /* ALSA */
-  midi_getdevs(indevlist, nindevs, outdevlist, noutdevs, maxndevs, devdescsize);
+        midi_getdevs(
+            indevlist, nindevs, outdevlist, noutdevs, maxndevs, devdescsize);
 }
 
 /* convert a device name to a (1-based) device number.  (Output device if
 'output' parameter is true, otherwise input device).  Negative on failure. */
 int sys_mididevnametonumber(int output, const char *name)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i;
 
-    sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        MAXNDEV, DEVDESCSIZE);
+    sys_get_midi_devs(
+        indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
 
-    if (output)
+    if(output)
     {
-            /* try first for exact match */
-        for (i = 0; i < noutdevs; i++)
-            if (!strcmp(name, outdevlist + i * DEVDESCSIZE))
-                return (i);
-            /* failing that, a match up to end of shorter string */
-        for (i = 0; i < noutdevs; i++)
+        /* try first for exact match */
+        for(i = 0; i < noutdevs; i++)
+            if(!strcmp(name, outdevlist + i * DEVDESCSIZE)) return (i);
+        /* failing that, a match up to end of shorter string */
+        for(i = 0; i < noutdevs; i++)
         {
             unsigned int comp = strlen(name);
-            if (comp > strlen(outdevlist + i * DEVDESCSIZE))
+            if(comp > strlen(outdevlist + i * DEVDESCSIZE))
                 comp = strlen(outdevlist + i * DEVDESCSIZE);
-            if (!strncmp(name, outdevlist + i * DEVDESCSIZE, comp))
-                return (i);
+            if(!strncmp(name, outdevlist + i * DEVDESCSIZE, comp)) return (i);
         }
     }
     else
     {
-        for (i = 0; i < nindevs; i++)
-            if (!strcmp(name, indevlist + i * DEVDESCSIZE))
-                return (i);
-        for (i = 0; i < nindevs; i++)
+        for(i = 0; i < nindevs; i++)
+            if(!strcmp(name, indevlist + i * DEVDESCSIZE)) return (i);
+        for(i = 0; i < nindevs; i++)
         {
             unsigned int comp = strlen(name);
-            if (comp > strlen(indevlist + i * DEVDESCSIZE))
+            if(comp > strlen(indevlist + i * DEVDESCSIZE))
                 comp = strlen(indevlist + i * DEVDESCSIZE);
-            if (!strncmp(name, indevlist + i * DEVDESCSIZE, comp))
-                return (i);
+            if(!strncmp(name, indevlist + i * DEVDESCSIZE, comp)) return (i);
         }
     }
     return (-1);
@@ -894,19 +907,20 @@ int sys_mididevnametonumber(int output, const char *name)
 'output' parameter is true, otherwise input device). Empty string on failure. */
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize)
 {
-    char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
+    char indevlist[MAXNDEV * DEVDESCSIZE], outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0, noutdevs = 0, i;
-    if (devno < 0)
+    if(devno < 0)
     {
         *name = 0;
         return;
     }
-    sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
-        MAXNDEV, DEVDESCSIZE);
-    if (output && (devno < noutdevs))
+    sys_get_midi_devs(
+        indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
+    if(output && (devno < noutdevs))
         strncpy(name, outdevlist + devno * DEVDESCSIZE, namesize);
-    else if (!output && (devno < nindevs))
+    else if(!output && (devno < nindevs))
         strncpy(name, indevlist + devno * DEVDESCSIZE, namesize);
-    else *name = 0;
-    name[namesize-1] = 0;
+    else
+        *name = 0;
+    name[namesize - 1] = 0;
 }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -154,11 +154,15 @@ static void sys_putnext(void)
 #endif /* ALSA */
     {
         if(midi_outqueue[midi_outtail].q_onebyte)
+        {
             sys_putmidibyte(portno, midi_outqueue[midi_outtail].q_byte1);
+        }
         else
+        {
             sys_putmidimess(portno, midi_outqueue[midi_outtail].q_byte1,
                 midi_outqueue[midi_outtail].q_byte2,
                 midi_outqueue[midi_outtail].q_byte3);
+        }
     }
     midi_outtail = (midi_outtail + 1 == MIDIQSIZE ? 0 : midi_outtail + 1);
 }
@@ -187,9 +191,13 @@ void sys_pollmidioutqueue(void)
         }
 #endif
         if(midi_outqueue[midi_outtail].q_time <= midirealtime)
+        {
             sys_putnext();
+        }
         else
+        {
             break;
+        }
     }
 }
 
@@ -216,26 +224,42 @@ static void sys_queuemidimess(int portno, int onebyte, int a, int b, int c)
 void outmidi_noteon(int portno, int channel, int pitch, int velo)
 {
     if(pitch < 0)
+    {
         pitch = 0;
+    }
     else if(pitch > 127)
+    {
         pitch = 127;
+    }
     if(velo < 0)
+    {
         velo = 0;
+    }
     else if(velo > 127)
+    {
         velo = 127;
+    }
     sys_queuemidimess(portno, 0, MIDI_NOTEON + (channel & 0xf), pitch, velo);
 }
 
 void outmidi_controlchange(int portno, int channel, int ctl, int value)
 {
     if(ctl < 0)
+    {
         ctl = 0;
+    }
     else if(ctl > 127)
+    {
         ctl = 127;
+    }
     if(value < 0)
+    {
         value = 0;
+    }
     else if(value > 127)
+    {
         value = 127;
+    }
     sys_queuemidimess(
         portno, 0, MIDI_CONTROLCHANGE + (channel & 0xf), ctl, value);
 }
@@ -243,9 +267,13 @@ void outmidi_controlchange(int portno, int channel, int ctl, int value)
 void outmidi_programchange(int portno, int channel, int value)
 {
     if(value < 0)
+    {
         value = 0;
+    }
     else if(value > 127)
+    {
         value = 127;
+    }
     sys_queuemidimess(
         portno, 0, MIDI_PROGRAMCHANGE + (channel & 0xf), value, 0);
 }
@@ -253,9 +281,13 @@ void outmidi_programchange(int portno, int channel, int value)
 void outmidi_pitchbend(int portno, int channel, int value)
 {
     if(value < 0)
+    {
         value = 0;
+    }
     else if(value > 16383)
+    {
         value = 16383;
+    }
     sys_queuemidimess(portno, 0, MIDI_PITCHBEND + (channel & 0xf),
         (value & 127), ((value >> 7) & 127));
 }
@@ -263,22 +295,34 @@ void outmidi_pitchbend(int portno, int channel, int value)
 void outmidi_aftertouch(int portno, int channel, int value)
 {
     if(value < 0)
+    {
         value = 0;
+    }
     else if(value > 127)
+    {
         value = 127;
+    }
     sys_queuemidimess(portno, 0, MIDI_AFTERTOUCH + (channel & 0xf), value, 0);
 }
 
 void outmidi_polyaftertouch(int portno, int channel, int pitch, int value)
 {
     if(pitch < 0)
+    {
         pitch = 0;
+    }
     else if(pitch > 127)
+    {
         pitch = 127;
+    }
     if(value < 0)
+    {
         value = 0;
+    }
     else if(value > 127)
+    {
         value = 127;
+    }
     sys_queuemidimess(
         portno, 0, MIDI_POLYAFTERTOUCH + (channel & 0xf), pitch, value);
 }
@@ -385,31 +429,47 @@ static void sys_dispatchnextmidiin(void)
             {
                 case MIDI_NOTEOFF:
                     if(gotbyte1)
+                    {
                         inmidi_noteon(portno, chan, byte1, 0),
                             parserp->mp_gotbyte1 = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_NOTEON:
                     if(gotbyte1)
+                    {
                         inmidi_noteon(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_POLYAFTERTOUCH:
                     if(gotbyte1)
+                    {
                         inmidi_polyaftertouch(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_CONTROLCHANGE:
                     if(gotbyte1)
+                    {
                         inmidi_controlchange(portno, chan, byte1, byte),
                             parserp->mp_gotbyte1 = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_PROGRAMCHANGE:
                     inmidi_programchange(portno, chan, byte);
@@ -419,10 +479,14 @@ static void sys_dispatchnextmidiin(void)
                     break;
                 case MIDI_PITCHBEND:
                     if(gotbyte1)
+                    {
                         inmidi_pitchbend(portno, chan, ((byte << 7) + byte1)),
                             parserp->mp_gotbyte1 = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_SYSEX:
                     inmidi_sysex(portno, byte);
@@ -435,9 +499,13 @@ static void sys_dispatchnextmidiin(void)
                     break;
                 case MIDI_SONGPOS:
                     if(gotbyte1)
+                    {
                         parserp->mp_gotbyte1 = 0, parserp->mp_status = 0;
+                    }
                     else
+                    {
                         parserp->mp_byte1 = byte, parserp->mp_gotbyte1 = 1;
+                    }
                     break;
                 case MIDI_SONGSELECT:
                     parserp->mp_status = 0;
@@ -575,18 +643,26 @@ void sys_get_midi_params(
     {
         if((devn = sys_mididevnametonumber(
                 0, &midi_indevnames[i * DEVDESCSIZE])) >= 0)
+        {
             pmidiindev[i] = devn;
+        }
         else
+        {
             pmidiindev[i] = midi_midiindev[i];
+        }
     }
     *pnmidioutdev = midi_nmidioutdev;
     for(i = 0; i < midi_nmidioutdev; i++)
     {
         if((devn = sys_mididevnametonumber(
                 1, &midi_outdevnames[i * DEVDESCSIZE])) >= 0)
+        {
             pmidioutdev[i] = devn;
+        }
         else
+        {
             pmidioutdev[i] = midi_midioutdev[i];
+        }
     }
 }
 
@@ -657,7 +733,9 @@ void sys_listmididevs(void)
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
 
     if(!nindevs)
+    {
         post("no MIDI input devices found");
+    }
     else
     {
         post("MIDI input devices:");
@@ -665,7 +743,9 @@ void sys_listmididevs(void)
             post("%d. %s", i + 1, indevlist + i * DEVDESCSIZE);
     }
     if(!noutdevs)
+    {
         post("no MIDI output devices found");
+    }
     else
     {
         post("MIDI output devices:");
@@ -761,15 +841,19 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
 
     sys_gui("global midi_indevlist; set midi_indevlist {none}\n");
     for(i = 0; i < nindevs; i++)
+    {
         sys_vgui("lappend midi_indevlist {%s}\n",
             pdgui_strnescape(
                 device, MAXPDSTRING, indevlist + i * DEVDESCSIZE, 0));
+    }
 
     sys_gui("global midi_outdevlist; set midi_outdevlist {none}\n");
     for(i = 0; i < noutdevs; i++)
+    {
         sys_vgui("lappend midi_outdevlist {%s}\n",
             pdgui_strnescape(
                 device, MAXPDSTRING, outdevlist + i * DEVDESCSIZE, 0));
+    }
 
     sys_get_midi_params(&nindev, midiindev, &noutdev, midioutdev);
 
@@ -958,10 +1042,16 @@ void sys_mididevnumbertoname(int output, int devno, char *name, int namesize)
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
     if(output && (devno < noutdevs))
+    {
         strncpy(name, outdevlist + devno * DEVDESCSIZE, namesize);
+    }
     else if(!output && (devno < nindevs))
+    {
         strncpy(name, indevlist + devno * DEVDESCSIZE, namesize);
+    }
     else
+    {
         *name = 0;
+    }
     name[namesize - 1] = 0;
 }

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -636,10 +636,9 @@ void sys_get_midi_apis(char *buf)
 void sys_get_midi_params(
     int *pnmidiindev, int *pmidiindev, int *pnmidioutdev, int *pmidioutdev)
 {
-    int i;
     int devn;
     *pnmidiindev = midi_nmidiindev;
-    for(i = 0; i < midi_nmidiindev; i++)
+    for(int i = 0; i < midi_nmidiindev; i++)
     {
         if((devn = sys_mididevnametonumber(
                 0, &midi_indevnames[i * DEVDESCSIZE])) >= 0)
@@ -652,7 +651,7 @@ void sys_get_midi_params(
         }
     }
     *pnmidioutdev = midi_nmidioutdev;
-    for(i = 0; i < midi_nmidioutdev; i++)
+    for(int i = 0; i < midi_nmidioutdev; i++)
     {
         if((devn = sys_mididevnametonumber(
                 1, &midi_outdevnames[i * DEVDESCSIZE])) >= 0)
@@ -669,16 +668,15 @@ void sys_get_midi_params(
 static void sys_save_midi_params(
     int nmidiindev, int *midiindev, int nmidioutdev, int *midioutdev)
 {
-    int i;
     midi_nmidiindev = nmidiindev;
-    for(i = 0; i < nmidiindev; i++)
+    for(int i = 0; i < nmidiindev; i++)
     {
         midi_midiindev[i] = midiindev[i];
         sys_mididevnumbertoname(
             0, midiindev[i], &midi_indevnames[i * DEVDESCSIZE], DEVDESCSIZE);
     }
     midi_nmidioutdev = nmidioutdev;
-    for(i = 0; i < nmidioutdev; i++)
+    for(int i = 0; i < nmidioutdev; i++)
     {
         midi_midioutdev[i] = midioutdev[i];
         sys_mididevnumbertoname(
@@ -727,7 +725,6 @@ void sys_listmididevs(void)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
 
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
@@ -739,7 +736,7 @@ void sys_listmididevs(void)
     else
     {
         post("MIDI input devices:");
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
             post("%d. %s", i + 1, indevlist + i * DEVDESCSIZE);
     }
     if(!noutdevs)
@@ -749,7 +746,7 @@ void sys_listmididevs(void)
     else
     {
         post("MIDI output devices:");
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
             post("%d. %s", i + DEVONSET, outdevlist + i * DEVDESCSIZE);
     }
 }
@@ -833,14 +830,13 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
     char device[MAXPDSTRING];
 
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
 
     sys_gui("global midi_indevlist; set midi_indevlist {none}\n");
-    for(i = 0; i < nindevs; i++)
+    for(int i = 0; i < nindevs; i++)
     {
         sys_vgui("lappend midi_indevlist {%s}\n",
             pdgui_strnescape(
@@ -848,7 +844,7 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
     }
 
     sys_gui("global midi_outdevlist; set midi_outdevlist {none}\n");
-    for(i = 0; i < noutdevs; i++)
+    for(int i = 0; i < noutdevs; i++)
     {
         sys_vgui("lappend midi_outdevlist {%s}\n",
             pdgui_strnescape(
@@ -991,7 +987,6 @@ int sys_mididevnametonumber(int output, const char *name)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
 
     sys_get_midi_devs(
         indevlist, &nindevs, outdevlist, &noutdevs, MAXNDEV, DEVDESCSIZE);
@@ -999,10 +994,10 @@ int sys_mididevnametonumber(int output, const char *name)
     if(output)
     {
         /* try first for exact match */
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
             if(!strcmp(name, outdevlist + i * DEVDESCSIZE)) return (i);
         /* failing that, a match up to end of shorter string */
-        for(i = 0; i < noutdevs; i++)
+        for(int i = 0; i < noutdevs; i++)
         {
             unsigned int comp = strlen(name);
             if(comp > strlen(outdevlist + i * DEVDESCSIZE))
@@ -1012,9 +1007,9 @@ int sys_mididevnametonumber(int output, const char *name)
     }
     else
     {
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
             if(!strcmp(name, indevlist + i * DEVDESCSIZE)) return (i);
-        for(i = 0; i < nindevs; i++)
+        for(int i = 0; i < nindevs; i++)
         {
             unsigned int comp = strlen(name);
             if(comp > strlen(indevlist + i * DEVDESCSIZE))
@@ -1033,7 +1028,6 @@ void sys_mididevnumbertoname(int output, int devno, char *name, int namesize)
     char outdevlist[MAXNDEV * DEVDESCSIZE];
     int nindevs = 0;
     int noutdevs = 0;
-    int i;
     if(devno < 0)
     {
         *name = 0;

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 1997-1999 Guenter Geiger, Miller Puckette, Larry Troxler,
-* Winfried Ritsch, Karl MacMillan, and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * Winfried Ritsch, Karl MacMillan, and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* MIDI I/O for Linux using ALSA */
 
@@ -20,20 +20,20 @@
 
 /* full status byte definitions in s_midi.c */
 /* channel voice messages */
-#define MIDI_NOTEOFF        0x80
-#define MIDI_NOTEON         0x90
+#define MIDI_NOTEOFF 0x80
+#define MIDI_NOTEON 0x90
 #define MIDI_POLYAFTERTOUCH 0xa0
-#define MIDI_CONTROLCHANGE  0xb0
-#define MIDI_PROGRAMCHANGE  0xc0
-#define MIDI_AFTERTOUCH     0xd0
-#define MIDI_PITCHBEND      0xe0
+#define MIDI_CONTROLCHANGE 0xb0
+#define MIDI_PROGRAMCHANGE 0xc0
+#define MIDI_AFTERTOUCH 0xd0
+#define MIDI_PITCHBEND 0xe0
 /* system common messages */
-#define MIDI_SYSEX          0xf0
-#define MIDI_TIMECODE       0xf1
-#define MIDI_SONGPOS        0xf2
-#define MIDI_SONGSELECT     0xf3
+#define MIDI_SYSEX 0xf0
+#define MIDI_TIMECODE 0xf1
+#define MIDI_SONGPOS 0xf2
+#define MIDI_SONGSELECT 0xf3
 
-//the maximum length of input messages
+// the maximum length of input messages
 #ifndef ALSA_MAX_EVENT_SIZE
 #define ALSA_MAX_EVENT_SIZE 512
 #endif
@@ -47,8 +47,8 @@ static snd_seq_t *midi_handle;
 
 static snd_midi_event_t *midiev;
 
-void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
-    int nmidiout, int *midioutvec)
+void sys_alsa_do_open_midi(
+    int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
 
     char portname[50];
@@ -60,57 +60,57 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
     alsa_nmidiin = 0;
     alsa_nmidiout = 0;
 
-    if (nmidiout == 0 && nmidiin == 0) return;
+    if(nmidiout == 0 && nmidiin == 0) return;
 
-    if (nmidiin > MAXMIDIINDEV )
+    if(nmidiin > MAXMIDIINDEV)
     {
         post("MIDI input ports reduced to maximum %d", MAXMIDIINDEV);
         nmidiin = MAXMIDIINDEV;
     }
-    if (nmidiout > MAXMIDIOUTDEV)
+    if(nmidiout > MAXMIDIOUTDEV)
     {
         post("MIDI output ports reduced to maximum %d", MAXMIDIOUTDEV);
         nmidiout = MAXMIDIOUTDEV;
     }
 
-    if (nmidiin > 0 && nmidiout > 0)
+    if(nmidiin > 0 && nmidiout > 0)
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_DUPLEX, 0);
-    else if (nmidiin > 0)
+    else if(nmidiin > 0)
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_INPUT, 0);
-    else if (nmidiout > 0)
+    else if(nmidiout > 0)
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_OUTPUT, 0);
 
-    if (err != 0)
+    if(err != 0)
     {
-            sys_setalarm(1000000);
-            post("couldn't open alsa sequencer");
-            return;
+        sys_setalarm(1000000);
+        post("couldn't open alsa sequencer");
+        return;
     }
-    for (i = 0; i < nmidiin; i++)
+    for(i = 0; i < nmidiin; i++)
     {
         int port;
-        sprintf(portname, "Pure Data Midi-In %d", i+1);
-        port = snd_seq_create_simple_port(midi_handle,portname,
-                                          SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE,
-                                          SND_SEQ_PORT_TYPE_APPLICATION);
+        sprintf(portname, "Pure Data Midi-In %d", i + 1);
+        port = snd_seq_create_simple_port(midi_handle, portname,
+            SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE,
+            SND_SEQ_PORT_TYPE_APPLICATION);
         alsa_midiinfd[i] = port;
-        if (port < 0) goto error;
+        if(port < 0) goto error;
     }
 
-    for (i = 0; i < nmidiout; i++)
+    for(i = 0; i < nmidiout; i++)
     {
         int port;
-        sprintf(portname,"Pure Data Midi-Out %d", i+1);
-        port = snd_seq_create_simple_port(midi_handle,portname,
-                                          SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ,
-                                          SND_SEQ_PORT_TYPE_APPLICATION);
+        sprintf(portname, "Pure Data Midi-Out %d", i + 1);
+        port = snd_seq_create_simple_port(midi_handle, portname,
+            SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ,
+            SND_SEQ_PORT_TYPE_APPLICATION);
         alsa_midioutfd[i] = port;
-        if (port < 0) goto error;
+        if(port < 0) goto error;
     }
 
     snd_seq_client_info_malloc(&alsainfo);
     snd_seq_get_client_info(midi_handle, alsainfo);
-    snd_seq_client_info_set_name(alsainfo,"Pure Data");
+    snd_seq_client_info_set_name(alsainfo, "Pure Data");
     client = snd_seq_client_info_get_client(alsainfo);
     snd_seq_set_client_info(midi_handle, alsainfo);
     snd_seq_client_info_free(alsainfo);
@@ -121,7 +121,7 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
     alsa_nmidiin = nmidiin;
 
     return;
- error:
+error:
     sys_setalarm(1000000);
     post("couldn't open alsa MIDI output device");
     return;
@@ -129,14 +129,14 @@ void sys_alsa_do_open_midi(int nmidiin, int *midiinvec,
 
 void sys_alsa_putmidimess(int portno, int a, int b, int c)
 {
-    if (portno >= 0 && portno < alsa_nmidiout)
+    if(portno >= 0 && portno < alsa_nmidiout)
     {
         snd_seq_event_t ev;
         int status = a & 0xf0;
         int channel = a & 0x0f;
         snd_seq_ev_clear(&ev);
         status = (status >= MIDI_SYSEX) ? status : (status & 0xf0);
-        switch (status)
+        switch(status)
         {
             case MIDI_NOTEON:
                 snd_seq_ev_set_noteon(&ev, channel, b, c);
@@ -157,8 +157,9 @@ void sys_alsa_putmidimess(int portno, int a, int b, int c)
                 snd_seq_ev_set_chanpress(&ev, channel, b);
                 break;
             case MIDI_PITCHBEND:
-                /* b and c are already correct but alsa needs to recalculate them */
-                snd_seq_ev_set_pitchbend(&ev, channel, (((c<<7)|b)-8192));
+                /* b and c are already correct but alsa needs to recalculate
+                 * them */
+                snd_seq_ev_set_pitchbend(&ev, channel, (((c << 7) | b) - 8192));
                 break;
             case MIDI_TIMECODE:
                 ev.type = SND_SEQ_EVENT_QFRAME;
@@ -188,69 +189,76 @@ void sys_alsa_putmidimess(int portno, int a, int b, int c)
         snd_seq_ev_set_source(&ev, alsa_midioutfd[portno]);
         snd_seq_event_output_direct(midi_handle, &ev);
     }
-    //post("%d %d %d\n", a, b, c);
+    // post("%d %d %d\n", a, b, c);
 }
 
 void sys_alsa_putmidibyte(int portno, int byte)
 {
-  static snd_midi_event_t *dev = NULL;
-  int res;
-  snd_seq_event_t ev;
-  if (!dev) {
-    snd_midi_event_new(ALSA_MAX_EVENT_SIZE, &dev);
-    //assert(dev);
-    snd_midi_event_init(dev);
-  }
-  snd_seq_ev_clear(&ev);
-  res = snd_midi_event_encode_byte(dev, byte, &ev);
-  if (res > 0 && ev.type != SND_SEQ_EVENT_NONE) {
-    // got a complete event, output it
-    snd_seq_ev_set_direct(&ev);
-    snd_seq_ev_set_subs(&ev);
-    snd_seq_ev_set_source(&ev, alsa_midioutfd[portno]);
-    snd_seq_event_output_direct(midi_handle, &ev);
-  }
-  if (res != 0)
-    // reinitialize the parser
-    snd_midi_event_init(dev);
+    static snd_midi_event_t *dev = NULL;
+    int res;
+    snd_seq_event_t ev;
+    if(!dev)
+    {
+        snd_midi_event_new(ALSA_MAX_EVENT_SIZE, &dev);
+        // assert(dev);
+        snd_midi_event_init(dev);
+    }
+    snd_seq_ev_clear(&ev);
+    res = snd_midi_event_encode_byte(dev, byte, &ev);
+    if(res > 0 && ev.type != SND_SEQ_EVENT_NONE)
+    {
+        // got a complete event, output it
+        snd_seq_ev_set_direct(&ev);
+        snd_seq_ev_set_subs(&ev);
+        snd_seq_ev_set_source(&ev, alsa_midioutfd[portno]);
+        snd_seq_event_output_direct(midi_handle, &ev);
+    }
+    if(res != 0)
+        // reinitialize the parser
+        snd_midi_event_init(dev);
 }
 
-
-    /* this version uses the asynchronous "read()" ... */
+/* this version uses the asynchronous "read()" ... */
 void sys_alsa_poll_midi(void)
 {
-   unsigned char buf[ALSA_MAX_EVENT_SIZE];
-   int count, alsa_source;
-   snd_seq_event_t *midievent = NULL;
+    unsigned char buf[ALSA_MAX_EVENT_SIZE];
+    int count, alsa_source;
+    snd_seq_event_t *midievent = NULL;
 
-   if (!alsa_nmidiout && !alsa_nmidiin) return;
+    if(!alsa_nmidiout && !alsa_nmidiin) return;
 
-   snd_midi_event_init(midiev);
+    snd_midi_event_init(midiev);
 
-   while (snd_seq_event_input_pending(midi_handle, 1) > 0) {
-       while (snd_seq_event_input_pending(midi_handle, 0) > 0) {
-           int rslt = snd_seq_event_input(midi_handle, &midievent);
-           if(rslt >= 0) {
-               long length = snd_midi_event_decode(midiev, buf, sizeof(buf), midievent);
-               long i;
-               alsa_source = midievent->dest.port;
-               for(i = 0; i < length; i++)
-                   sys_midibytein(alsa_source, (buf[i] & 0xff));
-           } else if (rslt == -ENOSPC) {
-               pd_error(0, "MIDI input queue overflow!");
-           }
-       }
-   }
+    while(snd_seq_event_input_pending(midi_handle, 1) > 0)
+    {
+        while(snd_seq_event_input_pending(midi_handle, 0) > 0)
+        {
+            int rslt = snd_seq_event_input(midi_handle, &midievent);
+            if(rslt >= 0)
+            {
+                long length =
+                    snd_midi_event_decode(midiev, buf, sizeof(buf), midievent);
+                long i;
+                alsa_source = midievent->dest.port;
+                for(i = 0; i < length; i++)
+                    sys_midibytein(alsa_source, (buf[i] & 0xff));
+            }
+            else if(rslt == -ENOSPC)
+            {
+                pd_error(0, "MIDI input queue overflow!");
+            }
+        }
+    }
 }
 
 void sys_alsa_close_midi()
 {
     alsa_nmidiin = alsa_nmidiout = 0;
-    if (midi_handle)
+    if(midi_handle)
     {
         snd_seq_close(midi_handle);
         midi_handle = NULL;
-        if (midiev)
+        if(midiev)
         {
             snd_midi_event_free(midiev);
             midiev = NULL;
@@ -260,9 +268,7 @@ void sys_alsa_close_midi()
 
 static int alsa_nmidiindevs = 1, alsa_nmidioutdevs = 1;
 
-void midi_alsa_init(void)
-{
-}
+void midi_alsa_init(void) {}
 
 void midi_alsa_setndevs(int in, int out)
 {
@@ -270,19 +276,17 @@ void midi_alsa_setndevs(int in, int out)
     alsa_nmidioutdevs = out;
 }
 
-void midi_alsa_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize)
+void midi_alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize)
 {
     int i, ndev;
-    if ((ndev = alsa_nmidiindevs) > maxndev)
-        ndev = maxndev;
-    for (i = 0; i < ndev; i++)
-        sprintf(indevlist + i * devdescsize, "ALSA MIDI device #%d", i+1);
+    if((ndev = alsa_nmidiindevs) > maxndev) ndev = maxndev;
+    for(i = 0; i < ndev; i++)
+        sprintf(indevlist + i * devdescsize, "ALSA MIDI device #%d", i + 1);
     *nindevs = ndev;
 
-    if ((ndev = alsa_nmidioutdevs) > maxndev)
-        ndev = maxndev;
-    for (i = 0; i < ndev; i++)
-        sprintf(outdevlist + i * devdescsize, "ALSA MIDI device #%d", i+1);
+    if((ndev = alsa_nmidioutdevs) > maxndev) ndev = maxndev;
+    for(i = 0; i < ndev; i++)
+        sprintf(outdevlist + i * devdescsize, "ALSA MIDI device #%d", i + 1);
     *noutdevs = ndev;
 }

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -124,7 +124,6 @@ void sys_alsa_do_open_midi(
 error:
     sys_setalarm(1000000);
     post("couldn't open alsa MIDI output device");
-    return;
 }
 
 void sys_alsa_putmidimess(int portno, int a, int b, int c)

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -54,7 +54,6 @@ void sys_alsa_do_open_midi(
     char portname[50];
     int err = 0;
     int client;
-    int i;
     snd_seq_client_info_t *alsainfo;
 
     alsa_nmidiin = 0;
@@ -92,7 +91,7 @@ void sys_alsa_do_open_midi(
         post("couldn't open alsa sequencer");
         return;
     }
-    for(i = 0; i < nmidiin; i++)
+    for(int i = 0; i < nmidiin; i++)
     {
         int port;
         sprintf(portname, "Pure Data Midi-In %d", i + 1);
@@ -103,7 +102,7 @@ void sys_alsa_do_open_midi(
         if(port < 0) goto error;
     }
 
-    for(i = 0; i < nmidiout; i++)
+    for(int i = 0; i < nmidiout; i++)
     {
         int port;
         sprintf(portname, "Pure Data Midi-Out %d", i + 1);
@@ -246,9 +245,8 @@ void sys_alsa_poll_midi(void)
             {
                 long length =
                     snd_midi_event_decode(midiev, buf, sizeof(buf), midievent);
-                long i;
                 alsa_source = midievent->dest.port;
-                for(i = 0; i < length; i++)
+                for(long i = 0; i < length; i++)
                     sys_midibytein(alsa_source, (buf[i] & 0xff));
             }
             else if(rslt == -ENOSPC)
@@ -287,15 +285,14 @@ void midi_alsa_setndevs(int in, int out)
 void midi_alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i;
     int ndev;
     if((ndev = alsa_nmidiindevs) > maxndev) ndev = maxndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
         sprintf(indevlist + i * devdescsize, "ALSA MIDI device #%d", i + 1);
     *nindevs = ndev;
 
     if((ndev = alsa_nmidioutdevs) > maxndev) ndev = maxndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
         sprintf(outdevlist + i * devdescsize, "ALSA MIDI device #%d", i + 1);
     *noutdevs = ndev;
 }

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -74,11 +74,17 @@ void sys_alsa_do_open_midi(
     }
 
     if(nmidiin > 0 && nmidiout > 0)
+    {
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_DUPLEX, 0);
+    }
     else if(nmidiin > 0)
+    {
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_INPUT, 0);
+    }
     else if(nmidiout > 0)
+    {
         err = snd_seq_open(&midi_handle, "default", SND_SEQ_OPEN_OUTPUT, 0);
+    }
 
     if(err != 0)
     {
@@ -213,8 +219,10 @@ void sys_alsa_putmidibyte(int portno, int byte)
         snd_seq_event_output_direct(midi_handle, &ev);
     }
     if(res != 0)
+    {
         // reinitialize the parser
         snd_midi_event_init(dev);
+    }
 }
 
 /* this version uses the asynchronous "read()" ... */

--- a/src/s_midi_alsa.c
+++ b/src/s_midi_alsa.c
@@ -222,7 +222,8 @@ void sys_alsa_putmidibyte(int portno, int byte)
 void sys_alsa_poll_midi(void)
 {
     unsigned char buf[ALSA_MAX_EVENT_SIZE];
-    int count, alsa_source;
+    int count;
+    int alsa_source;
     snd_seq_event_t *midievent = NULL;
 
     if(!alsa_nmidiout && !alsa_nmidiin) return;
@@ -279,7 +280,8 @@ void midi_alsa_setndevs(int in, int out)
 void midi_alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i, ndev;
+    int i;
+    int ndev;
     if((ndev = alsa_nmidiindevs) > maxndev) ndev = maxndev;
     for(i = 0; i < ndev; i++)
         sprintf(indevlist + i * devdescsize, "ALSA MIDI device #%d", i + 1);

--- a/src/s_midi_dummy.c
+++ b/src/s_midi_dummy.c
@@ -7,28 +7,20 @@
 
 */
 
-void sys_do_open_midi(int nmidiin, int *midiinvec,
-    int nmidiout, int *midioutvec)
+void sys_do_open_midi(
+    int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
 }
 
-void sys_close_midi(void)
-{
-}
+void sys_close_midi(void) {}
 
-void sys_putmidimess(int portno, int a, int b, int c)
-{
-}
+void sys_putmidimess(int portno, int a, int b, int c) {}
 
-void sys_putmidibyte(int portno, int byte)
-{
-}
+void sys_putmidibyte(int portno, int byte) {}
 
-void sys_poll_midi(void)
-{
-}
+void sys_poll_midi(void) {}
 
-void midi_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize)
+void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize)
 {
 }

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -79,9 +79,11 @@ void sys_do_open_midi(
         int devno = midiinvec[i];
         if(devno < 0 || devno >= oss_nmididevs) continue;
         for(j = 0; j < nmidiout; j++)
+        {
             if(midioutvec[j] >= 0 && midioutvec[j] <= oss_nmididevs &&
                 !strcmp(oss_midinames[midioutvec[j]], oss_midinames[devno]))
                 outdevindex = j;
+        }
 
         /* try to open the device for read/write. */
         if(outdevindex >= 0)
@@ -101,9 +103,13 @@ void sys_do_open_midi(
                 oss_midinames[devno], fd);
         }
         if(fd >= 0)
+        {
             oss_midiinfd[oss_nmidiin++] = fd;
+        }
         else
+        {
             post("couldn't open MIDI input device %s", oss_midinames[devno]);
+        }
     }
     for(i = 0, oss_nmidiout = 0; i < nmidiout; i++)
     {
@@ -118,14 +124,20 @@ void sys_do_open_midi(
                 oss_midinames[devno], fd);
         }
         if(fd >= 0)
+        {
             oss_midioutfd[oss_nmidiout++] = fd;
+        }
         else
+        {
             post("couldn't open MIDI output device %s", oss_midinames[devno]);
+        }
     }
 
     if(oss_nmidiin < nmidiin || oss_nmidiout < nmidiout || sys_verbose)
+    {
         post("opened %d MIDI input device(s) and %d MIDI output device(s).",
             oss_nmidiin, oss_nmidiout);
+    }
 
     sys_setalarm(0);
 }

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 1997-1999 Guenter Geiger, Miller Puckette, Larry Troxler,
-* Winfried Ritsch, Karl MacMillan, and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * Winfried Ritsch, Karl MacMillan, and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* MIDI I/O for Linux using OSS */
 
@@ -22,29 +22,30 @@
 static int oss_nmididevs;
 static char oss_midinames[MAXNDEV][20];
 static int oss_nmidiin;
-static int oss_midiinfd[MAXMIDIINDEV+1]; /* +1 to suppress buggy GCC warning */
+static int
+    oss_midiinfd[MAXMIDIINDEV + 1]; /* +1 to suppress buggy GCC warning */
 static int oss_nmidiout;
-static int oss_midioutfd[MAXMIDIOUTDEV+1];
+static int oss_midioutfd[MAXMIDIOUTDEV + 1];
 
 static void close_one_midi_fd(int fd)
 {
     int i, j;
     close(fd);
-    for (i = 0; i < oss_nmidiin; i++)
+    for(i = 0; i < oss_nmidiin; i++)
     {
-        if (oss_midiinfd[i] == fd)
+        if(oss_midiinfd[i] == fd)
         {
-            for (j = i; j < oss_nmidiin-1; j++)
-                oss_midiinfd[j] = oss_midiinfd[j+1];
+            for(j = i; j < oss_nmidiin - 1; j++)
+                oss_midiinfd[j] = oss_midiinfd[j + 1];
             oss_nmidiin--;
         }
     }
-    for (i = 0; i < oss_nmidiout; i++)
+    for(i = 0; i < oss_nmidiout; i++)
     {
-        if (oss_midioutfd[i] == fd)
+        if(oss_midioutfd[i] == fd)
         {
-            for (j = i; j < oss_nmidiout-1; j++)
-                oss_midioutfd[j] = oss_midioutfd[j+1];
+            for(j = i; j < oss_nmidiout - 1; j++)
+                oss_midioutfd[j] = oss_midioutfd[j + 1];
             oss_nmidiout--;
         }
     }
@@ -53,111 +54,112 @@ static void close_one_midi_fd(int fd)
 static void oss_midiout(int fd, int n)
 {
     char b = n;
-    if ((write(fd, (char *) &b, 1)) != 1)
+    if((write(fd, (char *) &b, 1)) != 1)
     {
         perror("MIDI write");
-        if (errno == ENODEV)  /* probably a USB dev got unplugged */
+        if(errno == ENODEV) /* probably a USB dev got unplugged */
             close_one_midi_fd(fd);
     }
 }
 
 #define O_MIDIFLAG O_NDELAY
 
-void sys_do_open_midi(int nmidiin, int *midiinvec,
-    int nmidiout, int *midioutvec)
+void sys_do_open_midi(
+    int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
     int i;
-    for (i = 0; i < nmidiout; i++)
+    for(i = 0; i < nmidiout; i++)
         oss_midioutfd[i] = -1;
-    for (i = 0, oss_nmidiin = 0; i < nmidiin; i++)
+    for(i = 0, oss_nmidiin = 0; i < nmidiin; i++)
     {
         int fd = -1, j, outdevindex = -1;
         int devno = midiinvec[i];
-        if (devno < 0 || devno >= oss_nmididevs)
-            continue;
-        for (j = 0; j < nmidiout; j++)
-            if (midioutvec[j] >= 0 && midioutvec[j] <= oss_nmididevs
-                && !strcmp(oss_midinames[midioutvec[j]],
-                oss_midinames[devno]))
-                    outdevindex = j;
+        if(devno < 0 || devno >= oss_nmididevs) continue;
+        for(j = 0; j < nmidiout; j++)
+            if(midioutvec[j] >= 0 && midioutvec[j] <= oss_nmididevs &&
+                !strcmp(oss_midinames[midioutvec[j]], oss_midinames[devno]))
+                outdevindex = j;
 
-            /* try to open the device for read/write. */
-        if (outdevindex >= 0)
+        /* try to open the device for read/write. */
+        if(outdevindex >= 0)
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_RDWR | O_MIDIFLAG);
             logpost(NULL, PD_VERBOSE, "tried to open %s read/write; got %d\n",
                 oss_midinames[devno], fd);
-            if (outdevindex >= 0 && fd >= 0)
-                oss_midioutfd[outdevindex] = fd;
+            if(outdevindex >= 0 && fd >= 0) oss_midioutfd[outdevindex] = fd;
         }
-            /* OK, try read-only */
-        if (fd < 0)
+        /* OK, try read-only */
+        if(fd < 0)
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_RDONLY | O_MIDIFLAG);
             logpost(NULL, PD_VERBOSE, "tried to open %s read-only; got %d\n",
                 oss_midinames[devno], fd);
         }
-        if (fd >= 0)
+        if(fd >= 0)
             oss_midiinfd[oss_nmidiin++] = fd;
-        else post("couldn't open MIDI input device %s",
-            oss_midinames[devno]);
+        else
+            post("couldn't open MIDI input device %s", oss_midinames[devno]);
     }
-    for (i = 0, oss_nmidiout = 0; i < nmidiout; i++)
+    for(i = 0, oss_nmidiout = 0; i < nmidiout; i++)
     {
         int fd = oss_midioutfd[i];
         int devno = midioutvec[i];
-        if (devno < 0 || devno >= oss_nmididevs)
-            continue;
-        if (fd < 0)
+        if(devno < 0 || devno >= oss_nmididevs) continue;
+        if(fd < 0)
         {
             sys_setalarm(1000000);
             fd = open(oss_midinames[devno], O_WRONLY | O_MIDIFLAG);
             logpost(NULL, PD_VERBOSE, "tried to open %s write-only; got %d\n",
                 oss_midinames[devno], fd);
         }
-        if (fd >= 0)
+        if(fd >= 0)
             oss_midioutfd[oss_nmidiout++] = fd;
-        else post("couldn't open MIDI output device %s",
-            oss_midinames[devno]);
+        else
+            post("couldn't open MIDI output device %s", oss_midinames[devno]);
     }
 
-    if (oss_nmidiin < nmidiin || oss_nmidiout < nmidiout || sys_verbose)
+    if(oss_nmidiin < nmidiin || oss_nmidiout < nmidiout || sys_verbose)
         post("opened %d MIDI input device(s) and %d MIDI output device(s).",
             oss_nmidiin, oss_nmidiout);
 
     sys_setalarm(0);
 }
 
-#define md_msglen(x) (((x)<0xC0)?2:((x)<0xE0)?1:((x)<0xF0)?2:\
-    ((x)==0xF2)?2:((x)<0xF4)?1:0)
+#define md_msglen(x)        \
+    (((x) < 0xC0)       ? 2 \
+        : ((x) < 0xE0)  ? 1 \
+        : ((x) < 0xF0)  ? 2 \
+        : ((x) == 0xF2) ? 2 \
+        : ((x) < 0xF4)  ? 1 \
+                        : 0)
 
 void sys_putmidimess(int portno, int a, int b, int c)
 {
-    if (portno >= 0 && portno < oss_nmidiout)
+    if(portno >= 0 && portno < oss_nmidiout)
     {
-       switch (md_msglen(a))
-       {
-       case 2:
-            oss_midiout(oss_midioutfd[portno],a);
-            oss_midiout(oss_midioutfd[portno],b);
-            oss_midiout(oss_midioutfd[portno],c);
-            return;
-       case 1:
-            oss_midiout(oss_midioutfd[portno],a);
-            oss_midiout(oss_midioutfd[portno],b);
-            return;
-       case 0:
-            oss_midiout(oss_midioutfd[portno],a);
-            return;
-       };
+        switch(md_msglen(a))
+        {
+            case 2:
+                oss_midiout(oss_midioutfd[portno], a);
+                oss_midiout(oss_midioutfd[portno], b);
+                oss_midiout(oss_midioutfd[portno], c);
+                return;
+            case 1:
+                oss_midiout(oss_midioutfd[portno], a);
+                oss_midiout(oss_midioutfd[portno], b);
+                return;
+            case 0:
+                oss_midiout(oss_midioutfd[portno], a);
+                return;
+        };
     }
 }
 
 void sys_putmidibyte(int portno, int byte)
 {
-    if (portno >= 0 && portno < oss_nmidiout)
+    if(portno >= 0 && portno < oss_nmidiout)
         oss_midiout(oss_midioutfd[portno], byte);
 }
 
@@ -165,26 +167,25 @@ void sys_poll_midi(void)
 {
     int i, throttle = 100;
     int did = 1, maxfd = 0;
-    while (did)
+    while(did)
     {
         did = 0;
-        if (throttle-- < 0)
-            break;
-        for (i = 0; i < oss_nmidiin; i++)
+        if(throttle-- < 0) break;
+        for(i = 0; i < oss_nmidiin; i++)
         {
             char c;
             int ret = read(oss_midiinfd[i], &c, 1);
-            if (ret < 0)
+            if(ret < 0)
             {
-                if (errno == ENODEV)
+                if(errno == ENODEV)
                 {
                     close_one_midi_fd(oss_midiinfd[i]);
                     return; /* oss_nmidiinfd changed so blow off the rest */
                 }
-                else if (errno != EAGAIN)
+                else if(errno != EAGAIN)
                     perror("MIDI");
             }
-            else if (ret != 0)
+            else if(ret != 0)
             {
                 sys_midibytein(i, (c & 0xff));
                 did = 1;
@@ -196,9 +197,9 @@ void sys_poll_midi(void)
 void sys_close_midi()
 {
     int i;
-    for (i = 0; i < oss_nmidiin; i++)
+    for(i = 0; i < oss_nmidiin; i++)
         close(oss_midiinfd[i]);
-    for (i = 0; i < oss_nmidiout; i++)
+    for(i = 0; i < oss_nmidiout; i++)
         close(oss_midioutfd[i]);
     oss_nmidiin = oss_nmidiout = 0;
 }
@@ -210,35 +211,32 @@ void midi_oss_init(void)
     char namebuf[80];
 
     oss_nmididevs = 0;
-    if (oss_nmididevs < MAXNDEV && !stat("/dev/midi", &statbuf))
+    if(oss_nmididevs < MAXNDEV && !stat("/dev/midi", &statbuf))
         strcpy(oss_midinames[oss_nmididevs++], "/dev/midi");
-    for (devno = 0; devno < MAXNDEV; devno++)
+    for(devno = 0; devno < MAXNDEV; devno++)
     {
         sprintf(namebuf, "/dev/midi%d", devno);
-        if (oss_nmididevs < MAXNDEV && !stat(namebuf, &statbuf))
+        if(oss_nmididevs < MAXNDEV && !stat(namebuf, &statbuf))
             strcpy(oss_midinames[oss_nmididevs++], namebuf);
         sprintf(namebuf, "/dev/midi%2.2d", devno);
-        if (oss_nmididevs < MAXNDEV && !stat(namebuf, &statbuf))
+        if(oss_nmididevs < MAXNDEV && !stat(namebuf, &statbuf))
             strcpy(oss_midinames[oss_nmididevs++], namebuf);
     }
 }
 
-void midi_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize)
+void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize)
 {
     int i, ndev;
     midi_oss_init();
 
-    if ((ndev = oss_nmididevs) > maxndev)
-        ndev = maxndev;
-    for (i = 0; i < ndev; i++)
+    if((ndev = oss_nmididevs) > maxndev) ndev = maxndev;
+    for(i = 0; i < ndev; i++)
         strcpy(indevlist + i * devdescsize, oss_midinames[i]);
     *nindevs = ndev;
 
-    if ((ndev = oss_nmididevs) > maxndev)
-        ndev = maxndev;
-    for (i = 0; i < ndev; i++)
-        strcpy(outdevlist + i * devdescsize,
-            oss_midinames[i]);
+    if((ndev = oss_nmididevs) > maxndev) ndev = maxndev;
+    for(i = 0; i < ndev; i++)
+        strcpy(outdevlist + i * devdescsize, oss_midinames[i]);
     *noutdevs = ndev;
 }

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -29,23 +29,21 @@ static int oss_midioutfd[MAXMIDIOUTDEV + 1];
 
 static void close_one_midi_fd(int fd)
 {
-    int i;
-    int j;
     close(fd);
-    for(i = 0; i < oss_nmidiin; i++)
+    for(int i = 0; i < oss_nmidiin; i++)
     {
         if(oss_midiinfd[i] == fd)
         {
-            for(j = i; j < oss_nmidiin - 1; j++)
+            for(int j = i; j < oss_nmidiin - 1; j++)
                 oss_midiinfd[j] = oss_midiinfd[j + 1];
             oss_nmidiin--;
         }
     }
-    for(i = 0; i < oss_nmidiout; i++)
+    for(int i = 0; i < oss_nmidiout; i++)
     {
         if(oss_midioutfd[i] == fd)
         {
-            for(j = i; j < oss_nmidiout - 1; j++)
+            for(int j = i; j < oss_nmidiout - 1; j++)
                 oss_midioutfd[j] = oss_midioutfd[j + 1];
             oss_nmidiout--;
         }
@@ -180,7 +178,6 @@ void sys_putmidibyte(int portno, int byte)
 
 void sys_poll_midi(void)
 {
-    int i;
     int throttle = 100;
     int did = 1;
     int maxfd = 0;
@@ -188,7 +185,7 @@ void sys_poll_midi(void)
     {
         did = 0;
         if(throttle-- < 0) break;
-        for(i = 0; i < oss_nmidiin; i++)
+        for(int i = 0; i < oss_nmidiin; i++)
         {
             char c;
             int ret = read(oss_midiinfd[i], &c, 1);
@@ -212,10 +209,9 @@ void sys_poll_midi(void)
 
 void sys_close_midi()
 {
-    int i;
-    for(i = 0; i < oss_nmidiin; i++)
+    for(int i = 0; i < oss_nmidiin; i++)
         close(oss_midiinfd[i]);
-    for(i = 0; i < oss_nmidiout; i++)
+    for(int i = 0; i < oss_nmidiout; i++)
         close(oss_midioutfd[i]);
     oss_nmidiin = oss_nmidiout = 0;
 }
@@ -244,17 +240,16 @@ void midi_oss_init(void)
 void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i;
     int ndev;
     midi_oss_init();
 
     if((ndev = oss_nmididevs) > maxndev) ndev = maxndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
         strcpy(indevlist + i * devdescsize, oss_midinames[i]);
     *nindevs = ndev;
 
     if((ndev = oss_nmididevs) > maxndev) ndev = maxndev;
-    for(i = 0; i < ndev; i++)
+    for(int i = 0; i < ndev; i++)
         strcpy(outdevlist + i * devdescsize, oss_midinames[i]);
     *noutdevs = ndev;
 }

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -29,7 +29,8 @@ static int oss_midioutfd[MAXMIDIOUTDEV + 1];
 
 static void close_one_midi_fd(int fd)
 {
-    int i, j;
+    int i;
+    int j;
     close(fd);
     for(i = 0; i < oss_nmidiin; i++)
     {
@@ -72,7 +73,9 @@ void sys_do_open_midi(
         oss_midioutfd[i] = -1;
     for(i = 0, oss_nmidiin = 0; i < nmidiin; i++)
     {
-        int fd = -1, j, outdevindex = -1;
+        int fd = -1;
+        int j;
+        int outdevindex = -1;
         int devno = midiinvec[i];
         if(devno < 0 || devno >= oss_nmididevs) continue;
         for(j = 0; j < nmidiout; j++)
@@ -165,8 +168,10 @@ void sys_putmidibyte(int portno, int byte)
 
 void sys_poll_midi(void)
 {
-    int i, throttle = 100;
-    int did = 1, maxfd = 0;
+    int i;
+    int throttle = 100;
+    int did = 1;
+    int maxfd = 0;
     while(did)
     {
         did = 0;
@@ -206,7 +211,8 @@ void sys_close_midi()
 
 void midi_oss_init(void)
 {
-    int fd, devno;
+    int fd;
+    int devno;
     struct stat statbuf;
     char namebuf[80];
 
@@ -227,7 +233,8 @@ void midi_oss_init(void)
 void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i, ndev;
+    int i;
+    int ndev;
     midi_oss_init();
 
     if((ndev = oss_nmididevs) > maxndev) ndev = maxndev;

--- a/src/s_midi_oss.c
+++ b/src/s_midi_oss.c
@@ -187,8 +187,7 @@ void sys_poll_midi(void)
                     close_one_midi_fd(oss_midiinfd[i]);
                     return; /* oss_nmidiinfd changed so blow off the rest */
                 }
-                else if(errno != EAGAIN)
-                    perror("MIDI");
+                if(errno != EAGAIN) perror("MIDI");
             }
             else if(ret != 0)
             {

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -69,8 +69,10 @@ void sys_do_open_midi(
                     err = Pm_OpenInput(&mac_midiindevlist[mac_nmidiindev], j,
                         NULL, 1024, NULL, NULL);
                     if(err)
+                    {
                         post("could not open MIDI input %d (%s): %s", j,
                             info->name, Pm_GetErrorText(err));
+                    }
                     else
                     {
                         /* disable default active sense filtering */
@@ -98,8 +100,10 @@ void sys_do_open_midi(
                     err = Pm_OpenOutput(&mac_midioutdevlist[mac_nmidioutdev], j,
                         NULL, 0, NULL, NULL, 0);
                     if(err)
+                    {
                         post("could not open MIDI output %d (%s): %s", j,
                             info->name, Pm_GetErrorText(err));
+                    }
                     else
                     {
                         logpost(NULL, PD_VERBOSE, "MIDI output (%s) opened.",
@@ -292,8 +296,11 @@ void sys_poll_midi(void)
                     sys_midibytein(i, status);
                 }
                 else if(nd_sysex_mode)
+                {
                     nd_sysex_inword(i, status, data1, data2, data3);
+                }
                 else
+                {
                     switch(msgtype)
                     {
                         /* 2 data bytes */
@@ -325,6 +332,7 @@ void sys_poll_midi(void)
                             sys_midibytein(i, status);
                             break;
                     }
+                }
             }
             else
             {

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -48,7 +48,9 @@ static int mac_nmidioutdev;
 void sys_do_open_midi(
     int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
-    int i = 0, j, devno;
+    int i = 0;
+    int j;
+    int devno;
     int n = 0;
     PmError err;
 
@@ -149,7 +151,9 @@ void sys_putmidibyte(int portno, int byte)
     /* try to parse the bytes into MIDI messages so they can
     fit into PortMidi buffers. */
     static int mess[4];
-    static int nbytes = 0, sysex = 0, i;
+    static int nbytes = 0;
+    static int sysex = 0;
+    static int i;
     if(byte > MIDI_SYSEXEND)
     {
         /* realtime */
@@ -264,7 +268,9 @@ void nd_sysex_inword(int midiindev, int status, int data1, int data2, int data3)
 
 void sys_poll_midi(void)
 {
-    int i, nmess, throttle = 100;
+    int i;
+    int nmess;
+    int throttle = 100;
     PmEvent buffer;
     for(i = 0; i < mac_nmidiindev; i++)
     {
@@ -333,7 +339,9 @@ overload:;
 void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i, nindev = 0, noutdev = 0;
+    int i;
+    int nindev = 0;
+    int noutdev = 0;
     char utf8device[MAXPDSTRING];
     utf8device[0] = 0;
     for(i = 0; i < Pm_CountDevices(); i++)

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -26,27 +26,27 @@
 
 /* full status byte definitions in s_midi.c */
 /* channel voice messages */
-#define MIDI_NOTEOFF        0x80
-#define MIDI_NOTEON         0x90
+#define MIDI_NOTEOFF 0x80
+#define MIDI_NOTEON 0x90
 #define MIDI_POLYAFTERTOUCH 0xa0
-#define MIDI_CONTROLCHANGE  0xb0
-#define MIDI_PROGRAMCHANGE  0xc0
-#define MIDI_AFTERTOUCH     0xd0
-#define MIDI_PITCHBEND      0xe0
+#define MIDI_CONTROLCHANGE 0xb0
+#define MIDI_PROGRAMCHANGE 0xc0
+#define MIDI_AFTERTOUCH 0xd0
+#define MIDI_PITCHBEND 0xe0
 /* system common messages */
-#define MIDI_SYSEX          0xf0
-#define MIDI_TIMECODE       0xf1
-#define MIDI_SONGPOS        0xf2
-#define MIDI_SONGSELECT     0xf3
-#define MIDI_SYSEXEND       0xf7
+#define MIDI_SYSEX 0xf0
+#define MIDI_TIMECODE 0xf1
+#define MIDI_SONGPOS 0xf2
+#define MIDI_SONGSELECT 0xf3
+#define MIDI_SYSEXEND 0xf7
 
 static PmStream *mac_midiindevlist[MAXMIDIINDEV];
 static PmStream *mac_midioutdevlist[MAXMIDIOUTDEV];
 static int mac_nmidiindev;
 static int mac_nmidioutdev;
 
-void sys_do_open_midi(int nmidiin, int *midiinvec,
-    int nmidiout, int *midioutvec)
+void sys_do_open_midi(
+    int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
     int i = 0, j, devno;
     int n = 0;
@@ -55,20 +55,20 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
     Pt_Start(1, 0, 0); /* start a timer with millisecond accuracy */
 
     mac_nmidiindev = 0;
-    for (i = 0; i < nmidiin; i++)
+    for(i = 0; i < nmidiin; i++)
     {
-        for (j = 0, devno = 0; j < Pm_CountDevices(); j++)
+        for(j = 0, devno = 0; j < Pm_CountDevices(); j++)
         {
             const PmDeviceInfo *info = Pm_GetDeviceInfo(j);
-            if (info->input)
+            if(info->input)
             {
-                if (devno == midiinvec[i])
+                if(devno == midiinvec[i])
                 {
-                    err = Pm_OpenInput(&mac_midiindevlist[mac_nmidiindev],
-                        j, NULL, 1024, NULL, NULL);
-                    if (err)
-                        post("could not open MIDI input %d (%s): %s",
-                            j, info->name, Pm_GetErrorText(err));
+                    err = Pm_OpenInput(&mac_midiindevlist[mac_nmidiindev], j,
+                        NULL, 1024, NULL, NULL);
+                    if(err)
+                        post("could not open MIDI input %d (%s): %s", j,
+                            info->name, Pm_GetErrorText(err));
                     else
                     {
                         /* disable default active sense filtering */
@@ -84,21 +84,20 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
     }
 
     mac_nmidioutdev = 0;
-    for (i = 0; i < nmidiout; i++)
+    for(i = 0; i < nmidiout; i++)
     {
-        for (j = 0, devno = 0; j < Pm_CountDevices(); j++)
+        for(j = 0, devno = 0; j < Pm_CountDevices(); j++)
         {
             const PmDeviceInfo *info = Pm_GetDeviceInfo(j);
-            if (info->output)
+            if(info->output)
             {
-                if (devno == midioutvec[i])
+                if(devno == midioutvec[i])
                 {
-                    err = Pm_OpenOutput(
-                        &mac_midioutdevlist[mac_nmidioutdev],
-                            j, NULL, 0, NULL, NULL, 0);
-                    if (err)
-                        post("could not open MIDI output %d (%s): %s",
-                            j, info->name, Pm_GetErrorText(err));
+                    err = Pm_OpenOutput(&mac_midioutdevlist[mac_nmidioutdev], j,
+                        NULL, 0, NULL, NULL, 0);
+                    if(err)
+                        post("could not open MIDI output %d (%s): %s", j,
+                            info->name, Pm_GetErrorText(err));
                     else
                     {
                         logpost(NULL, PD_VERBOSE, "MIDI output (%s) opened.",
@@ -115,10 +114,10 @@ void sys_do_open_midi(int nmidiin, int *midiinvec,
 void sys_close_midi(void)
 {
     int i;
-    for (i = 0; i < mac_nmidiindev; i++)
+    for(i = 0; i < mac_nmidiindev; i++)
         Pm_Close(mac_midiindevlist[i]);
     mac_nmidiindev = 0;
-    for (i = 0; i < mac_nmidioutdev; i++)
+    for(i = 0; i < mac_nmidioutdev; i++)
         Pm_Close(mac_midioutdevlist[i]);
     mac_nmidioutdev = 0;
 }
@@ -127,7 +126,7 @@ void sys_putmidimess(int portno, int a, int b, int c)
 {
     PmEvent buffer;
     /* fprintf(stderr, "put 1 msg %d %d\n", portno, mac_nmidioutdev); */
-    if (portno >= 0 && portno < mac_nmidioutdev)
+    if(portno >= 0 && portno < mac_nmidioutdev)
     {
         buffer.message = Pm_Message(a, b, c);
         buffer.timestamp = 0;
@@ -136,50 +135,49 @@ void sys_putmidimess(int portno, int a, int b, int c)
     }
 }
 
-static void writemidi4(PortMidiStream* stream, int a, int b, int c, int d)
+static void writemidi4(PortMidiStream *stream, int a, int b, int c, int d)
 {
     PmEvent buffer;
     buffer.timestamp = 0;
-    buffer.message = ((a & 0xff) | ((b & 0xff) << 8)
-        | ((c & 0xff) << 16) | ((d & 0xff) << 24));
+    buffer.message = ((a & 0xff) | ((b & 0xff) << 8) | ((c & 0xff) << 16) |
+                      ((d & 0xff) << 24));
     Pm_Write(stream, &buffer, 1);
 }
 
-
 void sys_putmidibyte(int portno, int byte)
 {
-        /* try to parse the bytes into MIDI messages so they can
-        fit into PortMidi buffers. */
+    /* try to parse the bytes into MIDI messages so they can
+    fit into PortMidi buffers. */
     static int mess[4];
     static int nbytes = 0, sysex = 0, i;
-    if (byte > MIDI_SYSEXEND)
+    if(byte > MIDI_SYSEXEND)
     {
         /* realtime */
         writemidi4(mac_midioutdevlist[portno], byte, 0, 0, 0);
     }
-    else if (byte == MIDI_SYSEX)
+    else if(byte == MIDI_SYSEX)
     {
         /* sysex start */
         mess[0] = MIDI_SYSEX;
         nbytes = 1;
         sysex = 1;
     }
-    else if (byte == MIDI_SYSEXEND)
+    else if(byte == MIDI_SYSEXEND)
     {
         /* sysex end */
         mess[nbytes] = byte;
-        for (i = nbytes+1; i < 4; i++)
+        for(i = nbytes + 1; i < 4; i++)
             mess[i] = 0;
-        writemidi4(mac_midioutdevlist[portno],
-            mess[0], mess[1], mess[2], mess[3]);
+        writemidi4(
+            mac_midioutdevlist[portno], mess[0], mess[1], mess[2], mess[3]);
         sysex = 0;
         nbytes = 0;
     }
-    else if (byte >= MIDI_NOTEOFF)
+    else if(byte >= MIDI_NOTEOFF)
     {
         /* status byte */
         sysex = 0;
-        if (byte > MIDI_SONGSELECT)
+        if(byte > MIDI_SONGSELECT)
         {
             /* 0 data bytes */
             writemidi4(mac_midioutdevlist[portno], byte, 0, 0, 0);
@@ -192,42 +190,40 @@ void sys_putmidibyte(int portno, int byte)
             nbytes = 1;
         }
     }
-    else if (sysex)
+    else if(sysex)
     {
         /* sysex data byte */
         mess[nbytes] = byte;
         nbytes++;
-        if (nbytes == 4)
+        if(nbytes == 4)
         {
-            writemidi4(mac_midioutdevlist[portno],
-                mess[0], mess[1], mess[2], mess[3]);
+            writemidi4(
+                mac_midioutdevlist[portno], mess[0], mess[1], mess[2], mess[3]);
             nbytes = 0;
         }
     }
-    else if (nbytes)
+    else if(nbytes)
     {
         /* channel or system message */
         int status = mess[0];
-        if (status < MIDI_SYSEX)
-            status &= 0xf0;
-        if (status == MIDI_PROGRAMCHANGE || status == MIDI_AFTERTOUCH ||
+        if(status < MIDI_SYSEX) status &= 0xf0;
+        if(status == MIDI_PROGRAMCHANGE || status == MIDI_AFTERTOUCH ||
             status == MIDI_TIMECODE || status == MIDI_SONGSELECT)
         {
-            writemidi4(mac_midioutdevlist[portno],
-                mess[0], byte, 0, 0);
+            writemidi4(mac_midioutdevlist[portno], mess[0], byte, 0, 0);
             nbytes = (status < MIDI_SYSEX ? 1 : 0);
         }
         else
         {
-            if (nbytes == 1)
+            if(nbytes == 1)
             {
                 mess[1] = byte;
                 nbytes = 2;
             }
             else
             {
-                writemidi4(mac_midioutdevlist[portno],
-                    mess[0], mess[1], byte, 0);
+                writemidi4(
+                    mac_midioutdevlist[portno], mess[0], mess[1], byte, 0);
                 nbytes = (status < 0xf0 ? 1 : 0);
             }
         }
@@ -241,28 +237,28 @@ int nd_sysex_mode = 0;
     stop and unset nd_sysex_mode */
 void nd_sysex_inword(int midiindev, int status, int data1, int data2, int data3)
 {
-    if (nd_sysex_mode) {
+    if(nd_sysex_mode)
+    {
         sys_midibytein(midiindev, status);
-        if (status == MIDI_SYSEXEND)
-            nd_sysex_mode = 0;
+        if(status == MIDI_SYSEXEND) nd_sysex_mode = 0;
     }
 
-    if (nd_sysex_mode) {
+    if(nd_sysex_mode)
+    {
         sys_midibytein(midiindev, data1);
-        if (data1 == MIDI_SYSEXEND)
-            nd_sysex_mode = 0;
+        if(data1 == MIDI_SYSEXEND) nd_sysex_mode = 0;
     }
 
-    if (nd_sysex_mode) {
+    if(nd_sysex_mode)
+    {
         sys_midibytein(midiindev, data2);
-        if (data2 == MIDI_SYSEXEND)
-            nd_sysex_mode = 0;
+        if(data2 == MIDI_SYSEXEND) nd_sysex_mode = 0;
     }
 
-    if (nd_sysex_mode) {
+    if(nd_sysex_mode)
+    {
         sys_midibytein(midiindev, data3);
-        if (data3 == MIDI_SYSEXEND)
-            nd_sysex_mode = 0;
+        if(data3 == MIDI_SYSEXEND) nd_sysex_mode = 0;
     }
 }
 
@@ -270,90 +266,88 @@ void sys_poll_midi(void)
 {
     int i, nmess, throttle = 100;
     PmEvent buffer;
-    for (i = 0; i < mac_nmidiindev; i++)
+    for(i = 0; i < mac_nmidiindev; i++)
     {
         while((nmess = Pm_Read(mac_midiindevlist[i], &buffer, 1)))
         {
-            if (!throttle--)
-                goto overload;
-            if (nmess > 0)
+            if(!throttle--) goto overload;
+            if(nmess > 0)
             {
                 int status = Pm_MessageStatus(buffer.message);
-                int data1  = Pm_MessageData1(buffer.message);
-                int data2  = Pm_MessageData2(buffer.message);
-                int data3  = ((buffer.message >> 24) & 0xff);
-                int msgtype = ((status & 0xf0) == 0xf0 ?
-                                status : (status & 0xf0));
+                int data1 = Pm_MessageData1(buffer.message);
+                int data2 = Pm_MessageData2(buffer.message);
+                int data3 = ((buffer.message >> 24) & 0xff);
+                int msgtype =
+                    ((status & 0xf0) == 0xf0 ? status : (status & 0xf0));
 
-                if (status > MIDI_SYSEXEND)
+                if(status > MIDI_SYSEXEND)
                 {
                     /* realtime message */
                     sys_midibytein(i, status);
                 }
-                else if (nd_sysex_mode)
+                else if(nd_sysex_mode)
                     nd_sysex_inword(i, status, data1, data2, data3);
-                else switch (msgtype)
-                {
-                    /* 2 data bytes */
-                    case MIDI_NOTEOFF:
-                    case MIDI_NOTEON:
-                    case MIDI_POLYAFTERTOUCH:
-                    case MIDI_CONTROLCHANGE:
-                    case MIDI_PITCHBEND:
-                    case MIDI_SONGPOS:
-                        sys_midibytein(i, status);
-                        sys_midibytein(i, data1);
-                        sys_midibytein(i, data2);
-                        break;
-                    /* 1 data byte */
-                    case MIDI_PROGRAMCHANGE:
-                    case MIDI_AFTERTOUCH:
-                    case MIDI_TIMECODE:
-                    case MIDI_SONGSELECT:
-                        sys_midibytein(i, status);
-                        sys_midibytein(i, data1);
-                        break;
-                    /* no data bytes */
-                    case MIDI_SYSEX:
-                        nd_sysex_mode = 1;
-                        nd_sysex_inword(i, status, data1, data2, data3);
-                        break;
-                    /* all others */
-                    default:
-                        sys_midibytein(i, status);
-                        break;
-                }
+                else
+                    switch(msgtype)
+                    {
+                        /* 2 data bytes */
+                        case MIDI_NOTEOFF:
+                        case MIDI_NOTEON:
+                        case MIDI_POLYAFTERTOUCH:
+                        case MIDI_CONTROLCHANGE:
+                        case MIDI_PITCHBEND:
+                        case MIDI_SONGPOS:
+                            sys_midibytein(i, status);
+                            sys_midibytein(i, data1);
+                            sys_midibytein(i, data2);
+                            break;
+                        /* 1 data byte */
+                        case MIDI_PROGRAMCHANGE:
+                        case MIDI_AFTERTOUCH:
+                        case MIDI_TIMECODE:
+                        case MIDI_SONGSELECT:
+                            sys_midibytein(i, status);
+                            sys_midibytein(i, data1);
+                            break;
+                        /* no data bytes */
+                        case MIDI_SYSEX:
+                            nd_sysex_mode = 1;
+                            nd_sysex_inword(i, status, data1, data2, data3);
+                            break;
+                        /* all others */
+                        default:
+                            sys_midibytein(i, status);
+                            break;
+                    }
             }
             else
             {
                 pd_error(0, "%s", Pm_GetErrorText(nmess));
-                if (nmess != pmBufferOverflow)
-                    break;
+                if(nmess != pmBufferOverflow) break;
             }
         }
     }
-    overload: ;
+overload:;
 }
 
-void midi_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize)
+void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize)
 {
     int i, nindev = 0, noutdev = 0;
     char utf8device[MAXPDSTRING];
     utf8device[0] = 0;
-    for (i = 0; i < Pm_CountDevices(); i++)
+    for(i = 0; i < Pm_CountDevices(); i++)
     {
         const PmDeviceInfo *info = Pm_GetDeviceInfo(i);
         /* post("%d: %s, %s (%d,%d)", i, info->interf, info->name,
             info->input, info->output); */
-        if(!u8_nativetoutf8(utf8device, MAXPDSTRING, info->name, -1))
-            continue;
-        if (info->input && nindev < maxndev)
+        if(!u8_nativetoutf8(utf8device, MAXPDSTRING, info->name, -1)) continue;
+        if(info->input && nindev < maxndev)
         {
             strcpy(indevlist + nindev * devdescsize, utf8device);
             nindev++;
         }
-        if (info->output && noutdev < maxndev)
+        if(info->output && noutdev < maxndev)
         {
             strcpy(outdevlist + noutdev * devdescsize, utf8device);
             noutdev++;

--- a/src/s_midi_pm.c
+++ b/src/s_midi_pm.c
@@ -48,8 +48,6 @@ static int mac_nmidioutdev;
 void sys_do_open_midi(
     int nmidiin, int *midiinvec, int nmidiout, int *midioutvec)
 {
-    int i = 0;
-    int j;
     int devno;
     int n = 0;
     PmError err;
@@ -57,9 +55,9 @@ void sys_do_open_midi(
     Pt_Start(1, 0, 0); /* start a timer with millisecond accuracy */
 
     mac_nmidiindev = 0;
-    for(i = 0; i < nmidiin; i++)
+    for(int i = 0; i < nmidiin; i++)
     {
-        for(j = 0, devno = 0; j < Pm_CountDevices(); j++)
+        for(int j = 0, devno = 0; j < Pm_CountDevices(); j++)
         {
             const PmDeviceInfo *info = Pm_GetDeviceInfo(j);
             if(info->input)
@@ -88,9 +86,9 @@ void sys_do_open_midi(
     }
 
     mac_nmidioutdev = 0;
-    for(i = 0; i < nmidiout; i++)
+    for(int i = 0; i < nmidiout; i++)
     {
-        for(j = 0, devno = 0; j < Pm_CountDevices(); j++)
+        for(int j = 0, devno = 0; j < Pm_CountDevices(); j++)
         {
             const PmDeviceInfo *info = Pm_GetDeviceInfo(j);
             if(info->output)
@@ -119,11 +117,10 @@ void sys_do_open_midi(
 
 void sys_close_midi(void)
 {
-    int i;
-    for(i = 0; i < mac_nmidiindev; i++)
+    for(int i = 0; i < mac_nmidiindev; i++)
         Pm_Close(mac_midiindevlist[i]);
     mac_nmidiindev = 0;
-    for(i = 0; i < mac_nmidioutdev; i++)
+    for(int i = 0; i < mac_nmidioutdev; i++)
         Pm_Close(mac_midioutdevlist[i]);
     mac_nmidioutdev = 0;
 }
@@ -272,11 +269,10 @@ void nd_sysex_inword(int midiindev, int status, int data1, int data2, int data3)
 
 void sys_poll_midi(void)
 {
-    int i;
     int nmess;
     int throttle = 100;
     PmEvent buffer;
-    for(i = 0; i < mac_nmidiindev; i++)
+    for(int i = 0; i < mac_nmidiindev; i++)
     {
         while((nmess = Pm_Read(mac_midiindevlist[i], &buffer, 1)))
         {
@@ -347,12 +343,11 @@ overload:;
 void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int maxndev, int devdescsize)
 {
-    int i;
     int nindev = 0;
     int noutdev = 0;
     char utf8device[MAXPDSTRING];
     utf8device[0] = 0;
-    for(i = 0; i < Pm_CountDevices(); i++)
+    for(int i = 0; i < Pm_CountDevices(); i++)
     {
         const PmDeviceInfo *info = Pm_GetDeviceInfo(i);
         /* post("%d: %s, %s (%d,%d)", i, info->interf, info->name,

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "s_net.h"
 
@@ -14,29 +14,30 @@
 #include <sys/time.h>
 #endif
 
-    /* Windows XP winsock doesn't provide inet_ntop */
+/* Windows XP winsock doesn't provide inet_ntop */
 #ifdef _WIN32
-const char* INET_NTOP(int af, const void *src, char *dst, socklen_t size) {
+const char *INET_NTOP(int af, const void *src, char *dst, socklen_t size)
+{
     struct sockaddr_storage addr;
     socklen_t addrlen;
     memset(&addr, 0, sizeof(struct sockaddr_storage));
     addr.ss_family = af;
-    if (af == AF_INET6)
+    if(af == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&addr;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) &addr;
         memcpy(&(sa6->sin6_addr.s6_addr), src, sizeof(sa6->sin6_addr.s6_addr));
         addrlen = sizeof(struct sockaddr_in6);
     }
-    else if (af == AF_INET)
+    else if(af == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)&addr;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) &addr;
         memcpy(&(sa4->sin_addr.s_addr), src, sizeof(sa4->sin_addr.s_addr));
         addrlen = sizeof(struct sockaddr_in);
     }
     else
         return NULL;
-    if (WSAAddressToStringA((struct sockaddr *)&addr, addrlen, 0, dst,
-        (LPDWORD)&size) != 0)
+    if(WSAAddressToStringA(
+           (struct sockaddr *) &addr, addrlen, 0, dst, (LPDWORD) &size) != 0)
         return NULL;
     return dst;
 }
@@ -44,8 +45,9 @@ const char* INET_NTOP(int af, const void *src, char *dst, socklen_t size) {
 #define INET_NTOP inet_ntop
 #endif
 
-int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
-                             int port, int protocol) {
+int addrinfo_get_list(
+    struct addrinfo **ailist, const char *hostname, int port, int protocol)
+{
     struct addrinfo hints;
     int result;
     char portstr[10]; /* largest port is 65535 */
@@ -55,28 +57,31 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
     hints.ai_protocol = (protocol == SOCK_STREAM ? IPPROTO_TCP : IPPROTO_UDP);
     hints.ai_flags =
 #ifdef AI_ALL
-                     AI_ALL |       /* both IPv4 and IPv6 addrs */
+        AI_ALL | /* both IPv4 and IPv6 addrs */
 #endif
 #ifdef AI_V4MAPPED
-                     AI_V4MAPPED |  /* fallback to IPv4-mapped IPv6 addrs */
+        AI_V4MAPPED | /* fallback to IPv4-mapped IPv6 addrs */
 #endif
-                     AI_PASSIVE;    /* listen to any addr if hostname is NULL */
+        AI_PASSIVE; /* listen to any addr if hostname is NULL */
     portstr[0] = '\0';
     sprintf(portstr, "%d", port);
     result = getaddrinfo(hostname, portstr, &hints, ailist);
-        /* There's currently a bug in the BSD libc where getaddrinfo()
-         * will return EAI_BADFLAGS for the AI_ALL and AI_V4MAPPED flags.
-         * NOTE: this also seems to affect Android!
-         * In practice, this means we can't use dual stack sockets,
-         * so we fall back to IPv4 networking... */
-    if (result == EAI_BADFLAGS)
+    /* There's currently a bug in the BSD libc where getaddrinfo()
+     * will return EAI_BADFLAGS for the AI_ALL and AI_V4MAPPED flags.
+     * NOTE: this also seems to affect Android!
+     * In practice, this means we can't use dual stack sockets,
+     * so we fall back to IPv4 networking... */
+    if(result == EAI_BADFLAGS)
     {
         static int warned = 0;
-        if (!warned)
+        if(!warned)
         {
-            fprintf(stderr, "Warning: can't create IPv6 dual-stack socket - falling "
-                "back to IPv4. (This is a known bug in the BSD libc, which doesn't "
-                "implement the AI_ALL and AI_V4MAPPED flags for getaddrinfo().)\n");
+            fprintf(stderr,
+                "Warning: can't create IPv6 dual-stack socket - falling "
+                "back to IPv4. (This is a known bug in the BSD libc, which "
+                "doesn't "
+                "implement the AI_ALL and AI_V4MAPPED flags for "
+                "getaddrinfo().)\n");
             warned = 1;
         }
         hints.ai_family = AF_INET;
@@ -86,34 +91,36 @@ int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
     return result;
 }
 
-int addrinfo_ipv4_first(const struct addrinfo* ai1, const struct addrinfo* ai2)
+int addrinfo_ipv4_first(const struct addrinfo *ai1, const struct addrinfo *ai2)
 {
-    return (ai1->ai_family == AF_INET) ?
-        ((ai2->ai_family == AF_INET) ? 0 : -1) : 1;
+    return (ai1->ai_family == AF_INET) ? ((ai2->ai_family == AF_INET) ? 0 : -1)
+                                       : 1;
 }
 
-int addrinfo_ipv6_first(const struct addrinfo* ai1, const struct addrinfo* ai2){
-    return (ai1->ai_family == AF_INET6) ?
-        ((ai2->ai_family == AF_INET6) ? 0 : -1) : 1;
+int addrinfo_ipv6_first(const struct addrinfo *ai1, const struct addrinfo *ai2)
+{
+    return (ai1->ai_family == AF_INET6)
+               ? ((ai2->ai_family == AF_INET6) ? 0 : -1)
+               : 1;
 }
 
 void addrinfo_sort_list(struct addrinfo **ailist,
-    int (*compare)(const struct addrinfo*, const struct addrinfo*))
+    int (*compare)(const struct addrinfo *, const struct addrinfo *))
 {
     struct addrinfo *result = NULL, *ai = (*ailist);
-    while (ai)
+    while(ai)
     {
         struct addrinfo *temp = ai;
         ai = ai->ai_next;
-        if (result)
+        if(result)
         {
             struct addrinfo *ai2 = result, *last = NULL;
-            while (ai2 && (compare(temp, ai2) >= 0))
+            while(ai2 && (compare(temp, ai2) >= 0))
             {
                 last = ai2;
                 ai2 = ai2->ai_next;
             }
-            if (last)
+            if(last)
             {
                 last->ai_next = temp;
                 temp->ai_next = ai2;
@@ -137,89 +144,92 @@ void addrinfo_print_list(const struct addrinfo *ailist)
 {
     const struct addrinfo *ai;
     char addrstr[INET6_ADDRSTRLEN];
-    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    for(ai = ailist; ai != NULL; ai = ai->ai_next)
     {
         char *ipver;
         void *addr;
         unsigned int port = 0;
-        if (ai->ai_family == AF_INET6)
+        if(ai->ai_family == AF_INET6)
         {
-            struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)ai->ai_addr;
+            struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) ai->ai_addr;
             addr = &(sa6->sin6_addr);
             ipver = "IPv6";
             port = ntohs(sa6->sin6_port);
         }
-        else if (ai->ai_family == AF_INET)
+        else if(ai->ai_family == AF_INET)
         {
-            struct sockaddr_in *sa4 = (struct sockaddr_in *)ai->ai_addr;
+            struct sockaddr_in *sa4 = (struct sockaddr_in *) ai->ai_addr;
             addr = &(sa4->sin_addr);
             ipver = "IPv4";
             port = ntohs(sa4->sin_port);
         }
-        else continue;
+        else
+            continue;
         INET_NTOP(ai->ai_family, addr, addrstr, INET6_ADDRSTRLEN);
         printf("%s %s %d\n", ipver, addrstr, port);
     }
 }
 
-const char* sockaddr_get_addrstr(const struct sockaddr *sa, char *addrstr,
-    int addrstrlen)
+const char *sockaddr_get_addrstr(
+    const struct sockaddr *sa, char *addrstr, int addrstrlen)
 {
     const void *addr;
     addrstr[0] = '\0';
-    if (sa->sa_family == AF_INET6)
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
-        addr = (const void *)&sa6->sin6_addr.s6_addr;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
+        addr = (const void *) &sa6->sin6_addr.s6_addr;
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
-        addr = (const void *)&sa4->sin_addr.s_addr;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
+        addr = (const void *) &sa4->sin_addr.s_addr;
     }
-    else return NULL;
+    else
+        return NULL;
     return INET_NTOP(sa->sa_family, addr, addrstr, addrstrlen);
 }
 
 unsigned int sockaddr_get_port(const struct sockaddr *sa)
 {
-    if (sa->sa_family == AF_INET6)
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         return ntohs(sa6->sin6_port);
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         return ntohs(sa4->sin_port);
     }
     else
         return 0;
 }
 
-void sockaddr_set_port(const struct sockaddr *sa, unsigned int port) {
-    if (sa->sa_family == AF_INET6)
+void sockaddr_set_port(const struct sockaddr *sa, unsigned int port)
+{
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         sa6->sin6_port = htons(port);
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         sa4->sin_port = htons(port);
     }
 }
 
 int sockaddr_is_multicast(const struct sockaddr *sa)
 {
-    if (sa->sa_family == AF_INET6)
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         return (sa6->sin6_addr.s6_addr[0] == 0xFF);
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         return ((ntohl(sa4->sin_addr.s_addr) & 0xF0000000) == 0xE0000000);
     }
     return 0;
@@ -229,71 +239,71 @@ int socket_init(void)
 {
 #ifdef _WIN32
     static int initialized = 0;
-    if (!initialized)
+    if(!initialized)
     {
         short version = MAKEWORD(2, 0);
         WSADATA nobby;
-        if (WSAStartup(version, &nobby))
-            return -1;
+        if(WSAStartup(version, &nobby)) return -1;
         initialized = 1;
     }
 #endif
     return 0;
 }
 
-    /* kudos to https://stackoverflow.com/a/46062474/6063908 */
-int socket_connect(int socket, const struct sockaddr *addr,
-                   socklen_t addrlen, float timeout)
+/* kudos to https://stackoverflow.com/a/46062474/6063908 */
+int socket_connect(
+    int socket, const struct sockaddr *addr, socklen_t addrlen, float timeout)
 {
     /* set nonblocking and connect */
     socket_set_nonblocking(socket, 1);
 
-    if (connect(socket, addr, addrlen) < 0)
+    if(connect(socket, addr, addrlen) < 0)
     {
         int status;
         struct timeval timeoutval;
         fd_set writefds, errfds;
-    #ifdef _WIN32
-        if (socket_errno() != WSAEWOULDBLOCK)
-    #else
-        if (socket_errno() != EINPROGRESS)
-    #endif
+#ifdef _WIN32
+        if(socket_errno() != WSAEWOULDBLOCK)
+#else
+        if(socket_errno() != EINPROGRESS)
+#endif
             return -1; /* break on "real" error */
 
         /* block with select using timeout */
-        if (timeout < 0) timeout = 0;
-        timeoutval.tv_sec = (int)timeout;
+        if(timeout < 0) timeout = 0;
+        timeoutval.tv_sec = (int) timeout;
         timeoutval.tv_usec = (timeout - timeoutval.tv_sec) * 1000000;
         FD_ZERO(&writefds);
         FD_SET(socket, &writefds); /* socket is connected when writable */
         FD_ZERO(&errfds);
         FD_SET(socket, &errfds); /* catch exceptions */
 
-        status = select(socket+1, NULL, &writefds, &errfds, &timeoutval);
-        if (status < 0) /* select failed */
+        status = select(socket + 1, NULL, &writefds, &errfds, &timeoutval);
+        if(status < 0) /* select failed */
         {
             fprintf(stderr, "socket_connect: select failed");
             return -1;
         }
-        else if (status == 0) /* connection timed out */
+        else if(status == 0) /* connection timed out */
         {
-        #ifdef _WIN32
+#ifdef _WIN32
             WSASetLastError(WSAETIMEDOUT);
-        #else
+#else
             errno = ETIMEDOUT;
-        #endif
+#endif
             return -1;
         }
 
-        if (FD_ISSET(socket, &errfds)) /* connection failed */
+        if(FD_ISSET(socket, &errfds)) /* connection failed */
         {
-            int err; socklen_t len = sizeof(err);
-            getsockopt(socket, SOL_SOCKET, SO_ERROR, (void *)&err, &len);
-        #ifdef _WIN32
+            int err;
+            socklen_t len = sizeof(err);
+            getsockopt(socket, SOL_SOCKET, SO_ERROR, (void *) &err, &len);
+#ifdef _WIN32
             WSASetLastError(err);
-        #else
+#else
             errno = err;
-        #endif
+#endif
             return -1;
         }
     }
@@ -307,7 +317,7 @@ void socket_close(int socket)
 #ifdef _WIN32
     closesocket(socket);
 #else
-    if (socket < 0) return;
+    if(socket < 0) return;
     close(socket);
 #endif
 }
@@ -316,17 +326,16 @@ unsigned int socket_get_port(int socket)
 {
     struct sockaddr_storage sa;
     socklen_t len = sizeof(sa);
-    if (getsockname(socket, (struct sockaddr *)&sa, &len) < 0)
-        return 0;
+    if(getsockname(socket, (struct sockaddr *) &sa, &len) < 0) return 0;
 
-    if (sa.ss_family == AF_INET6)
+    if(sa.ss_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)&sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) &sa;
         return ntohs(sa6->sin6_port);
     }
-    else if (sa.ss_family == AF_INET)
+    else if(sa.ss_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)&sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) &sa;
         return ntohs(sa4->sin_port);
     }
     else
@@ -335,24 +344,22 @@ unsigned int socket_get_port(int socket)
 
 int socket_set_boolopt(int socket, int level, int option_name, int bool_value)
 {
-    return setsockopt(socket, level, option_name,
-        (void *)&bool_value, sizeof(int));
+    return setsockopt(
+        socket, level, option_name, (void *) &bool_value, sizeof(int));
 }
 
 int socket_set_nonblocking(int socket, int nonblocking)
 {
 #ifdef _WIN32
     u_long modearg = nonblocking;
-    if (ioctlsocket(socket, FIONBIO, &modearg) != NO_ERROR)
-        return -1;
+    if(ioctlsocket(socket, FIONBIO, &modearg) != NO_ERROR) return -1;
 #else
     int sockflags = fcntl(socket, F_GETFL, 0);
-    if (nonblocking)
+    if(nonblocking)
         sockflags |= O_NONBLOCK;
     else
         sockflags &= ~O_NONBLOCK;
-    if (fcntl(socket, F_SETFL, sockflags) < 0)
-        return -1;
+    if(fcntl(socket, F_SETFL, sockflags) < 0) return -1;
 #endif
     return 0;
 }
@@ -361,59 +368,57 @@ int socket_bytes_available(int socket)
 {
 #ifdef _WIN32
     u_long n = 0;
-    if (ioctlsocket(socket, FIONREAD, &n) != NO_ERROR)
-        return -1;
+    if(ioctlsocket(socket, FIONREAD, &n) != NO_ERROR) return -1;
     return n;
 #else
     int n = 0;
-    if (ioctl(socket, FIONREAD, &n) < 0)
-        return -1;
+    if(ioctl(socket, FIONREAD, &n) < 0) return -1;
     return n;
 #endif
 }
 
 int socket_join_multicast_group(int socket, const struct sockaddr *sa)
 {
-    if (sa->sa_family == AF_INET6)
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         struct ipv6_mreq mreq6 = {0};
-        memcpy(&mreq6.ipv6mr_multiaddr, &sa6->sin6_addr,
-            sizeof(struct in6_addr));
+        memcpy(
+            &mreq6.ipv6mr_multiaddr, &sa6->sin6_addr, sizeof(struct in6_addr));
         return setsockopt(socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
-            (char *)&mreq6, sizeof(mreq6));
+            (char *) &mreq6, sizeof(mreq6));
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         struct ip_mreq mreq = {0};
         mreq.imr_multiaddr.s_addr = sa4->sin_addr.s_addr;
         mreq.imr_interface.s_addr = INADDR_ANY;
-        return setsockopt(socket, IPPROTO_IP, IP_ADD_MEMBERSHIP,
-            (char *)&mreq, sizeof(mreq));
+        return setsockopt(socket, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char *) &mreq,
+            sizeof(mreq));
     }
     return -1;
 }
 
 int socket_leave_multicast_group(int socket, const struct sockaddr *sa)
 {
-    if (sa->sa_family == AF_INET6)
+    if(sa->sa_family == AF_INET6)
     {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         struct ipv6_mreq mreq6 = {0};
-        memcpy(&mreq6.ipv6mr_multiaddr, &sa6->sin6_addr,
-            sizeof(struct in6_addr));
+        memcpy(
+            &mreq6.ipv6mr_multiaddr, &sa6->sin6_addr, sizeof(struct in6_addr));
         return setsockopt(socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
-            (char *)&mreq6, sizeof(mreq6));
+            (char *) &mreq6, sizeof(mreq6));
     }
-    else if (sa->sa_family == AF_INET)
+    else if(sa->sa_family == AF_INET)
     {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         struct ip_mreq mreq = {0};
         mreq.imr_multiaddr.s_addr = sa4->sin_addr.s_addr;
         mreq.imr_interface.s_addr = INADDR_ANY;
         return setsockopt(socket, IPPROTO_IP, IP_DROP_MEMBERSHIP,
-            (char *)&mreq, sizeof(mreq));
+            (char *) &mreq, sizeof(mreq));
     }
     return -1;
 }
@@ -422,7 +427,7 @@ int socket_errno(void)
 {
 #ifdef _WIN32
     int err = WSAGetLastError();
-    if (err == 10044) /* WSAESOCKTNOSUPPORT */
+    if(err == 10044) /* WSAESOCKTNOSUPPORT */
     {
         fprintf(stderr,
             "Warning: you might not have TCP/IP \"networking\" turned on\n");
@@ -439,7 +444,7 @@ int socket_errno_udp(void)
     int err = socket_errno();
     /* ignore WSAECONNRESET to prevent UDP sockets
        from closing in case of a missing receiver */
-    if (err == 10054)
+    if(err == 10054)
         return 0;
     else
         return err;
@@ -450,16 +455,18 @@ int socket_errno_udp(void)
 
 void socket_strerror(int err, char *buf, int size)
 {
-    if (size > 0)
+    if(size > 0)
     {
-    #ifdef _WIN32
+#ifdef _WIN32
         wchar_t wbuf[1024];
-        int count = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            0, err, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, 1024, NULL);
-        if (!count || !WideCharToMultiByte(CP_UTF8, 0, wbuf, count+1, buf, size, 0, 0))
+        int count = FormatMessageW(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, err,
+            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, 1024, NULL);
+        if(!count ||
+            !WideCharToMultiByte(CP_UTF8, 0, wbuf, count + 1, buf, size, 0, 0))
             *buf = '\0';
-    #else
+#else
         snprintf(buf, size, "%s", strerror(err));
-    #endif
+#endif
     }
 }

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -269,8 +269,10 @@ int socket_connect(
         if(socket_errno() != WSAEWOULDBLOCK)
 #else
         if(socket_errno() != EINPROGRESS)
+        {
 #endif
             return -1; /* break on "real" error */
+    }
 
         /* block with select using timeout */
         if(timeout < 0) timeout = 0;
@@ -359,9 +361,13 @@ int socket_set_nonblocking(int socket, int nonblocking)
 #else
     int sockflags = fcntl(socket, F_GETFL, 0);
     if(nonblocking)
+    {
         sockflags |= O_NONBLOCK;
+    }
     else
+    {
         sockflags &= ~O_NONBLOCK;
+    }
     if(fcntl(socket, F_SETFL, sockflags) < 0) return -1;
 #endif
     return 0;

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -199,7 +199,7 @@ unsigned int sockaddr_get_port(const struct sockaddr *sa)
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         return ntohs(sa6->sin6_port);
     }
-    else if(sa->sa_family == AF_INET)
+    if(sa->sa_family == AF_INET)
     {
         struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         return ntohs(sa4->sin_port);
@@ -229,7 +229,7 @@ int sockaddr_is_multicast(const struct sockaddr *sa)
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
         return (sa6->sin6_addr.s6_addr[0] == 0xFF);
     }
-    else if(sa->sa_family == AF_INET)
+    if(sa->sa_family == AF_INET)
     {
         struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         return ((ntohl(sa4->sin_addr.s_addr) & 0xF0000000) == 0xE0000000);
@@ -287,7 +287,7 @@ int socket_connect(
             fprintf(stderr, "socket_connect: select failed");
             return -1;
         }
-        else if(status == 0) /* connection timed out */
+        if(status == 0) /* connection timed out */
         {
 #ifdef _WIN32
             WSASetLastError(WSAETIMEDOUT);
@@ -336,7 +336,7 @@ unsigned int socket_get_port(int socket)
         struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) &sa;
         return ntohs(sa6->sin6_port);
     }
-    else if(sa.ss_family == AF_INET)
+    if(sa.ss_family == AF_INET)
     {
         struct sockaddr_in *sa4 = (struct sockaddr_in *) &sa;
         return ntohs(sa4->sin_port);
@@ -391,7 +391,7 @@ int socket_join_multicast_group(int socket, const struct sockaddr *sa)
         return setsockopt(socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
             (char *) &mreq6, sizeof(mreq6));
     }
-    else if(sa->sa_family == AF_INET)
+    if(sa->sa_family == AF_INET)
     {
         struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         struct ip_mreq mreq = {0};
@@ -414,7 +414,7 @@ int socket_leave_multicast_group(int socket, const struct sockaddr *sa)
         return setsockopt(socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
             (char *) &mreq6, sizeof(mreq6));
     }
-    else if(sa->sa_family == AF_INET)
+    if(sa->sa_family == AF_INET)
     {
         struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
         struct ip_mreq mreq = {0};

--- a/src/s_net.c
+++ b/src/s_net.c
@@ -107,14 +107,16 @@ int addrinfo_ipv6_first(const struct addrinfo *ai1, const struct addrinfo *ai2)
 void addrinfo_sort_list(struct addrinfo **ailist,
     int (*compare)(const struct addrinfo *, const struct addrinfo *))
 {
-    struct addrinfo *result = NULL, *ai = (*ailist);
+    struct addrinfo *result = NULL;
+    struct addrinfo *ai = (*ailist);
     while(ai)
     {
         struct addrinfo *temp = ai;
         ai = ai->ai_next;
         if(result)
         {
-            struct addrinfo *ai2 = result, *last = NULL;
+            struct addrinfo *ai2 = result;
+            struct addrinfo *last = NULL;
             while(ai2 && (compare(temp, ai2) >= 0))
             {
                 last = ai2;
@@ -261,7 +263,8 @@ int socket_connect(
     {
         int status;
         struct timeval timeoutval;
-        fd_set writefds, errfds;
+        fd_set writefds;
+        fd_set errfds;
 #ifdef _WIN32
         if(socket_errno() != WSAEWOULDBLOCK)
 #else

--- a/src/s_net.h
+++ b/src/s_net.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2019 Dan Wilcox.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* networking headers and helper functions */
 
@@ -24,120 +24,120 @@ typedef int socklen_t;
 
 /* ----- socket address ----- */
 
-    /** getaddrinfo() convenience wrapper which generates a list of IPv4 & IPv6
-        addresses from a given address/hostname string, port, and protocol
-        (SOCK_STREAM or SOCK_DGRAM), set hostname to NULL for "any" address
+/** getaddrinfo() convenience wrapper which generates a list of IPv4 & IPv6
+    addresses from a given address/hostname string, port, and protocol
+    (SOCK_STREAM or SOCK_DGRAM), set hostname to NULL for "any" address
 
-        returns 0 on success or < 0 on error
+    returns 0 on success or < 0 on error
 
-        the ailist must be freed after usage using freeaddrinfo(),
-        status errno can be printed using gai_strerr()
+    the ailist must be freed after usage using freeaddrinfo(),
+    status errno can be printed using gai_strerr()
 
-        basic usage example:
+    basic usage example:
 
-        int sockfd, status;
-        struct addrinfo *ailist = NULL, *ai;
-        struct sockaddr_storage ss = {0}; // IPv4 or IPv6 addr
+    int sockfd, status;
+    struct addrinfo *ailist = NULL, *ai;
+    struct sockaddr_storage ss = {0}; // IPv4 or IPv6 addr
 
-        // generate addrinfo list
-        status = addrinfo_get_list(&ailist, "127.0.0.1", 5000, SOCK_DGRAM);
-        if (status != 0)
-        {
-            printf("bad host or port? %s (%d)", gai_strerror(status), status);
-            return;
-        }
+    // generate addrinfo list
+    status = addrinfo_get_list(&ailist, "127.0.0.1", 5000, SOCK_DGRAM);
+    if (status != 0)
+    {
+        printf("bad host or port? %s (%d)", gai_strerror(status), status);
+        return;
+    }
 
-        // try each addr until we find one that works
-        for (ai = ailist; ai != NULL; ai = ai->ai_next)
-        {
-            sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-            if (sockfd < 0) continue; // go to the next addr
+    // try each addr until we find one that works
+    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    {
+        sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (sockfd < 0) continue; // go to the next addr
 
-            // perform socket setsockopt(), bind(), connect(), etc as required,
-            // cleanup and continue to next addr on failure
+        // perform socket setsockopt(), bind(), connect(), etc as required,
+        // cleanup and continue to next addr on failure
 
-            // save addr that worked and exit loop
-            memcpy(&ss, ai->ai_addr, ai->ai_addrlen);
-            break;
-        }
-        freeaddrinfo(ailist); // cleanup
+        // save addr that worked and exit loop
+        memcpy(&ss, ai->ai_addr, ai->ai_addrlen);
+        break;
+    }
+    freeaddrinfo(ailist); // cleanup
 
-        // confirm that socket setup succeeded
-        if (sockfd == -1)
-        {
-            int err = socket_errno();
-            printf("socket setup failed: %s (%d)", strerror(errno), errno);
-            return;
-        }
-    */
-int addrinfo_get_list(struct addrinfo **ailist, const char *hostname,
-                      int port, int protocol);
+    // confirm that socket setup succeeded
+    if (sockfd == -1)
+    {
+        int err = socket_errno();
+        printf("socket setup failed: %s (%d)", strerror(errno), errno);
+        return;
+    }
+*/
+int addrinfo_get_list(
+    struct addrinfo **ailist, const char *hostname, int port, int protocol);
 
-    /** sort an address list with a compare function */
+/** sort an address list with a compare function */
 void addrinfo_sort_list(struct addrinfo **ailist,
-    int (*compare)(const struct addrinfo*, const struct addrinfo*));
+    int (*compare)(const struct addrinfo *, const struct addrinfo *));
 
-    /** compare function which puts IPv4 addresses first */
-int addrinfo_ipv4_first(const struct addrinfo* ai1, const struct addrinfo* ai2);
+/** compare function which puts IPv4 addresses first */
+int addrinfo_ipv4_first(const struct addrinfo *ai1, const struct addrinfo *ai2);
 
-    /** compare function which puts IPv6 addresses first */
-int addrinfo_ipv6_first(const struct addrinfo* ai1, const struct addrinfo* ai2);
+/** compare function which puts IPv6 addresses first */
+int addrinfo_ipv6_first(const struct addrinfo *ai1, const struct addrinfo *ai2);
 
-    /** print addrinfo linked list sockaddrs: IP version, hostname, port */
+/** print addrinfo linked list sockaddrs: IP version, hostname, port */
 void addrinfo_print_list(const struct addrinfo *ailist);
 
-    /** read address/hostname string from a sockaddr,
-        fills addrstr and returns pointer on success or NULL on failure */
-const char* sockaddr_get_addrstr(const struct sockaddr *sa,
-                                 char *addrstr, int addrstrlen);
+/** read address/hostname string from a sockaddr,
+    fills addrstr and returns pointer on success or NULL on failure */
+const char *sockaddr_get_addrstr(
+    const struct sockaddr *sa, char *addrstr, int addrstrlen);
 
-    /** returns sockaddr port or 0 on failure */
+/** returns sockaddr port or 0 on failure */
 unsigned int sockaddr_get_port(const struct sockaddr *sa);
 
-    /** sets sockaddr port */
+/** sets sockaddr port */
 void sockaddr_set_port(const struct sockaddr *sa, unsigned int port);
 
-    /** returns 1 if address is a IPv4 or IPv6 multicast address, otherwise 0 */
+/** returns 1 if address is a IPv4 or IPv6 multicast address, otherwise 0 */
 int sockaddr_is_multicast(const struct sockaddr *sa);
 
 /* ----- socket ----- */
 
-    /** cross-platform initialization routine, returns -1 on failure */
+/** cross-platform initialization routine, returns -1 on failure */
 int socket_init(void);
 
-    /** connect a socket to an address with a settable timeout in seconds
-        returns -1 on error, use socket_errno() to get the actual error code */
-int socket_connect(int socket, const struct sockaddr *addr,
-                   socklen_t addrlen, float timeout);
+/** connect a socket to an address with a settable timeout in seconds
+    returns -1 on error, use socket_errno() to get the actual error code */
+int socket_connect(
+    int socket, const struct sockaddr *addr, socklen_t addrlen, float timeout);
 
-    /** cross-platform socket close() */
+/** cross-platform socket close() */
 void socket_close(int socket);
 
-    /** returns port or 0 on failure */
+/** returns port or 0 on failure */
 unsigned int socket_get_port(int socket);
 
-    /** get number of immediately readable bytes for the socket
-        returns -1 on error or bytes available on success */
+/** get number of immediately readable bytes for the socket
+    returns -1 on error or bytes available on success */
 int socket_bytes_available(int socket);
 
-    /** setsockopt() convenience wrapper for socket bool options */
+/** setsockopt() convenience wrapper for socket bool options */
 int socket_set_boolopt(int socket, int level, int option_name, int bool_value);
 
-    /** enable/disable socket non-blocking mode */
+/** enable/disable socket non-blocking mode */
 int socket_set_nonblocking(int socket, int nonblocking);
 
-    /** join a multicast group address, returns < 0 on error */
+/** join a multicast group address, returns < 0 on error */
 int socket_join_multicast_group(int socket, const struct sockaddr *sa);
 
-    /** leave a multicast group address, returns < 0 on error */
+/** leave a multicast group address, returns < 0 on error */
 int socket_leave_multicast_group(int socket, const struct sockaddr *sa);
 
-    /** cross-platform socket errno() which catches
-        WSAESOCKTNOSUPPORT on Windows */
+/** cross-platform socket errno() which catches
+    WSAESOCKTNOSUPPORT on Windows */
 int socket_errno(void);
 
-    /** like socket_errno() but ignores WSAECONNRESET on Windows */
+/** like socket_errno() but ignores WSAECONNRESET on Windows */
 int socket_errno_udp(void);
 
-    /** get an error string from errno */
+/** get an error string from errno */
 void socket_strerror(int err, char *buf, int size);

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1999 Guenter Geiger and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*
  * This file implements the loader for linux, which includes
@@ -24,11 +24,11 @@
 #endif
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #include <string.h>
@@ -41,38 +41,38 @@
 #include <ctype.h>
 
 #ifdef _LARGEFILE64_SOURCE
-# define open  open64
-# define lseek lseek64
-# define fstat fstat64
-# define stat  stat64
+#define open open64
+#define lseek lseek64
+#define fstat fstat64
+#define stat stat64
 #endif
 
 #ifdef _MSC_VER
-# define snprintf _snprintf
+#define snprintf _snprintf
 #endif
 
-    /* change '/' characters to the system's native file separator */
+/* change '/' characters to the system's native file separator */
 void sys_bashfilename(const char *from, char *to)
 {
     char c;
-    while ((c = *from++))
+    while((c = *from++))
     {
 #ifdef _WIN32
-        if (c == '/') c = '\\';
+        if(c == '/') c = '\\';
 #endif
         *to++ = c;
     }
     *to = 0;
 }
 
-    /* change the system's native file separator to '/' characters  */
+/* change the system's native file separator to '/' characters  */
 void sys_unbashfilename(const char *from, char *to)
 {
     char c;
-    while ((c = *from++))
+    while((c = *from++))
     {
 #ifdef _WIN32
-        if (c == '\\') c = '/';
+        if(c == '\\') c = '/';
 #endif
         *to++ = c;
     }
@@ -82,11 +82,11 @@ void sys_unbashfilename(const char *from, char *to)
 /* test if path is absolute or relative, based on leading /, env vars, ~, etc */
 int sys_isabsolutepath(const char *dir)
 {
-    if (dir[0] == '/' || dir[0] == '~'
+    if(dir[0] == '/' || dir[0] == '~'
 #ifdef _WIN32
         || dir[0] == '%' || (dir[1] == ':' && dir[2] == '/')
 #endif
-        )
+    )
     {
         return 1;
     }
@@ -99,34 +99,35 @@ int sys_isabsolutepath(const char *dir)
 /* expand env vars and ~ at the beginning of a path and make a copy to return */
 static void sys_expandpath(const char *from, char *to, int bufsize)
 {
-    if ((strlen(from) == 1 && from[0] == '~') || (strncmp(from,"~/", 2) == 0))
+    if((strlen(from) == 1 && from[0] == '~') || (strncmp(from, "~/", 2) == 0))
     {
 #ifdef _WIN32
         const char *home = getenv("USERPROFILE");
 #else
         const char *home = getenv("HOME");
 #endif
-        if (home)
+        if(home)
         {
             strncpy(to, home, bufsize);
-            to[bufsize-1] = 0;
+            to[bufsize - 1] = 0;
             strncpy(to + strlen(to), from + 1, bufsize - strlen(to));
-            to[bufsize-1] = 0;
+            to[bufsize - 1] = 0;
         }
-        else *to = 0;
+        else
+            *to = 0;
     }
     else
     {
         strncpy(to, from, bufsize);
-        to[bufsize-1] = 0;
+        to[bufsize - 1] = 0;
     }
 #ifdef _WIN32
     {
         char *buf = alloca(bufsize);
-        ExpandEnvironmentStrings(to, buf, bufsize-1);
-        buf[bufsize-1] = 0;
+        ExpandEnvironmentStrings(to, buf, bufsize - 1);
+        buf[bufsize - 1] = 0;
         strncpy(to, buf, bufsize);
-        to[bufsize-1] = 0;
+        to[bufsize - 1] = 0;
     }
 #endif
 }
@@ -144,18 +145,18 @@ static void sys_expandpath(const char *from, char *to, int bufsize)
  * \return position after delimiter in string.  If it was the last
  *         substring, return NULL.
  */
-static const char *strtokcpy(char *to, size_t to_len, const char *from, char delim)
+static const char *strtokcpy(
+    char *to, size_t to_len, const char *from, char delim)
 {
     unsigned int i = 0;
 
-        for (; i < (to_len - 1) && from[i] && from[i] != delim; i++)
-                to[i] = from[i];
-        to[i] = '\0';
+    for(; i < (to_len - 1) && from[i] && from[i] != delim; i++)
+        to[i] = from[i];
+    to[i] = '\0';
 
-        if (i && from[i] != '\0')
-                return from + i + 1;
+    if(i && from[i] != '\0') return from + i + 1;
 
-        return NULL;
+    return NULL;
 }
 
 /* add a single item to a namelist.  If "allowdup" is true, duplicates
@@ -164,24 +165,23 @@ may be added; otherwise they're dropped.  */
 t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup)
 {
     t_namelist *nl, *nl2;
-    nl2 = (t_namelist *)(getbytes(sizeof(*nl)));
+    nl2 = (t_namelist *) (getbytes(sizeof(*nl)));
     nl2->nl_next = 0;
-    nl2->nl_string = (char *)getbytes(strlen(s) + 1);
+    nl2->nl_string = (char *) getbytes(strlen(s) + 1);
     strcpy(nl2->nl_string, s);
     sys_unbashfilename(nl2->nl_string, nl2->nl_string);
-    if (!listwas)
+    if(!listwas)
         return (nl2);
     else
     {
-        for (nl = listwas; ;)
+        for(nl = listwas;;)
         {
-            if (!allowdup && !strcmp(nl->nl_string, s))
+            if(!allowdup && !strcmp(nl->nl_string, s))
             {
                 freebytes(nl2->nl_string, strlen(nl2->nl_string) + 1);
                 return (listwas);
             }
-            if (!nl->nl_next)
-                break;
+            if(!nl->nl_next) break;
             nl = nl->nl_next;
         }
         nl->nl_next = nl2;
@@ -192,7 +192,7 @@ t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup)
 /* add a colon-separated list of names to a namelist */
 
 #ifdef _WIN32
-#define SEPARATOR ';'   /* in MSW the natural separator is semicolon instead */
+#define SEPARATOR ';' /* in MSW the natural separator is semicolon instead */
 #else
 #define SEPARATOR ':'
 #endif
@@ -207,17 +207,16 @@ t_namelist *namelist_append_files(t_namelist *listwas, const char *s)
     do
     {
         npos = strtokcpy(temp, sizeof(temp), npos, SEPARATOR);
-        if (! *temp) continue;
+        if(!*temp) continue;
         nl = namelist_append(nl, temp, 0);
-    }
-        while (npos);
+    } while(npos);
     return (nl);
 }
 
 void namelist_free(t_namelist *listwas)
 {
     t_namelist *nl, *nl2;
-    for (nl = listwas; nl; nl = nl2)
+    for(nl = listwas; nl; nl = nl2)
     {
         nl2 = nl->nl_next;
         t_freebytes(nl->nl_string, strlen(nl->nl_string) + 1);
@@ -229,7 +228,7 @@ const char *namelist_get(const t_namelist *namelist, int n)
 {
     int i;
     const t_namelist *nl;
-    for (i = 0, nl = namelist; i < n && nl; i++, nl = nl->nl_next)
+    for(i = 0, nl = namelist; i < n && nl; i++, nl = nl->nl_next)
         ;
     return (nl ? nl->nl_string : 0);
 }
@@ -246,14 +245,15 @@ void sys_setextrapath(const char *p)
     STUFF->st_staticpath = namelist_append(0, pathbuf, 0);
     sys_expandpath("~/pd-externals", pathbuf, MAXPDSTRING);
     STUFF->st_staticpath = namelist_append(STUFF->st_staticpath, pathbuf, 0);
-    STUFF->st_staticpath = namelist_append(STUFF->st_staticpath,
-        "/usr/local/lib/pd-externals", 0);
+    STUFF->st_staticpath =
+        namelist_append(STUFF->st_staticpath, "/usr/local/lib/pd-externals", 0);
 #endif
 
 #ifdef __APPLE__
     sys_expandpath("~/Library/Pd", pathbuf, MAXPDSTRING);
     STUFF->st_staticpath = namelist_append(0, pathbuf, 0);
-    STUFF->st_staticpath = namelist_append(STUFF->st_staticpath, "/Library/Pd", 0);
+    STUFF->st_staticpath =
+        namelist_append(STUFF->st_staticpath, "/Library/Pd", 0);
 #endif
 
 #ifdef _WIN32
@@ -266,41 +266,39 @@ void sys_setextrapath(const char *p)
     STUFF->st_staticpath = namelist_append(STUFF->st_staticpath, p, 0);
 }
 
-    /* try to open a file in the directory "dir", named "name""ext",
-    for reading.  "Name" may have slashes.  The directory is copied to
-    "dirresult" which must be at least "size" bytes.  "nameresult" is set
-    to point to the filename (copied elsewhere into the same buffer).
-    The "bin" flag requests opening for binary (which only makes a difference
-    on Windows). */
+/* try to open a file in the directory "dir", named "name""ext",
+for reading.  "Name" may have slashes.  The directory is copied to
+"dirresult" which must be at least "size" bytes.  "nameresult" is set
+to point to the filename (copied elsewhere into the same buffer).
+The "bin" flag requests opening for binary (which only makes a difference
+on Windows). */
 
-int sys_trytoopenone(const char *dir, const char *name, const char* ext,
+int sys_trytoopenone(const char *dir, const char *name, const char *ext,
     char *dirresult, char **nameresult, unsigned int size, int bin)
 {
     int fd;
     char buf[MAXPDSTRING];
-    if (strlen(dir) + strlen(name) + strlen(ext) + 4 > size)
-        return (-1);
+    if(strlen(dir) + strlen(name) + strlen(ext) + 4 > size) return (-1);
     sys_expandpath(dir, buf, MAXPDSTRING);
     strcpy(dirresult, buf);
-    if (*dirresult && dirresult[strlen(dirresult)-1] != '/')
+    if(*dirresult && dirresult[strlen(dirresult) - 1] != '/')
         strcat(dirresult, "/");
     strcat(dirresult, name);
     strcat(dirresult, ext);
 
-    DEBUG(post("looking for %s",dirresult));
-        /* see if we can open the file for reading */
-    if ((fd=sys_open(dirresult, O_RDONLY)) >= 0)
+    DEBUG(post("looking for %s", dirresult));
+    /* see if we can open the file for reading */
+    if((fd = sys_open(dirresult, O_RDONLY)) >= 0)
     {
-            /* in unix, further check that it's not a directory */
+        /* in unix, further check that it's not a directory */
 #ifdef HAVE_UNISTD_H
         struct stat statbuf;
-        int ok =  ((fstat(fd, &statbuf) >= 0) &&
-            !S_ISDIR(statbuf.st_mode));
-        if (!ok)
+        int ok = ((fstat(fd, &statbuf) >= 0) && !S_ISDIR(statbuf.st_mode));
+        if(!ok)
         {
             logpost(NULL, PD_VERBOSE, "tried %s; stat failed or directory",
                 dirresult);
-            close (fd);
+            close(fd);
             fd = -1;
         }
         else
@@ -310,12 +308,13 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
             logpost(NULL, PD_VERBOSE, "tried %s and succeeded", dirresult);
             sys_unbashfilename(dirresult, dirresult);
             slash = strrchr(dirresult, '/');
-            if (slash)
+            if(slash)
             {
                 *slash = 0;
                 *nameresult = slash + 1;
             }
-            else *nameresult = dirresult;
+            else
+                *nameresult = dirresult;
 
             return (fd);
         }
@@ -327,27 +326,26 @@ int sys_trytoopenone(const char *dir, const char *name, const char* ext,
     return (-1);
 }
 
-    /* check if we were given an absolute pathname, if so try to open it
-    and return 1 to signal the caller to cancel any path searches */
-int sys_open_absolute(const char *name, const char* ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin, int *fdp)
+/* check if we were given an absolute pathname, if so try to open it
+and return 1 to signal the caller to cancel any path searches */
+int sys_open_absolute(const char *name, const char *ext, char *dirresult,
+    char **nameresult, unsigned int size, int bin, int *fdp)
 {
-    if (sys_isabsolutepath(name))
+    if(sys_isabsolutepath(name))
     {
         char dirbuf[MAXPDSTRING], *z = strrchr(name, '/');
         int dirlen;
-        if (!z)
-            return (0);
-        dirlen = (int)(z - name);
-        if (dirlen > MAXPDSTRING-1)
-            dirlen = MAXPDSTRING-1;
+        if(!z) return (0);
+        dirlen = (int) (z - name);
+        if(dirlen > MAXPDSTRING - 1) dirlen = MAXPDSTRING - 1;
         strncpy(dirbuf, name, dirlen);
         dirbuf[dirlen] = 0;
-        *fdp = sys_trytoopenone(dirbuf, name+(dirlen+1), ext,
-            dirresult, nameresult, size, bin);
+        *fdp = sys_trytoopenone(
+            dirbuf, name + (dirlen + 1), ext, dirresult, nameresult, size, bin);
         return (1);
     }
-    else return (0);
+    else
+        return (0);
 }
 
 /* search for a file in a specified directory, then along the globally
@@ -361,56 +359,56 @@ there is no search and instead we just try to open the file literally.  */
 /* see also canvas_open() which, in addition, searches down the
 canvas-specific path. */
 
-static int do_open_via_path(const char *dir, const char *name,
-    const char *ext, char *dirresult, char **nameresult, unsigned int size,
-    int bin, t_namelist *searchpath)
+static int do_open_via_path(const char *dir, const char *name, const char *ext,
+    char *dirresult, char **nameresult, unsigned int size, int bin,
+    t_namelist *searchpath)
 {
     t_namelist *nl;
     int fd = -1;
 
-        /* first check if "name" is absolute (and if so, try to open) */
-    if (sys_open_absolute(name, ext, dirresult, nameresult, size, bin, &fd))
+    /* first check if "name" is absolute (and if so, try to open) */
+    if(sys_open_absolute(name, ext, dirresult, nameresult, size, bin, &fd))
         return (fd);
 
-        /* otherwise "name" is relative; try the directory "dir" first. */
-    if ((fd = sys_trytoopenone(dir, name, ext,
-        dirresult, nameresult, size, bin)) >= 0)
-            return (fd);
+    /* otherwise "name" is relative; try the directory "dir" first. */
+    if((fd = sys_trytoopenone(
+            dir, name, ext, dirresult, nameresult, size, bin)) >= 0)
+        return (fd);
 
-        /* next go through the temp paths from the commandline */
-    for (nl = STUFF->st_temppath; nl; nl = nl->nl_next)
-        if ((fd = sys_trytoopenone(nl->nl_string, name, ext,
-            dirresult, nameresult, size, bin)) >= 0)
+    /* next go through the temp paths from the commandline */
+    for(nl = STUFF->st_temppath; nl; nl = nl->nl_next)
+        if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
+                nameresult, size, bin)) >= 0)
+            return (fd);
+    /* next look in built-in paths like "extra" */
+    for(nl = searchpath; nl; nl = nl->nl_next)
+        if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
+                nameresult, size, bin)) >= 0)
+            return (fd);
+    /* next look in built-in paths like "extra" */
+    if(sys_usestdpath)
+        for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
+            if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
+                    nameresult, size, bin)) >= 0)
                 return (fd);
-        /* next look in built-in paths like "extra" */
-    for (nl = searchpath; nl; nl = nl->nl_next)
-        if ((fd = sys_trytoopenone(nl->nl_string, name, ext,
-            dirresult, nameresult, size, bin)) >= 0)
-                return (fd);
-        /* next look in built-in paths like "extra" */
-    if (sys_usestdpath)
-        for (nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
-            if ((fd = sys_trytoopenone(nl->nl_string, name, ext,
-                dirresult, nameresult, size, bin)) >= 0)
-                    return (fd);
 
     *dirresult = 0;
     *nameresult = dirresult;
     return (-1);
 }
 
-    /* open via path, using the global search path. */
+/* open via path, using the global search path. */
 int open_via_path(const char *dir, const char *name, const char *ext,
     char *dirresult, char **nameresult, unsigned int size, int bin)
 {
-    return (do_open_via_path(dir, name, ext, dirresult, nameresult,
-        size, bin, STUFF->st_searchpath));
+    return (do_open_via_path(dir, name, ext, dirresult, nameresult, size, bin,
+        STUFF->st_searchpath));
 }
 
-    /* open a file with a UTF-8 filename
-    This is needed because WIN32 does not support UTF-8 filenames, only UCS2.
-    Having this function prevents lots of #ifdefs all over the place.
-    */
+/* open a file with a UTF-8 filename
+This is needed because WIN32 does not support UTF-8 filenames, only UCS2.
+Having this function prevents lots of #ifdefs all over the place.
+*/
 #ifdef _WIN32
 int sys_open(const char *path, int oflag, ...)
 {
@@ -418,10 +416,10 @@ int sys_open(const char *path, int oflag, ...)
     char pathbuf[MAXPDSTRING];
     wchar_t ucs2path[MAXPDSTRING];
     sys_bashfilename(path, pathbuf);
-    u8_utf8toucs2(ucs2path, MAXPDSTRING, pathbuf, MAXPDSTRING-1);
+    u8_utf8toucs2(ucs2path, MAXPDSTRING, pathbuf, MAXPDSTRING - 1);
     /* For the create mode, Win32 does not have the same possibilities,
      * so we ignore the argument and just hard-code read/write. */
-    if (oflag & O_CREAT)
+    if(oflag & O_CREAT)
         fd = _wopen(ucs2path, oflag | O_BINARY, _S_IREAD | _S_IWRITE);
     else
         fd = _wopen(ucs2path, oflag | O_BINARY);
@@ -434,19 +432,20 @@ FILE *sys_fopen(const char *filename, const char *mode)
     wchar_t ucs2buf[MAXPDSTRING];
     wchar_t ucs2mode[MAXPDSTRING];
     sys_bashfilename(filename, namebuf);
-    u8_utf8toucs2(ucs2buf, MAXPDSTRING, namebuf, MAXPDSTRING-1);
+    u8_utf8toucs2(ucs2buf, MAXPDSTRING, namebuf, MAXPDSTRING - 1);
     /* mode only uses ASCII, so no need for a full conversion, just copy it */
     mbstowcs(ucs2mode, mode, MAXPDSTRING);
     return (_wfopen(ucs2buf, ucs2mode));
 }
 #else
 #include <stdarg.h>
+
 int sys_open(const char *path, int oflag, ...)
 {
     int i, fd;
     char pathbuf[MAXPDSTRING];
     sys_bashfilename(path, pathbuf);
-    if (oflag & O_CREAT)
+    if(oflag & O_CREAT)
     {
         mode_t mode;
         int imode;
@@ -460,8 +459,8 @@ int sys_open(const char *path, int oflag, ...)
            -> http://bugs.debian.org/647345
         */
 
-        imode = va_arg (ap, int);
-        mode = (mode_t)imode;
+        imode = va_arg(ap, int);
+        mode = (mode_t) imode;
         va_end(ap);
         fd = open(pathbuf, oflag, mode);
     }
@@ -472,61 +471,57 @@ int sys_open(const char *path, int oflag, ...)
 
 FILE *sys_fopen(const char *filename, const char *mode)
 {
-  char namebuf[MAXPDSTRING];
-  sys_bashfilename(filename, namebuf);
-  return fopen(namebuf, mode);
+    char namebuf[MAXPDSTRING];
+    sys_bashfilename(filename, namebuf);
+    return fopen(namebuf, mode);
 }
 #endif /* _WIN32 */
 
-   /* close a previously opened file
-   this is needed on platforms where you cannot open/close resources
-   across dll-boundaries, but we provide it for other platforms as well */
+/* close a previously opened file
+this is needed on platforms where you cannot open/close resources
+across dll-boundaries, but we provide it for other platforms as well */
 int sys_close(int fd)
 {
 #ifdef _WIN32
-    return _close(fd);  /* Bill Gates is a big fat hen */
+    return _close(fd); /* Bill Gates is a big fat hen */
 #else
     return close(fd);
 #endif
 }
 
-int sys_fclose(FILE *stream)
-{
-    return fclose(stream);
-}
+int sys_fclose(FILE *stream) { return fclose(stream); }
 
-    /* Open a help file using the help search path.  We expect the ".pd"
-    suffix here, even though we have to tear it back off for one of the
-    search attempts. */
+/* Open a help file using the help search path.  We expect the ".pd"
+suffix here, even though we have to tear it back off for one of the
+search attempts. */
 void open_via_helppath(const char *name, const char *dir)
 {
     char realname[MAXPDSTRING], dirbuf[MAXPDSTRING], *basename;
-        /* make up a silly "dir" if none is supplied */
+    /* make up a silly "dir" if none is supplied */
     const char *usedir = (*dir ? dir : "./");
     int fd;
 
-        /* 1. "objectname-help.pd" */
-    strncpy(realname, name, MAXPDSTRING-10);
-    realname[MAXPDSTRING-10] = 0;
-    if (strlen(realname) > 3 && !strcmp(realname+strlen(realname)-3, ".pd"))
-        realname[strlen(realname)-3] = 0;
+    /* 1. "objectname-help.pd" */
+    strncpy(realname, name, MAXPDSTRING - 10);
+    realname[MAXPDSTRING - 10] = 0;
+    if(strlen(realname) > 3 && !strcmp(realname + strlen(realname) - 3, ".pd"))
+        realname[strlen(realname) - 3] = 0;
     strcat(realname, "-help.pd");
-    if ((fd = do_open_via_path(usedir, realname, "", dirbuf, &basename,
-        MAXPDSTRING, 0, STUFF->st_helppath)) >= 0)
-            goto gotone;
+    if((fd = do_open_via_path(usedir, realname, "", dirbuf, &basename,
+            MAXPDSTRING, 0, STUFF->st_helppath)) >= 0)
+        goto gotone;
 
-        /* 2. "help-objectname.pd" */
+    /* 2. "help-objectname.pd" */
     strcpy(realname, "help-");
-    strncat(realname, name, MAXPDSTRING-10);
-    realname[MAXPDSTRING-1] = 0;
-    if ((fd = do_open_via_path(usedir, realname, "", dirbuf, &basename,
-        MAXPDSTRING, 0, STUFF->st_helppath)) >= 0)
-            goto gotone;
+    strncat(realname, name, MAXPDSTRING - 10);
+    realname[MAXPDSTRING - 1] = 0;
+    if((fd = do_open_via_path(usedir, realname, "", dirbuf, &basename,
+            MAXPDSTRING, 0, STUFF->st_helppath)) >= 0)
+        goto gotone;
 
     post("sorry, couldn't find help patch for \"%s\"", name);
     return;
 gotone:
-    close (fd);
-    glob_evalfile(0, gensym((char*)basename), gensym(dirbuf));
+    close(fd);
+    glob_evalfile(0, gensym((char *) basename), gensym(dirbuf));
 }
-

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -90,10 +90,8 @@ int sys_isabsolutepath(const char *dir)
     {
         return 1;
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }
 
 /* expand env vars and ~ at the beginning of a path and make a copy to return */
@@ -173,20 +171,19 @@ t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup)
     sys_unbashfilename(nl2->nl_string, nl2->nl_string);
     if(!listwas)
         return (nl2);
-    else
+
+    for(nl = listwas;;)
     {
-        for(nl = listwas;;)
+        if(!allowdup && !strcmp(nl->nl_string, s))
         {
-            if(!allowdup && !strcmp(nl->nl_string, s))
-            {
-                freebytes(nl2->nl_string, strlen(nl2->nl_string) + 1);
-                return (listwas);
-            }
-            if(!nl->nl_next) break;
-            nl = nl->nl_next;
+            freebytes(nl2->nl_string, strlen(nl2->nl_string) + 1);
+            return (listwas);
         }
-        nl->nl_next = nl2;
+        if(!nl->nl_next) break;
+        nl = nl->nl_next;
     }
+    nl->nl_next = nl2;
+
     return (listwas);
 }
 
@@ -347,8 +344,7 @@ int sys_open_absolute(const char *name, const char *ext, char *dirresult,
             dirbuf, name + (dirlen + 1), ext, dirresult, nameresult, size, bin);
         return (1);
     }
-    else
-        return (0);
+    return (0);
 }
 
 /* search for a file in a specified directory, then along the globally

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -376,20 +376,28 @@ static int do_open_via_path(const char *dir, const char *name, const char *ext,
 
     /* next go through the temp paths from the commandline */
     for(nl = STUFF->st_temppath; nl; nl = nl->nl_next)
+    {
         if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
                 nameresult, size, bin)) >= 0)
             return (fd);
+    }
     /* next look in built-in paths like "extra" */
     for(nl = searchpath; nl; nl = nl->nl_next)
+    {
         if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
                 nameresult, size, bin)) >= 0)
             return (fd);
+    }
     /* next look in built-in paths like "extra" */
     if(sys_usestdpath)
+    {
         for(nl = STUFF->st_staticpath; nl; nl = nl->nl_next)
+        {
             if((fd = sys_trytoopenone(nl->nl_string, name, ext, dirresult,
                     nameresult, size, bin)) >= 0)
                 return (fd);
+        }
+    }
 
     *dirresult = 0;
     *nameresult = dirresult;

--- a/src/s_path.c
+++ b/src/s_path.c
@@ -164,7 +164,8 @@ may be added; otherwise they're dropped.  */
 
 t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup)
 {
-    t_namelist *nl, *nl2;
+    t_namelist *nl;
+    t_namelist *nl2;
     nl2 = (t_namelist *) (getbytes(sizeof(*nl)));
     nl2->nl_next = 0;
     nl2->nl_string = (char *) getbytes(strlen(s) + 1);
@@ -215,7 +216,8 @@ t_namelist *namelist_append_files(t_namelist *listwas, const char *s)
 
 void namelist_free(t_namelist *listwas)
 {
-    t_namelist *nl, *nl2;
+    t_namelist *nl;
+    t_namelist *nl2;
     for(nl = listwas; nl; nl = nl2)
     {
         nl2 = nl->nl_next;
@@ -333,7 +335,8 @@ int sys_open_absolute(const char *name, const char *ext, char *dirresult,
 {
     if(sys_isabsolutepath(name))
     {
-        char dirbuf[MAXPDSTRING], *z = strrchr(name, '/');
+        char dirbuf[MAXPDSTRING];
+        char *z = strrchr(name, '/');
         int dirlen;
         if(!z) return (0);
         dirlen = (int) (z - name);
@@ -442,7 +445,8 @@ FILE *sys_fopen(const char *filename, const char *mode)
 
 int sys_open(const char *path, int oflag, ...)
 {
-    int i, fd;
+    int i;
+    int fd;
     char pathbuf[MAXPDSTRING];
     sys_bashfilename(path, pathbuf);
     if(oflag & O_CREAT)
@@ -496,7 +500,9 @@ suffix here, even though we have to tear it back off for one of the
 search attempts. */
 void open_via_helppath(const char *name, const char *dir)
 {
-    char realname[MAXPDSTRING], dirbuf[MAXPDSTRING], *basename;
+    char realname[MAXPDSTRING];
+    char dirbuf[MAXPDSTRING];
+    char *basename;
     /* make up a silly "dir" if none is supplied */
     const char *usedir = (*dir ? dir : "./");
     int fd;

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -207,8 +207,7 @@ void poststring(const char *s)
 
 void postatom(int argc, const t_atom *argv)
 {
-    int i;
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
         atom_string(argv + i, buf, MAXPDSTRING);

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -44,9 +44,13 @@ char *pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
     }
 
     if(!dstlen || ptout < dstlen)
+    {
         dst[ptout] = 0;
+    }
     else
+    {
         dst[dstlen - 1] = 0;
+    }
 
     return dst;
 }
@@ -54,7 +58,9 @@ char *pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
 static void dopost(const char *s)
 {
     if(STUFF->st_printhook)
+    {
         (*STUFF->st_printhook)(s);
+    }
     else if(sys_printtostderr || !sys_havegui())
     {
 #ifdef _WIN32
@@ -101,8 +107,10 @@ static void doerror(const void *object, const char *s)
 #endif
     }
     else
+    {
         sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n", object,
             pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+    }
 }
 
 static void dologpost(const void *object, const int level, const char *s)
@@ -132,8 +140,10 @@ static void dologpost(const void *object, const int level, const char *s)
 #endif
     }
     else
+    {
         sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n", object, level,
             pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+    }
 }
 
 void logpost(const void *object, int level, const char *fmt, ...)
@@ -218,11 +228,17 @@ void postfloat(t_float f)
 void endpost(void)
 {
     if(STUFF->st_printhook)
+    {
         (*STUFF->st_printhook)("\n");
+    }
     else if(sys_printtostderr)
+    {
         fprintf(stderr, "\n");
+    }
     else
+    {
         post("");
+    }
 }
 
 /* keep this in the Pd app for binary extern compatibility but don't
@@ -300,7 +316,9 @@ void pd_error(const void *object, const char *fmt, ...)
 void glob_finderror(t_pd *dummy)
 {
     if(!error_object)
+    {
         post("no findable error yet");
+    }
     else
     {
         post("last trackable error:");

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -20,7 +20,8 @@ int sys_printtostderr;
 /* escape characters for tcl/tk */
 char *pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
 {
-    unsigned ptin = 0, ptout = 0;
+    unsigned ptin = 0;
+    unsigned ptout = 0;
     if(!dst || !src) return 0;
     while(1)
     {

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 #include <stdlib.h>
@@ -18,48 +18,50 @@ t_printhook sys_printhook = NULL;
 int sys_printtostderr;
 
 /* escape characters for tcl/tk */
-char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
+char *pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
 {
     unsigned ptin = 0, ptout = 0;
-    if(!dst || !src)return 0;
+    if(!dst || !src) return 0;
     while(1)
     {
         int c = src[ptin];
-        if (c == '\\' || c == '{' || c == '}' || c == '[' || c == ']') {
+        if(c == '\\' || c == '{' || c == '}' || c == '[' || c == ']')
+        {
             dst[ptout++] = '\\';
-            if (dstlen && ptout >= dstlen){
-                dst[ptout-1] = 0;
+            if(dstlen && ptout >= dstlen)
+            {
+                dst[ptout - 1] = 0;
                 break;
             }
         }
         dst[ptout] = c;
         ptin++;
         ptout++;
-        if (c==0) break;
-        if (srclen && ptin  >= srclen) break;
-        if (dstlen && ptout >= dstlen) break;
+        if(c == 0) break;
+        if(srclen && ptin >= srclen) break;
+        if(dstlen && ptout >= dstlen) break;
     }
 
     if(!dstlen || ptout < dstlen)
-        dst[ptout]=0;
+        dst[ptout] = 0;
     else
-        dst[dstlen-1]=0;
+        dst[dstlen - 1] = 0;
 
     return dst;
 }
 
 static void dopost(const char *s)
 {
-    if (STUFF->st_printhook)
+    if(STUFF->st_printhook)
         (*STUFF->st_printhook)(s);
-    else if (sys_printtostderr || !sys_havegui())
+    else if(sys_printtostderr || !sys_havegui())
     {
 #ifdef _WIN32
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         fwprintf(stderr, L"%S", s);
-    #else
+#else
         fwprintf(stderr, L"%s", s);
-    #endif
+#endif
         fflush(stderr);
 #else
         fprintf(stderr, "%s", s);
@@ -68,78 +70,78 @@ static void dopost(const char *s)
     else
     {
         char upbuf[MAXPDSTRING];
-        sys_vgui("::pdwindow::post {%s}\n", pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        sys_vgui("::pdwindow::post {%s}\n",
+            pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
     }
 }
 
 static void doerror(const void *object, const char *s)
 {
     char upbuf[MAXPDSTRING];
-    upbuf[MAXPDSTRING-1]=0;
+    upbuf[MAXPDSTRING - 1] = 0;
 
     // what about sys_printhook_error ?
-    if (STUFF->st_printhook)
+    if(STUFF->st_printhook)
     {
-        snprintf(upbuf, MAXPDSTRING-1, "error: %s", s);
+        snprintf(upbuf, MAXPDSTRING - 1, "error: %s", s);
         (*STUFF->st_printhook)(upbuf);
     }
-    else if (sys_printtostderr)
+    else if(sys_printtostderr)
     {
 #ifdef _WIN32
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         fwprintf(stderr, L"error: %S", s);
-    #else
+#else
         fwprintf(stderr, L"error: %s", s);
-    #endif
+#endif
         fflush(stderr);
 #else
         fprintf(stderr, "error: %s", s);
 #endif
     }
     else
-        sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n",
-            object, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        sys_vgui("::pdwindow::logpost .x%lx 1 {%s}\n", object,
+            pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 static void dologpost(const void *object, const int level, const char *s)
 {
     char upbuf[MAXPDSTRING];
-    upbuf[MAXPDSTRING-1]=0;
-        /* if it's a verbose message and we aren't set to 'verbose' just do
-            nothing */
-    if (level >= PD_VERBOSE && !sys_verbose)
-        return;
+    upbuf[MAXPDSTRING - 1] = 0;
+    /* if it's a verbose message and we aren't set to 'verbose' just do
+        nothing */
+    if(level >= PD_VERBOSE && !sys_verbose) return;
     // what about sys_printhook_verbose ?
-    if (STUFF->st_printhook)
+    if(STUFF->st_printhook)
     {
-        snprintf(upbuf, MAXPDSTRING-1, "verbose(%d): %s", level, s);
+        snprintf(upbuf, MAXPDSTRING - 1, "verbose(%d): %s", level, s);
         (*STUFF->st_printhook)(upbuf);
     }
-    else if (sys_printtostderr)
+    else if(sys_printtostderr)
     {
 #ifdef _WIN32
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
         fwprintf(stderr, L"verbose(%d): %S", level, s);
-    #else
+#else
         fwprintf(stderr, L"verbose(%d): %s", level, s);
-    #endif
+#endif
         fflush(stderr);
 #else
         fprintf(stderr, "verbose(%d): %s", level, s);
 #endif
     }
     else
-        sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n",
-            object, level, pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
+        sys_vgui("::pdwindow::logpost .x%lx %d {%s}\n", object, level,
+            pdgui_strnescape(upbuf, MAXPDSTRING, s, 0));
 }
 
 void logpost(const void *object, int level, const char *fmt, ...)
 {
     char buf[MAXPDSTRING];
     va_list ap;
-    if (level > PD_DEBUG && !sys_verbose) return;
+    if(level > PD_DEBUG && !sys_verbose) return;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -150,14 +152,13 @@ void startlogpost(const void *object, const int level, const char *fmt, ...)
 {
     char buf[MAXPDSTRING];
     va_list ap;
-    if (level > PD_DEBUG && !sys_verbose) return;
+    if(level > PD_DEBUG && !sys_verbose) return;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
 
     dologpost(object, level, buf);
 }
-
 
 void post(const char *fmt, ...)
 {
@@ -166,7 +167,7 @@ void post(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -180,7 +181,7 @@ void startpost(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
 
     dopost(buf);
@@ -196,10 +197,10 @@ void poststring(const char *s)
 void postatom(int argc, const t_atom *argv)
 {
     int i;
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
-        atom_string(argv+i, buf, MAXPDSTRING);
+        atom_string(argv + i, buf, MAXPDSTRING);
         poststring(buf);
     }
 }
@@ -215,15 +216,16 @@ void postfloat(t_float f)
 
 void endpost(void)
 {
-    if (STUFF->st_printhook)
+    if(STUFF->st_printhook)
         (*STUFF->st_printhook)("\n");
-    else if (sys_printtostderr)
+    else if(sys_printtostderr)
         fprintf(stderr, "\n");
-    else post("");
+    else
+        post("");
 }
 
-  /* keep this in the Pd app for binary extern compatibility but don't
-  include in libpd because it conflicts with the posix pd_error(0, ) function. */
+/* keep this in the Pd app for binary extern compatibility but don't
+include in libpd because it conflicts with the posix pd_error(0, ) function. */
 #ifdef PD_INTERNAL
 EXTERN void error(const char *fmt, ...)
 {
@@ -233,7 +235,7 @@ EXTERN void error(const char *fmt, ...)
     int i;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -247,21 +249,21 @@ void verbose(int level, const char *fmt, ...)
     char buf[MAXPDSTRING];
     va_list ap;
 
-    if (level > sys_verbose) return;
+    if(level > sys_verbose) return;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
-        /* log levels for verbose() traditionally start at -3,
-        so we have to adjust it before passing it on to dologpost() */
+    /* log levels for verbose() traditionally start at -3,
+    so we have to adjust it before passing it on to dologpost() */
     dologpost(NULL, level + 3, buf);
 }
 
-    /* here's the good way to log errors -- keep a pointer to the
-    offending or offended object around so the user can search for it
-    later. */
+/* here's the good way to log errors -- keep a pointer to the
+offending or offended object around so the user can search for it
+later. */
 
 static const void *error_object;
 static char error_string[256];
@@ -276,7 +278,7 @@ void pd_error(const void *object, const char *fmt, ...)
     static int saidit;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -286,17 +288,17 @@ void pd_error(const void *object, const char *fmt, ...)
     strncpy(error_string, buf, 256);
     error_string[255] = 0;
 
-    if (!saidit)
+    if(!saidit)
     {
         logpost(NULL, 4,
-                "... you might be able to track this down from the Find menu.");
+            "... you might be able to track this down from the Find menu.");
         saidit = 1;
     }
 }
 
 void glob_finderror(t_pd *dummy)
 {
-    if (!error_object)
+    if(!error_object)
         post("no findable error yet");
     else
     {
@@ -306,15 +308,15 @@ void glob_finderror(t_pd *dummy)
     }
 }
 
-void glob_findinstance(t_pd *dummy, t_symbol*s)
+void glob_findinstance(t_pd *dummy, t_symbol *s)
 {
     // revert s to (potential) pointer to object
     PD_LONGINTTYPE obj = 0;
-    if (sscanf(s->s_name, ".x%lx", &obj))
+    if(sscanf(s->s_name, ".x%lx", &obj))
     {
-        if (obj)
+        if(obj)
         {
-            canvas_finderror((void *)obj);
+            canvas_finderror((void *) obj);
         }
     }
 }
@@ -326,14 +328,16 @@ void bug(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    vsnprintf(buf, MAXPDSTRING - 1, fmt, ap);
     va_end(ap);
 
     pd_error(0, "consistency check failed: %s", buf);
 }
 
-    /* don't use these.  They're included for binary compatibility with
-    old externs but never worked and now do nothing. */
+/* don't use these.  They're included for binary compatibility with
+old externs but never worked and now do nothing. */
 void sys_logerror(const char *object, const char *s) {}
+
 void sys_unixerror(const char *object) {}
+
 void sys_ouch(void) {}

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -1,7 +1,8 @@
 #pragma once
+
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* Audio and MIDI I/O, and other scheduling and system stuff. */
 
@@ -10,10 +11,10 @@ in future releases.  The public (stable) API is in m_pd.h. */
 
 /* in s_path.c */
 
-typedef struct _namelist    /* element in a linked list of stored strings */
+typedef struct _namelist /* element in a linked list of stored strings */
 {
-    struct _namelist *nl_next;  /* next in list */
-    char *nl_string;            /* the string */
+    struct _namelist *nl_next; /* next in list */
+    char *nl_string;           /* the string */
 } t_namelist;
 
 t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup);
@@ -22,9 +23,9 @@ void namelist_free(t_namelist *listwas);
 const char *namelist_get(const t_namelist *namelist, int n);
 void sys_setextrapath(const char *p);
 extern int sys_usestdpath;
-int sys_open_absolute(const char *name, const char* ext,
-    char *dirresult, char **nameresult, unsigned int size, int bin, int *fdp);
-int sys_trytoopenone(const char *dir, const char *name, const char* ext,
+int sys_open_absolute(const char *name, const char *ext, char *dirresult,
+    char **nameresult, unsigned int size, int bin, int *fdp);
+int sys_trytoopenone(const char *dir, const char *name, const char *ext,
     char *dirresult, char **nameresult, unsigned int size, int bin);
 t_symbol *sys_decodedialog(t_symbol *s);
 
@@ -45,15 +46,16 @@ extern const char *sys_guicmd;
 EXTERN int sys_nearestfontsize(int fontsize);
 
 extern int sys_defaultfont;
-EXTERN t_symbol *sys_libdir;    /* library directory for auxiliary files */
+EXTERN t_symbol *sys_libdir; /* library directory for auxiliary files */
 
 /* s_loader.c */
 
-typedef int (*loader_t)(t_canvas *canvas, const char *classname, const char*path); /* callback type */
+typedef int (*loader_t)(t_canvas *canvas, const char *classname,
+    const char *path); /* callback type */
 EXTERN int sys_load_lib(t_canvas *canvas, const char *classname);
 EXTERN void sys_register_loader(loader_t loader);
 
-                        /* s_audio.c */
+/* s_audio.c */
 
 #define MAXAUDIOINDEV 4
 #define MAXAUDIOOUTDEV 4
@@ -75,58 +77,58 @@ typedef struct _audiosettings
     int a_blocksize;
 } t_audiosettings;
 
-#define SENDDACS_NO 0           /* return values for sys_send_dacs() */
+#define SENDDACS_NO 0 /* return values for sys_send_dacs() */
 #define SENDDACS_YES 1
 #define SENDDACS_SLEPT 2
 
 #define DEFDACBLKSIZE 64
 #define DEFDACSAMPLERATE 48000
 
-                    /* s_audio.c */
+/* s_audio.c */
 #define API_NONE 0
 #define API_ALSA 1
 #define API_OSS 2
 #define API_MMIO 3
 #define API_PORTAUDIO 4
 #define API_JACK 5
-#define API_SGI 6           /* gone */
+#define API_SGI 6 /* gone */
 #define API_AUDIOUNIT 7
-#define API_ESD 8           /* no idea what this was, probably gone now */
+#define API_ESD 8 /* no idea what this was, probably gone now */
 #define API_DUMMY 9
 
-    /* figure out which API should be the default.  The one we judge most
-    likely to offer a working device takes precedence so that if you
-    start up Pd for the first time there's a reasonable chance you'll have
-    sound.  (You'd think portaudio would be best but it seems to default
-    to jack on linux, and on Windows we only use it for ASIO).
-    If nobody shows up, define DUMMY and make it the default.*/
+/* figure out which API should be the default.  The one we judge most
+likely to offer a working device takes precedence so that if you
+start up Pd for the first time there's a reasonable chance you'll have
+sound.  (You'd think portaudio would be best but it seems to default
+to jack on linux, and on Windows we only use it for ASIO).
+If nobody shows up, define DUMMY and make it the default.*/
 #if defined(USEAPI_MMIO)
-# define API_DEFAULT API_MMIO
-# define API_DEFSTRING "MMIO"
+#define API_DEFAULT API_MMIO
+#define API_DEFSTRING "MMIO"
 #elif defined(USEAPI_ALSA)
-# define API_DEFAULT API_ALSA
-# define API_DEFSTRING "ALSA"
+#define API_DEFAULT API_ALSA
+#define API_DEFSTRING "ALSA"
 #elif defined(USEAPI_OSS)
-# define API_DEFAULT API_OSS
-# define API_DEFSTRING "OSS"
+#define API_DEFAULT API_OSS
+#define API_DEFSTRING "OSS"
 #elif defined(USEAPI_AUDIOUNIT)
-# define API_DEFAULT API_AUDIOUNIT
-# define API_DEFSTRING "AudioUnit"
+#define API_DEFAULT API_AUDIOUNIT
+#define API_DEFSTRING "AudioUnit"
 #elif defined(USEAPI_ESD)
-# define API_DEFAULT API_ESD
-# define API_DEFSTRING "ESD (?)"
+#define API_DEFAULT API_ESD
+#define API_DEFSTRING "ESD (?)"
 #elif defined(USEAPI_PORTAUDIO)
-# define API_DEFAULT API_PORTAUDIO
-# define API_DEFSTRING "portaudio"
+#define API_DEFAULT API_PORTAUDIO
+#define API_DEFSTRING "portaudio"
 #elif defined(USEAPI_JACK)
-# define API_DEFAULT API_JACK
-# define API_DEFSTRING "Jack audio connection kit"
+#define API_DEFAULT API_JACK
+#define API_DEFSTRING "Jack audio connection kit"
 #else
-# ifndef USEAPI_DUMMY   /* we need at least one so bring in the dummy */
-# define USEAPI_DUMMY
-# endif /* USEAPI_DUMMY */
-# define API_DEFAULT API_DUMMY
-# define API_DEFSTRING "dummy audio"
+#ifndef USEAPI_DUMMY /* we need at least one so bring in the dummy */
+#define USEAPI_DUMMY
+#endif /* USEAPI_DUMMY */
+#define API_DEFAULT API_DUMMY
+#define API_DEFSTRING "dummy audio"
 #endif
 
 #define DEFAULTAUDIODEV 0
@@ -137,7 +139,7 @@ typedef struct _audiosettings
 #if defined(_WIN32)
 #define DEFAULTADVANCE 80
 #elif defined(__APPLE__)
-#define DEFAULTADVANCE 5    /* this is in addition to their own delay */
+#define DEFAULTADVANCE 5 /* this is in addition to their own delay */
 #else
 #define DEFAULTADVANCE 25
 #endif
@@ -154,38 +156,35 @@ EXTERN void sys_set_audio_settings(t_audiosettings *as);
 EXTERN void sys_get_audio_settings(t_audiosettings *as);
 EXTERN void sys_reopen_audio(void);
 EXTERN void sys_close_audio(void);
-    /* return true if the interface prefers always being open (ala jack) : */
+/* return true if the interface prefers always being open (ala jack) : */
 EXTERN int audio_shouldkeepopen(void);
-EXTERN int audio_isopen(void);     /* true if audio interface is open */
+EXTERN int audio_isopen(void); /* true if audio interface is open */
 EXTERN int sys_audiodevnametonumber(int output, const char *name);
-EXTERN void sys_audiodevnumbertoname(int output, int devno, char *name,
-    int namesize);
-EXTERN void sys_get_audio_devs(char *indevlist, int *nindevs,
-                          char *outdevlist, int *noutdevs, int *canmulti, int *cancallback,
-                          int maxndev, int devdescsize, int api);
+EXTERN void sys_audiodevnumbertoname(
+    int output, int devno, char *name, int namesize);
+EXTERN void sys_get_audio_devs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int *cancallback, int maxndev,
+    int devdescsize, int api);
 EXTERN void sys_get_audio_apis(char *buf);
 
-
-        /* audio API specific functions */
+/* audio API specific functions */
 int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
-    t_sample *soundout, int framesperbuf, int nbuffers,
-    int indeviceno, int outdeviceno, t_audiocallback callback);
+    t_sample *soundout, int framesperbuf, int nbuffers, int indeviceno,
+    int outdeviceno, t_audiocallback callback);
 void pa_close_audio(void);
 int pa_send_dacs(void);
 void pa_listdevs(void);
-void pa_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void pa_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
+    int *canmulti, int maxndev, int devdescsize);
 
-int oss_open_audio(int naudioindev, int *audioindev, int nchindev,
-    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
-    int *choutdev, int rate, int blocksize);
+int oss_open_audio(int naudioindev, int *audioindev, int nchindev, int *chindev,
+    int naudiooutdev, int *audiooutdev, int nchoutdev, int *choutdev, int rate,
+    int blocksize);
 void oss_close_audio(void);
 int oss_send_dacs(void);
 void oss_reportidle(void);
-void oss_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void oss_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
+    int *canmulti, int maxndev, int devdescsize);
 
 int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
     int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
@@ -193,30 +192,27 @@ int alsa_open_audio(int naudioindev, int *audioindev, int nchindev,
 void alsa_close_audio(void);
 int alsa_send_dacs(void);
 void alsa_reportidle(void);
-void alsa_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize);
 
 int jack_open_audio(int inchans, int outchans, t_audiocallback callback);
 void jack_close_audio(void);
 int jack_send_dacs(void);
 void jack_reportidle(void);
-void jack_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void jack_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize);
 void jack_listdevs(void);
 void jack_client_name(const char *name);
 void jack_autoconnect(int);
 
-int mmio_open_audio(int naudioindev, int *audioindev,
-    int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,
-    int nchoutdev, int *choutdev, int rate, int blocksize);
+int mmio_open_audio(int naudioindev, int *audioindev, int nchindev,
+    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
+    int *choutdev, int rate, int blocksize);
 void mmio_close_audio(void);
 void mmio_reportidle(void);
 int mmio_send_dacs(void);
-void mmio_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void mmio_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize);
 
 int audiounit_open_audio(int naudioindev, int *audioindev, int nchindev,
     int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
@@ -224,19 +220,16 @@ int audiounit_open_audio(int naudioindev, int *audioindev, int nchindev,
 void audiounit_close_audio(void);
 int audiounit_send_dacs(void);
 void audiounit_listdevs(void);
-void audiounit_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void audiounit_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int *canmulti, int maxndev, int devdescsize);
 
-int esd_open_audio(int naudioindev, int *audioindev, int nchindev,
-    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
-    int *choutdev, int rate);
+int esd_open_audio(int naudioindev, int *audioindev, int nchindev, int *chindev,
+    int naudiooutdev, int *audiooutdev, int nchoutdev, int *choutdev, int rate);
 void esd_close_audio(void);
 int esd_send_dacs(void);
 void esd_listdevs(void);
-void esd_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int *canmulti,
-        int maxndev, int devdescsize);
+void esd_getdevs(char *indevlist, int *nindevs, char *outdevlist, int *noutdevs,
+    int *canmulti, int maxndev, int devdescsize);
 
 int dummy_open_audio(int nin, int nout, int sr);
 int dummy_close_audio(void);
@@ -245,27 +238,26 @@ void dummy_getdevs(char *indevlist, int *nindevs, char *outdevlist,
     int *noutdevs, int *canmulti, int maxndev, int devdescsize);
 void dummy_listdevs(void);
 
-                    /* s_midi.c */
-#define MAXMIDIINDEV 16         /* max. number of input ports */
-#define MAXMIDIOUTDEV 16        /* max. number of output ports */
+/* s_midi.c */
+#define MAXMIDIINDEV 16  /* max. number of input ports */
+#define MAXMIDIOUTDEV 16 /* max. number of output ports */
 extern int sys_midiapi;
 extern int sys_nmidiin;
 extern int sys_nmidiout;
 extern int sys_midiindevlist[];
 extern int sys_midioutdevlist[];
 
-EXTERN void sys_open_midi(int nmidiin, int *midiinvec,
-    int nmidiout, int *midioutvec, int enable);
+EXTERN void sys_open_midi(
+    int nmidiin, int *midiinvec, int nmidiout, int *midioutvec, int enable);
 
 EXTERN void sys_get_midi_apis(char *buf);
-EXTERN void sys_get_midi_devs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs,
-   int maxndev, int devdescsize);
-EXTERN void sys_get_midi_params(int *pnmidiindev, int *pmidiindev,
-    int *pnmidioutdev, int *pmidioutdev);
+EXTERN void sys_get_midi_devs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize);
+EXTERN void sys_get_midi_params(
+    int *pnmidiindev, int *pmidiindev, int *pnmidioutdev, int *pmidioutdev);
 EXTERN int sys_mididevnametonumber(int output, const char *name);
-EXTERN void sys_mididevnumbertoname(int output, int devno, char *name,
-    int namesize);
+EXTERN void sys_mididevnumbertoname(
+    int output, int devno, char *name, int namesize);
 
 EXTERN void sys_reopen_midi(void);
 EXTERN void sys_close_midi(void);
@@ -277,11 +269,11 @@ EXTERN void sys_midibytein(int portno, int byte);
 void sys_listmididevs(void);
 EXTERN void sys_set_midi_api(int whichapi);
 
-    /* implemented in the system dependent MIDI code (s_midi_pm.c, etc. ) */
-void midi_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize);
-void sys_do_open_midi(int nmidiindev, int *midiindev,
-    int nmidioutdev, int *midioutdev);
+/* implemented in the system dependent MIDI code (s_midi_pm.c, etc. ) */
+void midi_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize);
+void sys_do_open_midi(
+    int nmidiindev, int *midiindev, int nmidioutdev, int *midioutdev);
 
 #ifdef USEAPI_ALSA
 EXTERN void sys_alsa_putmidimess(int portno, int a, int b, int c);
@@ -289,12 +281,11 @@ EXTERN void sys_alsa_putmidibyte(int portno, int a);
 EXTERN void sys_alsa_poll_midi(void);
 EXTERN void sys_alsa_close_midi(void);
 
-
-    /* implemented in the system dependent MIDI code (s_midi_pm.c, etc. ) */
-void midi_alsa_getdevs(char *indevlist, int *nindevs,
-    char *outdevlist, int *noutdevs, int maxndev, int devdescsize);
-void sys_alsa_do_open_midi(int nmidiindev, int *midiindev,
-    int nmidioutdev, int *midioutdev);
+/* implemented in the system dependent MIDI code (s_midi_pm.c, etc. ) */
+void midi_alsa_getdevs(char *indevlist, int *nindevs, char *outdevlist,
+    int *noutdevs, int maxndev, int devdescsize);
+void sys_alsa_do_open_midi(
+    int nmidiindev, int *midiindev, int nmidioutdev, int *midioutdev);
 #endif
 
 /* m_sched.c */
@@ -309,12 +300,12 @@ EXTERN void sys_log_error(int type);
 #define SCHED_AUDIO_POLL 1
 #define SCHED_AUDIO_CALLBACK 2
 void sched_set_using_audio(int flag);
-extern int sys_sleepgrain;      /* override value set in command line */
-EXTERN int sched_get_sleepgrain( void);     /* returns actual value */
+extern int sys_sleepgrain;             /* override value set in command line */
+EXTERN int sched_get_sleepgrain(void); /* returns actual value */
 
 /* s_inter.c */
 
-EXTERN void sys_microsleep( void);
+EXTERN void sys_microsleep(void);
 EXTERN void sys_init_fdpoll(void);
 
 EXTERN void sys_bail(int exitcode);
@@ -325,14 +316,14 @@ EXTERN_STRUCT _socketreceiver;
 
 typedef void (*t_socketnotifier)(void *x, int n);
 typedef void (*t_socketreceivefn)(void *x, t_binbuf *b);
-    /* from addr sockaddr_storage struct, optional */
+/* from addr sockaddr_storage struct, optional */
 typedef void (*t_socketfromaddrfn)(void *x, const void *fromaddr);
 
 EXTERN t_socketreceiver *socketreceiver_new(void *owner,
     t_socketnotifier notifier, t_socketreceivefn socketreceivefn, int udp);
 EXTERN void socketreceiver_read(t_socketreceiver *x, int fd);
-EXTERN void socketreceiver_set_fromaddrfn(t_socketreceiver *x,
-    t_socketfromaddrfn fromaddrfn);
+EXTERN void socketreceiver_set_fromaddrfn(
+    t_socketreceiver *x, t_socketfromaddrfn fromaddrfn);
 EXTERN void sys_sockerror(const char *s);
 EXTERN void sys_closesocket(int fd);
 EXTERN unsigned char *sys_getrecvbuf(unsigned int *size);
@@ -345,7 +336,7 @@ void sys_setalarm(int microsec);
 #endif
 
 void sys_set_priority(int higher);
-extern int sys_hipriority;      /* real-time flag, true if priority boosted */
+extern int sys_hipriority; /* real-time flag, true if priority boosted */
 
 /* s_print.c */
 
@@ -359,15 +350,15 @@ extern int sys_printtostderr;
 
 EXTERN int sys_externalschedlib;
 
-EXTERN t_sample* get_sys_soundout(void);
-EXTERN t_sample* get_sys_soundin(void);
-EXTERN int* get_sys_main_advance(void);
-EXTERN double* get_sys_time_per_dsp_tick(void);
-EXTERN int* get_sys_schedblocksize(void);
-EXTERN double* get_sys_time(void);
-EXTERN t_float* get_sys_dacsr(void);
-EXTERN int* get_sys_sleepgrain(void);
-EXTERN int* get_sys_schedadvance(void);
+EXTERN t_sample *get_sys_soundout(void);
+EXTERN t_sample *get_sys_soundin(void);
+EXTERN int *get_sys_main_advance(void);
+EXTERN double *get_sys_time_per_dsp_tick(void);
+EXTERN int *get_sys_schedblocksize(void);
+EXTERN double *get_sys_time(void);
+EXTERN t_float *get_sys_dacsr(void);
+EXTERN int *get_sys_sleepgrain(void);
+EXTERN int *get_sys_schedadvance(void);
 
 EXTERN void sys_initmidiqueue(void);
 EXTERN void sched_tick(void);
@@ -378,17 +369,13 @@ EXTERN void inmidi_realtimein(int portno, int cmd);
 EXTERN void inmidi_byte(int portno, int byte);
 EXTERN void inmidi_sysex(int portno, int byte);
 EXTERN void inmidi_noteon(int portno, int channel, int pitch, int velo);
-EXTERN void inmidi_controlchange(int portno,
-                                 int channel,
-                                 int ctlnumber,
-                                 int value);
+EXTERN void inmidi_controlchange(
+    int portno, int channel, int ctlnumber, int value);
 EXTERN void inmidi_programchange(int portno, int channel, int value);
 EXTERN void inmidi_pitchbend(int portno, int channel, int value);
 EXTERN void inmidi_aftertouch(int portno, int channel, int value);
-EXTERN void inmidi_polyaftertouch(int portno,
-                                  int channel,
-                                  int pitch,
-                                  int value);
+EXTERN void inmidi_polyaftertouch(
+    int portno, int channel, int pitch, int value);
 /* } jsarlo */
 EXTERN int sys_zoom_open;
 
@@ -398,16 +385,16 @@ struct _instancestuff
     t_namelist *st_searchpath;
     t_namelist *st_staticpath;
     t_namelist *st_helppath;
-    t_namelist *st_temppath;    /* temp search paths ie. -path on commandline */
-    int st_schedblocksize;      /* audio block size for scheduler */
-    int st_blocksize;           /* audio I/O block size in sample frames */
-    t_float st_dacsr;           /* I/O sample rate */
+    t_namelist *st_temppath; /* temp search paths ie. -path on commandline */
+    int st_schedblocksize;   /* audio block size for scheduler */
+    int st_blocksize;        /* audio I/O block size in sample frames */
+    t_float st_dacsr;        /* I/O sample rate */
     int st_inchannels;
     int st_outchannels;
     t_sample *st_soundout;
     t_sample *st_soundin;
-    double st_time_per_dsp_tick;    /* obsolete - included for GEM?? */
-    t_printhook st_printhook;   /* set this to override per-instance printing */
+    double st_time_per_dsp_tick; /* obsolete - included for GEM?? */
+    t_printhook st_printhook; /* set this to override per-instance printing */
     void *st_impdata; /* optional implementation-specific data for libpd, etc */
 };
 
@@ -421,4 +408,5 @@ struct _instancestuff
  * fully escaped 'src' string, the result might be incomplete.
  * 'srclen' can be 0, in which case the 'src' string must be 0-terminated.
  */
-EXTERN char*pdgui_strnescape(char* dst, size_t dstlen, const char*src, size_t srclen);
+EXTERN char *pdgui_strnescape(
+    char *dst, size_t dstlen, const char *src, size_t srclen);

--- a/src/s_utf8.c
+++ b/src/s_utf8.c
@@ -22,36 +22,34 @@
 #include <string.h>
 #include <stdarg.h>
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #include "s_utf8.h"
 
-static const uint32_t offsetsFromUTF8[6] = {
-    0x00000000UL, 0x00003080UL, 0x000E2080UL,
-    0x03C82080UL, 0xFA082080UL, 0x82082080UL
-};
+static const uint32_t offsetsFromUTF8[6] = {0x00000000UL, 0x00003080UL,
+    0x000E2080UL, 0x03C82080UL, 0xFA082080UL, 0x82082080UL};
 
-static const char trailingBytesForUTF8[256] = {
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
-};
-
+static const char trailingBytesForUTF8[256] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5};
 
 /* returns length of next utf-8 sequence */
 int u8_seqlen(const char *s)
 {
-    return trailingBytesForUTF8[(unsigned int)(unsigned char)s[0]] + 1;
+    return trailingBytesForUTF8[(unsigned int) (unsigned char) s[0]] + 1;
 }
 
 /* conversions without error checking
@@ -69,29 +67,38 @@ int u8_utf8toucs2(uint16_t *dest, int sz, const char *src, int srcsz)
     uint16_t ch;
     const char *src_end = src + srcsz;
     int nb;
-    int i=0;
+    int i = 0;
 
-    while (i < sz-1) {
-        nb = trailingBytesForUTF8[(unsigned char)*src];
-        if (srcsz == -1) {
-            if (*src == 0)
-                goto done_toucs;
+    while(i < sz - 1)
+    {
+        nb = trailingBytesForUTF8[(unsigned char) *src];
+        if(srcsz == -1)
+        {
+            if(*src == 0) goto done_toucs;
         }
-        else {
-            if (src + nb >= src_end)
-                goto done_toucs;
+        else
+        {
+            if(src + nb >= src_end) goto done_toucs;
         }
         ch = 0;
-        switch (nb) {
-        case 3: ch += (unsigned char)*src++; ch <<= 6; /* falls through */
-        case 2: ch += (unsigned char)*src++; ch <<= 6; /* falls through */
-        case 1: ch += (unsigned char)*src++; ch <<= 6; /* falls through */
-        case 0: ch += (unsigned char)*src++; /* falls through */
+        switch(nb)
+        {
+            case 3:
+                ch += (unsigned char) *src++;
+                ch <<= 6; /* falls through */
+            case 2:
+                ch += (unsigned char) *src++;
+                ch <<= 6; /* falls through */
+            case 1:
+                ch += (unsigned char) *src++;
+                ch <<= 6; /* falls through */
+            case 0:
+                ch += (unsigned char) *src++; /* falls through */
         }
         ch -= offsetsFromUTF8[nb];
         dest[i++] = ch;
     }
- done_toucs:
+done_toucs:
     dest[i] = 0;
     return i;
 }
@@ -114,64 +121,68 @@ int u8_ucs2toutf8(char *dest, int sz, const uint16_t *src, int srcsz)
     int i = 0;
     char *dest_end = dest + sz;
 
-    while (srcsz<0 ? src[i]!=0 : i < srcsz) {
+    while(srcsz < 0 ? src[i] != 0 : i < srcsz)
+    {
         ch = src[i];
-        if (ch < 0x80) {
-            if (dest >= dest_end)
-                return i;
-            *dest++ = (char)ch;
+        if(ch < 0x80)
+        {
+            if(dest >= dest_end) return i;
+            *dest++ = (char) ch;
         }
-        else if (ch < 0x800) {
-            if (dest >= dest_end-1)
-                return i;
-            *dest++ = (ch>>6) | 0xC0;
+        else if(ch < 0x800)
+        {
+            if(dest >= dest_end - 1) return i;
+            *dest++ = (ch >> 6) | 0xC0;
             *dest++ = (ch & 0x3F) | 0x80;
         }
-        else {
-            if (dest >= dest_end-2)
-                return i;
-            *dest++ = (ch>>12) | 0xE0;
-            *dest++ = ((ch>>6) & 0x3F) | 0x80;
+        else
+        {
+            if(dest >= dest_end - 2) return i;
+            *dest++ = (ch >> 12) | 0xE0;
+            *dest++ = ((ch >> 6) & 0x3F) | 0x80;
             *dest++ = (ch & 0x3F) | 0x80;
         }
         i++;
     }
-    if (dest < dest_end)
-        *dest = '\0';
+    if(dest < dest_end) *dest = '\0';
     return i;
 }
 
 /* moo: get byte length of character number, or 0 if not supported */
 int u8_wc_nbytes(uint32_t ch)
 {
-  if (ch < 0x80) return 1;
-  if (ch < 0x800) return 2;
-  if (ch < 0x10000) return 3;
-  if (ch < 0x200000) return 4;
-  return 0; /*-- bad input --*/
+    if(ch < 0x80) return 1;
+    if(ch < 0x800) return 2;
+    if(ch < 0x10000) return 3;
+    if(ch < 0x200000) return 4;
+    return 0; /*-- bad input --*/
 }
 
 int u8_wc_toutf8(char *dest, uint32_t ch)
 {
-    if (ch < 0x80) {
-        dest[0] = (char)ch;
+    if(ch < 0x80)
+    {
+        dest[0] = (char) ch;
         return 1;
     }
-    if (ch < 0x800) {
-        dest[0] = (ch>>6) | 0xC0;
+    if(ch < 0x800)
+    {
+        dest[0] = (ch >> 6) | 0xC0;
         dest[1] = (ch & 0x3F) | 0x80;
         return 2;
     }
-    if (ch < 0x10000) {
-        dest[0] = (ch>>12) | 0xE0;
-        dest[1] = ((ch>>6) & 0x3F) | 0x80;
+    if(ch < 0x10000)
+    {
+        dest[0] = (ch >> 12) | 0xE0;
+        dest[1] = ((ch >> 6) & 0x3F) | 0x80;
         dest[2] = (ch & 0x3F) | 0x80;
         return 3;
     }
-    if (ch < 0x110000) {
-        dest[0] = (ch>>18) | 0xF0;
-        dest[1] = ((ch>>12) & 0x3F) | 0x80;
-        dest[2] = ((ch>>6) & 0x3F) | 0x80;
+    if(ch < 0x110000)
+    {
+        dest[0] = (ch >> 18) | 0xF0;
+        dest[1] = ((ch >> 12) & 0x3F) | 0x80;
+        dest[2] = ((ch >> 6) & 0x3F) | 0x80;
         dest[3] = (ch & 0x3F) | 0x80;
         return 4;
     }
@@ -181,9 +192,9 @@ int u8_wc_toutf8(char *dest, uint32_t ch)
 /*-- moo --*/
 int u8_wc_toutf8_nul(char *dest, uint32_t ch)
 {
-  int sz = u8_wc_toutf8(dest,ch);
-  dest[sz] = '\0';
-  return sz;
+    int sz = u8_wc_toutf8(dest, ch);
+    dest[sz] = '\0';
+    return sz;
 }
 
 /* charnum => byte offset */
@@ -191,13 +202,18 @@ int u8_offset(const char *str, int charnum)
 {
     const char *string = str;
 
-    while (charnum > 0 && *string != '\0') {
-        if (*string++ & 0x80) {
-            if (!isutf(*string)) {
+    while(charnum > 0 && *string != '\0')
+    {
+        if(*string++ & 0x80)
+        {
+            if(!isutf(*string))
+            {
                 ++string;
-                if (!isutf(*string)) {
+                if(!isutf(*string))
+                {
                     ++string;
-                    if (!isutf(*string)) {
+                    if(!isutf(*string))
+                    {
                         ++string;
                     }
                 }
@@ -206,7 +222,7 @@ int u8_offset(const char *str, int charnum)
         --charnum;
     }
 
-    return (int)(string - str);
+    return (int) (string - str);
 }
 
 /* byte offset => charnum */
@@ -216,13 +232,18 @@ int u8_charnum(const char *s, int offset)
     const char *string = s;
     const char *const end = string + offset;
 
-    while (string < end && *string != '\0') {
-        if (*string++ & 0x80) {
-            if (!isutf(*string)) {
+    while(string < end && *string != '\0')
+    {
+        if(*string++ & 0x80)
+        {
+            if(!isutf(*string))
+            {
                 ++string;
-                if (!isutf(*string)) {
+                if(!isutf(*string))
+                {
                     ++string;
-                    if (!isutf(*string)) {
+                    if(!isutf(*string))
+                    {
                         ++string;
                     }
                 }
@@ -239,12 +260,13 @@ uint32_t u8_nextchar(const char *s, int *i)
     uint32_t ch = 0;
     int sz = 0;
 
-    do {
+    do
+    {
         ch <<= 6;
-        ch += (unsigned char)s[(*i)++];
+        ch += (unsigned char) s[(*i)++];
         sz++;
-    } while (s[*i] && !isutf(s[*i]));
-    ch -= offsetsFromUTF8[sz-1];
+    } while(s[*i] && !isutf(s[*i]));
+    ch -= offsetsFromUTF8[sz - 1];
 
     return ch;
 }
@@ -255,7 +277,7 @@ int u8_strlen(const char *s)
     int count = 0;
     int i = 0;
 
-    while (u8_nextchar(s, &i) != 0)
+    while(u8_nextchar(s, &i) != 0)
         count++;
 
     return count;
@@ -263,12 +285,16 @@ int u8_strlen(const char *s)
 
 void u8_inc(const char *s, int *i)
 {
-    if (s[(*i)++] & 0x80) {
-        if (!isutf(s[*i])) {
+    if(s[(*i)++] & 0x80)
+    {
+        if(!isutf(s[*i]))
+        {
             ++(*i);
-            if (!isutf(s[*i])) {
+            if(!isutf(s[*i]))
+            {
                 ++(*i);
-                if (!isutf(s[*i])) {
+                if(!isutf(s[*i]))
+                {
                     ++(*i);
                 }
             }
@@ -278,10 +304,8 @@ void u8_inc(const char *s, int *i)
 
 void u8_dec(const char *s, int *i)
 {
-    (void)(isutf(s[--(*i)]) || isutf(s[--(*i)]) ||
-           isutf(s[--(*i)]) || --(*i));
+    (void) (isutf(s[--(*i)]) || isutf(s[--(*i)]) || isutf(s[--(*i)]) || --(*i));
 }
-
 
 /* srcsz = number of source characters, or -1 if 0-terminated
    sz = size of dest buffer in bytes
@@ -296,24 +320,27 @@ int u8_nativetoutf8(char *dest, int sz, const char *src, int srcsz)
     int len;
 #ifdef _WIN32
     int res;
-    wchar_t*wbuf = 0;
-    if(srcsz < 0) {
+    wchar_t *wbuf = 0;
+    if(srcsz < 0)
+    {
         len = MultiByteToWideChar(CP_OEMCP, 0, src, srcsz, wbuf, 0);
-    } else {
-        len = (srcsz < sz)?srcsz:sz;
+    }
+    else
+    {
+        len = (srcsz < sz) ? srcsz : sz;
     }
     wbuf = getbytes(len * sizeof(*wbuf));
     res = MultiByteToWideChar(CP_OEMCP, 0, src, srcsz, wbuf, len);
-    if(res) {
+    if(res)
+    {
         res = WideCharToMultiByte(CP_UTF8, 0, wbuf, len, dest, sz, 0, 0);
     }
     freebytes(wbuf, len * sizeof(*wbuf));
-    return (res)?len:0;
+    return (res) ? len : 0;
 #endif
-        /* on other systems, we use UTF-8 for everything, so this is a no-op */
-    if(srcsz < 0)
-        srcsz = strlen(src) + 1;
-    len = (srcsz < sz)?srcsz:sz;
+    /* on other systems, we use UTF-8 for everything, so this is a no-op */
+    if(srcsz < 0) srcsz = strlen(src) + 1;
+    len = (srcsz < sz) ? srcsz : sz;
     strncpy(dest, src, len);
     return len;
 }

--- a/src/s_utf8.h
+++ b/src/s_utf8.h
@@ -4,7 +4,7 @@
 #include "m_pd.h"
 
 #ifndef UCS4
-# define UCS4 uint32_t
+#define UCS4 uint32_t
 #endif
 
 /* UTF8_SUPPORT_FULL_UCS4
@@ -21,24 +21,24 @@
  *  maximum bytes per character including NUL terminator
  */
 #ifdef UTF8_SUPPORT_FULL_UCS4
-# ifndef UTF8_MAXBYTES
-#  define UTF8_MAXBYTES  6
-# endif
-# ifndef UTF8_MAXBYTES1
-#  define UTF8_MAXBYTES1 7
-# endif
+#ifndef UTF8_MAXBYTES
+#define UTF8_MAXBYTES 6
+#endif
+#ifndef UTF8_MAXBYTES1
+#define UTF8_MAXBYTES1 7
+#endif
 #else
-# ifndef UTF8_MAXBYTES
-#  define UTF8_MAXBYTES  4
-# endif
-# ifndef UTF8_MAXBYTES1
-#  define UTF8_MAXBYTES1 5
-# endif
+#ifndef UTF8_MAXBYTES
+#define UTF8_MAXBYTES 4
+#endif
+#ifndef UTF8_MAXBYTES1
+#define UTF8_MAXBYTES1 5
+#endif
 #endif
 /*--/moo--*/
 
 /* is c the start of a utf8 sequence? */
-#define isutf(c) (((c)&0xC0)!=0x80)
+#define isutf(c) (((c) &0xC0) != 0x80)
 
 /* convert UTF-8 data to UCS-2 wide character */
 int u8_utf8toucs2(uint16_t *dest, int sz, const char *src, int srcsz);
@@ -83,6 +83,6 @@ void u8_dec_ptr(char **sp);
 int u8_seqlen(const char *s);
 
 /* convert a string in the current encoding to UTF-8 */
-int u8_nativetoutf8(char* dest, int sz, const char* src, int srcsz);
+int u8_nativetoutf8(char *dest, int sz, const char *src, int srcsz);
 
 #endif /* S_UTF8_H */

--- a/src/s_watchdog.c
+++ b/src/s_watchdog.c
@@ -18,7 +18,8 @@ int main(int argc, char **argv)
     while(1)
     {
         struct timeval timeout;
-        fd_set readset, exceptset;
+        fd_set readset;
+        fd_set exceptset;
         if(happy)
         {
             timeout.tv_sec = 5;

--- a/src/s_watchdog.c
+++ b/src/s_watchdog.c
@@ -42,8 +42,7 @@ int main(int argc, char **argv)
             happy = 1;
             if(read(0, &buf, 100) <= 0)
                 return (0);
-            else
-                continue;
+            continue;
         }
         happy = 0;
         kill(getppid(), SIGHUP);

--- a/src/s_watchdog.c
+++ b/src/s_watchdog.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2000 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* This file is compiled into the separate program, "pd-watchdog," which
 tries to prevent Pd from locking up the processor if it's at realtime
@@ -15,11 +15,11 @@ priority.  Linux only.  Invoked from s_inter.c. */
 int main(int argc, char **argv)
 {
     int happy = 1;
-    while (1)
+    while(1)
     {
         struct timeval timeout;
         fd_set readset, exceptset;
-        if (happy)
+        if(happy)
         {
             timeout.tv_sec = 5;
             timeout.tv_usec = 0;
@@ -34,15 +34,15 @@ int main(int argc, char **argv)
         FD_ZERO(&exceptset);
         FD_SET(0, &exceptset);
         select(1, &readset, 0, &exceptset, &timeout);
-        if (FD_ISSET(0, &exceptset))
-            return (0);
-        if (FD_ISSET(0, &readset))
+        if(FD_ISSET(0, &exceptset)) return (0);
+        if(FD_ISSET(0, &readset))
         {
             char buf[100];
             happy = 1;
-            if (read(0, &buf, 100) <= 0)
+            if(read(0, &buf, 100) <= 0)
                 return (0);
-            else continue;
+            else
+                continue;
         }
         happy = 0;
         kill(getppid(), SIGHUP);

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -59,11 +59,17 @@ int main(int argc, char **argv)
     if(argc > 2)
     {
         if(!strcmp(argv[2], "tcp"))
+        {
             protocol = SOCK_STREAM;
+        }
         else if(!strcmp(argv[2], "udp"))
+        {
             protocol = SOCK_DGRAM;
+        }
         else
+        {
             goto usage;
+        }
     }
     else
         protocol = SOCK_STREAM; /* default */
@@ -281,9 +287,13 @@ static void doconnect(void)
 {
     int fd = accept(sockfd, 0, 0);
     if(fd < 0)
+    {
         perror("accept");
+    }
     else
+    {
         addport(fd);
+    }
 }
 
 static void makeoutput(char *buf, int len)
@@ -361,9 +371,13 @@ static void tcpread(t_fdpoll *x)
         rmport(x);
     }
     else if(ret == 0)
+    {
         rmport(x);
+    }
     else
+    {
         tcpmakeoutput(x, inbuf, ret);
+    }
 }
 
 static void dopoll(void)

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2000 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in the Pd distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in the Pd distribution.  */
 
 /* the "pdreceive" command. This is a standalone program that receives messages
 from Pd via the netsend/netreceive ("FUDI") protocol, and copies them to
@@ -27,7 +27,8 @@ typedef struct _fdpoll
     int fdp_fd;
     char *fdp_outbuf; /*output message buffer*/
     int fdp_outlen;   /*length of output message*/
-    int fdp_discard;  /*buffer overflow: output message is incomplete, discard it*/
+    int fdp_discard;  /*buffer overflow: output message is incomplete, discard
+                         it*/
     int fdp_gotsemi;  /*last char from input was a semicolon*/
 } t_fdpoll;
 
@@ -50,73 +51,75 @@ int main(int argc, char **argv)
     int status, portno, multicast = 0;
     char *hostname = NULL;
     struct addrinfo *ailist = NULL, *ai;
-    if (argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
+    if(argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
         goto usage;
-    if (argc > 2)
+    if(argc > 2)
     {
-        if (!strcmp(argv[2], "tcp"))
+        if(!strcmp(argv[2], "tcp"))
             protocol = SOCK_STREAM;
-        else if (!strcmp(argv[2], "udp"))
+        else if(!strcmp(argv[2], "udp"))
             protocol = SOCK_DGRAM;
-        else goto usage;
+        else
+            goto usage;
     }
     else
         protocol = SOCK_STREAM; /* default */
-    if (argc > 3)
-        hostname = argv[3];
-    if (socket_init())
+    if(argc > 3) hostname = argv[3];
+    if(socket_init())
     {
         sockerror("socket_init()");
         exit(EXIT_FAILURE);
     }
     status = addrinfo_get_list(&ailist, hostname, portno, protocol);
-    if (status != 0)
+    if(status != 0)
     {
-        fprintf(stderr, "bad host or port? %s (%d)\n",
-            gai_strerror(status), status);
+        fprintf(stderr, "bad host or port? %s (%d)\n", gai_strerror(status),
+            status);
         exit(EXIT_FAILURE);
     }
-    if (hostname)
+    if(hostname)
     {
-        /* If we specify a hostname or IP address we can only listen to a single adapter.
-         * For host names, we prefer IPv4 for now. LATER we might create several sockets */
+        /* If we specify a hostname or IP address we can only listen to a single
+         * adapter. For host names, we prefer IPv4 for now. LATER we might
+         * create several sockets */
         addrinfo_sort_list(&ailist, addrinfo_ipv4_first);
     }
     else
     {
-        /* For the "any" address we want to prefer IPv6, so we can create a dual stack socket */
+        /* For the "any" address we want to prefer IPv6, so we can create a dual
+         * stack socket */
         addrinfo_sort_list(&ailist, addrinfo_ipv6_first);
     }
 #ifdef PRINT_ADDRINFO
     addrinfo_print_list(ailist);
 #endif
     /* try each addr until we find one that works */
-    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    for(ai = ailist; ai != NULL; ai = ai->ai_next)
     {
         sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (sockfd < 0)
-            continue;
-    #if 1
-        /* ask OS to allow another process to reopen this port after we close it */
-        if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
+        if(sockfd < 0) continue;
+#if 1
+        /* ask OS to allow another process to reopen this port after we close it
+         */
+        if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
             fprintf(stderr, "setsockopt (SO_REUSEADDR) failed\n");
-    #endif
-        if (protocol == SOCK_STREAM)
+#endif
+        if(protocol == SOCK_STREAM)
         {
             /* stream (TCP) sockets are set NODELAY */
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 fprintf(stderr, "setsockopt (TCP_NODELAY) failed\n");
         }
-        else if (protocol == SOCK_DGRAM && ai->ai_family == AF_INET)
+        else if(protocol == SOCK_DGRAM && ai->ai_family == AF_INET)
         {
             /* enable IPv4 UDP broadcasting */
-            if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
+            if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
                 fprintf(stderr, "setsockopt (SO_BROADCAST) failed\n");
         }
         /* if this is an IPv6 address, also listen to IPv4 adapters
            (if not supported, fall back to IPv4) */
-        if (ai->ai_family == AF_INET6 &&
-                socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
+        if(ai->ai_family == AF_INET6 &&
+            socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
         {
             /* fprintf(stderr, "setsockopt (IPV6_V6ONLY) failed\n"); */
             socket_close(sockfd);
@@ -125,15 +128,16 @@ int main(int argc, char **argv)
         }
         multicast = sockaddr_is_multicast(ai->ai_addr);
 #if 1
-        if (multicast)
+        if(multicast)
         {
-            /* binding to the multicast address doesn't work on Windows and on Linux
-               it doesn't seem to work for IPv6 multicast addresses, so we bind to
-               the "any" address instead */
+            /* binding to the multicast address doesn't work on Windows and on
+               Linux it doesn't seem to work for IPv6 multicast addresses, so we
+               bind to the "any" address instead */
             struct addrinfo *any;
             int status = addrinfo_get_list(&any,
-                (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno, protocol);
-            if (status != 0)
+                (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno,
+                protocol);
+            if(status != 0)
             {
                 fprintf(stderr,
                     "getting \"any\" address for multicast failed %s (%d)\n",
@@ -144,7 +148,7 @@ int main(int argc, char **argv)
             /* name the socket */
             status = bind(sockfd, any->ai_addr, any->ai_addrlen);
             freeaddrinfo(any);
-            if (status < 0)
+            if(status < 0)
             {
                 socket_close(sockfd);
                 sockfd = -1;
@@ -155,7 +159,7 @@ int main(int argc, char **argv)
 #endif
         {
             /* name the socket */
-            if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
+            if(bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
             {
                 socket_close(sockfd);
                 sockfd = -1;
@@ -163,21 +167,19 @@ int main(int argc, char **argv)
             }
         }
         /* join multicast group */
-        if (multicast && socket_join_multicast_group(sockfd, ai->ai_addr) < 0)
+        if(multicast && socket_join_multicast_group(sockfd, ai->ai_addr) < 0)
         {
             int err = socket_errno();
             char buf[256];
             socket_strerror(err, buf, sizeof(buf));
-            fprintf(stderr,
-                "joining multicast group %s failed: %s (%d)\n",
+            fprintf(stderr, "joining multicast group %s failed: %s (%d)\n",
                 hostname, buf, err);
         }
         /* this addr worked */
-        if (hostname)
+        if(hostname)
         {
             char hostbuf[256];
-            sockaddr_get_addrstr(ai->ai_addr,
-                hostbuf, sizeof(hostbuf));
+            sockaddr_get_addrstr(ai->ai_addr, hostbuf, sizeof(hostbuf));
             fprintf(stderr, "listening on %s %d%s\n", hostbuf, portno,
                 (multicast ? " (multicast)" : ""));
         }
@@ -188,7 +190,7 @@ int main(int argc, char **argv)
     freeaddrinfo(ailist);
 
     /* confirm that socket/bind worked */
-    if (sockfd < 0)
+    if(sockfd < 0)
     {
         int err = socket_errno();
         char buf[256];
@@ -199,9 +201,9 @@ int main(int argc, char **argv)
 
     maxfd = sockfd + 1;
 
-    if (protocol == SOCK_STREAM) /* streaming protocol */
+    if(protocol == SOCK_STREAM) /* streaming protocol */
     {
-        if (listen(sockfd, 5) < 0)
+        if(listen(sockfd, 5) < 0)
         {
             sockerror("listen");
             socket_close(sockfd);
@@ -210,7 +212,7 @@ int main(int argc, char **argv)
     }
 
     /* now loop forever selecting on sockets */
-    while (1)
+    while(1)
         dopoll();
 
 usage:
@@ -223,9 +225,9 @@ static void addport(int fd)
 {
     int nfd = nfdpoll;
     t_fdpoll *fp;
-    t_fdpoll *fdtmp = (t_fdpoll *)realloc(fdpoll,
-        (nfdpoll+1) * sizeof(t_fdpoll));
-    if (!fdtmp)
+    t_fdpoll *fdtmp =
+        (t_fdpoll *) realloc(fdpoll, (nfdpoll + 1) * sizeof(t_fdpoll));
+    if(!fdtmp)
     {
         free(fdpoll);
         fprintf(stderr, "out of memory!");
@@ -235,9 +237,9 @@ static void addport(int fd)
     fp = fdpoll + nfdpoll;
     fp->fdp_fd = fd;
     nfdpoll++;
-    if (fd >= maxfd) maxfd = fd + 1;
+    if(fd >= maxfd) maxfd = fd + 1;
     fp->fdp_outlen = fp->fdp_discard = fp->fdp_gotsemi = 0;
-    if (!(fp->fdp_outbuf = (char*) malloc(NET_MAXPACKETSIZE)))
+    if(!(fp->fdp_outbuf = (char *) malloc(NET_MAXPACKETSIZE)))
     {
         fprintf(stderr, "out of memory");
         exit(EXIT_FAILURE);
@@ -250,19 +252,19 @@ static void rmport(t_fdpoll *x)
     int nfd = nfdpoll;
     int i, size = nfdpoll * sizeof(t_fdpoll);
     t_fdpoll *fp;
-    for (i = nfdpoll, fp = fdpoll; i--; fp++)
+    for(i = nfdpoll, fp = fdpoll; i--; fp++)
     {
-        if (fp == x)
+        if(fp == x)
         {
             socket_close(fp->fdp_fd);
             free(fp->fdp_outbuf);
-            while (i--)
+            while(i--)
             {
                 fp[0] = fp[1];
                 fp++;
             }
-            fdpoll = (t_fdpoll *)realloc(fdpoll,
-                (nfdpoll-1) * sizeof(t_fdpoll));
+            fdpoll =
+                (t_fdpoll *) realloc(fdpoll, (nfdpoll - 1) * sizeof(t_fdpoll));
             nfdpoll--;
             printf("number_connected %d;\n", nfdpoll);
             return;
@@ -274,19 +276,20 @@ static void rmport(t_fdpoll *x)
 static void doconnect(void)
 {
     int fd = accept(sockfd, 0, 0);
-    if (fd < 0)
+    if(fd < 0)
         perror("accept");
-    else addport(fd);
+    else
+        addport(fd);
 }
 
 static void makeoutput(char *buf, int len)
 {
 #ifdef _WIN32
     int j;
-    for (j = 0; j < len; j++)
+    for(j = 0; j < len; j++)
         putchar(buf[j]);
 #else
-    if (write(1, buf, len) < len)
+    if(write(1, buf, len) < len)
     {
         perror("write");
         exit(EXIT_FAILURE);
@@ -297,13 +300,13 @@ static void makeoutput(char *buf, int len)
 static void udpread(void)
 {
     int ret = recv(sockfd, recvbuf, NET_MAXPACKETSIZE, 0);
-    if (ret < 0)
+    if(ret < 0)
     {
         sockerror("recv (udp)");
         socket_close(sockfd);
         exit(EXIT_FAILURE);
     }
-    else if (ret > 0)
+    else if(ret > 0)
         makeoutput(recvbuf, ret);
 }
 
@@ -313,31 +316,30 @@ static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)
     int outlen = x->fdp_outlen;
     char *outbuf = x->fdp_outbuf;
 
-    for (i = 0 ; i < len ; i++)
+    for(i = 0; i < len; i++)
     {
         char c = inbuf[i];
 
-        if((c != '\n') || (!x->fdp_gotsemi))
-            outbuf[outlen++] = c;
+        if((c != '\n') || (!x->fdp_gotsemi)) outbuf[outlen++] = c;
         x->fdp_gotsemi = 0;
-        if (outlen >= (NET_MAXPACKETSIZE-1)) /*output buffer overflow; reserve 1 for '\n' */
+        if(outlen >= (NET_MAXPACKETSIZE -
+                         1)) /*output buffer overflow; reserve 1 for '\n' */
         {
             fprintf(stderr, "pdreceive: message too long; discarding\n");
             outlen = 0;
             x->fdp_discard = 1;
         }
-            /* search for a semicolon.   */
-        if (c == ';')
+        /* search for a semicolon.   */
+        if(c == ';')
         {
             outbuf[outlen++] = '\n';
-            if (!x->fdp_discard)
-               makeoutput(outbuf, outlen);
+            if(!x->fdp_discard) makeoutput(outbuf, outlen);
 
             outlen = 0;
             x->fdp_discard = 0;
             x->fdp_gotsemi = 1;
         } /* if (c == ';') */
-    } /* for */
+    }     /* for */
 
     x->fdp_outlen = outlen;
     return (0);
@@ -345,18 +347,19 @@ static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)
 
 static void tcpread(t_fdpoll *x)
 {
-    int  ret;
+    int ret;
     char inbuf[NET_MAXPACKETSIZE];
 
     ret = recv(x->fdp_fd, inbuf, NET_MAXPACKETSIZE, 0);
-    if (ret < 0)
+    if(ret < 0)
     {
         sockerror("recv (tcp)");
         rmport(x);
     }
-    else if (ret == 0)
+    else if(ret == 0)
         rmport(x);
-    else tcpmakeoutput(x, inbuf, ret);
+    else
+        tcpmakeoutput(x, inbuf, ret);
 }
 
 static void dopoll(void)
@@ -369,31 +372,27 @@ static void dopoll(void)
     FD_ZERO(&exceptset);
 
     FD_SET(sockfd, &readset);
-    if (protocol == SOCK_STREAM)
+    if(protocol == SOCK_STREAM)
     {
-        for (fp = fdpoll, i = nfdpoll; i--; fp++)
+        for(fp = fdpoll, i = nfdpoll; i--; fp++)
             FD_SET(fp->fdp_fd, &readset);
     }
-    if (select(maxfd+1, &readset, &writeset, &exceptset, 0) < 0)
+    if(select(maxfd + 1, &readset, &writeset, &exceptset, 0) < 0)
     {
         perror("select");
         exit(EXIT_FAILURE);
     }
-    if (protocol == SOCK_STREAM)
+    if(protocol == SOCK_STREAM)
     {
-        for (i = 0; i < nfdpoll; i++)
-            if (FD_ISSET(fdpoll[i].fdp_fd, &readset))
-                tcpread(&fdpoll[i]);
-        if (FD_ISSET(sockfd, &readset))
-            doconnect();
+        for(i = 0; i < nfdpoll; i++)
+            if(FD_ISSET(fdpoll[i].fdp_fd, &readset)) tcpread(&fdpoll[i]);
+        if(FD_ISSET(sockfd, &readset)) doconnect();
     }
     else
     {
-        if (FD_ISSET(sockfd, &readset))
-            udpread();
+        if(FD_ISSET(sockfd, &readset)) udpread();
     }
 }
-
 
 void sockerror(char *s)
 {

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -326,11 +326,10 @@ static void udpread(void)
 
 static int tcpmakeoutput(t_fdpoll *x, char *inbuf, int len)
 {
-    int i;
     int outlen = x->fdp_outlen;
     char *outbuf = x->fdp_outbuf;
 
-    for(i = 0; i < len; i++)
+    for(int i = 0; i < len; i++)
     {
         char c = inbuf[i];
 
@@ -382,7 +381,6 @@ static void tcpread(t_fdpoll *x)
 
 static void dopoll(void)
 {
-    int i;
     t_fdpoll *fp;
     fd_set readset;
     fd_set writeset;
@@ -394,6 +392,7 @@ static void dopoll(void)
     FD_SET(sockfd, &readset);
     if(protocol == SOCK_STREAM)
     {
+        int i;
         for(fp = fdpoll, i = nfdpoll; i--; fp++)
             FD_SET(fp->fdp_fd, &readset);
     }
@@ -404,7 +403,7 @@ static void dopoll(void)
     }
     if(protocol == SOCK_STREAM)
     {
-        for(i = 0; i < nfdpoll; i++)
+        for(int i = 0; i < nfdpoll; i++)
             if(FD_ISSET(fdpoll[i].fdp_fd, &readset)) tcpread(&fdpoll[i]);
         if(FD_ISSET(sockfd, &readset)) doconnect();
     }

--- a/src/u_pdreceive.c
+++ b/src/u_pdreceive.c
@@ -48,9 +48,12 @@ static void sockerror(char *s);
 
 int main(int argc, char **argv)
 {
-    int status, portno, multicast = 0;
+    int status;
+    int portno;
+    int multicast = 0;
     char *hostname = NULL;
-    struct addrinfo *ailist = NULL, *ai;
+    struct addrinfo *ailist = NULL;
+    struct addrinfo *ai;
     if(argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
         goto usage;
     if(argc > 2)
@@ -250,7 +253,8 @@ static void addport(int fd)
 static void rmport(t_fdpoll *x)
 {
     int nfd = nfdpoll;
-    int i, size = nfdpoll * sizeof(t_fdpoll);
+    int i;
+    int size = nfdpoll * sizeof(t_fdpoll);
     t_fdpoll *fp;
     for(i = nfdpoll, fp = fdpoll; i--; fp++)
     {
@@ -366,7 +370,9 @@ static void dopoll(void)
 {
     int i;
     t_fdpoll *fp;
-    fd_set readset, writeset, exceptset;
+    fd_set readset;
+    fd_set writeset;
+    fd_set exceptset;
     FD_ZERO(&writeset);
     FD_ZERO(&readset);
     FD_ZERO(&exceptset);

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -35,17 +35,27 @@ int main(int argc, char **argv)
     if(argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
         goto usage;
     if(argc >= 3)
+    {
         hostname = argv[2];
+    }
     else
+    {
         hostname = "localhost";
+    }
     if(argc >= 4)
     {
         if(!strcmp(argv[3], "tcp"))
+        {
             protocol = SOCK_STREAM;
+        }
         else if(!strcmp(argv[3], "udp"))
+        {
             protocol = SOCK_DGRAM;
+        }
         else
+        {
             goto usage;
+        }
     }
     else
         protocol = SOCK_STREAM;
@@ -104,9 +114,13 @@ int main(int argc, char **argv)
         sockaddr_get_addrstr(
             (struct sockaddr *) &server, addrstr, sizeof(addrstr));
         if(multicast)
+        {
             fprintf(stderr, "connected to %s (multicast)\n", addrstr);
+        }
         else
+        {
             fprintf(stderr, "connected to %s\n", addrstr);
+        }
         break;
     }
     freeaddrinfo(ailist);

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 2000 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in the Pd distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in the Pd distribution.  */
 
 /* the "pdsend" command.  This is a standalone program that forwards messages
 from its standard input to Pd via the netsend/netreceive ("FUDI") protocol. */
@@ -27,33 +27,35 @@ int main(int argc, char **argv)
     struct addrinfo *ailist = NULL, *ai;
     float timeout = 10;
     char *hostname;
-    if (argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
+    if(argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
         goto usage;
-    if (argc >= 3)
+    if(argc >= 3)
         hostname = argv[2];
-    else hostname = "localhost";
-    if (argc >= 4)
+    else
+        hostname = "localhost";
+    if(argc >= 4)
     {
-        if (!strcmp(argv[3], "tcp"))
+        if(!strcmp(argv[3], "tcp"))
             protocol = SOCK_STREAM;
-        else if (!strcmp(argv[3], "udp"))
+        else if(!strcmp(argv[3], "udp"))
             protocol = SOCK_DGRAM;
-        else goto usage;
+        else
+            goto usage;
     }
-    else protocol = SOCK_STREAM;
-    if (argc >= 5 && sscanf(argv[4], "%f", &timeout) < 1)
-        goto usage;
-    if (socket_init())
+    else
+        protocol = SOCK_STREAM;
+    if(argc >= 5 && sscanf(argv[4], "%f", &timeout) < 1) goto usage;
+    if(socket_init())
     {
         sockerror("socket_init()");
         exit(EXIT_FAILURE);
     }
     /* get addrinfo list using hostname & port */
     status = addrinfo_get_list(&ailist, hostname, portno, protocol);
-    if (status != 0)
+    if(status != 0)
     {
-        fprintf(stderr, "bad host or port? %s (%d)\n",
-            gai_strerror(status), status);
+        fprintf(stderr, "bad host or port? %s (%d)\n", gai_strerror(status),
+            status);
         exit(EXIT_FAILURE);
     }
     addrinfo_sort_list(&ailist, addrinfo_ipv4_first); /* IPv4 first! */
@@ -61,30 +63,30 @@ int main(int argc, char **argv)
     addrinfo_print_list(ailist);
 #endif
     /* try each addr until we find one that works */
-    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    for(ai = ailist; ai != NULL; ai = ai->ai_next)
     {
         char addrstr[256];
         /* create a socket */
         sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (sockfd < 0)
-            continue;
+        if(sockfd < 0) continue;
         /* for stream (TCP) sockets, specify "nodelay" */
-        if (protocol == SOCK_STREAM)
+        if(protocol == SOCK_STREAM)
         {
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 fprintf(stderr, "setsockopt (TCP_NODELAY) failed\n");
         }
         else /* datagram (UDP) broadcasting */
         {
-            if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
+            if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
                 fprintf(stderr, "setsockopt (SO_BROADCAST) failed\n");
         }
         multicast = sockaddr_is_multicast(ai->ai_addr);
-        if (protocol == SOCK_STREAM)
+        if(protocol == SOCK_STREAM)
         {
-            status = socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen,
-                                    timeout);
-            if (status < 0){
+            status =
+                socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen, timeout);
+            if(status < 0)
+            {
                 sockerror("connecting stream socket");
                 socket_close(sockfd);
                 freeaddrinfo(ailist);
@@ -94,44 +96,44 @@ int main(int argc, char **argv)
         /* this addr worked */
         memcpy(&server, ai->ai_addr, ai->ai_addrlen);
         /* print address */
-        sockaddr_get_addrstr((struct sockaddr *)&server,
-                             addrstr, sizeof(addrstr));
-        if (multicast)
+        sockaddr_get_addrstr(
+            (struct sockaddr *) &server, addrstr, sizeof(addrstr));
+        if(multicast)
             fprintf(stderr, "connected to %s (multicast)\n", addrstr);
         else
             fprintf(stderr, "connected to %s\n", addrstr);
         break;
     }
     freeaddrinfo(ailist);
-    if (sockfd < 0)
+    if(sockfd < 0)
     {
         fprintf(stderr, "couldn't create socket to connect to %s://%s:%d\n",
-            (SOCK_STREAM==protocol)?"tcp":"udp", hostname, portno);
+            (SOCK_STREAM == protocol) ? "tcp" : "udp", hostname, portno);
         exit(EXIT_FAILURE);
     }
 
     /* now loop reading stdin and sending it to socket */
-    while (1)
+    while(1)
     {
         char *bp;
         int nsent, nsend;
-        if (!fgets(sendbuf, NET_MAXPACKETSIZE, stdin))
-            break;
+        if(!fgets(sendbuf, NET_MAXPACKETSIZE, stdin)) break;
         nsend = strlen(sendbuf);
-        for (bp = sendbuf, nsent = 0; nsent < nsend;)
+        for(bp = sendbuf, nsent = 0; nsent < nsend;)
         {
             int res = 0;
-            if (protocol == SOCK_DGRAM)
+            if(protocol == SOCK_DGRAM)
             {
-                socklen_t addrlen = (server.ss_family == AF_INET6 ?
-                    sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
-                res = (int)sendto(sockfd, bp, nsend-nsent, 0,
-                    (struct sockaddr *)&server, addrlen);
+                socklen_t addrlen =
+                    (server.ss_family == AF_INET6 ? sizeof(struct sockaddr_in6)
+                                                  : sizeof(struct sockaddr_in));
+                res = (int) sendto(sockfd, bp, nsend - nsent, 0,
+                    (struct sockaddr *) &server, addrlen);
             }
             else
-                res = (int)send(sockfd, bp, nsend-nsent, 0);
+                res = (int) send(sockfd, bp, nsend - nsent, 0);
 
-            if (res < 0)
+            if(res < 0)
             {
                 sockerror("send");
                 goto done;
@@ -141,12 +143,12 @@ int main(int argc, char **argv)
         }
     }
 done:
-    if (ferror(stdin))
-        perror("stdin");
+    if(ferror(stdin)) perror("stdin");
     socket_close(sockfd);
     exit(EXIT_SUCCESS);
 usage:
-    fprintf(stderr, "usage: pdsend <portnumber> [host] [udp|tcp] [timeout(s)]\n");
+    fprintf(
+        stderr, "usage: pdsend <portnumber> [host] [udp|tcp] [timeout(s)]\n");
     fprintf(stderr, "(default is localhost and tcp with 10s timeout)\n");
     exit(EXIT_FAILURE);
 }

--- a/src/u_pdsend.c
+++ b/src/u_pdsend.c
@@ -22,9 +22,14 @@ char sendbuf[NET_MAXPACKETSIZE];
 
 int main(int argc, char **argv)
 {
-    int sockfd = -1, portno, protocol, status, multicast;
+    int sockfd = -1;
+    int portno;
+    int protocol;
+    int status;
+    int multicast;
     struct sockaddr_storage server;
-    struct addrinfo *ailist = NULL, *ai;
+    struct addrinfo *ailist = NULL;
+    struct addrinfo *ai;
     float timeout = 10;
     char *hostname;
     if(argc < 2 || sscanf(argv[1], "%d", &portno) < 1 || portno <= 0)
@@ -116,7 +121,8 @@ int main(int argc, char **argv)
     while(1)
     {
         char *bp;
-        int nsent, nsend;
+        int nsent;
+        int nsend;
         if(!fgets(sendbuf, NET_MAXPACKETSIZE, stdin)) break;
         nsend = strlen(sendbuf);
         for(bp = sendbuf, nsent = 0; nsent < nsend;)

--- a/src/x_acoustics.c
+++ b/src/x_acoustics.c
@@ -14,9 +14,13 @@ t_float mtof(t_float f)
     if(f <= -1500)
         return (0);
     if(f > 1499)
+    {
         return (mtof(1499));
+    }
     else
+    {
         return (8.17579891564 * exp(.0577622650 * f));
+    }
 }
 
 t_float ftom(t_float f)

--- a/src/x_acoustics.c
+++ b/src/x_acoustics.c
@@ -13,7 +13,7 @@ t_float mtof(t_float f)
 {
     if(f <= -1500)
         return (0);
-    else if(f > 1499)
+    if(f > 1499)
         return (mtof(1499));
     else
         return (8.17579891564 * exp(.0577622650 * f));
@@ -28,43 +28,36 @@ t_float powtodb(t_float f)
 {
     if(f <= 0)
         return (0);
-    else
-    {
-        t_float val = 100 + 10. / LOGTEN * log(f);
-        return (val < 0 ? 0 : val);
-    }
+
+    t_float val = 100 + 10. / LOGTEN * log(f);
+    return (val < 0 ? 0 : val);
 }
 
 t_float rmstodb(t_float f)
 {
     if(f <= 0)
         return (0);
-    else
-    {
-        t_float val = 100 + 20. / LOGTEN * log(f);
-        return (val < 0 ? 0 : val);
-    }
+
+    t_float val = 100 + 20. / LOGTEN * log(f);
+    return (val < 0 ? 0 : val);
 }
 
 t_float dbtopow(t_float f)
 {
     if(f <= 0)
         return (0);
-    else
-    {
-        if(f > 870) f = 870;
-        return (exp((LOGTEN * 0.1) * (f - 100.)));
-    }
+
+    if(f > 870) f = 870;
+    return (exp((LOGTEN * 0.1) * (f - 100.)));
 }
 
 t_float dbtorms(t_float f)
 {
     if(f <= 0)
         return (0);
-    else
-    {
-        if(f > 485) f = 485;
-    }
+
+    if(f > 485) f = 485;
+
     return (exp((LOGTEN * 0.05) * (f - 100.)));
 }
 

--- a/src/x_acoustics.c
+++ b/src/x_acoustics.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /*  utility functions for signals
-*/
+ */
 
 #include "m_pd.h"
 #include <math.h>
@@ -11,9 +11,12 @@
 
 t_float mtof(t_float f)
 {
-    if (f <= -1500) return(0);
-    else if (f > 1499) return(mtof(1499));
-    else return (8.17579891564 * exp(.0577622650 * f));
+    if(f <= -1500)
+        return (0);
+    else if(f > 1499)
+        return (mtof(1499));
+    else
+        return (8.17579891564 * exp(.0577622650 * f));
 }
 
 t_float ftom(t_float f)
@@ -23,46 +26,46 @@ t_float ftom(t_float f)
 
 t_float powtodb(t_float f)
 {
-    if (f <= 0) return (0);
+    if(f <= 0)
+        return (0);
     else
     {
-        t_float val = 100 + 10./LOGTEN * log(f);
+        t_float val = 100 + 10. / LOGTEN * log(f);
         return (val < 0 ? 0 : val);
     }
 }
 
 t_float rmstodb(t_float f)
 {
-    if (f <= 0) return (0);
+    if(f <= 0)
+        return (0);
     else
     {
-        t_float val = 100 + 20./LOGTEN * log(f);
+        t_float val = 100 + 20. / LOGTEN * log(f);
         return (val < 0 ? 0 : val);
     }
 }
 
 t_float dbtopow(t_float f)
 {
-    if (f <= 0)
-        return(0);
+    if(f <= 0)
+        return (0);
     else
     {
-        if (f > 870)
-            f = 870;
-        return (exp((LOGTEN * 0.1) * (f-100.)));
+        if(f > 870) f = 870;
+        return (exp((LOGTEN * 0.1) * (f - 100.)));
     }
 }
 
 t_float dbtorms(t_float f)
 {
-    if (f <= 0)
-        return(0);
+    if(f <= 0)
+        return (0);
     else
     {
-        if (f > 485)
-            f = 485;
+        if(f > 485) f = 485;
     }
-    return (exp((LOGTEN * 0.05) * (f-100.)));
+    return (exp((LOGTEN * 0.05) * (f - 100.)));
 }
 
 /* ------------- corresponding objects ----------------------- */
@@ -71,7 +74,7 @@ static t_class *mtof_class;
 
 static void *mtof_new(void)
 {
-    t_object *x = (t_object *)pd_new(mtof_class);
+    t_object *x = (t_object *) pd_new(mtof_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -81,12 +84,11 @@ static void mtof_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, mtof(f));
 }
 
-
 static t_class *ftom_class;
 
 static void *ftom_new(void)
 {
-    t_object *x = (t_object *)pd_new(ftom_class);
+    t_object *x = (t_object *) pd_new(ftom_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -96,12 +98,11 @@ static void ftom_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, ftom(f));
 }
 
-
 static t_class *rmstodb_class;
 
 static void *rmstodb_new(void)
 {
-    t_object *x = (t_object *)pd_new(rmstodb_class);
+    t_object *x = (t_object *) pd_new(rmstodb_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -111,12 +112,11 @@ static void rmstodb_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, rmstodb(f));
 }
 
-
 static t_class *powtodb_class;
 
 static void *powtodb_new(void)
 {
-    t_object *x = (t_object *)pd_new(powtodb_class);
+    t_object *x = (t_object *) pd_new(powtodb_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -126,12 +126,11 @@ static void powtodb_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, powtodb(f));
 }
 
-
 static t_class *dbtopow_class;
 
 static void *dbtopow_new(void)
 {
-    t_object *x = (t_object *)pd_new(dbtopow_class);
+    t_object *x = (t_object *) pd_new(dbtopow_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -141,12 +140,11 @@ static void dbtopow_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, dbtopow(f));
 }
 
-
 static t_class *dbtorms_class;
 
 static void *dbtorms_new(void)
 {
-    t_object *x = (t_object *)pd_new(dbtorms_class);
+    t_object *x = (t_object *) pd_new(dbtorms_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -156,38 +154,34 @@ static void dbtorms_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, dbtorms(f));
 }
 
-
 void x_acoustics_setup(void)
 {
     t_symbol *s = gensym("acoustics.pd");
-    mtof_class = class_new(gensym("mtof"), mtof_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(mtof_class, (t_method)mtof_float);
+    mtof_class = class_new(gensym("mtof"), mtof_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(mtof_class, (t_method) mtof_float);
     class_sethelpsymbol(mtof_class, s);
 
-    ftom_class = class_new(gensym("ftom"), ftom_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(ftom_class, (t_method)ftom_float);
+    ftom_class = class_new(gensym("ftom"), ftom_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(ftom_class, (t_method) ftom_float);
     class_sethelpsymbol(ftom_class, s);
 
-    powtodb_class = class_new(gensym("powtodb"), powtodb_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(powtodb_class, (t_method)powtodb_float);
+    powtodb_class =
+        class_new(gensym("powtodb"), powtodb_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(powtodb_class, (t_method) powtodb_float);
     class_sethelpsymbol(powtodb_class, s);
 
-    rmstodb_class = class_new(gensym("rmstodb"), rmstodb_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(rmstodb_class, (t_method)rmstodb_float);
+    rmstodb_class =
+        class_new(gensym("rmstodb"), rmstodb_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(rmstodb_class, (t_method) rmstodb_float);
     class_sethelpsymbol(rmstodb_class, s);
 
-    dbtopow_class = class_new(gensym("dbtopow"), dbtopow_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(dbtopow_class, (t_method)dbtopow_float);
+    dbtopow_class =
+        class_new(gensym("dbtopow"), dbtopow_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(dbtopow_class, (t_method) dbtopow_float);
     class_sethelpsymbol(dbtopow_class, s);
 
-    dbtorms_class = class_new(gensym("dbtorms"), dbtorms_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(dbtorms_class, (t_method)dbtorms_float);
+    dbtorms_class =
+        class_new(gensym("dbtorms"), dbtorms_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(dbtorms_class, (t_method) dbtorms_float);
     class_sethelpsymbol(dbtorms_class, s);
 }
-

--- a/src/x_arithmetic.c
+++ b/src/x_arithmetic.c
@@ -459,18 +459,26 @@ static void binop2_pc_bang(t_binop *x)
     int n2 = x->x_f2;
     /* apparently "%" raises an exception for INT_MIN and -1 */
     if(n2 == -1)
+    {
         outlet_float(x->x_obj.ob_outlet, 0);
+    }
     else
+    {
         outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) % (n2 ? n2 : 1));
+    }
 }
 
 static void binop2_pc_float(t_binop *x, t_float f)
 {
     int n2 = x->x_f2;
     if(n2 == -1)
+    {
         outlet_float(x->x_obj.ob_outlet, 0);
+    }
     else
+    {
         outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) % (n2 ? n2 : 1));
+    }
 }
 
 /* --------------------------- mod ---------------------------- */
@@ -487,9 +495,13 @@ static void binop3_mod_bang(t_binop *x)
     int n2 = x->x_f2;
     int result;
     if(n2 < 0)
+    {
         n2 = -n2;
+    }
     else if(!n2)
+    {
         n2 = 1;
+    }
     result = ((int) (x->x_f1)) % n2;
     if(result < 0) result += n2;
     outlet_float(x->x_obj.ob_outlet, (t_float) result);
@@ -516,9 +528,13 @@ static void binop3_div_bang(t_binop *x)
     int n2 = x->x_f2;
     int result;
     if(n2 < 0)
+    {
         n2 = -n2;
+    }
     else if(!n2)
+    {
         n2 = 1;
+    }
     if(n1 < 0) n1 -= (n2 - 1);
     result = n1 / n2;
     outlet_float(x->x_obj.ob_outlet, (t_float) result);
@@ -648,11 +664,17 @@ static void binop1_log_bang(t_binop *x)
 {
     t_float r;
     if(x->x_f1 <= 0)
+    {
         r = -1000;
+    }
     else if(x->x_f2 <= 0)
+    {
         r = LOG(x->x_f1);
+    }
     else
+    {
         r = LOG(x->x_f1) / LOG(x->x_f2);
+    }
     outlet_float(x->x_obj.ob_outlet, r);
 }
 

--- a/src/x_arithmetic.c
+++ b/src/x_arithmetic.c
@@ -484,7 +484,8 @@ static void *binop3_mod_new(t_floatarg f)
 
 static void binop3_mod_bang(t_binop *x)
 {
-    int n2 = x->x_f2, result;
+    int n2 = x->x_f2;
+    int result;
     if(n2 < 0)
         n2 = -n2;
     else if(!n2)
@@ -511,7 +512,9 @@ static void *binop3_div_new(t_floatarg f)
 
 static void binop3_div_bang(t_binop *x)
 {
-    int n1 = x->x_f1, n2 = x->x_f2, result;
+    int n1 = x->x_f1;
+    int n2 = x->x_f2;
+    int result;
     if(n2 < 0)
         n2 = -n2;
     else if(!n2)

--- a/src/x_arithmetic.c
+++ b/src/x_arithmetic.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* arithmetic: binops ala C language.  The 4 functions and relationals are
 done on floats; the logical and bitwise binops convert their
@@ -10,27 +10,27 @@ inputs to int and their outputs back to float. */
 #include <math.h>
 
 #if PD_FLOATSIZE == 32
-# define POW powf
-# define SIN sinf
-# define COS cosf
-# define ATAN atanf
-# define ATAN2 atan2f
-# define SQRT sqrtf
-# define LOG logf
-# define EXP expf
-# define FABS fabsf
-# define MAXLOG 87.3365 /* log(FLT_MAX / 4.) */
+#define POW powf
+#define SIN sinf
+#define COS cosf
+#define ATAN atanf
+#define ATAN2 atan2f
+#define SQRT sqrtf
+#define LOG logf
+#define EXP expf
+#define FABS fabsf
+#define MAXLOG 87.3365 /* log(FLT_MAX / 4.) */
 #else
-# define POW pow
-# define SIN sin
-# define COS cos
-# define ATAN atan
-# define ATAN2 atan2
-# define SQRT sqrt
-# define LOG log
-# define EXP exp
-# define FABS fabs
-# define MAXLOG 708.396 /* log(DBL_MAX / 4.) */
+#define POW pow
+#define SIN sin
+#define COS cos
+#define ATAN atan
+#define ATAN2 atan2
+#define SQRT sqrt
+#define LOG log
+#define EXP exp
+#define FABS fabs
+#define MAXLOG 708.396 /* log(DBL_MAX / 4.) */
 #endif
 
 typedef struct _binop
@@ -44,7 +44,7 @@ typedef struct _binop
 
 static void *binop1_new(t_class *floatclass, t_floatarg f)
 {
-    t_binop *x = (t_binop *)pd_new(floatclass);
+    t_binop *x = (t_binop *) pd_new(floatclass);
     outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f2);
     x->x_f1 = 0;
@@ -120,15 +120,13 @@ static void *binop1_div_new(t_floatarg f)
 
 static void binop1_div_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f2 != 0 ? x->x_f1 / x->x_f2 : 0));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f2 != 0 ? x->x_f1 / x->x_f2 : 0));
 }
 
 static void binop1_div_float(t_binop *x, t_float f)
 {
     x->x_f1 = f;
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f2 != 0 ? x->x_f1 / x->x_f2 : 0));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f2 != 0 ? x->x_f1 / x->x_f2 : 0));
 }
 
 /* ------------------------ pow -------------------------------- */
@@ -143,8 +141,9 @@ static void *binop1_pow_new(t_floatarg f)
 static void binop1_pow_bang(t_binop *x)
 {
     t_float r = (x->x_f1 == 0 && x->x_f2 < 0) ||
-        (x->x_f1 < 0 && (x->x_f2 - (int)x->x_f2) != 0) ?
-            0 : POW(x->x_f1, x->x_f2);
+                        (x->x_f1 < 0 && (x->x_f2 - (int) x->x_f2) != 0)
+                    ? 0
+                    : POW(x->x_f1, x->x_f2);
     outlet_float(x->x_obj.ob_outlet, r);
 }
 
@@ -165,15 +164,13 @@ static void *binop1_max_new(t_floatarg f)
 
 static void binop1_max_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f1 > x->x_f2 ? x->x_f1 : x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f1 > x->x_f2 ? x->x_f1 : x->x_f2));
 }
 
 static void binop1_max_float(t_binop *x, t_float f)
 {
     x->x_f1 = f;
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f1 > x->x_f2 ? x->x_f1 : x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f1 > x->x_f2 ? x->x_f1 : x->x_f2));
 }
 
 /* ------------------------ min -------------------------------- */
@@ -187,22 +184,20 @@ static void *binop1_min_new(t_floatarg f)
 
 static void binop1_min_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f1 < x->x_f2 ? x->x_f1 : x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f1 < x->x_f2 ? x->x_f1 : x->x_f2));
 }
 
 static void binop1_min_float(t_binop *x, t_float f)
 {
     x->x_f1 = f;
-    outlet_float(x->x_obj.ob_outlet,
-        (x->x_f1 < x->x_f2 ? x->x_f1 : x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, (x->x_f1 < x->x_f2 ? x->x_f1 : x->x_f2));
 }
 
 /* ------------------ binop2: ==, !=, >, <, >=, <=. -------------------- */
 
 static void *binop2_new(t_class *floatclass, t_floatarg f)
 {
-    t_binop *x = (t_binop *)pd_new(floatclass);
+    t_binop *x = (t_binop *) pd_new(floatclass);
     outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f2);
     x->x_f1 = 0;
@@ -328,7 +323,7 @@ static void binop2_le_float(t_binop *x, t_float f)
 
 static void *binop3_new(t_class *fixclass, t_floatarg f)
 {
-    t_binop *x = (t_binop *)pd_new(fixclass);
+    t_binop *x = (t_binop *) pd_new(fixclass);
     outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f2);
     x->x_f1 = 0;
@@ -347,12 +342,12 @@ static void *binop3_ba_new(t_floatarg f)
 
 static void binop2_ba_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) & (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) & (int) (x->x_f2));
 }
 
 static void binop2_ba_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) & (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) & (int) (x->x_f2));
 }
 
 /* --------------------------- && ---------------------------- */
@@ -366,12 +361,12 @@ static void *binop3_la_new(t_floatarg f)
 
 static void binop2_la_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) && (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) && (int) (x->x_f2));
 }
 
 static void binop2_la_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) && (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) && (int) (x->x_f2));
 }
 
 /* --------------------------- | ---------------------------- */
@@ -385,12 +380,12 @@ static void *binop3_bo_new(t_floatarg f)
 
 static void binop2_bo_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) | (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) | (int) (x->x_f2));
 }
 
 static void binop2_bo_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) | (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) | (int) (x->x_f2));
 }
 
 /* --------------------------- || ---------------------------- */
@@ -404,12 +399,12 @@ static void *binop3_lo_new(t_floatarg f)
 
 static void binop2_lo_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) || (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) || (int) (x->x_f2));
 }
 
 static void binop2_lo_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) || (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) || (int) (x->x_f2));
 }
 
 /* --------------------------- << ---------------------------- */
@@ -423,12 +418,12 @@ static void *binop3_ls_new(t_floatarg f)
 
 static void binop2_ls_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) << (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) << (int) (x->x_f2));
 }
 
 static void binop2_ls_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) << (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) << (int) (x->x_f2));
 }
 
 /* --------------------------- >> ---------------------------- */
@@ -442,12 +437,12 @@ static void *binop3_rs_new(t_floatarg f)
 
 static void binop2_rs_bang(t_binop *x)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) >> (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) >> (int) (x->x_f2));
 }
 
 static void binop2_rs_float(t_binop *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) >> (int)(x->x_f2));
+    outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) >> (int) (x->x_f2));
 }
 
 /* --------------------------- % ---------------------------- */
@@ -462,18 +457,20 @@ static void *binop3_pc_new(t_floatarg f)
 static void binop2_pc_bang(t_binop *x)
 {
     int n2 = x->x_f2;
-        /* apparently "%" raises an exception for INT_MIN and -1 */
-    if (n2 == -1)
+    /* apparently "%" raises an exception for INT_MIN and -1 */
+    if(n2 == -1)
         outlet_float(x->x_obj.ob_outlet, 0);
-    else outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1)) % (n2 ? n2 : 1));
+    else
+        outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1)) % (n2 ? n2 : 1));
 }
 
 static void binop2_pc_float(t_binop *x, t_float f)
 {
     int n2 = x->x_f2;
-    if (n2 == -1)
+    if(n2 == -1)
         outlet_float(x->x_obj.ob_outlet, 0);
-    else outlet_float(x->x_obj.ob_outlet, ((int)(x->x_f1 = f)) % (n2 ? n2 : 1));
+    else
+        outlet_float(x->x_obj.ob_outlet, ((int) (x->x_f1 = f)) % (n2 ? n2 : 1));
 }
 
 /* --------------------------- mod ---------------------------- */
@@ -488,11 +485,13 @@ static void *binop3_mod_new(t_floatarg f)
 static void binop3_mod_bang(t_binop *x)
 {
     int n2 = x->x_f2, result;
-    if (n2 < 0) n2 = -n2;
-    else if (!n2) n2 = 1;
-    result = ((int)(x->x_f1)) % n2;
-    if (result < 0) result += n2;
-    outlet_float(x->x_obj.ob_outlet, (t_float)result);
+    if(n2 < 0)
+        n2 = -n2;
+    else if(!n2)
+        n2 = 1;
+    result = ((int) (x->x_f1)) % n2;
+    if(result < 0) result += n2;
+    outlet_float(x->x_obj.ob_outlet, (t_float) result);
 }
 
 static void binop3_mod_float(t_binop *x, t_float f)
@@ -513,11 +512,13 @@ static void *binop3_div_new(t_floatarg f)
 static void binop3_div_bang(t_binop *x)
 {
     int n1 = x->x_f1, n2 = x->x_f2, result;
-    if (n2 < 0) n2 = -n2;
-    else if (!n2) n2 = 1;
-    if (n1 < 0) n1 -= (n2-1);
+    if(n2 < 0)
+        n2 = -n2;
+    else if(!n2)
+        n2 = 1;
+    if(n1 < 0) n1 -= (n2 - 1);
     result = n1 / n2;
-    outlet_float(x->x_obj.ob_outlet, (t_float)result);
+    outlet_float(x->x_obj.ob_outlet, (t_float) result);
 }
 
 static void binop3_div_float(t_binop *x, t_float f)
@@ -528,11 +529,11 @@ static void binop3_div_float(t_binop *x, t_float f)
 
 /* -------------------- mathematical functions ------------------ */
 
-static t_class *sin_class;      /* ----------- sin --------------- */
+static t_class *sin_class; /* ----------- sin --------------- */
 
 static void *sin_new(void)
 {
-    t_object *x = (t_object *)pd_new(sin_class);
+    t_object *x = (t_object *) pd_new(sin_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -542,11 +543,11 @@ static void sin_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, SIN(f));
 }
 
-static t_class *cos_class;      /* ----------- cos --------------- */
+static t_class *cos_class; /* ----------- cos --------------- */
 
 static void *cos_new(void)
 {
-    t_object *x = (t_object *)pd_new(cos_class);
+    t_object *x = (t_object *) pd_new(cos_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -556,11 +557,11 @@ static void cos_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, COS(f));
 }
 
-static t_class *tan_class;      /* ----------- tan --------------- */
+static t_class *tan_class; /* ----------- tan --------------- */
 
 static void *tan_new(void)
 {
-    t_object *x = (t_object *)pd_new(tan_class);
+    t_object *x = (t_object *) pd_new(tan_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -568,15 +569,15 @@ static void *tan_new(void)
 static void tan_float(t_object *x, t_float f)
 {
     t_float c = cosf(f);
-    t_float t = (c == 0 ? 0 : SIN(f)/c);
+    t_float t = (c == 0 ? 0 : SIN(f) / c);
     outlet_float(x->ob_outlet, t);
 }
 
-static t_class *atan_class;     /* ----------- atan --------------- */
+static t_class *atan_class; /* ----------- atan --------------- */
 
 static void *atan_new(void)
 {
-    t_object *x = (t_object *)pd_new(atan_class);
+    t_object *x = (t_object *) pd_new(atan_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -586,18 +587,18 @@ static void atan_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, ATAN(f));
 }
 
-static t_class *atan2_class;    /* ----------- atan2 --------------- */
+static t_class *atan2_class; /* ----------- atan2 --------------- */
 
 typedef struct _atan2
 {
     t_object x_ob;
-    t_float  x_f1;
-    t_float  x_f2;
+    t_float x_f1;
+    t_float x_f2;
 } t_atan2;
 
 static void *atan2_new(void)
 {
-    t_atan2 *x = (t_atan2 *)pd_new(atan2_class);
+    t_atan2 *x = (t_atan2 *) pd_new(atan2_class);
     floatinlet_new(&x->x_ob, &x->x_f2);
     x->x_f1 = x->x_f2 = 0;
     outlet_new(&x->x_ob, &s_float);
@@ -616,11 +617,11 @@ static void atan2_float(t_atan2 *x, t_float f)
     atan2_bang(x);
 }
 
-static t_class *sqrt_class;     /* ----------- sqrt --------------- */
+static t_class *sqrt_class; /* ----------- sqrt --------------- */
 
 static void *sqrt_new(void)
 {
-    t_object *x = (t_object *)pd_new(sqrt_class);
+    t_object *x = (t_object *) pd_new(sqrt_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -643,11 +644,12 @@ static void *binop1_log_new(t_floatarg f)
 static void binop1_log_bang(t_binop *x)
 {
     t_float r;
-    if (x->x_f1 <= 0)
+    if(x->x_f1 <= 0)
         r = -1000;
-    else if (x->x_f2 <= 0)
+    else if(x->x_f2 <= 0)
         r = LOG(x->x_f1);
-    else r = LOG(x->x_f1)/LOG(x->x_f2);
+    else
+        r = LOG(x->x_f1) / LOG(x->x_f2);
     outlet_float(x->x_obj.ob_outlet, r);
 }
 
@@ -657,11 +659,11 @@ static void binop1_log_float(t_binop *x, t_float f)
     binop1_log_bang(x);
 }
 
-static t_class *exp_class;      /* ----------- exp --------------- */
+static t_class *exp_class; /* ----------- exp --------------- */
 
 static void *exp_new(void)
 {
-    t_object *x = (t_object *)pd_new(exp_class);
+    t_object *x = (t_object *) pd_new(exp_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -672,16 +674,16 @@ static void exp_float(t_object *x, t_float f)
 #ifdef _WIN32
     char buf[10];
 #endif
-    if (f > MAXLOG) f = MAXLOG;
+    if(f > MAXLOG) f = MAXLOG;
     g = EXP(f);
     outlet_float(x->ob_outlet, g);
 }
 
-static t_class *abs_class;      /* ----------- abs --------------- */
+static t_class *abs_class; /* ----------- abs --------------- */
 
 static void *abs_new(void)
 {
-    t_object *x = (t_object *)pd_new(abs_class);
+    t_object *x = (t_object *) pd_new(abs_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -691,11 +693,11 @@ static void abs_float(t_object *x, t_float f)
     outlet_float(x->ob_outlet, FABS(f));
 }
 
-static t_class *wrap_class;      /* ----------- wrap --------------- */
+static t_class *wrap_class; /* ----------- wrap --------------- */
 
 static void *wrap_new(void)
 {
-    t_object *x = (t_object *)pd_new(wrap_class);
+    t_object *x = (t_object *) pd_new(wrap_class);
     outlet_new(x, &s_float);
     return (x);
 }
@@ -719,7 +721,7 @@ typedef struct _clip
 
 static void *clip_new(t_floatarg f1, t_floatarg f2)
 {
-    t_clip *x = (t_clip *)pd_new(clip_class);
+    t_clip *x = (t_clip *) pd_new(clip_class);
     floatinlet_new(&x->x_ob, &x->x_f2);
     floatinlet_new(&x->x_ob, &x->x_f3);
     outlet_new(&x->x_ob, &s_float);
@@ -730,20 +732,22 @@ static void *clip_new(t_floatarg f1, t_floatarg f2)
 
 static void clip_bang(t_clip *x)
 {
-        outlet_float(x->x_ob.ob_outlet, (x->x_f1 < x->x_f2 ? x->x_f2 : (
-        x->x_f1 > x->x_f3 ? x->x_f3 : x->x_f1)));
+    outlet_float(x->x_ob.ob_outlet,
+        (x->x_f1 < x->x_f2 ? x->x_f2
+                           : (x->x_f1 > x->x_f3 ? x->x_f3 : x->x_f1)));
 }
 
 static void clip_float(t_clip *x, t_float f)
 {
-        x->x_f1 = f;
-        outlet_float(x->x_ob.ob_outlet, (x->x_f1 < x->x_f2 ? x->x_f2 : (
-        x->x_f1 > x->x_f3 ? x->x_f3 : x->x_f1)));
+    x->x_f1 = f;
+    outlet_float(x->x_ob.ob_outlet,
+        (x->x_f1 < x->x_f2 ? x->x_f2
+                           : (x->x_f1 > x->x_f3 ? x->x_f3 : x->x_f1)));
 }
 
 static void clip_setup(void)
 {
-    clip_class = class_new(gensym("clip"), (t_newmethod)clip_new, 0,
+    clip_class = class_new(gensym("clip"), (t_newmethod) clip_new, 0,
         sizeof(t_clip), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addfloat(clip_class, clip_float);
     class_addbang(clip_class, clip_bang);
@@ -755,204 +759,189 @@ void x_arithmetic_setup(void)
     t_symbol *binop23_sym = gensym("binops-other");
     t_symbol *math_sym = gensym("math");
 
-    binop1_plus_class = class_new(gensym("+"), (t_newmethod)binop1_plus_new, 0,
+    binop1_plus_class = class_new(gensym("+"), (t_newmethod) binop1_plus_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_plus_class, binop1_plus_bang);
-    class_addfloat(binop1_plus_class, (t_method)binop1_plus_float);
+    class_addfloat(binop1_plus_class, (t_method) binop1_plus_float);
     class_sethelpsymbol(binop1_plus_class, binop1_sym);
 
-    binop1_minus_class = class_new(gensym("-"),
-        (t_newmethod)binop1_minus_new, 0,
-        sizeof(t_binop), 0, A_DEFFLOAT, 0);
+    binop1_minus_class = class_new(gensym("-"), (t_newmethod) binop1_minus_new,
+        0, sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_minus_class, binop1_minus_bang);
-    class_addfloat(binop1_minus_class, (t_method)binop1_minus_float);
+    class_addfloat(binop1_minus_class, (t_method) binop1_minus_float);
     class_sethelpsymbol(binop1_minus_class, binop1_sym);
 
-    binop1_times_class = class_new(gensym("*"),
-        (t_newmethod)binop1_times_new, 0,
-        sizeof(t_binop), 0, A_DEFFLOAT, 0);
+    binop1_times_class = class_new(gensym("*"), (t_newmethod) binop1_times_new,
+        0, sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_times_class, binop1_times_bang);
-    class_addfloat(binop1_times_class, (t_method)binop1_times_float);
+    class_addfloat(binop1_times_class, (t_method) binop1_times_float);
     class_sethelpsymbol(binop1_times_class, binop1_sym);
 
-    binop1_div_class = class_new(gensym("/"),
-        (t_newmethod)binop1_div_new, 0,
+    binop1_div_class = class_new(gensym("/"), (t_newmethod) binop1_div_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_div_class, binop1_div_bang);
-    class_addfloat(binop1_div_class, (t_method)binop1_div_float);
+    class_addfloat(binop1_div_class, (t_method) binop1_div_float);
     class_sethelpsymbol(binop1_div_class, binop1_sym);
 
-    binop1_pow_class = class_new(gensym("pow"),
-        (t_newmethod)binop1_pow_new, 0,
+    binop1_pow_class = class_new(gensym("pow"), (t_newmethod) binop1_pow_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_pow_class, binop1_pow_bang);
-    class_addfloat(binop1_pow_class, (t_method)binop1_pow_float);
+    class_addfloat(binop1_pow_class, (t_method) binop1_pow_float);
     class_sethelpsymbol(binop1_pow_class, math_sym);
 
-    binop1_max_class = class_new(gensym("max"),
-        (t_newmethod)binop1_max_new, 0,
+    binop1_max_class = class_new(gensym("max"), (t_newmethod) binop1_max_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_max_class, binop1_max_bang);
-    class_addfloat(binop1_max_class, (t_method)binop1_max_float);
+    class_addfloat(binop1_max_class, (t_method) binop1_max_float);
     class_sethelpsymbol(binop1_max_class, binop1_sym);
 
-    binop1_min_class = class_new(gensym("min"),
-        (t_newmethod)binop1_min_new, 0,
+    binop1_min_class = class_new(gensym("min"), (t_newmethod) binop1_min_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_min_class, binop1_min_bang);
-    class_addfloat(binop1_min_class, (t_method)binop1_min_float);
+    class_addfloat(binop1_min_class, (t_method) binop1_min_float);
     class_sethelpsymbol(binop1_min_class, binop1_sym);
 
-    binop1_log_class = class_new(gensym("log"),
-        (t_newmethod)binop1_log_new, 0,
+    binop1_log_class = class_new(gensym("log"), (t_newmethod) binop1_log_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop1_log_class, binop1_log_bang);
-    class_addfloat(binop1_log_class, (t_method)binop1_log_float);
+    class_addfloat(binop1_log_class, (t_method) binop1_log_float);
     class_sethelpsymbol(binop1_log_class, math_sym);
 
-        /* ------------------ binop2 ----------------------- */
+    /* ------------------ binop2 ----------------------- */
 
-    binop2_ee_class = class_new(gensym("=="), (t_newmethod)binop2_ee_new, 0,
+    binop2_ee_class = class_new(gensym("=="), (t_newmethod) binop2_ee_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_ee_class, binop2_ee_bang);
-    class_addfloat(binop2_ee_class, (t_method)binop2_ee_float);
+    class_addfloat(binop2_ee_class, (t_method) binop2_ee_float);
     class_sethelpsymbol(binop2_ee_class, binop23_sym);
 
-    binop2_ne_class = class_new(gensym("!="), (t_newmethod)binop2_ne_new, 0,
+    binop2_ne_class = class_new(gensym("!="), (t_newmethod) binop2_ne_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_ne_class, binop2_ne_bang);
-    class_addfloat(binop2_ne_class, (t_method)binop2_ne_float);
+    class_addfloat(binop2_ne_class, (t_method) binop2_ne_float);
     class_sethelpsymbol(binop2_ne_class, binop23_sym);
 
-    binop2_gt_class = class_new(gensym(">"), (t_newmethod)binop2_gt_new, 0,
+    binop2_gt_class = class_new(gensym(">"), (t_newmethod) binop2_gt_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_gt_class, binop2_gt_bang);
-    class_addfloat(binop2_gt_class, (t_method)binop2_gt_float);
+    class_addfloat(binop2_gt_class, (t_method) binop2_gt_float);
     class_sethelpsymbol(binop2_gt_class, binop23_sym);
 
-    binop2_lt_class = class_new(gensym("<"), (t_newmethod)binop2_lt_new, 0,
+    binop2_lt_class = class_new(gensym("<"), (t_newmethod) binop2_lt_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_lt_class, binop2_lt_bang);
-    class_addfloat(binop2_lt_class, (t_method)binop2_lt_float);
+    class_addfloat(binop2_lt_class, (t_method) binop2_lt_float);
     class_sethelpsymbol(binop2_lt_class, binop23_sym);
 
-    binop2_ge_class = class_new(gensym(">="), (t_newmethod)binop2_ge_new, 0,
+    binop2_ge_class = class_new(gensym(">="), (t_newmethod) binop2_ge_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_ge_class, binop2_ge_bang);
-    class_addfloat(binop2_ge_class, (t_method)binop2_ge_float);
+    class_addfloat(binop2_ge_class, (t_method) binop2_ge_float);
     class_sethelpsymbol(binop2_ge_class, binop23_sym);
 
-    binop2_le_class = class_new(gensym("<="), (t_newmethod)binop2_le_new, 0,
+    binop2_le_class = class_new(gensym("<="), (t_newmethod) binop2_le_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop2_le_class, binop2_le_bang);
-    class_addfloat(binop2_le_class, (t_method)binop2_le_float);
+    class_addfloat(binop2_le_class, (t_method) binop2_le_float);
     class_sethelpsymbol(binop2_le_class, binop23_sym);
 
-        /* ------------------ binop3 ----------------------- */
+    /* ------------------ binop3 ----------------------- */
 
-    binop3_ba_class = class_new(gensym("&"), (t_newmethod)binop3_ba_new, 0,
+    binop3_ba_class = class_new(gensym("&"), (t_newmethod) binop3_ba_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_ba_class, binop2_ba_bang);
-    class_addfloat(binop3_ba_class, (t_method)binop2_ba_float);
+    class_addfloat(binop3_ba_class, (t_method) binop2_ba_float);
     class_sethelpsymbol(binop3_ba_class, binop23_sym);
 
-    binop3_la_class = class_new(gensym("&&"), (t_newmethod)binop3_la_new, 0,
+    binop3_la_class = class_new(gensym("&&"), (t_newmethod) binop3_la_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_la_class, binop2_la_bang);
-    class_addfloat(binop3_la_class, (t_method)binop2_la_float);
+    class_addfloat(binop3_la_class, (t_method) binop2_la_float);
     class_sethelpsymbol(binop3_la_class, binop23_sym);
 
-    binop3_bo_class = class_new(gensym("|"), (t_newmethod)binop3_bo_new, 0,
+    binop3_bo_class = class_new(gensym("|"), (t_newmethod) binop3_bo_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_bo_class, binop2_bo_bang);
-    class_addfloat(binop3_bo_class, (t_method)binop2_bo_float);
+    class_addfloat(binop3_bo_class, (t_method) binop2_bo_float);
     class_sethelpsymbol(binop3_bo_class, binop23_sym);
 
-    binop3_lo_class = class_new(gensym("||"), (t_newmethod)binop3_lo_new, 0,
+    binop3_lo_class = class_new(gensym("||"), (t_newmethod) binop3_lo_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_lo_class, binop2_lo_bang);
-    class_addfloat(binop3_lo_class, (t_method)binop2_lo_float);
+    class_addfloat(binop3_lo_class, (t_method) binop2_lo_float);
     class_sethelpsymbol(binop3_lo_class, binop23_sym);
 
-    binop3_ls_class = class_new(gensym("<<"), (t_newmethod)binop3_ls_new, 0,
+    binop3_ls_class = class_new(gensym("<<"), (t_newmethod) binop3_ls_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_ls_class, binop2_ls_bang);
-    class_addfloat(binop3_ls_class, (t_method)binop2_ls_float);
+    class_addfloat(binop3_ls_class, (t_method) binop2_ls_float);
     class_sethelpsymbol(binop3_ls_class, binop23_sym);
 
-    binop3_rs_class = class_new(gensym(">>"), (t_newmethod)binop3_rs_new, 0,
+    binop3_rs_class = class_new(gensym(">>"), (t_newmethod) binop3_rs_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_rs_class, binop2_rs_bang);
-    class_addfloat(binop3_rs_class, (t_method)binop2_rs_float);
+    class_addfloat(binop3_rs_class, (t_method) binop2_rs_float);
     class_sethelpsymbol(binop3_rs_class, binop23_sym);
 
-    binop3_pc_class = class_new(gensym("%"), (t_newmethod)binop3_pc_new, 0,
+    binop3_pc_class = class_new(gensym("%"), (t_newmethod) binop3_pc_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_pc_class, binop2_pc_bang);
-    class_addfloat(binop3_pc_class, (t_method)binop2_pc_float);
+    class_addfloat(binop3_pc_class, (t_method) binop2_pc_float);
     class_sethelpsymbol(binop3_pc_class, binop23_sym);
 
-    binop3_mod_class = class_new(gensym("mod"), (t_newmethod)binop3_mod_new, 0,
+    binop3_mod_class = class_new(gensym("mod"), (t_newmethod) binop3_mod_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_mod_class, binop3_mod_bang);
-    class_addfloat(binop3_mod_class, (t_method)binop3_mod_float);
+    class_addfloat(binop3_mod_class, (t_method) binop3_mod_float);
     class_sethelpsymbol(binop3_mod_class, binop23_sym);
 
-    binop3_div_class = class_new(gensym("div"), (t_newmethod)binop3_div_new, 0,
+    binop3_div_class = class_new(gensym("div"), (t_newmethod) binop3_div_new, 0,
         sizeof(t_binop), 0, A_DEFFLOAT, 0);
     class_addbang(binop3_div_class, binop3_div_bang);
-    class_addfloat(binop3_div_class, (t_method)binop3_div_float);
+    class_addfloat(binop3_div_class, (t_method) binop3_div_float);
     class_sethelpsymbol(binop3_div_class, binop23_sym);
 
-        /* ------------------- math functions --------------- */
+    /* ------------------- math functions --------------- */
 
-    sin_class = class_new(gensym("sin"), sin_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(sin_class, (t_method)sin_float);
+    sin_class = class_new(gensym("sin"), sin_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(sin_class, (t_method) sin_float);
     class_sethelpsymbol(sin_class, math_sym);
 
-    cos_class = class_new(gensym("cos"), cos_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(cos_class, (t_method)cos_float);
+    cos_class = class_new(gensym("cos"), cos_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(cos_class, (t_method) cos_float);
     class_sethelpsymbol(cos_class, math_sym);
 
-    tan_class = class_new(gensym("tan"), tan_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(tan_class, (t_method)tan_float);
+    tan_class = class_new(gensym("tan"), tan_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(tan_class, (t_method) tan_float);
     class_sethelpsymbol(tan_class, math_sym);
 
-    atan_class = class_new(gensym("atan"), atan_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(atan_class, (t_method)atan_float);
+    atan_class = class_new(gensym("atan"), atan_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(atan_class, (t_method) atan_float);
     class_sethelpsymbol(atan_class, math_sym);
 
-    atan2_class = class_new(gensym("atan2"), atan2_new, 0,
-        sizeof(t_atan2), 0, 0);
-    class_addfloat(atan2_class, (t_method)atan2_float);
+    atan2_class =
+        class_new(gensym("atan2"), atan2_new, 0, sizeof(t_atan2), 0, 0);
+    class_addfloat(atan2_class, (t_method) atan2_float);
     class_addbang(atan2_class, atan2_bang);
     class_sethelpsymbol(atan2_class, math_sym);
 
-    sqrt_class = class_new(gensym("sqrt"), sqrt_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(sqrt_class, (t_method)sqrt_float);
+    sqrt_class = class_new(gensym("sqrt"), sqrt_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(sqrt_class, (t_method) sqrt_float);
     class_sethelpsymbol(sqrt_class, math_sym);
 
-    exp_class = class_new(gensym("exp"), exp_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(exp_class, (t_method)exp_float);
+    exp_class = class_new(gensym("exp"), exp_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(exp_class, (t_method) exp_float);
     class_sethelpsymbol(exp_class, math_sym);
 
-    abs_class = class_new(gensym("abs"), abs_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(abs_class, (t_method)abs_float);
+    abs_class = class_new(gensym("abs"), abs_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(abs_class, (t_method) abs_float);
     class_sethelpsymbol(abs_class, math_sym);
 
-    wrap_class = class_new(gensym("wrap"), wrap_new, 0,
-        sizeof(t_object), 0, 0);
-    class_addfloat(wrap_class, (t_method)wrap_float);
+    wrap_class = class_new(gensym("wrap"), wrap_new, 0, sizeof(t_object), 0, 0);
+    class_addfloat(wrap_class, (t_method) wrap_float);
     class_sethelpsymbol(wrap_class, math_sym);
 
-/* ------------------------  misc ------------------------ */
+    /* ------------------------  misc ------------------------ */
 
     clip_setup();
 }

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2013 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* The "array" object. */
 
@@ -16,24 +16,25 @@
 #endif
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+#ifndef HAVE_ALLOCA /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1
 #endif
 #define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
 #if HAVE_ALLOCA
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#define ATOMS_ALLOCA(x, n)                                                \
+    ((x) = (t_atom *) ((n) < TEXT_NGETBYTE ? alloca((n) * sizeof(t_atom)) \
+                                           : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) \
+    (((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 #else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *) getbytes((n) * sizeof(t_atom)))
 #define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
 #endif
 
@@ -41,39 +42,38 @@
 
 static int tabcount = 0;
 
-static void *table_donew(t_symbol *s, int size, int save, int savesize,
-    int xpix, int ypix)
+static void *table_donew(
+    t_symbol *s, int size, int save, int savesize, int xpix, int ypix)
 {
     t_atom a[9];
     t_glist *gl;
     t_canvas *x, *z = canvas_getcurrent();
-    if (s == &s_)
+    if(s == &s_)
     {
-         char  tabname[255];
-         t_symbol *t = gensym("table");
-         sprintf(tabname, "%s%d", t->s_name, tabcount++);
-         s = gensym(tabname);
+        char tabname[255];
+        t_symbol *t = gensym("table");
+        sprintf(tabname, "%s%d", t->s_name, tabcount++);
+        s = gensym(tabname);
     }
-    if (size < 1)
-        size = 100;
+    if(size < 1) size = 100;
     SETFLOAT(a, GLIST_DEFCANVASXLOC);
-    SETFLOAT(a+1, GLIST_DEFCANVASYLOC);
-    SETFLOAT(a+2, xpix + 100);
-    SETFLOAT(a+3, ypix + 100);
-    SETSYMBOL(a+4, s);
-    SETFLOAT(a+5, 0);
+    SETFLOAT(a + 1, GLIST_DEFCANVASYLOC);
+    SETFLOAT(a + 2, xpix + 100);
+    SETFLOAT(a + 3, ypix + 100);
+    SETSYMBOL(a + 4, s);
+    SETFLOAT(a + 5, 0);
     x = canvas_new(0, 0, 6, a);
 
     x->gl_owner = z;
 
-        /* create a graph for the table */
-    gl = glist_addglist((t_glist*)x, &s_, 0, -1, (size > 1 ? size-1 : 1), 1,
-        50, ypix+50, xpix+50, 50);
+    /* create a graph for the table */
+    gl = glist_addglist((t_glist *) x, &s_, 0, -1, (size > 1 ? size - 1 : 1), 1,
+        50, ypix + 50, xpix + 50, 50);
 
     graph_array(gl, s, &s_float, size,
-        save*GRAPH_ARRAY_SAVE + savesize*GRAPH_ARRAY_SAVESIZE);
+        save * GRAPH_ARRAY_SAVE + savesize * GRAPH_ARRAY_SAVESIZE);
 
-    pd_this->pd_newest = &x->gl_pd;     /* mimic action of canvas_pop() */
+    pd_this->pd_newest = &x->gl_pd; /* mimic action of canvas_pop() */
     pd_popsym(&x->gl_pd);
     x->gl_loading = 0;
 
@@ -85,13 +85,14 @@ static void *table_new(t_symbol *s, t_floatarg f)
     return (table_donew(s, f, 0, 0, 500, 300));
 }
 
-    /* return true if the "canvas" object is a "table". */
+/* return true if the "canvas" object is a "table". */
 int canvas_istable(const t_canvas *x)
 {
-    t_atom *argv = (x->gl_obj.te_binbuf? binbuf_getvec(x->gl_obj.te_binbuf):0);
-    int argc = (x->gl_obj.te_binbuf? binbuf_getnatom(x->gl_obj.te_binbuf) : 0);
+    t_atom *argv =
+        (x->gl_obj.te_binbuf ? binbuf_getvec(x->gl_obj.te_binbuf) : 0);
+    int argc = (x->gl_obj.te_binbuf ? binbuf_getnatom(x->gl_obj.te_binbuf) : 0);
     int istable = (argc && argv[0].a_type == A_SYMBOL &&
-        argv[0].a_w.w_symbol == gensym("table"));
+                   argv[0].a_w.w_symbol == gensym("table"));
     return (istable);
 }
 
@@ -100,18 +101,19 @@ t_class *array_define_class;
 static void array_define_yrange(t_glist *x, t_floatarg ylo, t_floatarg yhi)
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
-    if (gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
+    if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
     {
-        int n = garray_getarray((t_garray *)gl->gl_list)->a_n;
-        vmess(&x->gl_list->g_pd, gensym("bounds"),
-            "ffff", 0., yhi, (double)(n == 1 ? n : n-1), ylo);
-        vmess(&x->gl_list->g_pd, gensym("xlabel"),
-            "fff", ylo + glist_pixelstoy(gl, 2) - glist_pixelstoy(gl, 0),
-                0., (t_float)(n-1));
-        vmess(&x->gl_list->g_pd, gensym("ylabel"),
-            "fff", glist_pixelstox(gl, 0) - glist_pixelstox(gl, 5), ylo, yhi);
+        int n = garray_getarray((t_garray *) gl->gl_list)->a_n;
+        vmess(&x->gl_list->g_pd, gensym("bounds"), "ffff", 0., yhi,
+            (double) (n == 1 ? n : n - 1), ylo);
+        vmess(&x->gl_list->g_pd, gensym("xlabel"), "fff",
+            ylo + glist_pixelstoy(gl, 2) - glist_pixelstoy(gl, 0), 0.,
+            (t_float) (n - 1));
+        vmess(&x->gl_list->g_pd, gensym("ylabel"), "fff",
+            glist_pixelstox(gl, 0) - glist_pixelstox(gl, 5), ylo, yhi);
     }
-    else bug("array_define_yrange");
+    else
+        bug("array_define_yrange");
 }
 
 static void *array_define_new(t_symbol *s, int argc, t_atom *argv)
@@ -122,60 +124,62 @@ static void *array_define_new(t_symbol *s, int argc, t_atom *argv)
     int keep = 0, gavesize = 0;
     t_float ylo = -1, yhi = 1;
     t_float xpix = 500, ypix = 300;
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
             keep = 1;
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-yrange") &&
-            argc >= 3 && argv[1].a_type == A_FLOAT &&
-                argv[2].a_type == A_FLOAT)
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-yrange") && argc >= 3 &&
+                argv[1].a_type == A_FLOAT && argv[2].a_type == A_FLOAT)
         {
             ylo = atom_getfloatarg(1, argc, argv);
             yhi = atom_getfloatarg(2, argc, argv);
-            if (ylo == yhi)
-                ylo = -1, yhi = 1;
-            argc -= 2; argv += 2;
+            if(ylo == yhi) ylo = -1, yhi = 1;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-pix") &&
-            argc >= 3 && argv[1].a_type == A_FLOAT &&
-                argv[2].a_type == A_FLOAT)
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-pix") && argc >= 3 &&
+                argv[1].a_type == A_FLOAT && argv[2].a_type == A_FLOAT)
         {
-            if ((xpix = atom_getfloatarg(1, argc, argv)) < 10)
-                xpix = 10;
-            if ((ypix = atom_getfloatarg(2, argc, argv)) < 10)
-                ypix = 10;
-            argc -= 2; argv += 2;
+            if((xpix = atom_getfloatarg(1, argc, argv)) < 10) xpix = 10;
+            if((ypix = atom_getfloatarg(2, argc, argv)) < 10) ypix = 10;
+            argc -= 2;
+            argv += 2;
         }
         else
         {
             pd_error(0, "array define: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         arrayname = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
     {
         arraysize = argv->a_w.w_float;
         gavesize = 1;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: array define ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    x = (t_glist *)table_donew(arrayname, arraysize, keep, keep && !gavesize,
-        xpix, ypix);
+    x = (t_glist *) table_donew(
+        arrayname, arraysize, keep, keep && !gavesize, xpix, ypix);
 
-        /* bash the class to "array define".  We don't do this earlier in
-        part so that canvas_getcurrent() will work while the glist and
-        garray are being created.  There may be other, unknown side effects. */
+    /* bash the class to "array define".  We don't do this earlier in
+    part so that canvas_getcurrent() will work while the glist and
+    garray are being created.  There may be other, unknown side effects. */
     x->gl_obj.ob_pd = array_define_class;
     array_define_yrange(x, ylo, yhi);
     outlet_new(&x->gl_obj, &s_pointer);
@@ -186,16 +190,16 @@ void garray_savecontentsto(t_garray *x, t_binbuf *b);
 
 void array_define_save(t_gobj *z, t_binbuf *bb)
 {
-    t_glist *x = (t_glist *)z;
+    t_glist *x = (t_glist *) z;
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
-    binbuf_addv(bb, "ssff", &s__X, gensym("obj"),
-        (t_float)x->gl_obj.te_xpix, (t_float)x->gl_obj.te_ypix);
+    binbuf_addv(bb, "ssff", &s__X, gensym("obj"), (t_float) x->gl_obj.te_xpix,
+        (t_float) x->gl_obj.te_ypix);
     binbuf_addbinbuf(bb, x->gl_obj.ob_binbuf);
     binbuf_addsemi(bb);
 
-    if (gl)
+    if(gl)
     {
-        garray_savecontentsto((t_garray *)gl->gl_list, bb);
+        garray_savecontentsto((t_garray *) gl->gl_list, bb);
         obj_saveformat(&x->gl_obj, bb);
     }
     else
@@ -204,53 +208,53 @@ void array_define_save(t_gobj *z, t_binbuf *bb)
 
 t_scalar *garray_getscalar(t_garray *x);
 
-    /* send a pointer to the scalar that owns this array to
-    whomever is bound to the given symbol */
+/* send a pointer to the scalar that owns this array to
+whomever is bound to the given symbol */
 static void array_define_send(t_glist *x, t_symbol *s)
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
-    if (!s->s_thing)
+    if(!s->s_thing)
         pd_error(x, "array_define_send: %s: no such object", s->s_name);
-    else if (gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
+    else if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
     {
         t_gpointer gp;
         gpointer_init(&gp);
-        gpointer_setglist(&gp, gl,
-            garray_getscalar((t_garray *)gl->gl_list));
+        gpointer_setglist(&gp, gl, garray_getscalar((t_garray *) gl->gl_list));
         pd_pointer(s->s_thing, &gp);
         gpointer_unset(&gp);
     }
-    else bug("array_define_send");
+    else
+        bug("array_define_send");
 }
 
 static void array_define_bang(t_glist *x)
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
-    if (gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
+    if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
     {
         t_gpointer gp;
         gpointer_init(&gp);
-        gpointer_setglist(&gp, gl,
-            garray_getscalar((t_garray *)gl->gl_list));
+        gpointer_setglist(&gp, gl, garray_getscalar((t_garray *) gl->gl_list));
         outlet_pointer(x->gl_obj.ob_outlet, &gp);
         gpointer_unset(&gp);
     }
-    else bug("array_define_bang");
+    else
+        bug("array_define_bang");
 }
 
-    /* just forward any messages to the garray */
-static void array_define_anything(t_glist *x,
-    t_symbol *s, int argc, t_atom *argv)
+/* just forward any messages to the garray */
+static void array_define_anything(
+    t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
-    if (gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
+    if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
         typedmess(&gl->gl_list->g_pd, s, argc, argv);
-    else bug("array_define_anything");
+    else
+        bug("array_define_anything");
 }
 
-    /* ignore messages like "editmode" */
-static void array_define_ignore(t_glist *x,
-    t_symbol *s, int argc, t_atom *argv)
+/* ignore messages like "editmode" */
+static void array_define_ignore(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
 }
 
@@ -271,85 +275,83 @@ typedef struct _array_client
 #define x_field x_tc.tc_field
 #define x_gp x_tc.tc_gp
 
-    /* find the array for this object.  Prints an error  message and returns
-        0 on failure. */
+/* find the array for this object.  Prints an error  message and returns
+    0 on failure. */
 static t_array *array_client_getbuf(t_array_client *x, t_glist **glist)
 {
-    if (x->tc_sym)       /* named array object */
+    if(x->tc_sym) /* named array object */
     {
-        t_garray *y = (t_garray *)pd_findbyclass(x->tc_sym, garray_class);
-        if (y)
+        t_garray *y = (t_garray *) pd_findbyclass(x->tc_sym, garray_class);
+        if(y)
         {
             *glist = garray_getglist(y);
             return (garray_getarray(y));
         }
         else
         {
-            pd_error(x, "array: couldn't find named array '%s'",
-                x->tc_sym->s_name);
+            pd_error(
+                x, "array: couldn't find named array '%s'", x->tc_sym->s_name);
             *glist = 0;
             return (0);
         }
     }
-    else if (x->tc_struct)   /* by pointer */
+    else if(x->tc_struct) /* by pointer */
     {
         t_template *template = template_findbyname(x->tc_struct);
         t_gstub *gs = x->tc_gp.gp_stub;
         t_word *vec;
         int onset, type;
         t_symbol *arraytype;
-        if (!template)
+        if(!template)
         {
             pd_error(x, "array: couldn't find struct %s", x->tc_struct->s_name);
             return (0);
         }
-        if (!gpointer_check(&x->tc_gp, 0))
+        if(!gpointer_check(&x->tc_gp, 0))
         {
             pd_error(x, "array: stale or empty pointer");
             return (0);
         }
-        if (gs->gs_which == GP_ARRAY)
+        if(gs->gs_which == GP_ARRAY)
             vec = x->tc_gp.gp_un.gp_w;
-        else vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
+        else
+            vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
 
-        if (!template_find_field(template,
-            x->tc_field, &onset, &type, &arraytype))
+        if(!template_find_field(
+               template, x->tc_field, &onset, &type, &arraytype))
         {
             pd_error(x, "array: no field named %s", x->tc_field->s_name);
             return (0);
         }
-        if (type != DT_ARRAY)
+        if(type != DT_ARRAY)
         {
-            pd_error(x, "array: field %s not of type array",
-                x->tc_field->s_name);
+            pd_error(
+                x, "array: field %s not of type array", x->tc_field->s_name);
             return (0);
         }
-        if (gs->gs_which == GP_GLIST)
+        if(gs->gs_which == GP_GLIST)
             *glist = gs->gs_un.gs_glist;
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
-            while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+            while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
                 owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
             *glist = owner_array->a_gp.gp_stub->gs_un.gs_glist;
         }
-        return (*(t_array **)(((char *)vec) + onset));
+        return (*(t_array **) (((char *) vec) + onset));
     }
-    else return (0);    /* shouldn't happen */
+    else
+        return (0); /* shouldn't happen */
 }
 
 static void array_client_senditup(t_array_client *x)
 {
     t_glist *glist = 0;
     t_array *a = array_client_getbuf(x, &glist);
-    if (glist)
-       array_redraw(a, glist);
+    if(glist) array_redraw(a, glist);
 }
 
-static void array_client_free(t_array_client *x)
-{
-    gpointer_unset(&x->tc_gp);
-}
+static void array_client_free(t_array_client *x) { gpointer_unset(&x->tc_gp); }
 
 /* ----------  array size : get or set size of an array ---------------- */
 static t_class *array_size_class;
@@ -358,49 +360,57 @@ typedef struct _array_size
 {
     t_array_client x_tc;
 } t_array_size;
+
 #define x_outlet x_tc.tc_obj.ob_outlet
 
 static void *array_size_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_size *x = (t_array_size *)pd_new(array_size_class);
+    t_array_size *x = (t_array_size *) pd_new(array_size_class);
     x->x_sym = x->x_struct = x->x_field = 0;
     gpointer_init(&x->x_gp);
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-s") &&
-            argc >= 3 && argv[1].a_type == A_SYMBOL &&
-                argv[2].a_type == A_SYMBOL)
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-s") && argc >= 3 &&
+            argv[1].a_type == A_SYMBOL && argv[2].a_type == A_SYMBOL)
         {
             x->x_struct = canvas_makebindsym(argv[1].a_w.w_symbol);
             x->x_field = argv[2].a_w.w_symbol;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
         else
         {
             pd_error(x, "array setline: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
-        if (x->x_struct)
+        if(x->x_struct)
         {
             pd_error(x, "array setline: extra names after -s..");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        else x->x_sym = argv->a_w.w_symbol;
-        argc--; argv++;
+        else
+            x->x_sym = argv->a_w.w_symbol;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: array setline ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
     outlet_new(&x->x_tc.tc_obj, &s_float);
     return (x);
 }
@@ -409,25 +419,24 @@ static void array_size_bang(t_array_size *x)
 {
     t_glist *glist;
     t_array *a = array_client_getbuf(&x->x_tc, &glist);
-    if (a)
-        outlet_float(x->x_outlet, a->a_n);
+    if(a) outlet_float(x->x_outlet, a->a_n);
 }
 
 static void array_size_float(t_array_size *x, t_floatarg f)
 {
     t_glist *glist;
     t_array *a = array_client_getbuf(&x->x_tc, &glist);
-    if (a)
+    if(a)
     {
-              /* if it's a named array object we have to go back and find the
-              garray (repeating work done in array_client_getbuf()) because
-              the garray might want to adjust.  Maybe array_client_getbuf
-              should have a return slot for the garray if any?  */
-        if (x->x_tc.tc_sym)
+        /* if it's a named array object we have to go back and find the
+        garray (repeating work done in array_client_getbuf()) because
+        the garray might want to adjust.  Maybe array_client_getbuf
+        should have a return slot for the garray if any?  */
+        if(x->x_tc.tc_sym)
         {
-            t_garray *y = (t_garray *)pd_findbyclass(x->x_tc.tc_sym,
-                garray_class);
-            if (!y)
+            t_garray *y =
+                (t_garray *) pd_findbyclass(x->x_tc.tc_sym, garray_class);
+            if(!y)
             {
                 pd_error(x, "no such array '%s'", x->x_tc.tc_sym->s_name);
                 return;
@@ -437,9 +446,8 @@ static void array_size_float(t_array_size *x, t_floatarg f)
         else
         {
             int n = f;
-            if (n < 1)
-                n = 1;
-             array_resize_and_redraw(a, glist, n);
+            if(n < 1) n = 1;
+            array_resize_and_redraw(a, glist, n);
         }
     }
 }
@@ -447,133 +455,138 @@ static void array_size_float(t_array_size *x, t_floatarg f)
 /* ------  range operations - act on a specifiable range in an array ----- */
 static t_class *array_sum_class;
 
-typedef struct _array_rangeop   /* any operation meaningful on a subrange */
+typedef struct _array_rangeop /* any operation meaningful on a subrange */
 {
     t_array_client x_tc;
     t_float x_onset;
     t_float x_n;
     t_symbol *x_elemfield;
-    t_symbol *x_elemtemplate;   /* unused - perhaps should at least check it */
+    t_symbol *x_elemtemplate; /* unused - perhaps should at least check it */
 } t_array_rangeop;
 
-    /* generic creator for operations on ranges (array {get,set,sum,random,
-        quantile,search,...}  "onsetin" and "nin" are true if we should make
-        inlets for onset and n - if no inlet for 'n' we also won't allow
-        it to be specified as an argument.  Everything can take an onset but
-        sometimes we don't need an inlet because it's the inlet itself.  In
-        any case we allow onset to be specified as an argument (even if it's
-        the 'hot inlet') -- for the same reason as in the 'delay' object.
-        Finally we can optionally warn if there are extra arguments; some
-        specific arguments (e.g., search) allow them but most don't. */
-static void *array_rangeop_new(t_class *class,
-    t_symbol *s, int *argcp, t_atom **argvp,
-    int onsetin, int nin, int warnextra)
+/* generic creator for operations on ranges (array {get,set,sum,random,
+    quantile,search,...}  "onsetin" and "nin" are true if we should make
+    inlets for onset and n - if no inlet for 'n' we also won't allow
+    it to be specified as an argument.  Everything can take an onset but
+    sometimes we don't need an inlet because it's the inlet itself.  In
+    any case we allow onset to be specified as an argument (even if it's
+    the 'hot inlet') -- for the same reason as in the 'delay' object.
+    Finally we can optionally warn if there are extra arguments; some
+    specific arguments (e.g., search) allow them but most don't. */
+static void *array_rangeop_new(t_class *class, t_symbol *s, int *argcp,
+    t_atom **argvp, int onsetin, int nin, int warnextra)
 {
     int argc = *argcp;
     t_atom *argv = *argvp;
-    t_array_rangeop *x = (t_array_rangeop *)pd_new(class);
+    t_array_rangeop *x = (t_array_rangeop *) pd_new(class);
     x->x_sym = x->x_struct = x->x_field = 0;
     gpointer_init(&x->x_gp);
     x->x_elemtemplate = &s_;
     x->x_elemfield = gensym("y");
     x->x_onset = 0;
     x->x_n = -1;
-    if (onsetin)
-        floatinlet_new(&x->x_tc.tc_obj, &x->x_onset);
-    if (nin)
-        floatinlet_new(&x->x_tc.tc_obj, &x->x_n);
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    if(onsetin) floatinlet_new(&x->x_tc.tc_obj, &x->x_onset);
+    if(nin) floatinlet_new(&x->x_tc.tc_obj, &x->x_n);
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-s") &&
-            argc >= 3 && argv[1].a_type == A_SYMBOL &&
-                argv[2].a_type == A_SYMBOL)
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-s") && argc >= 3 &&
+            argv[1].a_type == A_SYMBOL && argv[2].a_type == A_SYMBOL)
         {
             x->x_struct = canvas_makebindsym(argv[1].a_w.w_symbol);
             x->x_field = argv[2].a_w.w_symbol;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-f") &&
-            argc >= 3 && argv[1].a_type == A_SYMBOL &&
-                argv[2].a_type == A_SYMBOL)
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-f") && argc >= 3 &&
+                argv[1].a_type == A_SYMBOL && argv[2].a_type == A_SYMBOL)
         {
             x->x_elemtemplate = argv[1].a_w.w_symbol;
             x->x_elemfield = argv[2].a_w.w_symbol;
-            argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
         else
         {
             pd_error(x, "%s: unknown flag ...", class_getname(class));
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
-        if (x->x_struct)
+        if(x->x_struct)
         {
             pd_error(x, "%s: extra names after -s..", class_getname(class));
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        else x->x_sym = argv->a_w.w_symbol;
-        argc--; argv++;
+        else
+            x->x_sym = argv->a_w.w_symbol;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
     {
         x->x_onset = argv->a_w.w_float;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
     {
         x->x_n = argv->a_w.w_float;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && warnextra)
+    if(argc && warnextra)
     {
         post("warning: %s ignoring extra argument: ", class_getname(class));
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
     *argcp = argc;
     *argvp = argv;
     return (x);
 }
 
-static int array_rangeop_getrange(t_array_rangeop *x,
-    char **firstitemp, int *nitemp, int *stridep, int *arrayonsetp)
+static int array_rangeop_getrange(t_array_rangeop *x, char **firstitemp,
+    int *nitemp, int *stridep, int *arrayonsetp)
 {
     t_glist *glist;
     t_array *a = array_client_getbuf(&x->x_tc, &glist);
     int stride, fieldonset, arrayonset, nitem, type;
     t_symbol *arraytype;
     t_template *template;
-    if (!a)
-        return (0);
+    if(!a) return (0);
     template = template_findbyname(a->a_templatesym);
-    if (!template_find_field(template, x->x_elemfield, &fieldonset,
-        &type, &arraytype) || type != DT_FLOAT)
+    if(!template_find_field(
+           template, x->x_elemfield, &fieldonset, &type, &arraytype) ||
+        type != DT_FLOAT)
     {
-        pd_error(x, "can't find field %s in struct %s",
-            x->x_elemfield->s_name, a->a_templatesym->s_name);
+        pd_error(x, "can't find field %s in struct %s", x->x_elemfield->s_name,
+            a->a_templatesym->s_name);
         return (0);
     }
     stride = a->a_elemsize;
     arrayonset = x->x_onset;
-    if (arrayonset < 0)
+    if(arrayonset < 0)
         arrayonset = 0;
-    else if (arrayonset > a->a_n)
+    else if(arrayonset > a->a_n)
         arrayonset = a->a_n;
-    if (x->x_n < 0)
+    if(x->x_n < 0)
         nitem = a->a_n - arrayonset;
     else
     {
         nitem = x->x_n;
-        if (nitem + arrayonset > a->a_n)
-            nitem = a->a_n - arrayonset;
+        if(nitem + arrayonset > a->a_n) nitem = a->a_n - arrayonset;
     }
-    *firstitemp = a->a_vec+(fieldonset+arrayonset*stride);
+    *firstitemp = a->a_vec + (fieldonset + arrayonset * stride);
     *nitemp = nitem;
     *stridep = stride;
     *arrayonsetp = arrayonset;
@@ -589,8 +602,8 @@ static t_class *array_sum_class;
 
 static void *array_sum_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_sum *x = array_rangeop_new(array_sum_class, s, &argc, &argv,
-        0, 1, 1);
+    t_array_sum *x =
+        array_rangeop_new(array_sum_class, s, &argc, &argv, 0, 1, 1);
     outlet_new(&x->x_tc.tc_obj, &s_float);
     return (x);
 }
@@ -600,10 +613,10 @@ static void array_sum_bang(t_array_rangeop *x)
     char *itemp, *firstitem;
     int stride, nitem, arrayonset, i;
     double sum;
-    if (!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
+    if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
-    for (i = 0, sum = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
-        sum += *(t_float *)itemp;
+    for(i = 0, sum = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
+        sum += *(t_float *) itemp;
     outlet_float(x->x_outlet, sum);
 }
 
@@ -620,8 +633,8 @@ static t_class *array_get_class;
 
 static void *array_get_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_get *x = array_rangeop_new(array_get_class, s, &argc, &argv,
-        0, 1, 1);
+    t_array_get *x =
+        array_rangeop_new(array_get_class, s, &argc, &argv, 0, 1, 1);
     outlet_new(&x->x_tc.tc_obj, &s_float);
     return (x);
 }
@@ -631,11 +644,11 @@ static void array_get_bang(t_array_rangeop *x)
     char *itemp, *firstitem;
     int stride, nitem, arrayonset, i;
     t_atom *outv;
-    if (!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
+    if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
     ATOMS_ALLOCA(outv, nitem);
-    for (i = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
-        SETFLOAT(&outv[i],  *(t_float *)itemp);
+    for(i = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
+        SETFLOAT(&outv[i], *(t_float *) itemp);
     outlet_list(x->x_outlet, 0, nitem, outv);
     ATOMS_FREEA(outv, nitem);
 }
@@ -653,22 +666,21 @@ static t_class *array_set_class;
 
 static void *array_set_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_set *x = array_rangeop_new(array_set_class, s, &argc, &argv,
-        1, 0, 1);
+    t_array_set *x =
+        array_rangeop_new(array_set_class, s, &argc, &argv, 1, 0, 1);
     return (x);
 }
 
-static void array_set_list(t_array_rangeop *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void array_set_list(
+    t_array_rangeop *x, t_symbol *s, int argc, t_atom *argv)
 {
     char *itemp, *firstitem;
     int stride, nitem, arrayonset, i;
-    if (!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
+    if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
-    if (nitem > argc)
-        nitem = argc;
-    for (i = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
-        *(t_float *)itemp = atom_getfloatarg(i, argc, argv);
+    if(nitem > argc) nitem = argc;
+    for(i = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
+        *(t_float *) itemp = atom_getfloatarg(i, argc, argv);
     array_client_senditup(&x->x_tc);
 }
 
@@ -679,8 +691,8 @@ static t_class *array_quantile_class;
 
 static void *array_quantile_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_quantile *x = array_rangeop_new(array_quantile_class, s,
-        &argc, &argv, 1, 1, 1);
+    t_array_quantile *x =
+        array_rangeop_new(array_quantile_class, s, &argc, &argv, 1, 1, 1);
     outlet_new(&x->x_tc.tc_obj, &s_float);
     return (x);
 }
@@ -690,16 +702,15 @@ static void array_quantile_float(t_array_rangeop *x, t_floatarg f)
     char *itemp, *firstitem;
     int stride, nitem, arrayonset, i;
     double sum;
-    if (!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
+    if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
-    for (i = 0, sum = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
-        sum += (*(t_float *)itemp > 0? *(t_float *)itemp : 0);
+    for(i = 0, sum = 0, itemp = firstitem; i < nitem; i++, itemp += stride)
+        sum += (*(t_float *) itemp > 0 ? *(t_float *) itemp : 0);
     sum *= f;
-    for (i = 0, itemp = firstitem; i < (nitem-1); i++, itemp += stride)
+    for(i = 0, itemp = firstitem; i < (nitem - 1); i++, itemp += stride)
     {
-        sum -= (*(t_float *)itemp > 0? *(t_float *)itemp : 0);
-        if (sum < 0)
-            break;
+        sum -= (*(t_float *) itemp > 0 ? *(t_float *) itemp : 0);
+        if(sum < 0) break;
     }
     outlet_float(x->x_outlet, i);
 }
@@ -707,7 +718,7 @@ static void array_quantile_float(t_array_rangeop *x, t_floatarg f)
 /* ----  array random -- output random value with array as distribution ---- */
 static t_class *array_random_class;
 
-typedef struct _array_random   /* any operation meaningful on a subrange */
+typedef struct _array_random /* any operation meaningful on a subrange */
 {
     t_array_rangeop x_r;
     unsigned int x_state;
@@ -715,8 +726,8 @@ typedef struct _array_random   /* any operation meaningful on a subrange */
 
 static void *array_random_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_random *x = array_rangeop_new(array_random_class, s,
-        &argc, &argv, 0, 1, 1);
+    t_array_random *x =
+        array_rangeop_new(array_random_class, s, &argc, &argv, 0, 1, 1);
     static unsigned int random_nextseed = 584926371;
     random_nextseed = random_nextseed * 435898247 + 938284287;
     x->x_state = random_nextseed;
@@ -734,11 +745,11 @@ static void array_random_bang(t_array_random *x)
     char *firstitem;
     int stride, nitem, arrayonset;
 
-    if (!array_rangeop_getrange(&x->x_r, &firstitem, &nitem, &stride,
-        &arrayonset))
-            return;
+    if(!array_rangeop_getrange(
+           &x->x_r, &firstitem, &nitem, &stride, &arrayonset))
+        return;
     x->x_state = x->x_state * 472940017 + 832416023;
-    array_quantile_float(&x->x_r, (1./4294967296.0) * (double)(x->x_state));
+    array_quantile_float(&x->x_r, (1. / 4294967296.0) * (double) (x->x_state));
 }
 
 static void array_random_float(t_array_random *x, t_floatarg f)
@@ -753,14 +764,14 @@ static t_class *array_max_class;
 typedef struct _array_max
 {
     t_array_rangeop x_rangeop;
-    t_outlet *x_out1;       /* value */
-    t_outlet *x_out2;       /* index */
+    t_outlet *x_out1; /* value */
+    t_outlet *x_out2; /* index */
 } t_array_max;
 
 static void *array_max_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_max *x = array_rangeop_new(array_max_class, s, &argc, &argv,
-        0, 1, 1);
+    t_array_max *x =
+        array_rangeop_new(array_max_class, s, &argc, &argv, 0, 1, 1);
     x->x_out1 = outlet_new(&x->x_rangeop.x_tc.tc_obj, &s_float);
     x->x_out2 = outlet_new(&x->x_rangeop.x_tc.tc_obj, &s_float);
     return (x);
@@ -771,13 +782,13 @@ static void array_max_bang(t_array_max *x)
     char *itemp, *firstitem;
     int stride, nitem, arrayonset, i, besti;
     t_float bestf;
-    if (!array_rangeop_getrange(&x->x_rangeop, &firstitem, &nitem, &stride,
-        &arrayonset))
-            return;
-    for (i = 0, besti = -1, bestf= -1e30, itemp = firstitem;
-        i < nitem; i++, itemp += stride)
-            if (*(t_float *)itemp > bestf)
-                bestf = *(t_float *)itemp, besti = i+arrayonset;
+    if(!array_rangeop_getrange(
+           &x->x_rangeop, &firstitem, &nitem, &stride, &arrayonset))
+        return;
+    for(i = 0, besti = -1, bestf = -1e30, itemp = firstitem; i < nitem;
+        i++, itemp += stride)
+        if(*(t_float *) itemp > bestf)
+            bestf = *(t_float *) itemp, besti = i + arrayonset;
     outlet_float(x->x_out2, besti);
     outlet_float(x->x_out1, bestf);
 }
@@ -794,14 +805,14 @@ static t_class *array_min_class;
 typedef struct _array_min
 {
     t_array_rangeop x_rangeop;
-    t_outlet *x_out1;       /* value */
-    t_outlet *x_out2;       /* index */
+    t_outlet *x_out1; /* value */
+    t_outlet *x_out2; /* index */
 } t_array_min;
 
 static void *array_min_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_array_min *x = array_rangeop_new(array_min_class, s, &argc, &argv,
-        0, 1, 1);
+    t_array_min *x =
+        array_rangeop_new(array_min_class, s, &argc, &argv, 0, 1, 1);
     x->x_out1 = outlet_new(&x->x_rangeop.x_tc.tc_obj, &s_float);
     x->x_out2 = outlet_new(&x->x_rangeop.x_tc.tc_obj, &s_float);
     return (x);
@@ -812,13 +823,13 @@ static void array_min_bang(t_array_min *x)
     char *itemp, *firstitem;
     int stride, nitem, i, arrayonset, besti;
     t_float bestf;
-    if (!array_rangeop_getrange(&x->x_rangeop, &firstitem, &nitem, &stride,
-        &arrayonset))
-            return;
-    for (i = 0, besti = -1, bestf= 1e30, itemp = firstitem;
-        i < nitem; i++, itemp += stride)
-            if (*(t_float *)itemp < bestf)
-                bestf = *(t_float *)itemp, besti = i+arrayonset;
+    if(!array_rangeop_getrange(
+           &x->x_rangeop, &firstitem, &nitem, &stride, &arrayonset))
+        return;
+    for(i = 0, besti = -1, bestf = 1e30, itemp = firstitem; i < nitem;
+        i++, itemp += stride)
+        if(*(t_float *) itemp < bestf)
+            bestf = *(t_float *) itemp, besti = i + arrayonset;
     outlet_float(x->x_out2, besti);
     outlet_float(x->x_out1, bestf);
 }
@@ -832,29 +843,29 @@ static void array_min_float(t_array_min *x, t_floatarg f)
 /* overall creator for "array" objects - dispatch to "array define" etc */
 static void *arrayobj_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (!argc || argv[0].a_type != A_SYMBOL)
+    if(!argc || argv[0].a_type != A_SYMBOL)
         pd_this->pd_newest = array_define_new(s, argc, argv);
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
-        if (!strcmp(str, "d") || !strcmp(str, "define"))
-            pd_this->pd_newest = array_define_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "size"))
-            pd_this->pd_newest = array_size_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "sum"))
-            pd_this->pd_newest = array_sum_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "get"))
-            pd_this->pd_newest = array_get_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "set"))
-            pd_this->pd_newest = array_set_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "quantile"))
-            pd_this->pd_newest = array_quantile_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "random"))
-            pd_this->pd_newest = array_random_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "max"))
-            pd_this->pd_newest = array_max_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "min"))
-            pd_this->pd_newest = array_min_new(s, argc-1, argv+1);
+        if(!strcmp(str, "d") || !strcmp(str, "define"))
+            pd_this->pd_newest = array_define_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "size"))
+            pd_this->pd_newest = array_size_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "sum"))
+            pd_this->pd_newest = array_sum_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "get"))
+            pd_this->pd_newest = array_get_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "set"))
+            pd_this->pd_newest = array_set_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "quantile"))
+            pd_this->pd_newest = array_quantile_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "random"))
+            pd_this->pd_newest = array_random_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "max"))
+            pd_this->pd_newest = array_max_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "min"))
+            pd_this->pd_newest = array_min_new(s, argc - 1, argv + 1);
         else
         {
             pd_error(0, "array %s: unknown function", str);
@@ -871,75 +882,75 @@ void canvas_add_for_class(t_class *c);
 void x_array_setup(void)
 {
     array_define_class = class_new(gensym("array define"), 0,
-        (t_method)canvas_free, sizeof(t_canvas), 0, 0);
+        (t_method) canvas_free, sizeof(t_canvas), 0, 0);
     canvas_add_for_class(array_define_class);
-    class_addmethod(array_define_class, (t_method)array_define_send,
+    class_addmethod(array_define_class, (t_method) array_define_send,
         gensym("send"), A_SYMBOL, 0);
     class_addbang(array_define_class, array_define_bang);
     class_addanything(array_define_class, array_define_anything);
     class_sethelpsymbol(array_define_class, gensym("array-object"));
     class_setsavefn(array_define_class, array_define_save);
 
-    class_addmethod(array_define_class, (t_method)array_define_ignore,
+    class_addmethod(array_define_class, (t_method) array_define_ignore,
         gensym("editmode"), A_GIMME, 0);
 
-    class_addcreator((t_newmethod)arrayobj_new, gensym("array"), A_GIMME, 0);
+    class_addcreator((t_newmethod) arrayobj_new, gensym("array"), A_GIMME, 0);
 
-    class_addcreator((t_newmethod)table_new, gensym("table"),
-        A_DEFSYM, A_DEFFLOAT, 0);
+    class_addcreator(
+        (t_newmethod) table_new, gensym("table"), A_DEFSYM, A_DEFFLOAT, 0);
 
-    array_size_class = class_new(gensym("array size"),
-        (t_newmethod)array_size_new, (t_method)array_client_free,
-            sizeof(t_array_size), 0, A_GIMME, 0);
+    array_size_class =
+        class_new(gensym("array size"), (t_newmethod) array_size_new,
+            (t_method) array_client_free, sizeof(t_array_size), 0, A_GIMME, 0);
     class_addbang(array_size_class, array_size_bang);
     class_addfloat(array_size_class, array_size_float);
     class_sethelpsymbol(array_size_class, gensym("array-object"));
 
-    array_sum_class = class_new(gensym("array sum"),
-        (t_newmethod)array_sum_new, (t_method)array_client_free,
-            sizeof(t_array_sum), 0, A_GIMME, 0);
+    array_sum_class =
+        class_new(gensym("array sum"), (t_newmethod) array_sum_new,
+            (t_method) array_client_free, sizeof(t_array_sum), 0, A_GIMME, 0);
     class_addbang(array_sum_class, array_sum_bang);
     class_addfloat(array_sum_class, array_sum_float);
     class_sethelpsymbol(array_sum_class, gensym("array-object"));
 
-    array_get_class = class_new(gensym("array get"),
-        (t_newmethod)array_get_new, (t_method)array_client_free,
-            sizeof(t_array_get), 0, A_GIMME, 0);
+    array_get_class =
+        class_new(gensym("array get"), (t_newmethod) array_get_new,
+            (t_method) array_client_free, sizeof(t_array_get), 0, A_GIMME, 0);
     class_addbang(array_get_class, array_get_bang);
     class_addfloat(array_get_class, array_get_float);
     class_sethelpsymbol(array_get_class, gensym("array-object"));
 
-    array_set_class = class_new(gensym("array set"),
-        (t_newmethod)array_set_new, (t_method)array_client_free,
-            sizeof(t_array_set), 0, A_GIMME, 0);
+    array_set_class =
+        class_new(gensym("array set"), (t_newmethod) array_set_new,
+            (t_method) array_client_free, sizeof(t_array_set), 0, A_GIMME, 0);
     class_addlist(array_set_class, array_set_list);
     class_sethelpsymbol(array_set_class, gensym("array-object"));
 
     array_quantile_class = class_new(gensym("array quantile"),
-        (t_newmethod)array_quantile_new, (t_method)array_client_free,
-            sizeof(t_array_quantile), 0, A_GIMME, 0);
+        (t_newmethod) array_quantile_new, (t_method) array_client_free,
+        sizeof(t_array_quantile), 0, A_GIMME, 0);
     class_addfloat(array_quantile_class, array_quantile_float);
     class_sethelpsymbol(array_quantile_class, gensym("array-object"));
 
     array_random_class = class_new(gensym("array random"),
-        (t_newmethod)array_random_new, (t_method)array_client_free,
-            sizeof(t_array_random), 0, A_GIMME, 0);
-    class_addmethod(array_random_class, (t_method)array_random_seed,
+        (t_newmethod) array_random_new, (t_method) array_client_free,
+        sizeof(t_array_random), 0, A_GIMME, 0);
+    class_addmethod(array_random_class, (t_method) array_random_seed,
         gensym("seed"), A_FLOAT, 0);
     class_addfloat(array_random_class, array_random_float);
     class_addbang(array_random_class, array_random_bang);
     class_sethelpsymbol(array_random_class, gensym("array-object"));
 
-    array_max_class = class_new(gensym("array max"),
-        (t_newmethod)array_max_new, (t_method)array_client_free,
-            sizeof(t_array_max), 0, A_GIMME, 0);
+    array_max_class =
+        class_new(gensym("array max"), (t_newmethod) array_max_new,
+            (t_method) array_client_free, sizeof(t_array_max), 0, A_GIMME, 0);
     class_addfloat(array_max_class, array_max_float);
     class_addbang(array_max_class, array_max_bang);
     class_sethelpsymbol(array_max_class, gensym("array-object"));
 
-    array_min_class = class_new(gensym("array min"),
-        (t_newmethod)array_min_new, (t_method)array_client_free,
-            sizeof(t_array_min), 0, A_GIMME, 0);
+    array_min_class =
+        class_new(gensym("array min"), (t_newmethod) array_min_new,
+            (t_method) array_client_free, sizeof(t_array_min), 0, A_GIMME, 0);
     class_addfloat(array_min_class, array_min_float);
     class_addbang(array_min_class, array_min_bang);
     class_sethelpsymbol(array_min_class, gensym("array-object"));

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -290,13 +290,10 @@ static t_array *array_client_getbuf(t_array_client *x, t_glist **glist)
             *glist = garray_getglist(y);
             return (garray_getarray(y));
         }
-        else
-        {
-            pd_error(
-                x, "array: couldn't find named array '%s'", x->tc_sym->s_name);
-            *glist = 0;
-            return (0);
-        }
+
+        pd_error(x, "array: couldn't find named array '%s'", x->tc_sym->s_name);
+        *glist = 0;
+        return (0);
     }
     else if(x->tc_struct) /* by pointer */
     {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -121,9 +121,12 @@ static void *array_define_new(t_symbol *s, int argc, t_atom *argv)
     t_symbol *arrayname = &s_;
     t_float arraysize = 100;
     t_glist *x;
-    int keep = 0, gavesize = 0;
-    t_float ylo = -1, yhi = 1;
-    t_float xpix = 500, ypix = 300;
+    int keep = 0;
+    int gavesize = 0;
+    t_float ylo = -1;
+    t_float yhi = 1;
+    t_float xpix = 500;
+    t_float ypix = 300;
     while(
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
@@ -300,7 +303,8 @@ static t_array *array_client_getbuf(t_array_client *x, t_glist **glist)
         t_template *template = template_findbyname(x->tc_struct);
         t_gstub *gs = x->tc_gp.gp_stub;
         t_word *vec;
-        int onset, type;
+        int onset;
+        int type;
         t_symbol *arraytype;
         if(!template)
         {
@@ -560,7 +564,11 @@ static int array_rangeop_getrange(t_array_rangeop *x, char **firstitemp,
 {
     t_glist *glist;
     t_array *a = array_client_getbuf(&x->x_tc, &glist);
-    int stride, fieldonset, arrayonset, nitem, type;
+    int stride;
+    int fieldonset;
+    int arrayonset;
+    int nitem;
+    int type;
     t_symbol *arraytype;
     t_template *template;
     if(!a) return (0);
@@ -610,8 +618,12 @@ static void *array_sum_new(t_symbol *s, int argc, t_atom *argv)
 
 static void array_sum_bang(t_array_rangeop *x)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int arrayonset;
+    int i;
     double sum;
     if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
@@ -641,8 +653,12 @@ static void *array_get_new(t_symbol *s, int argc, t_atom *argv)
 
 static void array_get_bang(t_array_rangeop *x)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int arrayonset;
+    int i;
     t_atom *outv;
     if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
@@ -674,8 +690,12 @@ static void *array_set_new(t_symbol *s, int argc, t_atom *argv)
 static void array_set_list(
     t_array_rangeop *x, t_symbol *s, int argc, t_atom *argv)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int arrayonset;
+    int i;
     if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
     if(nitem > argc) nitem = argc;
@@ -699,8 +719,12 @@ static void *array_quantile_new(t_symbol *s, int argc, t_atom *argv)
 
 static void array_quantile_float(t_array_rangeop *x, t_floatarg f)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int arrayonset;
+    int i;
     double sum;
     if(!array_rangeop_getrange(x, &firstitem, &nitem, &stride, &arrayonset))
         return;
@@ -743,7 +767,9 @@ static void array_random_seed(t_array_random *x, t_floatarg f)
 static void array_random_bang(t_array_random *x)
 {
     char *firstitem;
-    int stride, nitem, arrayonset;
+    int stride;
+    int nitem;
+    int arrayonset;
 
     if(!array_rangeop_getrange(
            &x->x_r, &firstitem, &nitem, &stride, &arrayonset))
@@ -779,8 +805,13 @@ static void *array_max_new(t_symbol *s, int argc, t_atom *argv)
 
 static void array_max_bang(t_array_max *x)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, arrayonset, i, besti;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int arrayonset;
+    int i;
+    int besti;
     t_float bestf;
     if(!array_rangeop_getrange(
            &x->x_rangeop, &firstitem, &nitem, &stride, &arrayonset))
@@ -820,8 +851,13 @@ static void *array_min_new(t_symbol *s, int argc, t_atom *argv)
 
 static void array_min_bang(t_array_min *x)
 {
-    char *itemp, *firstitem;
-    int stride, nitem, i, arrayonset, besti;
+    char *itemp;
+    char *firstitem;
+    int stride;
+    int nitem;
+    int i;
+    int arrayonset;
+    int besti;
     t_float bestf;
     if(!array_rangeop_getrange(
            &x->x_rangeop, &firstitem, &nitem, &stride, &arrayonset))

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -131,7 +131,9 @@ static void *array_define_new(t_symbol *s, int argc, t_atom *argv)
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        {
             keep = 1;
+        }
         else if(!strcmp(argv->a_w.w_symbol->s_name, "-yrange") && argc >= 3 &&
                 argv[1].a_type == A_FLOAT && argv[2].a_type == A_FLOAT)
         {
@@ -217,7 +219,9 @@ static void array_define_send(t_glist *x, t_symbol *s)
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
     if(!s->s_thing)
+    {
         pd_error(x, "array_define_send: %s: no such object", s->s_name);
+    }
     else if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
     {
         t_gpointer gp;
@@ -251,9 +255,13 @@ static void array_define_anything(
 {
     t_glist *gl = (x->gl_list ? pd_checkglist(&x->gl_list->g_pd) : 0);
     if(gl && gl->gl_list && pd_class(&gl->gl_list->g_pd) == garray_class)
+    {
         typedmess(&gl->gl_list->g_pd, s, argc, argv);
+    }
     else
+    {
         bug("array_define_anything");
+    }
 }
 
 /* ignore messages like "editmode" */
@@ -314,9 +322,13 @@ static t_array *array_client_getbuf(t_array_client *x, t_glist **glist)
             return (0);
         }
         if(gs->gs_which == GP_ARRAY)
+        {
             vec = x->tc_gp.gp_un.gp_w;
+        }
         else
+        {
             vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
+        }
 
         if(!template_find_field(
                template, x->tc_field, &onset, &type, &arraytype))
@@ -331,7 +343,9 @@ static t_array *array_client_getbuf(t_array_client *x, t_glist **glist)
             return (0);
         }
         if(gs->gs_which == GP_GLIST)
+        {
             *glist = gs->gs_un.gs_glist;
+        }
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
@@ -409,9 +423,13 @@ static void *array_size_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    }
     outlet_new(&x->x_tc.tc_obj, &s_float);
     return (x);
 }
@@ -548,9 +566,13 @@ static void *array_rangeop_new(t_class *class, t_symbol *s, int *argcp,
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    }
     *argcp = argc;
     *argvp = argv;
     return (x);
@@ -581,11 +603,17 @@ static int array_rangeop_getrange(t_array_rangeop *x, char **firstitemp,
     stride = a->a_elemsize;
     arrayonset = x->x_onset;
     if(arrayonset < 0)
+    {
         arrayonset = 0;
+    }
     else if(arrayonset > a->a_n)
+    {
         arrayonset = a->a_n;
+    }
     if(x->x_n < 0)
+    {
         nitem = a->a_n - arrayonset;
+    }
     else
     {
         nitem = x->x_n;
@@ -815,8 +843,10 @@ static void array_max_bang(t_array_max *x)
         return;
     for(i = 0, besti = -1, bestf = -1e30, itemp = firstitem; i < nitem;
         i++, itemp += stride)
+    {
         if(*(t_float *) itemp > bestf)
             bestf = *(t_float *) itemp, besti = i + arrayonset;
+    }
     outlet_float(x->x_out2, besti);
     outlet_float(x->x_out1, bestf);
 }
@@ -861,8 +891,10 @@ static void array_min_bang(t_array_min *x)
         return;
     for(i = 0, besti = -1, bestf = 1e30, itemp = firstitem; i < nitem;
         i++, itemp += stride)
+    {
         if(*(t_float *) itemp < bestf)
             bestf = *(t_float *) itemp, besti = i + arrayonset;
+    }
     outlet_float(x->x_out2, besti);
     outlet_float(x->x_out1, bestf);
 }
@@ -877,28 +909,48 @@ static void array_min_float(t_array_min *x, t_floatarg f)
 static void *arrayobj_new(t_symbol *s, int argc, t_atom *argv)
 {
     if(!argc || argv[0].a_type != A_SYMBOL)
+    {
         pd_this->pd_newest = array_define_new(s, argc, argv);
+    }
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
         if(!strcmp(str, "d") || !strcmp(str, "define"))
+        {
             pd_this->pd_newest = array_define_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "size"))
+        {
             pd_this->pd_newest = array_size_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "sum"))
+        {
             pd_this->pd_newest = array_sum_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "get"))
+        {
             pd_this->pd_newest = array_get_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "set"))
+        {
             pd_this->pd_newest = array_set_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "quantile"))
+        {
             pd_this->pd_newest = array_quantile_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "random"))
+        {
             pd_this->pd_newest = array_random_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "max"))
+        {
             pd_this->pd_newest = array_max_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "min"))
+        {
             pd_this->pd_newest = array_min_new(s, argc - 1, argv + 1);
+        }
         else
         {
             pd_error(0, "array %s: unknown function", str);

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -875,8 +875,7 @@ static void pack_list(t_pack *x, t_symbol *s, int ac, t_atom *av)
 static void pack_anything(t_pack *x, t_symbol *s, int ac, t_atom *av)
 {
     t_atom *av2 = (t_atom *) getbytes((ac + 1) * sizeof(t_atom));
-    int i;
-    for(i = 0; i < ac; i++)
+    for(int i = 0; i < ac; i++)
         av2[i + 1] = av[i];
     SETSYMBOL(av2, s);
     obj_list(&x->x_obj, 0, ac + 1, av2);
@@ -1006,8 +1005,7 @@ static void unpack_list(t_unpack *x, t_symbol *s, int argc, t_atom *argv)
 static void unpack_anything(t_unpack *x, t_symbol *s, int ac, t_atom *av)
 {
     t_atom *av2 = (t_atom *) getbytes((ac + 1) * sizeof(t_atom));
-    int i;
-    for(i = 0; i < ac; i++)
+    for(int i = 0; i < ac; i++)
         av2[i + 1] = av[i];
     SETSYMBOL(av2, s);
     unpack_list(x, 0, ac + 1, av2);

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -673,7 +673,10 @@ typedef struct _pack
 static void *pack_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_pack *x = (t_pack *) pd_new(pack_class);
-    t_atom defarg[2], *ap, *vec, *vp;
+    t_atom defarg[2];
+    t_atom *ap;
+    t_atom *vec;
+    t_atom *vp;
     t_gpointer *gp;
     int nptr = 0;
     int i;
@@ -733,7 +736,9 @@ static void *pack_new(t_symbol *s, int argc, t_atom *argv)
 
 static void pack_bang(t_pack *x)
 {
-    int i, reentered = 0, size = (int) (x->x_n * sizeof(t_atom));
+    int i;
+    int reentered = 0;
+    int size = (int) (x->x_n * sizeof(t_atom));
     t_gpointer *gp;
     t_atom *outvec;
     for(i = (int) x->x_nptr, gp = x->x_gpointer; i--; gp++)
@@ -859,7 +864,8 @@ typedef struct _unpack
 static void *unpack_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_unpack *x = (t_unpack *) pd_new(unpack_class);
-    t_atom defarg[2], *ap;
+    t_atom defarg[2];
+    t_atom *ap;
     t_unpackout *u;
     int i;
     if(!argc)
@@ -975,7 +981,8 @@ typedef struct _trigger
 static void *trigger_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_trigger *x = (t_trigger *) pd_new(trigger_class);
-    t_atom defarg[2], *ap;
+    t_atom defarg[2];
+    t_atom *ap;
     t_triggerout *u;
     int i;
     if(!argc)

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -41,9 +41,13 @@ static void pdint_float(t_pdint *x, t_float f)
 static void pdint_send(t_pdint *x, t_symbol *s)
 {
     if(s->s_thing)
+    {
         pd_float(s->s_thing, (t_float) (int64_t) x->x_f);
+    }
     else
+    {
         pd_error(x, "%s: no such object", s->s_name);
+    }
 }
 
 void pdint_setup(void)
@@ -98,17 +102,25 @@ static void pdfloat_symbol(t_pdfloat *x, t_symbol *s)
     char *str_end = NULL;
     f = strtod(s->s_name, &str_end);
     if(f == 0 && s->s_name == str_end)
+    {
         pd_error(x, "couldn't convert %s to float", s->s_name);
+    }
     else
+    {
         outlet_float(x->x_obj.ob_outlet, x->x_f = f);
+    }
 }
 
 static void pdfloat_send(t_pdfloat *x, t_symbol *s)
 {
     if(s->s_thing)
+    {
         pd_float(s->s_thing, x->x_f);
+    }
     else
+    {
         pd_error(x, "%s: no such object", s->s_name);
+    }
 }
 
 void pdfloat_setup(void)
@@ -167,11 +179,17 @@ object's responsibility?  Dunno... */
 static void pdsymbol_list(t_pdsymbol *x, t_symbol *s, int ac, t_atom *av)
 {
     if(!ac)
+    {
         pdsymbol_bang(x);
+    }
     else if(av->a_type == A_SYMBOL)
+    {
         pdsymbol_symbol(x, av->a_w.w_symbol);
+    }
     else
+    {
         pdsymbol_anything(x, s, ac, av);
+    }
 }
 
 void pdsymbol_setup(void)
@@ -354,17 +372,25 @@ typedef struct _sel1
 static void sel1_float(t_sel1 *x, t_float f)
 {
     if(x->x_atom.a_type == A_FLOAT && f == x->x_atom.a_w.w_float)
+    {
         outlet_bang(x->x_outlet1);
+    }
     else
+    {
         outlet_float(x->x_outlet2, f);
+    }
 }
 
 static void sel1_symbol(t_sel1 *x, t_symbol *s)
 {
     if(x->x_atom.a_type == A_SYMBOL && s == x->x_atom.a_w.w_symbol)
+    {
         outlet_bang(x->x_outlet1);
+    }
     else
+    {
         outlet_symbol(x->x_outlet2, s);
+    }
 }
 
 static t_class *sel2_class;
@@ -391,11 +417,13 @@ static void sel2_float(t_sel2 *x, t_float f)
     if(x->x_type == A_FLOAT)
     {
         for(nelement = (int) x->x_nelement, e = x->x_vec; nelement--; e++)
+        {
             if(e->e_w.w_float == f)
             {
                 outlet_bang(e->e_outlet);
                 return;
             }
+        }
     }
     outlet_float(x->x_rejectout, f);
 }
@@ -407,11 +435,13 @@ static void sel2_symbol(t_sel2 *x, t_symbol *s)
     if(x->x_type == A_SYMBOL)
     {
         for(nelement = (int) x->x_nelement, e = x->x_vec; nelement--; e++)
+        {
             if(e->e_w.w_symbol == s)
             {
                 outlet_bang(e->e_outlet);
                 return;
             }
+        }
     }
     outlet_symbol(x->x_rejectout, s);
 }
@@ -458,9 +488,13 @@ static void *select_new(t_symbol *s, int argc, t_atom *argv)
     {
         e->e_outlet = outlet_new(&x->x_obj, &s_bang);
         if((x->x_type = argv->a_type) == A_FLOAT)
+        {
             e->e_w.w_float = atom_getfloatarg(n, argc, argv);
+        }
         else
+        {
             e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
+        }
     }
     x->x_rejectout = outlet_new(&x->x_obj, &s_float);
     return (x);
@@ -507,15 +541,21 @@ static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
     if(x->x_type == A_SYMBOL)
     {
         for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        {
             if(e->e_w.w_symbol == sel)
             {
                 if(argc > 0 && argv[0].a_type == A_SYMBOL)
+                {
                     outlet_anything(
                         e->e_outlet, argv[0].a_w.w_symbol, argc - 1, argv + 1);
+                }
                 else
+                {
                     outlet_list(e->e_outlet, 0, argc, argv);
+                }
                 return;
             }
+        }
     }
     outlet_anything(x->x_rejectout, sel, argc, argv);
 }
@@ -531,15 +571,21 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
         if(argv->a_type != A_FLOAT) goto rejected;
         f = atom_getfloat(argv);
         for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        {
             if(e->e_w.w_float == f)
             {
                 if(argc > 1 && argv[1].a_type == A_SYMBOL)
+                {
                     outlet_anything(
                         e->e_outlet, argv[1].a_w.w_symbol, argc - 2, argv + 2);
+                }
                 else
+                {
                     outlet_list(e->e_outlet, 0, argc - 1, argv + 1);
+                }
                 return;
             }
+        }
     }
     else /* symbol arguments */
     {
@@ -550,10 +596,14 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
                 if(e->e_w.w_symbol == &s_list)
                 {
                     if(argc > 0 && argv[0].a_type == A_SYMBOL)
+                    {
                         outlet_anything(e->e_outlet, argv[0].a_w.w_symbol,
                             argc - 1, argv + 1);
+                    }
                     else
+                    {
                         outlet_list(e->e_outlet, 0, argc, argv);
+                    }
                     return;
                 }
             }
@@ -631,16 +681,24 @@ static void *route_new(t_symbol *s, int argc, t_atom *argv)
     {
         e->e_outlet = outlet_new(&x->x_obj, &s_list);
         if(x->x_type == A_FLOAT)
+        {
             e->e_w.w_float = atom_getfloatarg(n, argc, argv);
+        }
         else
+        {
             e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
+        }
     }
     if(argc == 1)
     {
         if(argv->a_type == A_FLOAT)
+        {
             floatinlet_new(&x->x_obj, &x->x_vec->e_w.w_float);
+        }
         else
+        {
             symbolinlet_new(&x->x_obj, &x->x_vec->e_w.w_symbol);
+        }
     }
     x->x_rejectout = outlet_new(&x->x_obj, &s_list);
     return (x);
@@ -740,11 +798,13 @@ static void pack_bang(t_pack *x)
     t_gpointer *gp;
     t_atom *outvec;
     for(i = (int) x->x_nptr, gp = x->x_gpointer; i--; gp++)
+    {
         if(!gpointer_check(gp, 1))
         {
             pd_error(x, "pack: stale pointer");
             return;
         }
+    }
     /* reentrancy protection.  The first time through use the pre-allocated
     x_outvec; if we're reentered we have to allocate new memory. */
     if(!x->x_outvec)
@@ -763,9 +823,13 @@ static void pack_bang(t_pack *x)
     memcpy(outvec, x->x_vec, size);
     outlet_list(x->x_obj.ob_outlet, &s_list, (int) x->x_n, outvec);
     if(reentered)
+    {
         t_freebytes(outvec, size);
+    }
     else
+    {
         x->x_outvec = outvec;
+    }
 }
 
 static void pack_pointer(t_pack *x, t_gpointer *gp)
@@ -894,8 +958,10 @@ static void *unpack_new(t_symbol *s, int argc, t_atom *argv)
             else
             {
                 if(c != 'f')
+                {
                     pd_error(
                         x, "unpack: %s: bad type", ap->a_w.w_symbol->s_name);
+                }
                 u->u_type = A_FLOAT;
                 u->u_outlet = outlet_new(&x->x_obj, &s_float);
             }
@@ -919,13 +985,21 @@ static void unpack_list(t_unpack *x, t_symbol *s, int argc, t_atom *argv)
     {
         t_atomtype type = u->u_type;
         if(type != ap->a_type)
+        {
             pd_error(x, "unpack: type mismatch");
+        }
         else if(type == A_FLOAT)
+        {
             outlet_float(u->u_outlet, ap->a_w.w_float);
+        }
         else if(type == A_SYMBOL)
+        {
             outlet_symbol(u->u_outlet, ap->a_w.w_symbol);
+        }
         else
+        {
             outlet_pointer(u->u_outlet, ap->a_w.w_gpointer);
+        }
     }
 }
 
@@ -997,26 +1071,44 @@ static void *trigger_new(t_symbol *s, int argc, t_atom *argv)
         t_atomtype thistype = ap->a_type;
         char c;
         if(thistype == TR_SYMBOL)
+        {
             c = ap->a_w.w_symbol->s_name[0];
+        }
         else if(thistype == TR_FLOAT)
+        {
             c = 'f';
+        }
         else
+        {
             c = 0;
+        }
         if(c == 'p')
+        {
             u->u_type = TR_POINTER,
             u->u_outlet = outlet_new(&x->x_obj, &s_pointer);
+        }
         else if(c == 'f')
+        {
             u->u_type = TR_FLOAT, u->u_outlet = outlet_new(&x->x_obj, &s_float);
+        }
         else if(c == 'b')
+        {
             u->u_type = TR_BANG, u->u_outlet = outlet_new(&x->x_obj, &s_bang);
+        }
         else if(c == 'l')
+        {
             u->u_type = TR_LIST, u->u_outlet = outlet_new(&x->x_obj, &s_list);
+        }
         else if(c == 's')
+        {
             u->u_type = TR_SYMBOL,
             u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
+        }
         else if(c == 'a')
+        {
             u->u_type = TR_ANYTHING,
             u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
+        }
         else
         {
             pd_error(x, "trigger: %s: bad type", ap->a_w.w_symbol->s_name);
@@ -1033,23 +1125,37 @@ static void trigger_list(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
     for(i = (int) x->x_n, u = x->x_vec + i; u--, i--;)
     {
         if(u->u_type == TR_FLOAT)
+        {
             outlet_float(u->u_outlet, (argc ? atom_getfloat(argv) : 0));
+        }
         else if(u->u_type == TR_BANG)
+        {
             outlet_bang(u->u_outlet);
+        }
         else if(u->u_type == TR_SYMBOL)
+        {
             outlet_symbol(
                 u->u_outlet, (argc ? atom_getsymbol(argv) : &s_symbol));
+        }
         else if(u->u_type == TR_POINTER)
         {
             if(!argc || argv->a_type != TR_POINTER)
+            {
                 pd_error(x, "trigger: bad pointer");
+            }
             else
+            {
                 outlet_pointer(u->u_outlet, argv->a_w.w_gpointer);
+            }
         }
         else if(u->u_type == TR_LIST)
+        {
             outlet_list(u->u_outlet, &s_list, argc, argv);
+        }
         else
+        {
             outlet_anything(u->u_outlet, s, argc, argv);
+        }
     }
 }
 
@@ -1060,12 +1166,18 @@ static void trigger_anything(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
     for(i = (int) x->x_n, u = x->x_vec + i; u--, i--;)
     {
         if(u->u_type == TR_BANG)
+        {
             outlet_bang(u->u_outlet);
+        }
         else if(u->u_type == TR_ANYTHING)
+        {
             outlet_anything(u->u_outlet, s, argc, argv);
+        }
         else
+        {
             pd_error(x, "trigger: generic messages can only be converted to "
                         "'b' or 'a'");
+        }
     }
 }
 
@@ -1193,9 +1305,13 @@ static void *moses_new(t_floatarg f)
 static void moses_float(t_moses *x, t_float f)
 {
     if(f < x->x_y)
+    {
         outlet_float(x->x_ob.ob_outlet, f);
+    }
     else
+    {
         outlet_float(x->x_out2, f);
+    }
 }
 
 static void moses_setup(void)
@@ -1625,8 +1741,10 @@ static void *value_new(t_symbol *s)
 {
     t_value *x = (t_value *) pd_new(value_class);
     if(!*s->s_name)
+    {
         inlet_new(
             &x->x_obj, &x->x_obj.ob_pd, gensym("symbol"), gensym("symbol2"));
+    }
     x->x_sym = s;
     x->x_floatstar = value_get(s);
     outlet_new(&x->x_obj, &s_float);
@@ -1651,9 +1769,13 @@ static void value_symbol2(t_value *x, t_symbol *s)
 static void value_send(t_value *x, t_symbol *s)
 {
     if(s->s_thing)
+    {
         pd_float(s->s_thing, *x->x_floatstar);
+    }
     else
+    {
         pd_error(x, "%s: no such object", s->s_name);
+    }
 }
 
 static void value_ff(t_value *x) { value_release(x->x_sym); }

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* connective objects */
 
@@ -21,7 +21,7 @@ typedef struct _pdint
 
 static void *pdint_new(t_floatarg f)
 {
-    t_pdint *x = (t_pdint *)pd_new(pdint_class);
+    t_pdint *x = (t_pdint *) pd_new(pdint_class);
     x->x_f = f;
     outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f);
@@ -30,28 +30,29 @@ static void *pdint_new(t_floatarg f)
 
 static void pdint_bang(t_pdint *x)
 {
-    outlet_float(x->x_obj.ob_outlet, (t_float)(int64_t)(x->x_f));
+    outlet_float(x->x_obj.ob_outlet, (t_float) (int64_t) (x->x_f));
 }
 
 static void pdint_float(t_pdint *x, t_float f)
 {
-    outlet_float(x->x_obj.ob_outlet, (t_float)(int64_t)(x->x_f = f));
+    outlet_float(x->x_obj.ob_outlet, (t_float) (int64_t) (x->x_f = f));
 }
 
 static void pdint_send(t_pdint *x, t_symbol *s)
 {
-    if (s->s_thing)
-        pd_float(s->s_thing, (t_float)(int64_t)x->x_f);
-    else pd_error(x, "%s: no such object", s->s_name);
+    if(s->s_thing)
+        pd_float(s->s_thing, (t_float) (int64_t) x->x_f);
+    else
+        pd_error(x, "%s: no such object", s->s_name);
 }
 
 void pdint_setup(void)
 {
-    pdint_class = class_new(gensym("int"), (t_newmethod)pdint_new, 0,
+    pdint_class = class_new(gensym("int"), (t_newmethod) pdint_new, 0,
         sizeof(t_pdint), 0, A_DEFFLOAT, 0);
-    class_addcreator((t_newmethod)pdint_new, gensym("i"), A_DEFFLOAT, 0);
-    class_addmethod(pdint_class, (t_method)pdint_send, gensym("send"),
-        A_SYMBOL, 0);
+    class_addcreator((t_newmethod) pdint_new, gensym("i"), A_DEFFLOAT, 0);
+    class_addmethod(
+        pdint_class, (t_method) pdint_send, gensym("send"), A_SYMBOL, 0);
     class_addbang(pdint_class, pdint_bang);
     class_addfloat(pdint_class, pdint_float);
 }
@@ -65,13 +66,13 @@ typedef struct _pdfloat
     t_float x_f;
 } t_pdfloat;
 
-    /* "float," "symbol," and "bang" are special because
-    they're created by short-circuited messages to the "new"
-    object which are handled specially in pd_typedmess(). */
+/* "float," "symbol," and "bang" are special because
+they're created by short-circuited messages to the "new"
+object which are handled specially in pd_typedmess(). */
 
 static void *pdfloat_new(t_pd *dummy, t_float f)
 {
-    t_pdfloat *x = (t_pdfloat *)pd_new(pdfloat_class);
+    t_pdfloat *x = (t_pdfloat *) pd_new(pdfloat_class);
     x->x_f = f;
     outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f);
@@ -79,10 +80,7 @@ static void *pdfloat_new(t_pd *dummy, t_float f)
     return (x);
 }
 
-static void *pdfloat_new2(t_floatarg f)
-{
-    return (pdfloat_new(0, f));
-}
+static void *pdfloat_new2(t_floatarg f) { return (pdfloat_new(0, f)); }
 
 static void pdfloat_bang(t_pdfloat *x)
 {
@@ -94,34 +92,35 @@ static void pdfloat_float(t_pdfloat *x, t_float f)
     outlet_float(x->x_obj.ob_outlet, x->x_f = f);
 }
 
-
 static void pdfloat_symbol(t_pdfloat *x, t_symbol *s)
 {
     t_float f = 0.0f;
     char *str_end = NULL;
     f = strtod(s->s_name, &str_end);
-    if (f == 0 && s->s_name == str_end)
+    if(f == 0 && s->s_name == str_end)
         pd_error(x, "couldn't convert %s to float", s->s_name);
-    else outlet_float(x->x_obj.ob_outlet, x->x_f = f);
+    else
+        outlet_float(x->x_obj.ob_outlet, x->x_f = f);
 }
 
 static void pdfloat_send(t_pdfloat *x, t_symbol *s)
 {
-    if (s->s_thing)
+    if(s->s_thing)
         pd_float(s->s_thing, x->x_f);
-    else pd_error(x, "%s: no such object", s->s_name);
+    else
+        pd_error(x, "%s: no such object", s->s_name);
 }
 
 void pdfloat_setup(void)
 {
-    pdfloat_class = class_new(gensym("float"), (t_newmethod)pdfloat_new, 0,
+    pdfloat_class = class_new(gensym("float"), (t_newmethod) pdfloat_new, 0,
         sizeof(t_pdfloat), 0, A_FLOAT, 0);
-    class_addcreator((t_newmethod)pdfloat_new2, gensym("f"), A_DEFFLOAT, 0);
-    class_addmethod(pdfloat_class, (t_method)pdfloat_send, gensym("send"),
-        A_SYMBOL, 0);
+    class_addcreator((t_newmethod) pdfloat_new2, gensym("f"), A_DEFFLOAT, 0);
+    class_addmethod(
+        pdfloat_class, (t_method) pdfloat_send, gensym("send"), A_SYMBOL, 0);
     class_addbang(pdfloat_class, pdfloat_bang);
-    class_addfloat(pdfloat_class, (t_method)pdfloat_float);
-    class_addsymbol(pdfloat_class, (t_method)pdfloat_symbol);
+    class_addfloat(pdfloat_class, (t_method) pdfloat_float);
+    class_addsymbol(pdfloat_class, (t_method) pdfloat_symbol);
 }
 
 /* -------------------------- symbol ------------------------------ */
@@ -135,7 +134,7 @@ typedef struct _pdsymbol
 
 static void *pdsymbol_new(t_pd *dummy, t_symbol *s)
 {
-    t_pdsymbol *x = (t_pdsymbol *)pd_new(pdsymbol_class);
+    t_pdsymbol *x = (t_pdsymbol *) pd_new(pdsymbol_class);
     x->x_s = s;
     outlet_new(&x->x_obj, &s_symbol);
     symbolinlet_new(&x->x_obj, &x->x_s);
@@ -158,25 +157,26 @@ static void pdsymbol_anything(t_pdsymbol *x, t_symbol *s, int ac, t_atom *av)
     outlet_symbol(x->x_obj.ob_outlet, x->x_s = s);
 }
 
-    /* For "list" message don't just output "list"; if empty, we want to
-    bang the symbol and if it starts with a symbol, we output that.
-    Otherwise it's not clear what we should do so we just go for the
-    "anything" method.  LATER figure out if there are other places where
-    empty lists aren't equivalent to "bang"???  Should Pd's message passer
-    always check and call the more specific method, or should it be the
-    object's responsibility?  Dunno... */
+/* For "list" message don't just output "list"; if empty, we want to
+bang the symbol and if it starts with a symbol, we output that.
+Otherwise it's not clear what we should do so we just go for the
+"anything" method.  LATER figure out if there are other places where
+empty lists aren't equivalent to "bang"???  Should Pd's message passer
+always check and call the more specific method, or should it be the
+object's responsibility?  Dunno... */
 static void pdsymbol_list(t_pdsymbol *x, t_symbol *s, int ac, t_atom *av)
 {
-    if (!ac)
+    if(!ac)
         pdsymbol_bang(x);
-    else if (av->a_type == A_SYMBOL)
+    else if(av->a_type == A_SYMBOL)
         pdsymbol_symbol(x, av->a_w.w_symbol);
-    else pdsymbol_anything(x, s, ac, av);
+    else
+        pdsymbol_anything(x, s, ac, av);
 }
 
 void pdsymbol_setup(void)
 {
-    pdsymbol_class = class_new(gensym("symbol"), (t_newmethod)pdsymbol_new, 0,
+    pdsymbol_class = class_new(gensym("symbol"), (t_newmethod) pdsymbol_new, 0,
         sizeof(t_pdsymbol), 0, A_SYMBOL, 0);
     class_addbang(pdsymbol_class, pdsymbol_bang);
     class_addsymbol(pdsymbol_class, pdsymbol_symbol);
@@ -193,27 +193,21 @@ typedef struct _bang
 
 static void *bang_new(t_pd *dummy)
 {
-    t_bang *x = (t_bang *)pd_new(bang_class);
+    t_bang *x = (t_bang *) pd_new(bang_class);
     outlet_new(&x->x_obj, &s_bang);
     pd_this->pd_newest = &x->x_obj.ob_pd;
     return (x);
 }
 
-static void *bang_new2(t_bang f)
-{
-    return (bang_new(0));
-}
+static void *bang_new2(t_bang f) { return (bang_new(0)); }
 
-static void bang_bang(t_bang *x)
-{
-    outlet_bang(x->x_obj.ob_outlet);
-}
+static void bang_bang(t_bang *x) { outlet_bang(x->x_obj.ob_outlet); }
 
 void bang_setup(void)
 {
-    bang_class = class_new(gensym("bang"), (t_newmethod)bang_new, 0,
-        sizeof(t_bang), 0, 0);
-    class_addcreator((t_newmethod)bang_new2, gensym("b"), 0);
+    bang_class = class_new(
+        gensym("bang"), (t_newmethod) bang_new, 0, sizeof(t_bang), 0, 0);
+    class_addcreator((t_newmethod) bang_new2, gensym("b"), 0);
     class_addbang(bang_class, bang_bang);
     class_addfloat(bang_class, bang_bang);
     class_addsymbol(bang_class, bang_bang);
@@ -233,48 +227,47 @@ typedef struct _send
 
 static void send_bang(t_send *x)
 {
-    if (x->x_sym->s_thing) pd_bang(x->x_sym->s_thing);
+    if(x->x_sym->s_thing) pd_bang(x->x_sym->s_thing);
 }
 
 static void send_float(t_send *x, t_float f)
 {
-    if (x->x_sym->s_thing) pd_float(x->x_sym->s_thing, f);
+    if(x->x_sym->s_thing) pd_float(x->x_sym->s_thing, f);
 }
 
 static void send_symbol(t_send *x, t_symbol *s)
 {
-    if (x->x_sym->s_thing) pd_symbol(x->x_sym->s_thing, s);
+    if(x->x_sym->s_thing) pd_symbol(x->x_sym->s_thing, s);
 }
 
 static void send_pointer(t_send *x, t_gpointer *gp)
 {
-    if (x->x_sym->s_thing) pd_pointer(x->x_sym->s_thing, gp);
+    if(x->x_sym->s_thing) pd_pointer(x->x_sym->s_thing, gp);
 }
 
 static void send_list(t_send *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_sym->s_thing) pd_list(x->x_sym->s_thing, s, argc, argv);
+    if(x->x_sym->s_thing) pd_list(x->x_sym->s_thing, s, argc, argv);
 }
 
 static void send_anything(t_send *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_sym->s_thing) typedmess(x->x_sym->s_thing, s, argc, argv);
+    if(x->x_sym->s_thing) typedmess(x->x_sym->s_thing, s, argc, argv);
 }
 
 static void *send_new(t_symbol *s)
 {
-    t_send *x = (t_send *)pd_new(send_class);
-    if (!*s->s_name)
-        symbolinlet_new(&x->x_obj, &x->x_sym);
+    t_send *x = (t_send *) pd_new(send_class);
+    if(!*s->s_name) symbolinlet_new(&x->x_obj, &x->x_sym);
     x->x_sym = s;
     return (x);
 }
 
 static void send_setup(void)
 {
-    send_class = class_new(gensym("send"), (t_newmethod)send_new, 0,
+    send_class = class_new(gensym("send"), (t_newmethod) send_new, 0,
         sizeof(t_send), 0, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)send_new, gensym("s"), A_DEFSYM, 0);
+    class_addcreator((t_newmethod) send_new, gensym("s"), A_DEFSYM, 0);
     class_addbang(send_class, send_bang);
     class_addfloat(send_class, send_float);
     class_addsymbol(send_class, send_symbol);
@@ -283,6 +276,7 @@ static void send_setup(void)
     class_addanything(send_class, send_anything);
     class_sethelpsymbol(send_class, gensym("send-receive"));
 }
+
 /* -------------------- receive ------------------------------ */
 
 static t_class *receive_class;
@@ -293,10 +287,7 @@ typedef struct _receive
     t_symbol *x_sym;
 } t_receive;
 
-static void receive_bang(t_receive *x)
-{
-    outlet_bang(x->x_obj.ob_outlet);
-}
+static void receive_bang(t_receive *x) { outlet_bang(x->x_obj.ob_outlet); }
 
 static void receive_float(t_receive *x, t_float f)
 {
@@ -325,25 +316,22 @@ static void receive_anything(t_receive *x, t_symbol *s, int argc, t_atom *argv)
 
 static void *receive_new(t_symbol *s)
 {
-    t_receive *x = (t_receive *)pd_new(receive_class);
+    t_receive *x = (t_receive *) pd_new(receive_class);
     x->x_sym = s;
     pd_bind(&x->x_obj.ob_pd, s);
     outlet_new(&x->x_obj, 0);
     return (x);
 }
 
-static void receive_free(t_receive *x)
-{
-    pd_unbind(&x->x_obj.ob_pd, x->x_sym);
-}
+static void receive_free(t_receive *x) { pd_unbind(&x->x_obj.ob_pd, x->x_sym); }
 
 static void receive_setup(void)
 {
-    receive_class = class_new(gensym("receive"), (t_newmethod)receive_new,
-        (t_method)receive_free, sizeof(t_receive), CLASS_NOINLET, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)receive_new, gensym("r"), A_DEFSYM, 0);
+    receive_class = class_new(gensym("receive"), (t_newmethod) receive_new,
+        (t_method) receive_free, sizeof(t_receive), CLASS_NOINLET, A_DEFSYM, 0);
+    class_addcreator((t_newmethod) receive_new, gensym("r"), A_DEFSYM, 0);
     class_addbang(receive_class, receive_bang);
-    class_addfloat(receive_class, (t_method)receive_float);
+    class_addfloat(receive_class, (t_method) receive_float);
     class_addsymbol(receive_class, receive_symbol);
     class_addpointer(receive_class, receive_pointer);
     class_addlist(receive_class, receive_list);
@@ -365,16 +353,18 @@ typedef struct _sel1
 
 static void sel1_float(t_sel1 *x, t_float f)
 {
-    if (x->x_atom.a_type == A_FLOAT && f == x->x_atom.a_w.w_float)
+    if(x->x_atom.a_type == A_FLOAT && f == x->x_atom.a_w.w_float)
         outlet_bang(x->x_outlet1);
-    else outlet_float(x->x_outlet2, f);
+    else
+        outlet_float(x->x_outlet2, f);
 }
 
 static void sel1_symbol(t_sel1 *x, t_symbol *s)
 {
-    if (x->x_atom.a_type == A_SYMBOL && s == x->x_atom.a_w.w_symbol)
+    if(x->x_atom.a_type == A_SYMBOL && s == x->x_atom.a_w.w_symbol)
         outlet_bang(x->x_outlet1);
-    else outlet_symbol(x->x_outlet2, s);
+    else
+        outlet_symbol(x->x_outlet2, s);
 }
 
 static t_class *sel2_class;
@@ -398,14 +388,14 @@ static void sel2_float(t_sel2 *x, t_float f)
 {
     t_selectelement *e;
     int nelement;
-    if (x->x_type == A_FLOAT)
+    if(x->x_type == A_FLOAT)
     {
-        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
-            if (e->e_w.w_float == f)
-        {
-            outlet_bang(e->e_outlet);
-            return;
-        }
+        for(nelement = (int) x->x_nelement, e = x->x_vec; nelement--; e++)
+            if(e->e_w.w_float == f)
+            {
+                outlet_bang(e->e_outlet);
+                return;
+            }
     }
     outlet_float(x->x_rejectout, f);
 }
@@ -414,14 +404,14 @@ static void sel2_symbol(t_sel2 *x, t_symbol *s)
 {
     t_selectelement *e;
     int nelement;
-    if (x->x_type == A_SYMBOL)
+    if(x->x_type == A_SYMBOL)
     {
-        for (nelement = (int)x->x_nelement, e = x->x_vec; nelement--; e++)
-            if (e->e_w.w_symbol == s)
-        {
-            outlet_bang(e->e_outlet);
-            return;
-        }
+        for(nelement = (int) x->x_nelement, e = x->x_vec; nelement--; e++)
+            if(e->e_w.w_symbol == s)
+            {
+                outlet_bang(e->e_outlet);
+                return;
+            }
     }
     outlet_symbol(x->x_rejectout, s);
 }
@@ -434,18 +424,18 @@ static void sel2_free(t_sel2 *x)
 static void *select_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_atom a;
-    if (argc == 0)
+    if(argc == 0)
     {
         argc = 1;
         SETFLOAT(&a, 0);
         argv = &a;
     }
-    if (argc == 1)
+    if(argc == 1)
     {
-        t_sel1 *x = (t_sel1 *)pd_new(sel1_class);
+        t_sel1 *x = (t_sel1 *) pd_new(sel1_class);
         x->x_atom = *argv;
         x->x_outlet1 = outlet_new(&x->x_obj, &s_bang);
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
         {
             floatinlet_new(&x->x_obj, &x->x_atom.a_w.w_float);
             x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
@@ -461,37 +451,36 @@ static void *select_new(t_symbol *s, int argc, t_atom *argv)
     {
         int n;
         t_selectelement *e;
-        t_sel2 *x = (t_sel2 *)pd_new(sel2_class);
+        t_sel2 *x = (t_sel2 *) pd_new(sel2_class);
         x->x_nelement = argc;
-        x->x_vec = (t_selectelement *)getbytes(argc * sizeof(*x->x_vec));
+        x->x_vec = (t_selectelement *) getbytes(argc * sizeof(*x->x_vec));
         x->x_type = argv[0].a_type;
-        for (n = 0, e = x->x_vec; n < argc; n++, e++)
+        for(n = 0, e = x->x_vec; n < argc; n++, e++)
         {
             e->e_outlet = outlet_new(&x->x_obj, &s_bang);
-            if ((x->x_type = argv->a_type) == A_FLOAT)
+            if((x->x_type = argv->a_type) == A_FLOAT)
                 e->e_w.w_float = atom_getfloatarg(n, argc, argv);
-            else e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
+            else
+                e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
         }
         x->x_rejectout = outlet_new(&x->x_obj, &s_float);
         return (x);
     }
-
 }
 
 void select_setup(void)
 {
-    sel1_class = class_new(gensym("select"), 0, 0,
-        sizeof(t_sel1), 0, 0);
+    sel1_class = class_new(gensym("select"), 0, 0, sizeof(t_sel1), 0, 0);
     class_addfloat(sel1_class, sel1_float);
     class_addsymbol(sel1_class, sel1_symbol);
 
-    sel2_class = class_new(gensym("select"), 0, (t_method)sel2_free,
-        sizeof(t_sel2), 0, 0);
+    sel2_class = class_new(
+        gensym("select"), 0, (t_method) sel2_free, sizeof(t_sel2), 0, 0);
     class_addfloat(sel2_class, sel2_float);
     class_addsymbol(sel2_class, sel2_symbol);
 
-    class_addcreator((t_newmethod)select_new, gensym("select"),  A_GIMME, 0);
-    class_addcreator((t_newmethod)select_new, gensym("sel"),  A_GIMME, 0);
+    class_addcreator((t_newmethod) select_new, gensym("select"), A_GIMME, 0);
+    class_addcreator((t_newmethod) select_new, gensym("sel"), A_GIMME, 0);
 }
 
 /* -------------------------- route ------------------------------ */
@@ -517,17 +506,18 @@ static void route_anything(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
     int nelement;
-    if (x->x_type == A_SYMBOL)
+    if(x->x_type == A_SYMBOL)
     {
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
-            if (e->e_w.w_symbol == sel)
-        {
-            if (argc > 0 && argv[0].a_type == A_SYMBOL)
-                outlet_anything(e->e_outlet, argv[0].a_w.w_symbol,
-                    argc-1, argv+1);
-            else outlet_list(e->e_outlet, 0, argc, argv);
-            return;
-        }
+        for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            if(e->e_w.w_symbol == sel)
+            {
+                if(argc > 0 && argv[0].a_type == A_SYMBOL)
+                    outlet_anything(
+                        e->e_outlet, argv[0].a_w.w_symbol, argc - 1, argv + 1);
+                else
+                    outlet_list(e->e_outlet, 0, argc, argv);
+                return;
+            }
     }
     outlet_anything(x->x_rejectout, sel, argc, argv);
 }
@@ -536,77 +526,78 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
 {
     t_routeelement *e;
     int nelement;
-    if (x->x_type == A_FLOAT)
+    if(x->x_type == A_FLOAT)
     {
         t_float f;
-        if (!argc) return;
-        if (argv->a_type != A_FLOAT)
-            goto rejected;
+        if(!argc) return;
+        if(argv->a_type != A_FLOAT) goto rejected;
         f = atom_getfloat(argv);
-        for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
-            if (e->e_w.w_float == f)
-        {
-            if (argc > 1 && argv[1].a_type == A_SYMBOL)
-                outlet_anything(e->e_outlet, argv[1].a_w.w_symbol,
-                    argc-2, argv+2);
-            else outlet_list(e->e_outlet, 0, argc-1, argv+1);
-            return;
-        }
-    }
-    else    /* symbol arguments */
-    {
-        if (argc > 1)       /* 2 or more args: treat as "list" */
-        {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+        for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            if(e->e_w.w_float == f)
             {
-                if (e->e_w.w_symbol == &s_list)
+                if(argc > 1 && argv[1].a_type == A_SYMBOL)
+                    outlet_anything(
+                        e->e_outlet, argv[1].a_w.w_symbol, argc - 2, argv + 2);
+                else
+                    outlet_list(e->e_outlet, 0, argc - 1, argv + 1);
+                return;
+            }
+    }
+    else /* symbol arguments */
+    {
+        if(argc > 1) /* 2 or more args: treat as "list" */
+        {
+            for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            {
+                if(e->e_w.w_symbol == &s_list)
                 {
-                    if (argc > 0 && argv[0].a_type == A_SYMBOL)
+                    if(argc > 0 && argv[0].a_type == A_SYMBOL)
                         outlet_anything(e->e_outlet, argv[0].a_w.w_symbol,
-                            argc-1, argv+1);
-                    else outlet_list(e->e_outlet, 0, argc, argv);
+                            argc - 1, argv + 1);
+                    else
+                        outlet_list(e->e_outlet, 0, argc, argv);
                     return;
                 }
             }
         }
-        else if (argc == 0)         /* no args: treat as "bang" */
+        else if(argc == 0) /* no args: treat as "bang" */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
-                if (e->e_w.w_symbol == &s_bang)
+                if(e->e_w.w_symbol == &s_bang)
                 {
                     outlet_bang(e->e_outlet);
                     return;
                 }
             }
         }
-        else if (argv[0].a_type == A_FLOAT)    /* one float arg */
+        else if(argv[0].a_type == A_FLOAT) /* one float arg */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
-                if (e->e_w.w_symbol == &s_float)
+                if(e->e_w.w_symbol == &s_float)
                 {
                     outlet_float(e->e_outlet, argv[0].a_w.w_float);
                     return;
                 }
             }
         }
-        else if (argv[0].a_type == A_POINTER)    /* one pointer arg */
+        else if(argv[0].a_type == A_POINTER) /* one pointer arg */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
-                if (e->e_w.w_symbol == &s_pointer)
+                if(e->e_w.w_symbol == &s_pointer)
                 {
                     outlet_pointer(e->e_outlet, argv[0].a_w.w_gpointer);
                     return;
                 }
             }
         }
-        else                                     /* one symbol arg */
+        else /* one symbol arg */
         {
-            for (nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
+            for(nelement = x->x_nelement, e = x->x_vec; nelement--; e++)
             {
-                if (e->e_w.w_symbol == &s_symbol)
+                if(e->e_w.w_symbol == &s_symbol)
                 {
                     outlet_symbol(e->e_outlet, argv[0].a_w.w_symbol);
                     return;
@@ -614,10 +605,9 @@ static void route_list(t_route *x, t_symbol *sel, int argc, t_atom *argv)
             }
         }
     }
- rejected:
+rejected:
     outlet_list(x->x_rejectout, 0, argc, argv);
 }
-
 
 static void route_free(t_route *x)
 {
@@ -628,9 +618,9 @@ static void *route_new(t_symbol *s, int argc, t_atom *argv)
 {
     int n;
     t_routeelement *e;
-    t_route *x = (t_route *)pd_new(route_class);
+    t_route *x = (t_route *) pd_new(route_class);
     t_atom a;
-    if (argc == 0)
+    if(argc == 0)
     {
         argc = 1;
         SETFLOAT(&a, 0);
@@ -638,19 +628,21 @@ static void *route_new(t_symbol *s, int argc, t_atom *argv)
     }
     x->x_type = argv[0].a_type;
     x->x_nelement = argc;
-    x->x_vec = (t_routeelement *)getbytes(argc * sizeof(*x->x_vec));
-    for (n = 0, e = x->x_vec; n < argc; n++, e++)
+    x->x_vec = (t_routeelement *) getbytes(argc * sizeof(*x->x_vec));
+    for(n = 0, e = x->x_vec; n < argc; n++, e++)
     {
         e->e_outlet = outlet_new(&x->x_obj, &s_list);
-        if (x->x_type == A_FLOAT)
+        if(x->x_type == A_FLOAT)
             e->e_w.w_float = atom_getfloatarg(n, argc, argv);
-        else e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
+        else
+            e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
     }
-    if (argc == 1)
+    if(argc == 1)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             floatinlet_new(&x->x_obj, &x->x_vec->e_w.w_float);
-        else symbolinlet_new(&x->x_obj, &x->x_vec->e_w.w_symbol);
+        else
+            symbolinlet_new(&x->x_obj, &x->x_vec->e_w.w_symbol);
     }
     x->x_rejectout = outlet_new(&x->x_obj, &s_list);
     return (x);
@@ -658,8 +650,8 @@ static void *route_new(t_symbol *s, int argc, t_atom *argv)
 
 void route_setup(void)
 {
-    route_class = class_new(gensym("route"), (t_newmethod)route_new,
-        (t_method)route_free, sizeof(t_route), 0, A_GIMME, 0);
+    route_class = class_new(gensym("route"), (t_newmethod) route_new,
+        (t_method) route_free, sizeof(t_route), 0, A_GIMME, 0);
     class_addlist(route_class, route_list);
     class_addanything(route_class, route_anything);
 }
@@ -680,12 +672,12 @@ typedef struct _pack
 
 static void *pack_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_pack *x = (t_pack *)pd_new(pack_class);
+    t_pack *x = (t_pack *) pd_new(pack_class);
     t_atom defarg[2], *ap, *vec, *vp;
     t_gpointer *gp;
     int nptr = 0;
     int i;
-    if (!argc)
+    if(!argc)
     {
         argv = defarg;
         argc = 2;
@@ -694,45 +686,44 @@ static void *pack_new(t_symbol *s, int argc, t_atom *argv)
     }
 
     x->x_n = argc;
-    vec = x->x_vec = (t_atom *)getbytes(argc * sizeof(*x->x_vec));
-    x->x_outvec = (t_atom *)getbytes(argc * sizeof(*x->x_outvec));
+    vec = x->x_vec = (t_atom *) getbytes(argc * sizeof(*x->x_vec));
+    x->x_outvec = (t_atom *) getbytes(argc * sizeof(*x->x_outvec));
 
-    for (i = argc, ap = argv; i--; ap++)
-        if (ap->a_type == A_SYMBOL && *ap->a_w.w_symbol->s_name == 'p')
-            nptr++;
+    for(i = argc, ap = argv; i--; ap++)
+        if(ap->a_type == A_SYMBOL && *ap->a_w.w_symbol->s_name == 'p') nptr++;
 
-    gp = x->x_gpointer = (t_gpointer *)t_getbytes(nptr * sizeof (*gp));
+    gp = x->x_gpointer = (t_gpointer *) t_getbytes(nptr * sizeof(*gp));
     x->x_nptr = nptr;
 
-    for (i = 0, vp = x->x_vec, ap = argv; i < argc; i++, ap++, vp++)
+    for(i = 0, vp = x->x_vec, ap = argv; i < argc; i++, ap++, vp++)
     {
-        if (ap->a_type == A_FLOAT)
+        if(ap->a_type == A_FLOAT)
         {
             *vp = *ap;
-            if (i) floatinlet_new(&x->x_obj, &vp->a_w.w_float);
+            if(i) floatinlet_new(&x->x_obj, &vp->a_w.w_float);
         }
-        else if (ap->a_type == A_SYMBOL)
+        else if(ap->a_type == A_SYMBOL)
         {
             char c = *ap->a_w.w_symbol->s_name;
-            if (c == 's')
+            if(c == 's')
             {
                 SETSYMBOL(vp, &s_symbol);
-                if (i) symbolinlet_new(&x->x_obj, &vp->a_w.w_symbol);
+                if(i) symbolinlet_new(&x->x_obj, &vp->a_w.w_symbol);
             }
-            else if (c == 'p')
+            else if(c == 'p')
             {
                 vp->a_type = A_POINTER;
                 vp->a_w.w_gpointer = gp;
                 gpointer_init(gp);
-                if (i) pointerinlet_new(&x->x_obj, gp);
+                if(i) pointerinlet_new(&x->x_obj, gp);
                 gp++;
             }
             else
             {
-                if (c != 'f') pd_error(x, "pack: %s: bad type",
-                    ap->a_w.w_symbol->s_name);
+                if(c != 'f')
+                    pd_error(x, "pack: %s: bad type", ap->a_w.w_symbol->s_name);
                 SETFLOAT(vp, 0);
-                if (i) floatinlet_new(&x->x_obj, &vp->a_w.w_float);
+                if(i) floatinlet_new(&x->x_obj, &vp->a_w.w_float);
             }
         }
     }
@@ -742,21 +733,21 @@ static void *pack_new(t_symbol *s, int argc, t_atom *argv)
 
 static void pack_bang(t_pack *x)
 {
-    int i, reentered = 0, size = (int)(x->x_n * sizeof(t_atom));
+    int i, reentered = 0, size = (int) (x->x_n * sizeof(t_atom));
     t_gpointer *gp;
     t_atom *outvec;
-    for (i = (int)x->x_nptr, gp = x->x_gpointer; i--; gp++)
-        if (!gpointer_check(gp, 1))
+    for(i = (int) x->x_nptr, gp = x->x_gpointer; i--; gp++)
+        if(!gpointer_check(gp, 1))
+        {
+            pd_error(x, "pack: stale pointer");
+            return;
+        }
+    /* reentrancy protection.  The first time through use the pre-allocated
+    x_outvec; if we're reentered we have to allocate new memory. */
+    if(!x->x_outvec)
     {
-        pd_error(x, "pack: stale pointer");
-        return;
-    }
-        /* reentrancy protection.  The first time through use the pre-allocated
-        x_outvec; if we're reentered we have to allocate new memory. */
-    if (!x->x_outvec)
-    {
-            /* LATER figure out how to deal with reentrancy and pointers... */
-        if (x->x_nptr)
+        /* LATER figure out how to deal with reentrancy and pointers... */
+        if(x->x_nptr)
             post("pack_bang: warning: reentry with pointers unprotected");
         outvec = t_getbytes(size);
         reentered = 1;
@@ -767,42 +758,46 @@ static void pack_bang(t_pack *x)
         x->x_outvec = 0;
     }
     memcpy(outvec, x->x_vec, size);
-    outlet_list(x->x_obj.ob_outlet, &s_list, (int)x->x_n, outvec);
-    if (reentered)
+    outlet_list(x->x_obj.ob_outlet, &s_list, (int) x->x_n, outvec);
+    if(reentered)
         t_freebytes(outvec, size);
-    else x->x_outvec = outvec;
+    else
+        x->x_outvec = outvec;
 }
 
 static void pack_pointer(t_pack *x, t_gpointer *gp)
 {
-    if (x->x_vec->a_type == A_POINTER)
+    if(x->x_vec->a_type == A_POINTER)
     {
         gpointer_unset(x->x_gpointer);
         *x->x_gpointer = *gp;
-        if (gp->gp_stub) gp->gp_stub->gs_refcount++;
+        if(gp->gp_stub) gp->gp_stub->gs_refcount++;
         pack_bang(x);
     }
-    else pd_error(x, "pack_pointer: wrong type");
+    else
+        pd_error(x, "pack_pointer: wrong type");
 }
 
 static void pack_float(t_pack *x, t_float f)
 {
-    if (x->x_vec->a_type == A_FLOAT)
+    if(x->x_vec->a_type == A_FLOAT)
     {
         x->x_vec->a_w.w_float = f;
         pack_bang(x);
     }
-    else pd_error(x, "pack_float: wrong type");
+    else
+        pd_error(x, "pack_float: wrong type");
 }
 
 static void pack_symbol(t_pack *x, t_symbol *s)
 {
-    if (x->x_vec->a_type == A_SYMBOL)
+    if(x->x_vec->a_type == A_SYMBOL)
     {
         x->x_vec->a_w.w_symbol = s;
         pack_bang(x);
     }
-    else pd_error(x, "pack_symbol: wrong type");
+    else
+        pd_error(x, "pack_symbol: wrong type");
 }
 
 static void pack_list(t_pack *x, t_symbol *s, int ac, t_atom *av)
@@ -812,12 +807,12 @@ static void pack_list(t_pack *x, t_symbol *s, int ac, t_atom *av)
 
 static void pack_anything(t_pack *x, t_symbol *s, int ac, t_atom *av)
 {
-    t_atom *av2 = (t_atom *)getbytes((ac + 1) * sizeof(t_atom));
+    t_atom *av2 = (t_atom *) getbytes((ac + 1) * sizeof(t_atom));
     int i;
-    for (i = 0; i < ac; i++)
+    for(i = 0; i < ac; i++)
         av2[i + 1] = av[i];
     SETSYMBOL(av2, s);
-    obj_list(&x->x_obj, 0, ac+1, av2);
+    obj_list(&x->x_obj, 0, ac + 1, av2);
     freebytes(av2, (ac + 1) * sizeof(t_atom));
 }
 
@@ -825,7 +820,7 @@ static void pack_free(t_pack *x)
 {
     t_gpointer *gp;
     int i;
-    for (gp = x->x_gpointer, i = (int)x->x_nptr; i--; gp++)
+    for(gp = x->x_gpointer, i = (int) x->x_nptr; i--; gp++)
         gpointer_unset(gp);
     freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
     freebytes(x->x_outvec, x->x_n * sizeof(*x->x_outvec));
@@ -834,8 +829,8 @@ static void pack_free(t_pack *x)
 
 static void pack_setup(void)
 {
-    pack_class = class_new(gensym("pack"), (t_newmethod)pack_new,
-        (t_method)pack_free, sizeof(t_pack), 0, A_GIMME, 0);
+    pack_class = class_new(gensym("pack"), (t_newmethod) pack_new,
+        (t_method) pack_free, sizeof(t_pack), 0, A_GIMME, 0);
     class_addbang(pack_class, pack_bang);
     class_addpointer(pack_class, pack_pointer);
     class_addfloat(pack_class, pack_float);
@@ -863,11 +858,11 @@ typedef struct _unpack
 
 static void *unpack_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_unpack *x = (t_unpack *)pd_new(unpack_class);
+    t_unpack *x = (t_unpack *) pd_new(unpack_class);
     t_atom defarg[2], *ap;
     t_unpackout *u;
     int i;
-    if (!argc)
+    if(!argc)
     {
         argv = defarg;
         argc = 2;
@@ -875,34 +870,35 @@ static void *unpack_new(t_symbol *s, int argc, t_atom *argv)
         SETFLOAT(&defarg[1], 0);
     }
     x->x_n = argc;
-    x->x_vec = (t_unpackout *)getbytes(argc * sizeof(*x->x_vec));
-    for (i = 0, ap = argv, u = x->x_vec; i < argc; u++, ap++, i++)
+    x->x_vec = (t_unpackout *) getbytes(argc * sizeof(*x->x_vec));
+    for(i = 0, ap = argv, u = x->x_vec; i < argc; u++, ap++, i++)
     {
         t_atomtype type = ap->a_type;
-        if (type == A_SYMBOL)
+        if(type == A_SYMBOL)
         {
             char c = *ap->a_w.w_symbol->s_name;
-            if (c == 's')
+            if(c == 's')
             {
                 u->u_type = A_SYMBOL;
                 u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
             }
-            else if (c == 'p')
+            else if(c == 'p')
             {
-                u->u_type =  A_POINTER;
+                u->u_type = A_POINTER;
                 u->u_outlet = outlet_new(&x->x_obj, &s_pointer);
             }
             else
             {
-                if (c != 'f') pd_error(x, "unpack: %s: bad type",
-                    ap->a_w.w_symbol->s_name);
+                if(c != 'f')
+                    pd_error(
+                        x, "unpack: %s: bad type", ap->a_w.w_symbol->s_name);
                 u->u_type = A_FLOAT;
                 u->u_outlet = outlet_new(&x->x_obj, &s_float);
             }
         }
         else
         {
-            u->u_type =  A_FLOAT;
+            u->u_type = A_FLOAT;
             u->u_outlet = outlet_new(&x->x_obj, &s_float);
         }
     }
@@ -914,28 +910,29 @@ static void unpack_list(t_unpack *x, t_symbol *s, int argc, t_atom *argv)
     t_atom *ap;
     t_unpackout *u;
     int i;
-    if (argc > x->x_n) argc = (int)x->x_n;
-    for (i = argc, u = x->x_vec + i, ap = argv + i; u--, ap--, i--;)
+    if(argc > x->x_n) argc = (int) x->x_n;
+    for(i = argc, u = x->x_vec + i, ap = argv + i; u--, ap--, i--;)
     {
         t_atomtype type = u->u_type;
-        if (type != ap->a_type)
+        if(type != ap->a_type)
             pd_error(x, "unpack: type mismatch");
-        else if (type == A_FLOAT)
+        else if(type == A_FLOAT)
             outlet_float(u->u_outlet, ap->a_w.w_float);
-        else if (type == A_SYMBOL)
+        else if(type == A_SYMBOL)
             outlet_symbol(u->u_outlet, ap->a_w.w_symbol);
-        else outlet_pointer(u->u_outlet, ap->a_w.w_gpointer);
+        else
+            outlet_pointer(u->u_outlet, ap->a_w.w_gpointer);
     }
 }
 
 static void unpack_anything(t_unpack *x, t_symbol *s, int ac, t_atom *av)
 {
-    t_atom *av2 = (t_atom *)getbytes((ac + 1) * sizeof(t_atom));
+    t_atom *av2 = (t_atom *) getbytes((ac + 1) * sizeof(t_atom));
     int i;
-    for (i = 0; i < ac; i++)
+    for(i = 0; i < ac; i++)
         av2[i + 1] = av[i];
     SETSYMBOL(av2, s);
-    unpack_list(x, 0, ac+1, av2);
+    unpack_list(x, 0, ac + 1, av2);
     freebytes(av2, (ac + 1) * sizeof(t_atom));
 }
 
@@ -946,8 +943,8 @@ static void unpack_free(t_unpack *x)
 
 static void unpack_setup(void)
 {
-    unpack_class = class_new(gensym("unpack"), (t_newmethod)unpack_new,
-        (t_method)unpack_free, sizeof(t_unpack), 0, A_GIMME, 0);
+    unpack_class = class_new(gensym("unpack"), (t_newmethod) unpack_new,
+        (t_method) unpack_free, sizeof(t_unpack), 0, A_GIMME, 0);
     class_addlist(unpack_class, unpack_list);
     class_addanything(unpack_class, unpack_anything);
 }
@@ -964,7 +961,7 @@ static t_class *trigger_class;
 
 typedef struct triggerout
 {
-    int u_type;         /* outlet type from above */
+    int u_type; /* outlet type from above */
     t_outlet *u_outlet;
 } t_triggerout;
 
@@ -977,11 +974,11 @@ typedef struct _trigger
 
 static void *trigger_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_trigger *x = (t_trigger *)pd_new(trigger_class);
+    t_trigger *x = (t_trigger *) pd_new(trigger_class);
     t_atom defarg[2], *ap;
     t_triggerout *u;
     int i;
-    if (!argc)
+    if(!argc)
     {
         argv = defarg;
         argc = 2;
@@ -989,29 +986,32 @@ static void *trigger_new(t_symbol *s, int argc, t_atom *argv)
         SETSYMBOL(&defarg[1], &s_bang);
     }
     x->x_n = argc;
-    x->x_vec = (t_triggerout *)getbytes(argc * sizeof(*x->x_vec));
-    for (i = 0, ap = argv, u = x->x_vec; i < argc; u++, ap++, i++)
+    x->x_vec = (t_triggerout *) getbytes(argc * sizeof(*x->x_vec));
+    for(i = 0, ap = argv, u = x->x_vec; i < argc; u++, ap++, i++)
     {
         t_atomtype thistype = ap->a_type;
         char c;
-        if (thistype == TR_SYMBOL) c = ap->a_w.w_symbol->s_name[0];
-        else if (thistype == TR_FLOAT) c = 'f';
-        else c = 0;
-        if (c == 'p')
+        if(thistype == TR_SYMBOL)
+            c = ap->a_w.w_symbol->s_name[0];
+        else if(thistype == TR_FLOAT)
+            c = 'f';
+        else
+            c = 0;
+        if(c == 'p')
             u->u_type = TR_POINTER,
-                u->u_outlet = outlet_new(&x->x_obj, &s_pointer);
-        else if (c == 'f')
+            u->u_outlet = outlet_new(&x->x_obj, &s_pointer);
+        else if(c == 'f')
             u->u_type = TR_FLOAT, u->u_outlet = outlet_new(&x->x_obj, &s_float);
-        else if (c == 'b')
+        else if(c == 'b')
             u->u_type = TR_BANG, u->u_outlet = outlet_new(&x->x_obj, &s_bang);
-        else if (c == 'l')
+        else if(c == 'l')
             u->u_type = TR_LIST, u->u_outlet = outlet_new(&x->x_obj, &s_list);
-        else if (c == 's')
+        else if(c == 's')
             u->u_type = TR_SYMBOL,
-                u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
-        else if (c == 'a')
+            u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
+        else if(c == 'a')
             u->u_type = TR_ANYTHING,
-                u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
+            u->u_outlet = outlet_new(&x->x_obj, &s_symbol);
         else
         {
             pd_error(x, "trigger: %s: bad type", ap->a_w.w_symbol->s_name);
@@ -1025,24 +1025,26 @@ static void trigger_list(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_triggerout *u;
     int i;
-    for (i = (int)x->x_n, u = x->x_vec + i; u--, i--;)
+    for(i = (int) x->x_n, u = x->x_vec + i; u--, i--;)
     {
-        if (u->u_type == TR_FLOAT)
+        if(u->u_type == TR_FLOAT)
             outlet_float(u->u_outlet, (argc ? atom_getfloat(argv) : 0));
-        else if (u->u_type == TR_BANG)
+        else if(u->u_type == TR_BANG)
             outlet_bang(u->u_outlet);
-        else if (u->u_type == TR_SYMBOL)
-            outlet_symbol(u->u_outlet,
-                (argc ? atom_getsymbol(argv) : &s_symbol));
-        else if (u->u_type == TR_POINTER)
+        else if(u->u_type == TR_SYMBOL)
+            outlet_symbol(
+                u->u_outlet, (argc ? atom_getsymbol(argv) : &s_symbol));
+        else if(u->u_type == TR_POINTER)
         {
-            if (!argc || argv->a_type != TR_POINTER)
+            if(!argc || argv->a_type != TR_POINTER)
                 pd_error(x, "trigger: bad pointer");
-            else outlet_pointer(u->u_outlet, argv->a_w.w_gpointer);
+            else
+                outlet_pointer(u->u_outlet, argv->a_w.w_gpointer);
         }
-        else if (u->u_type == TR_LIST)
+        else if(u->u_type == TR_LIST)
             outlet_list(u->u_outlet, &s_list, argc, argv);
-        else outlet_anything(u->u_outlet, s, argc, argv);
+        else
+            outlet_anything(u->u_outlet, s, argc, argv);
     }
 }
 
@@ -1050,20 +1052,19 @@ static void trigger_anything(t_trigger *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_triggerout *u;
     int i;
-    for (i = (int)x->x_n, u = x->x_vec + i; u--, i--;)
+    for(i = (int) x->x_n, u = x->x_vec + i; u--, i--;)
     {
-        if (u->u_type == TR_BANG)
+        if(u->u_type == TR_BANG)
             outlet_bang(u->u_outlet);
-        else if (u->u_type == TR_ANYTHING)
+        else if(u->u_type == TR_ANYTHING)
             outlet_anything(u->u_outlet, s, argc, argv);
-        else pd_error(x, "trigger: generic messages can only be converted to 'b' or 'a'");
+        else
+            pd_error(x, "trigger: generic messages can only be converted to "
+                        "'b' or 'a'");
     }
 }
 
-static void trigger_bang(t_trigger *x)
-{
-    trigger_list(x, &s_bang, 0, 0);
-}
+static void trigger_bang(t_trigger *x) { trigger_list(x, &s_bang, 0, 0); }
 
 static void trigger_pointer(t_trigger *x, t_gpointer *gp)
 {
@@ -1093,13 +1094,13 @@ static void trigger_free(t_trigger *x)
 
 static void trigger_setup(void)
 {
-    trigger_class = class_new(gensym("trigger"), (t_newmethod)trigger_new,
-        (t_method)trigger_free, sizeof(t_trigger), 0, A_GIMME, 0);
-    class_addcreator((t_newmethod)trigger_new, gensym("t"), A_GIMME, 0);
+    trigger_class = class_new(gensym("trigger"), (t_newmethod) trigger_new,
+        (t_method) trigger_free, sizeof(t_trigger), 0, A_GIMME, 0);
+    class_addcreator((t_newmethod) trigger_new, gensym("t"), A_GIMME, 0);
     class_addlist(trigger_class, trigger_list);
     class_addbang(trigger_class, trigger_bang);
     class_addpointer(trigger_class, trigger_pointer);
-    class_addfloat(trigger_class, (t_method)trigger_float);
+    class_addfloat(trigger_class, (t_method) trigger_float);
     class_addsymbol(trigger_class, trigger_symbol);
     class_addanything(trigger_class, trigger_anything);
 }
@@ -1115,7 +1116,7 @@ typedef struct _spigot
 
 static void *spigot_new(t_floatarg f)
 {
-    t_spigot *x = (t_spigot *)pd_new(spigot_class);
+    t_spigot *x = (t_spigot *) pd_new(spigot_class);
     floatinlet_new(&x->x_obj, &x->x_state);
     outlet_new(&x->x_obj, 0);
     x->x_state = f;
@@ -1124,37 +1125,37 @@ static void *spigot_new(t_floatarg f)
 
 static void spigot_bang(t_spigot *x)
 {
-    if (x->x_state != 0) outlet_bang(x->x_obj.ob_outlet);
+    if(x->x_state != 0) outlet_bang(x->x_obj.ob_outlet);
 }
 
 static void spigot_pointer(t_spigot *x, t_gpointer *gp)
 {
-    if (x->x_state != 0) outlet_pointer(x->x_obj.ob_outlet, gp);
+    if(x->x_state != 0) outlet_pointer(x->x_obj.ob_outlet, gp);
 }
 
 static void spigot_float(t_spigot *x, t_float f)
 {
-    if (x->x_state != 0) outlet_float(x->x_obj.ob_outlet, f);
+    if(x->x_state != 0) outlet_float(x->x_obj.ob_outlet, f);
 }
 
 static void spigot_symbol(t_spigot *x, t_symbol *s)
 {
-    if (x->x_state != 0) outlet_symbol(x->x_obj.ob_outlet, s);
+    if(x->x_state != 0) outlet_symbol(x->x_obj.ob_outlet, s);
 }
 
 static void spigot_list(t_spigot *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_state != 0) outlet_list(x->x_obj.ob_outlet, s, argc, argv);
+    if(x->x_state != 0) outlet_list(x->x_obj.ob_outlet, s, argc, argv);
 }
 
 static void spigot_anything(t_spigot *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_state != 0) outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
+    if(x->x_state != 0) outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
 }
 
 static void spigot_setup(void)
 {
-    spigot_class = class_new(gensym("spigot"), (t_newmethod)spigot_new, 0,
+    spigot_class = class_new(gensym("spigot"), (t_newmethod) spigot_new, 0,
         sizeof(t_spigot), 0, A_DEFFLOAT, 0);
     class_addbang(spigot_class, spigot_bang);
     class_addpointer(spigot_class, spigot_pointer);
@@ -1176,7 +1177,7 @@ typedef struct _moses
 
 static void *moses_new(t_floatarg f)
 {
-    t_moses *x = (t_moses *)pd_new(moses_class);
+    t_moses *x = (t_moses *) pd_new(moses_class);
     floatinlet_new(&x->x_ob, &x->x_y);
     outlet_new(&x->x_ob, &s_float);
     x->x_out2 = outlet_new(&x->x_ob, &s_float);
@@ -1186,13 +1187,15 @@ static void *moses_new(t_floatarg f)
 
 static void moses_float(t_moses *x, t_float f)
 {
-    if (f < x->x_y) outlet_float(x->x_ob.ob_outlet, f);
-    else outlet_float(x->x_out2, f);
+    if(f < x->x_y)
+        outlet_float(x->x_ob.ob_outlet, f);
+    else
+        outlet_float(x->x_out2, f);
 }
 
 static void moses_setup(void)
 {
-    moses_class = class_new(gensym("moses"), (t_newmethod)moses_new, 0,
+    moses_class = class_new(gensym("moses"), (t_newmethod) moses_new, 0,
         sizeof(t_moses), 0, A_DEFFLOAT, 0);
     class_addfloat(moses_class, moses_float);
 }
@@ -1210,7 +1213,7 @@ typedef struct _until
 
 static void *until_new(void)
 {
-    t_until *x = (t_until *)pd_new(until_class);
+    t_until *x = (t_until *) pd_new(until_class);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("bang"), gensym("bang2"));
     outlet_new(&x->x_obj, &s_bang);
     x->x_run = 0;
@@ -1221,39 +1224,36 @@ static void until_bang(t_until *x)
 {
     x->x_run = 1;
     x->x_count = -1;
-    while (x->x_run && x->x_count)
+    while(x->x_run && x->x_count)
         x->x_count--, outlet_bang(x->x_obj.ob_outlet);
 }
 
 static void until_float(t_until *x, t_float f)
 {
-    if (f < 0)
-        f = 0;
+    if(f < 0) f = 0;
     x->x_run = 1;
     x->x_count = f;
-    while (x->x_run && x->x_count)
+    while(x->x_run && x->x_count)
         x->x_count--, outlet_bang(x->x_obj.ob_outlet);
 }
 
-static void until_bang2(t_until *x)
-{
-    x->x_run = 0;
-}
+static void until_bang2(t_until *x) { x->x_run = 0; }
 
 static void until_setup(void)
 {
-    until_class = class_new(gensym("until"), (t_newmethod)until_new, 0,
-        sizeof(t_until), 0, 0);
+    until_class = class_new(
+        gensym("until"), (t_newmethod) until_new, 0, sizeof(t_until), 0, 0);
     class_addbang(until_class, until_bang);
     class_addfloat(until_class, until_float);
-    class_addmethod(until_class, (t_method)until_bang2, gensym("bang2"), 0);
+    class_addmethod(until_class, (t_method) until_bang2, gensym("bang2"), 0);
 }
 
 /* ----------------------- makefilename --------------------- */
 
 static t_class *makefilename_class;
 
-typedef enum {
+typedef enum
+{
     NONE = 0,
     INT,
     FLOAT,
@@ -1268,33 +1268,41 @@ typedef struct _makefilename
     t_printtype x_accept;
 } t_makefilename;
 
-static const char* _formatscan(const char*str, t_printtype*typ) {
-    int infmt=0;
-    for (; *str; str++) {
-        if (!infmt && *str=='%') {
-            infmt=1;
+static const char *_formatscan(const char *str, t_printtype *typ)
+{
+    int infmt = 0;
+    for(; *str; str++)
+    {
+        if(!infmt && *str == '%')
+        {
+            infmt = 1;
             continue;
         }
-        if (infmt) {
-            if (*str=='%') {
-                infmt=0;
+        if(infmt)
+        {
+            if(*str == '%')
+            {
+                infmt = 0;
                 continue;
             }
-            if (strchr("-.#0123456789",*str)!=0)
-                continue;
-            if (*str=='s') {
+            if(strchr("-.#0123456789", *str) != 0) continue;
+            if(*str == 's')
+            {
                 *typ = STRING;
                 return str;
             }
-            if (strchr("fgGeE",*str)!=0) {
+            if(strchr("fgGeE", *str) != 0)
+            {
                 *typ = FLOAT;
                 return str;
             }
-            if (strchr("xXdiouc",*str)!=0) {
+            if(strchr("xXdiouc", *str) != 0)
+            {
                 *typ = INT;
                 return str;
             }
-           if (strchr("p",*str)!=0) {
+            if(strchr("p", *str) != 0)
+            {
                 *typ = POINTER;
                 return str;
             }
@@ -1308,15 +1316,21 @@ static void makefilename_scanformat(t_makefilename *x)
 {
     const char *str;
     t_printtype typ;
-    if (!x->x_format) return;
+    if(!x->x_format) return;
     str = x->x_format->s_name;
     str = _formatscan(str, &typ);
     x->x_accept = typ;
-    if (str && (NONE != typ)) {
-            /* try again, to see if there's another format specifier (which we forbid) */
+    if(str && (NONE != typ))
+    {
+        /* try again, to see if there's another format specifier (which we
+         * forbid) */
         str = _formatscan(str, &typ);
-        if (NONE != typ) {
-            pd_error(x, "makefilename: invalid format string '%s' (too many format specifiers)", x->x_format->s_name);
+        if(NONE != typ)
+        {
+            pd_error(x,
+                "makefilename: invalid format string '%s' (too many format "
+                "specifiers)",
+                x->x_format->s_name);
             x->x_format = 0;
             return;
         }
@@ -1325,9 +1339,8 @@ static void makefilename_scanformat(t_makefilename *x)
 
 static void *makefilename_new(t_symbol *s)
 {
-    t_makefilename *x = (t_makefilename *)pd_new(makefilename_class);
-    if (!s || !*s->s_name)
-        s = gensym("file.%d");
+    t_makefilename *x = (t_makefilename *) pd_new(makefilename_class);
+    if(!s || !*s->s_name) s = gensym("file.%d");
     outlet_new(&x->x_obj, &s_symbol);
     x->x_format = s;
     x->x_accept = NONE;
@@ -1338,82 +1351,88 @@ static void *makefilename_new(t_symbol *s)
 static void makefilename_float(t_makefilename *x, t_floatarg f)
 {
     char buf[MAXPDSTRING];
-    if(!x->x_format) {
+    if(!x->x_format)
+    {
         pd_error(x, "makefilename: no format specifier given");
         return;
     }
-    switch(x->x_accept) {
-    case NONE:
-        sprintf(buf, "%s",  x->x_format->s_name);
-        break;
-    case INT: case POINTER:
-        sprintf(buf, x->x_format->s_name, (int)f);
-        break;
-    case FLOAT:
-        sprintf(buf, x->x_format->s_name, f);
-        break;
-    case STRING: {
-        char buf2[MAXPDSTRING];
-        sprintf(buf2, "%g", f);
-        sprintf(buf, x->x_format->s_name, buf2);
-        break;
+    switch(x->x_accept)
+    {
+        case NONE:
+            sprintf(buf, "%s", x->x_format->s_name);
+            break;
+        case INT:
+        case POINTER:
+            sprintf(buf, x->x_format->s_name, (int) f);
+            break;
+        case FLOAT:
+            sprintf(buf, x->x_format->s_name, f);
+            break;
+        case STRING:
+        {
+            char buf2[MAXPDSTRING];
+            sprintf(buf2, "%g", f);
+            sprintf(buf, x->x_format->s_name, buf2);
+            break;
+        }
+        default:
+            sprintf(buf, "%s", x->x_format->s_name);
     }
-    default:
-        sprintf(buf, "%s", x->x_format->s_name);
-    }
-    if (buf[0]!=0)
-        outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
+    if(buf[0] != 0) outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
 }
 
 static void makefilename_symbol(t_makefilename *x, t_symbol *s)
 {
     char buf[MAXPDSTRING];
-    if(!x->x_format) {
+    if(!x->x_format)
+    {
         pd_error(x, "makefilename: no format specifier given");
         return;
     }
-    switch(x->x_accept) {
-    case STRING: case POINTER:
-        sprintf(buf, x->x_format->s_name, s->s_name);
-        break;
-    case INT:
-        sprintf(buf, x->x_format->s_name, 0);
-        break;
-    case FLOAT:
-        sprintf(buf, x->x_format->s_name, 0.);
-        break;
-    case NONE:
-        sprintf(buf, "%s", x->x_format->s_name);
-        break;
-    default:
-        sprintf(buf, "%s", x->x_format->s_name);
+    switch(x->x_accept)
+    {
+        case STRING:
+        case POINTER:
+            sprintf(buf, x->x_format->s_name, s->s_name);
+            break;
+        case INT:
+            sprintf(buf, x->x_format->s_name, 0);
+            break;
+        case FLOAT:
+            sprintf(buf, x->x_format->s_name, 0.);
+            break;
+        case NONE:
+            sprintf(buf, "%s", x->x_format->s_name);
+            break;
+        default:
+            sprintf(buf, "%s", x->x_format->s_name);
     }
-    if (buf[0]!=0)
-        outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
+    if(buf[0] != 0) outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
 }
 
 static void makefilename_bang(t_makefilename *x)
 {
     char buf[MAXPDSTRING];
-    if(!x->x_format) {
+    if(!x->x_format)
+    {
         pd_error(x, "makefilename: no format specifier given");
         return;
     }
-    switch(x->x_accept) {
-    case INT:
-        sprintf(buf, x->x_format->s_name, 0);
-        break;
-    case FLOAT:
-        sprintf(buf, x->x_format->s_name, 0.);
-        break;
-    case NONE:
-        sprintf(buf, "%s", x->x_format->s_name);
-        break;
-    default:
-        sprintf(buf, "%s", x->x_format->s_name);
+    switch(x->x_accept)
+    {
+        case INT:
+            sprintf(buf, x->x_format->s_name, 0);
+            break;
+        case FLOAT:
+            sprintf(buf, x->x_format->s_name, 0.);
+            break;
+        case NONE:
+            sprintf(buf, "%s", x->x_format->s_name);
+            break;
+        default:
+            sprintf(buf, "%s", x->x_format->s_name);
     }
-    if (buf[0]!=0)
-        outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
+    if(buf[0] != 0) outlet_symbol(x->x_obj.ob_outlet, gensym(buf));
 }
 
 static void makefilename_set(t_makefilename *x, t_symbol *s)
@@ -1424,13 +1443,13 @@ static void makefilename_set(t_makefilename *x, t_symbol *s)
 
 static void makefilename_setup(void)
 {
-    makefilename_class = class_new(gensym("makefilename"),
-    (t_newmethod)makefilename_new, 0,
-        sizeof(t_makefilename), 0, A_DEFSYM, 0);
+    makefilename_class =
+        class_new(gensym("makefilename"), (t_newmethod) makefilename_new, 0,
+            sizeof(t_makefilename), 0, A_DEFSYM, 0);
     class_addfloat(makefilename_class, makefilename_float);
     class_addsymbol(makefilename_class, makefilename_symbol);
     class_addbang(makefilename_class, makefilename_bang);
-    class_addmethod(makefilename_class, (t_method)makefilename_set,
+    class_addmethod(makefilename_class, (t_method) makefilename_set,
         gensym("set"), A_SYMBOL, 0);
 }
 
@@ -1447,7 +1466,7 @@ typedef struct _swap
 
 static void *swap_new(t_floatarg f)
 {
-    t_swap *x = (t_swap *)pd_new(swap_class);
+    t_swap *x = (t_swap *) pd_new(swap_class);
     x->x_f2 = f;
     x->x_f1 = 0;
     outlet_new(&x->x_obj, &s_float);
@@ -1470,9 +1489,9 @@ static void swap_float(t_swap *x, t_float f)
 
 void swap_setup(void)
 {
-    swap_class = class_new(gensym("swap"), (t_newmethod)swap_new, 0,
+    swap_class = class_new(gensym("swap"), (t_newmethod) swap_new, 0,
         sizeof(t_swap), 0, A_DEFFLOAT, 0);
-    class_addcreator((t_newmethod)swap_new, gensym("fswap"), A_DEFFLOAT, 0);
+    class_addcreator((t_newmethod) swap_new, gensym("fswap"), A_DEFFLOAT, 0);
     class_addbang(swap_class, swap_bang);
     class_addfloat(swap_class, swap_float);
 }
@@ -1488,7 +1507,7 @@ typedef struct _change
 
 static void *change_new(t_floatarg f)
 {
-    t_change *x = (t_change *)pd_new(change_class);
+    t_change *x = (t_change *) pd_new(change_class);
     x->x_f = f;
     outlet_new(&x->x_obj, &s_float);
     return (x);
@@ -1501,26 +1520,23 @@ static void change_bang(t_change *x)
 
 static void change_float(t_change *x, t_float f)
 {
-    if (f != x->x_f)
+    if(f != x->x_f)
     {
         x->x_f = f;
         outlet_float(x->x_obj.ob_outlet, x->x_f);
     }
 }
 
-static void change_set(t_change *x, t_float f)
-{
-    x->x_f = f;
-}
+static void change_set(t_change *x, t_float f) { x->x_f = f; }
 
 void change_setup(void)
 {
-    change_class = class_new(gensym("change"), (t_newmethod)change_new, 0,
+    change_class = class_new(gensym("change"), (t_newmethod) change_new, 0,
         sizeof(t_change), 0, A_DEFFLOAT, 0);
     class_addbang(change_class, change_bang);
     class_addfloat(change_class, change_float);
-    class_addmethod(change_class, (t_method)change_set, gensym("set"),
-        A_DEFFLOAT, 0);
+    class_addmethod(
+        change_class, (t_method) change_set, gensym("set"), A_DEFFLOAT, 0);
 }
 
 /* -------------------- value ------------------------------ */
@@ -1541,14 +1557,14 @@ typedef struct _value
     t_float *x_floatstar;
 } t_value;
 
-    /* get a pointer to a named floating-point variable.  The variable
-    belongs to a "vcommon" object, which is created if necessary. */
+/* get a pointer to a named floating-point variable.  The variable
+belongs to a "vcommon" object, which is created if necessary. */
 t_float *value_get(t_symbol *s)
 {
-    t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
-    if (!c)
+    t_vcommon *c = (t_vcommon *) pd_findbyclass(s, vcommon_class);
+    if(!c)
     {
-        c = (t_vcommon *)pd_new(vcommon_class);
+        c = (t_vcommon *) pd_new(vcommon_class);
         c->c_f = 0;
         c->c_refcount = 0;
         pd_bind(&c->c_pd, s);
@@ -1557,20 +1573,21 @@ t_float *value_get(t_symbol *s)
     return (&c->c_f);
 }
 
-    /* release a variable.  This only frees the "vcommon" resource when the
-    last interested party releases it. */
+/* release a variable.  This only frees the "vcommon" resource when the
+last interested party releases it. */
 void value_release(t_symbol *s)
 {
-    t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
-    if (c)
+    t_vcommon *c = (t_vcommon *) pd_findbyclass(s, vcommon_class);
+    if(c)
     {
-        if (!--c->c_refcount)
+        if(!--c->c_refcount)
         {
             pd_unbind(&c->c_pd, s);
             pd_free(&c->c_pd);
         }
     }
-    else bug("value_release");
+    else
+        bug("value_release");
 }
 
 /*
@@ -1579,9 +1596,8 @@ void value_release(t_symbol *s)
  */
 int value_getfloat(t_symbol *s, t_float *f)
 {
-    t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
-    if (!c)
-        return (1);
+    t_vcommon *c = (t_vcommon *) pd_findbyclass(s, vcommon_class);
+    if(!c) return (1);
     *f = c->c_f;
     return (0);
 }
@@ -1592,23 +1608,20 @@ int value_getfloat(t_symbol *s, t_float *f)
  */
 int value_setfloat(t_symbol *s, t_float f)
 {
-    t_vcommon *c = (t_vcommon *)pd_findbyclass(s, vcommon_class);
-    if (!c)
-        return (1);
+    t_vcommon *c = (t_vcommon *) pd_findbyclass(s, vcommon_class);
+    if(!c) return (1);
     c->c_f = f;
     return (0);
 }
 
-static void vcommon_float(t_vcommon *x, t_float f)
-{
-    x->c_f = f;
-}
+static void vcommon_float(t_vcommon *x, t_float f) { x->c_f = f; }
 
 static void *value_new(t_symbol *s)
 {
-    t_value *x = (t_value *)pd_new(value_class);
-    if (!*s->s_name)
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("symbol"), gensym("symbol2"));
+    t_value *x = (t_value *) pd_new(value_class);
+    if(!*s->s_name)
+        inlet_new(
+            &x->x_obj, &x->x_obj.ob_pd, gensym("symbol"), gensym("symbol2"));
     x->x_sym = s;
     x->x_floatstar = value_get(s);
     outlet_new(&x->x_obj, &s_float);
@@ -1620,10 +1633,7 @@ static void value_bang(t_value *x)
     outlet_float(x->x_obj.ob_outlet, *x->x_floatstar);
 }
 
-static void value_float(t_value *x, t_float f)
-{
-    *x->x_floatstar = f;
-}
+static void value_float(t_value *x, t_float f) { *x->x_floatstar = f; }
 
 /* set method */
 static void value_symbol2(t_value *x, t_symbol *s)
@@ -1635,29 +1645,27 @@ static void value_symbol2(t_value *x, t_symbol *s)
 
 static void value_send(t_value *x, t_symbol *s)
 {
-    if (s->s_thing)
+    if(s->s_thing)
         pd_float(s->s_thing, *x->x_floatstar);
-    else pd_error(x, "%s: no such object", s->s_name);
+    else
+        pd_error(x, "%s: no such object", s->s_name);
 }
 
-static void value_ff(t_value *x)
-{
-    value_release(x->x_sym);
-}
+static void value_ff(t_value *x) { value_release(x->x_sym); }
 
 static void value_setup(void)
 {
-    value_class = class_new(gensym("value"), (t_newmethod)value_new,
-        (t_method)value_ff,
-        sizeof(t_value), 0, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)value_new, gensym("v"), A_DEFSYM, 0);
+    value_class = class_new(gensym("value"), (t_newmethod) value_new,
+        (t_method) value_ff, sizeof(t_value), 0, A_DEFSYM, 0);
+    class_addcreator((t_newmethod) value_new, gensym("v"), A_DEFSYM, 0);
     class_addbang(value_class, value_bang);
     class_addfloat(value_class, value_float);
-    class_addmethod(value_class, (t_method)value_symbol2, gensym("symbol2"),
-        A_DEFSYM, 0);
-    class_addmethod(value_class, (t_method)value_send, gensym("send"), A_SYMBOL, 0);
-    vcommon_class = class_new(gensym("value"), 0, 0,
-        sizeof(t_vcommon), CLASS_PD, 0);
+    class_addmethod(
+        value_class, (t_method) value_symbol2, gensym("symbol2"), A_DEFSYM, 0);
+    class_addmethod(
+        value_class, (t_method) value_send, gensym("send"), A_SYMBOL, 0);
+    vcommon_class =
+        class_new(gensym("value"), 0, 0, sizeof(t_vcommon), CLASS_PD, 0);
     class_addfloat(vcommon_class, vcommon_float);
 }
 

--- a/src/x_connective.c
+++ b/src/x_connective.c
@@ -447,25 +447,23 @@ static void *select_new(t_symbol *s, int argc, t_atom *argv)
         }
         return (x);
     }
-    else
+
+    int n;
+    t_selectelement *e;
+    t_sel2 *x = (t_sel2 *) pd_new(sel2_class);
+    x->x_nelement = argc;
+    x->x_vec = (t_selectelement *) getbytes(argc * sizeof(*x->x_vec));
+    x->x_type = argv[0].a_type;
+    for(n = 0, e = x->x_vec; n < argc; n++, e++)
     {
-        int n;
-        t_selectelement *e;
-        t_sel2 *x = (t_sel2 *) pd_new(sel2_class);
-        x->x_nelement = argc;
-        x->x_vec = (t_selectelement *) getbytes(argc * sizeof(*x->x_vec));
-        x->x_type = argv[0].a_type;
-        for(n = 0, e = x->x_vec; n < argc; n++, e++)
-        {
-            e->e_outlet = outlet_new(&x->x_obj, &s_bang);
-            if((x->x_type = argv->a_type) == A_FLOAT)
-                e->e_w.w_float = atom_getfloatarg(n, argc, argv);
-            else
-                e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
-        }
-        x->x_rejectout = outlet_new(&x->x_obj, &s_float);
-        return (x);
+        e->e_outlet = outlet_new(&x->x_obj, &s_bang);
+        if((x->x_type = argv->a_type) == A_FLOAT)
+            e->e_w.w_float = atom_getfloatarg(n, argc, argv);
+        else
+            e->e_w.w_symbol = atom_getsymbolarg(n, argc, argv);
     }
+    x->x_rejectout = outlet_new(&x->x_obj, &s_float);
+    return (x);
 }
 
 void select_setup(void)

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #ifdef HAVE_UNISTD_H
-# include <unistd.h>
+#include <unistd.h>
 #endif
 
 #include <sys/types.h>
@@ -23,281 +23,333 @@
 #include <time.h>
 
 #ifdef _WIN32
-# include <windows.h>
-# include <io.h>
+#include <windows.h>
+#include <io.h>
 #else
-# include <glob.h>
-# include <ftw.h>
+#include <glob.h>
+#include <ftw.h>
 #endif
 
 #ifdef _MSC_VER
-# include <BaseTsd.h>
+#include <BaseTsd.h>
 typedef unsigned int mode_t;
 typedef SSIZE_T ssize_t;
-# define wstat _wstat
-# define snprintf _snprintf
+#define wstat _wstat
+#define snprintf _snprintf
 #endif
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #ifndef S_ISREG
-  #define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#define S_ISREG(mode) (((mode) &S_IFMT) == S_IFREG)
 #endif
 #ifndef S_ISDIR
-# define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
+#define S_ISDIR(mode) (((mode) &S_IFMT) == S_IFDIR)
 #endif
 
 #ifdef _WIN32
-static int do_delete_ucs2(wchar_t*pathname) {
+static int do_delete_ucs2(wchar_t *pathname)
+{
     struct stat sb;
-    if (!wstat(pathname, &sb) && (S_ISDIR(sb.st_mode))) {
-            /* a directory */
+    if(!wstat(pathname, &sb) && (S_ISDIR(sb.st_mode)))
+    {
+        /* a directory */
         return !(RemoveDirectoryW(pathname));
-    } else {
-            /* probably a file */
+    }
+    else
+    {
+        /* probably a file */
         return !(DeleteFileW(pathname));
     }
 }
 
-static int sys_stat(const char *pathname, struct stat *statbuf) {
+static int sys_stat(const char *pathname, struct stat *statbuf)
+{
     int16_t ucs2buf[MAX_PATH];
     u8_utf8toucs2(ucs2buf, MAX_PATH, pathname, strlen(pathname));
     return wstat(ucs2buf, statbuf);
 }
 
-static int sys_rename(const char *oldpath, const char *newpath) {
+static int sys_rename(const char *oldpath, const char *newpath)
+{
     int16_t src[MAX_PATH], dst[MAX_PATH];
     u8_utf8toucs2(src, MAX_PATH, oldpath, MAX_PATH);
     u8_utf8toucs2(dst, MAX_PATH, newpath, MAX_PATH);
     return _wrename(src, dst);
 }
-static int sys_mkdir(const char *pathname, mode_t mode) {
+
+static int sys_mkdir(const char *pathname, mode_t mode)
+{
     uint16_t ucs2name[MAX_PATH];
     u8_utf8toucs2(ucs2name, MAX_PATH, pathname, MAX_PATH);
     return !(CreateDirectoryW(ucs2name, 0));
 }
-static int sys_remove(const char *pathname) {
+
+static int sys_remove(const char *pathname)
+{
     uint16_t ucs2buf[MAXPDSTRING];
     u8_utf8toucs2(ucs2buf, MAXPDSTRING, pathname, MAXPDSTRING);
     return do_delete_ucs2(ucs2buf);
 }
 #else
-static int sys_stat(const char *pathname, struct stat *statbuf) {
+static int sys_stat(const char *pathname, struct stat *statbuf)
+{
     return stat(pathname, statbuf);
 }
 
-static int sys_rename(const char *oldpath, const char *newpath) {
+static int sys_rename(const char *oldpath, const char *newpath)
+{
     return rename(oldpath, newpath);
 }
-static int sys_mkdir(const char *pathname, mode_t mode) {
+
+static int sys_mkdir(const char *pathname, mode_t mode)
+{
     return mkdir(pathname, mode);
 }
-static int sys_remove(const char *pathname) {
-    return remove(pathname);
-}
+
+static int sys_remove(const char *pathname) { return remove(pathname); }
 #endif
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
-# define HAVE_ALLOCA 1
+#ifndef HAVE_ALLOCA /* can work without alloca() but we never need it */
+#define HAVE_ALLOCA 1
 #endif
 #ifdef ALLOCA
-# undef ALLOCA
+#undef ALLOCA
 #endif
 #ifdef FREEA
-# undef FREEA
+#undef FREEA
 #endif
 
 #if HAVE_ALLOCA
-# define ALLOCA(t, x, n, max) ((x) = (t *)((n) < (max) ?            \
-            alloca((n) * sizeof(t)) : getbytes((n) * sizeof(t))))
-# define FREEA(t, x, n, max) (                                  \
-        ((n) < (max) || (freebytes((x), (n) * sizeof(t)), 0)))
+#define ALLOCA(t, x, n, max)                            \
+    ((x) = (t *) ((n) < (max) ? alloca((n) * sizeof(t)) \
+                              : getbytes((n) * sizeof(t))))
+#define FREEA(t, x, n, max) \
+    (((n) < (max) || (freebytes((x), (n) * sizeof(t)), 0)))
 #else
-# define ALLOCA(t, x, n, max) ((x) = (t *)getbytes((n) * sizeof(t)))
-# define FREEA(t, x, n, max) (freebytes((x), (n) * sizeof(t)))
+#define ALLOCA(t, x, n, max) ((x) = (t *) getbytes((n) * sizeof(t)))
+#define FREEA(t, x, n, max) (freebytes((x), (n) * sizeof(t)))
 #endif
 
-    /* expand env vars and ~ at the beginning of a path and make a copy to return */
-static char*do_expandpath(const char *from, char *to, int bufsize)
+/* expand env vars and ~ at the beginning of a path and make a copy to return */
+static char *do_expandpath(const char *from, char *to, int bufsize)
 {
-    if ((strlen(from) == 1 && from[0] == '~') || (strncmp(from,"~/", 2) == 0))
+    if((strlen(from) == 1 && from[0] == '~') || (strncmp(from, "~/", 2) == 0))
     {
 #ifdef _WIN32
         const char *home = getenv("USERPROFILE");
 #else
         const char *home = getenv("HOME");
 #endif
-        if (home)
+        if(home)
         {
             strncpy(to, home, bufsize);
-            to[bufsize-1] = 0;
+            to[bufsize - 1] = 0;
             strncpy(to + strlen(to), from + 1, bufsize - strlen(to));
-            to[bufsize-1] = 0;
+            to[bufsize - 1] = 0;
         }
-        else *to = 0;
+        else
+            *to = 0;
     }
     else
     {
         strncpy(to, from, bufsize);
-        to[bufsize-1] = 0;
+        to[bufsize - 1] = 0;
     }
 #ifdef _WIN32
     {
         char *buf = alloca(bufsize);
-        ExpandEnvironmentStrings(to, buf, bufsize-1);
-        buf[bufsize-1] = 0;
+        ExpandEnvironmentStrings(to, buf, bufsize - 1);
+        buf[bufsize - 1] = 0;
         strncpy(to, buf, bufsize);
-        to[bufsize-1] = 0;
+        to[bufsize - 1] = 0;
     }
 #endif
     return to;
 }
 
-    /* unbash '\' to '/', and drop duplicate '/' */
-static char*do_pathnormalize(const char *from, char *to) {
+/* unbash '\' to '/', and drop duplicate '/' */
+static char *do_pathnormalize(const char *from, char *to)
+{
     const char *rp;
     char *wp, c;
     sys_unbashfilename(from, to);
-    rp=wp=to;
-    while((*wp++=c=*rp++)) {
-        if('/' == c) {
-            while('/' == *rp++);
+    rp = wp = to;
+    while((*wp++ = c = *rp++))
+    {
+        if('/' == c)
+        {
+            while('/' == *rp++)
+                ;
             rp--;
         }
     }
     return to;
 }
 
-static char*do_expandunbash(const char *from, char *to, int bufsize) {
+static char *do_expandunbash(const char *from, char *to, int bufsize)
+{
     do_expandpath(from, to, bufsize);
-    to[bufsize-1]=0;
+    to[bufsize - 1] = 0;
     sys_unbashfilename(to, to);
-    to[bufsize-1]=0;
+    to[bufsize - 1] = 0;
     return to;
 }
 
-static int str_endswith(char* str, char* end){
+static int str_endswith(char *str, char *end)
+{
     size_t strsize = strlen(str), endsize = strlen(end);
-    if(strsize<endsize) return 0;
+    if(strsize < endsize) return 0;
     return strcmp(str + strsize - endsize, end) == 0;
 }
 
 #ifdef _WIN32
-static const char*do_errmsg(char*buffer, size_t bufsize) {
+static const char *do_errmsg(char *buffer, size_t bufsize)
+{
     char errcode[10];
-    char*s;
+    char *s;
     wchar_t wbuf[MAXPDSTRING];
     DWORD err = GetLastError();
-    DWORD count = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        0, err, MAKELANGID (LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, MAXPDSTRING, NULL);
-    if (!count || !WideCharToMultiByte(CP_UTF8, 0, wbuf, count+1, buffer, bufsize, 0, 0))
+    DWORD count = FormatMessageW(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0, err,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), wbuf, MAXPDSTRING, NULL);
+    if(!count || !WideCharToMultiByte(
+                     CP_UTF8, 0, wbuf, count + 1, buffer, bufsize, 0, 0))
         *buffer = '\0';
-    s=buffer + strlen(buffer)-1;
-    while(('\r' == *s || '\n' == *s) && s>buffer)
-        *s--=0;
+    s = buffer + strlen(buffer) - 1;
+    while(('\r' == *s || '\n' == *s) && s > buffer)
+        *s-- = 0;
     snprintf(errcode, sizeof(errcode), " [%ld]", err);
-    errcode[sizeof(errcode)-1] = 0;
+    errcode[sizeof(errcode) - 1] = 0;
     strcat(buffer, errcode);
     return buffer;
 }
-#else /* !_WIN32 */
-static const char*do_errmsg(char*buffer, size_t bufsize) {
-    (void)buffer; (void)bufsize;
+#else  /* !_WIN32 */
+static const char *do_errmsg(char *buffer, size_t bufsize)
+{
+    (void) buffer;
+    (void) bufsize;
     return strerror(errno);
 }
 #endif /* !_WIN32 */
 
-typedef struct _file_handler {
+typedef struct _file_handler
+{
     int fh_fd;
     int fh_mode; /* 0..read, 1..write */
 } t_file_handler;
+
 #define x_fd x_fhptr->fh_fd
 #define x_mode x_fhptr->fh_mode
-typedef struct _file_handle {
+
+typedef struct _file_handle
+{
     t_object x_obj;
     t_file_handler x_fh;
-    t_file_handler*x_fhptr;
-    t_symbol*x_fcname; /* multiple [file handle] object can refer to the same [file define] */
+    t_file_handler *x_fhptr;
+    t_symbol *x_fcname; /* multiple [file handle] object can refer to the same
+                           [file define] */
 
     mode_t x_creationmode; /* default: 0666, 0777 */
-    int x_verbose; /* default: 0 */
+    int x_verbose;         /* default: 0 */
 
-    t_canvas*x_canvas;
-    t_outlet*x_dataout;
-    t_outlet*x_infoout;
+    t_canvas *x_canvas;
+    t_outlet *x_dataout;
+    t_outlet *x_infoout;
 
 } t_file_handle;
 
-static int do_parse_creationmode(t_atom*ap) {
-    const char*s;
-    if(A_FLOAT==ap->a_type)
-        return atom_getfloat(ap);
-    if(A_SYMBOL!=ap->a_type)
-        return -1; /* oopsie */
+static int do_parse_creationmode(t_atom *ap)
+{
+    const char *s;
+    if(A_FLOAT == ap->a_type) return atom_getfloat(ap);
+    if(A_SYMBOL != ap->a_type) return -1; /* oopsie */
     s = atom_getsymbol(ap)->s_name;
-    if(!strncmp(s, "0o", 2)) {
-            /* octal mode */
-        char*endptr;
-        long mode = strtol(s+2, &endptr, 8);
-        return (*endptr)?-1:(int)mode;
-    } else if(!strncmp(s, "0x", 2)) {
-            /* hex mode: nobody sane uses this... */
-        char*endptr;
-        long mode = strtol(s+2, &endptr, 16);
-        return (*endptr)?-1:(int)mode;
-    } else {
-            /* free form mode: a+rwx,go-w */
-            /* not supported yet */
+    if(!strncmp(s, "0o", 2))
+    {
+        /* octal mode */
+        char *endptr;
+        long mode = strtol(s + 2, &endptr, 8);
+        return (*endptr) ? -1 : (int) mode;
+    }
+    else if(!strncmp(s, "0x", 2))
+    {
+        /* hex mode: nobody sane uses this... */
+        char *endptr;
+        long mode = strtol(s + 2, &endptr, 16);
+        return (*endptr) ? -1 : (int) mode;
+    }
+    else
+    {
+        /* free form mode: a+rwx,go-w */
+        /* not supported yet */
         return -1;
     }
     return -1;
 }
 
-static void do_parse_args(t_file_handle*x, int argc, t_atom*argv) {
-        /*
-         * -q: quiet mode
-         * -v: verbose mode
-         * -m <mode>: creation mode
-         */
-    t_symbol*flag_m = gensym("-m");
-    t_symbol*flag_q = gensym("-q");
-    t_symbol*flag_v = gensym("-v");
+static void do_parse_args(t_file_handle *x, int argc, t_atom *argv)
+{
+    /*
+     * -q: quiet mode
+     * -v: verbose mode
+     * -m <mode>: creation mode
+     */
+    t_symbol *flag_m = gensym("-m");
+    t_symbol *flag_q = gensym("-q");
+    t_symbol *flag_v = gensym("-v");
     x->x_fcname = 0;
-    while(argc--) {
-        const t_symbol*flag = atom_getsymbol(argv);
-        if (0);
-        else if (flag == flag_q) {
+    while(argc--)
+    {
+        const t_symbol *flag = atom_getsymbol(argv);
+        if(0)
+            ;
+        else if(flag == flag_q)
+        {
             x->x_verbose--;
-        } else if (flag == flag_v) {
+        }
+        else if(flag == flag_v)
+        {
             x->x_verbose++;
-        } else if (flag == flag_m) {
+        }
+        else if(flag == flag_m)
+        {
             int mode;
-            if(!argc) {
+            if(!argc)
+            {
                 pd_error(x, "'-m' requires an argument");
                 break;
             }
             argc--;
             argv++;
             mode = do_parse_creationmode(argv);
-            if(mode<0) {
+            if(mode < 0)
+            {
                 char buf[MAXPDSTRING];
                 atom_string(argv, buf, MAXPDSTRING);
                 pd_error(x, "invalid creation mode '%s'", buf);
                 break;
-            } else {
+            }
+            else
+            {
                 x->x_creationmode = mode;
             }
-        } else {
+        }
+        else
+        {
             int filearg = (!argc);
-            if(filearg) {
-                x->x_fcname = (t_symbol*)flag;
-            } else {
+            if(filearg)
+            {
+                x->x_fcname = (t_symbol *) flag;
+            }
+            else
+            {
                 pd_error(x, "unknown flag %s", flag->s_name);
             }
             break;
@@ -307,9 +359,11 @@ static void do_parse_args(t_file_handle*x, int argc, t_atom*argv) {
     x->x_verbose = x->x_verbose > 0;
 }
 
-static t_file_handle* do_file_handle_new(t_class*cls, t_symbol*s, int argc, t_atom*argv, int verbose, mode_t creationmode) {
-    t_file_handle*x = (t_file_handle*)pd_new(cls);
-    (void)s;
+static t_file_handle *do_file_handle_new(t_class *cls, t_symbol *s, int argc,
+    t_atom *argv, int verbose, mode_t creationmode)
+{
+    t_file_handle *x = (t_file_handle *) pd_new(cls);
+    (void) s;
     x->x_fhptr = &x->x_fh;
     x->x_fd = -1;
     x->x_canvas = canvas_getcurrent();
@@ -322,41 +376,53 @@ static t_file_handle* do_file_handle_new(t_class*cls, t_symbol*s, int argc, t_at
     return x;
 }
 
-static int do_file_open(t_file_handle*x, const char* filename, int mode) {
-    char expandbuf[MAXPDSTRING+1];
-    int fd = sys_open(do_expandpath(filename, expandbuf, MAXPDSTRING), mode, x?x->x_creationmode:0666);
-    if(x) {
+static int do_file_open(t_file_handle *x, const char *filename, int mode)
+{
+    char expandbuf[MAXPDSTRING + 1];
+    int fd = sys_open(do_expandpath(filename, expandbuf, MAXPDSTRING), mode,
+        x ? x->x_creationmode : 0666);
+    if(x)
+    {
         x->x_fd = fd;
-        if(fd<0) {
+        if(fd < 0)
+        {
             if(x->x_verbose)
-                pd_error(x, "unable to open '%s': %s", filename, strerror(errno));
-            if(x->x_infoout)
-                outlet_bang(x->x_infoout);
+                pd_error(
+                    x, "unable to open '%s': %s", filename, strerror(errno));
+            if(x->x_infoout) outlet_bang(x->x_infoout);
         }
     }
     return fd;
 }
 
-
-static void file_set_verbosity(t_file_handle*x, t_float f) {
-    x->x_verbose = (f>0.5);
+static void file_set_verbosity(t_file_handle *x, t_float f)
+{
+    x->x_verbose = (f > 0.5);
 }
-static void file_set_creationmode(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
-    if(argc!=1) {
+
+static void file_set_creationmode(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
+    if(argc != 1)
+    {
         pd_error(x, "usage: '%s <mode>'", s->s_name);
         return;
     }
     x->x_creationmode = do_parse_creationmode(argv);
 }
 
-    /* ================ [file handle] ====================== */
+/* ================ [file handle] ====================== */
 t_class *file_define_class;
-static int file_handle_getdefine(t_file_handle*x) {
-    if(x->x_fcname) {
-        t_file_handle *y = (t_file_handle *)pd_findbyclass(x->x_fcname,
-                                                           file_define_class);
-        if(y) {
-            x->x_fhptr=&y->x_fh;
+
+static int file_handle_getdefine(t_file_handle *x)
+{
+    if(x->x_fcname)
+    {
+        t_file_handle *y =
+            (t_file_handle *) pd_findbyclass(x->x_fcname, file_define_class);
+        if(y)
+        {
+            x->x_fhptr = &y->x_fh;
             return 1;
         }
         return 0;
@@ -365,290 +431,371 @@ static int file_handle_getdefine(t_file_handle*x) {
     return 1;
 }
 
-static void file_handle_close(t_file_handle*x) {
-    if (x->x_fd>=0)
-        sys_close(x->x_fd);
+static void file_handle_close(t_file_handle *x)
+{
+    if(x->x_fd >= 0) sys_close(x->x_fd);
     x->x_fd = -1;
 }
-static int file_handle_checkopen(t_file_handle*x, const char*cmd) {
-    if(x->x_fcname) {
-        if(!file_handle_getdefine(x)) {
-            pd_error(x, "file handle: couldn't find file-define '%s'", x->x_fcname->s_name);
+
+static int file_handle_checkopen(t_file_handle *x, const char *cmd)
+{
+    if(x->x_fcname)
+    {
+        if(!file_handle_getdefine(x))
+        {
+            pd_error(x, "file handle: couldn't find file-define '%s'",
+                x->x_fcname->s_name);
             return 0;
         }
     }
-    if(x->x_fd<0) {
-        if(!cmd)cmd=(x->x_mode)?"write":"read";
+    if(x->x_fd < 0)
+    {
+        if(!cmd) cmd = (x->x_mode) ? "write" : "read";
         pd_error(x, "'%s' without prior 'open'", cmd);
         return 0;
     }
     return 1;
 }
-static void file_handle_do_read(t_file_handle*x, t_float f) {
-    t_atom*outv;
-    unsigned char*buf;
-    ssize_t n, len, outc=f;
-    if(outc<1) {
-        pd_error(x, "cannot read %d bytes", (int)outc);
+
+static void file_handle_do_read(t_file_handle *x, t_float f)
+{
+    t_atom *outv;
+    unsigned char *buf;
+    ssize_t n, len, outc = f;
+    if(outc < 1)
+    {
+        pd_error(x, "cannot read %d bytes", (int) outc);
         return;
     }
     ALLOCA(unsigned char, buf, outc, 100);
     ALLOCA(t_atom, outv, outc, 100);
-    if(buf && outv) {
+    if(buf && outv)
+    {
         len = read(x->x_fd, buf, outc);
-        for(n=0; n<len; n++) {
-            SETFLOAT(outv+n, (t_float)buf[n]);
+        for(n = 0; n < len; n++)
+        {
+            SETFLOAT(outv + n, (t_float) buf[n]);
         }
-        if(len>0) {
+        if(len > 0)
+        {
             outlet_list(x->x_dataout, gensym("list"), len, outv);
-        } else if (!len) {
-            file_handle_close(x);
-            outlet_bang(x->x_infoout);
-        } else {
-            if(x->x_verbose)
-                pd_error(x, "read failed: %s", strerror(errno));
+        }
+        else if(!len)
+        {
             file_handle_close(x);
             outlet_bang(x->x_infoout);
         }
-    } else {
-        pd_error(x, "couldn't allocate buffer for %d bytes", (int)outc);
+        else
+        {
+            if(x->x_verbose) pd_error(x, "read failed: %s", strerror(errno));
+            file_handle_close(x);
+            outlet_bang(x->x_infoout);
+        }
+    }
+    else
+    {
+        pd_error(x, "couldn't allocate buffer for %d bytes", (int) outc);
     }
     FREEA(unsigned char, buf, outc, 100);
     FREEA(t_atom, outv, outc, 100);
 }
-static void file_handle_do_write(t_file_handle*x, int argc, t_atom*argv) {
-    unsigned char*buf;
-    size_t len = (argc>0)?argc:0;
+
+static void file_handle_do_write(t_file_handle *x, int argc, t_atom *argv)
+{
+    unsigned char *buf;
+    size_t len = (argc > 0) ? argc : 0;
     ALLOCA(unsigned char, buf, argc, 100);
-    if(buf) {
+    if(buf)
+    {
         ssize_t n;
-        for(n=0; n<argc; n++) {
-            buf[n] = atom_getfloat(argv+n);
+        for(n = 0; n < argc; n++)
+        {
+            buf[n] = atom_getfloat(argv + n);
         }
         n = write(x->x_fd, buf, len);
-        if(n >= 0 && (size_t)n < len) {
-            n = write(x->x_fd, buf+n, len-n);
+        if(n >= 0 && (size_t) n < len)
+        {
+            n = write(x->x_fd, buf + n, len - n);
         }
-        if (n<0) {
+        if(n < 0)
+        {
             pd_error(x, "write failed: %s", strerror(errno));
             file_handle_close(x);
             outlet_bang(x->x_infoout);
         }
-    } else {
+    }
+    else
+    {
         pd_error(x, "could not allocate %d bytes for writing", argc);
     }
     FREEA(unsigned char, buf, argc, 100);
 }
-static void file_handle_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
-    (void)s;
-    if(!file_handle_checkopen(x, 0))
-        return;
-    if(x->x_mode) {
-            /* write_mode */
+
+static void file_handle_list(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
+    (void) s;
+    if(!file_handle_checkopen(x, 0)) return;
+    if(x->x_mode)
+    {
+        /* write_mode */
         file_handle_do_write(x, argc, argv);
-        } else {
-            /* read mode */
-        if(1==argc && A_FLOAT==argv->a_type) {
+    }
+    else
+    {
+        /* read mode */
+        if(1 == argc && A_FLOAT == argv->a_type)
+        {
             file_handle_do_read(x, atom_getfloat(argv));
-        } else {
+        }
+        else
+        {
             pd_error(x, "no way to handle 'list' messages while reading file");
         }
     }
 }
-static void file_handle_set(t_file_handle*x, t_symbol*s) {
-    if (gensym("") == s)
-        s=0;
-    if (s && x->x_fhptr == &x->x_fh && x->x_fh.fh_fd >= 0) {
-            /* trying to set a name, even though we have an fd open... */
-        pd_error(x, "file handle: shadowing local file descriptor with '%s'", s->s_name);
-    } else if (!s && x->x_fhptr != &x->x_fh && x->x_fh.fh_fd >= 0) {
+
+static void file_handle_set(t_file_handle *x, t_symbol *s)
+{
+    if(gensym("") == s) s = 0;
+    if(s && x->x_fhptr == &x->x_fh && x->x_fh.fh_fd >= 0)
+    {
+        /* trying to set a name, even though we have an fd open... */
+        pd_error(x, "file handle: shadowing local file descriptor with '%s'",
+            s->s_name);
+    }
+    else if(!s && x->x_fhptr != &x->x_fh && x->x_fh.fh_fd >= 0)
+    {
         logpost(x, 3, "file handle: unshadowing local file descriptor");
     }
     x->x_fcname = s;
     file_handle_getdefine(x);
 }
-static void file_handle_seek(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
-    off_t offset=0;
+
+static void file_handle_seek(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
+    off_t offset = 0;
     int whence = SEEK_SET;
     t_atom a[1];
-    switch(argc) {
-    case 0:
+    switch(argc)
+    {
+        case 0:
             /* just output the current position */
-        whence=SEEK_CUR;
-        break;
-    case 2: {
-        if (A_SYMBOL!=argv[1].a_type)
-            goto usage;
-        s=atom_getsymbol(argv+1);
-        switch(*s->s_name) {
-        case 'S': case 's': case 0:
-            whence = SEEK_SET;
-            break;
-        case 'E': case 'e':
-            whence = SEEK_END;
-            break;
-        case 'C': case 'c': case 'R': case 'r':
             whence = SEEK_CUR;
             break;
-        default:
-            pd_error(x, "seek mode must be 'set', 'end' or 'current' (resp. 'relative')");
-            return;
+        case 2:
+        {
+            if(A_SYMBOL != argv[1].a_type) goto usage;
+            s = atom_getsymbol(argv + 1);
+            switch(*s->s_name)
+            {
+                case 'S':
+                case 's':
+                case 0:
+                    whence = SEEK_SET;
+                    break;
+                case 'E':
+                case 'e':
+                    whence = SEEK_END;
+                    break;
+                case 'C':
+                case 'c':
+                case 'R':
+                case 'r':
+                    whence = SEEK_CUR;
+                    break;
+                default:
+                    pd_error(x, "seek mode must be 'set', 'end' or 'current' "
+                                "(resp. 'relative')");
+                    return;
+            }
         }
-    }
             /* falls through */
-    case 1:
-        if (A_FLOAT!=argv[0].a_type)
-            goto usage;
-        offset = (int)atom_getfloat(argv);
-        break;
+        case 1:
+            if(A_FLOAT != argv[0].a_type) goto usage;
+            offset = (int) atom_getfloat(argv);
+            break;
     }
 
-    if(!file_handle_checkopen(x, "seek"))
-        return;
+    if(!file_handle_checkopen(x, "seek")) return;
     offset = lseek(x->x_fd, offset, whence);
     SETFLOAT(a, offset);
     outlet_anything(x->x_infoout, gensym("seek"), 1, a);
     return;
- usage:
+usage:
     pd_error(x, "usage: seek [<int:offset> [<symbol:mode>]]");
 }
-static void file_handle_open(t_file_handle*x, t_symbol*file, t_symbol*smode) {
+
+static void file_handle_open(t_file_handle *x, t_symbol *file, t_symbol *smode)
+{
     int mode = O_RDONLY;
-    if (x->x_fd>=0) {
+    if(x->x_fd >= 0)
+    {
         pd_error(x, "'open' without prior 'close'");
         return;
     }
-    if(!file_handle_getdefine(x)) {
-        pd_error(x, "file handle: couldn't find file-define '%s'", x->x_fcname->s_name);
+    if(!file_handle_getdefine(x))
+    {
+        pd_error(x, "file handle: couldn't find file-define '%s'",
+            x->x_fcname->s_name);
         return;
     }
-    if(smode && smode!=&s_) {
-        switch(smode->s_name[0]) {
-        case 'r': /* read */
-            mode = O_RDONLY;
-            break;
-        case 'w': /* write */
-            mode = O_WRONLY;
-            break;
-        case 'a': /* append */
-            mode = O_WRONLY | O_APPEND;
-            break;
-        case 'c': /* create */
-            mode = O_WRONLY | O_TRUNC;
-            break;
+    if(smode && smode != &s_)
+    {
+        switch(smode->s_name[0])
+        {
+            case 'r': /* read */
+                mode = O_RDONLY;
+                break;
+            case 'w': /* write */
+                mode = O_WRONLY;
+                break;
+            case 'a': /* append */
+                mode = O_WRONLY | O_APPEND;
+                break;
+            case 'c': /* create */
+                mode = O_WRONLY | O_TRUNC;
+                break;
         }
     }
-    if(mode & O_WRONLY) {
+    if(mode & O_WRONLY)
+    {
         mode |= O_CREAT;
     }
-    if(do_file_open(x, file->s_name, mode)>=0) {
-            /* check if we haven't accidentally opened a directory */
+    if(do_file_open(x, file->s_name, mode) >= 0)
+    {
+        /* check if we haven't accidentally opened a directory */
         struct stat sb;
-        if(fstat(x->x_fd, &sb)) {
+        if(fstat(x->x_fd, &sb))
+        {
             file_handle_close(x);
             if(x->x_verbose)
-                pd_error(x, "unable to stat '%s': %s", file->s_name, strerror(errno));
+                pd_error(x, "unable to stat '%s': %s", file->s_name,
+                    strerror(errno));
             outlet_bang(x->x_infoout);
             return;
         }
-        if(S_ISDIR(sb.st_mode)) {
+        if(S_ISDIR(sb.st_mode))
+        {
             file_handle_close(x);
             if(x->x_verbose)
-                pd_error(x, "unable to open directory '%s' as file", file->s_name);
+                pd_error(
+                    x, "unable to open directory '%s' as file", file->s_name);
             outlet_bang(x->x_infoout);
             return;
         }
-        x->x_mode = (mode&O_WRONLY)?1:0;
+        x->x_mode = (mode & O_WRONLY) ? 1 : 0;
     }
 }
 
-static void file_handle_free(t_file_handle*x) {
-        /* close our own file handle (if any) */
+static void file_handle_free(t_file_handle *x)
+{
+    /* close our own file handle (if any) */
     x->x_fhptr = &x->x_fh;
     file_handle_close(x);
 }
 
-    /* ================ [file stat] ====================== */
-static int do_file_stat(t_file_handle*x, const char*filename, struct stat*sb, int*is_symlink) {
+/* ================ [file stat] ====================== */
+static int do_file_stat(
+    t_file_handle *x, const char *filename, struct stat *sb, int *is_symlink)
+{
     int result = -1;
     int fd = -1;
-    char buf[MAXPDSTRING+1];
+    char buf[MAXPDSTRING + 1];
     do_expandpath(filename, buf, MAXPDSTRING);
 
-    if(is_symlink) {
-        *is_symlink=0;
+    if(is_symlink)
+    {
+        *is_symlink = 0;
 #ifdef S_IFLNK
-        if(!lstat(buf, sb)) {
+        if(!lstat(buf, sb))
+        {
             *is_symlink = !!(S_ISLNK(sb->st_mode));
         }
 #endif
     }
     result = sys_stat(buf, sb);
-    if(!result)
-        return result;
+    if(!result) return result;
 
     fd = do_file_open(0, filename, 0);
 
-    if(fd >= 0) {
+    if(fd >= 0)
+    {
         result = fstat(fd, sb);
         sys_close(fd);
-    } else
+    }
+    else
         result = -1;
 
-    if(x) {
+    if(x)
+    {
         x->x_fd = -1;
-        if(result && x->x_verbose) {
-            pd_error(x, "could not stat on '%s': %s", filename, strerror(errno));
+        if(result && x->x_verbose)
+        {
+            pd_error(
+                x, "could not stat on '%s': %s", filename, strerror(errno));
         }
     }
     return result;
 }
-static void do_dataout_symbol(t_file_handle*x, const char*selector, t_symbol*s) {
+
+static void do_dataout_symbol(
+    t_file_handle *x, const char *selector, t_symbol *s)
+{
     t_atom ap[1];
     SETSYMBOL(ap, s);
     outlet_anything(x->x_dataout, gensym(selector), 1, ap);
 }
-static void do_dataout_float(t_file_handle*x, const char*selector, t_float f) {
+
+static void do_dataout_float(t_file_handle *x, const char *selector, t_float f)
+{
     t_atom ap[1];
     SETFLOAT(ap, f);
     outlet_anything(x->x_dataout, gensym(selector), 1, ap);
 }
-static void do_dataout_time(t_file_handle*x, const char*selector, time_t t) {
+
+static void do_dataout_time(t_file_handle *x, const char *selector, time_t t)
+{
     t_atom ap[7];
     struct tm *ts = localtime(&t);
-    if(!ts) {
-        pd_error(x, "unable to convert timestamp %ld", (long int)t);
+    if(!ts)
+    {
+        pd_error(x, "unable to convert timestamp %ld", (long int) t);
     }
-    SETFLOAT(ap+0, ts->tm_year + 1900);
-    SETFLOAT(ap+1, ts->tm_mon + 1);
-    SETFLOAT(ap+2, ts->tm_mday);
-    SETFLOAT(ap+3, ts->tm_hour);
-    SETFLOAT(ap+4, ts->tm_min);
-    SETFLOAT(ap+5, ts->tm_sec);
-    SETFLOAT(ap+6, ts->tm_isdst);
+    SETFLOAT(ap + 0, ts->tm_year + 1900);
+    SETFLOAT(ap + 1, ts->tm_mon + 1);
+    SETFLOAT(ap + 2, ts->tm_mday);
+    SETFLOAT(ap + 3, ts->tm_hour);
+    SETFLOAT(ap + 4, ts->tm_min);
+    SETFLOAT(ap + 5, ts->tm_sec);
+    SETFLOAT(ap + 6, ts->tm_isdst);
     outlet_anything(x->x_dataout, gensym(selector), 7, ap);
 }
-static void file_stat_symbol(t_file_handle*x, t_symbol*filename) {
-        /* get all the info for the given file */
-    struct stat sb;
-    t_symbol*s;
-    int is_symlink=0;
-    int readable=0, writable=0, executable=0, owned=-1;
-    char buf[MAXPDSTRING+1];
 
-    if(do_file_stat(x, filename->s_name, &sb, &is_symlink) < 0) {
+static void file_stat_symbol(t_file_handle *x, t_symbol *filename)
+{
+    /* get all the info for the given file */
+    struct stat sb;
+    t_symbol *s;
+    int is_symlink = 0;
+    int readable = 0, writable = 0, executable = 0, owned = -1;
+    char buf[MAXPDSTRING + 1];
+
+    if(do_file_stat(x, filename->s_name, &sb, &is_symlink) < 0)
+    {
         outlet_bang(x->x_infoout);
         return;
     }
 
-        /* this is wrong: readable/writable/executable are supposed to report
-         * on the *current* user, not the *owner*
-         */
+    /* this is wrong: readable/writable/executable are supposed to report
+     * on the *current* user, not the *owner*
+     */
     readable = !!(sb.st_mode & 0400);
     writable = !!(sb.st_mode & 0200);
     executable = !!(sb.st_mode & 0100);
 #ifdef HAVE_UNISTD_H
-        /* this is the right way */
+    /* this is the right way */
     do_expandpath(filename->s_name, buf, MAXPDSTRING);
 
     readable = !(access(buf, R_OK));
@@ -659,19 +806,20 @@ static void file_stat_symbol(t_file_handle*x, t_symbol*filename) {
 #endif
 #endif
 
-    switch (sb.st_mode & S_IFMT) {
-    case S_IFREG:
+    switch(sb.st_mode & S_IFMT)
+    {
+        case S_IFREG:
 #ifdef S_IFLNK
-    case S_IFLNK:
+        case S_IFLNK:
 #endif
-        do_dataout_float(x, "size", (int)(sb.st_size));
-        break;
-    case S_IFDIR:
-        do_dataout_float(x, "size", 0);
-        break;
-    default:
-        do_dataout_float(x, "size", -1);
-        break;
+            do_dataout_float(x, "size", (int) (sb.st_size));
+            break;
+        case S_IFDIR:
+            do_dataout_float(x, "size", 0);
+            break;
+        default:
+            do_dataout_float(x, "size", -1);
+            break;
     }
     do_dataout_float(x, "readable", readable);
     do_dataout_float(x, "writable", writable);
@@ -682,28 +830,45 @@ static void file_stat_symbol(t_file_handle*x, t_symbol*filename) {
     do_dataout_float(x, "isdirectory", !!(S_ISDIR(sb.st_mode)));
     do_dataout_float(x, "issymlink", is_symlink);
 
-    do_dataout_float(x, "uid", (int)(sb.st_uid));
-    do_dataout_float(x, "gid", (int)(sb.st_gid));
-    do_dataout_float(x, "permissions", (int)(sb.st_mode & 0777));
-    switch (sb.st_mode & S_IFMT) {
-    case S_IFREG:  s = gensym("file");            break;
-    case S_IFDIR:  s = gensym("directory");       break;
+    do_dataout_float(x, "uid", (int) (sb.st_uid));
+    do_dataout_float(x, "gid", (int) (sb.st_gid));
+    do_dataout_float(x, "permissions", (int) (sb.st_mode & 0777));
+    switch(sb.st_mode & S_IFMT)
+    {
+        case S_IFREG:
+            s = gensym("file");
+            break;
+        case S_IFDIR:
+            s = gensym("directory");
+            break;
 #ifdef S_IFBLK
-    case S_IFBLK:  s = gensym("blockdevice");     break;
+        case S_IFBLK:
+            s = gensym("blockdevice");
+            break;
 #endif
 #ifdef S_IFCHR
-    case S_IFCHR:  s = gensym("characterdevice"); break;
+        case S_IFCHR:
+            s = gensym("characterdevice");
+            break;
 #endif
 #ifdef S_IFIFO
-    case S_IFIFO:  s = gensym("pipe");            break;
+        case S_IFIFO:
+            s = gensym("pipe");
+            break;
 #endif
 #ifdef S_IFLNK
-    case S_IFLNK:  s = gensym("symlink");         break;
+        case S_IFLNK:
+            s = gensym("symlink");
+            break;
 #endif
 #ifdef S_IFSOCK
-    case S_IFSOCK: s = gensym("socket");          break;
+        case S_IFSOCK:
+            s = gensym("socket");
+            break;
 #endif
-    default:       s = 0;                         break;
+        default:
+            s = 0;
+            break;
     }
     if(s)
         do_dataout_symbol(x, "type", s);
@@ -714,54 +879,72 @@ static void file_stat_symbol(t_file_handle*x, t_symbol*filename) {
     do_dataout_time(x, "mtime", sb.st_mtime);
 }
 
-static void file_size_symbol(t_file_handle*x, t_symbol*filename) {
+static void file_size_symbol(t_file_handle *x, t_symbol *filename)
+{
     struct stat sb;
-    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0)
+    {
         outlet_bang(x->x_infoout);
-    } else {
-        switch (sb.st_mode & S_IFMT) {
-        case S_IFREG:
+    }
+    else
+    {
+        switch(sb.st_mode & S_IFMT)
+        {
+            case S_IFREG:
 #ifdef S_IFLNK
-        case S_IFLNK:
+            case S_IFLNK:
 #endif
-            outlet_float(x->x_dataout, (int)(sb.st_size));
-            break;
-        case S_IFDIR:
-            outlet_float(x->x_dataout, 0);
-            break;
-        default:
-            outlet_float(x->x_dataout, -1);
-            break;
+                outlet_float(x->x_dataout, (int) (sb.st_size));
+                break;
+            case S_IFDIR:
+                outlet_float(x->x_dataout, 0);
+                break;
+            default:
+                outlet_float(x->x_dataout, -1);
+                break;
         }
     }
 }
-static void file_isfile_symbol(t_file_handle*x, t_symbol*filename) {
+
+static void file_isfile_symbol(t_file_handle *x, t_symbol *filename)
+{
     struct stat sb;
-    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0)
+    {
         outlet_bang(x->x_infoout);
-    } else {
+    }
+    else
+    {
         outlet_float(x->x_dataout, !!(S_ISREG(sb.st_mode)));
     }
 }
-static void file_isdirectory_symbol(t_file_handle*x, t_symbol*filename) {
+
+static void file_isdirectory_symbol(t_file_handle *x, t_symbol *filename)
+{
     struct stat sb;
-    if(do_file_stat(x, filename->s_name, &sb, 0) < 0) {
+    if(do_file_stat(x, filename->s_name, &sb, 0) < 0)
+    {
         outlet_bang(x->x_infoout);
-    } else {
+    }
+    else
+    {
         outlet_float(x->x_dataout, !!(S_ISDIR(sb.st_mode)));
     }
 }
 
-    /* ================ [file glob] ====================== */
+/* ================ [file glob] ====================== */
 #ifdef _WIN32
 /* idiosyncrasies:
- * - cases are ignored ('a*' matches 'A.txt' and 'a.txt'), even with wine on ext4
+ * - cases are ignored ('a*' matches 'A.txt' and 'a.txt'), even with wine on
+ * ext4
  * - only the filename component is returned (must prefix path separately)
  * - non-ASCII needs special handling
  * - '*?' seems to be illegal (e.g. 'f*?.txt'); '?*' seems to be fine though
- * - "*" matches files starting with '.' (including '.', '..', but also .gitignore)
+ * - "*" matches files starting with '.' (including '.', '..', but also
+ * .gitignore)
  * - if the pattern includes '*.', it matches a trailing '~'
- * - wildcards do not apply to directory-components (e.g. 'foo/ * /' (without the spaces, they are just due to C-comments constraints))
+ * - wildcards do not apply to directory-components (e.g. 'foo/ * /' (without
+ * the spaces, they are just due to C-comments constraints))
  *
  * plan:
  * - concat the path and the filename
@@ -770,170 +953,190 @@ static void file_isdirectory_symbol(t_file_handle*x, t_symbol*filename) {
  * - manually filter out:
  *   - matches starting with '.' if the pattern does not start with '.'
  *   - matches ending in '~' if the pattern does not end with '[*?~]'
- * - only (officially) support wildcards in the filename component (not in the paths)
+ * - only (officially) support wildcards in the filename component (not in the
+ * paths)
  * - if the pattern ends with '/', strip it, but return only directories
  */
-static void file_glob_symbol(t_file_handle*x, t_symbol*spattern) {
+static void file_glob_symbol(t_file_handle *x, t_symbol *spattern)
+{
     WIN32_FIND_DATAW FindFileData;
     HANDLE hFind;
     uint16_t ucs2pattern[MAXPDSTRING];
     char pattern[MAXPDSTRING];
-    int nostartdot=0, noendtilde=0, onlydirs=0;
+    int nostartdot = 0, noendtilde = 0, onlydirs = 0;
     char *filepattern, *strin, *strout;
-    int pathpatternlength=0;
-    int matchdot=0;
+    int pathpatternlength = 0;
+    int matchdot = 0;
 
     do_expandunbash(spattern->s_name, pattern, MAXPDSTRING);
 
-        /* '.' and '..' should only match if the pattern exquisitely asked for them */
-    if(!strcmp(".", pattern) || !strcmp("./", pattern)
-        || str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
-        matchdot=1;
-    else if(!strcmp("..", pattern) || !strcmp("../", pattern)
-        || str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
-        matchdot=2;
+    /* '.' and '..' should only match if the pattern exquisitely asked for them
+     */
+    if(!strcmp(".", pattern) || !strcmp("./", pattern) ||
+        str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
+        matchdot = 1;
+    else if(!strcmp("..", pattern) || !strcmp("../", pattern) ||
+            str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
+        matchdot = 2;
 
-    if (matchdot) {
-            /* windows FindFile would return the actual path rather than '.'
-             * (which would confuse our full-path construction)
-             * so we just return the result directly
-             */
+    if(matchdot)
+    {
+        /* windows FindFile would return the actual path rather than '.'
+         * (which would confuse our full-path construction)
+         * so we just return the result directly
+         */
         struct stat sb;
-        if (!do_file_stat(0, pattern, &sb, 0)) {
+        if(!do_file_stat(0, pattern, &sb, 0))
+        {
             t_atom outv[2];
             size_t end = strlen(pattern);
-                /* get rid of trailing slash */
-            if('/' == pattern[end-1])
-                pattern[end-1]=0;
-            SETSYMBOL(outv+0, gensym(pattern));
-            SETFLOAT(outv+1, S_ISDIR(sb.st_mode));
+            /* get rid of trailing slash */
+            if('/' == pattern[end - 1]) pattern[end - 1] = 0;
+            SETSYMBOL(outv + 0, gensym(pattern));
+            SETFLOAT(outv + 1, S_ISDIR(sb.st_mode));
             outlet_list(x->x_dataout, gensym("list"), 2, outv);
-        } else {
-                // this gets triggered if there is no match...
+        }
+        else
+        {
+            // this gets triggered if there is no match...
             outlet_bang(x->x_infoout);
         }
         return;
     }
 
-
-    filepattern=strrchr(pattern, '/');
-    if(filepattern && !filepattern[1]) {
-            /* patterns ends with slashes: filter for dirs, and bash the trailing slashes */
-        onlydirs=1;
-        while('/' == *filepattern && filepattern>pattern) {
-            *filepattern--=0;
+    filepattern = strrchr(pattern, '/');
+    if(filepattern && !filepattern[1])
+    {
+        /* patterns ends with slashes: filter for dirs, and bash the trailing
+         * slashes */
+        onlydirs = 1;
+        while('/' == *filepattern && filepattern > pattern)
+        {
+            *filepattern-- = 0;
         }
-        filepattern=strrchr(pattern, '/');
+        filepattern = strrchr(pattern, '/');
     }
     if(!filepattern)
-        filepattern=pattern;
-    else {
+        filepattern = pattern;
+    else
+    {
         filepattern++;
-        pathpatternlength=filepattern-pattern;
+        pathpatternlength = filepattern - pattern;
     }
-    nostartdot=('.' != *filepattern);
-    strin=filepattern;
-    strout=filepattern;
-    while(*strin) {
+    nostartdot = ('.' != *filepattern);
+    strin = filepattern;
+    strout = filepattern;
+    while(*strin)
+    {
         char c = *strin++;
         *strout++ = c;
-        if('*' == c) {
+        if('*' == c)
+        {
             while('?' == *strin || '*' == *strin)
                 strin++;
         }
     }
-    *strout=0;
-    if (strout>pattern) {
-        switch(strout[-1]) {
-        case '~':
-        case '*':
-        case '?':
-            noendtilde=0;
-            break;
-        default:
-            noendtilde=1;
+    *strout = 0;
+    if(strout > pattern)
+    {
+        switch(strout[-1])
+        {
+            case '~':
+            case '*':
+            case '?':
+                noendtilde = 0;
+                break;
+            default:
+                noendtilde = 1;
         }
     }
     u8_utf8toucs2(ucs2pattern, MAXPDSTRING, pattern, MAXPDSTRING);
 
     hFind = FindFirstFileW(ucs2pattern, &FindFileData);
-    if (hFind == INVALID_HANDLE_VALUE) {
-            // this gets triggered if there is no match...
+    if(hFind == INVALID_HANDLE_VALUE)
+    {
+        // this gets triggered if there is no match...
         outlet_bang(x->x_infoout);
         return;
     }
-    do {
-        t_symbol*s;
+    do
+    {
+        t_symbol *s;
         t_atom outv[2];
         int len = 0;
-        int isdir = !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
-        if (matchdot!=1 && !wcscmp(L"." , FindFileData.cFileName))
-            continue;
-        if (matchdot!=2 && !wcscmp(L".." , FindFileData.cFileName))
-            continue;
-        u8_ucs2toutf8(filepattern, MAXPDSTRING-pathpatternlength, FindFileData.cFileName, MAX_PATH);
+        int isdir =
+            !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
+        if(matchdot != 1 && !wcscmp(L".", FindFileData.cFileName)) continue;
+        if(matchdot != 2 && !wcscmp(L"..", FindFileData.cFileName)) continue;
+        u8_ucs2toutf8(filepattern, MAXPDSTRING - pathpatternlength,
+            FindFileData.cFileName, MAX_PATH);
         len = strlen(filepattern);
 
-        if(onlydirs && !isdir)
-            continue;
-        if(nostartdot && '.' == filepattern[0])
-            continue;
-        if(noendtilde && '~' == filepattern[len-1])
-            continue;
+        if(onlydirs && !isdir) continue;
+        if(nostartdot && '.' == filepattern[0]) continue;
+        if(noendtilde && '~' == filepattern[len - 1]) continue;
 
         s = gensym(pattern);
-        SETSYMBOL(outv+0, s);
-        SETFLOAT(outv+1, isdir);
+        SETSYMBOL(outv + 0, s);
+        SETFLOAT(outv + 1, isdir);
         outlet_list(x->x_dataout, gensym("list"), 2, outv);
-    } while (FindNextFileW(hFind, &FindFileData) != 0);
+    } while(FindNextFileW(hFind, &FindFileData) != 0);
     FindClose(hFind);
 }
-#else /* !_WIN32 */
-static void file_glob_symbol(t_file_handle*x, t_symbol*spattern) {
+#else  /* !_WIN32 */
+static void file_glob_symbol(t_file_handle *x, t_symbol *spattern)
+{
     t_atom outv[2];
     glob_t gg;
     int flags = 0;
-    int matchdot=0;
+    int matchdot = 0;
     char pattern[MAXPDSTRING];
     size_t patternlen;
     int onlydirs;
     do_expandpath(spattern->s_name, pattern, MAXPDSTRING);
-    patternlen=strlen(pattern);
-    onlydirs = ('/' == pattern[patternlen-1]);
-    if(!strcmp(".", pattern) || !strcmp("./", pattern)
-        || str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
-        matchdot=1;
-    else if(!strcmp("..", pattern) || !strcmp("../", pattern)
-        || str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
-        matchdot=2;
-    if(glob(pattern, flags, NULL, &gg)) {
-            // this gets triggered if there is no match...
+    patternlen = strlen(pattern);
+    onlydirs = ('/' == pattern[patternlen - 1]);
+    if(!strcmp(".", pattern) || !strcmp("./", pattern) ||
+        str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
+        matchdot = 1;
+    else if(!strcmp("..", pattern) || !strcmp("../", pattern) ||
+            str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
+        matchdot = 2;
+    if(glob(pattern, flags, NULL, &gg))
+    {
+        // this gets triggered if there is no match...
         outlet_bang(x->x_infoout);
-    } else {
+    }
+    else
+    {
         size_t i;
-        for(i=0; i<gg.gl_pathc; i++) {
+        for(i = 0; i < gg.gl_pathc; i++)
+        {
             t_symbol *s;
-            char*path = gg.gl_pathv[i];
+            char *path = gg.gl_pathv[i];
             int isdir = 0;
             struct stat sb;
             int end;
-            if(!do_file_stat(0, path, &sb, 0)) {
+            if(!do_file_stat(0, path, &sb, 0))
+            {
                 isdir = S_ISDIR(sb.st_mode);
             }
-            if(onlydirs && !isdir)
-                continue;
-            end=strlen(path);
-            if('/' == path[end-1]) {
-                path[end-1]=0;
+            if(onlydirs && !isdir) continue;
+            end = strlen(path);
+            if('/' == path[end - 1])
+            {
+                path[end - 1] = 0;
             }
-            if (matchdot!=1 && (!strcmp(path, ".") || str_endswith(path, "/.")))
+            if(matchdot != 1 &&
+                (!strcmp(path, ".") || str_endswith(path, "/.")))
                 continue;
-            if (matchdot!=2 && (!strcmp(path, "..") || str_endswith(path, "/..")))
+            if(matchdot != 2 &&
+                (!strcmp(path, "..") || str_endswith(path, "/..")))
                 continue;
 
             s = gensym(path);
-            SETSYMBOL(outv+0, s);
-            SETFLOAT(outv+1, isdir);
+            SETSYMBOL(outv + 0, s);
+            SETFLOAT(outv + 1, isdir);
             outlet_list(x->x_dataout, gensym("list"), 2, outv);
         }
     }
@@ -941,66 +1144,74 @@ static void file_glob_symbol(t_file_handle*x, t_symbol*spattern) {
 }
 #endif /* _WIN32 */
 
+/* ================ [file which] ====================== */
 
-    /* ================ [file which] ====================== */
-
-static void file_which_symbol(t_file_handle*x, t_symbol*s) {
-        /* LATER we might output directories as well,... */
-    int isdir=0;
+static void file_which_symbol(t_file_handle *x, t_symbol *s)
+{
+    /* LATER we might output directories as well,... */
+    int isdir = 0;
     t_atom outv[2];
     char dirresult[MAXPDSTRING], *nameresult;
-    int fd = canvas_open(x->x_canvas,
-        s->s_name, "",
-        dirresult, &nameresult, MAXPDSTRING,
-        1);
-    if(fd>=0) {
+    int fd = canvas_open(
+        x->x_canvas, s->s_name, "", dirresult, &nameresult, MAXPDSTRING, 1);
+    if(fd >= 0)
+    {
         sys_close(fd);
-        if(nameresult>dirresult)
-            nameresult[-1]='/';
-        SETSYMBOL(outv+0, gensym(dirresult));
-        SETFLOAT(outv+1, isdir);
+        if(nameresult > dirresult) nameresult[-1] = '/';
+        SETSYMBOL(outv + 0, gensym(dirresult));
+        SETFLOAT(outv + 1, isdir);
         outlet_list(x->x_dataout, gensym("list"), 2, outv);
-    } else {
+    }
+    else
+    {
         outlet_symbol(x->x_infoout, s);
     }
 }
 
-
-    /* ================ [file mkdir] ====================== */
-static void file_mkdir_symbol(t_file_handle*x, t_symbol*dir) {
-    char pathname[MAXPDSTRING], *path=pathname, *str;
+/* ================ [file mkdir] ====================== */
+static void file_mkdir_symbol(t_file_handle *x, t_symbol *dir)
+{
+    char pathname[MAXPDSTRING], *path = pathname, *str;
     struct stat sb;
 
     do_expandpath(dir->s_name, pathname, MAXPDSTRING);
-    pathname[MAXPDSTRING-1]=0;
+    pathname[MAXPDSTRING - 1] = 0;
     do_pathnormalize(pathname, pathname);
 
-    if(sys_isabsolutepath(pathname)) {
-        str=strchr(path, '/');
-        if(str)
-            path=str;
+    if(sys_isabsolutepath(pathname))
+    {
+        str = strchr(path, '/');
+        if(str) path = str;
     }
     path++;
-    while(*path) {
-            /* get to the next path separator */
-        str=strchr(path, '/');
-        if(str) {
-            *str=0;
+    while(*path)
+    {
+        /* get to the next path separator */
+        str = strchr(path, '/');
+        if(str)
+        {
+            *str = 0;
         }
-        if(!sys_stat(pathname, &sb) && (S_ISDIR(sb.st_mode))) {
-                // directory exists, skip...
-        } else {
-            if(sys_mkdir(pathname, x?x->x_creationmode:0777)) {
+        if(!sys_stat(pathname, &sb) && (S_ISDIR(sb.st_mode)))
+        {
+            // directory exists, skip...
+        }
+        else
+        {
+            if(sys_mkdir(pathname, x ? x->x_creationmode : 0777))
+            {
                 char buf[MAXPDSTRING];
-                pd_error(x, "failed to create '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+                pd_error(x, "failed to create '%s': %s", pathname,
+                    do_errmsg(buf, MAXPDSTRING));
                 outlet_bang(x->x_infoout);
                 return;
             }
         }
 
-        if(str) {
-            *str='/';
-            path=str+1;
+        if(str)
+        {
+            *str = '/';
+            path = str + 1;
         }
         else
             break;
@@ -1008,86 +1219,107 @@ static void file_mkdir_symbol(t_file_handle*x, t_symbol*dir) {
     outlet_symbol(x->x_dataout, gensym(pathname));
 }
 
-    /* ================ [file delete] ====================== */
+/* ================ [file delete] ====================== */
 #ifdef _WIN32
-static int file_do_delete_recursive_ucs2(uint16_t*path) {
+static int file_do_delete_recursive_ucs2(uint16_t *path)
+{
     WIN32_FIND_DATAW FindFileData;
     HANDLE hFind;
     uint16_t pattern[MAX_PATH];
     swprintf(pattern, MAX_PATH, L"%ls/*", path);
     hFind = FindFirstFileW(pattern, &FindFileData);
-    if (hFind == INVALID_HANDLE_VALUE) {
+    if(hFind == INVALID_HANDLE_VALUE)
+    {
         return 1;
     }
-    do {
-        int isdir = !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
+    do
+    {
+        int isdir =
+            !!(FILE_ATTRIBUTE_DIRECTORY & FindFileData.dwFileAttributes);
         swprintf(pattern, MAX_PATH, L"%ls/%ls", path, FindFileData.cFileName);
-        if(!isdir) {
+        if(!isdir)
+        {
             DeleteFileW(pattern);
-        } else {
-                /* skip self and parent */
-            if(!wcscmp(L".", FindFileData.cFileName))continue;
-            if(!wcscmp(L"..", FindFileData.cFileName))continue;
+        }
+        else
+        {
+            /* skip self and parent */
+            if(!wcscmp(L".", FindFileData.cFileName)) continue;
+            if(!wcscmp(L"..", FindFileData.cFileName)) continue;
             file_do_delete_recursive_ucs2(pattern);
         }
-    } while (FindNextFileW(hFind, &FindFileData) != 0);
+    } while(FindNextFileW(hFind, &FindFileData) != 0);
     FindClose(hFind);
     return do_delete_ucs2(path);
 }
 
-static int file_do_delete_recursive(const char*path) {
+static int file_do_delete_recursive(const char *path)
+{
     uint16_t ucs2path[MAXPDSTRING];
     u8_utf8toucs2(ucs2path, MAXPDSTRING, path, MAXPDSTRING);
     return file_do_delete_recursive_ucs2(ucs2path);
 }
-#else /* !_WIN32 */
-static int nftw_cb(const char *path, const struct stat *s, int flag, struct FTW *f) {
-    (void)s;
-    (void)f;
-    (void)flag;
+#else  /* !_WIN32 */
+static int nftw_cb(
+    const char *path, const struct stat *s, int flag, struct FTW *f)
+{
+    (void) s;
+    (void) f;
+    (void) flag;
     return remove(path);
 }
 
-static int file_do_delete_recursive(const char*pathname) {
-    return nftw(pathname, nftw_cb, 128, FTW_MOUNT|FTW_PHYS|FTW_DEPTH);
+static int file_do_delete_recursive(const char *pathname)
+{
+    return nftw(pathname, nftw_cb, 128, FTW_MOUNT | FTW_PHYS | FTW_DEPTH);
 }
 #endif /* !_WIN32 */
 
-
-static void file_delete_symbol(t_file_handle*x, t_symbol*path) {
+static void file_delete_symbol(t_file_handle *x, t_symbol *path)
+{
     char pathname[MAXPDSTRING];
 
     do_expandunbash(path->s_name, pathname, MAXPDSTRING);
 
-    if(sys_remove(pathname)) {
+    if(sys_remove(pathname))
+    {
         char buf[MAXPDSTRING];
         if(x && x->x_verbose)
-            pd_error(x, "unable to delete '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+            pd_error(x, "unable to delete '%s': %s", pathname,
+                do_errmsg(buf, MAXPDSTRING));
         outlet_bang(x->x_infoout);
-    } else {
+    }
+    else
+    {
         outlet_symbol(x->x_dataout, gensym(pathname));
     }
 }
 
-static void file_delete_recursive(t_file_handle*x, t_symbol*path) {
+static void file_delete_recursive(t_file_handle *x, t_symbol *path)
+{
     char pathname[MAXPDSTRING];
 
     do_expandunbash(path->s_name, pathname, MAXPDSTRING);
 
-    if(file_do_delete_recursive(pathname)) {
-        if(x->x_verbose) {
+    if(file_do_delete_recursive(pathname))
+    {
+        if(x->x_verbose)
+        {
             char buf[MAXPDSTRING];
-            pd_error(x, "unable to recursively delete '%s': %s", pathname, do_errmsg(buf, MAXPDSTRING));
+            pd_error(x, "unable to recursively delete '%s': %s", pathname,
+                do_errmsg(buf, MAXPDSTRING));
         }
         outlet_bang(x->x_infoout);
-    } else {
+    }
+    else
+    {
         outlet_symbol(x->x_dataout, gensym(pathname));
     }
 }
 
-
-    /* ================ [file copy]/[file move] ====================== */
-static int file_do_copy(const char*source, const char*destination, int mode) {
+/* ================ [file copy]/[file move] ====================== */
+static int file_do_copy(const char *source, const char *destination, int mode)
+{
     int result = 0;
     ssize_t len;
     char buf[1024];
@@ -1097,31 +1329,34 @@ static int file_do_copy(const char*source, const char*destination, int mode) {
     wflags |= O_BINARY;
 #endif
     src = sys_open(source, O_RDONLY);
-    if(src<0)
-        return 1;
+    if(src < 0) return 1;
     dst = sys_open(destination, wflags, mode);
-    if(dst<0) {
+    if(dst < 0)
+    {
         struct stat sb;
-            /* check if destination is a directory: if so calculate the new filename */
-        if(!do_file_stat(0, destination, &sb, 0) && (S_ISDIR(sb.st_mode))) {
+        /* check if destination is a directory: if so calculate the new filename
+         */
+        if(!do_file_stat(0, destination, &sb, 0) && (S_ISDIR(sb.st_mode)))
+        {
             char destfile[MAXPDSTRING];
-            const char*filename=strrchr(source, '/');
+            const char *filename = strrchr(source, '/');
             if(!filename)
-                filename=source;
+                filename = source;
             else
                 filename++;
             snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
             dst = sys_open(destfile, O_WRONLY | O_CREAT | O_TRUNC, mode);
         }
     }
-    if(dst<0)
-        return 1;
+    if(dst < 0) return 1;
 
-    while((len=read(src, buf, sizeof(buf)))>0) {
-        ssize_t wlen=write(dst, buf, len);
-            /* TODO: cater for partial writes */
-        if (wlen<1) {
-            result = 1 ;
+    while((len = read(src, buf, sizeof(buf))) > 0)
+    {
+        ssize_t wlen = write(dst, buf, len);
+        /* TODO: cater for partial writes */
+        if(wlen < 1)
+        {
+            result = 1;
         }
     }
     sys_close(src);
@@ -1129,28 +1364,33 @@ static int file_do_copy(const char*source, const char*destination, int mode) {
 
     return (result);
 }
-static int file_do_move(const char*source, const char*destination, int mode) {
-    int olderrno=0;
-    int result = sys_rename(source, destination);
-    (void)mode;
-    if(result) {
-        struct stat sb;
-        int isfile=0;
-        int isdir=0;
 
-        olderrno=errno;
-            /* check whether we are trying to move a file to a directory */
+static int file_do_move(const char *source, const char *destination, int mode)
+{
+    int olderrno = 0;
+    int result = sys_rename(source, destination);
+    (void) mode;
+    if(result)
+    {
+        struct stat sb;
+        int isfile = 0;
+        int isdir = 0;
+
+        olderrno = errno;
+        /* check whether we are trying to move a file to a directory */
         if(do_file_stat(0, source, &sb, 0) < 0)
             goto done; /* source is not statable, that's a serious error */
         isfile = !(S_ISDIR(sb.st_mode));
         if(do_file_stat(0, destination, &sb, 0) < 0)
-            goto done;  /* destination is not statable (so it doesn't exist and is not a directory either */
+            goto done; /* destination is not statable (so it doesn't exist and
+                          is not a directory either */
         isdir = (S_ISDIR(sb.st_mode));
-        if(isfile && isdir) {
+        if(isfile && isdir)
+        {
             char destfile[MAXPDSTRING];
-            const char*filename=strrchr(source, '/');
+            const char *filename = strrchr(source, '/');
             if(!filename)
-                filename=source;
+                filename = source;
             else
                 filename++;
             snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
@@ -1159,42 +1399,55 @@ static int file_do_move(const char*source, const char*destination, int mode) {
         }
     }
 
-    if(result && EXDEV == errno) {
-            /* need to manually copy the file to the another filesystem */
+    if(result && EXDEV == errno)
+    {
+        /* need to manually copy the file to the another filesystem */
         result = file_do_copy(source, destination, mode);
-        if(!result) {
-            olderrno=0;
-                /* copy succeeded, now get rid of the source file */
-            if(sys_remove(source)) {
-                    /* oops, couldn't delete the source-file...
-                     * we still report this as SUCCESS, as the file has been duplicated.
-                     * LATER we might try to unlink() the file first.
-                     * set the olderrno to print some error in verbose-mode
-                     */
-                olderrno=errno;
+        if(!result)
+        {
+            olderrno = 0;
+            /* copy succeeded, now get rid of the source file */
+            if(sys_remove(source))
+            {
+                /* oops, couldn't delete the source-file...
+                 * we still report this as SUCCESS, as the file has been
+                 * duplicated. LATER we might try to unlink() the file first.
+                 * set the olderrno to print some error in verbose-mode
+                 */
+                olderrno = errno;
             }
         }
     }
- done:
-    errno=olderrno;
+done:
+    errno = olderrno;
     return result;
 }
-static void file_do_copymove(t_file_handle*x,
-    const char*verb, int (*fun)(const char*,const char*,int),
-    t_symbol*s, int argc, t_atom*argv) {
+
+static void file_do_copymove(t_file_handle *x, const char *verb,
+    int (*fun)(const char *, const char *, int), t_symbol *s, int argc,
+    t_atom *argv)
+{
     struct stat sb;
     char src[MAXPDSTRING], dst[MAXPDSTRING];
-    if(argc != 2 || A_SYMBOL != argv[0].a_type || A_SYMBOL != argv[1].a_type) {
-        pd_error(x, "bad arguments for [file %s] - should be 'source:symbol destination:symbol'", verb);
+    if(argc != 2 || A_SYMBOL != argv[0].a_type || A_SYMBOL != argv[1].a_type)
+    {
+        pd_error(x,
+            "bad arguments for [file %s] - should be 'source:symbol "
+            "destination:symbol'",
+            verb);
         return;
     }
-    do_expandunbash(atom_getsymbol(argv+0)->s_name, src, MAXPDSTRING);
-    do_expandunbash(atom_getsymbol(argv+1)->s_name, dst, MAXPDSTRING);
+    do_expandunbash(atom_getsymbol(argv + 0)->s_name, src, MAXPDSTRING);
+    do_expandunbash(atom_getsymbol(argv + 1)->s_name, dst, MAXPDSTRING);
 
-    if(!sys_stat(src, &sb)) {
-        if(S_ISDIR(sb.st_mode)) {
-            if(x->x_verbose) {
-                pd_error(x, "failed to %s '%s': %s", verb, src, strerror(EISDIR));
+    if(!sys_stat(src, &sb))
+    {
+        if(S_ISDIR(sb.st_mode))
+        {
+            if(x->x_verbose)
+            {
+                pd_error(
+                    x, "failed to %s '%s': %s", verb, src, strerror(EISDIR));
             }
             outlet_bang(x->x_infoout);
             return;
@@ -1202,61 +1455,74 @@ static void file_do_copymove(t_file_handle*x,
     }
 
     errno = 0;
-    if(fun(src, dst, x->x_creationmode?x->x_creationmode:sb.st_mode)) {
-        if(x->x_verbose) {
+    if(fun(src, dst, x->x_creationmode ? x->x_creationmode : sb.st_mode))
+    {
+        if(x->x_verbose)
+        {
             char buf[MAXPDSTRING];
-            pd_error(x, "failed to %s '%s' to '%s': %s", verb, src, dst, do_errmsg(buf, MAXPDSTRING));
+            pd_error(x, "failed to %s '%s' to '%s': %s", verb, src, dst,
+                do_errmsg(buf, MAXPDSTRING));
         }
         outlet_bang(x->x_infoout);
-    } else {
-        if(errno && x->x_verbose) {
+    }
+    else
+    {
+        if(errno && x->x_verbose)
+        {
             char buf[MAXPDSTRING];
-            pd_error(x, "troubles (but overall success) to %s '%s' to '%s': %s", verb, src, dst, do_errmsg(buf, MAXPDSTRING));
+            pd_error(x, "troubles (but overall success) to %s '%s' to '%s': %s",
+                verb, src, dst, do_errmsg(buf, MAXPDSTRING));
         }
         outlet_list(x->x_dataout, s, argc, argv);
     }
 }
 
-static void file_copy_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+static void file_copy_list(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
     file_do_copymove(x, "copy", file_do_copy, s, argc, argv);
 }
-static void file_move_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
+
+static void file_move_list(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
     file_do_copymove(x, "move", file_do_move, s, argc, argv);
 }
 
 /* ================ file path operations ====================== */
-static void file_split_symbol(t_file_handle*x, t_symbol*path) {
-    t_symbol*slashsym = gensym("/");
-    t_atom*outv;
-    int outc=0, outsize=1;
-    char buffer[MAXPDSTRING], *pathname=buffer;
+static void file_split_symbol(t_file_handle *x, t_symbol *path)
+{
+    t_symbol *slashsym = gensym("/");
+    t_atom *outv;
+    int outc = 0, outsize = 1;
+    char buffer[MAXPDSTRING], *pathname = buffer;
     sys_unbashfilename(path->s_name, buffer);
-    buffer[MAXPDSTRING-1] = 0;
+    buffer[MAXPDSTRING - 1] = 0;
 
-        /* first count the number of path components */
+    /* first count the number of path components */
     while(*pathname)
-        outsize += ('/'==*pathname++);
-    pathname=buffer;
+        outsize += ('/' == *pathname++);
+    pathname = buffer;
     ALLOCA(t_atom, outv, outsize, 100);
 
-    if('/' == *pathname)
-        SETSYMBOL(outv+outc, slashsym), outc++;
+    if('/' == *pathname) SETSYMBOL(outv + outc, slashsym), outc++;
 
-    while(*pathname) {
-        char*pathsep;
+    while(*pathname)
+    {
+        char *pathsep;
         while('/' == *pathname)
             pathname++;
-        pathsep=strchr(pathname, '/');
-        if(!pathsep) {
-            if(*pathname)
-                SETSYMBOL(outv+outc, gensym(pathname)), outc++;
+        pathsep = strchr(pathname, '/');
+        if(!pathsep)
+        {
+            if(*pathname) SETSYMBOL(outv + outc, gensym(pathname)), outc++;
             break;
         }
-        *pathsep=0;
-        SETSYMBOL(outv+outc, gensym(pathname)), outc++;
-        pathname=pathsep+1;
+        *pathsep = 0;
+        SETSYMBOL(outv + outc, gensym(pathname)), outc++;
+        pathname = pathsep + 1;
     }
-    if (*pathname)
+    if(*pathname)
         outlet_bang(x->x_infoout);
     else
         outlet_symbol(x->x_infoout, slashsym);
@@ -1266,127 +1532,155 @@ static void file_split_symbol(t_file_handle*x, t_symbol*path) {
     FREEA(t_atom, outv, outsize, 100);
 }
 
-static void file_join_list(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
-        /* luckily for us, the path-separator in Pd is always '/' */
+static void file_join_list(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
+    /* luckily for us, the path-separator in Pd is always '/' */
     size_t bufsize = 1;
-    char*buffer = getbytes(bufsize);
-    (void)s;
-    while(argc--) {
+    char *buffer = getbytes(bufsize);
+    (void) s;
+    while(argc--)
+    {
         size_t newsize;
-        int needsep=(argc>0);
+        int needsep = (argc > 0);
         char abuf[MAXPDSTRING], *newbuffer;
         size_t alen;
         atom_string(argv++, abuf, MAXPDSTRING);
         alen = strlen(abuf);
         if(!alen) continue;
-        if('/' == abuf[alen-1])
-            needsep = 0;
+        if('/' == abuf[alen - 1]) needsep = 0;
         newsize = bufsize + alen + needsep;
-        if (!(newbuffer = resizebytes(buffer, bufsize, newsize))) break;
+        if(!(newbuffer = resizebytes(buffer, bufsize, newsize))) break;
         buffer = newbuffer;
-        strcpy(buffer+bufsize-1, abuf);
-        if(needsep)
-            buffer[newsize-2]='/';
+        strcpy(buffer + bufsize - 1, abuf);
+        if(needsep) buffer[newsize - 2] = '/';
         bufsize = newsize;
     }
-    buffer[bufsize-1] = 0;
+    buffer[bufsize - 1] = 0;
     outlet_symbol(x->x_dataout, gensym(do_pathnormalize(buffer, buffer)));
     freebytes(buffer, bufsize);
 }
 
-static void file_splitext_symbol(t_file_handle*x, t_symbol*path) {
+static void file_splitext_symbol(t_file_handle *x, t_symbol *path)
+{
     char pathname[MAXPDSTRING];
     t_atom outv[2];
-    char*str;
+    char *str;
     sys_unbashfilename(path->s_name, pathname);
-    pathname[MAXPDSTRING-1]=0;
-    str=pathname + strlen(pathname)-1;
+    pathname[MAXPDSTRING - 1] = 0;
+    str = pathname + strlen(pathname) - 1;
     if(str < pathname || '.' != *str)
     {
-        while(str>=pathname) {
+        while(str >= pathname)
+        {
             char c = *str;
-            switch(c) {
-            case '.':
-                str[0]=0;
-                SETSYMBOL(outv+0, gensym(pathname));
-                SETSYMBOL(outv+1, gensym(str+1));
-                outlet_list(x->x_dataout, gensym("list"), 2, outv);
-                return;
-            case '/':
-                str = pathname;
-                break;
-            default:
-                break;
+            switch(c)
+            {
+                case '.':
+                    str[0] = 0;
+                    SETSYMBOL(outv + 0, gensym(pathname));
+                    SETSYMBOL(outv + 1, gensym(str + 1));
+                    outlet_list(x->x_dataout, gensym("list"), 2, outv);
+                    return;
+                case '/':
+                    str = pathname;
+                    break;
+                default:
+                    break;
             }
             str--;
         }
     }
     outlet_symbol(x->x_infoout, gensym(pathname));
 }
-static void file_splitname_symbol(t_file_handle*x, t_symbol*path) {
+
+static void file_splitname_symbol(t_file_handle *x, t_symbol *path)
+{
     char pathname[MAXPDSTRING];
-    char*str;
+    char *str;
     sys_unbashfilename(path->s_name, pathname);
-    pathname[MAXPDSTRING-1]=0;
-    str=strrchr(pathname, '/');
-    if(str>pathname) {
-        t_symbol*s;
-        *str++=0;
+    pathname[MAXPDSTRING - 1] = 0;
+    str = strrchr(pathname, '/');
+    if(str > pathname)
+    {
+        t_symbol *s;
+        *str++ = 0;
         s = gensym(pathname);
-        if(*str) {
+        if(*str)
+        {
             t_atom outv[2];
-            SETSYMBOL(outv+0, s);
-            SETSYMBOL(outv+1, gensym(str));
+            SETSYMBOL(outv + 0, s);
+            SETSYMBOL(outv + 1, gensym(str));
             outlet_list(x->x_dataout, gensym("list"), 2, outv);
-        } else {
+        }
+        else
+        {
             outlet_symbol(x->x_dataout, s);
         }
-    } else {
+    }
+    else
+    {
         outlet_symbol(x->x_infoout, gensym(pathname));
     }
 }
 
-
-    /* overall creator for "file" objects - dispatch to "file handle" etc */
+/* overall creator for "file" objects - dispatch to "file handle" etc */
 t_class *file_handle_class, *file_which_class, *file_glob_class;
-t_class *file_stat_class, *file_size_class, *file_isfile_class, *file_isdirectory_class;
-t_class *file_mkdir_class, *file_delete_class, *file_copy_class, *file_move_class;
-t_class *file_split_class,*file_join_class,*file_splitext_class, *file_splitname_class;
+t_class *file_stat_class, *file_size_class, *file_isfile_class,
+    *file_isdirectory_class;
+t_class *file_mkdir_class, *file_delete_class, *file_copy_class,
+    *file_move_class;
+t_class *file_split_class, *file_join_class, *file_splitext_class,
+    *file_splitname_class;
 
-#define FILE_PD_NEW(verb, verbose, creationmode) static t_file_handle* file_##verb##_new(t_symbol*s, int argc, t_atom*argv) \
+#define FILE_PD_NEW(verb, verbose, creationmode)                        \
+    static t_file_handle *file_##verb##_new(                            \
+        t_symbol *s, int argc, t_atom *argv)                            \
     {                                                                   \
-        return do_file_handle_new(file_##verb##_class, s, argc, argv, verbose, creationmode); \
+        return do_file_handle_new(                                      \
+            file_##verb##_class, s, argc, argv, verbose, creationmode); \
     }
 
-static void file_define_ignore(t_file_handle*x, t_symbol*s, int argc, t_atom*argv) {
-        /* this is a noop (so the object does not bail out if somebody 'send's something to its label) */
-    (void)s;
-    (void)argc;
-    (void)argv;
-}
-static t_file_handle*file_define_new(t_symbol*s, int argc, t_atom*argv) {
-   t_file_handle*x = (t_file_handle*)pd_new(file_define_class);
-   x->x_fhptr = &x->x_fh;
-   x->x_fh.fh_fd = -1;
-   x->x_canvas = canvas_getcurrent();
-   x->x_creationmode = 0666;
-   x->x_verbose = 0;
-   if(1 == argc && A_SYMBOL == argv->a_type) {
-       x->x_fcname = atom_getsymbol(argv);
-       pd_bind(&x->x_obj.ob_pd, x->x_fcname);
-   } else {
-       pd_error(x, "%s requires an argument: handle name", s->s_name);
-   }
-   return x;
-}
-static void file_define_free(t_file_handle*x) {
-    file_handle_close(x);
-    if(x->x_fcname)
-        pd_unbind(&x->x_obj.ob_pd, x->x_fcname);
+static void file_define_ignore(
+    t_file_handle *x, t_symbol *s, int argc, t_atom *argv)
+{
+    /* this is a noop (so the object does not bail out if somebody 'send's
+     * something to its label) */
+    (void) s;
+    (void) argc;
+    (void) argv;
 }
 
-static t_file_handle*file_handle_new(t_symbol*s, int argc, t_atom*argv) {
-    t_file_handle*x=do_file_handle_new(file_handle_class, s, argc, argv, 1, 0666);
+static t_file_handle *file_define_new(t_symbol *s, int argc, t_atom *argv)
+{
+    t_file_handle *x = (t_file_handle *) pd_new(file_define_class);
+    x->x_fhptr = &x->x_fh;
+    x->x_fh.fh_fd = -1;
+    x->x_canvas = canvas_getcurrent();
+    x->x_creationmode = 0666;
+    x->x_verbose = 0;
+    if(1 == argc && A_SYMBOL == argv->a_type)
+    {
+        x->x_fcname = atom_getsymbol(argv);
+        pd_bind(&x->x_obj.ob_pd, x->x_fcname);
+    }
+    else
+    {
+        pd_error(x, "%s requires an argument: handle name", s->s_name);
+    }
+    return x;
+}
+
+static void file_define_free(t_file_handle *x)
+{
+    file_handle_close(x);
+    if(x->x_fcname) pd_unbind(&x->x_obj.ob_pd, x->x_fcname);
+}
+
+static t_file_handle *file_handle_new(t_symbol *s, int argc, t_atom *argv)
+{
+    t_file_handle *x =
+        do_file_handle_new(file_handle_class, s, argc, argv, 1, 0666);
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("symbol"), gensym("set"));
     return x;
 }
@@ -1409,31 +1703,39 @@ FILE_PD_NEW(join, 0, 0);
 FILE_PD_NEW(splitext, 0, 0);
 FILE_PD_NEW(splitname, 0, 0);
 
-static t_pd *fileobj_new(t_symbol *s, int argc, t_atom*argv)
+static t_pd *fileobj_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_file_handle*x = 0;
-    const char*verb=0;
-    if(gensym("file") == s) {
-        if (argc && A_SYMBOL == argv->a_type) {
+    t_file_handle *x = 0;
+    const char *verb = 0;
+    if(gensym("file") == s)
+    {
+        if(argc && A_SYMBOL == argv->a_type)
+        {
             verb = atom_getsymbol(argv)->s_name;
             argc--;
             argv++;
-        } else {
+        }
+        else
+        {
             verb = "handle";
         }
-    } else if (strlen(s->s_name)>5) {
+    }
+    else if(strlen(s->s_name) > 5)
+    {
         verb = s->s_name + 5;
     }
-    if (!verb || !*verb)
-        x = do_file_handle_new(file_handle_class, gensym("file handle"), argc, argv, 1, 0666);
-    else {
-#define ELIF_FILE_PD_NEW(name, verbose, creationmode) else              \
-            if (!strcmp(verb, #name))                                   \
-                x = do_file_handle_new(file_##name##_class, gensym("file "#name), argc, argv, verbose, creationmode)
+    if(!verb || !*verb)
+        x = do_file_handle_new(
+            file_handle_class, gensym("file handle"), argc, argv, 1, 0666);
+    else
+    {
+#define ELIF_FILE_PD_NEW(name, verbose, creationmode)                         \
+    else if(!strcmp(verb, #name)) x = do_file_handle_new(file_##name##_class, \
+        gensym("file " #name), argc, argv, verbose, creationmode)
 
-        if (!strcmp(verb, "define"))
+        if(!strcmp(verb, "define"))
             x = file_define_new(gensym("file define"), argc, argv);
-        else if (!strcmp(verb, "handle"))
+        else if(!strcmp(verb, "handle"))
             x = file_handle_new(gensym("file handle"), argc, argv);
         ELIF_FILE_PD_NEW(handle, 1, 0666);
         ELIF_FILE_PD_NEW(which, 0, 0);
@@ -1450,94 +1752,110 @@ static t_pd *fileobj_new(t_symbol *s, int argc, t_atom*argv)
         ELIF_FILE_PD_NEW(join, 0, 0);
         ELIF_FILE_PD_NEW(splitext, 0, 0);
         ELIF_FILE_PD_NEW(splitname, 0, 0);
-        else {
+        else
+        {
             pd_error(0, "file %s: unknown function", verb);
         }
     }
-    return (t_pd*)x;
+    return (t_pd *) x;
 }
 
-typedef enum _filenew_flag {
+typedef enum _filenew_flag
+{
     DEFAULT = 0,
-    VERBOSE = 1<<0,
-    MODE = 1<<1
+    VERBOSE = 1 << 0,
+    MODE = 1 << 1
 } t_filenew_flag;
 
-static t_class*file_class_new(const char*name
-    , t_file_handle* (*ctor)(t_symbol*,int,t_atom*), void (*dtor)(t_file_handle*)
-    , void (*symfun)(t_file_handle*, t_symbol*)
-    , t_filenew_flag flag
-    ) {
-    t_class*cls = class_new(gensym(name),
-        (t_newmethod)ctor, (t_method)dtor,
+static t_class *file_class_new(const char *name,
+    t_file_handle *(*ctor)(t_symbol *, int, t_atom *),
+    void (*dtor)(t_file_handle *), void (*symfun)(t_file_handle *, t_symbol *),
+    t_filenew_flag flag)
+{
+    t_class *cls = class_new(gensym(name), (t_newmethod) ctor, (t_method) dtor,
         sizeof(t_file_handle), 0, A_GIMME, 0);
-    if (flag & VERBOSE)
-        class_addmethod(cls, (t_method)file_set_verbosity, gensym("verbose"), A_FLOAT, 0);
-    if (flag & MODE)
-        class_addmethod(cls, (t_method)file_set_creationmode, gensym("creationmode"), A_GIMME, 0);
-    if(symfun)
-        class_addsymbol(cls, (t_method)symfun);
+    if(flag & VERBOSE)
+        class_addmethod(
+            cls, (t_method) file_set_verbosity, gensym("verbose"), A_FLOAT, 0);
+    if(flag & MODE)
+        class_addmethod(cls, (t_method) file_set_creationmode,
+            gensym("creationmode"), A_GIMME, 0);
+    if(symfun) class_addsymbol(cls, (t_method) symfun);
 
     class_sethelpsymbol(cls, gensym("file"));
     return cls;
 }
 
-    /* ---------------- global setup function -------------------- */
+/* ---------------- global setup function -------------------- */
 void x_file_setup(void)
 {
-    class_addcreator((t_newmethod)fileobj_new, gensym("file"), A_GIMME, 0);
+    class_addcreator((t_newmethod) fileobj_new, gensym("file"), A_GIMME, 0);
 
-        /* [file define] */
+    /* [file define] */
     file_define_class = class_new(gensym("file define"),
-                                  (t_newmethod)file_define_new, (t_method)file_define_free,
-                                  sizeof(t_file_handle), CLASS_NOINLET, A_GIMME, 0);
+        (t_newmethod) file_define_new, (t_method) file_define_free,
+        sizeof(t_file_handle), CLASS_NOINLET, A_GIMME, 0);
     class_addanything(file_define_class, file_define_ignore);
     class_sethelpsymbol(file_define_class, gensym("file"));
 
-        /* [file handle] */
-    file_handle_class = file_class_new("file handle", file_handle_new, file_handle_free, 0, MODE|VERBOSE);
-    class_addmethod(file_handle_class, (t_method)file_handle_open,
+    /* [file handle] */
+    file_handle_class = file_class_new(
+        "file handle", file_handle_new, file_handle_free, 0, MODE | VERBOSE);
+    class_addmethod(file_handle_class, (t_method) file_handle_open,
         gensym("open"), A_SYMBOL, A_DEFSYM, 0);
-    class_addmethod(file_handle_class, (t_method)file_handle_close,
-        gensym("close"), 0);
-    class_addmethod(file_handle_class, (t_method)file_handle_seek,
+    class_addmethod(
+        file_handle_class, (t_method) file_handle_close, gensym("close"), 0);
+    class_addmethod(file_handle_class, (t_method) file_handle_seek,
         gensym("seek"), A_GIMME, 0);
-    class_addmethod(file_handle_class, (t_method)file_handle_set,
+    class_addmethod(file_handle_class, (t_method) file_handle_set,
         gensym("set"), A_DEFSYMBOL, 0);
     class_addlist(file_handle_class, file_handle_list);
 
-        /* [file which] */
-    file_which_class = file_class_new("file which", file_which_new, 0, file_which_symbol, VERBOSE);
+    /* [file which] */
+    file_which_class = file_class_new(
+        "file which", file_which_new, 0, file_which_symbol, VERBOSE);
 
-        /* [file glob] */
-    file_glob_class = file_class_new("file glob", file_glob_new, 0, file_glob_symbol, VERBOSE);
+    /* [file glob] */
+    file_glob_class = file_class_new(
+        "file glob", file_glob_new, 0, file_glob_symbol, VERBOSE);
 
-        /* [file stat] */
-    file_stat_class = file_class_new("file stat", file_stat_new, 0, file_stat_symbol, VERBOSE);
-    file_size_class = file_class_new("file size", file_size_new, 0, file_size_symbol, VERBOSE);
-    file_isfile_class = file_class_new("file isfile", file_isfile_new, 0, file_isfile_symbol, VERBOSE);
-    file_isdirectory_class = file_class_new("file isdirectory", file_isdirectory_new, 0, file_isdirectory_symbol, VERBOSE);
+    /* [file stat] */
+    file_stat_class = file_class_new(
+        "file stat", file_stat_new, 0, file_stat_symbol, VERBOSE);
+    file_size_class = file_class_new(
+        "file size", file_size_new, 0, file_size_symbol, VERBOSE);
+    file_isfile_class = file_class_new(
+        "file isfile", file_isfile_new, 0, file_isfile_symbol, VERBOSE);
+    file_isdirectory_class = file_class_new("file isdirectory",
+        file_isdirectory_new, 0, file_isdirectory_symbol, VERBOSE);
 
-        /* [file mkdir] */
-    file_mkdir_class = file_class_new("file mkdir", file_mkdir_new, 0, file_mkdir_symbol, MODE|VERBOSE);
+    /* [file mkdir] */
+    file_mkdir_class = file_class_new(
+        "file mkdir", file_mkdir_new, 0, file_mkdir_symbol, MODE | VERBOSE);
 
-        /* [file delete] */
-    file_delete_class = file_class_new("file delete", file_delete_new, 0, file_delete_symbol, VERBOSE);
-    class_addmethod(file_delete_class, (t_method)file_delete_recursive,
+    /* [file delete] */
+    file_delete_class = file_class_new(
+        "file delete", file_delete_new, 0, file_delete_symbol, VERBOSE);
+    class_addmethod(file_delete_class, (t_method) file_delete_recursive,
         gensym("recursive"), A_SYMBOL, 0);
 
-        /* [file copy] */
-    file_copy_class = file_class_new("file copy", file_copy_new, 0, 0, MODE|VERBOSE);
-    class_addlist(file_copy_class, (t_method)file_copy_list);
+    /* [file copy] */
+    file_copy_class =
+        file_class_new("file copy", file_copy_new, 0, 0, MODE | VERBOSE);
+    class_addlist(file_copy_class, (t_method) file_copy_list);
 
-        /* [file move] */
-    file_move_class = file_class_new("file move", file_move_new, 0, 0, MODE|VERBOSE);
-    class_addlist(file_move_class, (t_method)file_move_list);
+    /* [file move] */
+    file_move_class =
+        file_class_new("file move", file_move_new, 0, 0, MODE | VERBOSE);
+    class_addlist(file_move_class, (t_method) file_move_list);
 
-        /* file path objects */
-    file_split_class = file_class_new("file split", file_split_new, 0, file_split_symbol, DEFAULT);
+    /* file path objects */
+    file_split_class = file_class_new(
+        "file split", file_split_new, 0, file_split_symbol, DEFAULT);
     file_join_class = file_class_new("file join", file_join_new, 0, 0, DEFAULT);
-    class_addlist(file_join_class, (t_method)file_join_list);
-    file_splitext_class = file_class_new("file splitext", file_splitext_new, 0, file_splitext_symbol, DEFAULT);
-    file_splitname_class = file_class_new("file splitname", file_splitname_new, 0, file_splitname_symbol, DEFAULT);
+    class_addlist(file_join_class, (t_method) file_join_list);
+    file_splitext_class = file_class_new(
+        "file splitext", file_splitext_new, 0, file_splitext_symbol, DEFAULT);
+    file_splitname_class = file_class_new("file splitname", file_splitname_new,
+        0, file_splitname_symbol, DEFAULT);
 }

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -1130,8 +1130,7 @@ static void file_glob_symbol(t_file_handle *x, t_symbol *spattern)
     }
     else
     {
-        size_t i;
-        for(i = 0; i < gg.gl_pathc; i++)
+        for(size_t i = 0; i < gg.gl_pathc; i++)
         {
             t_symbol *s;
             char *path = gg.gl_pathv[i];

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -311,7 +311,9 @@ static void do_parse_args(t_file_handle *x, int argc, t_atom *argv)
     {
         const t_symbol *flag = atom_getsymbol(argv);
         if(0)
+        {
             ;
+        }
         else if(flag == flag_q)
         {
             x->x_verbose--;
@@ -387,8 +389,10 @@ static int do_file_open(t_file_handle *x, const char *filename, int mode)
         if(fd < 0)
         {
             if(x->x_verbose)
+            {
                 pd_error(
                     x, "unable to open '%s': %s", filename, strerror(errno));
+            }
             if(x->x_infoout) outlet_bang(x->x_infoout);
         }
     }
@@ -673,8 +677,10 @@ static void file_handle_open(t_file_handle *x, t_symbol *file, t_symbol *smode)
         {
             file_handle_close(x);
             if(x->x_verbose)
+            {
                 pd_error(x, "unable to stat '%s': %s", file->s_name,
                     strerror(errno));
+            }
             outlet_bang(x->x_infoout);
             return;
         }
@@ -682,8 +688,10 @@ static void file_handle_open(t_file_handle *x, t_symbol *file, t_symbol *smode)
         {
             file_handle_close(x);
             if(x->x_verbose)
+            {
                 pd_error(
                     x, "unable to open directory '%s' as file", file->s_name);
+            }
             outlet_bang(x->x_infoout);
             return;
         }
@@ -876,9 +884,13 @@ static void file_stat_symbol(t_file_handle *x, t_symbol *filename)
             break;
     }
     if(s)
+    {
         do_dataout_symbol(x, "type", s);
+    }
     else
+    {
         do_dataout_symbol(x, "type", gensym("unknown"));
+    }
 
     do_dataout_time(x, "atime", sb.st_atime);
     do_dataout_time(x, "mtime", sb.st_mtime);
@@ -1103,10 +1115,14 @@ static void file_glob_symbol(t_file_handle *x, t_symbol *spattern)
     onlydirs = ('/' == pattern[patternlen - 1]);
     if(!strcmp(".", pattern) || !strcmp("./", pattern) ||
         str_endswith(pattern, "/.") || str_endswith(pattern, "/./"))
+    {
         matchdot = 1;
+    }
     else if(!strcmp("..", pattern) || !strcmp("../", pattern) ||
             str_endswith(pattern, "/..") || str_endswith(pattern, "/../"))
+    {
         matchdot = 2;
+    }
     if(glob(pattern, flags, NULL, &gg))
     {
         // this gets triggered if there is no match...
@@ -1293,8 +1309,10 @@ static void file_delete_symbol(t_file_handle *x, t_symbol *path)
     {
         char buf[MAXPDSTRING];
         if(x && x->x_verbose)
+        {
             pd_error(x, "unable to delete '%s': %s", pathname,
                 do_errmsg(buf, MAXPDSTRING));
+        }
         outlet_bang(x->x_infoout);
     }
     else
@@ -1350,9 +1368,13 @@ static int file_do_copy(const char *source, const char *destination, int mode)
             char destfile[MAXPDSTRING];
             const char *filename = strrchr(source, '/');
             if(!filename)
+            {
                 filename = source;
+            }
             else
+            {
                 filename++;
+            }
             snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
             dst = sys_open(destfile, O_WRONLY | O_CREAT | O_TRUNC, mode);
         }
@@ -1399,9 +1421,13 @@ static int file_do_move(const char *source, const char *destination, int mode)
             char destfile[MAXPDSTRING];
             const char *filename = strrchr(source, '/');
             if(!filename)
+            {
                 filename = source;
+            }
             else
+            {
                 filename++;
+            }
             snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
             result = sys_rename(source, destfile);
             olderrno = errno;
@@ -1535,9 +1561,13 @@ static void file_split_symbol(t_file_handle *x, t_symbol *path)
         pathname = pathsep + 1;
     }
     if(*pathname)
+    {
         outlet_bang(x->x_infoout);
+    }
     else
+    {
         outlet_symbol(x->x_infoout, slashsym);
+    }
 
     outlet_list(x->x_dataout, gensym("list"), outc, outv);
 
@@ -1738,8 +1768,10 @@ static t_pd *fileobj_new(t_symbol *s, int argc, t_atom *argv)
         verb = s->s_name + 5;
     }
     if(!verb || !*verb)
+    {
         x = do_file_handle_new(
             file_handle_class, gensym("file handle"), argc, argv, 1, 0666);
+    }
     else
     {
 #define ELIF_FILE_PD_NEW(name, verbose, creationmode)                         \
@@ -1747,7 +1779,9 @@ static t_pd *fileobj_new(t_symbol *s, int argc, t_atom *argv)
         gensym("file " #name), argc, argv, verbose, creationmode)
 
         if(!strcmp(verb, "define"))
+        {
             x = file_define_new(gensym("file define"), argc, argv);
+        }
         else if(!strcmp(verb, "handle"))
             x = file_handle_new(gensym("file handle"), argc, argv);
         ELIF_FILE_PD_NEW(handle, 1, 0666);
@@ -1788,11 +1822,15 @@ static t_class *file_class_new(const char *name,
     t_class *cls = class_new(gensym(name), (t_newmethod) ctor, (t_method) dtor,
         sizeof(t_file_handle), 0, A_GIMME, 0);
     if(flag & VERBOSE)
+    {
         class_addmethod(
             cls, (t_method) file_set_verbosity, gensym("verbose"), A_FLOAT, 0);
+    }
     if(flag & MODE)
+    {
         class_addmethod(cls, (t_method) file_set_creationmode,
             gensym("creationmode"), A_GIMME, 0);
+    }
     if(symfun) class_addsymbol(cls, (t_method) symfun);
 
     class_sethelpsymbol(cls, gensym("file"));

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -280,7 +280,7 @@ static int do_parse_creationmode(t_atom *ap)
         long mode = strtol(s + 2, &endptr, 8);
         return (*endptr) ? -1 : (int) mode;
     }
-    else if(!strncmp(s, "0x", 2))
+    if(!strncmp(s, "0x", 2))
     {
         /* hex mode: nobody sane uses this... */
         char *endptr;
@@ -338,10 +338,8 @@ static void do_parse_args(t_file_handle *x, int argc, t_atom *argv)
                 pd_error(x, "invalid creation mode '%s'", buf);
                 break;
             }
-            else
-            {
-                x->x_creationmode = mode;
-            }
+
+            x->x_creationmode = mode;
         }
         else
         {

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -178,7 +178,8 @@ static char *do_expandpath(const char *from, char *to, int bufsize)
 static char *do_pathnormalize(const char *from, char *to)
 {
     const char *rp;
-    char *wp, c;
+    char *wp;
+    char c;
     sys_unbashfilename(from, to);
     rp = wp = to;
     while((*wp++ = c = *rp++))
@@ -204,7 +205,8 @@ static char *do_expandunbash(const char *from, char *to, int bufsize)
 
 static int str_endswith(char *str, char *end)
 {
-    size_t strsize = strlen(str), endsize = strlen(end);
+    size_t strsize = strlen(str);
+    size_t endsize = strlen(end);
     if(strsize < endsize) return 0;
     return strcmp(str + strsize - endsize, end) == 0;
 }
@@ -461,7 +463,9 @@ static void file_handle_do_read(t_file_handle *x, t_float f)
 {
     t_atom *outv;
     unsigned char *buf;
-    ssize_t n, len, outc = f;
+    ssize_t n;
+    ssize_t len;
+    ssize_t outc = f;
     if(outc < 1)
     {
         pd_error(x, "cannot read %d bytes", (int) outc);
@@ -779,7 +783,10 @@ static void file_stat_symbol(t_file_handle *x, t_symbol *filename)
     struct stat sb;
     t_symbol *s;
     int is_symlink = 0;
-    int readable = 0, writable = 0, executable = 0, owned = -1;
+    int readable = 0;
+    int writable = 0;
+    int executable = 0;
+    int owned = -1;
     char buf[MAXPDSTRING + 1];
 
     if(do_file_stat(x, filename->s_name, &sb, &is_symlink) < 0)
@@ -1151,7 +1158,8 @@ static void file_which_symbol(t_file_handle *x, t_symbol *s)
     /* LATER we might output directories as well,... */
     int isdir = 0;
     t_atom outv[2];
-    char dirresult[MAXPDSTRING], *nameresult;
+    char dirresult[MAXPDSTRING];
+    char *nameresult;
     int fd = canvas_open(
         x->x_canvas, s->s_name, "", dirresult, &nameresult, MAXPDSTRING, 1);
     if(fd >= 0)
@@ -1171,7 +1179,9 @@ static void file_which_symbol(t_file_handle *x, t_symbol *s)
 /* ================ [file mkdir] ====================== */
 static void file_mkdir_symbol(t_file_handle *x, t_symbol *dir)
 {
-    char pathname[MAXPDSTRING], *path = pathname, *str;
+    char pathname[MAXPDSTRING];
+    char *path = pathname;
+    char *str;
     struct stat sb;
 
     do_expandpath(dir->s_name, pathname, MAXPDSTRING);
@@ -1323,7 +1333,8 @@ static int file_do_copy(const char *source, const char *destination, int mode)
     int result = 0;
     ssize_t len;
     char buf[1024];
-    int src, dst;
+    int src;
+    int dst;
     int wflags = O_WRONLY | O_CREAT | O_TRUNC;
 #ifdef _WIN32
     wflags |= O_BINARY;
@@ -1428,7 +1439,8 @@ static void file_do_copymove(t_file_handle *x, const char *verb,
     t_atom *argv)
 {
     struct stat sb;
-    char src[MAXPDSTRING], dst[MAXPDSTRING];
+    char src[MAXPDSTRING];
+    char dst[MAXPDSTRING];
     if(argc != 2 || A_SYMBOL != argv[0].a_type || A_SYMBOL != argv[1].a_type)
     {
         pd_error(x,
@@ -1494,8 +1506,10 @@ static void file_split_symbol(t_file_handle *x, t_symbol *path)
 {
     t_symbol *slashsym = gensym("/");
     t_atom *outv;
-    int outc = 0, outsize = 1;
-    char buffer[MAXPDSTRING], *pathname = buffer;
+    int outc = 0;
+    int outsize = 1;
+    char buffer[MAXPDSTRING];
+    char *pathname = buffer;
     sys_unbashfilename(path->s_name, buffer);
     buffer[MAXPDSTRING - 1] = 0;
 
@@ -1543,7 +1557,8 @@ static void file_join_list(
     {
         size_t newsize;
         int needsep = (argc > 0);
-        char abuf[MAXPDSTRING], *newbuffer;
+        char abuf[MAXPDSTRING];
+        char *newbuffer;
         size_t alen;
         atom_string(argv++, abuf, MAXPDSTRING);
         alen = strlen(abuf);

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -86,7 +86,8 @@ void gfxstub_new(t_pd *owner, void *key, const char *cmd)
 
 static void gfxstub_offlist(t_gfxstub *x)
 {
-    t_gfxstub *y1, *y2;
+    t_gfxstub *y1;
+    t_gfxstub *y2;
     if(gfxstub_list == x)
         gfxstub_list = x->x_next;
     else

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -419,8 +419,7 @@ static void *pdcontrol_new(void)
 static void pdcontrol_dir(t_pdcontrol *x, t_symbol *s, t_floatarg f)
 {
     t_canvas *c = x->x_canvas;
-    int i;
-    for(i = 0; i < (int) f; i++)
+    for(int i = 0; i < (int) f; i++)
     {
         while(!c->gl_env) /* back up to containing canvas or abstraction */
             c = c->gl_owner;
@@ -442,10 +441,9 @@ static void pdcontrol_dir(t_pdcontrol *x, t_symbol *s, t_floatarg f)
 static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
 {
     t_canvas *c = x->x_canvas;
-    int i;
     int argc;
     t_atom *argv;
-    for(i = 0; i < (int) f; i++)
+    for(int i = 0; i < (int) f; i++)
     {
         while(!c->gl_env) /* back up to containing canvas or abstraction */
             c = c->gl_owner;

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2000 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* dialogs.  LATER, deal with the situation where the object goes
 away before the panel does... */
@@ -13,7 +13,7 @@ away before the panel does... */
 #include <unistd.h>
 #endif
 #ifdef _MSC_VER
-#define snprintf _snprintf  /* for pdcontrol object */
+#define snprintf _snprintf /* for pdcontrol object */
 #endif
 
 /* --------------------- graphics responder  ---------------- */
@@ -39,34 +39,33 @@ typedef struct _gfxstub
 
 static t_gfxstub *gfxstub_list;
 
-    /* create a new one.  the "key" is an address by which the owner
-    will identify it later; if the owner only wants one dialog, this
-    could just be a pointer to the owner itself.  The string "cmd"
-    is a TK command to create the dialog, with "%s" embedded in
-    it so we can provide a name by which the GUI can send us back
-    messages; e.g., "pdtk_canvas_dofont %s 10". */
+/* create a new one.  the "key" is an address by which the owner
+will identify it later; if the owner only wants one dialog, this
+could just be a pointer to the owner itself.  The string "cmd"
+is a TK command to create the dialog, with "%s" embedded in
+it so we can provide a name by which the GUI can send us back
+messages; e.g., "pdtk_canvas_dofont %s 10". */
 
 void gfxstub_new(t_pd *owner, void *key, const char *cmd)
 {
-    char buf[4*MAXPDSTRING];
+    char buf[4 * MAXPDSTRING];
     char namebuf[80];
     char sprintfbuf[MAXPDSTRING];
     char *afterpercent;
     t_int afterpercentlen;
     t_gfxstub *x;
     t_symbol *s;
-        /* if any exists with matching key, burn it. */
-    for (x = gfxstub_list; x; x = x->x_next)
-        if (x->x_key == key)
-            gfxstub_deleteforkey(key);
-    if (strlen(cmd) + 50 > 4*MAXPDSTRING)
+    /* if any exists with matching key, burn it. */
+    for(x = gfxstub_list; x; x = x->x_next)
+        if(x->x_key == key) gfxstub_deleteforkey(key);
+    if(strlen(cmd) + 50 > 4 * MAXPDSTRING)
     {
         bug("audio dialog too long");
         bug("%s", cmd);
         return;
     }
-    x = (t_gfxstub *)pd_new(gfxstub_class);
-    sprintf(namebuf, ".gfxstub%lx", (t_int)x);
+    x = (t_gfxstub *) pd_new(gfxstub_class);
+    sprintf(namebuf, ".gfxstub%lx", (t_int) x);
 
     s = gensym(namebuf);
     pd_bind(&x->x_pd, s);
@@ -81,36 +80,37 @@ void gfxstub_new(t_pd *owner, void *key, const char *cmd)
     strncpy(sprintfbuf, cmd, afterpercentlen);
     sprintfbuf[afterpercentlen] = '\0';
     sprintf(buf, sprintfbuf, s->s_name);
-    strncat(buf, afterpercent, (4*MAXPDSTRING) - afterpercentlen);
+    strncat(buf, afterpercent, (4 * MAXPDSTRING) - afterpercentlen);
     sys_gui(buf);
 }
 
 static void gfxstub_offlist(t_gfxstub *x)
 {
     t_gfxstub *y1, *y2;
-    if (gfxstub_list == x)
+    if(gfxstub_list == x)
         gfxstub_list = x->x_next;
-    else for (y1 = gfxstub_list; (y2 = y1->x_next); y1 = y2)
-        if (y2 == x)
-    {
-        y1->x_next = y2->x_next;
-        break;
-    }
+    else
+        for(y1 = gfxstub_list; (y2 = y1->x_next); y1 = y2)
+            if(y2 == x)
+            {
+                y1->x_next = y2->x_next;
+                break;
+            }
 }
 
-    /* if the owner disappears, we still may have to stay around until our
-    dialog window signs off.  Anyway we can now tell the GUI to destroy the
-    window.  */
+/* if the owner disappears, we still may have to stay around until our
+dialog window signs off.  Anyway we can now tell the GUI to destroy the
+window.  */
 void gfxstub_deleteforkey(void *key)
 {
     t_gfxstub *y;
     int didit = 1;
-    while (didit)
+    while(didit)
     {
         didit = 0;
-        for (y = gfxstub_list; y; y = y->x_next)
+        for(y = gfxstub_list; y; y = y->x_next)
         {
-            if (y->x_key == key)
+            if(y->x_key == key)
             {
                 sys_vgui("destroy .gfxstub%lx\n", y);
                 y->x_owner = 0;
@@ -124,13 +124,10 @@ void gfxstub_deleteforkey(void *key)
 
 /* --------- pd messages for gfxstub (these come from the GUI) ---------- */
 
-    /* "cancel" to request that we close the dialog window. */
-static void gfxstub_cancel(t_gfxstub *x)
-{
-    gfxstub_deleteforkey(x->x_key);
-}
+/* "cancel" to request that we close the dialog window. */
+static void gfxstub_cancel(t_gfxstub *x) { gfxstub_deleteforkey(x->x_key); }
 
-    /* "signoff" comes from the GUI to say the dialog window closed. */
+/* "signoff" comes from the GUI to say the dialog window closed. */
 static void gfxstub_signoff(t_gfxstub *x)
 {
     gfxstub_offlist(x);
@@ -139,49 +136,44 @@ static void gfxstub_signoff(t_gfxstub *x)
 
 static t_binbuf *gfxstub_binbuf;
 
-    /* a series of "data" messages rebuilds a scalar */
+/* a series of "data" messages rebuilds a scalar */
 static void gfxstub_data(t_gfxstub *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (!gfxstub_binbuf)
-        gfxstub_binbuf = binbuf_new();
+    if(!gfxstub_binbuf) gfxstub_binbuf = binbuf_new();
     binbuf_add(gfxstub_binbuf, argc, argv);
     binbuf_addsemi(gfxstub_binbuf);
 }
-    /* the "end" message terminates rebuilding the scalar */
+
+/* the "end" message terminates rebuilding the scalar */
 static void gfxstub_end(t_gfxstub *x)
 {
-    canvas_dataproperties((t_canvas *)x->x_owner,
-        (t_scalar *)x->x_key, gfxstub_binbuf);
+    canvas_dataproperties(
+        (t_canvas *) x->x_owner, (t_scalar *) x->x_key, gfxstub_binbuf);
     binbuf_free(gfxstub_binbuf);
     gfxstub_binbuf = 0;
 }
 
-    /* anything else is a message from the dialog window to the owner;
-    just forward it. */
+/* anything else is a message from the dialog window to the owner;
+just forward it. */
 static void gfxstub_anything(t_gfxstub *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_owner)
-        pd_typedmess(x->x_owner, s, argc, argv);
+    if(x->x_owner) pd_typedmess(x->x_owner, s, argc, argv);
 }
 
-static void gfxstub_free(t_gfxstub *x)
-{
-    pd_unbind(&x->x_pd, x->x_sym);
-}
+static void gfxstub_free(t_gfxstub *x) { pd_unbind(&x->x_pd, x->x_sym); }
 
 static void gfxstub_setup(void)
 {
-    gfxstub_class = class_new(gensym("gfxstub"), 0, (t_method)gfxstub_free,
+    gfxstub_class = class_new(gensym("gfxstub"), 0, (t_method) gfxstub_free,
         sizeof(t_gfxstub), CLASS_PD, 0);
     class_addanything(gfxstub_class, gfxstub_anything);
-    class_addmethod(gfxstub_class, (t_method)gfxstub_signoff,
-        gensym("signoff"), 0);
-    class_addmethod(gfxstub_class, (t_method)gfxstub_data,
-        gensym("data"), A_GIMME, 0);
-    class_addmethod(gfxstub_class, (t_method)gfxstub_end,
-        gensym("end"), 0);
-    class_addmethod(gfxstub_class, (t_method)gfxstub_cancel,
-        gensym("cancel"), 0);
+    class_addmethod(
+        gfxstub_class, (t_method) gfxstub_signoff, gensym("signoff"), 0);
+    class_addmethod(
+        gfxstub_class, (t_method) gfxstub_data, gensym("data"), A_GIMME, 0);
+    class_addmethod(gfxstub_class, (t_method) gfxstub_end, gensym("end"), 0);
+    class_addmethod(
+        gfxstub_class, (t_method) gfxstub_cancel, gensym("cancel"), 0);
 }
 
 /* -------------------------- openpanel ------------------------------ */
@@ -198,10 +190,10 @@ typedef struct _openpanel
 static void *openpanel_new(t_floatarg mode)
 {
     char buf[50];
-    int m = (int)mode;
-    t_openpanel *x = (t_openpanel *)pd_new(openpanel_class);
+    int m = (int) mode;
+    t_openpanel *x = (t_openpanel *) pd_new(openpanel_class);
     x->x_mode = (mode < 0 || mode > 2) ? 0 : mode;
-    sprintf(buf, "d%lx", (t_int)x);
+    sprintf(buf, "d%lx", (t_int) x);
     x->x_s = gensym(buf);
     pd_bind(&x->x_obj.ob_pd, x->x_s);
     outlet_new(&x->x_obj, &s_symbol);
@@ -211,20 +203,17 @@ static void *openpanel_new(t_floatarg mode)
 static void openpanel_symbol(t_openpanel *x, t_symbol *s)
 {
     const char *path = (s && s->s_name) ? s->s_name : "\"\"";
-    sys_vgui("pdtk_openpanel {%s} {%s} %d\n",
-        x->x_s->s_name, path, x->x_mode);
+    sys_vgui("pdtk_openpanel {%s} {%s} %d\n", x->x_s->s_name, path, x->x_mode);
 }
 
-static void openpanel_bang(t_openpanel *x)
-{
-    openpanel_symbol(x, &s_);
-}
+static void openpanel_bang(t_openpanel *x) { openpanel_symbol(x, &s_); }
 
-static void openpanel_callback(t_openpanel *x, t_symbol *s, int argc, t_atom *argv)
+static void openpanel_callback(
+    t_openpanel *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_mode != 2) /* single file or folder */
+    if(x->x_mode != 2) /* single file or folder */
     {
-        if (argc == 1 && argv->a_type == A_SYMBOL)
+        if(argc == 1 && argv->a_type == A_SYMBOL)
             outlet_symbol(x->x_obj.ob_outlet, argv->a_w.w_symbol);
         else
             bug("openpanel_callback");
@@ -240,12 +229,12 @@ static void openpanel_free(t_openpanel *x)
 
 static void openpanel_setup(void)
 {
-    openpanel_class = class_new(gensym("openpanel"),
-        (t_newmethod)openpanel_new, (t_method)openpanel_free,
-        sizeof(t_openpanel), 0, A_DEFFLOAT, 0);
+    openpanel_class =
+        class_new(gensym("openpanel"), (t_newmethod) openpanel_new,
+            (t_method) openpanel_free, sizeof(t_openpanel), 0, A_DEFFLOAT, 0);
     class_addbang(openpanel_class, openpanel_bang);
     class_addsymbol(openpanel_class, openpanel_symbol);
-    class_addmethod(openpanel_class, (t_method)openpanel_callback,
+    class_addmethod(openpanel_class, (t_method) openpanel_callback,
         gensym("callback"), A_GIMME, 0);
 }
 
@@ -263,8 +252,8 @@ typedef struct _savepanel
 static void *savepanel_new(void)
 {
     char buf[50];
-    t_savepanel *x = (t_savepanel *)pd_new(savepanel_class);
-    sprintf(buf, "d%lx", (t_int)x);
+    t_savepanel *x = (t_savepanel *) pd_new(savepanel_class);
+    sprintf(buf, "d%lx", (t_int) x);
     x->x_s = gensym(buf);
     x->x_canvas = canvas_getcurrent();
     pd_bind(&x->x_obj.ob_pd, x->x_s);
@@ -278,10 +267,7 @@ static void savepanel_symbol(t_savepanel *x, t_symbol *s)
     sys_vgui("pdtk_savepanel {%s} {%s}\n", x->x_s->s_name, path);
 }
 
-static void savepanel_bang(t_savepanel *x)
-{
-    savepanel_symbol(x, &s_);
-}
+static void savepanel_bang(t_savepanel *x) { savepanel_symbol(x, &s_); }
 
 static void savepanel_callback(t_savepanel *x, t_symbol *s)
 {
@@ -295,12 +281,12 @@ static void savepanel_free(t_savepanel *x)
 
 static void savepanel_setup(void)
 {
-    savepanel_class = class_new(gensym("savepanel"),
-        (t_newmethod)savepanel_new, (t_method)savepanel_free,
-        sizeof(t_savepanel), 0, 0);
+    savepanel_class =
+        class_new(gensym("savepanel"), (t_newmethod) savepanel_new,
+            (t_method) savepanel_free, sizeof(t_savepanel), 0, 0);
     class_addbang(savepanel_class, savepanel_bang);
     class_addsymbol(savepanel_class, savepanel_symbol);
-    class_addmethod(savepanel_class, (t_method)savepanel_callback,
+    class_addmethod(savepanel_class, (t_method) savepanel_callback,
         gensym("callback"), A_SYMBOL, 0);
 }
 
@@ -315,7 +301,7 @@ typedef struct _key
 
 static void *key_new(void)
 {
-    t_key *x = (t_key *)pd_new(key_class);
+    t_key *x = (t_key *) pd_new(key_class);
     outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, gensym("#key"));
     return (x);
@@ -326,10 +312,7 @@ static void key_float(t_key *x, t_floatarg f)
     outlet_float(x->x_obj.ob_outlet, f);
 }
 
-static void key_free(t_key *x)
-{
-    pd_unbind(&x->x_obj.ob_pd, gensym("#key"));
-}
+static void key_free(t_key *x) { pd_unbind(&x->x_obj.ob_pd, gensym("#key")); }
 
 typedef struct _keyup
 {
@@ -338,7 +321,7 @@ typedef struct _keyup
 
 static void *keyup_new(void)
 {
-    t_keyup *x = (t_keyup *)pd_new(keyup_class);
+    t_keyup *x = (t_keyup *) pd_new(keyup_class);
     outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, gensym("#keyup"));
     return (x);
@@ -363,7 +346,7 @@ typedef struct _keyname
 
 static void *keyname_new(void)
 {
-    t_keyname *x = (t_keyname *)pd_new(keyname_class);
+    t_keyname *x = (t_keyname *) pd_new(keyname_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_symbol);
     pd_bind(&x->x_obj.ob_pd, gensym("#keyname"));
@@ -383,21 +366,18 @@ static void keyname_free(t_keyname *x)
 
 static void key_setup(void)
 {
-    key_class = class_new(gensym("key"),
-        (t_newmethod)key_new, (t_method)key_free,
-        sizeof(t_key), CLASS_NOINLET, 0);
+    key_class = class_new(gensym("key"), (t_newmethod) key_new,
+        (t_method) key_free, sizeof(t_key), CLASS_NOINLET, 0);
     class_addfloat(key_class, key_float);
     class_sethelpsymbol(key_class, gensym("key-input"));
 
-    keyup_class = class_new(gensym("keyup"),
-        (t_newmethod)keyup_new, (t_method)keyup_free,
-        sizeof(t_keyup), CLASS_NOINLET, 0);
+    keyup_class = class_new(gensym("keyup"), (t_newmethod) keyup_new,
+        (t_method) keyup_free, sizeof(t_keyup), CLASS_NOINLET, 0);
     class_addfloat(keyup_class, keyup_float);
     class_sethelpsymbol(keyup_class, gensym("key-input"));
 
-    keyname_class = class_new(gensym("keyname"),
-        (t_newmethod)keyname_new, (t_method)keyname_free,
-        sizeof(t_keyname), CLASS_NOINLET, 0);
+    keyname_class = class_new(gensym("keyname"), (t_newmethod) keyname_new,
+        (t_method) keyname_free, sizeof(t_keyname), CLASS_NOINLET, 0);
     class_addlist(keyname_class, keyname_list);
     class_sethelpsymbol(keyname_class, gensym("key-input"));
 }
@@ -413,38 +393,39 @@ typedef struct _pdcontrol
     t_outlet *x_outlet;
 } t_pdcontrol;
 
-static void *pdcontrol_new( void)
+static void *pdcontrol_new(void)
 {
-    t_pdcontrol *x = (t_pdcontrol *)pd_new(pdcontrol_class);
+    t_pdcontrol *x = (t_pdcontrol *) pd_new(pdcontrol_class);
     x->x_canvas = canvas_getcurrent();
     x->x_outlet = outlet_new(&x->x_obj, 0);
     return (x);
 }
 
-    /* output containing directory of patch.  optional args:
-    1. a number, zero for this patch, one for the parent, etc.;
-    2. a symbol to concatenate onto the directory; */
+/* output containing directory of patch.  optional args:
+1. a number, zero for this patch, one for the parent, etc.;
+2. a symbol to concatenate onto the directory; */
 
 static void pdcontrol_dir(t_pdcontrol *x, t_symbol *s, t_floatarg f)
 {
     t_canvas *c = x->x_canvas;
     int i;
-    for (i = 0; i < (int)f; i++)
+    for(i = 0; i < (int) f; i++)
     {
-        while (!c->gl_env)  /* back up to containing canvas or abstraction */
+        while(!c->gl_env) /* back up to containing canvas or abstraction */
             c = c->gl_owner;
-        if (c->gl_owner)    /* back up one more into an owner if any */
+        if(c->gl_owner) /* back up one more into an owner if any */
             c = c->gl_owner;
     }
-    if (*s->s_name)
+    if(*s->s_name)
     {
         char buf[MAXPDSTRING];
-        snprintf(buf, MAXPDSTRING, "%s/%s",
-            canvas_getdir(c)->s_name, s->s_name);
-        buf[MAXPDSTRING-1] = 0;
+        snprintf(
+            buf, MAXPDSTRING, "%s/%s", canvas_getdir(c)->s_name, s->s_name);
+        buf[MAXPDSTRING - 1] = 0;
         outlet_symbol(x->x_outlet, gensym(buf));
     }
-    else outlet_symbol(x->x_outlet, canvas_getdir(c));
+    else
+        outlet_symbol(x->x_outlet, canvas_getdir(c));
 }
 
 static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
@@ -453,11 +434,11 @@ static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
     int i;
     int argc;
     t_atom *argv;
-    for (i = 0; i < (int)f; i++)
+    for(i = 0; i < (int) f; i++)
     {
-        while (!c->gl_env)  /* back up to containing canvas or abstraction */
+        while(!c->gl_env) /* back up to containing canvas or abstraction */
             c = c->gl_owner;
-        if (c->gl_owner)    /* back up one more into an owner if any */
+        if(c->gl_owner) /* back up one more into an owner if any */
             c = c->gl_owner;
     }
     canvas_setcurrent(c);
@@ -469,9 +450,9 @@ static void pdcontrol_args(t_pdcontrol *x, t_floatarg f)
 static void pdcontrol_browse(t_pdcontrol *x, t_symbol *s)
 {
     char buf[MAXPDSTRING];
-    snprintf(buf, MAXPDSTRING, "::pd_menucommands::menu_openfile {%s}\n",
-        s->s_name);
-    buf[MAXPDSTRING-1] = 0;
+    snprintf(
+        buf, MAXPDSTRING, "::pd_menucommands::menu_openfile {%s}\n", s->s_name);
+    buf[MAXPDSTRING - 1] = 0;
     sys_gui(buf);
 }
 
@@ -483,14 +464,14 @@ static void pdcontrol_isvisible(t_pdcontrol *x)
 static void pdcontrol_setup(void)
 {
     pdcontrol_class = class_new(gensym("pdcontrol"),
-        (t_newmethod)pdcontrol_new, 0, sizeof(t_pdcontrol), 0, 0);
-    class_addmethod(pdcontrol_class, (t_method)pdcontrol_dir,
-        gensym("dir"), A_DEFFLOAT, A_DEFSYMBOL, 0);
-    class_addmethod(pdcontrol_class, (t_method)pdcontrol_args,
-        gensym("args"), A_DEFFLOAT, 0);
-    class_addmethod(pdcontrol_class, (t_method)pdcontrol_browse,
+        (t_newmethod) pdcontrol_new, 0, sizeof(t_pdcontrol), 0, 0);
+    class_addmethod(pdcontrol_class, (t_method) pdcontrol_dir, gensym("dir"),
+        A_DEFFLOAT, A_DEFSYMBOL, 0);
+    class_addmethod(pdcontrol_class, (t_method) pdcontrol_args, gensym("args"),
+        A_DEFFLOAT, 0);
+    class_addmethod(pdcontrol_class, (t_method) pdcontrol_browse,
         gensym("browse"), A_SYMBOL, 0);
-    class_addmethod(pdcontrol_class, (t_method)pdcontrol_isvisible,
+    class_addmethod(pdcontrol_class, (t_method) pdcontrol_isvisible,
         gensym("isvisible"), 0);
 }
 

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -89,14 +89,20 @@ static void gfxstub_offlist(t_gfxstub *x)
     t_gfxstub *y1;
     t_gfxstub *y2;
     if(gfxstub_list == x)
+    {
         gfxstub_list = x->x_next;
+    }
     else
+    {
         for(y1 = gfxstub_list; (y2 = y1->x_next); y1 = y2)
+        {
             if(y2 == x)
             {
                 y1->x_next = y2->x_next;
                 break;
             }
+        }
+    }
 }
 
 /* if the owner disappears, we still may have to stay around until our
@@ -215,9 +221,13 @@ static void openpanel_callback(
     if(x->x_mode != 2) /* single file or folder */
     {
         if(argc == 1 && argv->a_type == A_SYMBOL)
+        {
             outlet_symbol(x->x_obj.ob_outlet, argv->a_w.w_symbol);
+        }
         else
+        {
             bug("openpanel_callback");
+        }
     }
     else /* list of files */
         outlet_list(x->x_obj.ob_outlet, s, argc, argv);

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -38,14 +38,20 @@ static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 {
     t_print *x = (t_print *) pd_new(print_class);
     if(argc == 0)
+    {
         x->x_sym = gensym("print");
+    }
     else if(argc == 1 && argv->a_type == A_SYMBOL)
     {
         t_symbol *s = atom_getsymbolarg(0, argc, argv);
         if(!strcmp(s->s_name, "-n"))
+        {
             x->x_sym = &s_;
+        }
         else
+        {
             x->x_sym = s;
+        }
     }
     else
     {
@@ -101,7 +107,9 @@ static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
     if(!argc)
+    {
         print_bang(x);
+    }
     else if(argc == 1)
     {
         switch(argv->a_type)
@@ -125,10 +133,14 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
         int i;
         /* print first (numeric) atom, to avoid a leading space */
         if(*x->x_sym->s_name)
+        {
             print_startlogpost(
                 x, "%s: %g", x->x_sym->s_name, atom_getfloat(argv));
+        }
         else
+        {
             print_startlogpost(x, "%g", atom_getfloat(argv));
+        }
         argc--;
         argv++;
         for(i = 0; i < argc; i++)

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* interface objects */
 
@@ -13,17 +13,20 @@ static t_class *print_class;
 
 #define PRINT_LOGLEVEL 2
 
-  /* imported from s_print.c: */
-extern void startlogpost(const void *object, const int level, const char *fmt, ...)
-    ATTRIBUTE_FORMAT_PRINTF(3, 4);
+/* imported from s_print.c: */
+extern void startlogpost(const void *object, const int level, const char *fmt,
+    ...) ATTRIBUTE_FORMAT_PRINTF(3, 4);
 
-  /* avoid prefixing with "verbose(PRINT_LOGLEVEL): "
-  when printing to stderr or via printhook. */
-#define print_startlogpost(object, fmt, ...) do{ \
-    if (STUFF->st_printhook || sys_printtostderr) \
-        startpost(fmt, __VA_ARGS__); \
-    else startlogpost(object, PRINT_LOGLEVEL, fmt, __VA_ARGS__); \
-} while(0)
+/* avoid prefixing with "verbose(PRINT_LOGLEVEL): "
+when printing to stderr or via printhook. */
+#define print_startlogpost(object, fmt, ...)                        \
+    do                                                              \
+    {                                                               \
+        if(STUFF->st_printhook || sys_printtostderr)                \
+            startpost(fmt, __VA_ARGS__);                            \
+        else                                                        \
+            startlogpost(object, PRINT_LOGLEVEL, fmt, __VA_ARGS__); \
+    } while(0)
 
 typedef struct _print
 {
@@ -33,15 +36,16 @@ typedef struct _print
 
 static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 {
-    t_print *x = (t_print *)pd_new(print_class);
-    if (argc == 0)
+    t_print *x = (t_print *) pd_new(print_class);
+    if(argc == 0)
         x->x_sym = gensym("print");
-    else if (argc == 1 && argv->a_type == A_SYMBOL)
+    else if(argc == 1 && argv->a_type == A_SYMBOL)
     {
         t_symbol *s = atom_getsymbolarg(0, argc, argv);
-        if (!strcmp(s->s_name, "-n"))
+        if(!strcmp(s->s_name, "-n"))
             x->x_sym = &s_;
-        else x->x_sym = s;
+        else
+            x->x_sym = s;
     }
     else
     {
@@ -50,10 +54,10 @@ static void *print_new(t_symbol *sel, int argc, t_atom *argv)
         t_binbuf *bb = binbuf_new();
         binbuf_add(bb, argc, argv);
         binbuf_gettext(bb, &buf, &bufsize);
-        buf = resizebytes(buf, bufsize, bufsize+1);
+        buf = resizebytes(buf, bufsize, bufsize + 1);
         buf[bufsize] = 0;
         x->x_sym = gensym(buf);
-        freebytes(buf, bufsize+1);
+        freebytes(buf, bufsize + 1);
         binbuf_free(bb);
     }
     return (x);
@@ -61,31 +65,34 @@ static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 
 static void print_bang(t_print *x)
 {
-    print_startlogpost(x, "%s%sbang", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startlogpost(
+        x, "%s%sbang", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
     endpost();
 }
 
 static void print_pointer(t_print *x, t_gpointer *gp)
 {
-    print_startlogpost(x, "%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startlogpost(
+        x, "%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
     endpost();
 }
 
 static void print_float(t_print *x, t_float f)
 {
-    print_startlogpost(x, "%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
+    print_startlogpost(
+        x, "%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
     endpost();
 }
 
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    print_startlogpost(x, "%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
-        s->s_name);
-    for (i = 0; i < argc; i++)
+    print_startlogpost(x, "%s%s%s", x->x_sym->s_name,
+        (*x->x_sym->s_name ? ": " : ""), s->s_name);
+    for(i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
-        atom_string(argv+i, buf, MAXPDSTRING);
+        atom_string(argv + i, buf, MAXPDSTRING);
         print_startlogpost(x, " %s", buf);
     }
     endpost();
@@ -93,39 +100,41 @@ static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 
 static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (!argc)
+    if(!argc)
         print_bang(x);
-    else if (argc == 1)
+    else if(argc == 1)
     {
-        switch (argv->a_type)
+        switch(argv->a_type)
         {
-        case A_FLOAT:
-            print_float(x, argv->a_w.w_float);
-            break;
-        case A_SYMBOL:
-            print_anything(x, &s_symbol, 1, argv);
-            break;
-        case A_POINTER:
-            print_pointer(x, argv->a_w.w_gpointer);
-            break;
-        default:
-            bug("print");
-            break;
+            case A_FLOAT:
+                print_float(x, argv->a_w.w_float);
+                break;
+            case A_SYMBOL:
+                print_anything(x, &s_symbol, 1, argv);
+                break;
+            case A_POINTER:
+                print_pointer(x, argv->a_w.w_gpointer);
+                break;
+            default:
+                bug("print");
+                break;
         }
     }
-    else if (argv->a_type == A_FLOAT)
+    else if(argv->a_type == A_FLOAT)
     {
         int i;
         /* print first (numeric) atom, to avoid a leading space */
-        if (*x->x_sym->s_name)
-            print_startlogpost(x, "%s: %g", x->x_sym->s_name, atom_getfloat(argv));
+        if(*x->x_sym->s_name)
+            print_startlogpost(
+                x, "%s: %g", x->x_sym->s_name, atom_getfloat(argv));
         else
             print_startlogpost(x, "%g", atom_getfloat(argv));
-        argc--; argv++;
-        for (i = 0; i < argc; i++)
+        argc--;
+        argv++;
+        for(i = 0; i < argc; i++)
         {
             char buf[MAXPDSTRING];
-            atom_string(argv+i, buf, MAXPDSTRING);
+            atom_string(argv + i, buf, MAXPDSTRING);
             print_startlogpost(x, " %s", buf);
         }
         endpost();
@@ -136,7 +145,7 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
 
 static void print_setup(void)
 {
-    print_class = class_new(gensym("print"), (t_newmethod)print_new, 0,
+    print_class = class_new(gensym("print"), (t_newmethod) print_new, 0,
         sizeof(t_print), 0, A_GIMME, 0);
     class_addbang(print_class, print_bang);
     class_addfloat(print_class, print_float);
@@ -160,7 +169,7 @@ typedef struct _trace
 
 static void *trace_new(t_symbol *s)
 {
-    t_trace *x = (t_trace *)pd_new(trace_class);
+    t_trace *x = (t_trace *) pd_new(trace_class);
     x->x_sym = s;
     x->x_f = 0;
     floatinlet_new(&x->x_obj, &x->x_f);
@@ -171,26 +180,27 @@ static void *trace_new(t_symbol *s)
 static void trace_anything(t_trace *x, t_symbol *s, int argc, t_atom *argv)
 {
     int nturns = x->x_f;
-    if (nturns > 0)
+    if(nturns > 0)
     {
-        if (!backtracer_cantrace)
+        if(!backtracer_cantrace)
         {
             pd_error(x, "trace requested but tracing is not enabled");
             x->x_f = 0;
         }
-        else if (backtracer_settracing(x, 1))
+        else if(backtracer_settracing(x, 1))
         {
             outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
-            x->x_f = nturns-1;
-            (void)backtracer_settracing(x, 0);
+            x->x_f = nturns - 1;
+            (void) backtracer_settracing(x, 0);
         }
     }
-    else outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
+    else
+        outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
 }
 
 static void trace_setup(void)
 {
-    trace_class = class_new(gensym("trace"), (t_newmethod)trace_new, 0,
+    trace_class = class_new(gensym("trace"), (t_newmethod) trace_new, 0,
         sizeof(t_trace), 0, A_DEFSYM, 0);
     class_addanything(trace_class, trace_anything);
 }

--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -92,10 +92,9 @@ static void print_float(t_print *x, t_float f)
 
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     print_startlogpost(x, "%s%s%s", x->x_sym->s_name,
         (*x->x_sym->s_name ? ": " : ""), s->s_name);
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
         atom_string(argv + i, buf, MAXPDSTRING);
@@ -130,7 +129,6 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
     }
     else if(argv->a_type == A_FLOAT)
     {
-        int i;
         /* print first (numeric) atom, to avoid a leading space */
         if(*x->x_sym->s_name)
         {
@@ -143,7 +141,7 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
         }
         argc--;
         argv++;
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
         {
             char buf[MAXPDSTRING];
             atom_string(argv + i, buf, MAXPDSTRING);

--- a/src/x_libpdreceive.c
+++ b/src/x_libpdreceive.c
@@ -16,68 +16,78 @@
 
 static t_class *libpdrec_class;
 
-typedef struct _libpdrec {
+typedef struct _libpdrec
+{
     t_object x_obj;
     t_symbol *x_sym;
 } t_libpdrec;
 
-static void libpdrecbang(t_libpdrec *x) {
-  if (libpd_banghook) (*libpd_banghook)(x->x_sym->s_name);
+static void libpdrecbang(t_libpdrec *x)
+{
+    if(libpd_banghook) (*libpd_banghook)(x->x_sym->s_name);
 }
 
-static void libpdrecfloat(t_libpdrec *x, t_float f) {
-  if (libpd_floathook) (*libpd_floathook)(x->x_sym->s_name, f);
+static void libpdrecfloat(t_libpdrec *x, t_float f)
+{
+    if(libpd_floathook) (*libpd_floathook)(x->x_sym->s_name, f);
 }
 
-static void libpdrecsymbol(t_libpdrec *x, t_symbol *s) {
-  if (libpd_symbolhook) (*libpd_symbolhook)(x->x_sym->s_name, s->s_name);
+static void libpdrecsymbol(t_libpdrec *x, t_symbol *s)
+{
+    if(libpd_symbolhook) (*libpd_symbolhook)(x->x_sym->s_name, s->s_name);
 }
 
-static void libpdrecpointer(t_libpdrec *x, t_gpointer *gp) {
-  // just ignore pointers for now...
+static void libpdrecpointer(t_libpdrec *x, t_gpointer *gp)
+{
+    // just ignore pointers for now...
 }
 
-static void libpdreclist(t_libpdrec *x, t_symbol *s, int argc, t_atom *argv) {
-  if (libpd_listhook) (*libpd_listhook)(x->x_sym->s_name, argc, argv);
+static void libpdreclist(t_libpdrec *x, t_symbol *s, int argc, t_atom *argv)
+{
+    if(libpd_listhook) (*libpd_listhook)(x->x_sym->s_name, argc, argv);
 }
 
-static void libpdrecanything(t_libpdrec *x, t_symbol *s,
-                int argc, t_atom *argv) {
-  if (libpd_messagehook)
-    (*libpd_messagehook)(x->x_sym->s_name, s->s_name, argc, argv);
+static void libpdrecanything(t_libpdrec *x, t_symbol *s, int argc, t_atom *argv)
+{
+    if(libpd_messagehook)
+        (*libpd_messagehook)(x->x_sym->s_name, s->s_name, argc, argv);
 }
 
-static void libpdreceive_free(t_libpdrec *x) {
-  pd_unbind(&x->x_obj.ob_pd, x->x_sym);
+static void libpdreceive_free(t_libpdrec *x)
+{
+    pd_unbind(&x->x_obj.ob_pd, x->x_sym);
 }
 
-static void *libpdreceive_donew(t_symbol *s) {
-  t_libpdrec *x;
-  x = (t_libpdrec *)pd_new(libpdrec_class);
-  x->x_sym = s;
-  pd_bind(&x->x_obj.ob_pd, s);
-  return x;
+static void *libpdreceive_donew(t_symbol *s)
+{
+    t_libpdrec *x;
+    x = (t_libpdrec *) pd_new(libpdrec_class);
+    x->x_sym = s;
+    pd_bind(&x->x_obj.ob_pd, s);
+    return x;
 }
 
 // this is exposed in the libpd API so must set the lock
-void *libpdreceive_new(t_symbol *s) {
-  t_libpdrec *x;
-  sys_lock();
-  x = (t_libpdrec *)libpdreceive_donew(s);
-  sys_unlock();
-  return x;
+void *libpdreceive_new(t_symbol *s)
+{
+    t_libpdrec *x;
+    sys_lock();
+    x = (t_libpdrec *) libpdreceive_donew(s);
+    sys_unlock();
+    return x;
 }
 
-void libpdreceive_setup(void) {
-  sys_lock();
-  libpdrec_class = class_new(gensym("libpd_receive"),
-       (t_newmethod)libpdreceive_donew, (t_method)libpdreceive_free,
-       sizeof(t_libpdrec), CLASS_DEFAULT, A_DEFSYM, 0);
-  class_addbang(libpdrec_class, libpdrecbang);
-  class_addfloat(libpdrec_class, libpdrecfloat);
-  class_addsymbol(libpdrec_class, libpdrecsymbol);
-  class_addpointer(libpdrec_class, libpdrecpointer);
-  class_addlist(libpdrec_class, libpdreclist);
-  class_addanything(libpdrec_class, libpdrecanything);
-  sys_unlock();
+void libpdreceive_setup(void)
+{
+    sys_lock();
+    libpdrec_class = class_new(gensym("libpd_receive"),
+        (t_newmethod) libpdreceive_donew, (t_method) libpdreceive_free,
+        sizeof(t_libpdrec), CLASS_DEFAULT, A_DEFSYM, 0);
+    class_addbang(libpdrec_class, libpdrecbang);
+    class_addfloat(libpdrec_class, libpdrecfloat);
+    class_addsymbol(libpdrec_class, libpdrecsymbol);
+    class_addpointer(libpdrec_class, libpdrecpointer);
+    class_addlist(libpdrec_class, libpdreclist);
+    class_addanything(libpdrec_class, libpdrecanything);
+    sys_unlock();
 }

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -102,7 +102,8 @@ static void alist_clear(t_alist *x)
 static void alist_copyin(
     t_alist *x, t_symbol *s, int argc, t_atom *argv, int where)
 {
-    int i, j;
+    int i;
+    int j;
     for(i = 0, j = where; i < argc; i++, j++)
     {
         x->l_vec[j].l_a = argv[i];
@@ -305,7 +306,8 @@ static void list_prepend_list(
     t_list_prepend *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    int n, outc = x->x_alist.l_n + argc;
+    int n;
+    int outc = x->x_alist.l_n + argc;
     ATOMS_ALLOCA(outv, outc);
     atoms_copy(argc, argv, outv + x->x_alist.l_n);
     if(x->x_alist.l_npointer)
@@ -328,7 +330,8 @@ static void list_prepend_anything(
     t_list_prepend *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    int n, outc = x->x_alist.l_n + argc + 1;
+    int n;
+    int outc = x->x_alist.l_n + argc + 1;
     ATOMS_ALLOCA(outv, outc);
     SETSYMBOL(outv + x->x_alist.l_n, s);
     atoms_copy(argc, argv, outv + x->x_alist.l_n + 1);
@@ -413,7 +416,8 @@ static void list_store_list(
     t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    int n, outc = x->x_alist.l_n + argc;
+    int n;
+    int outc = x->x_alist.l_n + argc;
     ATOMS_ALLOCA(outv, outc);
     atoms_copy(argc, argv, outv);
     if(x->x_alist.l_npointer)
@@ -494,7 +498,10 @@ static void list_store_prepend(
 
 static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
 {
-    int i, max, index = (int) f1, n = (int) f2;
+    int i;
+    int max;
+    int index = (int) f1;
+    int n = (int) f2;
     t_listelem *oldptr = x->x_alist.l_vec;
     if(index < 0 || index >= x->x_alist.l_n)
     {
@@ -548,7 +555,8 @@ static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
 static void list_store_get(t_list_store *x, float f1, float f2)
 {
     t_atom *outv;
-    int onset = f1, outc = f2;
+    int onset = f1;
+    int outc = f2;
     if(!outc)
         outc = 1; /* default */
     else if(outc < 0)
@@ -586,7 +594,9 @@ static void list_store_set(t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
     if(argc > 1)
     {
-        int n, max, onset = atom_getfloat(argv);
+        int n;
+        int max;
+        int onset = atom_getfloat(argv);
         if(onset < 0 || onset >= x->x_alist.l_n)
         {
             pd_error(x, "list_store_set: index %d out of range", onset);
@@ -780,7 +790,8 @@ static void *list_fromsymbol_new(void)
 static void list_fromsymbol_symbol(t_list_fromsymbol *x, t_symbol *s)
 {
     t_atom *outv;
-    int n, outc = (int) strlen(s->s_name);
+    int n;
+    int outc = (int) strlen(s->s_name);
     ATOMS_ALLOCA(outv, outc);
     for(n = 0; n < outc; n++)
         SETFLOAT(outv + n, (unsigned char) s->s_name[n]);

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -72,8 +72,7 @@ typedef struct _alist
 
 static void atoms_copy(int argc, t_atom *from, t_atom *to)
 {
-    int i;
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         to[i] = from[i];
 }
 
@@ -90,8 +89,7 @@ static void alist_init(t_alist *x)
 
 static void alist_clear(t_alist *x)
 {
-    int i;
-    for(i = 0; i < x->l_n; i++)
+    for(int i = 0; i < x->l_n; i++)
     {
         if(x->l_vec[i].l_a.a_type == A_POINTER)
             gpointer_unset(x->l_vec[i].l_a.a_w.w_gpointer);
@@ -134,7 +132,6 @@ static void alist_list(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 /* set contents to an arbitrary non-list message */
 static void alist_anything(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     alist_clear(x);
     if(!(x->l_vec = (t_listelem *) getbytes((argc + 1) * sizeof(*x->l_vec))))
     {
@@ -145,7 +142,7 @@ static void alist_anything(t_alist *x, t_symbol *s, int argc, t_atom *argv)
     x->l_n = argc + 1;
     x->l_npointer = 0;
     SETSYMBOL(&x->l_vec[0].l_a, s);
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         x->l_vec[i + 1].l_a = argv[i];
         if(x->l_vec[i + 1].l_a.a_type == A_POINTER)
@@ -160,14 +157,12 @@ static void alist_anything(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 
 static void alist_toatoms(t_alist *x, t_atom *to, int onset, int count)
 {
-    int i;
-    for(i = 0; i < count; i++)
+    for(int i = 0; i < count; i++)
         to[i] = x->l_vec[onset + i].l_a;
 }
 
 static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
 {
-    int i;
     y->l_pd = alist_class;
     y->l_n = count;
     y->l_npointer = 0;
@@ -178,7 +173,7 @@ static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
     }
     else
     {
-        for(i = 0; i < count; i++)
+        for(int i = 0; i < count; i++)
         {
             y->l_vec[i].l_a = x->l_vec[onset + i].l_a;
             if(y->l_vec[i].l_a.a_type == A_POINTER)
@@ -501,7 +496,6 @@ static void list_store_prepend(
 
 static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
 {
-    int i;
     int max;
     int index = (int) f1;
     int n = (int) f2;
@@ -525,7 +519,7 @@ static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
     if(x->x_alist.l_npointer)
     {
         t_listelem *vec = x->x_alist.l_vec + index;
-        for(i = 0; i < n; i++)
+        for(int i = 0; i < n; i++)
         {
             if(vec[i].l_a.a_type == A_POINTER)
             {
@@ -843,13 +837,12 @@ static void *list_tosymbol_new(void)
 static void list_tosymbol_list(
     t_list_tosymbol *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
 #if HAVE_ALLOCA
     char *str = alloca(argc + 1);
 #else
     char *str = getbytes(argc + 1);
 #endif
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         str[i] = (char) atom_getfloatarg(i, argc, argv);
     str[argc] = 0;
     outlet_symbol(x->x_obj.ob_outlet, gensym(str));

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -1,19 +1,19 @@
 /* Copyright (c) 1997- Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 #include "m_pd.h"
 #include <string.h>
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+#ifndef HAVE_ALLOCA /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1
 #endif
 
@@ -43,8 +43,8 @@ Probably don't need:
 */
 
 /* -------------- utility functions: storage, copying  -------------- */
-    /* List element for storage.  Keep an atom and, in case it's a pointer,
-        an associated 'gpointer' to protect against stale pointers. */
+/* List element for storage.  Keep an atom and, in case it's a pointer,
+    an associated 'gpointer' to protect against stale pointers. */
 typedef struct _listelem
 {
     t_atom l_a;
@@ -53,26 +53,27 @@ typedef struct _listelem
 
 typedef struct _alist
 {
-    t_pd l_pd;          /* object to point inlets to */
-    int l_n;            /* number of items */
-    int l_npointer;     /* number of pointers */
-    t_listelem *l_vec;  /* pointer to items */
+    t_pd l_pd;         /* object to point inlets to */
+    int l_n;           /* number of items */
+    int l_npointer;    /* number of pointers */
+    t_listelem *l_vec; /* pointer to items */
 } t_alist;
 
 #if HAVE_ALLOCA
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < LIST_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#define ATOMS_ALLOCA(x, n)                                                \
+    ((x) = (t_atom *) ((n) < LIST_NGETBYTE ? alloca((n) * sizeof(t_atom)) \
+                                           : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) \
+    (((n) < LIST_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 #else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *) getbytes((n) * sizeof(t_atom)))
 #define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
 #endif
 
 static void atoms_copy(int argc, t_atom *from, t_atom *to)
 {
     int i;
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
         to[i] = from[i];
 }
 
@@ -90,23 +91,22 @@ static void alist_init(t_alist *x)
 static void alist_clear(t_alist *x)
 {
     int i;
-    for (i = 0; i < x->l_n; i++)
+    for(i = 0; i < x->l_n; i++)
     {
-        if (x->l_vec[i].l_a.a_type == A_POINTER)
+        if(x->l_vec[i].l_a.a_type == A_POINTER)
             gpointer_unset(x->l_vec[i].l_a.a_w.w_gpointer);
     }
-    if (x->l_vec)
-        freebytes(x->l_vec, x->l_n * sizeof(*x->l_vec));
+    if(x->l_vec) freebytes(x->l_vec, x->l_n * sizeof(*x->l_vec));
 }
 
-static void alist_copyin(t_alist *x, t_symbol *s, int argc, t_atom *argv,
-    int where)
+static void alist_copyin(
+    t_alist *x, t_symbol *s, int argc, t_atom *argv, int where)
 {
     int i, j;
-    for (i = 0, j = where; i < argc; i++, j++)
+    for(i = 0, j = where; i < argc; i++, j++)
     {
         x->l_vec[j].l_a = argv[i];
-        if (x->l_vec[j].l_a.a_type == A_POINTER)
+        if(x->l_vec[j].l_a.a_type == A_POINTER)
         {
             x->l_npointer++;
             gpointer_copy(x->l_vec[j].l_a.a_w.w_gpointer, &x->l_vec[j].l_p);
@@ -115,11 +115,11 @@ static void alist_copyin(t_alist *x, t_symbol *s, int argc, t_atom *argv,
     }
 }
 
-    /* set contents to a list */
+/* set contents to a list */
 static void alist_list(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 {
     alist_clear(x);
-    if (!(x->l_vec = (t_listelem *)getbytes(argc * sizeof(*x->l_vec))))
+    if(!(x->l_vec = (t_listelem *) getbytes(argc * sizeof(*x->l_vec))))
     {
         x->l_n = 0;
         pd_error(0, "list: out of memory");
@@ -130,28 +130,29 @@ static void alist_list(t_alist *x, t_symbol *s, int argc, t_atom *argv)
     alist_copyin(x, s, argc, argv, 0);
 }
 
-    /* set contents to an arbitrary non-list message */
+/* set contents to an arbitrary non-list message */
 static void alist_anything(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     alist_clear(x);
-    if (!(x->l_vec = (t_listelem *)getbytes((argc+1) * sizeof(*x->l_vec))))
+    if(!(x->l_vec = (t_listelem *) getbytes((argc + 1) * sizeof(*x->l_vec))))
     {
         x->l_n = 0;
         pd_error(0, "list_alloc: out of memory");
         return;
     }
-    x->l_n = argc+1;
+    x->l_n = argc + 1;
     x->l_npointer = 0;
     SETSYMBOL(&x->l_vec[0].l_a, s);
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
-        x->l_vec[i+1].l_a = argv[i];
-        if (x->l_vec[i+1].l_a.a_type == A_POINTER)
+        x->l_vec[i + 1].l_a = argv[i];
+        if(x->l_vec[i + 1].l_a.a_type == A_POINTER)
         {
             x->l_npointer++;
-            gpointer_copy(x->l_vec[i+1].l_a.a_w.w_gpointer, &x->l_vec[i+1].l_p);
-            x->l_vec[i+1].l_a.a_w.w_gpointer = &x->l_vec[i+1].l_p;
+            gpointer_copy(
+                x->l_vec[i + 1].l_a.a_w.w_gpointer, &x->l_vec[i + 1].l_p);
+            x->l_vec[i + 1].l_a.a_w.w_gpointer = &x->l_vec[i + 1].l_p;
         }
     }
 }
@@ -159,10 +160,9 @@ static void alist_anything(t_alist *x, t_symbol *s, int argc, t_atom *argv)
 static void alist_toatoms(t_alist *x, t_atom *to, int onset, int count)
 {
     int i;
-    for (i = 0; i < count; i++)
+    for(i = 0; i < count; i++)
         to[i] = x->l_vec[onset + i].l_a;
 }
-
 
 static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
 {
@@ -170,39 +170,38 @@ static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
     y->l_pd = alist_class;
     y->l_n = count;
     y->l_npointer = 0;
-    if (!(y->l_vec = (t_listelem *)getbytes(y->l_n * sizeof(*y->l_vec))))
+    if(!(y->l_vec = (t_listelem *) getbytes(y->l_n * sizeof(*y->l_vec))))
     {
         y->l_n = 0;
         pd_error(0, "list_alloc: out of memory");
     }
-    else for (i = 0; i < count; i++)
-    {
-        y->l_vec[i].l_a = x->l_vec[onset + i].l_a;
-        if (y->l_vec[i].l_a.a_type == A_POINTER)
+    else
+        for(i = 0; i < count; i++)
         {
-            gpointer_copy(y->l_vec[i].l_a.a_w.w_gpointer, &y->l_vec[i].l_p);
-            y->l_vec[i].l_a.a_w.w_gpointer = &y->l_vec[i].l_p;
-            y->l_npointer++;
+            y->l_vec[i].l_a = x->l_vec[onset + i].l_a;
+            if(y->l_vec[i].l_a.a_type == A_POINTER)
+            {
+                gpointer_copy(y->l_vec[i].l_a.a_w.w_gpointer, &y->l_vec[i].l_p);
+                y->l_vec[i].l_a.a_w.w_gpointer = &y->l_vec[i].l_p;
+                y->l_npointer++;
+            }
         }
-    }
 }
 
-    /* function to restore gpointers after the list has moved in memory */
+/* function to restore gpointers after the list has moved in memory */
 static void alist_restore_gpointers(t_alist *x, int offset, int count)
 {
     t_listelem *vec = x->l_vec + offset;
-    while (count--)
+    while(count--)
     {
-        if (vec->l_a.a_type == A_POINTER)
-            vec->l_a.a_w.w_gpointer = &vec->l_p;
+        if(vec->l_a.a_type == A_POINTER) vec->l_a.a_w.w_gpointer = &vec->l_p;
         vec++;
     }
 }
 
 static void alist_setup(void)
 {
-    alist_class = class_new(gensym("list inlet"),
-        0, 0, sizeof(t_alist), 0, 0);
+    alist_class = class_new(gensym("list inlet"), 0, 0, sizeof(t_alist), 0, 0);
     class_addlist(alist_class, alist_list);
     class_addanything(alist_class, alist_anything);
 }
@@ -219,7 +218,7 @@ typedef struct _list_append
 
 static void *list_append_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_list_append *x = (t_list_append *)pd_new(list_append_class);
+    t_list_append *x = (t_list_append *) pd_new(list_append_class);
     alist_init(&x->x_alist);
     alist_list(&x->x_alist, 0, argc, argv);
     outlet_new(&x->x_obj, &s_list);
@@ -227,38 +226,38 @@ static void *list_append_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
-static void list_append_list(t_list_append *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_append_list(
+    t_list_append *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
     int outc = x->x_alist.l_n + argc;
     ATOMS_ALLOCA(outv, outc);
     atoms_copy(argc, argv, outv);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, x->x_alist.l_n);
-        alist_toatoms(&y, outv+argc, 0, x->x_alist.l_n);
+        alist_toatoms(&y, outv + argc, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
         alist_clear(&y);
     }
     else
     {
-        alist_toatoms(&x->x_alist, outv+argc, 0, x->x_alist.l_n);
+        alist_toatoms(&x->x_alist, outv + argc, 0, x->x_alist.l_n);
         outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     }
     ATOMS_FREEA(outv, outc);
 }
 
-static void list_append_anything(t_list_append *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_append_anything(
+    t_list_append *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
     int outc = x->x_alist.l_n + argc + 1;
     ATOMS_ALLOCA(outv, outc);
     SETSYMBOL(outv, s);
     atoms_copy(argc, argv, outv + 1);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, x->x_alist.l_n);
@@ -274,16 +273,13 @@ static void list_append_anything(t_list_append *x, t_symbol *s,
     ATOMS_FREEA(outv, outc);
 }
 
-static void list_append_free(t_list_append *x)
-{
-    alist_clear(&x->x_alist);
-}
+static void list_append_free(t_list_append *x) { alist_clear(&x->x_alist); }
 
 static void list_append_setup(void)
 {
-    list_append_class = class_new(gensym("list append"),
-        (t_newmethod)list_append_new, (t_method)list_append_free,
-        sizeof(t_list_append), 0, A_GIMME, 0);
+    list_append_class =
+        class_new(gensym("list append"), (t_newmethod) list_append_new,
+            (t_method) list_append_free, sizeof(t_list_append), 0, A_GIMME, 0);
     class_addlist(list_append_class, list_append_list);
     class_addanything(list_append_class, list_append_anything);
     class_sethelpsymbol(list_append_class, &s_list);
@@ -297,7 +293,7 @@ typedef t_list_append t_list_prepend;
 
 static void *list_prepend_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_list_prepend *x = (t_list_prepend *)pd_new(list_prepend_class);
+    t_list_prepend *x = (t_list_prepend *) pd_new(list_prepend_class);
     alist_init(&x->x_alist);
     alist_list(&x->x_alist, 0, argc, argv);
     outlet_new(&x->x_obj, &s_list);
@@ -305,14 +301,14 @@ static void *list_prepend_new(t_symbol *s, int argc, t_atom *argv)
     return (x);
 }
 
-static void list_prepend_list(t_list_prepend *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_prepend_list(
+    t_list_prepend *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc;
     ATOMS_ALLOCA(outv, outc);
     atoms_copy(argc, argv, outv + x->x_alist.l_n);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, x->x_alist.l_n);
@@ -328,15 +324,15 @@ static void list_prepend_list(t_list_prepend *x, t_symbol *s,
     ATOMS_FREEA(outv, outc);
 }
 
-static void list_prepend_anything(t_list_prepend *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_prepend_anything(
+    t_list_prepend *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc + 1;
     ATOMS_ALLOCA(outv, outc);
     SETSYMBOL(outv + x->x_alist.l_n, s);
     atoms_copy(argc, argv, outv + x->x_alist.l_n + 1);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, x->x_alist.l_n);
@@ -352,15 +348,12 @@ static void list_prepend_anything(t_list_prepend *x, t_symbol *s,
     ATOMS_FREEA(outv, outc);
 }
 
-static void list_prepend_free(t_list_prepend *x)
-{
-    alist_clear(&x->x_alist);
-}
+static void list_prepend_free(t_list_prepend *x) { alist_clear(&x->x_alist); }
 
 static void list_prepend_setup(void)
 {
     list_prepend_class = class_new(gensym("list prepend"),
-        (t_newmethod)list_prepend_new, (t_method)list_prepend_free,
+        (t_newmethod) list_prepend_new, (t_method) list_prepend_free,
         sizeof(t_list_prepend), 0, A_GIMME, 0);
     class_addlist(list_prepend_class, list_prepend_list);
     class_addanything(list_prepend_class, list_prepend_anything);
@@ -381,7 +374,7 @@ typedef struct _list_store
 
 static void *list_store_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_list_store *x = (t_list_store *)pd_new(list_store_class);
+    t_list_store *x = (t_list_store *) pd_new(list_store_class);
     alist_init(&x->x_alist);
     alist_list(&x->x_alist, 0, argc, argv);
     x->x_out1 = outlet_new(&x->x_obj, &s_list);
@@ -394,13 +387,13 @@ static void list_store_send(t_list_store *x, t_symbol *s)
 {
     t_atom *vec;
     int n = x->x_alist.l_n;
-    if (!s->s_thing)
+    if(!s->s_thing)
     {
         pd_error(x, "%s: no such object", s->s_name);
         return;
     }
     ATOMS_ALLOCA(vec, n);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, n);
@@ -416,134 +409,138 @@ static void list_store_send(t_list_store *x, t_symbol *s)
     ATOMS_FREEA(vec, n);
 }
 
-static void list_store_list(t_list_store *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_store_list(
+    t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
     int n, outc = x->x_alist.l_n + argc;
     ATOMS_ALLOCA(outv, outc);
     atoms_copy(argc, argv, outv);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, 0, x->x_alist.l_n);
-        alist_toatoms(&y, outv+argc, 0, x->x_alist.l_n);
+        alist_toatoms(&y, outv + argc, 0, x->x_alist.l_n);
         outlet_list(x->x_out1, &s_list, outc, outv);
         alist_clear(&y);
     }
     else
     {
-        alist_toatoms(&x->x_alist, outv+argc, 0, x->x_alist.l_n);
+        alist_toatoms(&x->x_alist, outv + argc, 0, x->x_alist.l_n);
         outlet_list(x->x_out1, &s_list, outc, outv);
     }
     ATOMS_FREEA(outv, outc);
 }
 
-static void list_store_doinsert(t_list_store *x, t_symbol *s,
-    int argc, t_atom *argv, int index)
+static void list_store_doinsert(
+    t_list_store *x, t_symbol *s, int argc, t_atom *argv, int index)
 {
     t_listelem *oldptr = x->x_alist.l_vec;
-        /* try to allocate more memory */
-    if (!(x->x_alist.l_vec = (t_listelem *)resizebytes(x->x_alist.l_vec,
-        (x->x_alist.l_n) * sizeof(*x->x_alist.l_vec),
-        (x->x_alist.l_n + argc) * sizeof(*x->x_alist.l_vec))))
+    /* try to allocate more memory */
+    if(!(x->x_alist.l_vec = (t_listelem *) resizebytes(x->x_alist.l_vec,
+             (x->x_alist.l_n) * sizeof(*x->x_alist.l_vec),
+             (x->x_alist.l_n + argc) * sizeof(*x->x_alist.l_vec))))
     {
         x->x_alist.l_n = 0;
         pd_error(0, "list: out of memory");
         return;
     }
-        /* fix gpointers in case resizebytes() has moved the alist in memory */
-    if (x->x_alist.l_vec != oldptr && x->x_alist.l_npointer)
+    /* fix gpointers in case resizebytes() has moved the alist in memory */
+    if(x->x_alist.l_vec != oldptr && x->x_alist.l_npointer)
         alist_restore_gpointers(&x->x_alist, 0, x->x_alist.l_n);
-        /* shift existing elements after 'index' to the right */
-    if (index < x->x_alist.l_n)
+    /* shift existing elements after 'index' to the right */
+    if(index < x->x_alist.l_n)
     {
         memmove(x->x_alist.l_vec + index + argc, x->x_alist.l_vec + index,
             (x->x_alist.l_n - index) * sizeof(*x->x_alist.l_vec));
-            /* fix gpointers because of memmove() */
-        if (x->x_alist.l_npointer)
-            alist_restore_gpointers(&x->x_alist, index + argc, x->x_alist.l_n - index);
+        /* fix gpointers because of memmove() */
+        if(x->x_alist.l_npointer)
+            alist_restore_gpointers(
+                &x->x_alist, index + argc, x->x_alist.l_n - index);
     }
-        /* finally copy new elements */
+    /* finally copy new elements */
     alist_copyin(&x->x_alist, s, argc, argv, index);
     x->x_alist.l_n += argc;
 }
 
-static void list_store_insert(t_list_store *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_store_insert(
+    t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1)
+    if(argc > 1)
     {
         int index = atom_getfloat(argv);
-        if (index < 0)
+        if(index < 0)
         {
             pd_error(x, "list_store_insert: index %d out of range", index);
             return;
-        } else if (index > x->x_alist.l_n)
+        }
+        else if(index > x->x_alist.l_n)
             index = x->x_alist.l_n;
         list_store_doinsert(x, s, --argc, ++argv, index);
     }
 }
 
-static void list_store_append(t_list_store *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_store_append(
+    t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
     list_store_doinsert(x, s, argc, argv, x->x_alist.l_n);
 }
 
-static void list_store_prepend(t_list_store *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_store_prepend(
+    t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
     list_store_doinsert(x, s, argc, argv, 0);
 }
 
 static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
 {
-    int i, max, index = (int)f1, n = (int)f2;
+    int i, max, index = (int) f1, n = (int) f2;
     t_listelem *oldptr = x->x_alist.l_vec;
-    if (index < 0 || index >= x->x_alist.l_n)
+    if(index < 0 || index >= x->x_alist.l_n)
     {
         pd_error(x, "list_store_delete: index %d out of range", index);
         return;
     }
     max = x->x_alist.l_n - index;
-    if (!n)
+    if(!n)
         n = 1; /* default */
-    else if (n < 0 || n > max)
+    else if(n < 0 || n > max)
         n = max; /* till the end of the list */
 
-        /* unset pointers for elements which are to be deleted */
-    if (x->x_alist.l_npointer)
+    /* unset pointers for elements which are to be deleted */
+    if(x->x_alist.l_npointer)
     {
         t_listelem *vec = x->x_alist.l_vec + index;
-        for (i = 0; i < n; i++)
+        for(i = 0; i < n; i++)
         {
-            if (vec[i].l_a.a_type == A_POINTER)
+            if(vec[i].l_a.a_type == A_POINTER)
             {
                 gpointer_unset(vec[i].l_a.a_w.w_gpointer);
                 x->x_alist.l_npointer--;
             }
         }
     }
-        /* shift elements (after the deleted elements) to the left */
+    /* shift elements (after the deleted elements) to the left */
     memmove(x->x_alist.l_vec + index, x->x_alist.l_vec + index + n,
         (x->x_alist.l_n - index) * sizeof(*x->x_alist.l_vec));
-        /* shrink memory */
-    if (!(x->x_alist.l_vec = (t_listelem *)resizebytes(x->x_alist.l_vec,
-        (x->x_alist.l_n) * sizeof(*x->x_alist.l_vec),
-        (x->x_alist.l_n - n) * sizeof(*x->x_alist.l_vec))))
+    /* shrink memory */
+    if(!(x->x_alist.l_vec = (t_listelem *) resizebytes(x->x_alist.l_vec,
+             (x->x_alist.l_n) * sizeof(*x->x_alist.l_vec),
+             (x->x_alist.l_n - n) * sizeof(*x->x_alist.l_vec))))
     {
         x->x_alist.l_n = 0;
         pd_error(0, "list: out of memory");
         return;
     }
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
-            /* fix all gpointers in case resizebytes() has moved the alist in memory */
-        if (x->x_alist.l_vec != oldptr)
+        /* fix all gpointers in case resizebytes() has moved the alist in memory
+         */
+        if(x->x_alist.l_vec != oldptr)
             alist_restore_gpointers(&x->x_alist, 0, x->x_alist.l_n - n);
         else /* only fix gpointers after index (because of of memmove()) */
-            alist_restore_gpointers(&x->x_alist, index, x->x_alist.l_n - index - n);
+            alist_restore_gpointers(
+                &x->x_alist, index, x->x_alist.l_n - index - n);
     }
     x->x_alist.l_n -= n;
 }
@@ -552,24 +549,24 @@ static void list_store_get(t_list_store *x, float f1, float f2)
 {
     t_atom *outv;
     int onset = f1, outc = f2;
-    if (!outc)
+    if(!outc)
         outc = 1; /* default */
-    else if (outc < 0)
+    else if(outc < 0)
     {
         outc = x->x_alist.l_n - onset; /* till the end of the list */
-        if (outc <= 0) /* onset out of range */
+        if(outc <= 0)                  /* onset out of range */
         {
             outlet_bang(x->x_out2);
             return;
         }
     }
-    if (onset < 0 || (onset + outc > x->x_alist.l_n))
+    if(onset < 0 || (onset + outc > x->x_alist.l_n))
     {
         outlet_bang(x->x_out2);
         return;
     }
     ATOMS_ALLOCA(outv, outc);
-    if (x->x_alist.l_npointer)
+    if(x->x_alist.l_npointer)
     {
         t_alist y;
         alist_clone(&x->x_alist, &y, onset, outc);
@@ -587,46 +584,44 @@ static void list_store_get(t_list_store *x, float f1, float f2)
 
 static void list_store_set(t_list_store *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1)
+    if(argc > 1)
     {
         int n, max, onset = atom_getfloat(argv);
-        if (onset < 0 || onset >= x->x_alist.l_n)
+        if(onset < 0 || onset >= x->x_alist.l_n)
         {
             pd_error(x, "list_store_set: index %d out of range", onset);
             return;
         }
-        argc--; argv++;
+        argc--;
+        argv++;
         max = x->x_alist.l_n - onset;
         n = (argc > max) ? max : argc;
         alist_copyin(&x->x_alist, s, n, argv, onset);
     }
 }
 
-static void list_store_free(t_list_store *x)
-{
-    alist_clear(&x->x_alist);
-}
+static void list_store_free(t_list_store *x) { alist_clear(&x->x_alist); }
 
 static void list_store_setup(void)
 {
-    list_store_class = class_new(gensym("list store"),
-        (t_newmethod)list_store_new, (t_method)list_store_free,
-        sizeof(t_list_store), 0, A_GIMME, 0);
+    list_store_class =
+        class_new(gensym("list store"), (t_newmethod) list_store_new,
+            (t_method) list_store_free, sizeof(t_list_store), 0, A_GIMME, 0);
     class_addlist(list_store_class, list_store_list);
-    class_addmethod(list_store_class, (t_method)list_store_send,
+    class_addmethod(list_store_class, (t_method) list_store_send,
         gensym("send"), A_SYMBOL, 0);
-    class_addmethod(list_store_class, (t_method)list_store_append,
+    class_addmethod(list_store_class, (t_method) list_store_append,
         gensym("append"), A_GIMME, 0);
-    class_addmethod(list_store_class, (t_method)list_store_prepend,
+    class_addmethod(list_store_class, (t_method) list_store_prepend,
         gensym("prepend"), A_GIMME, 0);
-    class_addmethod(list_store_class, (t_method)list_store_insert,
+    class_addmethod(list_store_class, (t_method) list_store_insert,
         gensym("insert"), A_GIMME, 0);
-    class_addmethod(list_store_class, (t_method)list_store_delete,
+    class_addmethod(list_store_class, (t_method) list_store_delete,
         gensym("delete"), A_FLOAT, A_DEFFLOAT, 0);
-    class_addmethod(list_store_class, (t_method)list_store_get,
-        gensym("get"), A_FLOAT, A_DEFFLOAT, 0);
-    class_addmethod(list_store_class, (t_method)list_store_set,
-        gensym("set"), A_GIMME, 0);
+    class_addmethod(list_store_class, (t_method) list_store_get, gensym("get"),
+        A_FLOAT, A_DEFFLOAT, 0);
+    class_addmethod(
+        list_store_class, (t_method) list_store_set, gensym("set"), A_GIMME, 0);
     class_sethelpsymbol(list_store_class, &s_list);
 }
 
@@ -645,7 +640,7 @@ typedef struct _list_split
 
 static void *list_split_new(t_floatarg f)
 {
-    t_list_split *x = (t_list_split *)pd_new(list_split_class);
+    t_list_split *x = (t_list_split *) pd_new(list_split_class);
     x->x_out1 = outlet_new(&x->x_obj, &s_list);
     x->x_out2 = outlet_new(&x->x_obj, &s_list);
     x->x_out3 = outlet_new(&x->x_obj, &s_list);
@@ -654,36 +649,36 @@ static void *list_split_new(t_floatarg f)
     return (x);
 }
 
-static void list_split_list(t_list_split *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_split_list(
+    t_list_split *x, t_symbol *s, int argc, t_atom *argv)
 {
     int n = x->x_f;
-    if (n < 0)
-        n = 0;
-    if (argc >= n)
+    if(n < 0) n = 0;
+    if(argc >= n)
     {
-        outlet_list(x->x_out2, &s_list, argc-n, argv+n);
+        outlet_list(x->x_out2, &s_list, argc - n, argv + n);
         outlet_list(x->x_out1, &s_list, n, argv);
     }
-    else outlet_list(x->x_out3, &s_list, argc, argv);
+    else
+        outlet_list(x->x_out3, &s_list, argc, argv);
 }
 
-static void list_split_anything(t_list_split *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_split_anything(
+    t_list_split *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_atom *outv;
-    ATOMS_ALLOCA(outv, argc+1);
+    ATOMS_ALLOCA(outv, argc + 1);
     SETSYMBOL(outv, s);
     atoms_copy(argc, argv, outv + 1);
-    list_split_list(x, &s_list, argc+1, outv);
-    ATOMS_FREEA(outv, argc+1);
+    list_split_list(x, &s_list, argc + 1, outv);
+    ATOMS_FREEA(outv, argc + 1);
 }
 
 static void list_split_setup(void)
 {
-    list_split_class = class_new(gensym("list split"),
-        (t_newmethod)list_split_new, 0,
-        sizeof(t_list_split), 0, A_DEFFLOAT, 0);
+    list_split_class =
+        class_new(gensym("list split"), (t_newmethod) list_split_new, 0,
+            sizeof(t_list_split), 0, A_DEFFLOAT, 0);
     class_addlist(list_split_class, list_split_list);
     class_addanything(list_split_class, list_split_anything);
     class_sethelpsymbol(list_split_class, &s_list);
@@ -700,22 +695,22 @@ typedef struct _list_trim
 
 static void *list_trim_new(void)
 {
-    t_list_trim *x = (t_list_trim *)pd_new(list_trim_class);
+    t_list_trim *x = (t_list_trim *) pd_new(list_trim_class);
     outlet_new(&x->x_obj, &s_list);
     return (x);
 }
 
-static void list_trim_list(t_list_trim *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_trim_list(t_list_trim *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc < 1 || argv[0].a_type != A_SYMBOL)
+    if(argc < 1 || argv[0].a_type != A_SYMBOL)
         outlet_list(x->x_obj.ob_outlet, &s_list, argc, argv);
-    else outlet_anything(x->x_obj.ob_outlet, argv[0].a_w.w_symbol,
-        argc-1, argv+1);
+    else
+        outlet_anything(
+            x->x_obj.ob_outlet, argv[0].a_w.w_symbol, argc - 1, argv + 1);
 }
 
-static void list_trim_anything(t_list_trim *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_trim_anything(
+    t_list_trim *x, t_symbol *s, int argc, t_atom *argv)
 {
     outlet_anything(x->x_obj.ob_outlet, s, argc, argv);
 }
@@ -723,8 +718,7 @@ static void list_trim_anything(t_list_trim *x, t_symbol *s,
 static void list_trim_setup(void)
 {
     list_trim_class = class_new(gensym("list trim"),
-        (t_newmethod)list_trim_new, 0,
-        sizeof(t_list_trim), 0, 0);
+        (t_newmethod) list_trim_new, 0, sizeof(t_list_trim), 0, 0);
     class_addlist(list_trim_class, list_trim_list);
     class_addanything(list_trim_class, list_trim_anything);
     class_sethelpsymbol(list_trim_class, &s_list);
@@ -741,28 +735,27 @@ typedef struct _list_length
 
 static void *list_length_new(void)
 {
-    t_list_length *x = (t_list_length *)pd_new(list_length_class);
+    t_list_length *x = (t_list_length *) pd_new(list_length_class);
     outlet_new(&x->x_obj, &s_float);
     return (x);
 }
 
-static void list_length_list(t_list_length *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_length_list(
+    t_list_length *x, t_symbol *s, int argc, t_atom *argv)
 {
-    outlet_float(x->x_obj.ob_outlet, (t_float)argc);
+    outlet_float(x->x_obj.ob_outlet, (t_float) argc);
 }
 
-static void list_length_anything(t_list_length *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_length_anything(
+    t_list_length *x, t_symbol *s, int argc, t_atom *argv)
 {
-    outlet_float(x->x_obj.ob_outlet, (t_float)argc+1);
+    outlet_float(x->x_obj.ob_outlet, (t_float) argc + 1);
 }
 
 static void list_length_setup(void)
 {
     list_length_class = class_new(gensym("list length"),
-        (t_newmethod)list_length_new, 0,
-        sizeof(t_list_length), 0, 0);
+        (t_newmethod) list_length_new, 0, sizeof(t_list_length), 0, 0);
     class_addlist(list_length_class, list_length_list);
     class_addanything(list_length_class, list_length_anything);
     class_sethelpsymbol(list_length_class, &s_list);
@@ -779,7 +772,7 @@ typedef struct _list_fromsymbol
 
 static void *list_fromsymbol_new(void)
 {
-    t_list_fromsymbol *x = (t_list_fromsymbol *)pd_new(list_fromsymbol_class);
+    t_list_fromsymbol *x = (t_list_fromsymbol *) pd_new(list_fromsymbol_class);
     outlet_new(&x->x_obj, &s_list);
     return (x);
 }
@@ -787,10 +780,10 @@ static void *list_fromsymbol_new(void)
 static void list_fromsymbol_symbol(t_list_fromsymbol *x, t_symbol *s)
 {
     t_atom *outv;
-    int n, outc = (int)strlen(s->s_name);
+    int n, outc = (int) strlen(s->s_name);
     ATOMS_ALLOCA(outv, outc);
-    for (n = 0; n < outc; n++)
-        SETFLOAT(outv + n, (unsigned char)s->s_name[n]);
+    for(n = 0; n < outc; n++)
+        SETFLOAT(outv + n, (unsigned char) s->s_name[n]);
     outlet_list(x->x_obj.ob_outlet, &s_list, outc, outv);
     ATOMS_FREEA(outv, outc);
 }
@@ -798,7 +791,7 @@ static void list_fromsymbol_symbol(t_list_fromsymbol *x, t_symbol *s)
 static void list_fromsymbol_setup(void)
 {
     list_fromsymbol_class = class_new(gensym("list fromsymbol"),
-        (t_newmethod)list_fromsymbol_new, 0, sizeof(t_list_fromsymbol), 0, 0);
+        (t_newmethod) list_fromsymbol_new, 0, sizeof(t_list_fromsymbol), 0, 0);
     class_addsymbol(list_fromsymbol_class, list_fromsymbol_symbol);
     class_sethelpsymbol(list_fromsymbol_class, &s_list);
 }
@@ -814,13 +807,13 @@ typedef struct _list_tosymbol
 
 static void *list_tosymbol_new(void)
 {
-    t_list_tosymbol *x = (t_list_tosymbol *)pd_new(list_tosymbol_class);
+    t_list_tosymbol *x = (t_list_tosymbol *) pd_new(list_tosymbol_class);
     outlet_new(&x->x_obj, &s_symbol);
     return (x);
 }
 
-static void list_tosymbol_list(t_list_tosymbol *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void list_tosymbol_list(
+    t_list_tosymbol *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
 #if HAVE_ALLOCA
@@ -828,20 +821,20 @@ static void list_tosymbol_list(t_list_tosymbol *x, t_symbol *s,
 #else
     char *str = getbytes(argc + 1);
 #endif
-    for (i = 0; i < argc; i++)
-        str[i] = (char)atom_getfloatarg(i, argc, argv);
+    for(i = 0; i < argc; i++)
+        str[i] = (char) atom_getfloatarg(i, argc, argv);
     str[argc] = 0;
     outlet_symbol(x->x_obj.ob_outlet, gensym(str));
 #if HAVE_ALLOCA
 #else
-    freebytes(str, argc+1);
+    freebytes(str, argc + 1);
 #endif
 }
 
 static void list_tosymbol_setup(void)
 {
     list_tosymbol_class = class_new(gensym("list tosymbol"),
-        (t_newmethod)list_tosymbol_new, 0, sizeof(t_list_tosymbol), 0, 0);
+        (t_newmethod) list_tosymbol_new, 0, sizeof(t_list_tosymbol), 0, 0);
     class_addlist(list_tosymbol_class, list_tosymbol_list);
     class_sethelpsymbol(list_tosymbol_class, &s_list);
 }
@@ -850,28 +843,28 @@ static void list_tosymbol_setup(void)
 
 static void *list_new(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    if (!argc || argv[0].a_type != A_SYMBOL)
+    if(!argc || argv[0].a_type != A_SYMBOL)
         pd_this->pd_newest = list_append_new(s, argc, argv);
     else
     {
         t_symbol *s2 = argv[0].a_w.w_symbol;
-        if (s2 == gensym("append"))
-            pd_this->pd_newest = list_append_new(s, argc-1, argv+1);
-        else if (s2 == gensym("prepend"))
-            pd_this->pd_newest = list_prepend_new(s, argc-1, argv+1);
-        else if (s2 == gensym("split"))
+        if(s2 == gensym("append"))
+            pd_this->pd_newest = list_append_new(s, argc - 1, argv + 1);
+        else if(s2 == gensym("prepend"))
+            pd_this->pd_newest = list_prepend_new(s, argc - 1, argv + 1);
+        else if(s2 == gensym("split"))
             pd_this->pd_newest =
                 list_split_new(atom_getfloatarg(1, argc, argv));
-        else if (s2 == gensym("trim"))
+        else if(s2 == gensym("trim"))
             pd_this->pd_newest = list_trim_new();
-        else if (s2 == gensym("length"))
+        else if(s2 == gensym("length"))
             pd_this->pd_newest = list_length_new();
-        else if (s2 == gensym("fromsymbol"))
+        else if(s2 == gensym("fromsymbol"))
             pd_this->pd_newest = list_fromsymbol_new();
-        else if (s2 == gensym("tosymbol"))
+        else if(s2 == gensym("tosymbol"))
             pd_this->pd_newest = list_tosymbol_new();
-        else if (s2 == gensym("store"))
-            pd_this->pd_newest = list_store_new(s, argc-1, argv+1);
+        else if(s2 == gensym("store"))
+            pd_this->pd_newest = list_store_new(s, argc - 1, argv + 1);
         else
         {
             pd_error(0, "list %s: unknown function", s2->s_name);
@@ -892,5 +885,5 @@ void x_list_setup(void)
     list_length_setup();
     list_fromsymbol_setup();
     list_tosymbol_setup();
-    class_addcreator((t_newmethod)list_new, &s_list, A_GIMME, 0);
+    class_addcreator((t_newmethod) list_new, &s_list, A_GIMME, 0);
 }

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -177,6 +177,7 @@ static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
         pd_error(0, "list_alloc: out of memory");
     }
     else
+    {
         for(i = 0; i < count; i++)
         {
             y->l_vec[i].l_a = x->l_vec[onset + i].l_a;
@@ -187,6 +188,7 @@ static void alist_clone(t_alist *x, t_alist *y, int onset, int count)
                 y->l_npointer++;
             }
         }
+    }
 }
 
 /* function to restore gpointers after the list has moved in memory */
@@ -459,8 +461,10 @@ static void list_store_doinsert(
             (x->x_alist.l_n - index) * sizeof(*x->x_alist.l_vec));
         /* fix gpointers because of memmove() */
         if(x->x_alist.l_npointer)
+        {
             alist_restore_gpointers(
                 &x->x_alist, index + argc, x->x_alist.l_n - index);
+        }
     }
     /* finally copy new elements */
     alist_copyin(&x->x_alist, s, argc, argv, index);
@@ -509,9 +513,13 @@ static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
     }
     max = x->x_alist.l_n - index;
     if(!n)
+    {
         n = 1; /* default */
+    }
     else if(n < 0 || n > max)
+    {
         n = max; /* till the end of the list */
+    }
 
     /* unset pointers for elements which are to be deleted */
     if(x->x_alist.l_npointer)
@@ -543,10 +551,14 @@ static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
         /* fix all gpointers in case resizebytes() has moved the alist in memory
          */
         if(x->x_alist.l_vec != oldptr)
+        {
             alist_restore_gpointers(&x->x_alist, 0, x->x_alist.l_n - n);
-        else /* only fix gpointers after index (because of of memmove()) */
+        }
+        else
+        { /* only fix gpointers after index (because of of memmove()) */
             alist_restore_gpointers(
                 &x->x_alist, index, x->x_alist.l_n - index - n);
+        }
     }
     x->x_alist.l_n -= n;
 }
@@ -557,7 +569,9 @@ static void list_store_get(t_list_store *x, float f1, float f2)
     int onset = f1;
     int outc = f2;
     if(!outc)
+    {
         outc = 1; /* default */
+    }
     else if(outc < 0)
     {
         outc = x->x_alist.l_n - onset; /* till the end of the list */
@@ -712,10 +726,14 @@ static void *list_trim_new(void)
 static void list_trim_list(t_list_trim *x, t_symbol *s, int argc, t_atom *argv)
 {
     if(argc < 1 || argv[0].a_type != A_SYMBOL)
+    {
         outlet_list(x->x_obj.ob_outlet, &s_list, argc, argv);
+    }
     else
+    {
         outlet_anything(
             x->x_obj.ob_outlet, argv[0].a_w.w_symbol, argc - 1, argv + 1);
+    }
 }
 
 static void list_trim_anything(
@@ -854,27 +872,45 @@ static void list_tosymbol_setup(void)
 static void *list_new(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     if(!argc || argv[0].a_type != A_SYMBOL)
+    {
         pd_this->pd_newest = list_append_new(s, argc, argv);
+    }
     else
     {
         t_symbol *s2 = argv[0].a_w.w_symbol;
         if(s2 == gensym("append"))
+        {
             pd_this->pd_newest = list_append_new(s, argc - 1, argv + 1);
+        }
         else if(s2 == gensym("prepend"))
+        {
             pd_this->pd_newest = list_prepend_new(s, argc - 1, argv + 1);
+        }
         else if(s2 == gensym("split"))
+        {
             pd_this->pd_newest =
                 list_split_new(atom_getfloatarg(1, argc, argv));
+        }
         else if(s2 == gensym("trim"))
+        {
             pd_this->pd_newest = list_trim_new();
+        }
         else if(s2 == gensym("length"))
+        {
             pd_this->pd_newest = list_length_new();
+        }
         else if(s2 == gensym("fromsymbol"))
+        {
             pd_this->pd_newest = list_fromsymbol_new();
+        }
         else if(s2 == gensym("tosymbol"))
+        {
             pd_this->pd_newest = list_tosymbol_new();
+        }
         else if(s2 == gensym("store"))
+        {
             pd_this->pd_newest = list_store_new(s, argc - 1, argv + 1);
+        }
         else
         {
             pd_error(0, "list %s: unknown function", s2->s_name);

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -478,8 +478,7 @@ static void list_store_insert(
             pd_error(x, "list_store_insert: index %d out of range", index);
             return;
         }
-        else if(index > x->x_alist.l_n)
-            index = x->x_alist.l_n;
+        if(index > x->x_alist.l_n) index = x->x_alist.l_n;
         list_store_doinsert(x, s, --argc, ++argv, index);
     }
 }

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2001 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* MIDI. */
 
@@ -39,7 +39,7 @@ typedef struct _midiin
 
 static void *midiin_new(void)
 {
-    t_midiin *x = (t_midiin *)pd_new(midiin_class);
+    t_midiin *x = (t_midiin *) pd_new(midiin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_midiin_sym);
@@ -59,7 +59,7 @@ static void midiin_free(t_midiin *x)
 
 static void *sysexin_new(void)
 {
-    t_midiin *x = (t_midiin *)pd_new(sysexin_class);
+    t_midiin *x = (t_midiin *) pd_new(sysexin_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_sysexin_sym);
@@ -73,15 +73,14 @@ static void sysexin_free(t_midiin *x)
 
 static void midiin_setup(void)
 {
-    midiin_class = class_new(gensym("midiin"), (t_newmethod)midiin_new,
-        (t_method)midiin_free, sizeof(t_midiin),
-            CLASS_NOINLET, A_DEFFLOAT, 0);
+    midiin_class = class_new(gensym("midiin"), (t_newmethod) midiin_new,
+        (t_method) midiin_free, sizeof(t_midiin), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(midiin_class, midiin_list);
     class_sethelpsymbol(midiin_class, gensym("midi"));
 
-    sysexin_class = class_new(gensym("sysexin"), (t_newmethod)sysexin_new,
-        (t_method)sysexin_free, sizeof(t_midiin),
-            CLASS_NOINLET, A_DEFFLOAT, 0);
+    sysexin_class = class_new(gensym("sysexin"), (t_newmethod) sysexin_new,
+        (t_method) sysexin_free, sizeof(t_midiin), CLASS_NOINLET, A_DEFFLOAT,
+        0);
     class_addlist(sysexin_class, midiin_list);
     class_sethelpsymbol(sysexin_class, gensym("midi"));
 }
@@ -89,10 +88,10 @@ static void midiin_setup(void)
 void inmidi_byte(int portno, int byte)
 {
     t_atom at[2];
-    if (pd_this->pd_midi->m_midiin_sym->s_thing)
+    if(pd_this->pd_midi->m_midiin_sym->s_thing)
     {
         SETFLOAT(at, byte);
-        SETFLOAT(at+1, portno);
+        SETFLOAT(at + 1, portno);
         pd_list(pd_this->pd_midi->m_midiin_sym->s_thing, 0, 2, at);
     }
 }
@@ -100,10 +99,10 @@ void inmidi_byte(int portno, int byte)
 void inmidi_sysex(int portno, int byte)
 {
     t_atom at[2];
-    if (pd_this->pd_midi->m_sysexin_sym->s_thing)
+    if(pd_this->pd_midi->m_sysexin_sym->s_thing)
     {
         SETFLOAT(at, byte);
-        SETFLOAT(at+1, portno);
+        SETFLOAT(at + 1, portno);
         pd_list(pd_this->pd_midi->m_sysexin_sym->s_thing, 0, 2, at);
     }
 }
@@ -123,11 +122,11 @@ typedef struct _notein
 
 static void *notein_new(t_floatarg f)
 {
-    t_notein *x = (t_notein *)pd_new(notein_class);
+    t_notein *x = (t_notein *) pd_new(notein_class);
     x->x_channel = f;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
-    if (f == 0) x->x_outlet3 = outlet_new(&x->x_obj, &s_float);
+    if(f == 0) x->x_outlet3 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_notein_sym);
     return (x);
 }
@@ -137,9 +136,9 @@ static void notein_list(t_notein *x, t_symbol *s, int argc, t_atom *argv)
     t_float pitch = atom_getfloatarg(0, argc, argv);
     t_float velo = atom_getfloatarg(1, argc, argv);
     t_float channel = atom_getfloatarg(2, argc, argv);
-    if (x->x_channel != 0)
+    if(x->x_channel != 0)
     {
-        if (channel != x->x_channel) return;
+        if(channel != x->x_channel) return;
         outlet_float(x->x_outlet2, velo);
         outlet_float(x->x_outlet1, pitch);
     }
@@ -158,20 +157,20 @@ static void notein_free(t_notein *x)
 
 static void notein_setup(void)
 {
-    notein_class = class_new(gensym("notein"), (t_newmethod)notein_new,
-        (t_method)notein_free, sizeof(t_notein), CLASS_NOINLET, A_DEFFLOAT, 0);
+    notein_class = class_new(gensym("notein"), (t_newmethod) notein_new,
+        (t_method) notein_free, sizeof(t_notein), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(notein_class, notein_list);
     class_sethelpsymbol(notein_class, gensym("midi"));
 }
 
 void inmidi_noteon(int portno, int channel, int pitch, int velo)
 {
-    if (pd_this->pd_midi->m_notein_sym->s_thing)
+    if(pd_this->pd_midi->m_notein_sym->s_thing)
     {
         t_atom at[3];
         SETFLOAT(at, pitch);
-        SETFLOAT(at+1, velo);
-        SETFLOAT(at+2, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, velo);
+        SETFLOAT(at + 2, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_notein_sym->s_thing, &s_list, 3, at);
     }
 }
@@ -193,16 +192,18 @@ typedef struct _ctlin
 static void *ctlin_new(t_symbol *s, int argc, t_atom *argv)
 {
     int ctlno, channel;
-    t_ctlin *x = (t_ctlin *)pd_new(ctlin_class);
-    if (!argc) ctlno = -1;
-    else ctlno = atom_getfloatarg(0, argc, argv);
+    t_ctlin *x = (t_ctlin *) pd_new(ctlin_class);
+    if(!argc)
+        ctlno = -1;
+    else
+        ctlno = atom_getfloatarg(0, argc, argv);
     channel = atom_getfloatarg(1, argc, argv);
     x->x_channel = channel;
     x->x_ctlno = ctlno;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
-    if (!channel)
+    if(!channel)
     {
-        if (x->x_ctlno < 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
+        if(x->x_ctlno < 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
         x->x_outlet3 = outlet_new(&x->x_obj, &s_float);
     }
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_ctlin_sym);
@@ -214,10 +215,10 @@ static void ctlin_list(t_ctlin *x, t_symbol *s, int argc, t_atom *argv)
     t_float ctlnumber = atom_getfloatarg(0, argc, argv);
     t_float value = atom_getfloatarg(1, argc, argv);
     t_float channel = atom_getfloatarg(2, argc, argv);
-    if (x->x_ctlno >= 0 && x->x_ctlno != ctlnumber) return;
-    if (x->x_channel > 0  && x->x_channel != channel) return;
-    if (x->x_channel == 0) outlet_float(x->x_outlet3, channel);
-    if (x->x_ctlno < 0) outlet_float(x->x_outlet2, ctlnumber);
+    if(x->x_ctlno >= 0 && x->x_ctlno != ctlnumber) return;
+    if(x->x_channel > 0 && x->x_channel != channel) return;
+    if(x->x_channel == 0) outlet_float(x->x_outlet3, channel);
+    if(x->x_ctlno < 0) outlet_float(x->x_outlet2, ctlnumber);
     outlet_float(x->x_outlet1, value);
 }
 
@@ -228,21 +229,20 @@ static void ctlin_free(t_ctlin *x)
 
 static void ctlin_setup(void)
 {
-    ctlin_class = class_new(gensym("ctlin"), (t_newmethod)ctlin_new,
-        (t_method)ctlin_free, sizeof(t_ctlin),
-            CLASS_NOINLET, A_GIMME, 0);
+    ctlin_class = class_new(gensym("ctlin"), (t_newmethod) ctlin_new,
+        (t_method) ctlin_free, sizeof(t_ctlin), CLASS_NOINLET, A_GIMME, 0);
     class_addlist(ctlin_class, ctlin_list);
     class_sethelpsymbol(ctlin_class, gensym("midi"));
 }
 
 void inmidi_controlchange(int portno, int channel, int ctlnumber, int value)
 {
-    if (pd_this->pd_midi->m_ctlin_sym->s_thing)
+    if(pd_this->pd_midi->m_ctlin_sym->s_thing)
     {
         t_atom at[3];
         SETFLOAT(at, ctlnumber);
-        SETFLOAT(at+1, value);
-        SETFLOAT(at+2, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, value);
+        SETFLOAT(at + 2, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_ctlin_sym->s_thing, &s_list, 3, at);
     }
 }
@@ -261,10 +261,10 @@ typedef struct _pgmin
 
 static void *pgmin_new(t_floatarg f)
 {
-    t_pgmin *x = (t_pgmin *)pd_new(pgmin_class);
+    t_pgmin *x = (t_pgmin *) pd_new(pgmin_class);
     x->x_channel = f;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
-    if (f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
+    if(f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_pgmin_sym);
     return (x);
 }
@@ -273,9 +273,9 @@ static void pgmin_list(t_pgmin *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float value = atom_getfloatarg(0, argc, argv);
     t_float channel = atom_getfloatarg(1, argc, argv);
-    if (x->x_channel != 0)
+    if(x->x_channel != 0)
     {
-        if (channel != x->x_channel) return;
+        if(channel != x->x_channel) return;
         outlet_float(x->x_outlet1, value);
     }
     else
@@ -292,20 +292,19 @@ static void pgmin_free(t_pgmin *x)
 
 static void pgmin_setup(void)
 {
-    pgmin_class = class_new(gensym("pgmin"), (t_newmethod)pgmin_new,
-        (t_method)pgmin_free, sizeof(t_pgmin),
-            CLASS_NOINLET, A_DEFFLOAT, 0);
+    pgmin_class = class_new(gensym("pgmin"), (t_newmethod) pgmin_new,
+        (t_method) pgmin_free, sizeof(t_pgmin), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(pgmin_class, pgmin_list);
     class_sethelpsymbol(pgmin_class, gensym("midi"));
 }
 
 void inmidi_programchange(int portno, int channel, int value)
 {
-    if (pd_this->pd_midi->m_pgmin_sym->s_thing)
+    if(pd_this->pd_midi->m_pgmin_sym->s_thing)
     {
         t_atom at[2];
         SETFLOAT(at, value + 1);
-        SETFLOAT(at+1, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_pgmin_sym->s_thing, &s_list, 2, at);
     }
 }
@@ -324,10 +323,10 @@ typedef struct _bendin
 
 static void *bendin_new(t_floatarg f)
 {
-    t_bendin *x = (t_bendin *)pd_new(bendin_class);
+    t_bendin *x = (t_bendin *) pd_new(bendin_class);
     x->x_channel = f;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
-    if (f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
+    if(f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_bendin_sym);
     return (x);
 }
@@ -336,9 +335,9 @@ static void bendin_list(t_bendin *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float value = atom_getfloatarg(0, argc, argv);
     t_float channel = atom_getfloatarg(1, argc, argv);
-    if (x->x_channel != 0)
+    if(x->x_channel != 0)
     {
-        if (channel != x->x_channel) return;
+        if(channel != x->x_channel) return;
         outlet_float(x->x_outlet1, value);
     }
     else
@@ -355,19 +354,19 @@ static void bendin_free(t_bendin *x)
 
 static void bendin_setup(void)
 {
-    bendin_class = class_new(gensym("bendin"), (t_newmethod)bendin_new,
-        (t_method)bendin_free, sizeof(t_bendin), CLASS_NOINLET, A_DEFFLOAT, 0);
+    bendin_class = class_new(gensym("bendin"), (t_newmethod) bendin_new,
+        (t_method) bendin_free, sizeof(t_bendin), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(bendin_class, bendin_list);
     class_sethelpsymbol(bendin_class, gensym("midi"));
 }
 
 void inmidi_pitchbend(int portno, int channel, int value)
 {
-    if (pd_this->pd_midi->m_bendin_sym->s_thing)
+    if(pd_this->pd_midi->m_bendin_sym->s_thing)
     {
         t_atom at[2];
         SETFLOAT(at, value);
-        SETFLOAT(at+1, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_bendin_sym->s_thing, &s_list, 2, at);
     }
 }
@@ -386,10 +385,10 @@ typedef struct _touchin
 
 static void *touchin_new(t_floatarg f)
 {
-    t_touchin *x = (t_touchin *)pd_new(touchin_class);
+    t_touchin *x = (t_touchin *) pd_new(touchin_class);
     x->x_channel = f;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
-    if (f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
+    if(f == 0) x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_touchin_sym);
     return (x);
 }
@@ -398,9 +397,9 @@ static void touchin_list(t_touchin *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float value = atom_getfloatarg(0, argc, argv);
     t_float channel = atom_getfloatarg(1, argc, argv);
-    if (x->x_channel)
+    if(x->x_channel)
     {
-        if (channel != x->x_channel) return;
+        if(channel != x->x_channel) return;
         outlet_float(x->x_outlet1, value);
     }
     else
@@ -417,20 +416,20 @@ static void touchin_free(t_touchin *x)
 
 static void touchin_setup(void)
 {
-    touchin_class = class_new(gensym("touchin"), (t_newmethod)touchin_new,
-        (t_method)touchin_free, sizeof(t_touchin),
-            CLASS_NOINLET, A_DEFFLOAT, 0);
+    touchin_class = class_new(gensym("touchin"), (t_newmethod) touchin_new,
+        (t_method) touchin_free, sizeof(t_touchin), CLASS_NOINLET, A_DEFFLOAT,
+        0);
     class_addlist(touchin_class, touchin_list);
     class_sethelpsymbol(touchin_class, gensym("midi"));
 }
 
 void inmidi_aftertouch(int portno, int channel, int value)
 {
-    if (pd_this->pd_midi->m_touchin_sym->s_thing)
+    if(pd_this->pd_midi->m_touchin_sym->s_thing)
     {
         t_atom at[2];
         SETFLOAT(at, value);
-        SETFLOAT(at+1, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_touchin_sym->s_thing, &s_list, 2, at);
     }
 }
@@ -450,24 +449,24 @@ typedef struct _polytouchin
 
 static void *polytouchin_new(t_floatarg f)
 {
-    t_polytouchin *x = (t_polytouchin *)pd_new(polytouchin_class);
+    t_polytouchin *x = (t_polytouchin *) pd_new(polytouchin_class);
     x->x_channel = f;
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
-    if (f == 0) x->x_outlet3 = outlet_new(&x->x_obj, &s_float);
+    if(f == 0) x->x_outlet3 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_polytouchin_sym);
     return (x);
 }
 
-static void polytouchin_list(t_polytouchin *x, t_symbol *s, int argc,
-    t_atom *argv)
+static void polytouchin_list(
+    t_polytouchin *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float pitch = atom_getfloatarg(0, argc, argv);
     t_float value = atom_getfloatarg(1, argc, argv);
     t_float channel = atom_getfloatarg(2, argc, argv);
-    if (x->x_channel != 0)
+    if(x->x_channel != 0)
     {
-        if (channel != x->x_channel) return;
+        if(channel != x->x_channel) return;
         outlet_float(x->x_outlet2, pitch);
         outlet_float(x->x_outlet1, value);
     }
@@ -487,7 +486,7 @@ static void polytouchin_free(t_polytouchin *x)
 static void polytouchin_setup(void)
 {
     polytouchin_class = class_new(gensym("polytouchin"),
-        (t_newmethod)polytouchin_new, (t_method)polytouchin_free,
+        (t_newmethod) polytouchin_new, (t_method) polytouchin_free,
         sizeof(t_polytouchin), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(polytouchin_class, polytouchin_list);
     class_sethelpsymbol(polytouchin_class, gensym("midi"));
@@ -495,12 +494,12 @@ static void polytouchin_setup(void)
 
 void inmidi_polyaftertouch(int portno, int channel, int pitch, int value)
 {
-    if (pd_this->pd_midi->m_polytouchin_sym->s_thing)
+    if(pd_this->pd_midi->m_polytouchin_sym->s_thing)
     {
         t_atom at[3];
         SETFLOAT(at, pitch);
-        SETFLOAT(at+1, value);
-        SETFLOAT(at+2, (channel + (portno << 4) + 1));
+        SETFLOAT(at + 1, value);
+        SETFLOAT(at + 2, (channel + (portno << 4) + 1));
         pd_list(pd_this->pd_midi->m_polytouchin_sym->s_thing, &s_list, 3, at);
     }
 }
@@ -518,15 +517,15 @@ typedef struct _midirealtimein
 
 static void *midirealtimein_new(void)
 {
-    t_midirealtimein *x = (t_midirealtimein *)pd_new(midirealtimein_class);
+    t_midirealtimein *x = (t_midirealtimein *) pd_new(midirealtimein_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
     x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     pd_bind(&x->x_obj.ob_pd, pd_this->pd_midi->m_midirealtimein_sym);
     return (x);
 }
 
-static void midirealtimein_list(t_midirealtimein *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void midirealtimein_list(
+    t_midirealtimein *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_float portno = atom_getfloatarg(0, argc, argv);
     t_float byte = atom_getfloatarg(1, argc, argv);
@@ -543,20 +542,21 @@ static void midirealtimein_free(t_midirealtimein *x)
 static void midirealtimein_setup(void)
 {
     midirealtimein_class = class_new(gensym("midirealtimein"),
-        (t_newmethod)midirealtimein_new, (t_method)midirealtimein_free,
-            sizeof(t_midirealtimein), CLASS_NOINLET, A_DEFFLOAT, 0);
+        (t_newmethod) midirealtimein_new, (t_method) midirealtimein_free,
+        sizeof(t_midirealtimein), CLASS_NOINLET, A_DEFFLOAT, 0);
     class_addlist(midirealtimein_class, midirealtimein_list);
-        class_sethelpsymbol(midirealtimein_class, gensym("midi"));
+    class_sethelpsymbol(midirealtimein_class, gensym("midi"));
 }
 
 void inmidi_realtimein(int portno, int SysMsg)
 {
-    if (pd_this->pd_midi->m_midirealtimein_sym->s_thing)
+    if(pd_this->pd_midi->m_midirealtimein_sym->s_thing)
     {
         t_atom at[2];
         SETFLOAT(at, portno);
-        SETFLOAT(at+1, SysMsg);
-        pd_list(pd_this->pd_midi->m_midirealtimein_sym->s_thing, &s_list, 2, at);
+        SETFLOAT(at + 1, SysMsg);
+        pd_list(
+            pd_this->pd_midi->m_midirealtimein_sym->s_thing, &s_list, 2, at);
     }
 }
 
@@ -574,8 +574,8 @@ typedef struct _midiout
 
 static void *midiout_new(t_floatarg portno)
 {
-    t_midiout *x = (t_midiout *)pd_new(midiout_class);
-    if (portno <= 0) portno = 1;
+    t_midiout *x = (t_midiout *) pd_new(midiout_class);
+    if(portno <= 0) portno = 1;
     x->x_portno = portno;
     floatinlet_new(&x->x_obj, &x->x_portno);
     return (x);
@@ -589,7 +589,7 @@ static void midiout_float(t_midiout *x, t_floatarg f)
 static void midiout_list(t_midiout *x, t_symbol *s, int ac, t_atom *av)
 {
     int i;
-    for (i = 0; i < ac; ++i)
+    for(i = 0; i < ac; ++i)
     {
         if(av[i].a_type == A_FLOAT)
             outmidi_byte(x->x_portno - 1, av[i].a_w.w_float);
@@ -598,7 +598,7 @@ static void midiout_list(t_midiout *x, t_symbol *s, int ac, t_atom *av)
 
 static void midiout_setup(void)
 {
-    midiout_class = class_new(gensym("midiout"), (t_newmethod)midiout_new, 0,
+    midiout_class = class_new(gensym("midiout"), (t_newmethod) midiout_new, 0,
         sizeof(t_midiout), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addfloat(midiout_class, midiout_float);
     class_addlist(midiout_class, midiout_list);
@@ -618,9 +618,9 @@ typedef struct _noteout
 
 static void *noteout_new(t_floatarg channel)
 {
-    t_noteout *x = (t_noteout *)pd_new(noteout_class);
+    t_noteout *x = (t_noteout *) pd_new(noteout_class);
     x->x_velo = 0;
-    if (channel < 1) channel = 1;
+    if(channel < 1) channel = 1;
     x->x_channel = channel;
     floatinlet_new(&x->x_obj, &x->x_velo);
     floatinlet_new(&x->x_obj, &x->x_channel);
@@ -630,20 +630,17 @@ static void *noteout_new(t_floatarg channel)
 static void noteout_float(t_noteout *x, t_float f)
 {
     int binchan = x->x_channel - 1;
-    if (binchan < 0)
-        binchan = 0;
-    outmidi_noteon((binchan >> 4),
-        (binchan & 15), (int)f, (int)x->x_velo);
+    if(binchan < 0) binchan = 0;
+    outmidi_noteon((binchan >> 4), (binchan & 15), (int) f, (int) x->x_velo);
 }
 
 static void noteout_setup(void)
 {
-    noteout_class = class_new(gensym("noteout"), (t_newmethod)noteout_new, 0,
+    noteout_class = class_new(gensym("noteout"), (t_newmethod) noteout_new, 0,
         sizeof(t_noteout), 0, A_DEFFLOAT, 0);
     class_addfloat(noteout_class, noteout_float);
     class_sethelpsymbol(noteout_class, gensym("midi"));
 }
-
 
 /* -------------------------- ctlout -------------------------- */
 
@@ -658,9 +655,9 @@ typedef struct _ctlout
 
 static void *ctlout_new(t_floatarg ctl, t_floatarg channel)
 {
-    t_ctlout *x = (t_ctlout *)pd_new(ctlout_class);
+    t_ctlout *x = (t_ctlout *) pd_new(ctlout_class);
     x->x_ctl = ctl;
-    if (channel <= 0) channel = 1;
+    if(channel <= 0) channel = 1;
     x->x_channel = channel;
     floatinlet_new(&x->x_obj, &x->x_ctl);
     floatinlet_new(&x->x_obj, &x->x_channel);
@@ -670,20 +667,18 @@ static void *ctlout_new(t_floatarg ctl, t_floatarg channel)
 static void ctlout_float(t_ctlout *x, t_float f)
 {
     int binchan = x->x_channel - 1;
-    if (binchan < 0)
-        binchan = 0;
-    outmidi_controlchange((binchan >> 4),
-        (binchan & 15), (int)(x->x_ctl), (int)f);
+    if(binchan < 0) binchan = 0;
+    outmidi_controlchange(
+        (binchan >> 4), (binchan & 15), (int) (x->x_ctl), (int) f);
 }
 
 static void ctlout_setup(void)
 {
-    ctlout_class = class_new(gensym("ctlout"), (t_newmethod)ctlout_new, 0,
+    ctlout_class = class_new(gensym("ctlout"), (t_newmethod) ctlout_new, 0,
         sizeof(t_ctlout), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addfloat(ctlout_class, ctlout_float);
     class_sethelpsymbol(ctlout_class, gensym("midi"));
 }
-
 
 /* -------------------------- pgmout -------------------------- */
 
@@ -697,8 +692,8 @@ typedef struct _pgmout
 
 static void *pgmout_new(t_floatarg channel)
 {
-    t_pgmout *x = (t_pgmout *)pd_new(pgmout_class);
-    if (channel <= 0) channel = 1;
+    t_pgmout *x = (t_pgmout *) pd_new(pgmout_class);
+    if(channel <= 0) channel = 1;
     x->x_channel = channel;
     floatinlet_new(&x->x_obj, &x->x_channel);
     return (x);
@@ -708,22 +703,21 @@ static void pgmout_float(t_pgmout *x, t_floatarg f)
 {
     int binchan = x->x_channel - 1;
     int n = f - 1;
-    if (binchan < 0)
-        binchan = 0;
-    if (n < 0) n = 0;
-    else if (n > 127) n = 127;
-    outmidi_programchange((binchan >> 4),
-        (binchan & 15), n);
+    if(binchan < 0) binchan = 0;
+    if(n < 0)
+        n = 0;
+    else if(n > 127)
+        n = 127;
+    outmidi_programchange((binchan >> 4), (binchan & 15), n);
 }
 
 static void pgmout_setup(void)
 {
-    pgmout_class = class_new(gensym("pgmout"), (t_newmethod)pgmout_new, 0,
+    pgmout_class = class_new(gensym("pgmout"), (t_newmethod) pgmout_new, 0,
         sizeof(t_pgmout), 0, A_DEFFLOAT, 0);
     class_addfloat(pgmout_class, pgmout_float);
     class_sethelpsymbol(pgmout_class, gensym("midi"));
 }
-
 
 /* -------------------------- bendout -------------------------- */
 
@@ -737,8 +731,8 @@ typedef struct _bendout
 
 static void *bendout_new(t_floatarg channel)
 {
-    t_bendout *x = (t_bendout *)pd_new(bendout_class);
-    if (channel <= 0) channel = 1;
+    t_bendout *x = (t_bendout *) pd_new(bendout_class);
+    if(channel <= 0) channel = 1;
     x->x_channel = channel;
     floatinlet_new(&x->x_obj, &x->x_channel);
     return (x);
@@ -747,15 +741,14 @@ static void *bendout_new(t_floatarg channel)
 static void bendout_float(t_bendout *x, t_float f)
 {
     int binchan = x->x_channel - 1;
-    int n = (int)f +  8192;
-    if (binchan < 0)
-        binchan = 0;
+    int n = (int) f + 8192;
+    if(binchan < 0) binchan = 0;
     outmidi_pitchbend((binchan >> 4), (binchan & 15), n);
 }
 
 static void bendout_setup(void)
 {
-    bendout_class = class_new(gensym("bendout"), (t_newmethod)bendout_new, 0,
+    bendout_class = class_new(gensym("bendout"), (t_newmethod) bendout_new, 0,
         sizeof(t_bendout), 0, A_DEFFLOAT, 0);
     class_addfloat(bendout_class, bendout_float);
     class_sethelpsymbol(bendout_class, gensym("midi"));
@@ -773,8 +766,8 @@ typedef struct _touchout
 
 static void *touchout_new(t_floatarg channel)
 {
-    t_touchout *x = (t_touchout *)pd_new(touchout_class);
-    if (channel <= 0) channel = 1;
+    t_touchout *x = (t_touchout *) pd_new(touchout_class);
+    if(channel <= 0) channel = 1;
     x->x_channel = channel;
     floatinlet_new(&x->x_obj, &x->x_channel);
     return (x);
@@ -783,15 +776,14 @@ static void *touchout_new(t_floatarg channel)
 static void touchout_float(t_touchout *x, t_float f)
 {
     int binchan = x->x_channel - 1;
-    if (binchan < 0)
-        binchan = 0;
-    outmidi_aftertouch((binchan >> 4), (binchan & 15), (int)f);
+    if(binchan < 0) binchan = 0;
+    outmidi_aftertouch((binchan >> 4), (binchan & 15), (int) f);
 }
 
 static void touchout_setup(void)
 {
-    touchout_class = class_new(gensym("touchout"), (t_newmethod)touchout_new, 0,
-        sizeof(t_touchout), 0, A_DEFFLOAT, 0);
+    touchout_class = class_new(gensym("touchout"), (t_newmethod) touchout_new,
+        0, sizeof(t_touchout), 0, A_DEFFLOAT, 0);
     class_addfloat(touchout_class, touchout_float);
     class_sethelpsymbol(touchout_class, gensym("midi"));
 }
@@ -809,8 +801,8 @@ typedef struct _polytouchout
 
 static void *polytouchout_new(t_floatarg channel)
 {
-    t_polytouchout *x = (t_polytouchout *)pd_new(polytouchout_class);
-    if (channel <= 0) channel = 1;
+    t_polytouchout *x = (t_polytouchout *) pd_new(polytouchout_class);
+    if(channel <= 0) channel = 1;
     x->x_channel = channel;
     x->x_pitch = 0;
     floatinlet_new(&x->x_obj, &x->x_pitch);
@@ -821,16 +813,15 @@ static void *polytouchout_new(t_floatarg channel)
 static void polytouchout_float(t_polytouchout *x, t_float n)
 {
     int binchan = x->x_channel - 1;
-    if (binchan < 0)
-        binchan = 0;
+    if(binchan < 0) binchan = 0;
     outmidi_polyaftertouch((binchan >> 4), (binchan & 15), x->x_pitch, n);
 }
 
 static void polytouchout_setup(void)
 {
-    polytouchout_class = class_new(gensym("polytouchout"),
-        (t_newmethod)polytouchout_new, 0,
-        sizeof(t_polytouchout), 0, A_DEFFLOAT, 0);
+    polytouchout_class =
+        class_new(gensym("polytouchout"), (t_newmethod) polytouchout_new, 0,
+            sizeof(t_polytouchout), 0, A_DEFFLOAT, 0);
     class_addfloat(polytouchout_class, polytouchout_float);
     class_sethelpsymbol(polytouchout_class, gensym("midi"));
 }
@@ -859,7 +850,7 @@ typedef struct _makenote
 
 static void *makenote_new(t_floatarg velo, t_floatarg dur)
 {
-    t_makenote *x = (t_makenote *)pd_new(makenote_class);
+    t_makenote *x = (t_makenote *) pd_new(makenote_class);
     x->x_velo = velo;
     x->x_dur = dur;
     floatinlet_new(&x->x_obj, &x->x_velo);
@@ -876,15 +867,17 @@ static void makenote_tick(t_hang *hang)
     t_hang *h2, *h3;
     outlet_float(x->x_velout, 0);
     outlet_float(x->x_pitchout, hang->h_pitch);
-    if (x->x_hang == hang) x->x_hang = hang->h_next;
-    else for (h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
-    {
-        if (h3 == hang)
+    if(x->x_hang == hang)
+        x->x_hang = hang->h_next;
+    else
+        for(h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
         {
-            h2->h_next = h3->h_next;
-            break;
+            if(h3 == hang)
+            {
+                h2->h_next = h3->h_next;
+                break;
+            }
         }
-    }
     clock_free(hang->h_clock);
     freebytes(hang, sizeof(*hang));
 }
@@ -892,22 +885,22 @@ static void makenote_tick(t_hang *hang)
 static void makenote_float(t_makenote *x, t_float f)
 {
     t_hang *hang;
-    if (!x->x_velo) return;
+    if(!x->x_velo) return;
     outlet_float(x->x_velout, x->x_velo);
     outlet_float(x->x_pitchout, f);
-    hang = (t_hang *)getbytes(sizeof *hang);
+    hang = (t_hang *) getbytes(sizeof *hang);
     hang->h_next = x->x_hang;
     x->x_hang = hang;
     hang->h_pitch = f;
     hang->h_owner = x;
-    hang->h_clock = clock_new(hang, (t_method)makenote_tick);
+    hang->h_clock = clock_new(hang, (t_method) makenote_tick);
     clock_delay(hang->h_clock, (x->x_dur >= 0 ? x->x_dur : 0));
 }
 
 static void makenote_stop(t_makenote *x)
 {
     t_hang *hang;
-    while ((hang = x->x_hang))
+    while((hang = x->x_hang))
     {
         outlet_float(x->x_velout, 0);
         outlet_float(x->x_pitchout, hang->h_pitch);
@@ -920,7 +913,7 @@ static void makenote_stop(t_makenote *x)
 static void makenote_clear(t_makenote *x)
 {
     t_hang *hang;
-    while ((hang = x->x_hang))
+    while((hang = x->x_hang))
     {
         x->x_hang = hang->h_next;
         clock_free(hang->h_clock);
@@ -930,14 +923,14 @@ static void makenote_clear(t_makenote *x)
 
 static void makenote_setup(void)
 {
-    makenote_class = class_new(gensym("makenote"),
-        (t_newmethod)makenote_new, (t_method)makenote_clear,
-        sizeof(t_makenote), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
+    makenote_class = class_new(gensym("makenote"), (t_newmethod) makenote_new,
+        (t_method) makenote_clear, sizeof(t_makenote), 0, A_DEFFLOAT,
+        A_DEFFLOAT, 0);
     class_addfloat(makenote_class, makenote_float);
-    class_addmethod(makenote_class, (t_method)makenote_stop, gensym("stop"),
-        0);
-    class_addmethod(makenote_class, (t_method)makenote_clear, gensym("clear"),
-        0);
+    class_addmethod(
+        makenote_class, (t_method) makenote_stop, gensym("stop"), 0);
+    class_addmethod(
+        makenote_class, (t_method) makenote_clear, gensym("clear"), 0);
 }
 
 /* -------------------------- stripnote -------------------------- */
@@ -954,7 +947,7 @@ typedef struct _stripnote
 
 static void *stripnote_new(void)
 {
-    t_stripnote *x = (t_stripnote *)pd_new(stripnote_class);
+    t_stripnote *x = (t_stripnote *) pd_new(stripnote_class);
     floatinlet_new(&x->x_obj, &x->x_velo);
     x->x_pitchout = outlet_new(&x->x_obj, &s_float);
     x->x_velout = outlet_new(&x->x_obj, &s_float);
@@ -963,7 +956,7 @@ static void *stripnote_new(void)
 
 static void stripnote_float(t_stripnote *x, t_float f)
 {
-    if (!x->x_velo) return;
+    if(!x->x_velo) return;
     outlet_float(x->x_velout, x->x_velo);
     outlet_float(x->x_pitchout, f);
 }
@@ -971,7 +964,7 @@ static void stripnote_float(t_stripnote *x, t_float f)
 static void stripnote_setup(void)
 {
     stripnote_class = class_new(gensym("stripnote"),
-        (t_newmethod)stripnote_new, 0, sizeof(t_stripnote), 0, 0);
+        (t_newmethod) stripnote_new, 0, sizeof(t_stripnote), 0, 0);
     class_addfloat(stripnote_class, stripnote_float);
 }
 
@@ -1001,12 +994,12 @@ typedef struct poly
 static void *poly_new(t_float fnvoice, t_float fsteal)
 {
     int i, n = fnvoice;
-    t_poly *x = (t_poly *)pd_new(poly_class);
+    t_poly *x = (t_poly *) pd_new(poly_class);
     t_voice *v;
-    if (n < 1) n = 1;
+    if(n < 1) n = 1;
     x->x_n = n;
-    x->x_vec = (t_voice *)getbytes(n * sizeof(*x->x_vec));
-    for (v = x->x_vec, i = n; i--; v++)
+    x->x_vec = (t_voice *) getbytes(n * sizeof(*x->x_vec));
+    for(v = x->x_vec, i = n; i--; v++)
         v->v_pitch = v->v_used = v->v_serial = 0;
     x->x_vel = 0;
     x->x_steal = (fsteal != 0);
@@ -1024,50 +1017,52 @@ static void poly_float(t_poly *x, t_float f)
     t_voice *v;
     t_voice *firston, *firstoff;
     unsigned int serialon, serialoff, onindex = 0, offindex = 0;
-    if (x->x_vel > 0)
+    if(x->x_vel > 0)
     {
-            /* note on.  Look for a vacant voice */
-        for (v = x->x_vec, i = 0, firston = firstoff = 0,
-            serialon = serialoff = 0xffffffff; i < x->x_n; v++, i++)
+        /* note on.  Look for a vacant voice */
+        for(v = x->x_vec, i = 0, firston = firstoff = 0,
+        serialon = serialoff = 0xffffffff;
+            i < x->x_n; v++, i++)
         {
-            if (v->v_used && v->v_serial < serialon)
-                    firston = v, serialon = (unsigned int)v->v_serial, onindex = i;
-            else if (!v->v_used && v->v_serial < serialoff)
-                    firstoff = v, serialoff = (unsigned int)v->v_serial, offindex = i;
+            if(v->v_used && v->v_serial < serialon)
+                firston = v, serialon = (unsigned int) v->v_serial, onindex = i;
+            else if(!v->v_used && v->v_serial < serialoff)
+                firstoff = v, serialoff = (unsigned int) v->v_serial,
+                offindex = i;
         }
-        if (firstoff)
+        if(firstoff)
         {
             outlet_float(x->x_velout, x->x_vel);
             outlet_float(x->x_pitchout, firstoff->v_pitch = f);
-            outlet_float(x->x_obj.ob_outlet, offindex+1);
+            outlet_float(x->x_obj.ob_outlet, offindex + 1);
             firstoff->v_used = 1;
             firstoff->v_serial = x->x_serial++;
         }
-            /* if none, steal one */
-        else if (firston && x->x_steal)
+        /* if none, steal one */
+        else if(firston && x->x_steal)
         {
             outlet_float(x->x_velout, 0);
             outlet_float(x->x_pitchout, firston->v_pitch);
-            outlet_float(x->x_obj.ob_outlet, onindex+1);
+            outlet_float(x->x_obj.ob_outlet, onindex + 1);
             outlet_float(x->x_velout, x->x_vel);
             outlet_float(x->x_pitchout, firston->v_pitch = f);
-            outlet_float(x->x_obj.ob_outlet, onindex+1);
+            outlet_float(x->x_obj.ob_outlet, onindex + 1);
             firston->v_serial = x->x_serial++;
         }
     }
-    else    /* note off. Turn off oldest match */
+    else /* note off. Turn off oldest match */
     {
-        for (v = x->x_vec, i = 0, firston = 0, serialon = 0xffffffff;
-            i < x->x_n; v++, i++)
-                if (v->v_used && v->v_pitch == f && v->v_serial < serialon)
-                    firston = v, serialon = (unsigned int)v->v_serial, onindex = i;
-        if (firston)
+        for(v = x->x_vec, i = 0, firston = 0, serialon = 0xffffffff; i < x->x_n;
+            v++, i++)
+            if(v->v_used && v->v_pitch == f && v->v_serial < serialon)
+                firston = v, serialon = (unsigned int) v->v_serial, onindex = i;
+        if(firston)
         {
             firston->v_used = 0;
             firston->v_serial = x->x_serial++;
             outlet_float(x->x_velout, 0);
             outlet_float(x->x_pitchout, firston->v_pitch);
-            outlet_float(x->x_obj.ob_outlet, onindex+1);
+            outlet_float(x->x_obj.ob_outlet, onindex + 1);
         }
     }
 }
@@ -1076,37 +1071,37 @@ static void poly_stop(t_poly *x)
 {
     int i;
     t_voice *v;
-    for (i = 0, v = x->x_vec; i < x->x_n; i++, v++)
-        if (v->v_used)
-    {
-        outlet_float(x->x_velout, 0L);
-        outlet_float(x->x_pitchout, v->v_pitch);
-        outlet_float(x->x_obj.ob_outlet, i+1);
-        v->v_used = 0;
-        v->v_serial = x->x_serial++;
-    }
+    for(i = 0, v = x->x_vec; i < x->x_n; i++, v++)
+        if(v->v_used)
+        {
+            outlet_float(x->x_velout, 0L);
+            outlet_float(x->x_pitchout, v->v_pitch);
+            outlet_float(x->x_obj.ob_outlet, i + 1);
+            v->v_used = 0;
+            v->v_serial = x->x_serial++;
+        }
 }
 
 static void poly_clear(t_poly *x)
 {
     int i;
     t_voice *v;
-    for (v = x->x_vec, i = x->x_n; i--; v++) v->v_used = v->v_serial = 0;
+    for(v = x->x_vec, i = x->x_n; i--; v++)
+        v->v_used = v->v_serial = 0;
 }
 
 static void poly_free(t_poly *x)
 {
-    freebytes(x->x_vec, x->x_n * sizeof (*x->x_vec));
+    freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
 }
 
 static void poly_setup(void)
 {
-    poly_class = class_new(gensym("poly"),
-        (t_newmethod)poly_new, (t_method)poly_free,
-        sizeof(t_poly), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
+    poly_class = class_new(gensym("poly"), (t_newmethod) poly_new,
+        (t_method) poly_free, sizeof(t_poly), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
     class_addfloat(poly_class, poly_float);
-    class_addmethod(poly_class, (t_method)poly_stop, gensym("stop"), 0);
-    class_addmethod(poly_class, (t_method)poly_clear, gensym("clear"), 0);
+    class_addmethod(poly_class, (t_method) poly_stop, gensym("stop"), 0);
+    class_addmethod(poly_class, (t_method) poly_clear, gensym("clear"), 0);
 }
 
 /* -------------------------- bag -------------------------- */
@@ -1128,7 +1123,7 @@ typedef struct _bag
 
 static void *bag_new(void)
 {
-    t_bag *x = (t_bag *)pd_new(bag_class);
+    t_bag *x = (t_bag *) pd_new(bag_class);
     x->x_velo = 0;
     floatinlet_new(&x->x_obj, &x->x_velo);
     outlet_new(&x->x_obj, &s_float);
@@ -1139,43 +1134,44 @@ static void *bag_new(void)
 static void bag_float(t_bag *x, t_float f)
 {
     t_bagelem *bagelem, *e2, *e3;
-    if (x->x_velo != 0)
+    if(x->x_velo != 0)
     {
-        bagelem = (t_bagelem *)getbytes(sizeof *bagelem);
+        bagelem = (t_bagelem *) getbytes(sizeof *bagelem);
         bagelem->e_next = 0;
         bagelem->e_value = f;
-        if (!x->x_first) x->x_first = bagelem;
-        else    /* LATER replace with a faster algorithm */
+        if(!x->x_first)
+            x->x_first = bagelem;
+        else /* LATER replace with a faster algorithm */
         {
-            for (e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
+            for(e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
                 ;
             e2->e_next = bagelem;
         }
     }
     else
     {
-        if (!x->x_first) return;
-        if (x->x_first->e_value == f)
+        if(!x->x_first) return;
+        if(x->x_first->e_value == f)
         {
             bagelem = x->x_first;
             x->x_first = x->x_first->e_next;
             freebytes(bagelem, sizeof(*bagelem));
             return;
         }
-        for (e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
-            if (e3->e_value == f)
-        {
-            e2->e_next = e3->e_next;
-            freebytes(e3, sizeof(*e3));
-            return;
-        }
+        for(e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
+            if(e3->e_value == f)
+            {
+                e2->e_next = e3->e_next;
+                freebytes(e3, sizeof(*e3));
+                return;
+            }
     }
 }
 
 static void bag_flush(t_bag *x)
 {
     t_bagelem *bagelem;
-    while ((bagelem = x->x_first))
+    while((bagelem = x->x_first))
     {
         outlet_float(x->x_obj.ob_outlet, bagelem->e_value);
         x->x_first = bagelem->e_next;
@@ -1186,7 +1182,7 @@ static void bag_flush(t_bag *x)
 static void bag_clear(t_bag *x)
 {
     t_bagelem *bagelem;
-    while ((bagelem = x->x_first))
+    while((bagelem = x->x_first))
     {
         x->x_first = bagelem->e_next;
         freebytes(bagelem, sizeof(*bagelem));
@@ -1195,12 +1191,11 @@ static void bag_clear(t_bag *x)
 
 static void bag_setup(void)
 {
-    bag_class = class_new(gensym("bag"),
-        (t_newmethod)bag_new, (t_method)bag_clear,
-        sizeof(t_bag), 0, 0);
+    bag_class = class_new(gensym("bag"), (t_newmethod) bag_new,
+        (t_method) bag_clear, sizeof(t_bag), 0, 0);
     class_addfloat(bag_class, bag_float);
-    class_addmethod(bag_class, (t_method)bag_flush, gensym("flush"), 0);
-    class_addmethod(bag_class, (t_method)bag_clear, gensym("clear"), 0);
+    class_addmethod(bag_class, (t_method) bag_flush, gensym("flush"), 0);
+    class_addmethod(bag_class, (t_method) bag_clear, gensym("clear"), 0);
 }
 
 void x_midi_setup(void)

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -191,7 +191,8 @@ typedef struct _ctlin
 
 static void *ctlin_new(t_symbol *s, int argc, t_atom *argv)
 {
-    int ctlno, channel;
+    int ctlno;
+    int channel;
     t_ctlin *x = (t_ctlin *) pd_new(ctlin_class);
     if(!argc)
         ctlno = -1;
@@ -864,7 +865,8 @@ static void *makenote_new(t_floatarg velo, t_floatarg dur)
 static void makenote_tick(t_hang *hang)
 {
     t_makenote *x = hang->h_owner;
-    t_hang *h2, *h3;
+    t_hang *h2;
+    t_hang *h3;
     outlet_float(x->x_velout, 0);
     outlet_float(x->x_pitchout, hang->h_pitch);
     if(x->x_hang == hang)
@@ -993,7 +995,8 @@ typedef struct poly
 
 static void *poly_new(t_float fnvoice, t_float fsteal)
 {
-    int i, n = fnvoice;
+    int i;
+    int n = fnvoice;
     t_poly *x = (t_poly *) pd_new(poly_class);
     t_voice *v;
     if(n < 1) n = 1;
@@ -1015,8 +1018,12 @@ static void poly_float(t_poly *x, t_float f)
 {
     int i;
     t_voice *v;
-    t_voice *firston, *firstoff;
-    unsigned int serialon, serialoff, onindex = 0, offindex = 0;
+    t_voice *firston;
+    t_voice *firstoff;
+    unsigned int serialon;
+    unsigned int serialoff;
+    unsigned int onindex = 0;
+    unsigned int offindex = 0;
     if(x->x_vel > 0)
     {
         /* note on.  Look for a vacant voice */
@@ -1133,7 +1140,9 @@ static void *bag_new(void)
 
 static void bag_float(t_bag *x, t_float f)
 {
-    t_bagelem *bagelem, *e2, *e3;
+    t_bagelem *bagelem;
+    t_bagelem *e2;
+    t_bagelem *e3;
     if(x->x_velo != 0)
     {
         bagelem = (t_bagelem *) getbytes(sizeof *bagelem);

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -195,9 +195,13 @@ static void *ctlin_new(t_symbol *s, int argc, t_atom *argv)
     int channel;
     t_ctlin *x = (t_ctlin *) pd_new(ctlin_class);
     if(!argc)
+    {
         ctlno = -1;
+    }
     else
+    {
         ctlno = atom_getfloatarg(0, argc, argv);
+    }
     channel = atom_getfloatarg(1, argc, argv);
     x->x_channel = channel;
     x->x_ctlno = ctlno;
@@ -706,9 +710,13 @@ static void pgmout_float(t_pgmout *x, t_floatarg f)
     int n = f - 1;
     if(binchan < 0) binchan = 0;
     if(n < 0)
+    {
         n = 0;
+    }
     else if(n > 127)
+    {
         n = 127;
+    }
     outmidi_programchange((binchan >> 4), (binchan & 15), n);
 }
 
@@ -870,8 +878,11 @@ static void makenote_tick(t_hang *hang)
     outlet_float(x->x_velout, 0);
     outlet_float(x->x_pitchout, hang->h_pitch);
     if(x->x_hang == hang)
+    {
         x->x_hang = hang->h_next;
+    }
     else
+    {
         for(h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
         {
             if(h3 == hang)
@@ -880,6 +891,7 @@ static void makenote_tick(t_hang *hang)
                 break;
             }
         }
+    }
     clock_free(hang->h_clock);
     freebytes(hang, sizeof(*hang));
 }
@@ -1032,10 +1044,14 @@ static void poly_float(t_poly *x, t_float f)
             i < x->x_n; v++, i++)
         {
             if(v->v_used && v->v_serial < serialon)
+            {
                 firston = v, serialon = (unsigned int) v->v_serial, onindex = i;
+            }
             else if(!v->v_used && v->v_serial < serialoff)
+            {
                 firstoff = v, serialoff = (unsigned int) v->v_serial,
                 offindex = i;
+            }
         }
         if(firstoff)
         {
@@ -1061,8 +1077,10 @@ static void poly_float(t_poly *x, t_float f)
     {
         for(v = x->x_vec, i = 0, firston = 0, serialon = 0xffffffff; i < x->x_n;
             v++, i++)
+        {
             if(v->v_used && v->v_pitch == f && v->v_serial < serialon)
                 firston = v, serialon = (unsigned int) v->v_serial, onindex = i;
+        }
         if(firston)
         {
             firston->v_used = 0;
@@ -1079,6 +1097,7 @@ static void poly_stop(t_poly *x)
     int i;
     t_voice *v;
     for(i = 0, v = x->x_vec; i < x->x_n; i++, v++)
+    {
         if(v->v_used)
         {
             outlet_float(x->x_velout, 0L);
@@ -1087,6 +1106,7 @@ static void poly_stop(t_poly *x)
             v->v_used = 0;
             v->v_serial = x->x_serial++;
         }
+    }
 }
 
 static void poly_clear(t_poly *x)
@@ -1149,7 +1169,9 @@ static void bag_float(t_bag *x, t_float f)
         bagelem->e_next = 0;
         bagelem->e_value = f;
         if(!x->x_first)
+        {
             x->x_first = bagelem;
+        }
         else /* LATER replace with a faster algorithm */
         {
             for(e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
@@ -1168,12 +1190,14 @@ static void bag_float(t_bag *x, t_float f)
             return;
         }
         for(e2 = x->x_first; (e3 = e2->e_next); e2 = e3)
+        {
             if(e3->e_value == f)
             {
                 e2->e_next = e3->e_next;
                 freebytes(e3, sizeof(*e3));
                 return;
             }
+        }
     }
 }
 

--- a/src/x_midi.c
+++ b/src/x_midi.c
@@ -593,8 +593,7 @@ static void midiout_float(t_midiout *x, t_floatarg f)
 
 static void midiout_list(t_midiout *x, t_symbol *s, int ac, t_atom *av)
 {
-    int i;
-    for(i = 0; i < ac; ++i)
+    for(int i = 0; i < ac; ++i)
     {
         if(av[i].a_type == A_FLOAT)
             outmidi_byte(x->x_portno - 1, av[i].a_w.w_float);

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -72,7 +72,8 @@ static void *random_new(t_floatarg f)
 
 static void random_bang(t_random *x)
 {
-    int n = x->x_f, nval;
+    int n = x->x_f;
+    int nval;
     int range = (n < 1 ? 1 : n);
     unsigned int randval = x->x_state;
     x->x_state = randval = randval * 472940017 + 832416023;
@@ -302,7 +303,8 @@ typedef struct _oscparse
 static t_symbol *grabstring(int argc, t_atom *argv, int *ip, int slash)
 {
     char buf[MAXPDSTRING];
-    int first, nchar;
+    int first;
+    int nchar;
     if(slash)
         while(*ip < argc && argv[*ip].a_w.w_float == '/')
             (*ip)++;
@@ -320,7 +322,15 @@ static t_symbol *grabstring(int argc, t_atom *argv, int *ip, int slash)
 
 static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i, j, j2, k, outc = 1, blob = 0, typeonset, dataonset, nfield;
+    int i;
+    int j;
+    int j2;
+    int k;
+    int outc = 1;
+    int blob = 0;
+    int typeonset;
+    int dataonset;
+    int nfield;
     t_atom *outv;
     if(!argc) return;
     for(i = 0; i < argc; i++)
@@ -544,9 +554,15 @@ static void putstring(t_atom *msg, int *ip, const char *s)
 
 static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int typeindex = 0, j, msgindex, msgsize, datastart, ndata;
+    int typeindex = 0;
+    int j;
+    int msgindex;
+    int msgsize;
+    int datastart;
+    int ndata;
     t_atom *msg;
-    const char *sp, *formatp = x->x_format->s_name;
+    const char *sp;
+    const char *formatp = x->x_format->s_name;
     char typecode;
     /* pass 1: go through args to find overall message size */
     for(j = ndata = 0, sp = formatp, msgindex = 0; j < argc;)
@@ -571,7 +587,8 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
         }
         else if(typecode == 'b')
         {
-            int blobsize = 0x7fffffff, blobindex;
+            int blobsize = 0x7fffffff;
+            int blobindex;
             /* check if we have a nonnegative size field */
             if(argv[j].a_type == A_FLOAT && (int) (argv[j].a_w.w_float) >= 0)
                 blobsize = (int) (argv[j].a_w.w_float);
@@ -625,7 +642,8 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
             putstring(msg, &msgindex, argv[j].a_w.w_symbol->s_name);
         else if(typecode == 'b')
         {
-            int blobsize = 0x7fffffff, blobindex;
+            int blobsize = 0x7fffffff;
+            int blobindex;
             if(argv[j].a_type == A_FLOAT && (int) (argv[j].a_w.w_float) >= 0)
                 blobsize = (int) (argv[j].a_w.w_float);
             if(blobsize > argc - j - 1) blobsize = argc - j - 1;
@@ -710,7 +728,8 @@ typedef struct _fudiparse
 
 static void fudiparse_binbufout(t_fudiparse *x, t_binbuf *b)
 {
-    int msg, natom = binbuf_getnatom(b);
+    int msg;
+    int natom = binbuf_getnatom(b);
     t_atom *at = binbuf_getvec(b);
     for(msg = 0; msg < natom;)
     {

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -363,7 +363,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
         }
         return;
     }
-    else if(argv[0].a_w.w_float != '/')
+    if(argv[0].a_w.w_float != '/')
     {
         pd_error(x, "oscparse: not an OSC message (no leading slash)");
         return;

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -503,11 +503,10 @@ typedef struct _oscformat
 static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
 {
     char buf[MAXPDSTRING];
-    int i;
     size_t newsize;
     *x->x_pathbuf = 0;
     buf[0] = '/';
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         char *where =
             (argv[i].a_type == A_SYMBOL && *argv[i].a_w.w_symbol->s_name == '/'
@@ -868,7 +867,6 @@ static void fudiformat_any(t_fudiformat *x, t_symbol *s, int argc, t_atom *argv)
 {
     char *buf;
     int length;
-    int i;
     t_atom at;
     t_binbuf *bbuf = binbuf_new();
     SETSYMBOL(&at, s);
@@ -891,7 +889,7 @@ static void fudiformat_any(t_fudiformat *x, t_symbol *s, int argc, t_atom *argv)
         x->x_atoms = getbytes(sizeof(*x->x_atoms) * x->x_numatoms);
     }
 
-    for(i = 0; i < length; i++)
+    for(int i = 0; i < length; i++)
     {
         SETFLOAT(x->x_atoms + i, buf[i]);
     }

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* misc. */
 
@@ -21,24 +21,24 @@
 #include <unistd.h>
 #endif /* _WIN32 */
 
-#if defined (__APPLE__) || defined (__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #define CLOCKHZ CLK_TCK
 #endif
-#if defined (__linux__) || defined (__CYGWIN__) || defined (ANDROID)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(ANDROID)
 #define CLOCKHZ sysconf(_SC_CLK_TCK)
 #endif
-#if defined (__FreeBSD_kernel__) || defined(__GNU__) || defined(__OpenBSD__) \
-    || defined(_WIN32)
+#if defined(__FreeBSD_kernel__) || defined(__GNU__) || defined(__OpenBSD__) || \
+    defined(_WIN32)
 #include <time.h>
 #define CLOCKHZ CLOCKS_PER_SEC
 #endif
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 /* -------------------------- random ------------------------------ */
@@ -53,7 +53,6 @@ typedef struct _random
     unsigned int x_state;
 } t_random;
 
-
 static int makeseed(void)
 {
     static unsigned int random_nextseed = 1489853723;
@@ -63,7 +62,7 @@ static int makeseed(void)
 
 static void *random_new(t_floatarg f)
 {
-    t_random *x = (t_random *)pd_new(random_class);
+    t_random *x = (t_random *) pd_new(random_class);
     x->x_f = f;
     x->x_state = makeseed();
     floatinlet_new(&x->x_obj, &x->x_f);
@@ -77,9 +76,8 @@ static void random_bang(t_random *x)
     int range = (n < 1 ? 1 : n);
     unsigned int randval = x->x_state;
     x->x_state = randval = randval * 472940017 + 832416023;
-    nval = ((double)range) * ((double)randval)
-        * (1./4294967296.);
-    if (nval >= range) nval = range-1;
+    nval = ((double) range) * ((double) randval) * (1. / 4294967296.);
+    if(nval >= range) nval = range - 1;
     outlet_float(x->x_obj.ob_outlet, nval);
 }
 
@@ -90,13 +88,12 @@ static void random_seed(t_random *x, t_float f, t_float glob)
 
 static void random_setup(void)
 {
-    random_class = class_new(gensym("random"), (t_newmethod)random_new, 0,
+    random_class = class_new(gensym("random"), (t_newmethod) random_new, 0,
         sizeof(t_random), 0, A_DEFFLOAT, 0);
     class_addbang(random_class, random_bang);
-    class_addmethod(random_class, (t_method)random_seed,
-        gensym("seed"), A_FLOAT, 0);
+    class_addmethod(
+        random_class, (t_method) random_seed, gensym("seed"), A_FLOAT, 0);
 }
-
 
 /* -------------------------- loadbang ------------------------------ */
 static t_class *loadbang_class;
@@ -108,22 +105,21 @@ typedef struct _loadbang
 
 static void *loadbang_new(void)
 {
-    t_loadbang *x = (t_loadbang *)pd_new(loadbang_class);
+    t_loadbang *x = (t_loadbang *) pd_new(loadbang_class);
     outlet_new(&x->x_obj, &s_bang);
     return (x);
 }
 
 static void loadbang_loadbang(t_loadbang *x, t_floatarg action)
 {
-    if (action == LB_LOAD)
-        outlet_bang(x->x_obj.ob_outlet);
+    if(action == LB_LOAD) outlet_bang(x->x_obj.ob_outlet);
 }
 
 static void loadbang_setup(void)
 {
-    loadbang_class = class_new(gensym("loadbang"), (t_newmethod)loadbang_new, 0,
-        sizeof(t_loadbang), CLASS_NOINLET, 0);
-    class_addmethod(loadbang_class, (t_method)loadbang_loadbang,
+    loadbang_class = class_new(gensym("loadbang"), (t_newmethod) loadbang_new,
+        0, sizeof(t_loadbang), CLASS_NOINLET, 0);
+    class_addmethod(loadbang_class, (t_method) loadbang_loadbang,
         gensym("loadbang"), A_DEFFLOAT, 0);
 }
 
@@ -139,23 +135,23 @@ typedef struct _namecanvas
 
 static void *namecanvas_new(t_symbol *s)
 {
-    t_namecanvas *x = (t_namecanvas *)pd_new(namecanvas_class);
-    x->x_owner = (t_pd *)canvas_getcurrent();
+    t_namecanvas *x = (t_namecanvas *) pd_new(namecanvas_class);
+    x->x_owner = (t_pd *) canvas_getcurrent();
     x->x_sym = s;
-    if (*s->s_name) pd_bind(x->x_owner, s);
+    if(*s->s_name) pd_bind(x->x_owner, s);
     return (x);
 }
 
 static void namecanvas_free(t_namecanvas *x)
 {
-    if (*x->x_sym->s_name) pd_unbind(x->x_owner, x->x_sym);
+    if(*x->x_sym->s_name) pd_unbind(x->x_owner, x->x_sym);
 }
 
 static void namecanvas_setup(void)
 {
     namecanvas_class = class_new(gensym("namecanvas"),
-        (t_newmethod)namecanvas_new, (t_method)namecanvas_free,
-            sizeof(t_namecanvas), CLASS_NOINLET, A_DEFSYM, 0);
+        (t_newmethod) namecanvas_new, (t_method) namecanvas_free,
+        sizeof(t_namecanvas), CLASS_NOINLET, A_DEFSYM, 0);
 }
 
 /* -------------------------- cputime ------------------------------ */
@@ -181,10 +177,10 @@ static void cputime_bang(t_cputime *x)
     FILETIME ignorethis, ignorethat;
     BOOL retval;
     retval = GetProcessTimes(GetCurrentProcess(), &ignorethis, &ignorethat,
-        (FILETIME *)&x->x_kerneltime, (FILETIME *)&x->x_usertime);
-    if (!retval)
+        (FILETIME *) &x->x_kerneltime, (FILETIME *) &x->x_usertime);
+    if(!retval)
     {
-        if (!x->x_warned)
+        if(!x->x_warned)
             post("cputime is apparently not supported on your platform");
         x->x_warned = 1;
         x->x_kerneltime.QuadPart = 0;
@@ -201,9 +197,10 @@ static void cputime_bang2(t_cputime *x)
     t_float elapsedcpu;
     struct tms newcputime;
     times(&newcputime);
-    elapsedcpu = 1000 * (
-        newcputime.tms_utime + newcputime.tms_stime -
-            x->x_setcputime.tms_utime - x->x_setcputime.tms_stime) / CLOCKHZ;
+    elapsedcpu = 1000 *
+                 (newcputime.tms_utime + newcputime.tms_stime -
+                     x->x_setcputime.tms_utime - x->x_setcputime.tms_stime) /
+                 CLOCKHZ;
     outlet_float(x->x_obj.ob_outlet, elapsedcpu);
 #else
     t_float elapsedcpu;
@@ -212,19 +209,20 @@ static void cputime_bang2(t_cputime *x)
     BOOL retval;
 
     retval = GetProcessTimes(GetCurrentProcess(), &ignorethis, &ignorethat,
-        (FILETIME *)&kerneltime, (FILETIME *)&usertime);
-    if (retval)
-        elapsedcpu = 0.0001 *
-            ((kerneltime.QuadPart - x->x_kerneltime.QuadPart) +
-                (usertime.QuadPart - x->x_usertime.QuadPart));
-    else elapsedcpu = 0;
+        (FILETIME *) &kerneltime, (FILETIME *) &usertime);
+    if(retval)
+        elapsedcpu =
+            0.0001 * ((kerneltime.QuadPart - x->x_kerneltime.QuadPart) +
+                         (usertime.QuadPart - x->x_usertime.QuadPart));
+    else
+        elapsedcpu = 0;
     outlet_float(x->x_obj.ob_outlet, elapsedcpu);
 #endif /* NOT _WIN32 */
 }
 
 static void *cputime_new(void)
 {
-    t_cputime *x = (t_cputime *)pd_new(cputime_class);
+    t_cputime *x = (t_cputime *) pd_new(cputime_class);
     outlet_new(&x->x_obj, gensym("float"));
 
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("bang"), gensym("bang2"));
@@ -237,10 +235,11 @@ static void *cputime_new(void)
 
 static void cputime_setup(void)
 {
-    cputime_class = class_new(gensym("cputime"), (t_newmethod)cputime_new, 0,
+    cputime_class = class_new(gensym("cputime"), (t_newmethod) cputime_new, 0,
         sizeof(t_cputime), 0, 0);
     class_addbang(cputime_class, cputime_bang);
-    class_addmethod(cputime_class, (t_method)cputime_bang2, gensym("bang2"), 0);
+    class_addmethod(
+        cputime_class, (t_method) cputime_bang2, gensym("bang2"), 0);
 }
 #endif /* CLOCKHZ */
 
@@ -261,13 +260,13 @@ static void realtime_bang(t_realtime *x)
 
 static void realtime_bang2(t_realtime *x)
 {
-    outlet_float(x->x_obj.ob_outlet,
-        (sys_getrealtime() - x->x_setrealtime) * 1000.);
+    outlet_float(
+        x->x_obj.ob_outlet, (sys_getrealtime() - x->x_setrealtime) * 1000.);
 }
 
 static void *realtime_new(void)
 {
-    t_realtime *x = (t_realtime *)pd_new(realtime_class);
+    t_realtime *x = (t_realtime *) pd_new(realtime_class);
     outlet_new(&x->x_obj, gensym("float"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("bang"), gensym("bang2"));
     realtime_bang(x);
@@ -276,11 +275,11 @@ static void *realtime_new(void)
 
 static void realtime_setup(void)
 {
-    realtime_class = class_new(gensym("realtime"), (t_newmethod)realtime_new, 0,
-        sizeof(t_realtime), 0, 0);
+    realtime_class = class_new(gensym("realtime"), (t_newmethod) realtime_new,
+        0, sizeof(t_realtime), 0, 0);
     class_addbang(realtime_class, realtime_bang);
-    class_addmethod(realtime_class, (t_method)realtime_bang2, gensym("bang2"),
-        0);
+    class_addmethod(
+        realtime_class, (t_method) realtime_bang2, gensym("bang2"), 0);
 }
 
 /* ---------- oscparse - parse simple OSC messages ----------------- */
@@ -294,30 +293,28 @@ typedef struct _oscparse
 
 #define ROUNDUPTO4(x) (((x) + 3) & (~3))
 
-#define READINT(x)  ((((int)(((x)  )->a_w.w_float)) & 0xff) << 24) | \
-                    ((((int)(((x)+1)->a_w.w_float)) & 0xff) << 16) | \
-                    ((((int)(((x)+2)->a_w.w_float)) & 0xff) << 8) | \
-                    ((((int)(((x)+3)->a_w.w_float)) & 0xff) << 0)
+#define READINT(x)                                          \
+    ((((int) (((x))->a_w.w_float)) & 0xff) << 24) |         \
+        ((((int) (((x) + 1)->a_w.w_float)) & 0xff) << 16) | \
+        ((((int) (((x) + 2)->a_w.w_float)) & 0xff) << 8) |  \
+        ((((int) (((x) + 3)->a_w.w_float)) & 0xff) << 0)
 
 static t_symbol *grabstring(int argc, t_atom *argv, int *ip, int slash)
 {
     char buf[MAXPDSTRING];
     int first, nchar;
-    if (slash)
-        while (*ip < argc && argv[*ip].a_w.w_float == '/')
+    if(slash)
+        while(*ip < argc && argv[*ip].a_w.w_float == '/')
             (*ip)++;
-    for (nchar = 0; nchar < MAXPDSTRING-1 && *ip < argc; nchar++, (*ip)++)
+    for(nchar = 0; nchar < MAXPDSTRING - 1 && *ip < argc; nchar++, (*ip)++)
     {
         char c = argv[*ip].a_w.w_float;
-        if (c == 0 || (slash && c == '/'))
-            break;
+        if(c == 0 || (slash && c == '/')) break;
         buf[nchar] = c;
     }
     buf[nchar] = 0;
-    if (!slash)
-        *ip = ROUNDUPTO4(*ip+1);
-    if (*ip > argc)
-        *ip = argc;
+    if(!slash) *ip = ROUNDUPTO4(*ip + 1);
+    if(*ip > argc) *ip = argc;
     return (gensym(buf));
 }
 
@@ -325,137 +322,132 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i, j, j2, k, outc = 1, blob = 0, typeonset, dataonset, nfield;
     t_atom *outv;
-    if (!argc)
-        return;
-    for (i = 0; i < argc; i++)
-        if (argv[i].a_type != A_FLOAT)
+    if(!argc) return;
+    for(i = 0; i < argc; i++)
+        if(argv[i].a_type != A_FLOAT)
+        {
+            pd_error(x, "oscparse: takes numbers only");
+            return;
+        }
+    if(argv[0].a_w.w_float == '#') /* it's a bundle */
     {
-        pd_error(x, "oscparse: takes numbers only");
-        return;
-    }
-    if (argv[0].a_w.w_float == '#') /* it's a bundle */
-    {
-        if (argv[1].a_w.w_float != 'b' || argc < 16)
+        if(argv[1].a_w.w_float != 'b' || argc < 16)
         {
             pd_error(x, "oscparse: malformed bundle");
             return;
         }
-            /* we ignore the timetag since there's no correct way to
-            convert it to Pd logical time that I can think of.  LATER
-            consider at least outputting timetag differentially converted
-            into Pd time units. */
-        for (i = 16; i < argc-4; )
+        /* we ignore the timetag since there's no correct way to
+        convert it to Pd logical time that I can think of.  LATER
+        consider at least outputting timetag differentially converted
+        into Pd time units. */
+        for(i = 16; i < argc - 4;)
         {
-            int msize = READINT(argv+i);
-            if (msize <= 0 || msize & 3)
+            int msize = READINT(argv + i);
+            if(msize <= 0 || msize & 3)
             {
                 pd_error(x, "oscparse: bad bundle element size");
                 return;
             }
-            oscparse_list(x, 0, msize, argv+i+4);
-            i += msize+4;
+            oscparse_list(x, 0, msize, argv + i + 4);
+            i += msize + 4;
         }
         return;
     }
-    else if (argv[0].a_w.w_float != '/')
+    else if(argv[0].a_w.w_float != '/')
     {
         pd_error(x, "oscparse: not an OSC message (no leading slash)");
         return;
     }
-    for (i = 1; i < argc && argv[i].a_w.w_float != 0; i++)
-        if (argv[i].a_w.w_float == '/')
-            outc++;
-    i = ROUNDUPTO4(i+1);
-    if (argv[i].a_w.w_float != ',' || (i+1) >= argc)
+    for(i = 1; i < argc && argv[i].a_w.w_float != 0; i++)
+        if(argv[i].a_w.w_float == '/') outc++;
+    i = ROUNDUPTO4(i + 1);
+    if(argv[i].a_w.w_float != ',' || (i + 1) >= argc)
     {
         pd_error(x, "oscparse: malformed type string (char %d, index %d)",
-            (int)(argv[i].a_w.w_float), i);
+            (int) (argv[i].a_w.w_float), i);
         return;
     }
     typeonset = ++i;
-    for (; i < argc && argv[i].a_w.w_float != 0; i++)
-        if (argv[i].a_w.w_float == 'b')
-            blob = 1;
+    for(; i < argc && argv[i].a_w.w_float != 0; i++)
+        if(argv[i].a_w.w_float == 'b') blob = 1;
     nfield = i - typeonset;
-    if (blob)
+    if(blob)
         outc += argc - typeonset;
-    else outc += nfield;
-    outv = (t_atom *)alloca(outc * sizeof(t_atom));
+    else
+        outc += nfield;
+    outv = (t_atom *) alloca(outc * sizeof(t_atom));
     dataonset = ROUNDUPTO4(i + 1);
     /* post("outc %d, typeonset %d, dataonset %d, nfield %d", outc, typeonset,
         dataonset, nfield); */
-    for (i = j = 0; i < typeonset-1 && argv[i].a_w.w_float != 0 &&
-        j < outc; j++)
-            SETSYMBOL(outv+j, grabstring(argc, argv, &i, 1));
-    for (i = typeonset, k = dataonset; i < typeonset + nfield; i++)
+    for(i = j = 0; i < typeonset - 1 && argv[i].a_w.w_float != 0 && j < outc;
+        j++)
+        SETSYMBOL(outv + j, grabstring(argc, argv, &i, 1));
+    for(i = typeonset, k = dataonset; i < typeonset + nfield; i++)
     {
         union
         {
             float z_f;
             uint32_t z_i;
         } z;
+
         t_float f;
         int blobsize;
-        switch ((int)(argv[i].a_w.w_float))
+        switch((int) (argv[i].a_w.w_float))
         {
-        case 'f':
-            if (k > argc - 4)
-                goto tooshort;
-            z.z_i = READINT(argv+k);
-            f = z.z_f;
-            if (PD_BADFLOAT(f))
-                f = 0;
-            if (j >= outc)
-            {
-                bug("oscparse 1: %d >=%d", j, outc);
-                return;
-            }
-            SETFLOAT(outv+j, f);
-            j++; k += 4;
-            break;
-        case 'i':
-            if (k > argc - 4)
-                goto tooshort;
-            if (j >= outc)
-            {
-                bug("oscparse 2");
-                return;
-            }
-            SETFLOAT(outv+j, READINT(argv+k));
-            j++; k += 4;
-            break;
-        case 's':
-            if (j >= outc)
-            {
-                bug("oscparse 3");
-                return;
-            }
-            SETSYMBOL(outv+j, grabstring(argc, argv, &k, 0));
-            j++;
-            break;
-        case 'b':
-            if (k > argc - 4)
-                goto tooshort;
-            blobsize = READINT(argv+k);
-            k += 4;
-            if (blobsize < 0 || blobsize > argc - k)
-                goto tooshort;
-            if (j + blobsize + 1 > outc)
-            {
-                bug("oscparse 4");
-                return;
-            }
-            if (k + blobsize > argc)
-                goto tooshort;
-            SETFLOAT(outv+j, blobsize);
-            j++;
-            for (j2 = 0; j2 < blobsize; j++, j2++, k++)
-                SETFLOAT(outv+j, argv[k].a_w.w_float);
-            k = ROUNDUPTO4(k);
-            break;
-        default:
-            pd_error(x, "oscparse: unknown tag '%c' (%d)",
-                (int)(argv[i].a_w.w_float), (int)(argv[i].a_w.w_float));
+            case 'f':
+                if(k > argc - 4) goto tooshort;
+                z.z_i = READINT(argv + k);
+                f = z.z_f;
+                if(PD_BADFLOAT(f)) f = 0;
+                if(j >= outc)
+                {
+                    bug("oscparse 1: %d >=%d", j, outc);
+                    return;
+                }
+                SETFLOAT(outv + j, f);
+                j++;
+                k += 4;
+                break;
+            case 'i':
+                if(k > argc - 4) goto tooshort;
+                if(j >= outc)
+                {
+                    bug("oscparse 2");
+                    return;
+                }
+                SETFLOAT(outv + j, READINT(argv + k));
+                j++;
+                k += 4;
+                break;
+            case 's':
+                if(j >= outc)
+                {
+                    bug("oscparse 3");
+                    return;
+                }
+                SETSYMBOL(outv + j, grabstring(argc, argv, &k, 0));
+                j++;
+                break;
+            case 'b':
+                if(k > argc - 4) goto tooshort;
+                blobsize = READINT(argv + k);
+                k += 4;
+                if(blobsize < 0 || blobsize > argc - k) goto tooshort;
+                if(j + blobsize + 1 > outc)
+                {
+                    bug("oscparse 4");
+                    return;
+                }
+                if(k + blobsize > argc) goto tooshort;
+                SETFLOAT(outv + j, blobsize);
+                j++;
+                for(j2 = 0; j2 < blobsize; j++, j2++, k++)
+                    SETFLOAT(outv + j, argv[k].a_w.w_float);
+                k = ROUNDUPTO4(k);
+                break;
+            default:
+                pd_error(x, "oscparse: unknown tag '%c' (%d)",
+                    (int) (argv[i].a_w.w_float), (int) (argv[i].a_w.w_float));
         }
     }
     outlet_list(x->x_obj.ob_outlet, 0, j, outv);
@@ -466,14 +458,14 @@ tooshort:
 
 static t_oscparse *oscparse_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_oscparse *x = (t_oscparse *)pd_new(oscparse_class);
+    t_oscparse *x = (t_oscparse *) pd_new(oscparse_class);
     outlet_new(&x->x_obj, gensym("list"));
     return (x);
 }
 
 void oscparse_setup(void)
 {
-    oscparse_class = class_new(gensym("oscparse"), (t_newmethod)oscparse_new,
+    oscparse_class = class_new(gensym("oscparse"), (t_newmethod) oscparse_new,
         0, sizeof(t_oscparse), 0, A_GIMME, 0);
     class_addlist(oscparse_class, oscparse_list);
     class_sethelpsymbol(oscparse_class, gensym("osc-format-parse"));
@@ -497,12 +489,14 @@ static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
     size_t newsize;
     *x->x_pathbuf = 0;
     buf[0] = '/';
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
-        char *where = (argv[i].a_type == A_SYMBOL &&
-            *argv[i].a_w.w_symbol->s_name == '/' ? buf : buf+1);
-        atom_string(&argv[i], where, MAXPDSTRING-1);
-        if ((newsize = strlen(buf) + strlen(x->x_pathbuf) + 1) > x->x_pathsize)
+        char *where =
+            (argv[i].a_type == A_SYMBOL && *argv[i].a_w.w_symbol->s_name == '/'
+                    ? buf
+                    : buf + 1);
+        atom_string(&argv[i], where, MAXPDSTRING - 1);
+        if((newsize = strlen(buf) + strlen(x->x_pathbuf) + 1) > x->x_pathsize)
         {
             x->x_pathbuf = resizebytes(x->x_pathbuf, x->x_pathsize, newsize);
             x->x_pathsize = newsize;
@@ -514,23 +508,24 @@ static void oscformat_set(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
 static void oscformat_format(t_oscformat *x, t_symbol *s)
 {
     const char *sp;
-    for (sp = s->s_name; *sp; sp++)
+    for(sp = s->s_name; *sp; sp++)
     {
-        if (*sp != 'f' && *sp != 'i' && *sp != 's' && *sp != 'b')
+        if(*sp != 'f' && *sp != 'i' && *sp != 's' && *sp != 'b')
         {
             pd_error(x,
                 "oscformat '%s' may only contain 'f', 'i'. 's', and/or 'b'",
-                    sp);
+                sp);
             return;
         }
     }
     x->x_format = s;
 }
 
-#define WRITEINT(msg, i)    SETFLOAT((msg),   (((i) >> 24) & 0xff)); \
-                            SETFLOAT((msg)+1, (((i) >> 16) & 0xff)); \
-                            SETFLOAT((msg)+2, (((i) >>  8) & 0xff)); \
-                            SETFLOAT((msg)+3, (((i)      ) & 0xff))
+#define WRITEINT(msg, i)                       \
+    SETFLOAT((msg), (((i) >> 24) & 0xff));     \
+    SETFLOAT((msg) + 1, (((i) >> 16) & 0xff)); \
+    SETFLOAT((msg) + 2, (((i) >> 8) & 0xff));  \
+    SETFLOAT((msg) + 3, (((i)) & 0xff))
 
 static void putstring(t_atom *msg, int *ip, const char *s)
 {
@@ -539,9 +534,8 @@ static void putstring(t_atom *msg, int *ip, const char *s)
     {
         SETFLOAT(&msg[*ip], *sp & 0xff);
         (*ip)++;
-    }
-    while (*sp++);
-    while (*ip & 3)
+    } while(*sp++);
+    while(*ip & 3)
     {
         SETFLOAT(&msg[*ip], 0);
         (*ip)++;
@@ -554,104 +548,110 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
     t_atom *msg;
     const char *sp, *formatp = x->x_format->s_name;
     char typecode;
-        /* pass 1: go through args to find overall message size */
-    for (j = ndata = 0, sp = formatp, msgindex = 0; j < argc;)
+    /* pass 1: go through args to find overall message size */
+    for(j = ndata = 0, sp = formatp, msgindex = 0; j < argc;)
     {
-        if (*sp)
+        if(*sp)
             typecode = *sp++;
-        else if (argv[j].a_type == A_SYMBOL)
+        else if(argv[j].a_type == A_SYMBOL)
             typecode = 's';
-        else typecode = 'f';
-        if (typecode == 's')
+        else
+            typecode = 'f';
+        if(typecode == 's')
         {
-            if (argv[j].a_type == A_SYMBOL)
-                msgindex += ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
+            if(argv[j].a_type == A_SYMBOL)
+                msgindex +=
+                    ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
             else
             {
-                pd_error(x, "oscformat: expected symbol for argument %d", j+1);
+                pd_error(
+                    x, "oscformat: expected symbol for argument %d", j + 1);
                 return;
             }
         }
-        else if (typecode == 'b')
+        else if(typecode == 'b')
         {
             int blobsize = 0x7fffffff, blobindex;
-                /* check if we have a nonnegative size field */
-            if (argv[j].a_type == A_FLOAT &&
-                (int)(argv[j].a_w.w_float) >= 0)
-                    blobsize = (int)(argv[j].a_w.w_float);
-            if (blobsize > argc - j - 1)
-                blobsize = argc - j - 1;    /* if no or bad size, eat it all */
+            /* check if we have a nonnegative size field */
+            if(argv[j].a_type == A_FLOAT && (int) (argv[j].a_w.w_float) >= 0)
+                blobsize = (int) (argv[j].a_w.w_float);
+            if(blobsize > argc - j - 1)
+                blobsize = argc - j - 1; /* if no or bad size, eat it all */
             msgindex += 4 + ROUNDUPTO4(blobsize);
             j += blobsize;
         }
-        else msgindex += 4;
+        else
+            msgindex += 4;
         j++;
         ndata++;
     }
-    datastart = (int)(ROUNDUPTO4(strlen(x->x_pathbuf)+1) + ROUNDUPTO4(ndata + 2));
+    datastart =
+        (int) (ROUNDUPTO4(strlen(x->x_pathbuf) + 1) + ROUNDUPTO4(ndata + 2));
     msgsize = datastart + msgindex;
-    msg = (t_atom *)alloca(msgsize * sizeof(t_atom));
+    msg = (t_atom *) alloca(msgsize * sizeof(t_atom));
     putstring(msg, &typeindex, x->x_pathbuf);
     SETFLOAT(&msg[typeindex], ',');
     typeindex++;
-        /* pass 2: fill in types and data portion of packet */
-    for (j = 0, sp = formatp, msgindex = datastart; j < argc;)
+    /* pass 2: fill in types and data portion of packet */
+    for(j = 0, sp = formatp, msgindex = datastart; j < argc;)
     {
-        if (*sp)
+        if(*sp)
             typecode = *sp++;
-        else if (argv[j].a_type == A_SYMBOL)
+        else if(argv[j].a_type == A_SYMBOL)
             typecode = 's';
-        else typecode = 'f';
+        else
+            typecode = 'f';
         SETFLOAT(&msg[typeindex], typecode & 0xff);
         typeindex++;
-        if (typecode == 'f')
+        if(typecode == 'f')
         {
             union
             {
                 float z_f;
                 uint32_t z_i;
             } z;
+
             z.z_f = atom_getfloat(&argv[j]);
-            WRITEINT(msg+msgindex, z.z_i);
+            WRITEINT(msg + msgindex, z.z_i);
             msgindex += 4;
         }
-        else if (typecode == 'i')
+        else if(typecode == 'i')
         {
             int dat = atom_getfloat(&argv[j]);
-            WRITEINT(msg+msgindex, dat);
+            WRITEINT(msg + msgindex, dat);
             msgindex += 4;
         }
-        else if (typecode == 's')
+        else if(typecode == 's')
             putstring(msg, &msgindex, argv[j].a_w.w_symbol->s_name);
-        else if (typecode == 'b')
+        else if(typecode == 'b')
         {
             int blobsize = 0x7fffffff, blobindex;
-            if (argv[j].a_type == A_FLOAT &&
-                (int)(argv[j].a_w.w_float) >= 0)
-                    blobsize = (int)(argv[j].a_w.w_float);
-            if (blobsize > argc - j - 1)
-                blobsize = argc - j - 1;
-            WRITEINT(msg+msgindex, blobsize);
+            if(argv[j].a_type == A_FLOAT && (int) (argv[j].a_w.w_float) >= 0)
+                blobsize = (int) (argv[j].a_w.w_float);
+            if(blobsize > argc - j - 1) blobsize = argc - j - 1;
+            WRITEINT(msg + msgindex, blobsize);
             msgindex += 4;
-            for (blobindex = 0; blobindex < blobsize; blobindex++)
-                SETFLOAT(msg+msgindex+blobindex,
-                    (argv[j+1+blobindex].a_type == A_FLOAT ?
-                        argv[j+1+blobindex].a_w.w_float :
-                        (argv[j+1+blobindex].a_type == A_SYMBOL ?
-                            argv[j+1+blobindex].a_w.w_symbol->s_name[0] & 0xff :
-                            0)));
+            for(blobindex = 0; blobindex < blobsize; blobindex++)
+                SETFLOAT(msg + msgindex + blobindex,
+                    (argv[j + 1 + blobindex].a_type == A_FLOAT
+                            ? argv[j + 1 + blobindex].a_w.w_float
+                            : (argv[j + 1 + blobindex].a_type == A_SYMBOL
+                                      ? argv[j + 1 + blobindex]
+                                                .a_w.w_symbol->s_name[0] &
+                                            0xff
+                                      : 0)));
             j += blobsize;
-            while (blobsize & 3)
-                SETFLOAT(msg+msgindex+blobsize, 0), blobsize++;
+            while(blobsize & 3)
+                SETFLOAT(msg + msgindex + blobsize, 0), blobsize++;
             msgindex += blobsize;
         }
         j++;
     }
     SETFLOAT(&msg[typeindex], 0);
     typeindex++;
-    while (typeindex & 3)
+    while(typeindex & 3)
         SETFLOAT(&msg[typeindex], 0), typeindex++;
-    if (typeindex != datastart || msgindex != msgsize)
+    if(typeindex != datastart || msgindex != msgsize)
         bug("oscformat: typeindex %d, datastart %d, msgindex %d, msgsize %d",
             typeindex, datastart, msgindex, msgsize);
     /* else post("datastart %d, msgsize %d", datastart, msgsize); */
@@ -665,15 +665,14 @@ static void oscformat_free(t_oscformat *x)
 
 static void *oscformat_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_oscformat *x = (t_oscformat *)pd_new(oscformat_class);
+    t_oscformat *x = (t_oscformat *) pd_new(oscformat_class);
     outlet_new(&x->x_obj, gensym("list"));
     x->x_pathbuf = getbytes(1);
     x->x_pathsize = 1;
     *x->x_pathbuf = 0;
     x->x_format = &s_;
-    if (argc > 1 && argv[0].a_type == A_SYMBOL &&
-        argv[1].a_type == A_SYMBOL &&
-            !strcmp(argv[0].a_w.w_symbol->s_name, "-f"))
+    if(argc > 1 && argv[0].a_type == A_SYMBOL && argv[1].a_type == A_SYMBOL &&
+        !strcmp(argv[0].a_w.w_symbol->s_name, "-f"))
     {
         oscformat_format(x, argv[1].a_w.w_symbol);
         argc -= 2;
@@ -685,181 +684,201 @@ static void *oscformat_new(t_symbol *s, int argc, t_atom *argv)
 
 void oscformat_setup(void)
 {
-    oscformat_class = class_new(gensym("oscformat"), (t_newmethod)oscformat_new,
-        (t_method)oscformat_free, sizeof(t_oscformat), 0, A_GIMME, 0);
-    class_addmethod(oscformat_class, (t_method)oscformat_set,
-        gensym("set"), A_GIMME, 0);
-    class_addmethod(oscformat_class, (t_method)oscformat_format,
+    oscformat_class =
+        class_new(gensym("oscformat"), (t_newmethod) oscformat_new,
+            (t_method) oscformat_free, sizeof(t_oscformat), 0, A_GIMME, 0);
+    class_addmethod(
+        oscformat_class, (t_method) oscformat_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(oscformat_class, (t_method) oscformat_format,
         gensym("format"), A_DEFSYM, 0);
     class_addlist(oscformat_class, oscformat_list);
     class_sethelpsymbol(oscformat_class, gensym("osc-format-parse"));
 }
 
-
-/* ---------- fudiparse - parse bytelists to to FUDI messages ----------------- */
+/* ---------- fudiparse - parse bytelists to to FUDI messages -----------------
+ */
 
 static t_class *fudiparse_class;
 
-typedef struct _fudiparse {
-  t_object  x_obj;
-  t_outlet *x_msgout;
-  char     *x_bytes;
-  size_t    x_numbytes;
+typedef struct _fudiparse
+{
+    t_object x_obj;
+    t_outlet *x_msgout;
+    char *x_bytes;
+    size_t x_numbytes;
 } t_fudiparse;
 
 static void fudiparse_binbufout(t_fudiparse *x, t_binbuf *b)
 {
-  int msg, natom = binbuf_getnatom(b);
-  t_atom *at = binbuf_getvec(b);
-  for (msg = 0; msg < natom;) {
-    int emsg;
-    for (emsg = msg; emsg < natom && at[emsg].a_type != A_COMMA
-           && at[emsg].a_type != A_SEMI; emsg++)
-      ;
-    if (emsg > msg) {
-      int i;
-      /* check for illegal atoms */
-      for (i = msg; i < emsg; i++)
-        if (at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM) {
-          pd_error(x, "fudiparse: got dollar sign in message");
-          goto nodice;
+    int msg, natom = binbuf_getnatom(b);
+    t_atom *at = binbuf_getvec(b);
+    for(msg = 0; msg < natom;)
+    {
+        int emsg;
+        for(emsg = msg; emsg < natom && at[emsg].a_type != A_COMMA &&
+                        at[emsg].a_type != A_SEMI;
+            emsg++)
+            ;
+        if(emsg > msg)
+        {
+            int i;
+            /* check for illegal atoms */
+            for(i = msg; i < emsg; i++)
+                if(at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM)
+                {
+                    pd_error(x, "fudiparse: got dollar sign in message");
+                    goto nodice;
+                }
+
+            if(at[msg].a_type == A_FLOAT)
+            {
+                if(emsg > msg + 1)
+                    outlet_list(x->x_msgout, 0, emsg - msg, at + msg);
+                else
+                    outlet_float(x->x_msgout, at[msg].a_w.w_float);
+            }
+            else if(at[msg].a_type == A_SYMBOL)
+            {
+                outlet_anything(x->x_msgout, at[msg].a_w.w_symbol,
+                    emsg - msg - 1, at + msg + 1);
+            }
         }
-
-      if (at[msg].a_type == A_FLOAT) {
-        if (emsg > msg + 1)
-          outlet_list(x->x_msgout, 0, emsg-msg, at + msg);
-        else outlet_float(x->x_msgout, at[msg].a_w.w_float);
-      }
-      else if (at[msg].a_type == A_SYMBOL) {
-        outlet_anything(x->x_msgout, at[msg].a_w.w_symbol,
-                        emsg-msg-1, at + msg + 1);
-      }
+    nodice:
+        msg = emsg + 1;
     }
-  nodice:
-    msg = emsg + 1;
-  }
 }
-static void fudiparse_list(t_fudiparse *x, t_symbol*s, int argc, t_atom*argv) {
-  size_t len = argc;
-  t_binbuf* bbuf = binbuf_new();
-  char*cbuf;
-  if((size_t)argc > x->x_numbytes) {
+
+static void fudiparse_list(t_fudiparse *x, t_symbol *s, int argc, t_atom *argv)
+{
+    size_t len = argc;
+    t_binbuf *bbuf = binbuf_new();
+    char *cbuf;
+    if((size_t) argc > x->x_numbytes)
+    {
+        freebytes(x->x_bytes, x->x_numbytes);
+        x->x_numbytes = argc;
+        x->x_bytes = getbytes(x->x_numbytes);
+    }
+    cbuf = x->x_bytes;
+
+    while(argc--)
+    {
+        char b = atom_getfloat(argv++);
+        *cbuf++ = b;
+    }
+    binbuf_text(bbuf, x->x_bytes, len);
+
+    fudiparse_binbufout(x, bbuf);
+
+    binbuf_free(bbuf);
+}
+
+static void fudiparse_free(t_fudiparse *x)
+{
     freebytes(x->x_bytes, x->x_numbytes);
-    x->x_numbytes = argc;
+    x->x_bytes = NULL;
+    x->x_numbytes = 0;
+}
+
+static void *fudiparse_new(void)
+{
+    t_fudiparse *x = (t_fudiparse *) pd_new(fudiparse_class);
+    x->x_msgout = outlet_new(&x->x_obj, 0);
+    x->x_numbytes = 1024;
     x->x_bytes = getbytes(x->x_numbytes);
-  }
-  cbuf = x->x_bytes;
-
-  while(argc--) {
-    char b = atom_getfloat(argv++);
-    *cbuf++ = b;
-  }
-  binbuf_text(bbuf, x->x_bytes, len);
-
-  fudiparse_binbufout(x, bbuf);
-
-  binbuf_free(bbuf);
+    return (void *) x;
 }
 
-static void fudiparse_free(t_fudiparse *x) {
-  freebytes(x->x_bytes, x->x_numbytes);
-  x->x_bytes = NULL;
-  x->x_numbytes = 0;
+void fudiparse_setup(void)
+{
+    fudiparse_class =
+        class_new(gensym("fudiparse"), (t_newmethod) fudiparse_new,
+            (t_method) fudiparse_free, sizeof(t_fudiparse), CLASS_DEFAULT, 0);
+    class_addlist(fudiparse_class, fudiparse_list);
+    class_sethelpsymbol(fudiparse_class, gensym("fudi-format-parse"));
 }
 
-static void *fudiparse_new(void) {
-  t_fudiparse *x = (t_fudiparse *)pd_new(fudiparse_class);
-  x->x_msgout = outlet_new(&x->x_obj, 0);
-  x->x_numbytes = 1024;
-  x->x_bytes = getbytes(x->x_numbytes);
-  return (void *)x;
-}
-
-void fudiparse_setup(void) {
-  fudiparse_class = class_new(gensym("fudiparse"),
-                              (t_newmethod)fudiparse_new,
-                              (t_method)fudiparse_free,
-                              sizeof(t_fudiparse), CLASS_DEFAULT,
-                              0);
-  class_addlist(fudiparse_class, fudiparse_list);
-  class_sethelpsymbol(fudiparse_class, gensym("fudi-format-parse"));
-}
 /* --------- fudiformat - format Pd (FUDI) messages to bytelists ------------ */
 
 static t_class *fudiformat_class;
 
-typedef struct _fudiformat {
-  t_object  x_obj;
-  t_outlet *x_msgout;
-  t_atom   *x_atoms;
-  size_t    x_numatoms;
-  int       x_udp;
+typedef struct _fudiformat
+{
+    t_object x_obj;
+    t_outlet *x_msgout;
+    t_atom *x_atoms;
+    size_t x_numatoms;
+    int x_udp;
 } t_fudiformat;
 
-static void fudiformat_any(t_fudiformat *x, t_symbol*s, int argc, t_atom*argv) {
-  char *buf;
-  int length;
-  int i;
-  t_atom at;
-  t_binbuf*bbuf = binbuf_new();
-  SETSYMBOL(&at, s);
-  binbuf_add(bbuf, 1, &at);
-
-  binbuf_add(bbuf, argc, argv);
-
-  if(!x->x_udp) {
-    SETSEMI(&at);
+static void fudiformat_any(t_fudiformat *x, t_symbol *s, int argc, t_atom *argv)
+{
+    char *buf;
+    int length;
+    int i;
+    t_atom at;
+    t_binbuf *bbuf = binbuf_new();
+    SETSYMBOL(&at, s);
     binbuf_add(bbuf, 1, &at);
-  }
-  binbuf_gettext(bbuf, &buf, &length);
-  binbuf_free(bbuf);
 
-  if((size_t)length>x->x_numatoms) {
+    binbuf_add(bbuf, argc, argv);
+
+    if(!x->x_udp)
+    {
+        SETSEMI(&at);
+        binbuf_add(bbuf, 1, &at);
+    }
+    binbuf_gettext(bbuf, &buf, &length);
+    binbuf_free(bbuf);
+
+    if((size_t) length > x->x_numatoms)
+    {
+        freebytes(x->x_atoms, sizeof(*x->x_atoms) * x->x_numatoms);
+        x->x_numatoms = length;
+        x->x_atoms = getbytes(sizeof(*x->x_atoms) * x->x_numatoms);
+    }
+
+    for(i = 0; i < length; i++)
+    {
+        SETFLOAT(x->x_atoms + i, buf[i]);
+    }
+    freebytes(buf, length);
+    outlet_list(x->x_msgout, 0, length, x->x_atoms);
+}
+
+static void fudiformat_free(t_fudiformat *x)
+{
     freebytes(x->x_atoms, sizeof(*x->x_atoms) * x->x_numatoms);
-    x->x_numatoms = length;
+    x->x_atoms = NULL;
+    x->x_numatoms = 0;
+}
+
+static void *fudiformat_new(t_symbol *s)
+{
+    t_fudiformat *x = (t_fudiformat *) pd_new(fudiformat_class);
+    x->x_msgout = outlet_new(&x->x_obj, 0);
+    x->x_numatoms = 1024;
     x->x_atoms = getbytes(sizeof(*x->x_atoms) * x->x_numatoms);
-  }
+    if(gensym("-u") == s)
+        x->x_udp = 1;
+    else if(gensym("-t") == s)
+        x->x_udp = 0;
+    else if(gensym("") != s)
+    {
+        pd_error(x, "fudiformat: unsupported mode '%s'", s->s_name);
+    }
 
-  for(i=0; i<length; i++) {
-    SETFLOAT(x->x_atoms+i, buf[i]);
-  }
-  freebytes(buf, length);
-  outlet_list(x->x_msgout, 0, length, x->x_atoms);
+    return (void *) x;
 }
 
-static void fudiformat_free(t_fudiformat *x) {
-  freebytes(x->x_atoms, sizeof(*x->x_atoms) * x->x_numatoms);
-  x->x_atoms = NULL;
-  x->x_numatoms = 0;
+static void fudiformat_setup(void)
+{
+    fudiformat_class = class_new(gensym("fudiformat"),
+        (t_newmethod) fudiformat_new, (t_method) fudiformat_free,
+        sizeof(t_fudiformat), CLASS_DEFAULT, A_DEFSYMBOL, 0);
+    class_addanything(fudiformat_class, fudiformat_any);
+    class_sethelpsymbol(fudiformat_class, gensym("fudi-format-parse"));
 }
-
-static void *fudiformat_new(t_symbol*s) {
-  t_fudiformat *x = (t_fudiformat *)pd_new(fudiformat_class);
-  x->x_msgout = outlet_new(&x->x_obj, 0);
-  x->x_numatoms = 1024;
-  x->x_atoms = getbytes(sizeof(*x->x_atoms) * x->x_numatoms);
-  if (gensym("-u") == s)
-    x->x_udp = 1;
-  else if (gensym("-t") == s)
-    x->x_udp = 0;
-  else if (gensym("") != s) {
-    pd_error(x, "fudiformat: unsupported mode '%s'", s->s_name);
-  }
-
-  return (void *)x;
-}
-
-static void fudiformat_setup(void) {
-  fudiformat_class = class_new(gensym("fudiformat"),
-                               (t_newmethod)fudiformat_new,
-                               (t_method)fudiformat_free,
-                               sizeof(t_fudiformat), CLASS_DEFAULT,
-                               A_DEFSYMBOL, 0);
-  class_addanything(fudiformat_class, fudiformat_any);
-  class_sethelpsymbol(fudiformat_class, gensym("fudi-format-parse"));
-}
-
-
 
 void x_misc_setup(void)
 {

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -306,8 +306,10 @@ static t_symbol *grabstring(int argc, t_atom *argv, int *ip, int slash)
     int first;
     int nchar;
     if(slash)
+    {
         while(*ip < argc && argv[*ip].a_w.w_float == '/')
             (*ip)++;
+    }
     for(nchar = 0; nchar < MAXPDSTRING - 1 && *ip < argc; nchar++, (*ip)++)
     {
         char c = argv[*ip].a_w.w_float;
@@ -334,11 +336,13 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
     t_atom *outv;
     if(!argc) return;
     for(i = 0; i < argc; i++)
+    {
         if(argv[i].a_type != A_FLOAT)
         {
             pd_error(x, "oscparse: takes numbers only");
             return;
         }
+    }
     if(argv[0].a_w.w_float == '#') /* it's a bundle */
     {
         if(argv[1].a_w.w_float != 'b' || argc < 16)
@@ -382,9 +386,13 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
         if(argv[i].a_w.w_float == 'b') blob = 1;
     nfield = i - typeonset;
     if(blob)
+    {
         outc += argc - typeonset;
+    }
     else
+    {
         outc += nfield;
+    }
     outv = (t_atom *) alloca(outc * sizeof(t_atom));
     dataonset = ROUNDUPTO4(i + 1);
     /* post("outc %d, typeonset %d, dataonset %d, nfield %d", outc, typeonset,
@@ -568,16 +576,24 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
     for(j = ndata = 0, sp = formatp, msgindex = 0; j < argc;)
     {
         if(*sp)
+        {
             typecode = *sp++;
+        }
         else if(argv[j].a_type == A_SYMBOL)
+        {
             typecode = 's';
+        }
         else
+        {
             typecode = 'f';
+        }
         if(typecode == 's')
         {
             if(argv[j].a_type == A_SYMBOL)
+            {
                 msgindex +=
                     ROUNDUPTO4(strlen(argv[j].a_w.w_symbol->s_name) + 1);
+            }
             else
             {
                 pd_error(
@@ -613,11 +629,17 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
     for(j = 0, sp = formatp, msgindex = datastart; j < argc;)
     {
         if(*sp)
+        {
             typecode = *sp++;
+        }
         else if(argv[j].a_type == A_SYMBOL)
+        {
             typecode = 's';
+        }
         else
+        {
             typecode = 'f';
+        }
         SETFLOAT(&msg[typeindex], typecode & 0xff);
         typeindex++;
         if(typecode == 'f')
@@ -639,7 +661,9 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
             msgindex += 4;
         }
         else if(typecode == 's')
+        {
             putstring(msg, &msgindex, argv[j].a_w.w_symbol->s_name);
+        }
         else if(typecode == 'b')
         {
             int blobsize = 0x7fffffff;
@@ -650,6 +674,7 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
             WRITEINT(msg + msgindex, blobsize);
             msgindex += 4;
             for(blobindex = 0; blobindex < blobsize; blobindex++)
+            {
                 SETFLOAT(msg + msgindex + blobindex,
                     (argv[j + 1 + blobindex].a_type == A_FLOAT
                             ? argv[j + 1 + blobindex].a_w.w_float
@@ -658,6 +683,7 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
                                                 .a_w.w_symbol->s_name[0] &
                                             0xff
                                       : 0)));
+            }
             j += blobsize;
             while(blobsize & 3)
                 SETFLOAT(msg + msgindex + blobsize, 0), blobsize++;
@@ -670,8 +696,10 @@ static void oscformat_list(t_oscformat *x, t_symbol *s, int argc, t_atom *argv)
     while(typeindex & 3)
         SETFLOAT(&msg[typeindex], 0), typeindex++;
     if(typeindex != datastart || msgindex != msgsize)
+    {
         bug("oscformat: typeindex %d, datastart %d, msgindex %d, msgsize %d",
             typeindex, datastart, msgindex, msgsize);
+    }
     /* else post("datastart %d, msgsize %d", datastart, msgsize); */
     outlet_list(x->x_obj.ob_outlet, 0, msgsize, msg);
 }
@@ -743,18 +771,24 @@ static void fudiparse_binbufout(t_fudiparse *x, t_binbuf *b)
             int i;
             /* check for illegal atoms */
             for(i = msg; i < emsg; i++)
+            {
                 if(at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM)
                 {
                     pd_error(x, "fudiparse: got dollar sign in message");
                     goto nodice;
                 }
+            }
 
             if(at[msg].a_type == A_FLOAT)
             {
                 if(emsg > msg + 1)
+                {
                     outlet_list(x->x_msgout, 0, emsg - msg, at + msg);
+                }
                 else
+                {
                     outlet_float(x->x_msgout, at[msg].a_w.w_float);
+                }
             }
             else if(at[msg].a_type == A_SYMBOL)
             {
@@ -879,9 +913,13 @@ static void *fudiformat_new(t_symbol *s)
     x->x_numatoms = 1024;
     x->x_atoms = getbytes(sizeof(*x->x_atoms) * x->x_numatoms);
     if(gensym("-u") == s)
+    {
         x->x_udp = 1;
+    }
     else if(gensym("-t") == s)
+    {
         x->x_udp = 0;
+    }
     else if(gensym("") != s)
     {
         pd_error(x, "fudiformat: unsupported mode '%s'", s->s_name);

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -501,11 +501,9 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
             fail = 1;
             break;
         }
-        else
-        {
-            sent += res;
-            bp += res;
-        }
+
+        sent += res;
+        bp += res;
     }
 done:
     if(!x->x_bin)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* network */
 
@@ -14,9 +14,9 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #endif
 
 /* print addrinfo lists for debugging */
@@ -30,11 +30,11 @@ static void outlet_sockaddr(t_outlet *o, const struct sockaddr *sa)
 {
     char addrstr[INET6_ADDRSTRLEN];
     unsigned short port = sockaddr_get_port(sa);
-    if (sockaddr_get_addrstr(sa, addrstr, INET6_ADDRSTRLEN))
+    if(sockaddr_get_addrstr(sa, addrstr, INET6_ADDRSTRLEN))
     {
         t_atom ap[2];
         SETSYMBOL(&ap[0], gensym(addrstr));
-        SETFLOAT(&ap[1], (t_float)port);
+        SETFLOAT(&ap[1], (t_float) port);
         outlet_list(o, NULL, 2, ap);
     }
 }
@@ -76,33 +76,37 @@ static void netreceive_notify(t_netreceive *x, int fd);
 
 static void *netsend_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_netsend *x = (t_netsend *)pd_new(netsend_class);
+    t_netsend *x = (t_netsend *) pd_new(netsend_class);
     outlet_new(&x->x_obj, &s_float);
     x->x_protocol = SOCK_STREAM;
     x->x_bin = 0;
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
     {
         x->x_protocol = (argv->a_w.w_float != 0 ? SOCK_DGRAM : SOCK_STREAM);
         argc = 0;
     }
-    else while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
-    {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-b"))
-            x->x_bin = 1;
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-u"))
-            x->x_protocol = SOCK_DGRAM;
-        else
+    else
+        while(argc && argv->a_type == A_SYMBOL &&
+              *argv->a_w.w_symbol->s_name == '-')
         {
-            pd_error(x, "netsend: unknown flag ...");
-            postatom(argc, argv); endpost();
+            if(!strcmp(argv->a_w.w_symbol->s_name, "-b"))
+                x->x_bin = 1;
+            else if(!strcmp(argv->a_w.w_symbol->s_name, "-u"))
+                x->x_protocol = SOCK_DGRAM;
+            else
+            {
+                pd_error(x, "netsend: unknown flag ...");
+                postatom(argc, argv);
+                endpost();
+            }
+            argc--;
+            argv++;
         }
-        argc--; argv++;
-    }
-    if (argc)
+    if(argc)
     {
         pd_error(x, "netsend: extra arguments ignored:");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
     x->x_sockfd = -1;
     x->x_receiver = NULL;
@@ -120,71 +124,71 @@ static void netsend_readbin(t_netsend *x, int fd)
     int ret = 0, readbytes = 0, i;
     struct sockaddr_storage fromaddr = {0};
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
-    if (!x->x_msgout)
+    if(!x->x_msgout)
     {
         bug("netsend_readbin");
         return;
     }
-    while (1)
+    while(1)
     {
-        if (x->x_protocol == SOCK_DGRAM)
-            ret = (int)recvfrom(fd, inbuf, NET_MAXPACKETSIZE, 0,
-                (struct sockaddr *)&fromaddr, &fromaddrlen);
+        if(x->x_protocol == SOCK_DGRAM)
+            ret = (int) recvfrom(fd, inbuf, NET_MAXPACKETSIZE, 0,
+                (struct sockaddr *) &fromaddr, &fromaddrlen);
         else
-            ret = (int)recv(fd, inbuf, NET_MAXPACKETSIZE, 0);
-        if (ret <= 0)
+            ret = (int) recv(fd, inbuf, NET_MAXPACKETSIZE, 0);
+        if(ret <= 0)
         {
-            if (ret < 0)
+            if(ret < 0)
             {
                 /* socket_errno_udp() ignores some error codes */
-                if (x->x_protocol == SOCK_DGRAM && !socket_errno_udp())
-                    return;
+                if(x->x_protocol == SOCK_DGRAM && !socket_errno_udp()) return;
                 sys_sockerror("recv (bin)");
             }
-            if (x->x_obj.ob_pd == netreceive_class)
+            if(x->x_obj.ob_pd == netreceive_class)
             {
-                    /* never close UDP socket because we can't really notify it */
-                if (x->x_protocol != SOCK_DGRAM)
+                /* never close UDP socket because we can't really notify it */
+                if(x->x_protocol != SOCK_DGRAM)
                 {
                     sys_rmpollfn(fd);
                     sys_closesocket(fd);
-                    netreceive_notify((t_netreceive *)x, fd);
+                    netreceive_notify((t_netreceive *) x, fd);
                 }
             }
             else /* properly shutdown netsend */
                 netsend_disconnect(x);
             return;
         }
-        if (x->x_protocol == SOCK_DGRAM)
+        if(x->x_protocol == SOCK_DGRAM)
         {
             t_atom *ap;
-            if (x->x_fromout)
-                outlet_sockaddr(x->x_fromout, (const struct sockaddr *)&fromaddr);
-                /* handle too large UDP packets */
-            if (ret > NET_MAXPACKETSIZE)
+            if(x->x_fromout)
+                outlet_sockaddr(
+                    x->x_fromout, (const struct sockaddr *) &fromaddr);
+            /* handle too large UDP packets */
+            if(ret > NET_MAXPACKETSIZE)
             {
-                post("warning: incoming UDP packet truncated from %d to %d bytes.",
+                post("warning: incoming UDP packet truncated from %d to %d "
+                     "bytes.",
                     ret, NET_MAXPACKETSIZE);
                 ret = NET_MAXPACKETSIZE;
             }
-            ap = (t_atom *)alloca(ret * sizeof(t_atom));
-            for (i = 0; i < ret; i++)
-                SETFLOAT(ap+i, inbuf[i]);
+            ap = (t_atom *) alloca(ret * sizeof(t_atom));
+            for(i = 0; i < ret; i++)
+                SETFLOAT(ap + i, inbuf[i]);
             outlet_list(x->x_msgout, 0, ret, ap);
             readbytes += ret;
             /* throttle */
-            if (readbytes >= NET_MAXPACKETSIZE)
-                return;
+            if(readbytes >= NET_MAXPACKETSIZE) return;
             /* check for pending UDP packets */
-            if (socket_bytes_available(fd) <= 0)
-                return;
+            if(socket_bytes_available(fd) <= 0) return;
         }
         else
         {
-            if (x->x_fromout &&
-                !getpeername(fd, (struct sockaddr *)&fromaddr, &fromaddrlen))
-                    outlet_sockaddr(x->x_fromout, (const struct sockaddr *)&fromaddr);
-            for (i = 0; i < ret; i++)
+            if(x->x_fromout &&
+                !getpeername(fd, (struct sockaddr *) &fromaddr, &fromaddrlen))
+                outlet_sockaddr(
+                    x->x_fromout, (const struct sockaddr *) &fromaddr);
+            for(i = 0; i < ret; i++)
                 outlet_float(x->x_msgout, inbuf[i]);
             return;
         }
@@ -193,33 +197,35 @@ static void netsend_readbin(t_netsend *x, int fd)
 
 static void netsend_read(void *z, t_binbuf *b)
 {
-    t_netsend *x = (t_netsend *)z;
+    t_netsend *x = (t_netsend *) z;
     int msg, natom = binbuf_getnatom(b);
     t_atom *at = binbuf_getvec(b);
-    for (msg = 0; msg < natom;)
+    for(msg = 0; msg < natom;)
     {
         int emsg;
-        for (emsg = msg; emsg < natom && at[emsg].a_type != A_COMMA
-             && at[emsg].a_type != A_SEMI; emsg++)
+        for(emsg = msg; emsg < natom && at[emsg].a_type != A_COMMA &&
+                        at[emsg].a_type != A_SEMI;
+            emsg++)
             ;
-        if (emsg > msg)
+        if(emsg > msg)
         {
             int i;
-            for (i = msg; i < emsg; i++)
-                if (at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM)
+            for(i = msg; i < emsg; i++)
+                if(at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM)
                 {
                     pd_error(x, "netreceive: got dollar sign in message");
                     goto nodice;
                 }
-            if (at[msg].a_type == A_FLOAT)
+            if(at[msg].a_type == A_FLOAT)
             {
-                if (emsg > msg + 1)
-                    outlet_list(x->x_msgout, 0, emsg-msg, at + msg);
-                else outlet_float(x->x_msgout, at[msg].a_w.w_float);
+                if(emsg > msg + 1)
+                    outlet_list(x->x_msgout, 0, emsg - msg, at + msg);
+                else
+                    outlet_float(x->x_msgout, at[msg].a_w.w_float);
             }
-            else if (at[msg].a_type == A_SYMBOL)
+            else if(at[msg].a_type == A_SYMBOL)
                 outlet_anything(x->x_msgout, at[msg].a_w.w_symbol,
-                    emsg-msg-1, at + msg + 1);
+                    emsg - msg - 1, at + msg + 1);
         }
     nodice:
         msg = emsg + 1;
@@ -228,14 +234,13 @@ static void netsend_read(void *z, t_binbuf *b)
 
 static void netsend_notify(void *z, int fd)
 {
-    t_netsend *x = (t_netsend *)z;
-    if (x->x_sockfd >= 0)
+    t_netsend *x = (t_netsend *) z;
+    if(x->x_sockfd >= 0)
     {
         /* sys_rmpollfn() and sys_closesocket() are
            already called in socketreceiver_read */
         x->x_sockfd = -1;
-        if (x->x_receiver)
-            socketreceiver_free(x->x_receiver);
+        if(x->x_receiver) socketreceiver_free(x->x_receiver);
         x->x_receiver = NULL;
         memset(&x->x_server, 0, sizeof(struct sockaddr_storage));
         outlet_float(x->x_obj.ob_outlet, 0);
@@ -250,18 +255,16 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     char hostbuf[256];
 
     /* check argument types */
-    if ((argc < 2) ||
-        argv[0].a_type != A_SYMBOL ||
-        argv[1].a_type != A_FLOAT ||
+    if((argc < 2) || argv[0].a_type != A_SYMBOL || argv[1].a_type != A_FLOAT ||
         ((argc > 2) && argv[2].a_type != A_FLOAT))
     {
         pd_error(0, "netsend: bad connect arguments");
         return;
     }
     hostname = argv[0].a_w.w_symbol->s_name;
-    portno = (int)argv[1].a_w.w_float;
-    sportno = (argc > 2 ? (int)argv[2].a_w.w_float : 0);
-    if (x->x_sockfd >= 0)
+    portno = (int) argv[1].a_w.w_float;
+    sportno = (argc > 2 ? (int) argv[2].a_w.w_float : 0);
+    if(x->x_sockfd >= 0)
     {
         pd_error(0, "netsend: already connected");
         return;
@@ -269,10 +272,10 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 
     /* get addrinfo list using hostname & port */
     status = addrinfo_get_list(&ailist, hostname, portno, x->x_protocol);
-    if (status != 0)
+    if(status != 0)
     {
-        pd_error(x, "netsend: bad host or port? %s (%d)",
-            gai_strerror(status), status);
+        pd_error(x, "netsend: bad host or port? %s (%d)", gai_strerror(status),
+            status);
         return;
     }
     addrinfo_sort_list(&ailist, addrinfo_ipv4_first); /* IPv4 first! */
@@ -280,15 +283,14 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     addrinfo_print_list(ailist);
 #endif
     /* try each addr until we find one that works */
-    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    for(ai = ailist; ai != NULL; ai = ai->ai_next)
     {
         /* create a socket */
         sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 #if 0
         fprintf(stderr, "send socket %d\n", sockfd);
 #endif
-        if (sockfd < 0)
-            continue;
+        if(sockfd < 0) continue;
 
 #if 0
         if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_SNDBUF, 0) < 0)
@@ -296,19 +298,19 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 #endif
 
         /* for stream (TCP) sockets, specify "nodelay" */
-        if (x->x_protocol == SOCK_STREAM)
+        if(x->x_protocol == SOCK_STREAM)
         {
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 post("netsend: setsockopt (TCP_NODELAY) failed");
         }
         else /* datagram (UDP) broadcasting */
         {
-            if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
+            if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
                 post("netsend: setsockopt (SO_BROADCAST) failed");
             multicast = sockaddr_is_multicast(ai->ai_addr);
         }
         /* if this is an IPv6 address, also listen to IPv4 adapters */
-        if (ai->ai_family == AF_INET6 &&
+        if(ai->ai_family == AF_INET6 &&
             socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
         {
             /* post("netreceive: setsockopt (IPV6_V6ONLY) failed"); */
@@ -317,13 +319,14 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
         sockaddr_get_addrstr(ai->ai_addr, hostbuf, sizeof(hostbuf));
 
         /* bind optional src listening port */
-        if (sportno != 0)
+        if(sportno != 0)
         {
             int bound = 0;
             struct addrinfo *sailist = NULL, *sai;
-            logpost(NULL, PD_VERBOSE, "connecting to %s %d, src port %d", hostbuf, portno, sportno);
+            logpost(NULL, PD_VERBOSE, "connecting to %s %d, src port %d",
+                hostbuf, portno, sportno);
             status = addrinfo_get_list(&sailist, NULL, sportno, x->x_protocol);
-            if (status != 0)
+            if(status != 0)
             {
                 pd_error(x, "netsend: could not set src port: %s (%d)",
                     gai_strerror(status), status);
@@ -331,37 +334,38 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
                 goto connect_fail;
             }
             addrinfo_sort_list(&sailist, addrinfo_ipv6_first); /* IPv6 first! */
-            for (sai = sailist; sai != NULL; sai = sai->ai_next)
+            for(sai = sailist; sai != NULL; sai = sai->ai_next)
             {
                 /* if this is an IPv6 address, also listen to IPv4 adapters
                    (if not supported, fall back to IPv4) */
-                if (sai->ai_family == AF_INET6 &&
-                        socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
+                if(sai->ai_family == AF_INET6 &&
+                    socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) <
+                        0)
                 {
                     /* post("netreceive: setsockopt (IPV6_V6ONLY) failed"); */
                     continue;
                 }
-                if (bind(sockfd, sai->ai_addr, sai->ai_addrlen) < 0)
-                    continue;
+                if(bind(sockfd, sai->ai_addr, sai->ai_addrlen) < 0) continue;
                 bound = 1;
                 break;
             }
             freeaddrinfo(sailist);
-            if (!bound)
+            if(!bound)
             {
                 sys_sockerror("setting source port");
                 goto connect_fail;
             }
         }
-        else if (hostname && multicast)
-            logpost(NULL, PD_VERBOSE, "connecting to %s %d (multicast)", hostbuf, portno);
+        else if(hostname && multicast)
+            logpost(NULL, PD_VERBOSE, "connecting to %s %d (multicast)",
+                hostbuf, portno);
         else
             logpost(NULL, PD_VERBOSE, "connecting to %s %d", hostbuf, portno);
 
-        if (x->x_protocol == SOCK_STREAM)
+        if(x->x_protocol == SOCK_STREAM)
         {
-            if (socket_connect(sockfd, ai->ai_addr, ai->ai_addrlen,
-                                    x->x_timeout) < 0)
+            if(socket_connect(
+                   sockfd, ai->ai_addr, ai->ai_addrlen, x->x_timeout) < 0)
             {
                 sys_sockerror("connecting stream socket");
                 sys_closesocket(sockfd);
@@ -380,7 +384,7 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     freeaddrinfo(ailist);
 
     /* confirm that socket worked */
-    if (sockfd < 0)
+    if(sockfd < 0)
     {
         int err = socket_errno();
         char buf[MAXPDSTRING];
@@ -390,16 +394,15 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     }
 
     x->x_sockfd = sockfd;
-    if (x->x_msgout) /* add polling function for return messages */
+    if(x->x_msgout) /* add polling function for return messages */
     {
-        if (x->x_bin)
-            sys_addpollfn(x->x_sockfd, (t_fdpollfn)netsend_readbin, x);
+        if(x->x_bin)
+            sys_addpollfn(x->x_sockfd, (t_fdpollfn) netsend_readbin, x);
         else
         {
-            t_socketreceiver *y =
-              socketreceiver_new((void *)x, netsend_notify, netsend_read,
-                                 x->x_protocol == SOCK_DGRAM);
-            sys_addpollfn(x->x_sockfd, (t_fdpollfn)socketreceiver_read, y);
+            t_socketreceiver *y = socketreceiver_new((void *) x, netsend_notify,
+                netsend_read, x->x_protocol == SOCK_DGRAM);
+            sys_addpollfn(x->x_sockfd, (t_fdpollfn) socketreceiver_read, y);
             x->x_receiver = y;
         }
     }
@@ -407,19 +410,17 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
     return;
 connect_fail:
     freeaddrinfo(ailist);
-    if (sockfd > 0)
-        sys_closesocket(sockfd);
+    if(sockfd > 0) sys_closesocket(sockfd);
 }
 
 static void netsend_disconnect(t_netsend *x)
 {
-    if (x->x_sockfd >= 0)
+    if(x->x_sockfd >= 0)
     {
         sys_rmpollfn(x->x_sockfd);
         sys_closesocket(x->x_sockfd);
         x->x_sockfd = -1;
-        if (x->x_receiver)
-            socketreceiver_free(x->x_receiver);
+        if(x->x_receiver) socketreceiver_free(x->x_receiver);
         x->x_receiver = NULL;
         memset(&x->x_server, 0, sizeof(struct sockaddr_storage));
         outlet_float(x->x_obj.ob_outlet, 0);
@@ -431,12 +432,12 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
     char *buf, *bp;
     int length, sent, fail = 0;
     t_binbuf *b = 0;
-    if (x->x_bin)
+    if(x->x_bin)
     {
         int i;
         buf = alloca(argc);
-        for (i = 0; i < argc; i++)
-            ((unsigned char *)buf)[i] = atom_getfloatarg(i, argc, argv);
+        for(i = 0; i < argc; i++)
+            ((unsigned char *) buf)[i] = atom_getfloatarg(i, argc, argv);
         length = argc;
     }
     else
@@ -448,7 +449,7 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
         binbuf_add(b, 1, &at);
         binbuf_gettext(b, &buf, &length);
     }
-    for (bp = buf, sent = 0; sent < length;)
+    for(bp = buf, sent = 0; sent < length;)
     {
         static double lastwarntime;
         static double pleasewarn;
@@ -456,31 +457,32 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
         int late;
 
         int res = 0;
-        if (x->x_protocol == SOCK_DGRAM)
+        if(x->x_protocol == SOCK_DGRAM)
         {
-            socklen_t addrlen = (x->x_server.ss_family == AF_INET6 ?
-                sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in));
-            res = (int)sendto(sockfd, bp, length-sent, 0,
-                (struct sockaddr *)&x->x_server, addrlen);
+            socklen_t addrlen = (x->x_server.ss_family == AF_INET6
+                                     ? sizeof(struct sockaddr_in6)
+                                     : sizeof(struct sockaddr_in));
+            res = (int) sendto(sockfd, bp, length - sent, 0,
+                (struct sockaddr *) &x->x_server, addrlen);
         }
         else
-            res = (int)send(sockfd, bp, length-sent, 0);
+            res = (int) send(sockfd, bp, length - sent, 0);
 
         timeafter = sys_getrealtime();
         late = (timeafter - timebefore > 0.005);
-        if (late || pleasewarn)
+        if(late || pleasewarn)
         {
-            if (timeafter > lastwarntime + 2)
+            if(timeafter > lastwarntime + 2)
             {
                 logpost(NULL, PD_DEBUG, "netsend/netreceive: blocked %d msec",
-                     (int)(1000 * ((timeafter - timebefore) +
-                     pleasewarn)));
+                    (int) (1000 * ((timeafter - timebefore) + pleasewarn)));
                 pleasewarn = 0;
                 lastwarntime = timeafter;
             }
-            else if (late) pleasewarn += timeafter - timebefore;
+            else if(late)
+                pleasewarn += timeafter - timebefore;
         }
-        if (res <= 0)
+        if(res <= 0)
         {
             sys_sockerror("send");
             fail = 1;
@@ -492,8 +494,8 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
             bp += res;
         }
     }
-    done:
-    if (!x->x_bin)
+done:
+    if(!x->x_bin)
     {
         t_freebytes(buf, length);
         binbuf_free(b);
@@ -503,37 +505,31 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
 
 static void netsend_send(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->x_sockfd >= 0)
+    if(x->x_sockfd >= 0)
     {
-        if (netsend_dosend(x, x->x_sockfd, argc, argv))
-            netsend_disconnect(x);
+        if(netsend_dosend(x, x->x_sockfd, argc, argv)) netsend_disconnect(x);
     }
 }
 
 static void netsend_timeout(t_netsend *x, t_float timeout)
 {
-    if (timeout >= 0)
-        x->x_timeout = timeout * 0.001;
+    if(timeout >= 0) x->x_timeout = timeout * 0.001;
 }
 
-static void netsend_free(t_netsend *x)
-{
-    netsend_disconnect(x);
-}
+static void netsend_free(t_netsend *x) { netsend_disconnect(x); }
 
 static void netsend_setup(void)
 {
-    netsend_class = class_new(gensym("netsend"), (t_newmethod)netsend_new,
-        (t_method)netsend_free,
-        sizeof(t_netsend), 0, A_GIMME, 0);
-    class_addmethod(netsend_class, (t_method)netsend_connect,
+    netsend_class = class_new(gensym("netsend"), (t_newmethod) netsend_new,
+        (t_method) netsend_free, sizeof(t_netsend), 0, A_GIMME, 0);
+    class_addmethod(netsend_class, (t_method) netsend_connect,
         gensym("connect"), A_GIMME, 0);
-    class_addmethod(netsend_class, (t_method)netsend_disconnect,
-        gensym("disconnect"), 0);
-    class_addmethod(netsend_class, (t_method)netsend_send,
-        gensym("send"), A_GIMME, 0);
-    class_addlist(netsend_class, (t_method)netsend_send);
-    class_addmethod(netsend_class, (t_method)netsend_timeout,
+    class_addmethod(
+        netsend_class, (t_method) netsend_disconnect, gensym("disconnect"), 0);
+    class_addmethod(
+        netsend_class, (t_method) netsend_send, gensym("send"), A_GIMME, 0);
+    class_addlist(netsend_class, (t_method) netsend_send);
+    class_addmethod(netsend_class, (t_method) netsend_timeout,
         gensym("timeout"), A_DEFFLOAT, 0);
 }
 
@@ -542,28 +538,27 @@ static void netsend_setup(void)
 static void netreceive_notify(t_netreceive *x, int fd)
 {
     int i;
-    for (i = 0; i < x->x_nconnections; i++)
+    for(i = 0; i < x->x_nconnections; i++)
     {
-        if (x->x_connections[i] == fd)
+        if(x->x_connections[i] == fd)
         {
-            memmove(x->x_connections+i, x->x_connections+(i+1),
-                sizeof(int) * (x->x_nconnections - (i+1)));
-            x->x_connections = (int *)t_resizebytes(x->x_connections,
+            memmove(x->x_connections + i, x->x_connections + (i + 1),
+                sizeof(int) * (x->x_nconnections - (i + 1)));
+            x->x_connections = (int *) t_resizebytes(x->x_connections,
                 x->x_nconnections * sizeof(int),
-                    (x->x_nconnections-1) * sizeof(int));
+                (x->x_nconnections - 1) * sizeof(int));
 
-            if (x->x_receivers[i])
-                socketreceiver_free(x->x_receivers[i]);
-            memmove(x->x_receivers+i, x->x_receivers+(i+1),
-                sizeof(t_socketreceiver*) * (x->x_nconnections - (i+1)));
+            if(x->x_receivers[i]) socketreceiver_free(x->x_receivers[i]);
+            memmove(x->x_receivers + i, x->x_receivers + (i + 1),
+                sizeof(t_socketreceiver *) * (x->x_nconnections - (i + 1)));
 
-            x->x_receivers = (t_socketreceiver **)t_resizebytes(x->x_receivers,
-                x->x_nconnections * sizeof(t_socketreceiver*),
-                    (x->x_nconnections-1) * sizeof(t_socketreceiver*));
+            x->x_receivers = (t_socketreceiver **) t_resizebytes(x->x_receivers,
+                x->x_nconnections * sizeof(t_socketreceiver *),
+                (x->x_nconnections - 1) * sizeof(t_socketreceiver *));
             x->x_nconnections--;
         }
     }
-    if (x->x_ns.x_connectout)
+    if(x->x_ns.x_connectout)
     {
         outlet_float(x->x_ns.x_connectout, x->x_nconnections);
     }
@@ -571,40 +566,41 @@ static void netreceive_notify(t_netreceive *x, int fd)
         bug("netreceive_notify");
 }
 
-    /* socketreceiver from sockaddr_in */
+/* socketreceiver from sockaddr_in */
 static void netreceive_fromaddr(void *z, const void *fromaddr)
 {
-    t_netreceive *x = (t_netreceive *)z;
-    if (x->x_ns.x_fromout)
-        outlet_sockaddr(x->x_ns.x_fromout, (const struct sockaddr *)fromaddr);
+    t_netreceive *x = (t_netreceive *) z;
+    if(x->x_ns.x_fromout)
+        outlet_sockaddr(x->x_ns.x_fromout, (const struct sockaddr *) fromaddr);
 }
 
 static void netreceive_connectpoll(t_netreceive *x)
 {
     int fd = accept(x->x_ns.x_sockfd, 0, 0);
-    if (fd < 0) post("netreceive: accept failed");
+    if(fd < 0)
+        post("netreceive: accept failed");
     else
     {
-        int nconnections = x->x_nconnections+1;
+        int nconnections = x->x_nconnections + 1;
 
-        x->x_connections = (int *)t_resizebytes(x->x_connections,
+        x->x_connections = (int *) t_resizebytes(x->x_connections,
             x->x_nconnections * sizeof(int), nconnections * sizeof(int));
         x->x_connections[x->x_nconnections] = fd;
-        x->x_receivers = (t_socketreceiver **)t_resizebytes(x->x_receivers,
-            x->x_nconnections * sizeof(t_socketreceiver*),
-            nconnections * sizeof(t_socketreceiver*));
+        x->x_receivers = (t_socketreceiver **) t_resizebytes(x->x_receivers,
+            x->x_nconnections * sizeof(t_socketreceiver *),
+            nconnections * sizeof(t_socketreceiver *));
         x->x_receivers[x->x_nconnections] = NULL;
-        if (x->x_ns.x_bin)
-            sys_addpollfn(fd, (t_fdpollfn)netsend_readbin, x);
+        if(x->x_ns.x_bin)
+            sys_addpollfn(fd, (t_fdpollfn) netsend_readbin, x);
         else
         {
-            t_socketreceiver *y = socketreceiver_new((void *)x,
-            (t_socketnotifier)netreceive_notify,
+            t_socketreceiver *y = socketreceiver_new((void *) x,
+                (t_socketnotifier) netreceive_notify,
                 (x->x_ns.x_msgout ? netsend_read : 0), 0);
-            if (x->x_ns.x_fromout)
-                socketreceiver_set_fromaddrfn(y,
-                    (t_socketfromaddrfn)netreceive_fromaddr);
-            sys_addpollfn(fd, (t_fdpollfn)socketreceiver_read, y);
+            if(x->x_ns.x_fromout)
+                socketreceiver_set_fromaddrfn(
+                    y, (t_socketfromaddrfn) netreceive_fromaddr);
+            sys_addpollfn(fd, (t_fdpollfn) socketreceiver_read, y);
             x->x_receivers[x->x_nconnections] = y;
         }
         outlet_float(x->x_ns.x_connectout, (x->x_nconnections = nconnections));
@@ -614,114 +610,117 @@ static void netreceive_connectpoll(t_netreceive *x)
 static void netreceive_closeall(t_netreceive *x)
 {
     int i;
-    for (i = 0; i < x->x_nconnections; i++)
+    for(i = 0; i < x->x_nconnections; i++)
     {
         sys_rmpollfn(x->x_connections[i]);
         sys_closesocket(x->x_connections[i]);
-        if (x->x_receivers[i])
+        if(x->x_receivers[i])
         {
             socketreceiver_free(x->x_receivers[i]);
             x->x_receivers[i] = NULL;
         }
     }
-    x->x_connections = (int *)t_resizebytes(x->x_connections,
-        x->x_nconnections * sizeof(int), 0);
-    x->x_receivers = (t_socketreceiver**)t_resizebytes(x->x_receivers,
-                x->x_nconnections * sizeof(t_socketreceiver*), 0);
+    x->x_connections = (int *) t_resizebytes(
+        x->x_connections, x->x_nconnections * sizeof(int), 0);
+    x->x_receivers = (t_socketreceiver **) t_resizebytes(
+        x->x_receivers, x->x_nconnections * sizeof(t_socketreceiver *), 0);
     x->x_nconnections = 0;
-    if (x->x_ns.x_sockfd >= 0)
+    if(x->x_ns.x_sockfd >= 0)
     {
         sys_rmpollfn(x->x_ns.x_sockfd);
         sys_closesocket(x->x_ns.x_sockfd);
     }
     x->x_ns.x_sockfd = -1;
-    if (x->x_ns.x_receiver)
-        socketreceiver_free(x->x_ns.x_receiver);
+    if(x->x_ns.x_receiver) socketreceiver_free(x->x_ns.x_receiver);
     x->x_ns.x_receiver = NULL;
-    if (x->x_ns.x_connectout)
+    if(x->x_ns.x_connectout)
         outlet_float(x->x_ns.x_connectout, x->x_nconnections);
 }
 
-static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
+static void netreceive_listen(
+    t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int portno = 0, sockfd, status, protocol = x->x_ns.x_protocol, multicast = 0;
+    int portno = 0, sockfd, status, protocol = x->x_ns.x_protocol,
+        multicast = 0;
     struct addrinfo *ailist = NULL, *ai;
     const char *hostname = NULL; /* allowed or UDP multicast hostname */
 
     netreceive_closeall(x);
 
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
         portno = argv->a_w.w_float, argc--, argv++;
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         hostname = argv->a_w.w_symbol->s_name;
-        argv++; argc--;
+        argv++;
+        argc--;
     }
-    if (argc)
+    if(argc)
     {
         pd_error(x, "netreceive: extra arguments ignored:");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (portno <= 0)
-        return;
+    if(portno <= 0) return;
     status = addrinfo_get_list(&ailist, hostname, portno, protocol);
-    if (status != 0)
+    if(status != 0)
     {
         pd_error(x, "netreceive: bad host or port? %s (%d)",
             gai_strerror(status), status);
         return;
     }
-    if (hostname)
+    if(hostname)
     {
-        /* If we specify a hostname or IP address we can only listen to a single adapter.
-         * For host names, we prefer IPv4 for now. LATER we might create several sockets */
+        /* If we specify a hostname or IP address we can only listen to a single
+         * adapter. For host names, we prefer IPv4 for now. LATER we might
+         * create several sockets */
         addrinfo_sort_list(&ailist, addrinfo_ipv4_first);
     }
     else
     {
-        /* For the "any" address we want to prefer IPv6, so we can create a dual stack socket */
+        /* For the "any" address we want to prefer IPv6, so we can create a dual
+         * stack socket */
         addrinfo_sort_list(&ailist, addrinfo_ipv6_first);
     }
 #ifdef PRINT_ADDRINFO
     addrinfo_print_list(ailist);
 #endif
     /* try each addr until we find one that works */
-    for (ai = ailist; ai != NULL; ai = ai->ai_next)
+    for(ai = ailist; ai != NULL; ai = ai->ai_next)
     {
         /* create a socket */
         sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
-        if (sockfd < 0)
-            continue;
-    #if 0
+        if(sockfd < 0) continue;
+#if 0
         fprintf(stderr, "receive socket %d\n", sockfd);
-    #endif
+#endif
 
-    #if 1
+#if 1
         /* ask OS to allow another Pd to reopen this port after we close it */
-        if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
+        if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_REUSEADDR, 1) < 0)
             post("netreceive: setsockopt (SO_REUSEADDR) failed");
-    #endif
-    #if 0
+#endif
+#if 0
         intarg = 0;
         if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_RCVBUF, 0) < 0)
             post("netreceive: setsockopt (SO_RCVBUF) failed");
-    #endif
-        if (protocol == SOCK_STREAM)
+#endif
+        if(protocol == SOCK_STREAM)
         {
             /* stream (TCP) sockets are set NODELAY */
-            if (socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
+            if(socket_set_boolopt(sockfd, IPPROTO_TCP, TCP_NODELAY, 1) < 0)
                 post("netreceive: setsockopt (TCP_NODELAY) failed");
         }
-        else if (protocol == SOCK_DGRAM && ai->ai_family == AF_INET)
+        else if(protocol == SOCK_DGRAM && ai->ai_family == AF_INET)
         {
             /* enable IPv4 UDP broadcasting */
-            if (socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
+            if(socket_set_boolopt(sockfd, SOL_SOCKET, SO_BROADCAST, 1) < 0)
                 post("netreceive: setsockopt (SO_BROADCAST) failed");
         }
         /* if this is the IPv6 "any" address, also listen to IPv4 adapters
            (if not supported, fall back to IPv4) */
-        if (!hostname && ai->ai_family == AF_INET6 &&
-                socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
+        if(!hostname && ai->ai_family == AF_INET6 &&
+            socket_set_boolopt(sockfd, IPPROTO_IPV6, IPV6_V6ONLY, 0) < 0)
         {
             /* post("netreceive: setsockopt (IPV6_V6ONLY) failed"); */
             sys_closesocket(sockfd);
@@ -730,18 +729,20 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
         }
         multicast = sockaddr_is_multicast(ai->ai_addr);
 #if 1
-        if (multicast)
+        if(multicast)
         {
-            /* binding to the multicast address doesn't work on Windows and on Linux
-               it doesn't seem to work for IPv6 multicast addresses, so we bind to
-               the "any" address instead */
+            /* binding to the multicast address doesn't work on Windows and on
+               Linux it doesn't seem to work for IPv6 multicast addresses, so we
+               bind to the "any" address instead */
             struct addrinfo *any;
             int status = addrinfo_get_list(&any,
-                (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno, protocol);
-            if (status != 0)
+                (ai->ai_family == AF_INET6) ? "::" : "0.0.0.0", portno,
+                protocol);
+            if(status != 0)
             {
                 pd_error(x,
-                    "netreceive: getting \"any\" address for multicast failed %s (%d)",
+                    "netreceive: getting \"any\" address for multicast failed "
+                    "%s (%d)",
                     gai_strerror(status), status);
                 sys_closesocket(sockfd);
                 return;
@@ -749,7 +750,7 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
             /* name the socket */
             status = bind(sockfd, any->ai_addr, any->ai_addrlen);
             freeaddrinfo(any);
-            if (status < 0)
+            if(status < 0)
             {
                 sys_closesocket(sockfd);
                 sockfd = -1;
@@ -760,7 +761,7 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
 #endif
         {
             /* name the socket */
-            if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
+            if(bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0)
             {
                 sys_closesocket(sockfd);
                 sockfd = -1;
@@ -768,7 +769,7 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
             }
         }
         /* join multicast group */
-        if (multicast && socket_join_multicast_group(sockfd, ai->ai_addr) < 0)
+        if(multicast && socket_join_multicast_group(sockfd, ai->ai_addr) < 0)
         {
             int err = socket_errno();
             char buf[MAXPDSTRING];
@@ -778,11 +779,10 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
                 hostname, buf, err);
         }
         /* this addr worked */
-        if (hostname)
+        if(hostname)
         {
             char hostbuf[256];
-            sockaddr_get_addrstr(ai->ai_addr,
-                hostbuf, sizeof(hostbuf));
+            sockaddr_get_addrstr(ai->ai_addr, hostbuf, sizeof(hostbuf));
             logpost(NULL, PD_VERBOSE, "listening on %s %d%s", hostbuf, portno,
                 (multicast ? " (multicast)" : ""));
         }
@@ -793,37 +793,37 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
     freeaddrinfo(ailist);
 
     /* confirm that socket/bind worked */
-    if (sockfd < 0)
+    if(sockfd < 0)
     {
         int err = socket_errno();
         char buf[MAXPDSTRING];
         socket_strerror(err, buf, sizeof(buf));
-        pd_error(x, "netreceive: listen failed: %s (%d)",
-            buf, err);
+        pd_error(x, "netreceive: listen failed: %s (%d)", buf, err);
         return;
     }
     x->x_ns.x_sockfd = sockfd;
 
-    if (protocol == SOCK_DGRAM) /* datagram protocol */
+    if(protocol == SOCK_DGRAM) /* datagram protocol */
     {
-        if (x->x_ns.x_bin)
-            sys_addpollfn(x->x_ns.x_sockfd, (t_fdpollfn)netsend_readbin, x);
+        if(x->x_ns.x_bin)
+            sys_addpollfn(x->x_ns.x_sockfd, (t_fdpollfn) netsend_readbin, x);
         else
         {
-                /* a UDP receiver doesn't get notifications! */
-            t_socketreceiver *y = socketreceiver_new(x, 0,
-                    (x->x_ns.x_msgout ? netsend_read : 0), 1);
-            if (x->x_ns.x_fromout)
-                socketreceiver_set_fromaddrfn(y,
-                    (t_socketfromaddrfn)netreceive_fromaddr);
-            sys_addpollfn(x->x_ns.x_sockfd, (t_fdpollfn)socketreceiver_read, y);
+            /* a UDP receiver doesn't get notifications! */
+            t_socketreceiver *y = socketreceiver_new(
+                x, 0, (x->x_ns.x_msgout ? netsend_read : 0), 1);
+            if(x->x_ns.x_fromout)
+                socketreceiver_set_fromaddrfn(
+                    y, (t_socketfromaddrfn) netreceive_fromaddr);
+            sys_addpollfn(
+                x->x_ns.x_sockfd, (t_fdpollfn) socketreceiver_read, y);
             x->x_ns.x_connectout = 0;
             x->x_ns.x_receiver = y;
         }
     }
     else /* streaming protocol */
     {
-        if (listen(x->x_ns.x_sockfd, 5) < 0)
+        if(listen(x->x_ns.x_sockfd, 5) < 0)
         {
             sys_sockerror("listen");
             sys_closesocket(x->x_ns.x_sockfd);
@@ -831,102 +831,102 @@ static void netreceive_listen(t_netreceive *x, t_symbol *s, int argc, t_atom *ar
         }
         else
         {
-            sys_addpollfn(x->x_ns.x_sockfd,
-                (t_fdpollfn)netreceive_connectpoll,x);
+            sys_addpollfn(
+                x->x_ns.x_sockfd, (t_fdpollfn) netreceive_connectpoll, x);
         }
     }
 }
 
-static void netreceive_send(t_netreceive *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void netreceive_send(
+    t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    if (x->x_ns.x_protocol != SOCK_STREAM)
+    if(x->x_ns.x_protocol != SOCK_STREAM)
     {
         pd_error(x, "netreceive: 'send' only works for TCP");
         return;
     }
-    for (i = 0; i < x->x_nconnections; i++)
+    for(i = 0; i < x->x_nconnections; i++)
     {
-        if (netsend_dosend(&x->x_ns, x->x_connections[i], argc, argv))
+        if(netsend_dosend(&x->x_ns, x->x_connections[i], argc, argv))
             pd_error(x, "netreceive: send message failed");
-                /* should we now close the connection? */
+        /* should we now close the connection? */
     }
 }
 
 static void *netreceive_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_netreceive *x = (t_netreceive *)pd_new(netreceive_class);
+    t_netreceive *x = (t_netreceive *) pd_new(netreceive_class);
     int from = 0;
     x->x_ns.x_protocol = SOCK_STREAM;
     x->x_old = 0;
     x->x_ns.x_bin = 0;
     x->x_nconnections = 0;
-    x->x_connections = (int *)t_getbytes(0);
-    x->x_receivers = (t_socketreceiver **)t_getbytes(0);
+    x->x_connections = (int *) t_getbytes(0);
+    x->x_receivers = (t_socketreceiver **) t_getbytes(0);
     x->x_ns.x_sockfd = -1;
-    if (argc && argv->a_type == A_FLOAT)
+    if(argc && argv->a_type == A_FLOAT)
     {
         /* port argument is later passed to netreceive_listen */
-        x->x_ns.x_protocol = (atom_getfloatarg(1, argc, argv) != 0 ?
-            SOCK_DGRAM : SOCK_STREAM);
+        x->x_ns.x_protocol =
+            (atom_getfloatarg(1, argc, argv) != 0 ? SOCK_DGRAM : SOCK_STREAM);
         x->x_old = (!strcmp(atom_getsymbolarg(2, argc, argv)->s_name, "old"));
         argc = 1; /* don't pass other arguments */
     }
     else
     {
-        while (argc && argv->a_type == A_SYMBOL &&
-            *argv->a_w.w_symbol->s_name == '-')
+        while(argc && argv->a_type == A_SYMBOL &&
+              *argv->a_w.w_symbol->s_name == '-')
         {
-            if (!strcmp(argv->a_w.w_symbol->s_name, "-b"))
+            if(!strcmp(argv->a_w.w_symbol->s_name, "-b"))
                 x->x_ns.x_bin = 1;
-            else if (!strcmp(argv->a_w.w_symbol->s_name, "-u"))
+            else if(!strcmp(argv->a_w.w_symbol->s_name, "-u"))
                 x->x_ns.x_protocol = SOCK_DGRAM;
-            else if (!strcmp(argv->a_w.w_symbol->s_name, "-f"))
+            else if(!strcmp(argv->a_w.w_symbol->s_name, "-f"))
                 from = 1;
             else
             {
                 pd_error(x, "netreceive: unknown flag ...");
-                postatom(argc, argv); endpost();
+                postatom(argc, argv);
+                endpost();
             }
-            argc--; argv++;
+            argc--;
+            argv++;
         }
     }
-    if (x->x_old)
+    if(x->x_old)
     {
         /* old style, nonsecure version */
         x->x_ns.x_msgout = 0;
     }
-    else x->x_ns.x_msgout = outlet_new(&x->x_ns.x_obj, &s_anything);
-    if (x->x_ns.x_protocol == SOCK_STREAM)
+    else
+        x->x_ns.x_msgout = outlet_new(&x->x_ns.x_obj, &s_anything);
+    if(x->x_ns.x_protocol == SOCK_STREAM)
         x->x_ns.x_connectout = outlet_new(&x->x_ns.x_obj, &s_float);
     else
         x->x_ns.x_connectout = 0;
-    if (from)
+    if(from)
         x->x_ns.x_fromout = outlet_new(&x->x_ns.x_obj, &s_symbol);
     else
         x->x_ns.x_fromout = NULL;
-        /* create a socket */
+    /* create a socket */
     netreceive_listen(x, 0, argc, argv); /* pass arguments */
 
     return (x);
 }
 
-static void netreceive_free(t_netreceive *x)
-{
-    netreceive_closeall(x);
-}
+static void netreceive_free(t_netreceive *x) { netreceive_closeall(x); }
 
 static void netreceive_setup(void)
 {
-    netreceive_class = class_new(gensym("netreceive"),
-        (t_newmethod)netreceive_new, (t_method)netreceive_free,
-        sizeof(t_netreceive), 0, A_GIMME, 0);
-    class_addmethod(netreceive_class, (t_method)netreceive_listen,
+    netreceive_class =
+        class_new(gensym("netreceive"), (t_newmethod) netreceive_new,
+            (t_method) netreceive_free, sizeof(t_netreceive), 0, A_GIMME, 0);
+    class_addmethod(netreceive_class, (t_method) netreceive_listen,
         gensym("listen"), A_GIMME, 0);
-    class_addmethod(netreceive_class, (t_method)netreceive_send,
+    class_addmethod(netreceive_class, (t_method) netreceive_send,
         gensym("send"), A_GIMME, 0);
-    class_addlist(netreceive_class, (t_method)netreceive_send);
+    class_addlist(netreceive_class, (t_method) netreceive_send);
 }
 
 void x_net_setup(void)

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -129,7 +129,6 @@ static void netsend_readbin(t_netsend *x, int fd)
     unsigned char *inbuf = sys_getrecvbuf(0);
     int ret = 0;
     int readbytes = 0;
-    int i;
     struct sockaddr_storage fromaddr = {0};
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
     if(!x->x_msgout)
@@ -187,7 +186,7 @@ static void netsend_readbin(t_netsend *x, int fd)
                 ret = NET_MAXPACKETSIZE;
             }
             ap = (t_atom *) alloca(ret * sizeof(t_atom));
-            for(i = 0; i < ret; i++)
+            for(int i = 0; i < ret; i++)
                 SETFLOAT(ap + i, inbuf[i]);
             outlet_list(x->x_msgout, 0, ret, ap);
             readbytes += ret;
@@ -204,7 +203,7 @@ static void netsend_readbin(t_netsend *x, int fd)
                 outlet_sockaddr(
                     x->x_fromout, (const struct sockaddr *) &fromaddr);
             }
-            for(i = 0; i < ret; i++)
+            for(int i = 0; i < ret; i++)
                 outlet_float(x->x_msgout, inbuf[i]);
             return;
         }
@@ -226,8 +225,7 @@ static void netsend_read(void *z, t_binbuf *b)
             ;
         if(emsg > msg)
         {
-            int i;
-            for(i = msg; i < emsg; i++)
+            for(int i = msg; i < emsg; i++)
             {
                 if(at[i].a_type == A_DOLLAR || at[i].a_type == A_DOLLSYM)
                 {
@@ -474,9 +472,8 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
     t_binbuf *b = 0;
     if(x->x_bin)
     {
-        int i;
         buf = alloca(argc);
-        for(i = 0; i < argc; i++)
+        for(int i = 0; i < argc; i++)
             ((unsigned char *) buf)[i] = atom_getfloatarg(i, argc, argv);
         length = argc;
     }
@@ -576,8 +573,7 @@ static void netsend_setup(void)
 
 static void netreceive_notify(t_netreceive *x, int fd)
 {
-    int i;
-    for(i = 0; i < x->x_nconnections; i++)
+    for(int i = 0; i < x->x_nconnections; i++)
     {
         if(x->x_connections[i] == fd)
         {
@@ -654,8 +650,7 @@ static void netreceive_connectpoll(t_netreceive *x)
 
 static void netreceive_closeall(t_netreceive *x)
 {
-    int i;
-    for(i = 0; i < x->x_nconnections; i++)
+    for(int i = 0; i < x->x_nconnections; i++)
     {
         sys_rmpollfn(x->x_connections[i]);
         sys_closesocket(x->x_connections[i]);
@@ -893,13 +888,12 @@ static void netreceive_listen(
 static void netreceive_send(
     t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     if(x->x_ns.x_protocol != SOCK_STREAM)
     {
         pd_error(x, "netreceive: 'send' only works for TCP");
         return;
     }
-    for(i = 0; i < x->x_nconnections; i++)
+    for(int i = 0; i < x->x_nconnections; i++)
     {
         if(netsend_dosend(&x->x_ns, x->x_connections[i], argc, argv))
             pd_error(x, "netreceive: send message failed");

--- a/src/x_net.c
+++ b/src/x_net.c
@@ -121,7 +121,9 @@ static void *netsend_new(t_symbol *s, int argc, t_atom *argv)
 static void netsend_readbin(t_netsend *x, int fd)
 {
     unsigned char *inbuf = sys_getrecvbuf(0);
-    int ret = 0, readbytes = 0, i;
+    int ret = 0;
+    int readbytes = 0;
+    int i;
     struct sockaddr_storage fromaddr = {0};
     socklen_t fromaddrlen = sizeof(struct sockaddr_storage);
     if(!x->x_msgout)
@@ -198,7 +200,8 @@ static void netsend_readbin(t_netsend *x, int fd)
 static void netsend_read(void *z, t_binbuf *b)
 {
     t_netsend *x = (t_netsend *) z;
-    int msg, natom = binbuf_getnatom(b);
+    int msg;
+    int natom = binbuf_getnatom(b);
     t_atom *at = binbuf_getvec(b);
     for(msg = 0; msg < natom;)
     {
@@ -249,8 +252,13 @@ static void netsend_notify(void *z, int fd)
 
 static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int portno, sportno, sockfd, multicast = 0, status;
-    struct addrinfo *ailist = NULL, *ai;
+    int portno;
+    int sportno;
+    int sockfd;
+    int multicast = 0;
+    int status;
+    struct addrinfo *ailist = NULL;
+    struct addrinfo *ai;
     const char *hostname = NULL;
     char hostbuf[256];
 
@@ -322,7 +330,8 @@ static void netsend_connect(t_netsend *x, t_symbol *s, int argc, t_atom *argv)
         if(sportno != 0)
         {
             int bound = 0;
-            struct addrinfo *sailist = NULL, *sai;
+            struct addrinfo *sailist = NULL;
+            struct addrinfo *sai;
             logpost(NULL, PD_VERBOSE, "connecting to %s %d, src port %d",
                 hostbuf, portno, sportno);
             status = addrinfo_get_list(&sailist, NULL, sportno, x->x_protocol);
@@ -429,8 +438,11 @@ static void netsend_disconnect(t_netsend *x)
 
 static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
 {
-    char *buf, *bp;
-    int length, sent, fail = 0;
+    char *buf;
+    char *bp;
+    int length;
+    int sent;
+    int fail = 0;
     t_binbuf *b = 0;
     if(x->x_bin)
     {
@@ -453,7 +465,8 @@ static int netsend_dosend(t_netsend *x, int sockfd, int argc, t_atom *argv)
     {
         static double lastwarntime;
         static double pleasewarn;
-        double timebefore = sys_getrealtime(), timeafter;
+        double timebefore = sys_getrealtime();
+        double timeafter;
         int late;
 
         int res = 0;
@@ -640,9 +653,13 @@ static void netreceive_closeall(t_netreceive *x)
 static void netreceive_listen(
     t_netreceive *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int portno = 0, sockfd, status, protocol = x->x_ns.x_protocol,
-        multicast = 0;
-    struct addrinfo *ailist = NULL, *ai;
+    int portno = 0;
+    int sockfd;
+    int status;
+    int protocol = x->x_ns.x_protocol;
+    int multicast = 0;
+    struct addrinfo *ailist = NULL;
+    struct addrinfo *ai;
     const char *hostname = NULL; /* allowed or UDP multicast hostname */
 
     netreceive_closeall(x);

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-2013 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* The "scalar" object. */
 
@@ -25,50 +25,52 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
     t_template *template;
     t_scalar *sc;
     int keep = 0;
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
             keep = 1;
         else
         {
             pd_error(0, "scalar define: unknown flag ...");
             postatom(argc, argv);
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         templatesym = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: scalar define ignoring extra argument: ");
         postatom(argc, argv);
     }
 
-        /* make a canvas... */
-    SETFLOAT(a+0, GLIST_DEFCANVASXLOC); /* xpos */
-    SETFLOAT(a+1, GLIST_DEFCANVASYLOC); /* ypos */
-    SETFLOAT(a+2, 600); /* width */
-    SETFLOAT(a+3, 400); /* height */
-    SETSYMBOL(a+4, s);
-    SETFLOAT(a+5, 0);
+    /* make a canvas... */
+    SETFLOAT(a + 0, GLIST_DEFCANVASXLOC); /* xpos */
+    SETFLOAT(a + 1, GLIST_DEFCANVASYLOC); /* ypos */
+    SETFLOAT(a + 2, 600);                 /* width */
+    SETFLOAT(a + 3, 400);                 /* height */
+    SETSYMBOL(a + 4, s);
+    SETFLOAT(a + 5, 0);
     x = canvas_new(0, 0, 6, a);
 
     x->gl_owner = z;
     x->gl_private = 0;
-        /* put a scalar in it */
+    /* put a scalar in it */
     template = template_findbyname(canvas_makebindsym(templatesym));
-    if (!template)
+    if(!template)
     {
-        pd_error(x, "scalar define: couldn't find template %s",
-            templatesym->s_name);
+        pd_error(
+            x, "scalar define: couldn't find template %s", templatesym->s_name);
         goto noscalar;
     }
     sc = scalar_new(x, canvas_makebindsym(templatesym));
-    if (!sc)
+    if(!sc)
     {
         pd_error(x, "%s: couldn't create scalar", templatesym->s_name);
         goto noscalar;
@@ -76,57 +78,59 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
     sc->sc_gobj.g_next = 0;
     x->gl_list = &sc->sc_gobj;
     x->gl_private = keep;
-           /* bashily unbind #A -- this would create garbage if #A were
-           multiply bound but we believe in this context it's at most
-           bound to whichever text_define or array was created most recently */
+    /* bashily unbind #A -- this would create garbage if #A were
+    multiply bound but we believe in this context it's at most
+    bound to whichever text_define or array was created most recently */
     asym->s_thing = 0;
-        /* and now bind #A to us to receive following messages in the
-        saved file or copy buffer */
+    /* and now bind #A to us to receive following messages in the
+    saved file or copy buffer */
     pd_bind(&x->gl_obj.ob_pd, asym);
 noscalar:
-    pd_this->pd_newest = &x->gl_pd;     /* mimic action of canvas_pop() */
+    pd_this->pd_newest = &x->gl_pd; /* mimic action of canvas_pop() */
     pd_popsym(&x->gl_pd);
     x->gl_loading = 0;
 
-        /* bash the class to "scalar define" -- see comment in x_array,c */
+    /* bash the class to "scalar define" -- see comment in x_array,c */
     x->gl_obj.ob_pd = scalar_define_class;
     outlet_new(&x->gl_obj, &s_pointer);
     return (x);
 }
 
-    /* send a pointer to the scalar to whomever is bound to the symbol */
+/* send a pointer to the scalar to whomever is bound to the symbol */
 static void scalar_define_send(t_glist *x, t_symbol *s)
 {
-    if (!s->s_thing)
+    if(!s->s_thing)
         pd_error(x, "scalar_define_send: %s: no such object", s->s_name);
-    else if (x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
+    else if(x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_gpointer gp;
         gpointer_init(&gp);
-        gpointer_setglist(&gp, x, (t_scalar *)&x->gl_list->g_pd);
+        gpointer_setglist(&gp, x, (t_scalar *) &x->gl_list->g_pd);
         pd_pointer(s->s_thing, &gp);
         gpointer_unset(&gp);
     }
-    else bug("scalar_define_send");
+    else
+        bug("scalar_define_send");
 }
 
 static void scalar_define_bang(t_glist *x)
 {
-    if (x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
+    if(x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_gpointer gp;
         gpointer_init(&gp);
-        gpointer_setglist(&gp, x, (t_scalar *)&x->gl_list->g_pd);
+        gpointer_setglist(&gp, x, (t_scalar *) &x->gl_list->g_pd);
         outlet_pointer(x->gl_obj.ob_outlet, &gp);
         gpointer_unset(&gp);
     }
-    else bug("scalar_define_bang");
+    else
+        bug("scalar_define_bang");
 }
 
-    /* set to a list, used to restore from scalar_define_save()s below */
+/* set to a list, used to restore from scalar_define_save()s below */
 static void scalar_define_set(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-    if (x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
+    if(x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_binbuf *b = binbuf_new();
         int nextmsg = 0, natoms;
@@ -138,22 +142,23 @@ static void scalar_define_set(t_glist *x, t_symbol *s, int argc, t_atom *argv)
         canvas_readscalar(x, natoms, vec, &nextmsg, 0);
         binbuf_free(b);
     }
-    else bug("scalar_define_set");
+    else
+        bug("scalar_define_set");
 }
 
-    /* save to a binbuf (for file save or copy) */
+/* save to a binbuf (for file save or copy) */
 static void scalar_define_save(t_gobj *z, t_binbuf *bb)
 {
-    t_glist *x = (t_glist *)z;
-    binbuf_addv(bb, "ssff", &s__X, gensym("obj"),
-        (t_float)x->gl_obj.te_xpix, (t_float)x->gl_obj.te_ypix);
+    t_glist *x = (t_glist *) z;
+    binbuf_addv(bb, "ssff", &s__X, gensym("obj"), (t_float) x->gl_obj.te_xpix,
+        (t_float) x->gl_obj.te_ypix);
     binbuf_addbinbuf(bb, x->gl_obj.ob_binbuf);
     binbuf_addsemi(bb);
-    if (x->gl_private && x->gl_list &&
+    if(x->gl_private && x->gl_list &&
         pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_binbuf *b2 = binbuf_new();
-        t_scalar *sc = (t_scalar *)(x->gl_list);
+        t_scalar *sc = (t_scalar *) (x->gl_list);
         binbuf_addv(bb, "ss", gensym("#A"), gensym("set"));
         canvas_writescalar(sc->sc_template, sc->sc_vec, b2, 0);
         binbuf_addbinbuf(bb, b2);
@@ -165,13 +170,13 @@ static void scalar_define_save(t_gobj *z, t_binbuf *bb)
 /* overall creator for "scalar" objects - dispatch to "scalar define" etc */
 static void *scalarobj_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (!argc || argv[0].a_type != A_SYMBOL)
+    if(!argc || argv[0].a_type != A_SYMBOL)
         pd_this->pd_newest = scalar_define_new(s, argc, argv);
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
-        if (!strcmp(str, "d") || !strcmp(str, "define"))
-            pd_this->pd_newest = scalar_define_new(s, argc-1, argv+1);
+        if(!strcmp(str, "d") || !strcmp(str, "define"))
+            pd_this->pd_newest = scalar_define_new(s, argc - 1, argv + 1);
         else
         {
             pd_error(0, "scalar %s: unknown function", str);
@@ -188,15 +193,15 @@ void canvas_add_for_class(t_class *c);
 void x_scalar_setup(void)
 {
     scalar_define_class = class_new(gensym("scalar define"), 0,
-        (t_method)canvas_free, sizeof(t_canvas), 0, 0);
+        (t_method) canvas_free, sizeof(t_canvas), 0, 0);
     canvas_add_for_class(scalar_define_class);
-    class_addmethod(scalar_define_class, (t_method)scalar_define_send,
+    class_addmethod(scalar_define_class, (t_method) scalar_define_send,
         gensym("send"), A_SYMBOL, 0);
-    class_addbang(scalar_define_class, (t_method)scalar_define_bang);
-    class_addmethod(scalar_define_class, (t_method)scalar_define_set,
+    class_addbang(scalar_define_class, (t_method) scalar_define_bang);
+    class_addmethod(scalar_define_class, (t_method) scalar_define_set,
         gensym("set"), A_GIMME, 0);
     class_sethelpsymbol(scalar_define_class, gensym("scalar-object"));
     class_setsavefn(scalar_define_class, scalar_define_save);
 
-    class_addcreator((t_newmethod)scalarobj_new, gensym("scalar"), A_GIMME, 0);
+    class_addcreator((t_newmethod) scalarobj_new, gensym("scalar"), A_GIMME, 0);
 }

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -21,7 +21,8 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_atom a[9];
     t_canvas *x, *z = canvas_getcurrent();
-    t_symbol *templatesym = &s_float, *asym = gensym("#A");
+    t_symbol *templatesym = &s_float;
+    t_symbol *asym = gensym("#A");
     t_template *template;
     t_scalar *sc;
     int keep = 0;
@@ -133,7 +134,8 @@ static void scalar_define_set(t_glist *x, t_symbol *s, int argc, t_atom *argv)
     if(x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_binbuf *b = binbuf_new();
-        int nextmsg = 0, natoms;
+        int nextmsg = 0;
+        int natoms;
         t_atom *vec;
         glist_clear(x);
         binbuf_restore(b, argc, argv);

--- a/src/x_scalar.c
+++ b/src/x_scalar.c
@@ -30,7 +30,9 @@ static void *scalar_define_new(t_symbol *s, int argc, t_atom *argv)
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        {
             keep = 1;
+        }
         else
         {
             pd_error(0, "scalar define: unknown flag ...");
@@ -101,7 +103,9 @@ noscalar:
 static void scalar_define_send(t_glist *x, t_symbol *s)
 {
     if(!s->s_thing)
+    {
         pd_error(x, "scalar_define_send: %s: no such object", s->s_name);
+    }
     else if(x->gl_list && pd_class(&x->gl_list->g_pd) == scalar_class)
     {
         t_gpointer gp;
@@ -173,12 +177,16 @@ static void scalar_define_save(t_gobj *z, t_binbuf *bb)
 static void *scalarobj_new(t_symbol *s, int argc, t_atom *argv)
 {
     if(!argc || argv[0].a_type != A_SYMBOL)
+    {
         pd_this->pd_newest = scalar_define_new(s, argc, argv);
+    }
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
         if(!strcmp(str, "d") || !strcmp(str, "define"))
+        {
             pd_this->pd_newest = scalar_define_new(s, argc - 1, argv + 1);
+        }
         else
         {
             pd_error(0, "scalar %s: unknown function", str);

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -66,7 +66,8 @@ static void textbuf_init(t_textbuf *x, t_symbol *sym)
 
 static void textbuf_senditup(t_textbuf *x)
 {
-    int i, ntxt;
+    int i;
+    int ntxt;
     char *txt;
     if(!x->b_guiconnect) return;
     binbuf_gettext(x->b_binbuf, &txt, &ntxt);
@@ -220,7 +221,8 @@ static void textbuf_free(t_textbuf *x)
 /* random helper function to find the nth line in a text buffer */
 static int text_nthline(int n, t_atom *vec, int line, int *startp, int *endp)
 {
-    int i, cnt = 0;
+    int i;
+    int cnt = 0;
     for(i = 0; i < n; i++)
     {
         if(cnt == line)
@@ -413,7 +415,8 @@ static int text_sortcompare(void *zkeyinfo, const void *z1, const void *z2)
 static int text_sortcompare(const void *z1, const void *z2, void *zkeyinfo)
 #endif
 {
-    const t_atom *a1 = *(t_atom **) z1, *a2 = *(t_atom **) z2;
+    const t_atom *a1 = *(t_atom **) z1;
+    const t_atom *a2 = *(t_atom **) z2;
     t_keyinfo *k = (t_keyinfo *) zkeyinfo;
     int count;
     /* advance first line by key onset and react if we run out early */
@@ -502,9 +505,16 @@ static int stupid_sortcompare(const void *z1, const void *z2)
 static void text_define_sort(
     t_text_define *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int nlines = 0, unique = 0, natom = binbuf_getnatom(x->x_binbuf), i,
-        thisline, startline;
-    t_atom *vec = binbuf_getvec(x->x_binbuf), **sortbuf, *a1, *a2;
+    int nlines = 0;
+    int unique = 0;
+    int natom = binbuf_getnatom(x->x_binbuf);
+    int i;
+    int thisline;
+    int startline;
+    t_atom *vec = binbuf_getvec(x->x_binbuf);
+    t_atom **sortbuf;
+    t_atom *a1;
+    t_atom *a2;
     t_binbuf *newb;
     t_keyinfo k;
     k.ki_forward = 1;
@@ -683,7 +693,8 @@ static t_binbuf *text_client_getbuf(t_text_client *x)
         t_template *template = template_findbyname(x->tc_struct);
         t_gstub *gs = x->tc_gp.gp_stub;
         t_word *vec;
-        int onset, type;
+        int onset;
+        int type;
         t_symbol *arraytype;
         if(!template)
         {
@@ -827,7 +838,11 @@ static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
 static void text_get_float(t_text_get *x, t_floatarg f)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n, startfield, nfield;
+    int start;
+    int end;
+    int n;
+    int startfield;
+    int nfield;
     t_atom *vec;
     if(!b) return;
     vec = binbuf_getvec(b);
@@ -836,7 +851,8 @@ static void text_get_float(t_text_get *x, t_floatarg f)
     nfield = x->x_f2;
     if(text_nthline(n, vec, f, &start, &end))
     {
-        int outc = end - start, k;
+        int outc = end - start;
+        int k;
         t_atom *outv;
         if(x->x_f1 < 0) /* negative start field for whole line */
         {
@@ -929,8 +945,12 @@ static void *text_set_new(t_symbol *s, int argc, t_atom *argv)
 static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n, fieldno = x->x_f2, i,
-                       /* check for overflow in this conversion: */
+    int start;
+    int end;
+    int n;
+    int fieldno = x->x_f2;
+    int i;
+    int /* check for overflow in this conversion: */
         lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
     t_atom *vec;
     if(!b) return;
@@ -974,9 +994,9 @@ static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
     }
     else if(fieldno < 0) /* if line number too high just append to end */
     {
-        int addsemi = (n && vec[n - 1].a_type != A_SEMI &&
-                       vec[n - 1].a_type != A_COMMA),
-            newsize = n + addsemi + argc + 1;
+        int addsemi =
+            (n && vec[n - 1].a_type != A_SEMI && vec[n - 1].a_type != A_COMMA);
+        int newsize = n + addsemi + argc + 1;
         (void) binbuf_resize(b, newsize);
         vec = binbuf_getvec(b);
         if(addsemi) SETSEMI(&vec[n]);
@@ -1043,8 +1063,12 @@ static void text_insert_list(
     t_text_insert *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n, nwas, i,
-        lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
+    int start;
+    int end;
+    int n;
+    int nwas;
+    int i;
+    int lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
 
     t_atom *vec;
     if(!b) return;
@@ -1100,7 +1124,10 @@ static void *text_delete_new(t_symbol *s, int argc, t_atom *argv)
 static void text_delete_float(t_text_delete *x, t_floatarg f)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n, lineno = (f > (double) 0x7fffffff ? 0x7fffffff : f);
+    int start;
+    int end;
+    int n;
+    int lineno = (f > (double) 0x7fffffff ? 0x7fffffff : f);
     t_atom *vec;
     if(!b) return;
     vec = binbuf_getvec(b);
@@ -1151,7 +1178,9 @@ static void *text_size_new(t_symbol *s, int argc, t_atom *argv)
 static void text_size_bang(t_text_size *x)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int n, i, cnt = 0;
+    int n;
+    int i;
+    int cnt = 0;
     t_atom *vec;
     if(!b) return;
     vec = binbuf_getvec(b);
@@ -1167,7 +1196,9 @@ static void text_size_bang(t_text_size *x)
 static void text_size_float(t_text_size *x, t_floatarg f)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n;
+    int start;
+    int end;
+    int n;
     t_atom *vec;
     if(!b) return;
     vec = binbuf_getvec(b);
@@ -1274,7 +1305,10 @@ typedef struct _text_search
 static void *text_search_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_text_search *x = (t_text_search *) pd_new(text_search_class);
-    int i, key, nkey, nextop;
+    int i;
+    int key;
+    int nkey;
+    int nextop;
     x->x_out1 = outlet_new(&x->x_obj, &s_list);
     text_client_argparse(&x->x_tc, &argc, &argv, "text search");
     for(i = nkey = 0; i < argc; i++)
@@ -1329,8 +1363,15 @@ static void text_search_list(
     t_text_search *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int i, n, lineno, bestline = -1, beststart = -1, bestn, thisstart,
-                      nkeys = x->x_nkeys, failed = 0;
+    int i;
+    int n;
+    int lineno;
+    int bestline = -1;
+    int beststart = -1;
+    int bestn;
+    int thisstart;
+    int nkeys = x->x_nkeys;
+    int failed = 0;
     t_atom *vec;
     if(!b) return;
     if(argc < nkeys)
@@ -1344,7 +1385,10 @@ static void text_search_list(
     {
         if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA || i == n - 1)
         {
-            int thisn, j, field, binop;
+            int thisn;
+            int j;
+            int field;
+            int binop;
             if(lineno < x->x_onset) goto nomatch;
             if(lineno >= x->x_onset + x->x_range) break;
             thisn = i - thisstart;
@@ -1425,10 +1469,10 @@ static void text_search_list(
                         bug("text search 2");
                     if(argv[j].a_type == A_FLOAT) /* arg is a float */
                     {
-                        float thisv = vec[thisstart + field].a_w.w_float,
-                              bestv = (beststart >= 0
-                                           ? vec[beststart + field].a_w.w_float
-                                           : -1e20);
+                        float thisv = vec[thisstart + field].a_w.w_float;
+                        float bestv =
+                            (beststart >= 0 ? vec[beststart + field].a_w.w_float
+                                            : -1e20);
                         switch(binop)
                         {
                             case KB_GT:
@@ -1464,8 +1508,8 @@ static void text_search_list(
                                 }
                                 else
                                 {
-                                    float d1 = thisv - argv[j].a_w.w_float,
-                                          d2 = bestv - argv[j].a_w.w_float;
+                                    float d1 = thisv - argv[j].a_w.w_float;
+                                    float d2 = bestv - argv[j].a_w.w_float;
                                     if(d1 < 0) d1 = -d1;
                                     if(d2 < 0) d2 = -d2;
 
@@ -1611,8 +1655,16 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
 static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int n, i, onset, nfield, wait, eatsemi = 1, gotcomma = 0;
-    t_atom *vec, *outvec, *ap;
+    int n;
+    int i;
+    int onset;
+    int nfield;
+    int wait;
+    int eatsemi = 1;
+    int gotcomma = 0;
+    t_atom *vec;
+    t_atom *outvec;
+    t_atom *ap;
     if(!b) goto nosequence;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
@@ -1815,7 +1867,9 @@ static void text_sequence_step(t_text_sequence *x)
 static void text_sequence_line(t_text_sequence *x, t_floatarg f)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int n, start, end;
+    int n;
+    int start;
+    int end;
     t_atom *vec;
     if(!b) return;
     x->x_lastto = 0;
@@ -1956,10 +2010,14 @@ static void qlist_donext(t_qlist *x, int drop, int automatic)
     x->x_innext = 1;
     while(1)
     {
-        int argc = binbuf_getnatom(x->x_binbuf), count, onset = x->x_onset,
-            onset2, wasrewound;
+        int argc = binbuf_getnatom(x->x_binbuf);
+        int count;
+        int onset = x->x_onset;
+        int onset2;
+        int wasrewound;
         t_atom *argv = binbuf_getvec(x->x_binbuf);
-        t_atom *ap = argv + onset, *ap2;
+        t_atom *ap = argv + onset;
+        t_atom *ap2;
         if(onset >= argc) goto end;
         while(ap->a_type == A_SEMI || ap->a_type == A_COMMA)
         {
@@ -2171,9 +2229,12 @@ static void *textfile_new(void)
 
 static void textfile_bang(t_qlist *x)
 {
-    int argc = binbuf_getnatom(x->x_binbuf), onset = x->x_onset, onset2;
+    int argc = binbuf_getnatom(x->x_binbuf);
+    int onset = x->x_onset;
+    int onset2;
     t_atom *argv = binbuf_getvec(x->x_binbuf);
-    t_atom *ap = argv + onset, *ap2;
+    t_atom *ap = argv + onset;
+    t_atom *ap2;
     while(onset < argc && (ap->a_type == A_SEMI || ap->a_type == A_COMMA))
         onset++, ap++;
     onset2 = onset;

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -234,8 +234,7 @@ static int text_nthline(int n, t_atom *vec, int line, int *startp, int *endp)
             *endp = j;
             return (1);
         }
-        else if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA)
-            cnt++;
+        if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA) cnt++;
     }
     return (0);
 }
@@ -455,8 +454,7 @@ static int text_sortcompare(const void *z1, const void *z2, void *zkeyinfo)
             {
                 if(a1->a_w.w_float < a2->a_w.w_float)
                     return (-k->ki_forward);
-                else if(a1->a_w.w_float > a2->a_w.w_float)
-                    return (k->ki_forward);
+                if(a1->a_w.w_float > a2->a_w.w_float) return (k->ki_forward);
             }
             else
                 return (-k->ki_forward);
@@ -681,12 +679,9 @@ static t_binbuf *text_client_getbuf(t_text_client *x)
             (t_textbuf *) pd_findbyclass(x->tc_sym, text_define_class);
         if(y)
             return (y->b_binbuf);
-        else
-        {
-            pd_error(
-                x, "text: couldn't find text buffer '%s'", x->tc_sym->s_name);
-            return (0);
-        }
+
+        pd_error(x, "text: couldn't find text buffer '%s'", x->tc_sym->s_name);
+        return (0);
     }
     else if(x->tc_struct) /* by pointer */
     {
@@ -2055,7 +2050,7 @@ static void qlist_donext(t_qlist *x, int drop, int automatic)
         {
             if(ap->a_type != A_SYMBOL)
                 continue;
-            else if(!(target = ap->a_w.w_symbol->s_thing))
+            if(!(target = ap->a_w.w_symbol->s_thing))
             {
                 pd_error(
                     x, "qlist: %s: no such object", ap->a_w.w_symbol->s_name);
@@ -2452,8 +2447,7 @@ t_binbuf *text_getbufbyname(t_symbol *s)
     t_text_define *y = (t_text_define *) pd_findbyclass(s, text_define_class);
     if(y)
         return (y->x_textbuf.b_binbuf);
-    else
-        return (0);
+    return (0);
 }
 
 /* notify text object that binbuf was modified */

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -1,15 +1,15 @@
 /* Copyright (c) 1997-1999 Miller Puckette and others.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* historically this file defined the qlist and textfile objects - at the
 moment it also defines "text" but it may later be better to split this off. */
 
 #include "m_pd.h"
-#include "g_canvas.h"    /* just for glist_getfont, bother */
+#include "g_canvas.h" /* just for glist_getfont, bother */
 #include <string.h>
 #include <stdio.h>
-#define __USE_GNU     /* needed so stdlib will define qsort_r */
+#define __USE_GNU /* needed so stdlib will define qsort_r */
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -20,28 +20,29 @@ moment it also defines "text" but it may later be better to split this off. */
 static t_class *text_define_class;
 
 #ifdef _WIN32
-# include <malloc.h> /* MSVC or mingw on windows */
+#include <malloc.h> /* MSVC or mingw on windows */
 #elif defined(__linux__) || defined(__APPLE__) || defined(HAVE_ALLOCA_H)
-# include <alloca.h> /* linux, mac, mingw, cygwin */
+#include <alloca.h> /* linux, mac, mingw, cygwin */
 #else
-# include <stdlib.h> /* BSDs for example */
+#include <stdlib.h> /* BSDs for example */
 #endif
 
 #ifdef _WIN32
-#define qsort_r qsort_s   /* of course Microsoft decides to be different */
+#define qsort_r qsort_s /* of course Microsoft decides to be different */
 #endif
 
-#ifndef HAVE_ALLOCA     /* can work without alloca() but we never need it */
+#ifndef HAVE_ALLOCA /* can work without alloca() but we never need it */
 #define HAVE_ALLOCA 1
 #endif
 #define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
 #if HAVE_ALLOCA
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)((n) < TEXT_NGETBYTE ?  \
-        alloca((n) * sizeof(t_atom)) : getbytes((n) * sizeof(t_atom))))
-#define ATOMS_FREEA(x, n) ( \
-    ((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
+#define ATOMS_ALLOCA(x, n)                                                \
+    ((x) = (t_atom *) ((n) < TEXT_NGETBYTE ? alloca((n) * sizeof(t_atom)) \
+                                           : getbytes((n) * sizeof(t_atom))))
+#define ATOMS_FREEA(x, n) \
+    (((n) < TEXT_NGETBYTE || (freebytes((x), (n) * sizeof(t_atom)), 0)))
 #else
-#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *)getbytes((n) * sizeof(t_atom)))
+#define ATOMS_ALLOCA(x, n) ((x) = (t_atom *) getbytes((n) * sizeof(t_atom)))
 #define ATOMS_FREEA(x, n) (freebytes((x), (n) * sizeof(t_atom)))
 #endif
 
@@ -67,17 +68,16 @@ static void textbuf_senditup(t_textbuf *x)
 {
     int i, ntxt;
     char *txt;
-    if (!x->b_guiconnect)
-        return;
+    if(!x->b_guiconnect) return;
     binbuf_gettext(x->b_binbuf, &txt, &ntxt);
     sys_vgui("pdtk_textwindow_clear .x%lx\n", x);
-    for (i = 0; i < ntxt; )
+    for(i = 0; i < ntxt;)
     {
-        char *j = strchr(txt+i, '\n');
-        if (!j) j = txt + ntxt;
-        sys_vgui("pdtk_textwindow_append .x%lx {%.*s\n}\n",
-            x, j-txt-i, txt+i);
-        i = (int)((j-txt)+1);
+        char *j = strchr(txt + i, '\n');
+        if(!j) j = txt + ntxt;
+        sys_vgui(
+            "pdtk_textwindow_append .x%lx {%.*s\n}\n", x, j - txt - i, txt + i);
+        i = (int) ((j - txt) + 1);
     }
     sys_vgui("pdtk_textwindow_setdirty .x%lx 0\n", x);
     t_freebytes(txt, ntxt);
@@ -85,7 +85,7 @@ static void textbuf_senditup(t_textbuf *x)
 
 static void textbuf_open(t_textbuf *x)
 {
-    if (x->b_guiconnect)
+    if(x->b_guiconnect)
     {
         sys_vgui("wm deiconify .x%lx\n", x);
         sys_vgui("raise .x%lx\n", x);
@@ -94,10 +94,10 @@ static void textbuf_open(t_textbuf *x)
     else
     {
         char buf[40];
-        sys_vgui("pdtk_textwindow_open .x%lx %dx%d {%s} %d\n",
-            x, 600, 340, x->b_sym->s_name,
-                 sys_hostfontsize(glist_getfont(x->b_canvas),
-                    glist_getzoom(x->b_canvas)));
+        sys_vgui("pdtk_textwindow_open .x%lx %dx%d {%s} %d\n", x, 600, 340,
+            x->b_sym->s_name,
+            sys_hostfontsize(
+                glist_getfont(x->b_canvas), glist_getzoom(x->b_canvas)));
         sprintf(buf, ".x%lx", x);
         x->b_guiconnect = guiconnect_new(&x->b_ob.ob_pd, gensym(buf));
         textbuf_senditup(x);
@@ -106,7 +106,7 @@ static void textbuf_open(t_textbuf *x)
 
 static void textbuf_close(t_textbuf *x)
 {
-    if (x->b_guiconnect)
+    if(x->b_guiconnect)
     {
         sys_vgui("pdtk_textwindow_doclose .x%lx\n", x);
         guiconnect_notarget(x->b_guiconnect, 1000);
@@ -126,35 +126,39 @@ static void textbuf_read(t_textbuf *x, t_symbol *s, int argc, t_atom *argv)
 {
     int cr = 0;
     t_symbol *filename;
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-c"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-c"))
             cr = 1;
         else
         {
             pd_error(x, "text read: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         filename = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
     else
     {
         pd_error(x, "text read: no file name given");
         return;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text define ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (binbuf_read_via_canvas(x->b_binbuf, filename->s_name, x->b_canvas, cr))
-            pd_error(x, "%s: read failed", filename->s_name);
+    if(binbuf_read_via_canvas(x->b_binbuf, filename->s_name, x->b_canvas, cr))
+        pd_error(x, "%s: read failed", filename->s_name);
     textbuf_senditup(x);
 }
 
@@ -163,71 +167,72 @@ static void textbuf_write(t_textbuf *x, t_symbol *s, int argc, t_atom *argv)
     int cr = 0;
     t_symbol *filename;
     char buf[MAXPDSTRING];
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-c"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-c"))
             cr = 1;
         else
         {
             pd_error(x, "text write: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         filename = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
     else
     {
         pd_error(x, "text write: no file name given");
         return;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text define ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    canvas_makefilename(x->b_canvas, filename->s_name,
-        buf, MAXPDSTRING);
-    if (binbuf_write(x->b_binbuf, buf, "", cr))
-            pd_error(x, "%s: write failed", filename->s_name);
+    canvas_makefilename(x->b_canvas, filename->s_name, buf, MAXPDSTRING);
+    if(binbuf_write(x->b_binbuf, buf, "", cr))
+        pd_error(x, "%s: write failed", filename->s_name);
 }
 
 static void textbuf_free(t_textbuf *x)
 {
     t_pd *x2;
-    if (x->b_binbuf)
-        binbuf_free(x->b_binbuf);
-    if (x->b_guiconnect)
+    if(x->b_binbuf) binbuf_free(x->b_binbuf);
+    if(x->b_guiconnect)
     {
         sys_vgui("destroy .x%lx\n", x);
         guiconnect_notarget(x->b_guiconnect, 1000);
     }
-        /* just in case we're still bound to #A from loading... */
-    while ((x2 = pd_findbyclass(gensym("#A"), text_define_class)))
+    /* just in case we're still bound to #A from loading... */
+    while((x2 = pd_findbyclass(gensym("#A"), text_define_class)))
         pd_unbind(x2, gensym("#A"));
 }
 
-    /* random helper function to find the nth line in a text buffer */
+/* random helper function to find the nth line in a text buffer */
 static int text_nthline(int n, t_atom *vec, int line, int *startp, int *endp)
 {
     int i, cnt = 0;
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        if (cnt == line)
+        if(cnt == line)
         {
             int j = i;
-            while (j < n && vec[j].a_type != A_SEMI &&
-                vec[j].a_type != A_COMMA)
-                    j++;
+            while(j < n && vec[j].a_type != A_SEMI && vec[j].a_type != A_COMMA)
+                j++;
             *startp = i;
             *endp = j;
             return (1);
         }
-        else if (vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA)
+        else if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA)
             cnt++;
     }
     return (0);
@@ -241,10 +246,10 @@ typedef struct _text_define
     t_outlet *x_out;
     t_outlet *x_notifyout;
     t_symbol *x_bindsym;
-    t_scalar *x_scalar;     /* faux scalar (struct text-scalar) to point to */
-    t_gpointer x_gp;        /* pointer to it */
-    t_canvas *x_canvas;     /* owning canvas whose stub we use for x_gp */
-    unsigned char x_keep;   /* whether to embed contents in patch on save */
+    t_scalar *x_scalar;   /* faux scalar (struct text-scalar) to point to */
+    t_gpointer x_gp;      /* pointer to it */
+    t_canvas *x_canvas;   /* owning canvas whose stub we use for x_gp */
+    unsigned char x_keep; /* whether to embed contents in patch on save */
 } t_text_define;
 
 #define x_ob x_textbuf.b_ob
@@ -253,36 +258,40 @@ typedef struct _text_define
 
 static void *text_define_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_define *x = (t_text_define *)pd_new(text_define_class);
+    t_text_define *x = (t_text_define *) pd_new(text_define_class);
     t_symbol *asym = gensym("#A");
     x->x_keep = 0;
     x->x_bindsym = &s_;
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
             x->x_keep = 1;
         else
         {
             pd_error(x, "text define: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc && argv->a_type == A_SYMBOL)
+    if(argc && argv->a_type == A_SYMBOL)
     {
         pd_bind(&x->x_ob.ob_pd, argv->a_w.w_symbol);
         x->x_bindsym = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text define ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    textbuf_init(&x->x_textbuf, *x->x_bindsym->s_name ? x->x_bindsym :
-        gensym("text"));
-        /* set up a scalar and a pointer to it that we can output */
+    textbuf_init(
+        &x->x_textbuf, *x->x_bindsym->s_name ? x->x_bindsym : gensym("text"));
+    /* set up a scalar and a pointer to it that we can output */
     x->x_scalar = scalar_new(canvas_getcurrent(), gensym("pd-text"));
     binbuf_free(x->x_scalar->sc_vec[2].w_binbuf);
     x->x_scalar->sc_vec[2].w_binbuf = x->x_binbuf;
@@ -290,12 +299,12 @@ static void *text_define_new(t_symbol *s, int argc, t_atom *argv)
     x->x_notifyout = outlet_new(&x->x_ob, 0);
     gpointer_init(&x->x_gp);
     x->x_canvas = canvas_getcurrent();
-           /* bashily unbind #A -- this would create garbage if #A were
-           multiply bound but we believe in this context it's at most
-           bound to whichever text_define or array was created most recently */
+    /* bashily unbind #A -- this would create garbage if #A were
+    multiply bound but we believe in this context it's at most
+    bound to whichever text_define or array was created most recently */
     asym->s_thing = 0;
-        /* and now bind #A to us to receive following messages in the
-        saved file or copy buffer */
+    /* and now bind #A to us to receive following messages in the
+    saved file or copy buffer */
     pd_bind(&x->x_ob.ob_pd, asym);
     return (x);
 }
@@ -306,18 +315,18 @@ static void text_define_clear(t_text_define *x)
     textbuf_senditup(&x->x_textbuf);
 }
 
-    /* from g_traversal.c - maybe put in a header? */
-t_binbuf *pointertobinbuf(t_pd *x, t_gpointer *gp, t_symbol *s,
-    const char *fname);
+/* from g_traversal.c - maybe put in a header? */
+t_binbuf *pointertobinbuf(
+    t_pd *x, t_gpointer *gp, t_symbol *s, const char *fname);
 
-    /* these are unused; they copy text from this object to and from a text
-        field in a scalar. */
-static void text_define_frompointer(t_text_define *x, t_gpointer *gp,
-    t_symbol *s)
+/* these are unused; they copy text from this object to and from a text
+    field in a scalar. */
+static void text_define_frompointer(
+    t_text_define *x, t_gpointer *gp, t_symbol *s)
 {
-    t_binbuf *b = pointertobinbuf(&x->x_textbuf.b_ob.ob_pd,
-        gp, s, "text_frompointer");
-    if (b)
+    t_binbuf *b =
+        pointertobinbuf(&x->x_textbuf.b_ob.ob_pd, gp, s, "text_frompointer");
+    if(b)
     {
         binbuf_clear(x->x_textbuf.b_binbuf);
         binbuf_add(x->x_textbuf.b_binbuf, binbuf_getnatom(b), binbuf_getvec(b));
@@ -326,20 +335,20 @@ static void text_define_frompointer(t_text_define *x, t_gpointer *gp,
 
 static void text_define_topointer(t_text_define *x, t_gpointer *gp, t_symbol *s)
 {
-    t_binbuf *b = pointertobinbuf(&x->x_textbuf.b_ob.ob_pd,
-        gp, s, "text_topointer");
-    if (b)
+    t_binbuf *b =
+        pointertobinbuf(&x->x_textbuf.b_ob.ob_pd, gp, s, "text_topointer");
+    if(b)
     {
         t_gstub *gs = gp->gp_stub;
         binbuf_clear(b);
         binbuf_add(b, binbuf_getnatom(x->x_textbuf.b_binbuf),
             binbuf_getvec(x->x_textbuf.b_binbuf));
-        if (gs->gs_which == GP_GLIST)
+        if(gs->gs_which == GP_GLIST)
             scalar_redraw(gp->gp_un.gp_scalar, gs->gs_un.gs_glist);
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
-            while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+            while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
                 owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
             scalar_redraw(owner_array->a_gp.gp_un.gp_scalar,
                 owner_array->a_gp.gp_stub->gs_un.gs_glist);
@@ -347,14 +356,14 @@ static void text_define_topointer(t_text_define *x, t_gpointer *gp, t_symbol *s)
     }
 }
 
-    /* bang: output a pointer to a struct containing this text */
+/* bang: output a pointer to a struct containing this text */
 void text_define_bang(t_text_define *x)
 {
     gpointer_setglist(&x->x_gp, x->x_canvas, x->x_scalar);
     outlet_pointer(x->x_out, &x->x_gp);
 }
 
-    /* set from a list */
+/* set from a list */
 void text_define_set(t_text_define *x, t_symbol *s, int argc, t_atom *argv)
 {
     binbuf_clear(x->x_binbuf);
@@ -364,12 +373,12 @@ void text_define_set(t_text_define *x, t_symbol *s, int argc, t_atom *argv)
 
 static void text_define_save(t_gobj *z, t_binbuf *bb)
 {
-    t_text_define *x = (t_text_define *)z;
-    binbuf_addv(bb, "ssff", &s__X, gensym("obj"),
-        (float)x->x_ob.te_xpix, (float)x->x_ob.te_ypix);
+    t_text_define *x = (t_text_define *) z;
+    binbuf_addv(bb, "ssff", &s__X, gensym("obj"), (float) x->x_ob.te_xpix,
+        (float) x->x_ob.te_ypix);
     binbuf_addbinbuf(bb, x->x_ob.ob_binbuf);
     binbuf_addsemi(bb);
-    if (x->x_keep)
+    if(x->x_keep)
     {
         binbuf_addv(bb, "ss", gensym("#A"), gensym("set"));
         binbuf_addbinbuf(bb, x->x_binbuf);
@@ -378,11 +387,11 @@ static void text_define_save(t_gobj *z, t_binbuf *bb)
     obj_saveformat(&x->x_ob, bb);
 }
 
-    /* send a pointer to the scalar that owns this text to
-    whomever is bound to the given symbol */
+/* send a pointer to the scalar that owns this text to
+whomever is bound to the given symbol */
 static void text_define_send(t_text_define *x, t_symbol *s)
 {
-    if (!s->s_thing)
+    if(!s->s_thing)
         pd_error(x, "text_define_send: %s: no such object", s->s_name);
     else
     {
@@ -397,67 +406,68 @@ typedef struct _keyinfo
     int ki_onset;   /* number of fields to skip over */
 } t_keyinfo;
 
-    /* apple products seem to have their own prototypes for qsort_r (?) */
+/* apple products seem to have their own prototypes for qsort_r (?) */
 #ifdef __APPLE__
 static int text_sortcompare(void *zkeyinfo, const void *z1, const void *z2)
 #else
 static int text_sortcompare(const void *z1, const void *z2, void *zkeyinfo)
 #endif
 {
-    const t_atom *a1 = *(t_atom **)z1, *a2 = *(t_atom **)z2;
-    t_keyinfo *k = (t_keyinfo *)zkeyinfo;
+    const t_atom *a1 = *(t_atom **) z1, *a2 = *(t_atom **) z2;
+    t_keyinfo *k = (t_keyinfo *) zkeyinfo;
     int count;
-        /* advance first line by key onset and react if we run out early */
-    for (count = k->ki_onset; count--; a1++)
+    /* advance first line by key onset and react if we run out early */
+    for(count = k->ki_onset; count--; a1++)
     {
-        if (a1->a_type == A_SEMI || a1->a_type == A_COMMA)
+        if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
         {
-                /* if second line runs out early too consider them equal */
-            for (count = k->ki_onset; count--; a2++)
-                if (a2->a_type == A_SEMI || a2->a_type == A_COMMA)
-                    goto equal;
+            /* if second line runs out early too consider them equal */
+            for(count = k->ki_onset; count--; a2++)
+                if(a2->a_type == A_SEMI || a2->a_type == A_COMMA) goto equal;
             return (-k->ki_forward);
         }
     }
-    for (count = k->ki_onset; count--; a2++)
-        if (a2->a_type == A_SEMI || a2->a_type == A_COMMA)
+    for(count = k->ki_onset; count--; a2++)
+        if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
             return (-k->ki_forward);
-        /* compare remaining fields */
-    for (; ; a1++, a2++)
+    /* compare remaining fields */
+    for(;; a1++, a2++)
     {
-        if (a1->a_type == A_SEMI || a1->a_type == A_COMMA)
+        if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
         {
-                /* hit end of first line */
-            if (a2->a_type == A_SEMI || a2->a_type == A_COMMA)
-                 goto equal;
-            else return (-k->ki_forward);
+            /* hit end of first line */
+            if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
+                goto equal;
+            else
+                return (-k->ki_forward);
         }
-        else if (a2->a_type == A_SEMI || a2->a_type == A_COMMA)
+        else if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
             return (k->ki_forward); /* hit end of second line */
 
-            /* otherwise if they're different return something, and
-            if not proceed to next field */
-        else if (a1->a_type == A_FLOAT)
+        /* otherwise if they're different return something, and
+        if not proceed to next field */
+        else if(a1->a_type == A_FLOAT)
         {
-            if (a2->a_type == A_FLOAT)
+            if(a2->a_type == A_FLOAT)
             {
-                if (a1->a_w.w_float < a2->a_w.w_float)
+                if(a1->a_w.w_float < a2->a_w.w_float)
                     return (-k->ki_forward);
-                else if (a1->a_w.w_float > a2->a_w.w_float)
+                else if(a1->a_w.w_float > a2->a_w.w_float)
                     return (k->ki_forward);
             }
-            else return (-k->ki_forward);
+            else
+                return (-k->ki_forward);
         }
-        else if (a1->a_type == A_SYMBOL)
+        else if(a1->a_type == A_SYMBOL)
         {
-            if (a2->a_type == A_SYMBOL)
+            if(a2->a_type == A_SYMBOL)
             {
-                int z = strcmp(a1->a_w.w_symbol->s_name,
-                    a2->a_w.w_symbol->s_name);
-                if (z)
-                    return (z * k->ki_forward);
+                int z =
+                    strcmp(a1->a_w.w_symbol->s_name, a2->a_w.w_symbol->s_name);
+                if(z) return (z * k->ki_forward);
             }
-            else return (k->ki_forward);
+            else
+                return (k->ki_forward);
         }
     }
 equal:
@@ -465,11 +475,11 @@ equal:
     in this case compare pointers so that "equal" lines (which
     might not be identical because of a nonzero onset) stay in the
     same order as before. */
-    if (a1 < a2)
+    if(a1 < a2)
         return (-1);
-    else return (1);
+    else
+        return (1);
 }
-
 
 /* 'qsort_r' is a GNU extension and 'qsort_s' is part of C11.
  * Both are not available in Emscripten, Android or older MSVC versions.
@@ -481,69 +491,68 @@ equal:
 
 #ifdef STUPID_SORT
 static PERTHREAD void *stupid_zkeyinfo;
+
 static int stupid_sortcompare(const void *z1, const void *z2)
 {
     return (text_sortcompare(z1, z2, stupid_zkeyinfo));
 }
 #endif
 
-    /* sort the contents */
-static void text_define_sort(t_text_define *x, t_symbol *s,
-    int argc, t_atom *argv)
+/* sort the contents */
+static void text_define_sort(
+    t_text_define *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int nlines = 0, unique = 0,  natom = binbuf_getnatom(x->x_binbuf), i,
+    int nlines = 0, unique = 0, natom = binbuf_getnatom(x->x_binbuf), i,
         thisline, startline;
     t_atom *vec = binbuf_getvec(x->x_binbuf), **sortbuf, *a1, *a2;
     t_binbuf *newb;
     t_keyinfo k;
     k.ki_forward = 1;
     k.ki_onset = 0;
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-u"))
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-u"))
             unique = 1;
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-r"))
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-r"))
             k.ki_forward = -1;
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-k")  && argc > 1
-            && argv[1].a_type == A_FLOAT)
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-k") && argc > 1 &&
+                argv[1].a_type == A_FLOAT)
         {
-            if ((k.ki_onset = argv[1].a_w.w_float) < 0)
-                k.ki_onset = 0;
-            argc--; argv++;
+            if((k.ki_onset = argv[1].a_w.w_float) < 0) k.ki_onset = 0;
+            argc--;
+            argv++;
         }
         else
         {
             pd_error(x, "text define sort: unknown flag ...");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text define sort ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (!natom)
-        return;
-            /* last thing in buffer should be a terminator */
-    if (vec[natom-1].a_type != A_SEMI &&
-        vec[natom-1].a_type != A_COMMA)
-            binbuf_addsemi(x->x_binbuf),
-                vec = binbuf_getvec(x->x_binbuf),
-                    natom = binbuf_getnatom(x->x_binbuf),
-                        nlines++;
-    for (i = nlines = 0; i < natom; i++)
-        if (vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA)
-            nlines++;
-    sortbuf = (t_atom **)getbytes(nlines * sizeof(*sortbuf));
-    for (i = thisline = 0, startline = 1; i < natom; i++)
+    if(!natom) return;
+    /* last thing in buffer should be a terminator */
+    if(vec[natom - 1].a_type != A_SEMI && vec[natom - 1].a_type != A_COMMA)
+        binbuf_addsemi(x->x_binbuf), vec = binbuf_getvec(x->x_binbuf),
+                                     natom = binbuf_getnatom(x->x_binbuf),
+                                     nlines++;
+    for(i = nlines = 0; i < natom; i++)
+        if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA) nlines++;
+    sortbuf = (t_atom **) getbytes(nlines * sizeof(*sortbuf));
+    for(i = thisline = 0, startline = 1; i < natom; i++)
     {
-        if (startline)
+        if(startline)
         {
-            if (thisline >= nlines)
-                bug("text_define_sort");
-            sortbuf[thisline++] = vec+i;
+            if(thisline >= nlines) bug("text_define_sort");
+            sortbuf[thisline++] = vec + i;
         }
         startline = (vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA);
     }
@@ -553,37 +562,38 @@ static void text_define_sort(t_text_define *x, t_symbol *s,
 #else
 #ifdef __APPLE__
     qsort_r(sortbuf, nlines, sizeof(*sortbuf), &k, text_sortcompare);
-#else /* __APPLE__ */
+#else  /* __APPLE__ */
     qsort_r(sortbuf, nlines, sizeof(*sortbuf), text_sortcompare, &k);
 #endif /* __APPLE__ */
 #endif /* STUPID_SORT */
     newb = binbuf_new();
-    for (thisline = 0; thisline < nlines; thisline++)
+    for(thisline = 0; thisline < nlines; thisline++)
     {
-        if (unique && thisline > 0)   /* check for duplicates */
+        if(unique && thisline > 0) /* check for duplicates */
         {
-            for (a1 = sortbuf[thisline-1], a2 = sortbuf[thisline]; ; a1++, a2++)
+            for(a1 = sortbuf[thisline - 1], a2 = sortbuf[thisline];; a1++, a2++)
             {
-                if (a1->a_type == A_SEMI || a1->a_type == A_COMMA)
+                if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
                 {
-                    if (a1->a_type == a2->a_type)
+                    if(a1->a_type == a2->a_type)
                         goto skipit; /* duplicate line, don't copy */
-                    else goto doit;
+                    else
+                        goto doit;
                 }
-                else if (a1->a_type != a2->a_type ||
-                    (a1->a_type == A_FLOAT &&
-                        a1->a_w.w_float != a2->a_w.w_float) ||
-                    (a1->a_type == A_SYMBOL &&
-                        a1->a_w.w_symbol != a2->a_w.w_symbol))
-                            goto doit;
+                else if(a1->a_type != a2->a_type ||
+                        (a1->a_type == A_FLOAT &&
+                            a1->a_w.w_float != a2->a_w.w_float) ||
+                        (a1->a_type == A_SYMBOL &&
+                            a1->a_w.w_symbol != a2->a_w.w_symbol))
+                    goto doit;
             }
         }
     doit:
-        for (i = 0, a1 = sortbuf[thisline];
+        for(i = 0, a1 = sortbuf[thisline];
             a1->a_type != A_SEMI && a1->a_type != A_COMMA; i++, a1++)
-                ;
-        binbuf_add(newb, i+1, sortbuf[thisline]);
-    skipit: ;
+            ;
+        binbuf_add(newb, i + 1, sortbuf[thisline]);
+    skipit:;
     }
     binbuf_free(x->x_binbuf);
     x->x_scalar->sc_vec[2].w_binbuf = x->x_binbuf = newb;
@@ -591,7 +601,7 @@ static void text_define_sort(t_text_define *x, t_symbol *s,
     textbuf_senditup(&x->x_textbuf);
 }
 
-    /* notification from GUI that we've been updated */
+/* notification from GUI that we've been updated */
 static void text_define_notify(t_text_define *x)
 {
     outlet_anything(x->x_notifyout, gensym("updated"), 0, 0);
@@ -602,8 +612,7 @@ static void text_define_free(t_text_define *x)
 {
     x->x_binbuf = 0; /* prevent double deletion */
     textbuf_free(&x->x_textbuf);
-    if (x->x_bindsym != &s_)
-        pd_unbind(&x->x_ob.ob_pd, x->x_bindsym);
+    if(x->x_bindsym != &s_) pd_unbind(&x->x_ob.ob_pd, x->x_bindsym);
     gpointer_unset(&x->x_gp);
     /* deleting the scalar will automatically free the binbuf */
     pd_free(&x->x_scalar->sc_gobj.g_pd);
@@ -621,120 +630,124 @@ typedef struct _text_client
     t_symbol *tc_field;
 } t_text_client;
 
-    /* parse buffer-finding arguments */
-static void text_client_argparse(t_text_client *x, int *argcp, t_atom **argvp,
-    char *name)
+/* parse buffer-finding arguments */
+static void text_client_argparse(
+    t_text_client *x, int *argcp, t_atom **argvp, char *name)
 {
     int argc = *argcp;
     t_atom *argv = *argvp;
     x->tc_sym = x->tc_struct = x->tc_field = 0;
     gpointer_init(&x->tc_gp);
-    if (argc && argv->a_type == A_SYMBOL &&
+    if(argc && argv->a_type == A_SYMBOL &&
         !strcmp(argv->a_w.w_symbol->s_name, "-s"))
     {
-        if (argc < 3 || argv[1].a_type != A_SYMBOL ||
-            argv[2].a_type != A_SYMBOL)
-                pd_error(x, "%s: '-s' needs a struct and field name", name);
+        if(argc < 3 || argv[1].a_type != A_SYMBOL || argv[2].a_type != A_SYMBOL)
+            pd_error(x, "%s: '-s' needs a struct and field name", name);
         else
         {
             x->tc_struct = canvas_makebindsym(argv[1].a_w.w_symbol);
             x->tc_field = argv[2].a_w.w_symbol;
-            argc -= 3; argv += 3;
+            argc -= 3;
+            argv += 3;
         }
     }
-    else if (argc && argv->a_type == A_SYMBOL)
+    else if(argc && argv->a_type == A_SYMBOL)
     {
         x->tc_sym = argv->a_w.w_symbol;
-        argc--; argv++;
+        argc--;
+        argv++;
     }
     *argcp = argc;
     *argvp = argv;
 }
 
-    /* find the binbuf for this object.  This should be reusable for other
-    objects.  Prints an error  message and returns 0 on failure. */
+/* find the binbuf for this object.  This should be reusable for other
+objects.  Prints an error  message and returns 0 on failure. */
 static t_binbuf *text_client_getbuf(t_text_client *x)
 {
-    if (x->tc_sym)       /* named text object */
+    if(x->tc_sym) /* named text object */
     {
-        t_textbuf *y = (t_textbuf *)pd_findbyclass(x->tc_sym,
-            text_define_class);
-        if (y)
+        t_textbuf *y =
+            (t_textbuf *) pd_findbyclass(x->tc_sym, text_define_class);
+        if(y)
             return (y->b_binbuf);
         else
         {
-            pd_error(x, "text: couldn't find text buffer '%s'",
-                x->tc_sym->s_name);
+            pd_error(
+                x, "text: couldn't find text buffer '%s'", x->tc_sym->s_name);
             return (0);
         }
     }
-    else if (x->tc_struct)   /* by pointer */
+    else if(x->tc_struct) /* by pointer */
     {
         t_template *template = template_findbyname(x->tc_struct);
         t_gstub *gs = x->tc_gp.gp_stub;
         t_word *vec;
         int onset, type;
         t_symbol *arraytype;
-        if (!template)
+        if(!template)
         {
             pd_error(x, "text: couldn't find struct %s", x->tc_struct->s_name);
             return (0);
         }
-        if (!gpointer_check(&x->tc_gp, 0))
+        if(!gpointer_check(&x->tc_gp, 0))
         {
             pd_error(x, "text: stale or empty pointer");
             return (0);
         }
-        if (gs->gs_which == GP_ARRAY)
+        if(gs->gs_which == GP_ARRAY)
             vec = x->tc_gp.gp_un.gp_w;
-        else vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
+        else
+            vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
 
-        if (!template_find_field(template,
-            x->tc_field, &onset, &type, &arraytype))
+        if(!template_find_field(
+               template, x->tc_field, &onset, &type, &arraytype))
         {
             pd_error(x, "text: no field named %s", x->tc_field->s_name);
             return (0);
         }
-        if (type != DT_TEXT)
+        if(type != DT_TEXT)
         {
             pd_error(x, "text: field %s not of type text", x->tc_field->s_name);
             return (0);
         }
-        return (*(t_binbuf **)(((char *)vec) + onset));
+        return (*(t_binbuf **) (((char *) vec) + onset));
     }
-    else return (0);    /* shouldn't happen */
+    else
+        return (0); /* shouldn't happen */
 }
 
-static  void text_client_senditup(t_text_client *x)
+static void text_client_senditup(t_text_client *x)
 {
-    if (x->tc_sym)       /* named text object */
+    if(x->tc_sym) /* named text object */
     {
-        t_textbuf *y = (t_textbuf *)pd_findbyclass(x->tc_sym,
-            text_define_class);
-        if (y)
+        t_textbuf *y =
+            (t_textbuf *) pd_findbyclass(x->tc_sym, text_define_class);
+        if(y)
             textbuf_senditup(y);
-        else bug("text_client_senditup");
+        else
+            bug("text_client_senditup");
     }
-    else if (x->tc_struct)   /* by pointer */
+    else if(x->tc_struct) /* by pointer */
     {
         t_template *template = template_findbyname(x->tc_struct);
         t_gstub *gs = x->tc_gp.gp_stub;
-        if (!template)
+        if(!template)
         {
             pd_error(x, "text: couldn't find struct %s", x->tc_struct->s_name);
             return;
         }
-        if (!gpointer_check(&x->tc_gp, 0))
+        if(!gpointer_check(&x->tc_gp, 0))
         {
             pd_error(x, "text: stale or empty pointer");
             return;
         }
-        if (gs->gs_which == GP_GLIST)
+        if(gs->gs_which == GP_GLIST)
             scalar_redraw(x->tc_gp.gp_un.gp_scalar, gs->gs_un.gs_glist);
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
-            while (owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
+            while(owner_array->a_gp.gp_stub->gs_which == GP_ARRAY)
                 owner_array = owner_array->a_gp.gp_stub->gs_un.gs_array;
             scalar_redraw(owner_array->a_gp.gp_un.gp_scalar,
                 owner_array->a_gp.gp_stub->gs_un.gs_glist);
@@ -742,10 +755,7 @@ static  void text_client_senditup(t_text_client *x)
     }
 }
 
-static void text_client_free(t_text_client *x)
-{
-    gpointer_unset(&x->tc_gp);
-}
+static void text_client_free(t_text_client *x) { gpointer_unset(&x->tc_gp); }
 
 /* ------- text_get object - output all or part of nth lines ----------- */
 t_class *text_get_class;
@@ -753,10 +763,10 @@ t_class *text_get_class;
 typedef struct _text_get
 {
     t_text_client x_tc;
-    t_outlet *x_out1;       /* list */
-    t_outlet *x_out2;       /* 1 if comma terminated, 0 if semi, 2 if none */
-    t_float x_f1;           /* field number, -1 for whole line */
-    t_float x_f2;           /* number of fields */
+    t_outlet *x_out1; /* list */
+    t_outlet *x_out2; /* 1 if comma terminated, 0 if semi, 2 if none */
+    t_float x_f1;     /* field number, -1 for whole line */
+    t_float x_f2;     /* number of fields */
 } t_text_get;
 
 #define x_obj x_tc.tc_obj
@@ -767,7 +777,7 @@ typedef struct _text_get
 
 static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_get *x = (t_text_get *)pd_new(text_get_class);
+    t_text_get *x = (t_text_get *) pd_new(text_get_class);
     x->x_out1 = outlet_new(&x->x_obj, &s_list);
     x->x_out2 = outlet_new(&x->x_obj, &s_float);
     floatinlet_new(&x->x_obj, &x->x_f1);
@@ -775,36 +785,42 @@ static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
     x->x_f1 = -1;
     x->x_f2 = 1;
     text_client_argparse(&x->x_tc, &argc, &argv, "text get");
-    if (argc)
+    if(argc)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             x->x_f1 = argv->a_w.w_float;
         else
         {
             post("text get: can't understand field number");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             x->x_f2 = argv->a_w.w_float;
         else
         {
             post("text get: can't understand field count");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text get ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
@@ -813,44 +829,43 @@ static void text_get_float(t_text_get *x, t_floatarg f)
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int start, end, n, startfield, nfield;
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
     startfield = x->x_f1;
     nfield = x->x_f2;
-    if (text_nthline(n, vec, f, &start, &end))
+    if(text_nthline(n, vec, f, &start, &end))
     {
         int outc = end - start, k;
         t_atom *outv;
-        if (x->x_f1 < 0)    /* negative start field for whole line */
+        if(x->x_f1 < 0) /* negative start field for whole line */
         {
-                /* tell us what terminated the line (semi or comma) */
+            /* tell us what terminated the line (semi or comma) */
             outlet_float(x->x_out2, (end < n && vec[end].a_type == A_COMMA));
             ATOMS_ALLOCA(outv, outc);
-            for (k = 0; k < outc; k++)
-                outv[k] = vec[start+k];
+            for(k = 0; k < outc; k++)
+                outv[k] = vec[start + k];
             outlet_list(x->x_out1, 0, outc, outv);
             ATOMS_FREEA(outv, outc);
         }
-        else if (startfield + nfield > outc)
+        else if(startfield + nfield > outc)
             pd_error(x, "text get: field request (%d %d) out of range",
                 startfield, nfield);
-        else if (nfield < 0)
+        else if(nfield < 0)
             pd_error(x, "text get: bad field count (%d)", nfield);
         else
         {
             ATOMS_ALLOCA(outv, nfield);
-            for (k = 0; k < nfield; k++)
-                outv[k] = vec[(start+startfield)+k];
+            for(k = 0; k < nfield; k++)
+                outv[k] = vec[(start + startfield) + k];
             outlet_list(x->x_out1, 0, nfield, outv);
             ATOMS_FREEA(outv, nfield);
         }
     }
-    else if (x->x_f1 < 0)   /* whole line but out of range: empty list and 2 */
+    else if(x->x_f1 < 0) /* whole line but out of range: empty list and 2 */
     {
-        outlet_float(x->x_out2, 2);         /* 2 for out of range */
-        outlet_list(x->x_out1, 0, 0, 0);    /* ... and empty list */
+        outlet_float(x->x_out2, 2);      /* 2 for out of range */
+        outlet_list(x->x_out1, 0, 0, 0); /* ... and empty list */
     }
 }
 
@@ -858,124 +873,127 @@ static void text_get_float(t_text_get *x, t_floatarg f)
 typedef struct _text_set
 {
     t_text_client x_tc;
-    t_float x_f1;           /* line number */
-    t_float x_f2;           /* field number, -1 for whole line */
+    t_float x_f1; /* line number */
+    t_float x_f2; /* field number, -1 for whole line */
 } t_text_set;
 
 t_class *text_set_class;
 
 static void *text_set_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_set *x = (t_text_set *)pd_new(text_set_class);
+    t_text_set *x = (t_text_set *) pd_new(text_set_class);
     floatinlet_new(&x->x_obj, &x->x_f1);
     floatinlet_new(&x->x_obj, &x->x_f2);
     x->x_f1 = 0;
     x->x_f2 = -1;
     text_client_argparse(&x->x_tc, &argc, &argv, "text set");
-    if (argc)
+    if(argc)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             x->x_f1 = argv->a_w.w_float;
         else
         {
             post("text set: can't understand line number");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             x->x_f2 = argv->a_w.w_float;
         else
         {
             post("text set: can't understand field number");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text set ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
-static void text_set_list(t_text_set *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int start, end, n, fieldno = x->x_f2, i,
-            /* check for overflow in this conversion: */
-        lineno = (x->x_f1 > (double)0x7fffffff ? 0x7fffffff : (int)x->x_f1);
+                       /* check for overflow in this conversion: */
+        lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (lineno < 0)
+    if(lineno < 0)
     {
         pd_error(x, "text set: line number (%d) < 0", lineno);
         return;
     }
-    if (text_nthline(n, vec, lineno, &start, &end))
+    if(text_nthline(n, vec, lineno, &start, &end))
     {
-        if (fieldno < 0)
+        if(fieldno < 0)
         {
-            if (end - start != argc)  /* grow or shrink */
+            if(end - start != argc) /* grow or shrink */
             {
                 int oldn = n;
-                n = n + (argc - (end-start));
-                if (n > oldn)
-                    (void)binbuf_resize(b, n);
+                n = n + (argc - (end - start));
+                if(n > oldn) (void) binbuf_resize(b, n);
                 vec = binbuf_getvec(b);
-                memmove(&vec[start + argc], &vec[end],
-                    sizeof(*vec) * (oldn - end));
-                if (n < oldn)
+                memmove(
+                    &vec[start + argc], &vec[end], sizeof(*vec) * (oldn - end));
+                if(n < oldn)
                 {
-                    (void)binbuf_resize(b, n);
+                    (void) binbuf_resize(b, n);
                     vec = binbuf_getvec(b);
                 }
             }
         }
         else
         {
-            if (fieldno >= end - start)
+            if(fieldno >= end - start)
             {
-                pd_error(x, "text set: field number (%d) past end of line",
-                    fieldno);
+                pd_error(
+                    x, "text set: field number (%d) past end of line", fieldno);
                 return;
             }
-            if (fieldno + argc > end - start)
-                argc = (end - start) - fieldno;
+            if(fieldno + argc > end - start) argc = (end - start) - fieldno;
             start += fieldno;
         }
     }
-    else if (fieldno < 0)  /* if line number too high just append to end */
+    else if(fieldno < 0) /* if line number too high just append to end */
     {
-        int addsemi = (n && vec[n-1].a_type != A_SEMI &&
-            vec[n-1].a_type != A_COMMA), newsize = n + addsemi + argc + 1;
-        (void)binbuf_resize(b, newsize);
+        int addsemi = (n && vec[n - 1].a_type != A_SEMI &&
+                       vec[n - 1].a_type != A_COMMA),
+            newsize = n + addsemi + argc + 1;
+        (void) binbuf_resize(b, newsize);
         vec = binbuf_getvec(b);
-        if (addsemi)
-            SETSEMI(&vec[n]);
-        SETSEMI(&vec[newsize-1]);
-        start = n+addsemi;
+        if(addsemi) SETSEMI(&vec[n]);
+        SETSEMI(&vec[newsize - 1]);
+        start = n + addsemi;
     }
     else
     {
         post("text set: %d: line number out of range", lineno);
         return;
     }
-    for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
     {
-        if (argv[i].a_type == A_POINTER)
-            SETSYMBOL(&vec[start+i], gensym("(pointer)"));
-        else vec[start+i] = argv[i];
+        if(argv[i].a_type == A_POINTER)
+            SETSYMBOL(&vec[start + i], gensym("(pointer)"));
+        else
+            vec[start + i] = argv[i];
     }
     text_client_senditup(&x->x_tc);
 }
@@ -984,68 +1002,73 @@ static void text_set_list(t_text_set *x,
 typedef struct _text_insert
 {
     t_text_client x_tc;
-    t_float x_f1;           /* line number */
+    t_float x_f1; /* line number */
 } t_text_insert;
 
 t_class *text_insert_class;
 
 static void *text_insert_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_insert *x = (t_text_insert *)pd_new(text_insert_class);
+    t_text_insert *x = (t_text_insert *) pd_new(text_insert_class);
     floatinlet_new(&x->x_obj, &x->x_f1);
     x->x_f1 = 0;
     text_client_argparse(&x->x_tc, &argc, &argv, "text insert");
-    if (argc)
+    if(argc)
     {
-        if (argv->a_type == A_FLOAT)
+        if(argv->a_type == A_FLOAT)
             x->x_f1 = argv->a_w.w_float;
         else
         {
             post("text insert: can't understand line number");
-            postatom(argc, argv); endpost();
+            postatom(argc, argv);
+            endpost();
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text insert ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
-static void text_insert_list(t_text_insert *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void text_insert_list(
+    t_text_insert *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int start, end, n, nwas, i,
-         lineno = (x->x_f1 > (double)0x7fffffff ? 0x7fffffff : (int)x->x_f1);
+        lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
 
     t_atom *vec;
-    if (!b)
-       return;
-    if (lineno < 0)
+    if(!b) return;
+    if(lineno < 0)
     {
         pd_error(x, "text insert: line number (%d) < 0", lineno);
         return;
     }
     nwas = binbuf_getnatom(b);
-    if (!text_nthline(nwas, binbuf_getvec(b), lineno, &start, &end))
+    if(!text_nthline(nwas, binbuf_getvec(b), lineno, &start, &end))
         start = nwas;
-    (void)binbuf_resize(b, (n = nwas + argc + 1));
+    (void) binbuf_resize(b, (n = nwas + argc + 1));
     vec = binbuf_getvec(b);
-    if (start < n)
-        memmove(&vec[start+(argc+1)], &vec[start], sizeof(*vec) * (nwas-start));
-    for (i = 0; i < argc; i++)
+    if(start < n)
+        memmove(&vec[start + (argc + 1)], &vec[start],
+            sizeof(*vec) * (nwas - start));
+    for(i = 0; i < argc; i++)
     {
-        if (argv[i].a_type == A_POINTER)
-            SETSYMBOL(&vec[start+i], gensym("(pointer)"));
-        else vec[start+i] = argv[i];
+        if(argv[i].a_type == A_POINTER)
+            SETSYMBOL(&vec[start + i], gensym("(pointer)"));
+        else
+            vec[start + i] = argv[i];
     }
-    SETSEMI(&vec[start+argc]);
+    SETSEMI(&vec[start + argc]);
     text_client_senditup(&x->x_tc);
 }
 
@@ -1059,37 +1082,36 @@ t_class *text_delete_class;
 
 static void *text_delete_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_delete *x = (t_text_delete *)pd_new(text_delete_class);
+    t_text_delete *x = (t_text_delete *) pd_new(text_delete_class);
     text_client_argparse(&x->x_tc, &argc, &argv, "text delete");
-    if (argc)
+    if(argc)
     {
         post("warning: text delete ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
 static void text_delete_float(t_text_delete *x, t_floatarg f)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int start, end, n,
-         lineno = (f > (double)0x7fffffff ? 0x7fffffff : f);
+    int start, end, n, lineno = (f > (double) 0x7fffffff ? 0x7fffffff : f);
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (lineno < 0)
+    if(lineno < 0)
         binbuf_clear(b);
-    else if (text_nthline(n, vec, lineno, &start, &end))
+    else if(text_nthline(n, vec, lineno, &start, &end))
     {
-        if (end < n)
-            end++;
+        if(end < n) end++;
         memmove(&vec[start], &vec[end], sizeof(*vec) * (n - end));
-        (void)binbuf_resize(b, n - (end - start));
+        (void) binbuf_resize(b, n - (end - start));
     }
     else
     {
@@ -1105,22 +1127,24 @@ t_class *text_size_class;
 typedef struct _text_size
 {
     t_text_client x_tc;
-    t_outlet *x_out1;       /* float */
+    t_outlet *x_out1; /* float */
 } t_text_size;
 
 static void *text_size_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_size *x = (t_text_size *)pd_new(text_size_class);
+    t_text_size *x = (t_text_size *) pd_new(text_size_class);
     x->x_out1 = outlet_new(&x->x_obj, &s_float);
     text_client_argparse(&x->x_tc, &argc, &argv, "text size");
-    if (argc)
+    if(argc)
     {
         post("warning: text size ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
@@ -1129,17 +1153,14 @@ static void text_size_bang(t_text_size *x)
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n, i, cnt = 0;
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    for (i = 0; i < n; i++)
+    for(i = 0; i < n; i++)
     {
-        if (vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA)
-            cnt++;
+        if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA) cnt++;
     }
-    if (n && vec[n-1].a_type != A_SEMI && vec[n-1].a_type != A_COMMA)
-        cnt++;
+    if(n && vec[n - 1].a_type != A_SEMI && vec[n - 1].a_type != A_COMMA) cnt++;
     outlet_float(x->x_out1, cnt);
 }
 
@@ -1148,13 +1169,13 @@ static void text_size_float(t_text_size *x, t_floatarg f)
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int start, end, n;
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (text_nthline(n, vec, f, &start, &end))
-        outlet_float(x->x_out1, end-start);
-    else outlet_float(x->x_out1, -1);
+    if(text_nthline(n, vec, f, &start, &end))
+        outlet_float(x->x_out1, end - start);
+    else
+        outlet_float(x->x_out1, -1);
 }
 
 /* ---------------- text_tolist object - output text as a list ----------- */
@@ -1164,25 +1185,26 @@ t_class *text_tolist_class;
 
 static void *text_tolist_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_tolist *x = (t_text_tolist *)pd_new(text_tolist_class);
+    t_text_tolist *x = (t_text_tolist *) pd_new(text_tolist_class);
     outlet_new(&x->tc_obj, &s_list);
     text_client_argparse(x, &argc, &argv, "text tolist");
-    if (argc)
+    if(argc)
     {
         post("warning: text tolist ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->tc_struct)
+    if(x->tc_struct)
         pointerinlet_new(&x->tc_obj, &x->tc_gp);
-    else symbolinlet_new(&x->tc_obj, &x->tc_sym);
+    else
+        symbolinlet_new(&x->tc_obj, &x->tc_sym);
     return (x);
 }
 
 static void text_tolist_bang(t_text_tolist *x)
 {
     t_binbuf *b = text_client_getbuf(x), *b2;
-    if (!b)
-       return;
+    if(!b) return;
     b2 = binbuf_new();
     binbuf_addbinbuf(b2, b);
     outlet_list(x->tc_obj.ob_outlet, 0, binbuf_getnatom(b2), binbuf_getvec(b2));
@@ -1196,25 +1218,26 @@ t_class *text_fromlist_class;
 
 static void *text_fromlist_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_fromlist *x = (t_text_fromlist *)pd_new(text_fromlist_class);
+    t_text_fromlist *x = (t_text_fromlist *) pd_new(text_fromlist_class);
     text_client_argparse(x, &argc, &argv, "text fromlist");
-    if (argc)
+    if(argc)
     {
         post("warning: text fromlist ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->tc_struct)
+    if(x->tc_struct)
         pointerinlet_new(&x->tc_obj, &x->tc_gp);
-    else symbolinlet_new(&x->tc_obj, &x->tc_sym);
+    else
+        symbolinlet_new(&x->tc_obj, &x->tc_sym);
     return (x);
 }
 
-static void text_fromlist_list(t_text_fromlist *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void text_fromlist_list(
+    t_text_fromlist *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(x);
-    if (!b)
-       return;
+    if(!b) return;
     binbuf_clear(b);
     binbuf_restore(b, argc, argv);
     text_client_senditup(x);
@@ -1224,13 +1247,13 @@ static void text_fromlist_list(t_text_fromlist *x,
 
 t_class *text_search_class;
 
-    /* relations we can test when searching: */
-#define KB_EQ 0     /*  equal */
-#define KB_GT 1     /* > (etc..) */
+/* relations we can test when searching: */
+#define KB_EQ 0 /*  equal */
+#define KB_GT 1 /* > (etc..) */
 #define KB_GE 2
 #define KB_LT 3
 #define KB_LE 4
-#define KB_NEAR 5   /* anything matches but closer is better */
+#define KB_NEAR 5 /* anything matches but closer is better */
 
 typedef struct _key
 {
@@ -1241,244 +1264,243 @@ typedef struct _key
 typedef struct _text_search
 {
     t_text_client x_tc;
-    t_outlet *x_out1;       /* line indices */
+    t_outlet *x_out1; /* line indices */
     int x_nkeys;
-    int x_onset;        /* first line to include in search */
-    int x_range;        /* max number of lines to search */
+    int x_onset; /* first line to include in search */
+    int x_range; /* max number of lines to search */
     t_key *x_keyvec;
 } t_text_search;
 
 static void *text_search_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_search *x = (t_text_search *)pd_new(text_search_class);
+    t_text_search *x = (t_text_search *) pd_new(text_search_class);
     int i, key, nkey, nextop;
     x->x_out1 = outlet_new(&x->x_obj, &s_list);
     text_client_argparse(&x->x_tc, &argc, &argv, "text search");
-    for (i = nkey = 0; i < argc; i++)
-        if (argv[i].a_type == A_FLOAT)
-            nkey++;
-    if (nkey == 0)
-        nkey = 1;
+    for(i = nkey = 0; i < argc; i++)
+        if(argv[i].a_type == A_FLOAT) nkey++;
+    if(nkey == 0) nkey = 1;
     x->x_nkeys = nkey;
     x->x_onset = 0;
     x->x_range = 0x7fffffff;
-    x->x_keyvec = (t_key *)getbytes(nkey * sizeof(*x->x_keyvec));
-    if (!argc)
+    x->x_keyvec = (t_key *) getbytes(nkey * sizeof(*x->x_keyvec));
+    if(!argc)
         x->x_keyvec[0].k_field = 0, x->x_keyvec[0].k_binop = KB_EQ;
-    else for (i = key = 0, nextop = -1; i < argc; i++)
-    {
-        if (argv[i].a_type == A_FLOAT)
+    else
+        for(i = key = 0, nextop = -1; i < argc; i++)
         {
-            x->x_keyvec[key].k_field =
-                (argv[i].a_w.w_float > 0 ? argv[i].a_w.w_float : 0);
-            x->x_keyvec[key].k_binop = (nextop >= 0 ? nextop : KB_EQ);
-            nextop = -1;
-            key++;
+            if(argv[i].a_type == A_FLOAT)
+            {
+                x->x_keyvec[key].k_field =
+                    (argv[i].a_w.w_float > 0 ? argv[i].a_w.w_float : 0);
+                x->x_keyvec[key].k_binop = (nextop >= 0 ? nextop : KB_EQ);
+                nextop = -1;
+                key++;
+            }
+            else
+            {
+                const char *s = argv[i].a_w.w_symbol->s_name;
+                if(nextop >= 0)
+                    pd_error(x,
+                        "text search: extra operation argument ignored: %s", s);
+                else if(!strcmp(argv[i].a_w.w_symbol->s_name, ">"))
+                    nextop = KB_GT;
+                else if(!strcmp(argv[i].a_w.w_symbol->s_name, ">="))
+                    nextop = KB_GE;
+                else if(!strcmp(argv[i].a_w.w_symbol->s_name, "<"))
+                    nextop = KB_LT;
+                else if(!strcmp(argv[i].a_w.w_symbol->s_name, "<="))
+                    nextop = KB_LE;
+                else if(!strcmp(argv[i].a_w.w_symbol->s_name, "near"))
+                    nextop = KB_NEAR;
+                else
+                    pd_error(
+                        x, "text search: unknown operation argument: %s", s);
+            }
         }
-        else
-        {
-            const char *s = argv[i].a_w.w_symbol->s_name;
-            if (nextop >= 0)
-                pd_error(x,
-                    "text search: extra operation argument ignored: %s", s);
-            else if (!strcmp(argv[i].a_w.w_symbol->s_name, ">"))
-                nextop = KB_GT;
-            else if (!strcmp(argv[i].a_w.w_symbol->s_name, ">="))
-                nextop = KB_GE;
-            else if (!strcmp(argv[i].a_w.w_symbol->s_name, "<"))
-                nextop = KB_LT;
-            else if (!strcmp(argv[i].a_w.w_symbol->s_name, "<="))
-                nextop = KB_LE;
-            else if (!strcmp(argv[i].a_w.w_symbol->s_name, "near"))
-                nextop = KB_NEAR;
-            else pd_error(x,
-                    "text search: unknown operation argument: %s", s);
-        }
-    }
-    if (x->x_struct)
+    if(x->x_struct)
         pointerinlet_new(&x->x_obj, &x->x_gp);
-    else symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
     return (x);
 }
 
-static void text_search_list(t_text_search *x,
-    t_symbol *s, int argc, t_atom *argv)
+static void text_search_list(
+    t_text_search *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
-    int i, n, lineno, bestline = -1, beststart=-1, bestn, thisstart,
-        nkeys = x->x_nkeys, failed = 0;
+    int i, n, lineno, bestline = -1, beststart = -1, bestn, thisstart,
+                      nkeys = x->x_nkeys, failed = 0;
     t_atom *vec;
-    if (!b)
-       return;
-    if (argc < nkeys)
+    if(!b) return;
+    if(argc < nkeys)
     {
-        pd_error(x, "need %d keys, only got %d in list",
-            nkeys, argc);
+        pd_error(x, "need %d keys, only got %d in list", nkeys, argc);
     }
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (nkeys < 1)
-        bug("text_search");
-    for (i = lineno = thisstart = 0; i < n; i++)
+    if(nkeys < 1) bug("text_search");
+    for(i = lineno = thisstart = 0; i < n; i++)
     {
-        if (vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA || i == n-1)
+        if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA || i == n - 1)
         {
             int thisn, j, field, binop;
-            if (lineno < x->x_onset)
-                goto nomatch;
-            if (lineno >= x->x_onset + x->x_range)
-                break;
+            if(lineno < x->x_onset) goto nomatch;
+            if(lineno >= x->x_onset + x->x_range) break;
             thisn = i - thisstart;
             field = x->x_keyvec[0].k_field;
             binop = x->x_keyvec[0].k_binop;
-                /* do we match? */
-            for (j = 0; j < argc; )
+            /* do we match? */
+            for(j = 0; j < argc;)
             {
-                if (field >= thisn ||
-                    vec[thisstart+field].a_type != argv[j].a_type)
-                        goto nomatch;
-                if (argv[j].a_type == A_FLOAT)      /* arg is a float */
+                if(field >= thisn ||
+                    vec[thisstart + field].a_type != argv[j].a_type)
+                    goto nomatch;
+                if(argv[j].a_type == A_FLOAT) /* arg is a float */
                 {
-                    switch (binop)
+                    switch(binop)
                     {
                         case KB_EQ:
-                            if (vec[thisstart+field].a_w.w_float !=
+                            if(vec[thisstart + field].a_w.w_float !=
                                 argv[j].a_w.w_float)
-                                    goto nomatch;
-                        break;
+                                goto nomatch;
+                            break;
                         case KB_GT:
-                            if (vec[thisstart+field].a_w.w_float <=
+                            if(vec[thisstart + field].a_w.w_float <=
                                 argv[j].a_w.w_float)
-                                    goto nomatch;
-                        break;
+                                goto nomatch;
+                            break;
                         case KB_GE:
-                            if (vec[thisstart+field].a_w.w_float <
+                            if(vec[thisstart + field].a_w.w_float <
                                 argv[j].a_w.w_float)
-                                    goto nomatch;
-                        break;
+                                goto nomatch;
+                            break;
                         case KB_LT:
-                            if (vec[thisstart+field].a_w.w_float >=
+                            if(vec[thisstart + field].a_w.w_float >=
                                 argv[j].a_w.w_float)
-                                    goto nomatch;
-                        break;
+                                goto nomatch;
+                            break;
                         case KB_LE:
-                            if (vec[thisstart+field].a_w.w_float >
+                            if(vec[thisstart + field].a_w.w_float >
                                 argv[j].a_w.w_float)
-                                    goto nomatch;
-                        break;
+                                goto nomatch;
+                            break;
                             /* the other possibility ('near') never fails */
                     }
                 }
-                else                                /* arg is a symbol */
+                else /* arg is a symbol */
                 {
-                    if (binop != KB_EQ)
+                    if(binop != KB_EQ)
                     {
-                        if (!failed)
+                        if(!failed)
                         {
                             pd_error(x,
-                    "text search (%s): only exact matches allowed for symbols",
+                                "text search (%s): only exact matches allowed "
+                                "for symbols",
                                 argv[j].a_w.w_symbol->s_name);
                             failed = 1;
                         }
                         goto nomatch;
                     }
-                    if (vec[thisstart+field].a_w.w_symbol !=
+                    if(vec[thisstart + field].a_w.w_symbol !=
                         argv[j].a_w.w_symbol)
-                            goto nomatch;
+                        goto nomatch;
                 }
-                if (++j >= nkeys)    /* if at last key just increment field */
+                if(++j >= nkeys) /* if at last key just increment field */
                     field++;
-                else field = x->x_keyvec[j].k_field,    /* else next key */
+                else
+                    field = x->x_keyvec[j].k_field, /* else next key */
                         binop = x->x_keyvec[j].k_binop;
             }
-                /* the line matches.  Now, if there is a previous match, are
-                we better than it? */
-            if (bestline >= 0)
+            /* the line matches.  Now, if there is a previous match, are
+            we better than it? */
+            if(bestline >= 0)
             {
                 field = x->x_keyvec[0].k_field;
                 binop = x->x_keyvec[0].k_binop;
-                for (j = 0; j < argc; )
+                for(j = 0; j < argc;)
                 {
-                    if (field >= thisn
-                        || vec[thisstart+field].a_type != argv[j].a_type)
-                            bug("text search 2");
-                    if (argv[j].a_type == A_FLOAT)      /* arg is a float */
+                    if(field >= thisn ||
+                        vec[thisstart + field].a_type != argv[j].a_type)
+                        bug("text search 2");
+                    if(argv[j].a_type == A_FLOAT) /* arg is a float */
                     {
-                        float thisv = vec[thisstart+field].a_w.w_float,
-                            bestv = (beststart >= 0 ?
-                                vec[beststart+field].a_w.w_float : -1e20);
-                        switch (binop)
+                        float thisv = vec[thisstart + field].a_w.w_float,
+                              bestv = (beststart >= 0
+                                           ? vec[beststart + field].a_w.w_float
+                                           : -1e20);
+                        switch(binop)
                         {
                             case KB_GT:
                             case KB_GE:
-                                if (thisv < bestv)
+                                if(thisv < bestv)
                                     goto replace;
-                                else if (thisv > bestv)
+                                else if(thisv > bestv)
                                     goto nomatch;
-                            break;
+                                break;
                             case KB_LT:
                             case KB_LE:
-                                if (thisv > bestv)
+                                if(thisv > bestv)
                                     goto replace;
-                                else if (thisv < bestv)
+                                else if(thisv < bestv)
                                     goto nomatch;
-                            break;
+                                break;
                             case KB_NEAR:
-                                if (thisv >= argv[j].a_w.w_float &&
+                                if(thisv >= argv[j].a_w.w_float &&
                                     bestv >= argv[j].a_w.w_float)
                                 {
-                                    if (thisv < bestv)
+                                    if(thisv < bestv)
                                         goto replace;
-                                    else if (thisv > bestv)
+                                    else if(thisv > bestv)
                                         goto nomatch;
                                 }
-                                else if (thisv <= argv[j].a_w.w_float &&
-                                    bestv <= argv[j].a_w.w_float)
+                                else if(thisv <= argv[j].a_w.w_float &&
+                                        bestv <= argv[j].a_w.w_float)
                                 {
-                                    if (thisv > bestv)
+                                    if(thisv > bestv)
                                         goto replace;
-                                    else if (thisv < bestv)
+                                    else if(thisv < bestv)
                                         goto nomatch;
                                 }
                                 else
                                 {
                                     float d1 = thisv - argv[j].a_w.w_float,
-                                        d2 = bestv - argv[j].a_w.w_float;
-                                    if (d1 < 0)
-                                        d1 = -d1;
-                                    if (d2 < 0)
-                                        d2 = -d2;
+                                          d2 = bestv - argv[j].a_w.w_float;
+                                    if(d1 < 0) d1 = -d1;
+                                    if(d2 < 0) d2 = -d2;
 
-                                    if (d1 < d2)
+                                    if(d1 < d2)
                                         goto replace;
-                                    else if (d1 > d2)
+                                    else if(d1 > d2)
                                         goto nomatch;
                                 }
-                            break;
+                                break;
                                 /* the other possibility ('=') never decides */
                         }
                     }
-                    if (++j >= nkeys)    /* last key - increment field */
+                    if(++j >= nkeys) /* last key - increment field */
                         field++;
-                    else field = x->x_keyvec[j].k_field,    /* else next key */
+                    else
+                        field = x->x_keyvec[j].k_field, /* else next key */
                             binop = x->x_keyvec[j].k_binop;
                 }
-                goto nomatch;   /* a tie - keep the old one */
+                goto nomatch; /* a tie - keep the old one */
             replace:
                 bestline = lineno, beststart = thisstart, bestn = thisn;
             }
-                /* no previous match so we're best */
-            else bestline = lineno, beststart = thisstart, bestn = thisn;
+            /* no previous match so we're best */
+            else
+                bestline = lineno, beststart = thisstart, bestn = thisn;
         nomatch:
             lineno++;
-            thisstart = i+1;
+            thisstart = i + 1;
         }
     }
     outlet_float(x->x_out1, bestline);
 }
 
-static void text_search_range(t_text_search *x, t_floatarg onset,
-    t_floatarg range)
+static void text_search_range(
+    t_text_search *x, t_floatarg onset, t_floatarg range)
 {
     x->x_onset = (onset >= 0x7fffffff ? 0x7ffffff : (onset < 0 ? 0 : onset));
     x->x_range = (range >= 0x7fffffff ? 0x7ffffff : (range < 0 ? 0 : range));
@@ -1490,31 +1512,31 @@ t_class *text_sequence_class;
 typedef struct _text_sequence
 {
     t_text_client x_tc;
-    t_outlet *x_mainout;    /* outlet for lists, zero if "global" */
-    t_outlet *x_waitout;    /* outlet for wait times, zero if we never wait */
-    t_outlet *x_endout;    /* bang when hit end */
+    t_outlet *x_mainout; /* outlet for lists, zero if "global" */
+    t_outlet *x_waitout; /* outlet for wait times, zero if we never wait */
+    t_outlet *x_endout;  /* bang when hit end */
     int x_onset;
     int x_argc;
     t_atom *x_argv;
-    t_symbol *x_waitsym;    /* symbol to initiate wait, zero if none */
-    int x_waitargc;         /* how many leading numbers to use for waiting */
-    t_clock *x_clock;       /* callback for auto mode */
+    t_symbol *x_waitsym; /* symbol to initiate wait, zero if none */
+    int x_waitargc;      /* how many leading numbers to use for waiting */
+    t_clock *x_clock;    /* callback for auto mode */
     t_float x_nextdelay;
-    t_symbol *x_lastto;     /* destination symbol if we're after a comma */
-    unsigned char x_eaten;  /* true if we've eaten leading numbers already */
-    unsigned char x_loop;   /* true if we can send multiple lines */
-    unsigned char x_auto;   /* set timer when we hit single-number time list */
+    t_symbol *x_lastto;    /* destination symbol if we're after a comma */
+    unsigned char x_eaten; /* true if we've eaten leading numbers already */
+    unsigned char x_loop;  /* true if we can send multiple lines */
+    unsigned char x_auto;  /* set timer when we hit single-number time list */
 } t_text_sequence;
 
 static void text_sequence_tick(t_text_sequence *x);
-static void text_sequence_tempo(t_text_sequence *x,
-    t_symbol *unitname, t_floatarg tempo);
-void parsetimeunits(void *x, t_float amount, t_symbol *unitname,
-    t_float *unit, int *samps); /* time unit parsing from x_time.c */
+static void text_sequence_tempo(
+    t_text_sequence *x, t_symbol *unitname, t_floatarg tempo);
+void parsetimeunits(void *x, t_float amount, t_symbol *unitname, t_float *unit,
+    int *samps); /* time unit parsing from x_time.c */
 
 static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_text_sequence *x = (t_text_sequence *)pd_new(text_sequence_class);
+    t_text_sequence *x = (t_text_sequence *) pd_new(text_sequence_class);
     int global = 0;
     text_client_argparse(&x->x_tc, &argc, &argv, "text sequence");
     x->x_waitsym = 0;
@@ -1522,13 +1544,13 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
     x->x_eaten = 0;
     x->x_loop = 0;
     x->x_lastto = 0;
-    x->x_clock = clock_new(x, (t_method)text_sequence_tick);
-    while (argc && argv->a_type == A_SYMBOL &&
-        *argv->a_w.w_symbol->s_name == '-')
+    x->x_clock = clock_new(x, (t_method) text_sequence_tick);
+    while(
+        argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
-        if (!strcmp(argv->a_w.w_symbol->s_name, "-w") && argc >= 2)
+        if(!strcmp(argv->a_w.w_symbol->s_name, "-w") && argc >= 2)
         {
-            if (argv[1].a_type == A_SYMBOL)
+            if(argv[1].a_type == A_SYMBOL)
             {
                 x->x_waitsym = argv[1].a_w.w_symbol;
                 x->x_waitargc = 0;
@@ -1536,46 +1558,51 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
             else
             {
                 x->x_waitsym = 0;
-                if ((x->x_waitargc = argv[1].a_w.w_float) < 0)
-                    x->x_waitargc = 0;
+                if((x->x_waitargc = argv[1].a_w.w_float) < 0) x->x_waitargc = 0;
             }
-            argc -= 1; argv += 1;
+            argc -= 1;
+            argv += 1;
         }
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-g"))
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-g"))
             global = 1;
-        else if (!strcmp(argv->a_w.w_symbol->s_name, "-t") && argc >= 3)
+        else if(!strcmp(argv->a_w.w_symbol->s_name, "-t") && argc >= 3)
         {
             text_sequence_tempo(x, atom_getsymbolarg(2, argc, argv),
                 atom_getfloatarg(1, argc, argv));
-             argc -= 2; argv += 2;
+            argc -= 2;
+            argv += 2;
         }
         else
         {
             pd_error(x, "text sequence: unknown flag '%s'...",
                 argv->a_w.w_symbol->s_name);
         }
-        argc--; argv++;
+        argc--;
+        argv++;
     }
-    if (argc)
+    if(argc)
     {
         post("warning: text sequence ignoring extra argument: ");
-        postatom(argc, argv); endpost();
+        postatom(argc, argv);
+        endpost();
     }
-    if (x->x_tc.tc_struct)
+    if(x->x_tc.tc_struct)
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_gp);
-    else symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    else
+        symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
     x->x_argc = 0;
-    x->x_argv = (t_atom *)getbytes(0);
+    x->x_argv = (t_atom *) getbytes(0);
     x->x_onset = 0x7fffffff;
     x->x_mainout = (!global ? outlet_new(&x->x_obj, &s_list) : 0);
-    x->x_waitout = (global || x->x_waitsym || x->x_waitargc ?
-        outlet_new(&x->x_obj, &s_list) : 0);
+    x->x_waitout = (global || x->x_waitsym || x->x_waitargc
+                        ? outlet_new(&x->x_obj, &s_list)
+                        : 0);
     x->x_endout = outlet_new(&x->x_obj, &s_bang);
-    if (global)
+    if(global)
     {
-        if (x->x_waitargc)
-            pd_error(x,
-       "warning: text sequence: numeric 'w' argument ignored if '-g' given");
+        if(x->x_waitargc)
+            pd_error(x, "warning: text sequence: numeric 'w' argument ignored "
+                        "if '-g' given");
         x->x_waitargc = 0x40000000;
     }
     return (x);
@@ -1586,11 +1613,10 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n, i, onset, nfield, wait, eatsemi = 1, gotcomma = 0;
     t_atom *vec, *outvec, *ap;
-    if (!b)
-        goto nosequence;
+    if(!b) goto nosequence;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (x->x_onset >= n)
+    if(x->x_onset >= n)
     {
     nosequence:
         x->x_onset = 0x7fffffff;
@@ -1600,86 +1626,88 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
     }
     onset = x->x_onset;
 
-        /* test if leading numbers, or a leading symbol equal to our
-        "wait symbol", are directing us to wait */
-    if (!x->x_lastto && (
-        (vec[onset].a_type == A_FLOAT && x->x_waitargc && !x->x_eaten) ||
+    /* test if leading numbers, or a leading symbol equal to our
+    "wait symbol", are directing us to wait */
+    if(!x->x_lastto &&
+        ((vec[onset].a_type == A_FLOAT && x->x_waitargc && !x->x_eaten) ||
             (vec[onset].a_type == A_SYMBOL &&
                 vec[onset].a_w.w_symbol == x->x_waitsym)))
     {
-        if (vec[onset].a_type == A_FLOAT)
+        if(vec[onset].a_type == A_FLOAT)
         {
-            for (i = onset; i < n && i < onset + x->x_waitargc &&
-                vec[i].a_type == A_FLOAT; i++)
-                    ;
+            for(i = onset;
+                i < n && i < onset + x->x_waitargc && vec[i].a_type == A_FLOAT;
+                i++)
+                ;
             x->x_eaten = 1;
             eatsemi = 0;
         }
         else
         {
-            for (i = onset; i < n && vec[i].a_type != A_SEMI &&
-                vec[i].a_type != A_COMMA; i++)
-                    ;
+            for(i = onset;
+                i < n && vec[i].a_type != A_SEMI && vec[i].a_type != A_COMMA;
+                i++)
+                ;
             x->x_eaten = 1;
-            onset++;    /* symbol isn't part of wait list */
+            onset++; /* symbol isn't part of wait list */
         }
         wait = 1;
     }
-    else    /* message to send */
+    else /* message to send */
     {
-        for (i = onset; i < n && vec[i].a_type != A_SEMI &&
-            vec[i].a_type != A_COMMA; i++)
-                ;
+        for(i = onset;
+            i < n && vec[i].a_type != A_SEMI && vec[i].a_type != A_COMMA; i++)
+            ;
         wait = 0;
         x->x_eaten = 0;
-        if (i < n && vec[i].a_type == A_COMMA)
-            gotcomma = 1;
+        if(i < n && vec[i].a_type == A_COMMA) gotcomma = 1;
     }
     nfield = i - onset;
     i += eatsemi;
-    if (i >= n)
-        i = 0x7fffffff;
+    if(i >= n) i = 0x7fffffff;
     x->x_onset = i;
-        /* generate output list, realizing dolar sign atoms.  Allocate one
-        extra atom in case we want to prepend a symbol later */
-    ATOMS_ALLOCA(outvec, nfield+1);
-    for (i = 0, ap = vec+onset; i < nfield; i++, ap++)
+    /* generate output list, realizing dolar sign atoms.  Allocate one
+    extra atom in case we want to prepend a symbol later */
+    ATOMS_ALLOCA(outvec, nfield + 1);
+    for(i = 0, ap = vec + onset; i < nfield; i++, ap++)
     {
         int type = ap->a_type;
-        if (type == A_FLOAT || type == A_SYMBOL)
+        if(type == A_FLOAT || type == A_SYMBOL)
             outvec[i] = *ap;
-        else if (type == A_DOLLAR)
+        else if(type == A_DOLLAR)
         {
-            int atno = ap->a_w.w_index-1;
-            if (atno < 0 || atno >= argc)
+            int atno = ap->a_w.w_index - 1;
+            if(atno < 0 || atno >= argc)
             {
-                pd_error(x, "argument $%d out of range", atno+1);
-                SETFLOAT(outvec+i, 0);
+                pd_error(x, "argument $%d out of range", atno + 1);
+                SETFLOAT(outvec + i, 0);
             }
-            else outvec[i] = argv[atno];
+            else
+                outvec[i] = argv[atno];
         }
-        else if (type == A_DOLLSYM)
+        else if(type == A_DOLLSYM)
         {
             t_symbol *s =
                 binbuf_realizedollsym(ap->a_w.w_symbol, argc, argv, 0);
-            if (s)
-                SETSYMBOL(outvec+i, s);
+            if(s)
+                SETSYMBOL(outvec + i, s);
             else
             {
                 pd_error(0, "$%s: not enough arguments supplied",
                     ap->a_w.w_symbol->s_name);
-                SETSYMBOL(outvec+i, &s_symbol);
+                SETSYMBOL(outvec + i, &s_symbol);
             }
         }
-        else bug("text sequence");
+        else
+            bug("text sequence");
     }
-    if (wait)
+    if(wait)
     {
         x->x_loop = 0;
         x->x_lastto = 0;
-        if (x->x_auto && nfield == 1 && outvec[0].a_type == A_FLOAT)
+        if(x->x_auto && nfield == 1 && outvec[0].a_type == A_FLOAT)
             x->x_nextdelay = outvec[0].a_w.w_float;
-        else if (!x->x_waitout)
+        else if(!x->x_waitout)
             bug("text sequence 3");
         else
         {
@@ -1687,93 +1715,93 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
             outlet_list(x->x_waitout, 0, nfield, outvec);
         }
     }
-    else if (x->x_mainout)
+    else if(x->x_mainout)
     {
         int n2 = nfield;
-        if (x->x_lastto)
+        if(x->x_lastto)
         {
-            memmove(outvec+1, outvec, nfield * sizeof(*outvec));
+            memmove(outvec + 1, outvec, nfield * sizeof(*outvec));
             SETSYMBOL(outvec, x->x_lastto);
             n2++;
         }
-        if (!gotcomma)
+        if(!gotcomma)
             x->x_lastto = 0;
-        else if (!x->x_lastto && nfield && outvec->a_type == A_SYMBOL)
+        else if(!x->x_lastto && nfield && outvec->a_type == A_SYMBOL)
             x->x_lastto = outvec->a_w.w_symbol;
         outlet_list(x->x_mainout, 0, n2, outvec);
     }
-    else if (nfield)
+    else if(nfield)
     {
         t_symbol *tosym = x->x_lastto;
         t_pd *to = 0;
         t_atom *vecleft = outvec;
         int nleft = nfield;
-        if (!tosym)
+        if(!tosym)
         {
-            if (outvec[0].a_type != A_SYMBOL)
+            if(outvec[0].a_type != A_SYMBOL)
                 bug("text sequence 2");
-            else tosym = outvec[0].a_w.w_symbol;
+            else
+                tosym = outvec[0].a_w.w_symbol;
             vecleft++;
             nleft--;
         }
-        if (tosym)
+        if(tosym)
         {
-            if (!(to = tosym->s_thing))
+            if(!(to = tosym->s_thing))
                 pd_error(x, "%s: no such object", tosym->s_name);
         }
         x->x_lastto = (gotcomma ? tosym : 0);
-        if (to)
+        if(to)
         {
-            if (nleft > 0 && vecleft[0].a_type == A_SYMBOL)
-                typedmess(to, vecleft->a_w.w_symbol, nleft-1, vecleft+1);
-            else pd_list(to, 0, nleft, vecleft);
+            if(nleft > 0 && vecleft[0].a_type == A_SYMBOL)
+                typedmess(to, vecleft->a_w.w_symbol, nleft - 1, vecleft + 1);
+            else
+                pd_list(to, 0, nleft, vecleft);
         }
     }
-    ATOMS_FREEA(outvec, nfield+1);
+    ATOMS_FREEA(outvec, nfield + 1);
 }
 
-static void text_sequence_list(t_text_sequence *x, t_symbol *s, int argc,
-    t_atom *argv)
+static void text_sequence_list(
+    t_text_sequence *x, t_symbol *s, int argc, t_atom *argv)
 {
     x->x_loop = 1;
-    while (x->x_loop)
+    while(x->x_loop)
     {
-        if (argc)
+        if(argc)
             text_sequence_doit(x, argc, argv);
-        else text_sequence_doit(x, x->x_argc, x->x_argv);
+        else
+            text_sequence_doit(x, x->x_argc, x->x_argv);
     }
 }
 
 static void text_sequence_stop(t_text_sequence *x)
 {
     x->x_loop = 0;
-    if (x->x_auto)
+    if(x->x_auto)
     {
         clock_unset(x->x_clock);
         x->x_auto = 0;
     }
 }
 
-static void text_sequence_tick(t_text_sequence *x)  /* clock callback */
+static void text_sequence_tick(t_text_sequence *x) /* clock callback */
 {
     x->x_lastto = 0;
-    while (x->x_auto)
+    while(x->x_auto)
     {
         x->x_loop = 1;
-        while (x->x_loop)
+        while(x->x_loop)
             text_sequence_doit(x, x->x_argc, x->x_argv);
-        if (x->x_nextdelay > 0)
-            break;
+        if(x->x_nextdelay > 0) break;
     }
-    if (x->x_auto)
-        clock_delay(x->x_clock, x->x_nextdelay);
+    if(x->x_auto) clock_delay(x->x_clock, x->x_nextdelay);
 }
 
 static void text_sequence_auto(t_text_sequence *x)
 {
     x->x_lastto = 0;
-    if (x->x_auto)
-        clock_unset(x->x_clock);
+    if(x->x_auto) clock_unset(x->x_clock);
     x->x_auto = 1;
     text_sequence_tick(x);
 }
@@ -1789,33 +1817,33 @@ static void text_sequence_line(t_text_sequence *x, t_floatarg f)
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n, start, end;
     t_atom *vec;
-    if (!b)
-       return;
+    if(!b) return;
     x->x_lastto = 0;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    if (!text_nthline(n, vec, f, &start, &end))
+    if(!text_nthline(n, vec, f, &start, &end))
     {
-        pd_error(x, "text sequence: line number %d out of range", (int)f);
+        pd_error(x, "text sequence: line number %d out of range", (int) f);
         x->x_onset = 0x7fffffff;
     }
-    else x->x_onset = start;
+    else
+        x->x_onset = start;
     x->x_eaten = 0;
 }
 
-static void text_sequence_args(t_text_sequence *x, t_symbol *s,
-    int argc, t_atom *argv)
+static void text_sequence_args(
+    t_text_sequence *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    x->x_argv = t_resizebytes(x->x_argv,
-        x->x_argc * sizeof(t_atom), argc * sizeof(t_atom));
-    for (i = 0; i < argc; i++)
+    x->x_argv = t_resizebytes(
+        x->x_argv, x->x_argc * sizeof(t_atom), argc * sizeof(t_atom));
+    for(i = 0; i < argc; i++)
         x->x_argv[i] = argv[i];
     x->x_argc = argc;
 }
 
-static void text_sequence_tempo(t_text_sequence *x,
-    t_symbol *unitname, t_floatarg tempo)
+static void text_sequence_tempo(
+    t_text_sequence *x, t_symbol *unitname, t_floatarg tempo)
 {
     t_float unit;
     int samps;
@@ -1833,31 +1861,31 @@ static void text_sequence_free(t_text_sequence *x)
 /* --- overall creator for "text" objects: dispatch to "text define" etc --- */
 static void *text_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (!argc || argv[0].a_type != A_SYMBOL)
+    if(!argc || argv[0].a_type != A_SYMBOL)
         pd_this->pd_newest = text_define_new(s, argc, argv);
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
-        if (!strcmp(str, "d") || !strcmp(str, "define"))
-            pd_this->pd_newest = text_define_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "get"))
-            pd_this->pd_newest = text_get_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "set"))
-            pd_this->pd_newest = text_set_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "insert"))
-            pd_this->pd_newest = text_insert_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "delete"))
-            pd_this->pd_newest = text_delete_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "size"))
-            pd_this->pd_newest = text_size_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "tolist"))
-            pd_this->pd_newest = text_tolist_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "fromlist"))
-            pd_this->pd_newest = text_fromlist_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "search"))
-            pd_this->pd_newest = text_search_new(s, argc-1, argv+1);
-        else if (!strcmp(str, "sequence"))
-            pd_this->pd_newest = text_sequence_new(s, argc-1, argv+1);
+        if(!strcmp(str, "d") || !strcmp(str, "define"))
+            pd_this->pd_newest = text_define_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "get"))
+            pd_this->pd_newest = text_get_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "set"))
+            pd_this->pd_newest = text_set_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "insert"))
+            pd_this->pd_newest = text_insert_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "delete"))
+            pd_this->pd_newest = text_delete_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "size"))
+            pd_this->pd_newest = text_size_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "tolist"))
+            pd_this->pd_newest = text_tolist_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "fromlist"))
+            pd_this->pd_newest = text_fromlist_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "search"))
+            pd_this->pd_newest = text_search_new(s, argc - 1, argv + 1);
+        else if(!strcmp(str, "sequence"))
+            pd_this->pd_newest = text_sequence_new(s, argc - 1, argv + 1);
         else
         {
             pd_error(0, "list %s: unknown function", str);
@@ -1868,23 +1896,24 @@ static void *text_new(t_symbol *s, int argc, t_atom *argv)
 }
 
 /*  the qlist and textfile objects, as of 0.44, are 'derived' from
-* the text object above.  Maybe later it will be desirable to add new
-* functionality to textfile; qlist is an ancient holdover (1987) and
-* is probably best left alone.
-*/
+ * the text object above.  Maybe later it will be desirable to add new
+ * functionality to textfile; qlist is an ancient holdover (1987) and
+ * is probably best left alone.
+ */
 
 typedef struct _qlist
 {
     t_textbuf x_textbuf;
     t_outlet *x_bangout;
-    int x_onset;                /* playback position */
+    int x_onset; /* playback position */
     t_clock *x_clock;
     t_float x_tempo;
     double x_whenclockset;
     t_float x_clockdelay;
-    int x_rewound;          /* we've been rewound since last start */
-    int x_innext;           /* we're currently inside the "next" routine */
+    int x_rewound; /* we've been rewound since last start */
+    int x_innext;  /* we're currently inside the "next" routine */
 } t_qlist;
+
 #define x_ob x_textbuf.b_ob
 #define x_binbuf x_textbuf.b_binbuf
 #define x_canvas x_textbuf.b_canvas
@@ -1895,9 +1924,9 @@ static t_class *qlist_class;
 
 static void *qlist_new(void)
 {
-    t_qlist *x = (t_qlist *)pd_new(qlist_class);
+    t_qlist *x = (t_qlist *) pd_new(qlist_class);
     textbuf_init(&x->x_textbuf, gensym("qlist"));
-    x->x_clock = clock_new(x, (t_method)qlist_tick);
+    x->x_clock = clock_new(x, (t_method) qlist_tick);
     outlet_new(&x->x_ob, &s_list);
     x->x_bangout = outlet_new(&x->x_ob, &s_bang);
     x->x_onset = 0x7fffffff;
@@ -1911,7 +1940,7 @@ static void *qlist_new(void)
 static void qlist_rewind(t_qlist *x)
 {
     x->x_onset = 0;
-    if (x->x_clock) clock_unset(x->x_clock);
+    if(x->x_clock) clock_unset(x->x_clock);
     x->x_whenclockset = 0;
     x->x_rewound = 1;
 }
@@ -1919,63 +1948,65 @@ static void qlist_rewind(t_qlist *x)
 static void qlist_donext(t_qlist *x, int drop, int automatic)
 {
     t_pd *target = 0;
-    if (x->x_innext)
+    if(x->x_innext)
     {
         pd_error(x, "qlist sent 'next' from within itself");
         return;
     }
     x->x_innext = 1;
-    while (1)
+    while(1)
     {
-        int argc = binbuf_getnatom(x->x_binbuf),
-            count, onset = x->x_onset, onset2, wasrewound;
+        int argc = binbuf_getnatom(x->x_binbuf), count, onset = x->x_onset,
+            onset2, wasrewound;
         t_atom *argv = binbuf_getvec(x->x_binbuf);
         t_atom *ap = argv + onset, *ap2;
-        if (onset >= argc) goto end;
-        while (ap->a_type == A_SEMI || ap->a_type == A_COMMA)
+        if(onset >= argc) goto end;
+        while(ap->a_type == A_SEMI || ap->a_type == A_COMMA)
         {
-            if (ap->a_type == A_SEMI) target = 0;
+            if(ap->a_type == A_SEMI) target = 0;
             onset++, ap++;
-            if (onset >= argc) goto end;
+            if(onset >= argc) goto end;
         }
 
-        if (!target && ap->a_type == A_FLOAT)
+        if(!target && ap->a_type == A_FLOAT)
         {
             ap2 = ap + 1;
             onset2 = onset + 1;
-            while (onset2 < argc && ap2->a_type == A_FLOAT)
+            while(onset2 < argc && ap2->a_type == A_FLOAT)
                 onset2++, ap2++;
             x->x_onset = onset2;
-            if (automatic)
+            if(automatic)
             {
-                clock_delay(x->x_clock,
-                    x->x_clockdelay = ap->a_w.w_float * x->x_tempo);
+                clock_delay(
+                    x->x_clock, x->x_clockdelay = ap->a_w.w_float * x->x_tempo);
                 x->x_whenclockset = clock_getsystime();
             }
-            else outlet_list(x->x_ob.ob_outlet, 0, onset2-onset, ap);
+            else
+                outlet_list(x->x_ob.ob_outlet, 0, onset2 - onset, ap);
             x->x_innext = 0;
             return;
         }
         ap2 = ap + 1;
         onset2 = onset + 1;
-        while (onset2 < argc &&
-            (ap2->a_type == A_FLOAT || ap2->a_type == A_SYMBOL))
-                onset2++, ap2++;
+        while(onset2 < argc &&
+              (ap2->a_type == A_FLOAT || ap2->a_type == A_SYMBOL))
+            onset2++, ap2++;
         x->x_onset = onset2;
         count = onset2 - onset;
-        if (!target)
+        if(!target)
         {
-            if (ap->a_type != A_SYMBOL) continue;
-            else if (!(target = ap->a_w.w_symbol->s_thing))
+            if(ap->a_type != A_SYMBOL)
+                continue;
+            else if(!(target = ap->a_w.w_symbol->s_thing))
             {
-                pd_error(x, "qlist: %s: no such object",
-                    ap->a_w.w_symbol->s_name);
+                pd_error(
+                    x, "qlist: %s: no such object", ap->a_w.w_symbol->s_name);
                 continue;
             }
             ap++;
             onset++;
             count--;
-            if (!count)
+            if(!count)
             {
                 x->x_onset = onset2;
                 continue;
@@ -1983,20 +2014,20 @@ static void qlist_donext(t_qlist *x, int drop, int automatic)
         }
         wasrewound = x->x_rewound;
         x->x_rewound = 0;
-        if (!drop)
+        if(!drop)
         {
-            if (ap->a_type == A_FLOAT)
+            if(ap->a_type == A_FLOAT)
                 typedmess(target, &s_list, count, ap);
-            else if (ap->a_type == A_SYMBOL)
-                typedmess(target, ap->a_w.w_symbol, count-1, ap+1);
+            else if(ap->a_type == A_SYMBOL)
+                typedmess(target, ap->a_w.w_symbol, count - 1, ap + 1);
         }
-        if (x->x_rewound)
+        if(x->x_rewound)
         {
             x->x_innext = 0;
             return;
         }
         x->x_rewound = wasrewound;
-    }  /* while (1); never falls through */
+    } /* while (1); never falls through */
 
 end:
     x->x_onset = 0x7fffffff;
@@ -2013,15 +2044,16 @@ static void qlist_next(t_qlist *x, t_floatarg drop)
 static void qlist_bang(t_qlist *x)
 {
     qlist_rewind(x);
-        /* if we're restarted reentrantly from a "next" message set ourselves
-        up to do this non-reentrantly after a delay of 0 */
-    if (x->x_innext)
+    /* if we're restarted reentrantly from a "next" message set ourselves
+    up to do this non-reentrantly after a delay of 0 */
+    if(x->x_innext)
     {
         x->x_whenclockset = clock_getsystime();
         x->x_clockdelay = 0;
         clock_delay(x->x_clock, 0);
     }
-    else qlist_donext(x, 0, 1);
+    else
+        qlist_donext(x, 0, 1);
 }
 
 static void qlist_tick(t_qlist *x)
@@ -2058,13 +2090,13 @@ static void qlist_set(t_qlist *x, t_symbol *s, int argc, t_atom *argv)
 static void qlist_read(t_qlist *x, t_symbol *filename, t_symbol *format)
 {
     int cr = 0;
-    if (!strcmp(format->s_name, "cr"))
+    if(!strcmp(format->s_name, "cr"))
         cr = 1;
-    else if (*format->s_name)
+    else if(*format->s_name)
         pd_error(x, "qlist_read: unknown flag: %s", format->s_name);
 
-    if (binbuf_read_via_canvas(x->x_binbuf, filename->s_name, x->x_canvas, cr))
-            pd_error(x, "%s: read failed", filename->s_name);
+    if(binbuf_read_via_canvas(x->x_binbuf, filename->s_name, x->x_canvas, cr))
+        pd_error(x, "%s: read failed", filename->s_name);
     x->x_onset = 0x7fffffff;
     x->x_rewound = 1;
 }
@@ -2073,14 +2105,13 @@ static void qlist_write(t_qlist *x, t_symbol *filename, t_symbol *format)
 {
     int cr = 0;
     char buf[MAXPDSTRING];
-    canvas_makefilename(x->x_canvas, filename->s_name,
-        buf, MAXPDSTRING);
-    if (!strcmp(format->s_name, "cr"))
+    canvas_makefilename(x->x_canvas, filename->s_name, buf, MAXPDSTRING);
+    if(!strcmp(format->s_name, "cr"))
         cr = 1;
-    else if (*format->s_name)
+    else if(*format->s_name)
         pd_error(x, "qlist_read: unknown flag: %s", format->s_name);
-    if (binbuf_write(x->x_binbuf, buf, "", cr))
-            pd_error(x, "%s: write failed", filename->s_name);
+    if(binbuf_write(x->x_binbuf, buf, "", cr))
+        pd_error(x, "%s: write failed", filename->s_name);
 }
 
 static void qlist_print(t_qlist *x)
@@ -2092,14 +2123,16 @@ static void qlist_print(t_qlist *x)
 static void qlist_tempo(t_qlist *x, t_float f)
 {
     t_float newtempo;
-    if (f < 1e-20) f = 1e-20;
-    else if (f > 1e20) f = 1e20;
-    newtempo = 1./f;
-    if (x->x_whenclockset != 0)
+    if(f < 1e-20)
+        f = 1e-20;
+    else if(f > 1e20)
+        f = 1e20;
+    newtempo = 1. / f;
+    if(x->x_whenclockset != 0)
     {
         t_float elapsed = clock_gettimesince(x->x_whenclockset);
         t_float left = x->x_clockdelay - elapsed;
-        if (left < 0) left = 0;
+        if(left < 0) left = 0;
         left *= newtempo / x->x_tempo;
         clock_delay(x->x_clock, left);
     }
@@ -2115,15 +2148,15 @@ static void qlist_free(t_qlist *x)
 /* -------------------- textfile ------------------------------- */
 
 /* has the same struct as qlist (so we can reuse some of its
-* methods) but "sequencing" here only relies on 'binbuf' and 'onset'
-* fields.
-*/
+ * methods) but "sequencing" here only relies on 'binbuf' and 'onset'
+ * fields.
+ */
 
 static t_class *textfile_class;
 
 static void *textfile_new(void)
 {
-    t_qlist *x = (t_qlist *)pd_new(textfile_class);
+    t_qlist *x = (t_qlist *) pd_new(textfile_class);
     textbuf_init(&x->x_textbuf, gensym("textfile"));
     outlet_new(&x->x_ob, &s_list);
     x->x_bangout = outlet_new(&x->x_ob, &s_bang);
@@ -2138,25 +2171,23 @@ static void *textfile_new(void)
 
 static void textfile_bang(t_qlist *x)
 {
-    int argc = binbuf_getnatom(x->x_binbuf),
-        onset = x->x_onset, onset2;
+    int argc = binbuf_getnatom(x->x_binbuf), onset = x->x_onset, onset2;
     t_atom *argv = binbuf_getvec(x->x_binbuf);
     t_atom *ap = argv + onset, *ap2;
-    while (onset < argc &&
-        (ap->a_type == A_SEMI || ap->a_type == A_COMMA))
-            onset++, ap++;
+    while(onset < argc && (ap->a_type == A_SEMI || ap->a_type == A_COMMA))
+        onset++, ap++;
     onset2 = onset;
     ap2 = ap;
-    while (onset2 < argc &&
-        (ap2->a_type != A_SEMI && ap2->a_type != A_COMMA))
-            onset2++, ap2++;
-    if (onset2 > onset)
+    while(onset2 < argc && (ap2->a_type != A_SEMI && ap2->a_type != A_COMMA))
+        onset2++, ap2++;
+    if(onset2 > onset)
     {
         x->x_onset = onset2;
-        if (ap->a_type == A_SYMBOL)
+        if(ap->a_type == A_SYMBOL)
             outlet_anything(x->x_ob.ob_outlet, ap->a_w.w_symbol,
-                onset2-onset-1, ap+1);
-        else outlet_list(x->x_ob.ob_outlet, 0, onset2-onset, ap);
+                onset2 - onset - 1, ap + 1);
+        else
+            outlet_list(x->x_ob.ob_outlet, 0, onset2 - onset, ap);
     }
     else
     {
@@ -2165,10 +2196,7 @@ static void textfile_bang(t_qlist *x)
     }
 }
 
-static void textfile_rewind(t_qlist *x)
-{
-    x->x_onset = 0;
-}
+static void textfile_rewind(t_qlist *x) { x->x_onset = 0; }
 
 /* ---------------- global setup function -------------------- */
 
@@ -2200,160 +2228,159 @@ void text_template_init(void)
 void x_qlist_setup(void)
 {
     text_template_init();
-    text_define_class = class_new(gensym("text define"),
-        (t_newmethod)text_define_new,
-        (t_method)text_define_free, sizeof(t_text_define), 0, A_GIMME, 0);
-    class_addmethod(text_define_class, (t_method)textbuf_open,
-        gensym("click"), 0);
-    class_addmethod(text_define_class, (t_method)textbuf_close,
-        gensym("close"), 0);
-    class_addmethod(text_define_class, (t_method)textbuf_addline,
+    text_define_class =
+        class_new(gensym("text define"), (t_newmethod) text_define_new,
+            (t_method) text_define_free, sizeof(t_text_define), 0, A_GIMME, 0);
+    class_addmethod(
+        text_define_class, (t_method) textbuf_open, gensym("click"), 0);
+    class_addmethod(
+        text_define_class, (t_method) textbuf_close, gensym("close"), 0);
+    class_addmethod(text_define_class, (t_method) textbuf_addline,
         gensym("addline"), A_GIMME, 0);
-    class_addmethod(text_define_class, (t_method)text_define_notify,
+    class_addmethod(text_define_class, (t_method) text_define_notify,
         gensym("notify"), 0, 0);
-    class_addmethod(text_define_class, (t_method)text_define_set,
+    class_addmethod(text_define_class, (t_method) text_define_set,
         gensym("set"), A_GIMME, 0);
-    class_addmethod(text_define_class, (t_method)text_define_clear,
-        gensym("clear"), 0);
-    class_addmethod(text_define_class, (t_method)textbuf_write,
+    class_addmethod(
+        text_define_class, (t_method) text_define_clear, gensym("clear"), 0);
+    class_addmethod(text_define_class, (t_method) textbuf_write,
         gensym("write"), A_GIMME, 0);
-    class_addmethod(text_define_class, (t_method)textbuf_read,
-        gensym("read"), A_GIMME, 0);
-    class_addmethod(text_define_class, (t_method)text_define_send,
+    class_addmethod(
+        text_define_class, (t_method) textbuf_read, gensym("read"), A_GIMME, 0);
+    class_addmethod(text_define_class, (t_method) text_define_send,
         gensym("send"), A_SYMBOL, 0);
-    class_addmethod(text_define_class, (t_method)text_define_sort,
+    class_addmethod(text_define_class, (t_method) text_define_sort,
         gensym("sort"), A_GIMME, 0);
     class_setsavefn(text_define_class, text_define_save);
     class_addbang(text_define_class, text_define_bang);
     class_sethelpsymbol(text_define_class, gensym("text-object"));
 
-    class_addcreator((t_newmethod)text_new, gensym("text"), A_GIMME, 0);
+    class_addcreator((t_newmethod) text_new, gensym("text"), A_GIMME, 0);
 
-    text_get_class = class_new(gensym("text get"),
-        (t_newmethod)text_get_new, (t_method)text_client_free,
-            sizeof(t_text_get), 0, A_GIMME, 0);
+    text_get_class = class_new(gensym("text get"), (t_newmethod) text_get_new,
+        (t_method) text_client_free, sizeof(t_text_get), 0, A_GIMME, 0);
     class_addfloat(text_get_class, text_get_float);
     class_sethelpsymbol(text_get_class, gensym("text-object"));
 
-    text_set_class = class_new(gensym("text set"),
-        (t_newmethod)text_set_new, (t_method)text_client_free,
-            sizeof(t_text_set), 0, A_GIMME, 0);
+    text_set_class = class_new(gensym("text set"), (t_newmethod) text_set_new,
+        (t_method) text_client_free, sizeof(t_text_set), 0, A_GIMME, 0);
     class_addlist(text_set_class, text_set_list);
     class_sethelpsymbol(text_set_class, gensym("text-object"));
 
-    text_insert_class = class_new(gensym("text insert"),
-        (t_newmethod)text_insert_new, (t_method)text_client_free,
-            sizeof(t_text_insert), 0, A_GIMME, 0);
+    text_insert_class =
+        class_new(gensym("text insert"), (t_newmethod) text_insert_new,
+            (t_method) text_client_free, sizeof(t_text_insert), 0, A_GIMME, 0);
     class_addlist(text_insert_class, text_insert_list);
     class_sethelpsymbol(text_insert_class, gensym("text-object"));
 
-    text_delete_class = class_new(gensym("text delete"),
-        (t_newmethod)text_delete_new, (t_method)text_client_free,
-            sizeof(t_text_delete), 0, A_GIMME, 0);
+    text_delete_class =
+        class_new(gensym("text delete"), (t_newmethod) text_delete_new,
+            (t_method) text_client_free, sizeof(t_text_delete), 0, A_GIMME, 0);
     class_addfloat(text_delete_class, text_delete_float);
     class_sethelpsymbol(text_delete_class, gensym("text-object"));
 
-    text_size_class = class_new(gensym("text size"),
-        (t_newmethod)text_size_new, (t_method)text_client_free,
-            sizeof(t_text_size), 0, A_GIMME, 0);
+    text_size_class =
+        class_new(gensym("text size"), (t_newmethod) text_size_new,
+            (t_method) text_client_free, sizeof(t_text_size), 0, A_GIMME, 0);
     class_addbang(text_size_class, text_size_bang);
     class_addfloat(text_size_class, text_size_float);
     class_sethelpsymbol(text_size_class, gensym("text-object"));
 
-    text_tolist_class = class_new(gensym("text tolist"),
-        (t_newmethod)text_tolist_new, (t_method)text_client_free,
-            sizeof(t_text_tolist), 0, A_GIMME, 0);
+    text_tolist_class =
+        class_new(gensym("text tolist"), (t_newmethod) text_tolist_new,
+            (t_method) text_client_free, sizeof(t_text_tolist), 0, A_GIMME, 0);
     class_addbang(text_tolist_class, text_tolist_bang);
     class_sethelpsymbol(text_tolist_class, gensym("text-object"));
 
     text_fromlist_class = class_new(gensym("text fromlist"),
-        (t_newmethod)text_fromlist_new, (t_method)text_client_free,
-            sizeof(t_text_fromlist), 0, A_GIMME, 0);
+        (t_newmethod) text_fromlist_new, (t_method) text_client_free,
+        sizeof(t_text_fromlist), 0, A_GIMME, 0);
     class_addlist(text_fromlist_class, text_fromlist_list);
     class_sethelpsymbol(text_fromlist_class, gensym("text-object"));
 
-    text_search_class = class_new(gensym("text search"),
-        (t_newmethod)text_search_new, (t_method)text_client_free,
-            sizeof(t_text_search), 0, A_GIMME, 0);
+    text_search_class =
+        class_new(gensym("text search"), (t_newmethod) text_search_new,
+            (t_method) text_client_free, sizeof(t_text_search), 0, A_GIMME, 0);
     class_addlist(text_search_class, text_search_list);
-    class_addmethod(text_search_class, (t_method)text_search_range,
+    class_addmethod(text_search_class, (t_method) text_search_range,
         gensym("range"), A_FLOAT, A_FLOAT, 0);
     class_sethelpsymbol(text_search_class, gensym("text-object"));
 
     text_sequence_class = class_new(gensym("text sequence"),
-        (t_newmethod)text_sequence_new, (t_method)text_sequence_free,
-            sizeof(t_text_sequence), 0, A_GIMME, 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_step,
-        gensym("step"), 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_line,
+        (t_newmethod) text_sequence_new, (t_method) text_sequence_free,
+        sizeof(t_text_sequence), 0, A_GIMME, 0);
+    class_addmethod(
+        text_sequence_class, (t_method) text_sequence_step, gensym("step"), 0);
+    class_addmethod(text_sequence_class, (t_method) text_sequence_line,
         gensym("line"), A_FLOAT, 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_auto,
-        gensym("auto"), 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_stop,
-        gensym("stop"), 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_args,
+    class_addmethod(
+        text_sequence_class, (t_method) text_sequence_auto, gensym("auto"), 0);
+    class_addmethod(
+        text_sequence_class, (t_method) text_sequence_stop, gensym("stop"), 0);
+    class_addmethod(text_sequence_class, (t_method) text_sequence_args,
         gensym("args"), A_GIMME, 0);
-    class_addmethod(text_sequence_class, (t_method)text_sequence_tempo,
+    class_addmethod(text_sequence_class, (t_method) text_sequence_tempo,
         gensym("tempo"), A_FLOAT, A_SYMBOL, 0);
     class_addlist(text_sequence_class, text_sequence_list);
     class_sethelpsymbol(text_sequence_class, gensym("text-object"));
 
-    qlist_class = class_new(gensym("qlist"), (t_newmethod)qlist_new,
-        (t_method)qlist_free, sizeof(t_qlist), 0, 0);
-    class_addmethod(qlist_class, (t_method)qlist_rewind, gensym("rewind"), 0);
-    class_addmethod(qlist_class, (t_method)qlist_next,
-        gensym("next"), A_DEFFLOAT, 0);
-    class_addmethod(qlist_class, (t_method)qlist_set, gensym("set"),
-        A_GIMME, 0);
-    class_addmethod(qlist_class, (t_method)qlist_clear, gensym("clear"), 0);
-    class_addmethod(qlist_class, (t_method)qlist_add, gensym("add"),
-        A_GIMME, 0);
-    class_addmethod(qlist_class, (t_method)qlist_add2, gensym("add2"),
-        A_GIMME, 0);
-    class_addmethod(qlist_class, (t_method)qlist_add, gensym("append"),
-        A_GIMME, 0);
-    class_addmethod(qlist_class, (t_method)qlist_read, gensym("read"),
+    qlist_class = class_new(gensym("qlist"), (t_newmethod) qlist_new,
+        (t_method) qlist_free, sizeof(t_qlist), 0, 0);
+    class_addmethod(qlist_class, (t_method) qlist_rewind, gensym("rewind"), 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_next, gensym("next"), A_DEFFLOAT, 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(qlist_class, (t_method) qlist_clear, gensym("clear"), 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_add, gensym("add"), A_GIMME, 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_add2, gensym("add2"), A_GIMME, 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_add, gensym("append"), A_GIMME, 0);
+    class_addmethod(qlist_class, (t_method) qlist_read, gensym("read"),
         A_SYMBOL, A_DEFSYM, 0);
-    class_addmethod(qlist_class, (t_method)qlist_write, gensym("write"),
+    class_addmethod(qlist_class, (t_method) qlist_write, gensym("write"),
         A_SYMBOL, A_DEFSYM, 0);
-    class_addmethod(qlist_class, (t_method)textbuf_open, gensym("click"), 0);
-    class_addmethod(qlist_class, (t_method)textbuf_close, gensym("close"), 0);
-    class_addmethod(qlist_class, (t_method)textbuf_addline,
-        gensym("addline"), A_GIMME, 0);
-    class_addmethod(qlist_class, (t_method)textbuf_senditup,
-        gensym("notify"), 0, 0);
-    class_addmethod(qlist_class, (t_method)qlist_print, gensym("print"),
-        A_DEFSYM, 0);
-    class_addmethod(qlist_class, (t_method)qlist_tempo,
-        gensym("tempo"), A_FLOAT, 0);
+    class_addmethod(qlist_class, (t_method) textbuf_open, gensym("click"), 0);
+    class_addmethod(qlist_class, (t_method) textbuf_close, gensym("close"), 0);
+    class_addmethod(
+        qlist_class, (t_method) textbuf_addline, gensym("addline"), A_GIMME, 0);
+    class_addmethod(
+        qlist_class, (t_method) textbuf_senditup, gensym("notify"), 0, 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_print, gensym("print"), A_DEFSYM, 0);
+    class_addmethod(
+        qlist_class, (t_method) qlist_tempo, gensym("tempo"), A_FLOAT, 0);
     class_addbang(qlist_class, qlist_bang);
 
-    textfile_class = class_new(gensym("textfile"), (t_newmethod)textfile_new,
-        (t_method)textbuf_free, sizeof(t_qlist), 0, 0);
-    class_addmethod(textfile_class, (t_method)textfile_rewind, gensym("rewind"),
-        0);
-    class_addmethod(textfile_class, (t_method)qlist_set, gensym("set"),
-        A_GIMME, 0);
-    class_addmethod(textfile_class, (t_method)qlist_clear, gensym("clear"), 0);
-    class_addmethod(textfile_class, (t_method)qlist_add, gensym("add"),
-        A_GIMME, 0);
-    class_addmethod(textfile_class, (t_method)qlist_add2, gensym("add2"),
-        A_GIMME, 0);
-    class_addmethod(textfile_class, (t_method)qlist_add, gensym("append"),
-        A_GIMME, 0);
-    class_addmethod(textfile_class, (t_method)qlist_read, gensym("read"),
+    textfile_class = class_new(gensym("textfile"), (t_newmethod) textfile_new,
+        (t_method) textbuf_free, sizeof(t_qlist), 0, 0);
+    class_addmethod(
+        textfile_class, (t_method) textfile_rewind, gensym("rewind"), 0);
+    class_addmethod(
+        textfile_class, (t_method) qlist_set, gensym("set"), A_GIMME, 0);
+    class_addmethod(textfile_class, (t_method) qlist_clear, gensym("clear"), 0);
+    class_addmethod(
+        textfile_class, (t_method) qlist_add, gensym("add"), A_GIMME, 0);
+    class_addmethod(
+        textfile_class, (t_method) qlist_add2, gensym("add2"), A_GIMME, 0);
+    class_addmethod(
+        textfile_class, (t_method) qlist_add, gensym("append"), A_GIMME, 0);
+    class_addmethod(textfile_class, (t_method) qlist_read, gensym("read"),
         A_SYMBOL, A_DEFSYM, 0);
-    class_addmethod(textfile_class, (t_method)qlist_write, gensym("write"),
+    class_addmethod(textfile_class, (t_method) qlist_write, gensym("write"),
         A_SYMBOL, A_DEFSYM, 0);
-    class_addmethod(textfile_class, (t_method)textbuf_open, gensym("click"), 0);
-    class_addmethod(textfile_class, (t_method)textbuf_close, gensym("close"),
-        0);
-    class_addmethod(textfile_class, (t_method)textbuf_addline,
+    class_addmethod(
+        textfile_class, (t_method) textbuf_open, gensym("click"), 0);
+    class_addmethod(
+        textfile_class, (t_method) textbuf_close, gensym("close"), 0);
+    class_addmethod(textfile_class, (t_method) textbuf_addline,
         gensym("addline"), A_GIMME, 0);
-    class_addmethod(textfile_class, (t_method)textbuf_senditup,
-        gensym("notify"), 0, 0);
-    class_addmethod(textfile_class, (t_method)qlist_print, gensym("print"),
-        A_DEFSYM, 0);
+    class_addmethod(
+        textfile_class, (t_method) textbuf_senditup, gensym("notify"), 0, 0);
+    class_addmethod(
+        textfile_class, (t_method) qlist_print, gensym("print"), A_DEFSYM, 0);
     class_addbang(textfile_class, textfile_bang);
 }
 
@@ -2361,16 +2388,16 @@ void x_qlist_setup(void)
 
 t_binbuf *text_getbufbyname(t_symbol *s)
 {
-    t_text_define *y = (t_text_define *)pd_findbyclass(s, text_define_class);
-    if (y)
+    t_text_define *y = (t_text_define *) pd_findbyclass(s, text_define_class);
+    if(y)
         return (y->x_textbuf.b_binbuf);
-    else return (0);
+    else
+        return (0);
 }
 
-    /* notify text object that binbuf was modified */
+/* notify text object that binbuf was modified */
 void text_notifybyname(t_symbol *s)
 {
-    t_text_define *y = (t_text_define *)pd_findbyclass(s, text_define_class);
-    if (y)
-        text_define_notify(y);
+    t_text_define *y = (t_text_define *) pd_findbyclass(s, text_define_class);
+    if(y) text_define_notify(y);
 }

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -131,7 +131,9 @@ static void textbuf_read(t_textbuf *x, t_symbol *s, int argc, t_atom *argv)
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-c"))
+        {
             cr = 1;
+        }
         else
         {
             pd_error(x, "text read: unknown flag ...");
@@ -172,7 +174,9 @@ static void textbuf_write(t_textbuf *x, t_symbol *s, int argc, t_atom *argv)
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-c"))
+        {
             cr = 1;
+        }
         else
         {
             pd_error(x, "text write: unknown flag ...");
@@ -267,7 +271,9 @@ static void *text_define_new(t_symbol *s, int argc, t_atom *argv)
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-k"))
+        {
             x->x_keep = 1;
+        }
         else
         {
             pd_error(x, "text define: unknown flag ...");
@@ -345,7 +351,9 @@ static void text_define_topointer(t_text_define *x, t_gpointer *gp, t_symbol *s)
         binbuf_add(b, binbuf_getnatom(x->x_textbuf.b_binbuf),
             binbuf_getvec(x->x_textbuf.b_binbuf));
         if(gs->gs_which == GP_GLIST)
+        {
             scalar_redraw(gp->gp_un.gp_scalar, gs->gs_un.gs_glist);
+        }
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
@@ -393,7 +401,9 @@ whomever is bound to the given symbol */
 static void text_define_send(t_text_define *x, t_symbol *s)
 {
     if(!s->s_thing)
+    {
         pd_error(x, "text_define_send: %s: no such object", s->s_name);
+    }
     else
     {
         gpointer_setglist(&x->x_gp, x->x_canvas, x->x_scalar);
@@ -430,8 +440,10 @@ static int text_sortcompare(const void *z1, const void *z2, void *zkeyinfo)
         }
     }
     for(count = k->ki_onset; count--; a2++)
+    {
         if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
             return (-k->ki_forward);
+    }
     /* compare remaining fields */
     for(;; a1++, a2++)
     {
@@ -439,15 +451,21 @@ static int text_sortcompare(const void *z1, const void *z2, void *zkeyinfo)
         {
             /* hit end of first line */
             if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
+            {
                 goto equal;
+            }
             else
+            {
                 return (-k->ki_forward);
+            }
         }
         else if(a2->a_type == A_SEMI || a2->a_type == A_COMMA)
+        {
             return (k->ki_forward); /* hit end of second line */
 
         /* otherwise if they're different return something, and
         if not proceed to next field */
+        }
         else if(a1->a_type == A_FLOAT)
         {
             if(a2->a_type == A_FLOAT)
@@ -477,9 +495,13 @@ equal:
     might not be identical because of a nonzero onset) stay in the
     same order as before. */
     if(a1 < a2)
+    {
         return (-1);
+    }
     else
+    {
         return (1);
+    }
 }
 
 /* 'qsort_r' is a GNU extension and 'qsort_s' is part of C11.
@@ -521,9 +543,13 @@ static void text_define_sort(
         argc && argv->a_type == A_SYMBOL && *argv->a_w.w_symbol->s_name == '-')
     {
         if(!strcmp(argv->a_w.w_symbol->s_name, "-u"))
+        {
             unique = 1;
+        }
         else if(!strcmp(argv->a_w.w_symbol->s_name, "-r"))
+        {
             k.ki_forward = -1;
+        }
         else if(!strcmp(argv->a_w.w_symbol->s_name, "-k") && argc > 1 &&
                 argv[1].a_type == A_FLOAT)
         {
@@ -549,9 +575,11 @@ static void text_define_sort(
     if(!natom) return;
     /* last thing in buffer should be a terminator */
     if(vec[natom - 1].a_type != A_SEMI && vec[natom - 1].a_type != A_COMMA)
+    {
         binbuf_addsemi(x->x_binbuf), vec = binbuf_getvec(x->x_binbuf),
                                      natom = binbuf_getnatom(x->x_binbuf),
                                      nlines++;
+    }
     for(i = nlines = 0; i < natom; i++)
         if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA) nlines++;
     sortbuf = (t_atom **) getbytes(nlines * sizeof(*sortbuf));
@@ -584,9 +612,13 @@ static void text_define_sort(
                 if(a1->a_type == A_SEMI || a1->a_type == A_COMMA)
                 {
                     if(a1->a_type == a2->a_type)
+                    {
                         goto skipit; /* duplicate line, don't copy */
+                    }
                     else
+                    {
                         goto doit;
+                    }
                 }
                 else if(a1->a_type != a2->a_type ||
                         (a1->a_type == A_FLOAT &&
@@ -650,7 +682,9 @@ static void text_client_argparse(
         !strcmp(argv->a_w.w_symbol->s_name, "-s"))
     {
         if(argc < 3 || argv[1].a_type != A_SYMBOL || argv[2].a_type != A_SYMBOL)
+        {
             pd_error(x, "%s: '-s' needs a struct and field name", name);
+        }
         else
         {
             x->tc_struct = canvas_makebindsym(argv[1].a_w.w_symbol);
@@ -702,9 +736,13 @@ static t_binbuf *text_client_getbuf(t_text_client *x)
             return (0);
         }
         if(gs->gs_which == GP_ARRAY)
+        {
             vec = x->tc_gp.gp_un.gp_w;
+        }
         else
+        {
             vec = x->tc_gp.gp_un.gp_scalar->sc_vec;
+        }
 
         if(!template_find_field(
                template, x->tc_field, &onset, &type, &arraytype))
@@ -730,9 +768,13 @@ static void text_client_senditup(t_text_client *x)
         t_textbuf *y =
             (t_textbuf *) pd_findbyclass(x->tc_sym, text_define_class);
         if(y)
+        {
             textbuf_senditup(y);
+        }
         else
+        {
             bug("text_client_senditup");
+        }
     }
     else if(x->tc_struct) /* by pointer */
     {
@@ -749,7 +791,9 @@ static void text_client_senditup(t_text_client *x)
             return;
         }
         if(gs->gs_which == GP_GLIST)
+        {
             scalar_redraw(x->tc_gp.gp_un.gp_scalar, gs->gs_un.gs_glist);
+        }
         else
         {
             t_array *owner_array = gs->gs_un.gs_array;
@@ -794,7 +838,9 @@ static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
     if(argc)
     {
         if(argv->a_type == A_FLOAT)
+        {
             x->x_f1 = argv->a_w.w_float;
+        }
         else
         {
             post("text get: can't understand field number");
@@ -807,7 +853,9 @@ static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
     if(argc)
     {
         if(argv->a_type == A_FLOAT)
+        {
             x->x_f2 = argv->a_w.w_float;
+        }
         else
         {
             post("text get: can't understand field count");
@@ -824,9 +872,13 @@ static void *text_get_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -860,10 +912,14 @@ static void text_get_float(t_text_get *x, t_floatarg f)
             ATOMS_FREEA(outv, outc);
         }
         else if(startfield + nfield > outc)
+        {
             pd_error(x, "text get: field request (%d %d) out of range",
                 startfield, nfield);
+        }
         else if(nfield < 0)
+        {
             pd_error(x, "text get: bad field count (%d)", nfield);
+        }
         else
         {
             ATOMS_ALLOCA(outv, nfield);
@@ -901,7 +957,9 @@ static void *text_set_new(t_symbol *s, int argc, t_atom *argv)
     if(argc)
     {
         if(argv->a_type == A_FLOAT)
+        {
             x->x_f1 = argv->a_w.w_float;
+        }
         else
         {
             post("text set: can't understand line number");
@@ -914,7 +972,9 @@ static void *text_set_new(t_symbol *s, int argc, t_atom *argv)
     if(argc)
     {
         if(argv->a_type == A_FLOAT)
+        {
             x->x_f2 = argv->a_w.w_float;
+        }
         else
         {
             post("text set: can't understand field number");
@@ -931,9 +991,13 @@ static void *text_set_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -1006,9 +1070,13 @@ static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
     for(i = 0; i < argc; i++)
     {
         if(argv[i].a_type == A_POINTER)
+        {
             SETSYMBOL(&vec[start + i], gensym("(pointer)"));
+        }
         else
+        {
             vec[start + i] = argv[i];
+        }
     }
     text_client_senditup(&x->x_tc);
 }
@@ -1031,7 +1099,9 @@ static void *text_insert_new(t_symbol *s, int argc, t_atom *argv)
     if(argc)
     {
         if(argv->a_type == A_FLOAT)
+        {
             x->x_f1 = argv->a_w.w_float;
+        }
         else
         {
             post("text insert: can't understand line number");
@@ -1048,9 +1118,13 @@ static void *text_insert_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -1078,14 +1152,20 @@ static void text_insert_list(
     (void) binbuf_resize(b, (n = nwas + argc + 1));
     vec = binbuf_getvec(b);
     if(start < n)
+    {
         memmove(&vec[start + (argc + 1)], &vec[start],
             sizeof(*vec) * (nwas - start));
+    }
     for(i = 0; i < argc; i++)
     {
         if(argv[i].a_type == A_POINTER)
+        {
             SETSYMBOL(&vec[start + i], gensym("(pointer)"));
+        }
         else
+        {
             vec[start + i] = argv[i];
+        }
     }
     SETSEMI(&vec[start + argc]);
     text_client_senditup(&x->x_tc);
@@ -1110,9 +1190,13 @@ static void *text_delete_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -1128,7 +1212,9 @@ static void text_delete_float(t_text_delete *x, t_floatarg f)
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
     if(lineno < 0)
+    {
         binbuf_clear(b);
+    }
     else if(text_nthline(n, vec, lineno, &start, &end))
     {
         if(end < n) end++;
@@ -1164,9 +1250,13 @@ static void *text_size_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -1199,9 +1289,13 @@ static void text_size_float(t_text_size *x, t_floatarg f)
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
     if(text_nthline(n, vec, f, &start, &end))
+    {
         outlet_float(x->x_out1, end - start);
+    }
     else
+    {
         outlet_float(x->x_out1, -1);
+    }
 }
 
 /* ---------------- text_tolist object - output text as a list ----------- */
@@ -1221,9 +1315,13 @@ static void *text_tolist_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->tc_struct)
+    {
         pointerinlet_new(&x->tc_obj, &x->tc_gp);
+    }
     else
+    {
         symbolinlet_new(&x->tc_obj, &x->tc_sym);
+    }
     return (x);
 }
 
@@ -1253,9 +1351,13 @@ static void *text_fromlist_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->tc_struct)
+    {
         pointerinlet_new(&x->tc_obj, &x->tc_gp);
+    }
     else
+    {
         symbolinlet_new(&x->tc_obj, &x->tc_sym);
+    }
     return (x);
 }
 
@@ -1314,8 +1416,11 @@ static void *text_search_new(t_symbol *s, int argc, t_atom *argv)
     x->x_range = 0x7fffffff;
     x->x_keyvec = (t_key *) getbytes(nkey * sizeof(*x->x_keyvec));
     if(!argc)
+    {
         x->x_keyvec[0].k_field = 0, x->x_keyvec[0].k_binop = KB_EQ;
+    }
     else
+    {
         for(i = key = 0, nextop = -1; i < argc; i++)
         {
             if(argv[i].a_type == A_FLOAT)
@@ -1330,27 +1435,46 @@ static void *text_search_new(t_symbol *s, int argc, t_atom *argv)
             {
                 const char *s = argv[i].a_w.w_symbol->s_name;
                 if(nextop >= 0)
+                {
                     pd_error(x,
                         "text search: extra operation argument ignored: %s", s);
+                }
                 else if(!strcmp(argv[i].a_w.w_symbol->s_name, ">"))
+                {
                     nextop = KB_GT;
+                }
                 else if(!strcmp(argv[i].a_w.w_symbol->s_name, ">="))
+                {
                     nextop = KB_GE;
+                }
                 else if(!strcmp(argv[i].a_w.w_symbol->s_name, "<"))
+                {
                     nextop = KB_LT;
+                }
                 else if(!strcmp(argv[i].a_w.w_symbol->s_name, "<="))
+                {
                     nextop = KB_LE;
+                }
                 else if(!strcmp(argv[i].a_w.w_symbol->s_name, "near"))
+                {
                     nextop = KB_NEAR;
+                }
                 else
+                {
                     pd_error(
                         x, "text search: unknown operation argument: %s", s);
+                }
             }
         }
+    }
     if(x->x_struct)
+    {
         pointerinlet_new(&x->x_obj, &x->x_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_obj, &x->x_tc.tc_sym);
+    }
     return (x);
 }
 
@@ -1445,11 +1569,15 @@ static void text_search_list(
                         argv[j].a_w.w_symbol)
                         goto nomatch;
                 }
-                if(++j >= nkeys) /* if at last key just increment field */
+                if(++j >= nkeys)
+                { /* if at last key just increment field */
                     field++;
+                }
                 else
+                {
                     field = x->x_keyvec[j].k_field, /* else next key */
                         binop = x->x_keyvec[j].k_binop;
+                }
             }
             /* the line matches.  Now, if there is a previous match, are
             we better than it? */
@@ -1473,33 +1601,49 @@ static void text_search_list(
                             case KB_GT:
                             case KB_GE:
                                 if(thisv < bestv)
+                                {
                                     goto replace;
+                                }
                                 else if(thisv > bestv)
+                                {
                                     goto nomatch;
+                                }
                                 break;
                             case KB_LT:
                             case KB_LE:
                                 if(thisv > bestv)
+                                {
                                     goto replace;
+                                }
                                 else if(thisv < bestv)
+                                {
                                     goto nomatch;
+                                }
                                 break;
                             case KB_NEAR:
                                 if(thisv >= argv[j].a_w.w_float &&
                                     bestv >= argv[j].a_w.w_float)
                                 {
                                     if(thisv < bestv)
+                                    {
                                         goto replace;
+                                    }
                                     else if(thisv > bestv)
+                                    {
                                         goto nomatch;
+                                    }
                                 }
                                 else if(thisv <= argv[j].a_w.w_float &&
                                         bestv <= argv[j].a_w.w_float)
                                 {
                                     if(thisv > bestv)
+                                    {
                                         goto replace;
+                                    }
                                     else if(thisv < bestv)
+                                    {
                                         goto nomatch;
+                                    }
                                 }
                                 else
                                 {
@@ -1509,19 +1653,27 @@ static void text_search_list(
                                     if(d2 < 0) d2 = -d2;
 
                                     if(d1 < d2)
+                                    {
                                         goto replace;
+                                    }
                                     else if(d1 > d2)
+                                    {
                                         goto nomatch;
+                                    }
                                 }
                                 break;
                                 /* the other possibility ('=') never decides */
                         }
                     }
-                    if(++j >= nkeys) /* last key - increment field */
+                    if(++j >= nkeys)
+                    { /* last key - increment field */
                         field++;
+                    }
                     else
+                    {
                         field = x->x_keyvec[j].k_field, /* else next key */
                             binop = x->x_keyvec[j].k_binop;
+                    }
                 }
                 goto nomatch; /* a tie - keep the old one */
             replace:
@@ -1603,7 +1755,9 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
             argv += 1;
         }
         else if(!strcmp(argv->a_w.w_symbol->s_name, "-g"))
+        {
             global = 1;
+        }
         else if(!strcmp(argv->a_w.w_symbol->s_name, "-t") && argc >= 3)
         {
             text_sequence_tempo(x, atom_getsymbolarg(2, argc, argv),
@@ -1626,9 +1780,13 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
         endpost();
     }
     if(x->x_tc.tc_struct)
+    {
         pointerinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_gp);
+    }
     else
+    {
         symbolinlet_new(&x->x_tc.tc_obj, &x->x_tc.tc_sym);
+    }
     x->x_argc = 0;
     x->x_argv = (t_atom *) getbytes(0);
     x->x_onset = 0x7fffffff;
@@ -1640,8 +1798,10 @@ static void *text_sequence_new(t_symbol *s, int argc, t_atom *argv)
     if(global)
     {
         if(x->x_waitargc)
+        {
             pd_error(x, "warning: text sequence: numeric 'w' argument ignored "
                         "if '-g' given");
+        }
         x->x_waitargc = 0x40000000;
     }
     return (x);
@@ -1720,7 +1880,9 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
     {
         int type = ap->a_type;
         if(type == A_FLOAT || type == A_SYMBOL)
+        {
             outvec[i] = *ap;
+        }
         else if(type == A_DOLLAR)
         {
             int atno = ap->a_w.w_index - 1;
@@ -1737,7 +1899,9 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
             t_symbol *s =
                 binbuf_realizedollsym(ap->a_w.w_symbol, argc, argv, 0);
             if(s)
+            {
                 SETSYMBOL(outvec + i, s);
+            }
             else
             {
                 pd_error(0, "$%s: not enough arguments supplied",
@@ -1753,9 +1917,13 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
         x->x_loop = 0;
         x->x_lastto = 0;
         if(x->x_auto && nfield == 1 && outvec[0].a_type == A_FLOAT)
+        {
             x->x_nextdelay = outvec[0].a_w.w_float;
+        }
         else if(!x->x_waitout)
+        {
             bug("text sequence 3");
+        }
         else
         {
             x->x_auto = 0;
@@ -1772,9 +1940,13 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
             n2++;
         }
         if(!gotcomma)
+        {
             x->x_lastto = 0;
+        }
         else if(!x->x_lastto && nfield && outvec->a_type == A_SYMBOL)
+        {
             x->x_lastto = outvec->a_w.w_symbol;
+        }
         outlet_list(x->x_mainout, 0, n2, outvec);
     }
     else if(nfield)
@@ -1786,9 +1958,13 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
         if(!tosym)
         {
             if(outvec[0].a_type != A_SYMBOL)
+            {
                 bug("text sequence 2");
+            }
             else
+            {
                 tosym = outvec[0].a_w.w_symbol;
+            }
             vecleft++;
             nleft--;
         }
@@ -1801,9 +1977,13 @@ static void text_sequence_doit(t_text_sequence *x, int argc, t_atom *argv)
         if(to)
         {
             if(nleft > 0 && vecleft[0].a_type == A_SYMBOL)
+            {
                 typedmess(to, vecleft->a_w.w_symbol, nleft - 1, vecleft + 1);
+            }
             else
+            {
                 pd_list(to, 0, nleft, vecleft);
+            }
         }
     }
     ATOMS_FREEA(outvec, nfield + 1);
@@ -1816,9 +1996,13 @@ static void text_sequence_list(
     while(x->x_loop)
     {
         if(argc)
+        {
             text_sequence_doit(x, argc, argv);
+        }
         else
+        {
             text_sequence_doit(x, x->x_argc, x->x_argv);
+        }
     }
 }
 
@@ -1911,30 +2095,52 @@ static void text_sequence_free(t_text_sequence *x)
 static void *text_new(t_symbol *s, int argc, t_atom *argv)
 {
     if(!argc || argv[0].a_type != A_SYMBOL)
+    {
         pd_this->pd_newest = text_define_new(s, argc, argv);
+    }
     else
     {
         const char *str = argv[0].a_w.w_symbol->s_name;
         if(!strcmp(str, "d") || !strcmp(str, "define"))
+        {
             pd_this->pd_newest = text_define_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "get"))
+        {
             pd_this->pd_newest = text_get_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "set"))
+        {
             pd_this->pd_newest = text_set_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "insert"))
+        {
             pd_this->pd_newest = text_insert_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "delete"))
+        {
             pd_this->pd_newest = text_delete_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "size"))
+        {
             pd_this->pd_newest = text_size_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "tolist"))
+        {
             pd_this->pd_newest = text_tolist_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "fromlist"))
+        {
             pd_this->pd_newest = text_fromlist_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "search"))
+        {
             pd_this->pd_newest = text_search_new(s, argc - 1, argv + 1);
+        }
         else if(!strcmp(str, "sequence"))
+        {
             pd_this->pd_newest = text_sequence_new(s, argc - 1, argv + 1);
+        }
         else
         {
             pd_error(0, "list %s: unknown function", str);
@@ -2070,9 +2276,13 @@ static void qlist_donext(t_qlist *x, int drop, int automatic)
         if(!drop)
         {
             if(ap->a_type == A_FLOAT)
+            {
                 typedmess(target, &s_list, count, ap);
+            }
             else if(ap->a_type == A_SYMBOL)
+            {
                 typedmess(target, ap->a_w.w_symbol, count - 1, ap + 1);
+            }
         }
         if(x->x_rewound)
         {
@@ -2144,9 +2354,13 @@ static void qlist_read(t_qlist *x, t_symbol *filename, t_symbol *format)
 {
     int cr = 0;
     if(!strcmp(format->s_name, "cr"))
+    {
         cr = 1;
+    }
     else if(*format->s_name)
+    {
         pd_error(x, "qlist_read: unknown flag: %s", format->s_name);
+    }
 
     if(binbuf_read_via_canvas(x->x_binbuf, filename->s_name, x->x_canvas, cr))
         pd_error(x, "%s: read failed", filename->s_name);
@@ -2160,9 +2374,13 @@ static void qlist_write(t_qlist *x, t_symbol *filename, t_symbol *format)
     char buf[MAXPDSTRING];
     canvas_makefilename(x->x_canvas, filename->s_name, buf, MAXPDSTRING);
     if(!strcmp(format->s_name, "cr"))
+    {
         cr = 1;
+    }
     else if(*format->s_name)
+    {
         pd_error(x, "qlist_read: unknown flag: %s", format->s_name);
+    }
     if(binbuf_write(x->x_binbuf, buf, "", cr))
         pd_error(x, "%s: write failed", filename->s_name);
 }
@@ -2177,9 +2395,13 @@ static void qlist_tempo(t_qlist *x, t_float f)
 {
     t_float newtempo;
     if(f < 1e-20)
+    {
         f = 1e-20;
+    }
     else if(f > 1e20)
+    {
         f = 1e20;
+    }
     newtempo = 1. / f;
     if(x->x_whenclockset != 0)
     {
@@ -2240,10 +2462,14 @@ static void textfile_bang(t_qlist *x)
     {
         x->x_onset = onset2;
         if(ap->a_type == A_SYMBOL)
+        {
             outlet_anything(x->x_ob.ob_outlet, ap->a_w.w_symbol,
                 onset2 - onset - 1, ap + 1);
+        }
         else
+        {
             outlet_list(x->x_ob.ob_outlet, 0, onset2 - onset, ap);
+        }
     }
     else
     {

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -66,13 +66,12 @@ static void textbuf_init(t_textbuf *x, t_symbol *sym)
 
 static void textbuf_senditup(t_textbuf *x)
 {
-    int i;
     int ntxt;
     char *txt;
     if(!x->b_guiconnect) return;
     binbuf_gettext(x->b_binbuf, &txt, &ntxt);
     sys_vgui("pdtk_textwindow_clear .x%lx\n", x);
-    for(i = 0; i < ntxt;)
+    for(int i = 0; i < ntxt;)
     {
         char *j = strchr(txt + i, '\n');
         if(!j) j = txt + ntxt;
@@ -225,9 +224,8 @@ static void textbuf_free(t_textbuf *x)
 /* random helper function to find the nth line in a text buffer */
 static int text_nthline(int n, t_atom *vec, int line, int *startp, int *endp)
 {
-    int i;
     int cnt = 0;
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(cnt == line)
         {
@@ -1008,7 +1006,6 @@ static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
     int end;
     int n;
     int fieldno = x->x_f2;
-    int i;
     int /* check for overflow in this conversion: */
         lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
     t_atom *vec;
@@ -1067,7 +1064,7 @@ static void text_set_list(t_text_set *x, t_symbol *s, int argc, t_atom *argv)
         post("text set: %d: line number out of range", lineno);
         return;
     }
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         if(argv[i].a_type == A_POINTER)
         {
@@ -1136,7 +1133,6 @@ static void text_insert_list(
     int end;
     int n;
     int nwas;
-    int i;
     int lineno = (x->x_f1 > (double) 0x7fffffff ? 0x7fffffff : (int) x->x_f1);
 
     t_atom *vec;
@@ -1156,7 +1152,7 @@ static void text_insert_list(
         memmove(&vec[start + (argc + 1)], &vec[start],
             sizeof(*vec) * (nwas - start));
     }
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         if(argv[i].a_type == A_POINTER)
         {
@@ -1264,13 +1260,12 @@ static void text_size_bang(t_text_size *x)
 {
     t_binbuf *b = text_client_getbuf(&x->x_tc);
     int n;
-    int i;
     int cnt = 0;
     t_atom *vec;
     if(!b) return;
     vec = binbuf_getvec(b);
     n = binbuf_getnatom(b);
-    for(i = 0; i < n; i++)
+    for(int i = 0; i < n; i++)
     {
         if(vec[i].a_type == A_SEMI || vec[i].a_type == A_COMMA) cnt++;
     }
@@ -2067,10 +2062,9 @@ static void text_sequence_line(t_text_sequence *x, t_floatarg f)
 static void text_sequence_args(
     t_text_sequence *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
     x->x_argv = t_resizebytes(
         x->x_argv, x->x_argc * sizeof(t_atom), argc * sizeof(t_atom));
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
         x->x_argv[i] = argv[i];
     x->x_argc = argc;
 }

--- a/src/x_time.c
+++ b/src/x_time.c
@@ -1,6 +1,6 @@
 /* Copyright (c) 1997-1999 Miller Puckette.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* clock objects */
 
@@ -8,52 +8,53 @@
 #include <stdio.h>
 #include <string.h>
 
-    /* parse a time unit such as "5 msec", "60 perminute", or "1 sample" to
-    a form usable by clock_setunit)( and clock_gettimesincewithunits().
-    This brute-force search through symbols really ought not to be done on
-    the fly for incoming 'tempo' messages, hmm...  This isn't public because
-    its interface might want to change - but it's used in x_text.c as well
-    as here. */
-void parsetimeunits(void *x, t_float amount, t_symbol *unitname,
-    t_float *unit, int *samps)
+/* parse a time unit such as "5 msec", "60 perminute", or "1 sample" to
+a form usable by clock_setunit)( and clock_gettimesincewithunits().
+This brute-force search through symbols really ought not to be done on
+the fly for incoming 'tempo' messages, hmm...  This isn't public because
+its interface might want to change - but it's used in x_text.c as well
+as here. */
+void parsetimeunits(
+    void *x, t_float amount, t_symbol *unitname, t_float *unit, int *samps)
 {
     const char *s = unitname->s_name;
-    if (amount <= 0)
-        amount = 1;
-    if (s[0] == 'p' && s[1] == 'e' && s[2] == 'r')  /* starts with 'per' */
+    if(amount <= 0) amount = 1;
+    if(s[0] == 'p' && s[1] == 'e' && s[2] == 'r') /* starts with 'per' */
     {
-        const char *s2 = s+3;
-        if (!strcmp(s2, "millisecond") || !strcmp(s2, "msec"))  /* msec */
-            *samps = 0, *unit = 1./amount;
-        else if (!strncmp(s2, "sec", 3))        /* seconds */
-            *samps = 0, *unit = 1000./amount;
-        else if (!strncmp(s2, "min", 3))        /* minutes */
-            *samps = 0, *unit = 60000./amount;
-        else if (!strncmp(s2, "sam", 3))        /* samples */
-            *samps = 1, *unit = 1./amount;
-        else goto fail;
+        const char *s2 = s + 3;
+        if(!strcmp(s2, "millisecond") || !strcmp(s2, "msec")) /* msec */
+            *samps = 0, *unit = 1. / amount;
+        else if(!strncmp(s2, "sec", 3)) /* seconds */
+            *samps = 0, *unit = 1000. / amount;
+        else if(!strncmp(s2, "min", 3)) /* minutes */
+            *samps = 0, *unit = 60000. / amount;
+        else if(!strncmp(s2, "sam", 3)) /* samples */
+            *samps = 1, *unit = 1. / amount;
+        else
+            goto fail;
     }
     else
     {
-            /* empty string defaults to msec */
-        if (!strcmp(s, "millisecond") || !strcmp(s, "msec"))
+        /* empty string defaults to msec */
+        if(!strcmp(s, "millisecond") || !strcmp(s, "msec"))
             *samps = 0, *unit = amount;
-        else if (!strncmp(s, "sec", 3))
-            *samps = 0, *unit = 1000.*amount;
-        else if (!strncmp(s, "min", 3))
-            *samps = 0, *unit = 60000.*amount;
-        else if (!strncmp(s, "sam", 3))
+        else if(!strncmp(s, "sec", 3))
+            *samps = 0, *unit = 1000. * amount;
+        else if(!strncmp(s, "min", 3))
+            *samps = 0, *unit = 60000. * amount;
+        else if(!strncmp(s, "sam", 3))
             *samps = 1, *unit = amount;
         else
         {
         fail:
-                /* empty time unit specification defaults to 1 msec for
-                back compatibility, since it's possible someone threw a
-                float argument to timer which had previously been ignored. */
-            if (*s)
+            /* empty time unit specification defaults to 1 msec for
+            back compatibility, since it's possible someone threw a
+            float argument to timer which had previously been ignored. */
+            if(*s)
                 pd_error(x, "%s: unknown time unit", s);
-            else pd_error(x,
-                "tempo setting needs time unit ('sec', 'samp', 'permin', etc.");
+            else
+                pd_error(x, "tempo setting needs time unit ('sec', 'samp', "
+                            "'permin', etc.");
             *unit = 1;
             *samps = 0;
         }
@@ -72,24 +73,15 @@ typedef struct _delay
 
 static void delay_ft1(t_delay *x, t_floatarg g)
 {
-    if (g < 0) g = 0;
+    if(g < 0) g = 0;
     x->x_deltime = g;
 }
 
-static void delay_tick(t_delay *x)
-{
-    outlet_bang(x->x_obj.ob_outlet);
-}
+static void delay_tick(t_delay *x) { outlet_bang(x->x_obj.ob_outlet); }
 
-static void delay_bang(t_delay *x)
-{
-    clock_delay(x->x_clock, x->x_deltime);
-}
+static void delay_bang(t_delay *x) { clock_delay(x->x_clock, x->x_deltime); }
 
-static void delay_stop(t_delay *x)
-{
-    clock_unset(x->x_clock);
-}
+static void delay_stop(t_delay *x) { clock_unset(x->x_clock); }
 
 static void delay_float(t_delay *x, t_float f)
 {
@@ -105,37 +97,33 @@ static void delay_tempo(t_delay *x, t_symbol *unitname, t_floatarg tempo)
     clock_setunit(x->x_clock, unit, samps);
 }
 
-static void delay_free(t_delay *x)
-{
-    clock_free(x->x_clock);
-}
+static void delay_free(t_delay *x) { clock_free(x->x_clock); }
 
 static void *delay_new(t_symbol *unitname, t_floatarg f, t_floatarg tempo)
 {
-    t_delay *x = (t_delay *)pd_new(delay_class);
+    t_delay *x = (t_delay *) pd_new(delay_class);
     delay_ft1(x, f);
-    x->x_clock = clock_new(x, (t_method)delay_tick);
+    x->x_clock = clock_new(x, (t_method) delay_tick);
     outlet_new(&x->x_obj, gensym("bang"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
-    if (tempo != 0)
-        delay_tempo(x, unitname, tempo);
+    if(tempo != 0) delay_tempo(x, unitname, tempo);
     return (x);
 }
 
 static void delay_setup(void)
 {
-    delay_class = class_new(gensym("delay"), (t_newmethod)delay_new,
-        (t_method)delay_free, sizeof(t_delay), 0,
-            A_DEFFLOAT, A_DEFFLOAT, A_DEFSYM, 0);
-    class_addcreator((t_newmethod)delay_new, gensym("del"),
-        A_DEFFLOAT, A_DEFFLOAT, A_DEFSYM, 0);
+    delay_class = class_new(gensym("delay"), (t_newmethod) delay_new,
+        (t_method) delay_free, sizeof(t_delay), 0, A_DEFFLOAT, A_DEFFLOAT,
+        A_DEFSYM, 0);
+    class_addcreator((t_newmethod) delay_new, gensym("del"), A_DEFFLOAT,
+        A_DEFFLOAT, A_DEFSYM, 0);
     class_addbang(delay_class, delay_bang);
-    class_addmethod(delay_class, (t_method)delay_stop, gensym("stop"), 0);
-    class_addmethod(delay_class, (t_method)delay_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(delay_class, (t_method)delay_tempo,
-        gensym("tempo"), A_FLOAT, A_SYMBOL, 0);
-    class_addfloat(delay_class, (t_method)delay_float);
+    class_addmethod(delay_class, (t_method) delay_stop, gensym("stop"), 0);
+    class_addmethod(
+        delay_class, (t_method) delay_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(delay_class, (t_method) delay_tempo, gensym("tempo"),
+        A_FLOAT, A_SYMBOL, 0);
+    class_addfloat(delay_class, (t_method) delay_float);
 }
 
 /* -------------------------- metro ------------------------------ */
@@ -151,8 +139,8 @@ typedef struct _metro
 
 static void metro_ft1(t_metro *x, t_floatarg g)
 {
-    if (g <= 0) /* as of 0.45, we're willing to try any positive time value */
-        g = 1;  /* but default to 1 (arbitrary and probably not so good) */
+    if(g <= 0) /* as of 0.45, we're willing to try any positive time value */
+        g = 1; /* but default to 1 (arbitrary and probably not so good) */
     x->x_deltime = g;
 }
 
@@ -160,25 +148,21 @@ static void metro_tick(t_metro *x)
 {
     x->x_hit = 0;
     outlet_bang(x->x_obj.ob_outlet);
-    if (!x->x_hit) clock_delay(x->x_clock, x->x_deltime);
+    if(!x->x_hit) clock_delay(x->x_clock, x->x_deltime);
 }
 
 static void metro_float(t_metro *x, t_float f)
 {
-    if (f != 0) metro_tick(x);
-    else clock_unset(x->x_clock);
+    if(f != 0)
+        metro_tick(x);
+    else
+        clock_unset(x->x_clock);
     x->x_hit = 1;
 }
 
-static void metro_bang(t_metro *x)
-{
-    metro_float(x, 1);
-}
+static void metro_bang(t_metro *x) { metro_float(x, 1); }
 
-static void metro_stop(t_metro *x)
-{
-    metro_float(x, 0);
-}
+static void metro_stop(t_metro *x) { metro_float(x, 0); }
 
 static void metro_tempo(t_metro *x, t_symbol *unitname, t_floatarg tempo)
 {
@@ -188,36 +172,32 @@ static void metro_tempo(t_metro *x, t_symbol *unitname, t_floatarg tempo)
     clock_setunit(x->x_clock, unit, samps);
 }
 
-static void metro_free(t_metro *x)
-{
-    clock_free(x->x_clock);
-}
+static void metro_free(t_metro *x) { clock_free(x->x_clock); }
 
 static void *metro_new(t_symbol *unitname, t_floatarg f, t_floatarg tempo)
 {
-    t_metro *x = (t_metro *)pd_new(metro_class);
+    t_metro *x = (t_metro *) pd_new(metro_class);
     metro_ft1(x, f);
     x->x_hit = 0;
-    x->x_clock = clock_new(x, (t_method)metro_tick);
+    x->x_clock = clock_new(x, (t_method) metro_tick);
     outlet_new(&x->x_obj, gensym("bang"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("float"), gensym("ft1"));
-    if (tempo != 0)
-        metro_tempo(x, unitname, tempo);
+    if(tempo != 0) metro_tempo(x, unitname, tempo);
     return (x);
 }
 
 static void metro_setup(void)
 {
-    metro_class = class_new(gensym("metro"), (t_newmethod)metro_new,
-        (t_method)metro_free, sizeof(t_metro), 0,
-            A_DEFFLOAT, A_DEFFLOAT, A_DEFSYM, 0);
+    metro_class = class_new(gensym("metro"), (t_newmethod) metro_new,
+        (t_method) metro_free, sizeof(t_metro), 0, A_DEFFLOAT, A_DEFFLOAT,
+        A_DEFSYM, 0);
     class_addbang(metro_class, metro_bang);
-    class_addmethod(metro_class, (t_method)metro_stop, gensym("stop"), 0);
-    class_addmethod(metro_class, (t_method)metro_ft1, gensym("ft1"),
-        A_FLOAT, 0);
-    class_addmethod(metro_class, (t_method)metro_tempo,
-        gensym("tempo"), A_FLOAT, A_SYMBOL, 0);
-    class_addfloat(metro_class, (t_method)metro_float);
+    class_addmethod(metro_class, (t_method) metro_stop, gensym("stop"), 0);
+    class_addmethod(
+        metro_class, (t_method) metro_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(metro_class, (t_method) metro_tempo, gensym("tempo"),
+        A_FLOAT, A_SYMBOL, 0);
+    class_addfloat(metro_class, (t_method) metro_float);
 }
 
 /* -------------------------- line ------------------------------ */
@@ -241,43 +221,42 @@ typedef struct _line
 static void line_tick(t_line *x)
 {
     double timenow = clock_getsystime();
-    double msectogo = - clock_gettimesince(x->x_targettime);
-    if (msectogo < 1E-9)
+    double msectogo = -clock_gettimesince(x->x_targettime);
+    if(msectogo < 1E-9)
     {
         outlet_float(x->x_obj.ob_outlet, x->x_targetval);
     }
     else
     {
         outlet_float(x->x_obj.ob_outlet,
-            x->x_setval + x->x_1overtimediff * (timenow - x->x_prevtime)
-                * (x->x_targetval - x->x_setval));
-        if (x->x_grain <= 0)
-            x->x_grain = DEFAULTLINEGRAIN;
-        clock_delay(x->x_clock,
-            (x->x_grain > msectogo ? msectogo : x->x_grain));
+            x->x_setval + x->x_1overtimediff * (timenow - x->x_prevtime) *
+                              (x->x_targetval - x->x_setval));
+        if(x->x_grain <= 0) x->x_grain = DEFAULTLINEGRAIN;
+        clock_delay(
+            x->x_clock, (x->x_grain > msectogo ? msectogo : x->x_grain));
     }
 }
 
 static void line_float(t_line *x, t_float f)
 {
     double timenow = clock_getsystime();
-    if (x->x_gotinlet && x->x_in1val > 0)
+    if(x->x_gotinlet && x->x_in1val > 0)
     {
-        if (timenow > x->x_targettime) x->x_setval = x->x_targetval;
-        else x->x_setval = x->x_setval + x->x_1overtimediff *
-            (timenow - x->x_prevtime)
-            * (x->x_targetval - x->x_setval);
+        if(timenow > x->x_targettime)
+            x->x_setval = x->x_targetval;
+        else
+            x->x_setval = x->x_setval + x->x_1overtimediff *
+                                            (timenow - x->x_prevtime) *
+                                            (x->x_targetval - x->x_setval);
         x->x_prevtime = timenow;
         x->x_targettime = clock_getsystimeafter(x->x_in1val);
         x->x_targetval = f;
         line_tick(x);
         x->x_gotinlet = 0;
-        x->x_1overtimediff = 1./ (x->x_targettime - timenow);
-        if (x->x_grain <= 0)
-            x->x_grain = DEFAULTLINEGRAIN;
-        clock_delay(x->x_clock,
-            (x->x_grain > x->x_in1val ? x->x_in1val : x->x_grain));
-
+        x->x_1overtimediff = 1. / (x->x_targettime - timenow);
+        if(x->x_grain <= 0) x->x_grain = DEFAULTLINEGRAIN;
+        clock_delay(
+            x->x_clock, (x->x_grain > x->x_in1val ? x->x_in1val : x->x_grain));
     }
     else
     {
@@ -296,13 +275,14 @@ static void line_ft1(t_line *x, t_floatarg g)
 
 static void line_stop(t_line *x)
 {
-    if (pd_compatibilitylevel >= 48)
+    if(pd_compatibilitylevel >= 48)
     {
-        if (clock_getsystime() >= x->x_targettime)
+        if(clock_getsystime() >= x->x_targettime)
             x->x_setval = x->x_targetval;
-        else x->x_setval += x->x_1overtimediff *
-            (clock_getsystime() - x->x_prevtime) *
-                (x->x_targetval - x->x_setval);
+        else
+            x->x_setval += x->x_1overtimediff *
+                           (clock_getsystime() - x->x_prevtime) *
+                           (x->x_targetval - x->x_setval);
     }
     x->x_targetval = x->x_setval;
     clock_unset(x->x_clock);
@@ -314,18 +294,15 @@ static void line_set(t_line *x, t_floatarg f)
     x->x_targetval = x->x_setval = f;
 }
 
-static void line_free(t_line *x)
-{
-    clock_free(x->x_clock);
-}
+static void line_free(t_line *x) { clock_free(x->x_clock); }
 
 static void *line_new(t_floatarg f, t_floatarg grain)
 {
-    t_line *x = (t_line *)pd_new(line_class);
+    t_line *x = (t_line *) pd_new(line_class);
     x->x_targetval = x->x_setval = f;
     x->x_gotinlet = 0;
     x->x_1overtimediff = 1;
-    x->x_clock = clock_new(x, (t_method)line_tick);
+    x->x_clock = clock_new(x, (t_method) line_tick);
     x->x_targettime = x->x_prevtime = clock_getsystime();
     x->x_grain = grain;
     outlet_new(&x->x_obj, gensym("float"));
@@ -336,15 +313,12 @@ static void *line_new(t_floatarg f, t_floatarg grain)
 
 static void line_setup(void)
 {
-    line_class = class_new(gensym("line"), (t_newmethod)line_new,
-        (t_method)line_free, sizeof(t_line), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
-    class_addmethod(line_class, (t_method)line_ft1,
-        gensym("ft1"), A_FLOAT, 0);
-    class_addmethod(line_class, (t_method)line_stop,
-        gensym("stop"), 0);
-    class_addmethod(line_class, (t_method)line_set,
-        gensym("set"), A_FLOAT, 0);
-    class_addfloat(line_class, (t_method)line_float);
+    line_class = class_new(gensym("line"), (t_newmethod) line_new,
+        (t_method) line_free, sizeof(t_line), 0, A_DEFFLOAT, A_DEFFLOAT, 0);
+    class_addmethod(line_class, (t_method) line_ft1, gensym("ft1"), A_FLOAT, 0);
+    class_addmethod(line_class, (t_method) line_stop, gensym("stop"), 0);
+    class_addmethod(line_class, (t_method) line_set, gensym("set"), A_FLOAT, 0);
+    class_addfloat(line_class, (t_method) line_float);
 }
 
 /* -------------------------- timer ------------------------------ */
@@ -368,41 +342,39 @@ static void timer_bang(t_timer *x)
 static void timer_bang2(t_timer *x)
 {
     outlet_float(x->x_obj.ob_outlet,
-        clock_gettimesincewithunits(x->x_settime, x->x_unit, x->x_samps)
-            + x->x_moreelapsed);
+        clock_gettimesincewithunits(x->x_settime, x->x_unit, x->x_samps) +
+            x->x_moreelapsed);
 }
 
 static void timer_tempo(t_timer *x, t_symbol *unitname, t_floatarg tempo)
 {
-    x->x_moreelapsed +=  clock_gettimesincewithunits(x->x_settime,
-        x->x_unit, x->x_samps);
+    x->x_moreelapsed +=
+        clock_gettimesincewithunits(x->x_settime, x->x_unit, x->x_samps);
     x->x_settime = clock_getsystime();
     parsetimeunits(x, tempo, unitname, &x->x_unit, &x->x_samps);
 }
 
 static void *timer_new(t_symbol *unitname, t_floatarg tempo)
 {
-    t_timer *x = (t_timer *)pd_new(timer_class);
+    t_timer *x = (t_timer *) pd_new(timer_class);
     x->x_unit = 1;
     x->x_samps = 0;
     timer_bang(x);
     outlet_new(&x->x_obj, gensym("float"));
     inlet_new(&x->x_obj, &x->x_obj.ob_pd, gensym("bang"), gensym("bang2"));
-    if (tempo != 0)
-        timer_tempo(x, unitname, tempo);
+    if(tempo != 0) timer_tempo(x, unitname, tempo);
     return (x);
 }
 
 static void timer_setup(void)
 {
-    timer_class = class_new(gensym("timer"), (t_newmethod)timer_new, 0,
+    timer_class = class_new(gensym("timer"), (t_newmethod) timer_new, 0,
         sizeof(t_timer), 0, A_DEFFLOAT, A_DEFSYM, 0);
     class_addbang(timer_class, timer_bang);
-    class_addmethod(timer_class, (t_method)timer_bang2, gensym("bang2"), 0);
-    class_addmethod(timer_class, (t_method)timer_tempo,
-        gensym("tempo"), A_FLOAT, A_SYMBOL, 0);
+    class_addmethod(timer_class, (t_method) timer_bang2, gensym("bang2"), 0);
+    class_addmethod(timer_class, (t_method) timer_tempo, gensym("tempo"),
+        A_FLOAT, A_SYMBOL, 0);
 }
-
 
 /* -------------------------- pipe -------------------------- */
 
@@ -414,7 +386,7 @@ typedef struct _hang
     struct _hang *h_next;
     struct _pipe *h_owner;
     t_gpointer *h_gp;
-    union word h_vec[1];        /* not the actual number. */
+    union word h_vec[1]; /* not the actual number. */
 } t_hang;
 
 typedef struct pipeout
@@ -436,75 +408,76 @@ typedef struct _pipe
 
 static void *pipe_new(t_symbol *s, int argc, t_atom *argv)
 {
-    t_pipe *x = (t_pipe *)pd_new(pipe_class);
+    t_pipe *x = (t_pipe *) pd_new(pipe_class);
     t_atom defarg, *ap;
     t_pipeout *vec, *vp;
     t_gpointer *gp;
     int nptr = 0;
     int i;
     t_float deltime;
-    if (argc)
+    if(argc)
     {
-        if (argv[argc-1].a_type != A_FLOAT)
+        if(argv[argc - 1].a_type != A_FLOAT)
         {
             char stupid[80];
-            atom_string(&argv[argc-1], stupid, 79);
+            atom_string(&argv[argc - 1], stupid, 79);
             pd_error(x, "pipe: %s: bad time delay value", stupid);
             deltime = 0;
         }
-        else deltime = argv[argc-1].a_w.w_float;
+        else
+            deltime = argv[argc - 1].a_w.w_float;
         argc--;
     }
-    else deltime = 0;
-    if (!argc)
+    else
+        deltime = 0;
+    if(!argc)
     {
         argv = &defarg;
         argc = 1;
         SETFLOAT(&defarg, 0);
     }
     x->x_n = argc;
-    vec = x->x_vec = (t_pipeout *)getbytes(argc * sizeof(*x->x_vec));
+    vec = x->x_vec = (t_pipeout *) getbytes(argc * sizeof(*x->x_vec));
 
-    for (i = argc, ap = argv; i--; ap++)
-        if (ap->a_type == A_SYMBOL && *ap->a_w.w_symbol->s_name == 'p')
-            nptr++;
+    for(i = argc, ap = argv; i--; ap++)
+        if(ap->a_type == A_SYMBOL && *ap->a_w.w_symbol->s_name == 'p') nptr++;
 
-    gp = x->x_gp = (t_gpointer *)t_getbytes(nptr * sizeof (*gp));
+    gp = x->x_gp = (t_gpointer *) t_getbytes(nptr * sizeof(*gp));
     x->x_nptr = nptr;
 
-    for (i = 0, vp = vec, ap = argv; i < argc; i++, ap++, vp++)
+    for(i = 0, vp = vec, ap = argv; i < argc; i++, ap++, vp++)
     {
-        if (ap->a_type == A_FLOAT)
+        if(ap->a_type == A_FLOAT)
         {
             vp->p_atom = *ap;
             vp->p_outlet = outlet_new(&x->x_obj, &s_float);
-            if (i) floatinlet_new(&x->x_obj, &vp->p_atom.a_w.w_float);
+            if(i) floatinlet_new(&x->x_obj, &vp->p_atom.a_w.w_float);
         }
-        else if (ap->a_type == A_SYMBOL)
+        else if(ap->a_type == A_SYMBOL)
         {
             char c = *ap->a_w.w_symbol->s_name;
-            if (c == 's')
+            if(c == 's')
             {
                 SETSYMBOL(&vp->p_atom, &s_symbol);
                 vp->p_outlet = outlet_new(&x->x_obj, &s_symbol);
-                if (i) symbolinlet_new(&x->x_obj, &vp->p_atom.a_w.w_symbol);
+                if(i) symbolinlet_new(&x->x_obj, &vp->p_atom.a_w.w_symbol);
             }
-            else if (c == 'p')
+            else if(c == 'p')
             {
                 vp->p_atom.a_type = A_POINTER;
                 vp->p_atom.a_w.w_gpointer = gp;
                 gpointer_init(gp);
                 vp->p_outlet = outlet_new(&x->x_obj, &s_pointer);
-                if (i) pointerinlet_new(&x->x_obj, gp);
+                if(i) pointerinlet_new(&x->x_obj, gp);
                 gp++;
             }
             else
             {
-                if (c != 'f') pd_error(x, "pipe: %s: bad type",
-                    ap->a_w.w_symbol->s_name);
+                if(c != 'f')
+                    pd_error(x, "pipe: %s: bad type", ap->a_w.w_symbol->s_name);
                 SETFLOAT(&vp->p_atom, 0);
                 vp->p_outlet = outlet_new(&x->x_obj, &s_float);
-                if (i) floatinlet_new(&x->x_obj, &vp->p_atom.a_w.w_float);
+                if(i) floatinlet_new(&x->x_obj, &vp->p_atom.a_w.w_float);
             }
         }
     }
@@ -519,7 +492,7 @@ static void hang_free(t_hang *h)
     t_pipe *x = h->h_owner;
     t_gpointer *gp;
     int i;
-    for (gp = h->h_gp, i = x->x_nptr; i--; gp++)
+    for(gp = h->h_gp, i = x->x_nptr; i--; gp++)
         gpointer_unset(gp);
     freebytes(h->h_gp, x->x_nptr * sizeof(*h->h_gp));
     clock_free(h->h_clock);
@@ -533,28 +506,36 @@ static void hang_tick(t_hang *h)
     t_pipeout *p;
     int i;
     union word *w;
-    if (x->x_hang == h) x->x_hang = h->h_next;
-    else for (h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
-    {
-        if (h3 == h)
+    if(x->x_hang == h)
+        x->x_hang = h->h_next;
+    else
+        for(h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
         {
-            h2->h_next = h3->h_next;
-            break;
+            if(h3 == h)
+            {
+                h2->h_next = h3->h_next;
+                break;
+            }
         }
-    }
-    for (i = x->x_n, p = x->x_vec + (x->x_n - 1), w = h->h_vec + (x->x_n - 1);
+    for(i = x->x_n, p = x->x_vec + (x->x_n - 1), w = h->h_vec + (x->x_n - 1);
         i--; p--, w--)
     {
-        switch (p->p_atom.a_type)
+        switch(p->p_atom.a_type)
         {
-        case A_FLOAT: outlet_float(p->p_outlet, w->w_float); break;
-        case A_SYMBOL: outlet_symbol(p->p_outlet, w->w_symbol); break;
-        case A_POINTER:
-            if (gpointer_check(w->w_gpointer, 1))
-                outlet_pointer(p->p_outlet, w->w_gpointer);
-            else pd_error(x, "pipe: stale pointer");
-            break;
-        default: break;
+            case A_FLOAT:
+                outlet_float(p->p_outlet, w->w_float);
+                break;
+            case A_SYMBOL:
+                outlet_symbol(p->p_outlet, w->w_symbol);
+                break;
+            case A_POINTER:
+                if(gpointer_check(w->w_gpointer, 1))
+                    outlet_pointer(p->p_outlet, w->w_gpointer);
+                else
+                    pd_error(x, "pipe: stale pointer");
+                break;
+            default:
+                break;
         }
     }
     hang_free(h);
@@ -562,68 +543,75 @@ static void hang_tick(t_hang *h)
 
 static void pipe_list(t_pipe *x, t_symbol *s, int ac, t_atom *av)
 {
-    t_hang *h = (t_hang *)
-        getbytes(sizeof(*h) + (x->x_n - 1) * sizeof(*h->h_vec));
+    t_hang *h =
+        (t_hang *) getbytes(sizeof(*h) + (x->x_n - 1) * sizeof(*h->h_vec));
     t_gpointer *gp, *gp2;
     t_pipeout *p;
     int i, n = x->x_n;
     t_atom *ap;
     t_word *w;
-    h->h_gp = (t_gpointer *)getbytes(x->x_nptr * sizeof(t_gpointer));
-    if (ac > n)
+    h->h_gp = (t_gpointer *) getbytes(x->x_nptr * sizeof(t_gpointer));
+    if(ac > n)
     {
-        if (av[n].a_type == A_FLOAT)
+        if(av[n].a_type == A_FLOAT)
             x->x_deltime = av[n].a_w.w_float;
-        else pd_error(x, "pipe: symbol or pointer in time inlet");
+        else
+            pd_error(x, "pipe: symbol or pointer in time inlet");
         ac = n;
     }
-    for (i = 0, gp = x->x_gp, p = x->x_vec, ap = av; i < ac;
-        i++, p++, ap++)
+    for(i = 0, gp = x->x_gp, p = x->x_vec, ap = av; i < ac; i++, p++, ap++)
     {
-        switch (p->p_atom.a_type)
+        switch(p->p_atom.a_type)
         {
-        case A_FLOAT: p->p_atom.a_w.w_float = atom_getfloat(ap); break;
-        case A_SYMBOL: p->p_atom.a_w.w_symbol = atom_getsymbol(ap); break;
-        case A_POINTER:
-            gpointer_unset(gp);
-            if (ap->a_type != A_POINTER)
-                pd_error(x, "pipe: bad pointer");
-            else
-            {
-                *gp = *(ap->a_w.w_gpointer);
-                if (gp->gp_stub) gp->gp_stub->gs_refcount++;
-            }
-            gp++;
-        default: break;
+            case A_FLOAT:
+                p->p_atom.a_w.w_float = atom_getfloat(ap);
+                break;
+            case A_SYMBOL:
+                p->p_atom.a_w.w_symbol = atom_getsymbol(ap);
+                break;
+            case A_POINTER:
+                gpointer_unset(gp);
+                if(ap->a_type != A_POINTER)
+                    pd_error(x, "pipe: bad pointer");
+                else
+                {
+                    *gp = *(ap->a_w.w_gpointer);
+                    if(gp->gp_stub) gp->gp_stub->gs_refcount++;
+                }
+                gp++;
+            default:
+                break;
         }
     }
-    for (i = 0, gp = x->x_gp, gp2 = h->h_gp, p = x->x_vec, w = h->h_vec;
-        i < n; i++, p++, w++)
+    for(i = 0, gp = x->x_gp, gp2 = h->h_gp, p = x->x_vec, w = h->h_vec; i < n;
+        i++, p++, w++)
     {
-        if (p->p_atom.a_type == A_POINTER)
+        if(p->p_atom.a_type == A_POINTER)
         {
-            if (gp->gp_stub) gp->gp_stub->gs_refcount++;
+            if(gp->gp_stub) gp->gp_stub->gs_refcount++;
             w->w_gpointer = gp2;
             *gp2++ = *gp++;
         }
-        else *w = p->p_atom.a_w;
+        else
+            *w = p->p_atom.a_w;
     }
     h->h_next = x->x_hang;
     x->x_hang = h;
     h->h_owner = x;
-    h->h_clock = clock_new(h, (t_method)hang_tick);
+    h->h_clock = clock_new(h, (t_method) hang_tick);
     clock_delay(h->h_clock, (x->x_deltime >= 0 ? x->x_deltime : 0));
 }
 
 static void pipe_flush(t_pipe *x)
 {
-    while (x->x_hang) hang_tick(x->x_hang);
+    while(x->x_hang)
+        hang_tick(x->x_hang);
 }
 
 static void pipe_clear(t_pipe *x)
 {
     t_hang *hang;
-    while ((hang = x->x_hang))
+    while((hang = x->x_hang))
     {
         x->x_hang = hang->h_next;
         hang_free(hang);
@@ -635,17 +623,15 @@ static void pipe_free(t_pipe *x)
     pipe_clear(x);
     freebytes(x->x_vec, x->x_n * sizeof(*x->x_vec));
     freebytes(x->x_gp, x->x_nptr * sizeof(*x->x_gp));
-
 }
 
 static void pipe_setup(void)
 {
-    pipe_class = class_new(gensym("pipe"),
-        (t_newmethod)pipe_new, (t_method)pipe_free,
-        sizeof(t_pipe), 0, A_GIMME, 0);
+    pipe_class = class_new(gensym("pipe"), (t_newmethod) pipe_new,
+        (t_method) pipe_free, sizeof(t_pipe), 0, A_GIMME, 0);
     class_addlist(pipe_class, pipe_list);
-    class_addmethod(pipe_class, (t_method)pipe_flush, gensym("flush"), 0);
-    class_addmethod(pipe_class, (t_method)pipe_clear, gensym("clear"), 0);
+    class_addmethod(pipe_class, (t_method) pipe_flush, gensym("flush"), 0);
+    class_addmethod(pipe_class, (t_method) pipe_clear, gensym("clear"), 0);
 }
 
 void x_time_setup(void)

--- a/src/x_time.c
+++ b/src/x_time.c
@@ -409,8 +409,10 @@ typedef struct _pipe
 static void *pipe_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_pipe *x = (t_pipe *) pd_new(pipe_class);
-    t_atom defarg, *ap;
-    t_pipeout *vec, *vp;
+    t_atom defarg;
+    t_atom *ap;
+    t_pipeout *vec;
+    t_pipeout *vp;
     t_gpointer *gp;
     int nptr = 0;
     int i;
@@ -502,7 +504,8 @@ static void hang_free(t_hang *h)
 static void hang_tick(t_hang *h)
 {
     t_pipe *x = h->h_owner;
-    t_hang *h2, *h3;
+    t_hang *h2;
+    t_hang *h3;
     t_pipeout *p;
     int i;
     union word *w;
@@ -545,9 +548,11 @@ static void pipe_list(t_pipe *x, t_symbol *s, int ac, t_atom *av)
 {
     t_hang *h =
         (t_hang *) getbytes(sizeof(*h) + (x->x_n - 1) * sizeof(*h->h_vec));
-    t_gpointer *gp, *gp2;
+    t_gpointer *gp;
+    t_gpointer *gp2;
     t_pipeout *p;
-    int i, n = x->x_n;
+    int i;
+    int n = x->x_n;
     t_atom *ap;
     t_word *w;
     h->h_gp = (t_gpointer *) getbytes(x->x_nptr * sizeof(t_gpointer));

--- a/src/x_time.c
+++ b/src/x_time.c
@@ -22,28 +22,46 @@ void parsetimeunits(
     if(s[0] == 'p' && s[1] == 'e' && s[2] == 'r') /* starts with 'per' */
     {
         const char *s2 = s + 3;
-        if(!strcmp(s2, "millisecond") || !strcmp(s2, "msec")) /* msec */
+        if(!strcmp(s2, "millisecond") || !strcmp(s2, "msec"))
+        { /* msec */
             *samps = 0, *unit = 1. / amount;
-        else if(!strncmp(s2, "sec", 3)) /* seconds */
+        }
+        else if(!strncmp(s2, "sec", 3))
+        { /* seconds */
             *samps = 0, *unit = 1000. / amount;
-        else if(!strncmp(s2, "min", 3)) /* minutes */
+        }
+        else if(!strncmp(s2, "min", 3))
+        { /* minutes */
             *samps = 0, *unit = 60000. / amount;
-        else if(!strncmp(s2, "sam", 3)) /* samples */
+        }
+        else if(!strncmp(s2, "sam", 3))
+        { /* samples */
             *samps = 1, *unit = 1. / amount;
+        }
         else
+        {
             goto fail;
+        }
     }
     else
     {
         /* empty string defaults to msec */
         if(!strcmp(s, "millisecond") || !strcmp(s, "msec"))
+        {
             *samps = 0, *unit = amount;
+        }
         else if(!strncmp(s, "sec", 3))
+        {
             *samps = 0, *unit = 1000. * amount;
+        }
         else if(!strncmp(s, "min", 3))
+        {
             *samps = 0, *unit = 60000. * amount;
+        }
         else if(!strncmp(s, "sam", 3))
+        {
             *samps = 1, *unit = amount;
+        }
         else
         {
         fail:
@@ -51,10 +69,14 @@ void parsetimeunits(
             back compatibility, since it's possible someone threw a
             float argument to timer which had previously been ignored. */
             if(*s)
+            {
                 pd_error(x, "%s: unknown time unit", s);
+            }
             else
+            {
                 pd_error(x, "tempo setting needs time unit ('sec', 'samp', "
                             "'permin', etc.");
+            }
             *unit = 1;
             *samps = 0;
         }
@@ -154,9 +176,13 @@ static void metro_tick(t_metro *x)
 static void metro_float(t_metro *x, t_float f)
 {
     if(f != 0)
+    {
         metro_tick(x);
+    }
     else
+    {
         clock_unset(x->x_clock);
+    }
     x->x_hit = 1;
 }
 
@@ -243,11 +269,15 @@ static void line_float(t_line *x, t_float f)
     if(x->x_gotinlet && x->x_in1val > 0)
     {
         if(timenow > x->x_targettime)
+        {
             x->x_setval = x->x_targetval;
+        }
         else
+        {
             x->x_setval = x->x_setval + x->x_1overtimediff *
                                             (timenow - x->x_prevtime) *
                                             (x->x_targetval - x->x_setval);
+        }
         x->x_prevtime = timenow;
         x->x_targettime = clock_getsystimeafter(x->x_in1val);
         x->x_targetval = f;
@@ -278,11 +308,15 @@ static void line_stop(t_line *x)
     if(pd_compatibilitylevel >= 48)
     {
         if(clock_getsystime() >= x->x_targettime)
+        {
             x->x_setval = x->x_targetval;
+        }
         else
+        {
             x->x_setval += x->x_1overtimediff *
                            (clock_getsystime() - x->x_prevtime) *
                            (x->x_targetval - x->x_setval);
+        }
     }
     x->x_targetval = x->x_setval;
     clock_unset(x->x_clock);
@@ -510,8 +544,11 @@ static void hang_tick(t_hang *h)
     int i;
     union word *w;
     if(x->x_hang == h)
+    {
         x->x_hang = h->h_next;
+    }
     else
+    {
         for(h2 = x->x_hang; (h3 = h2->h_next); h2 = h3)
         {
             if(h3 == h)
@@ -520,6 +557,7 @@ static void hang_tick(t_hang *h)
                 break;
             }
         }
+    }
     for(i = x->x_n, p = x->x_vec + (x->x_n - 1), w = h->h_vec + (x->x_n - 1);
         i--; p--, w--)
     {
@@ -533,9 +571,13 @@ static void hang_tick(t_hang *h)
                 break;
             case A_POINTER:
                 if(gpointer_check(w->w_gpointer, 1))
+                {
                     outlet_pointer(p->p_outlet, w->w_gpointer);
+                }
                 else
+                {
                     pd_error(x, "pipe: stale pointer");
+                }
                 break;
             default:
                 break;
@@ -559,9 +601,13 @@ static void pipe_list(t_pipe *x, t_symbol *s, int ac, t_atom *av)
     if(ac > n)
     {
         if(av[n].a_type == A_FLOAT)
+        {
             x->x_deltime = av[n].a_w.w_float;
+        }
         else
+        {
             pd_error(x, "pipe: symbol or pointer in time inlet");
+        }
         ac = n;
     }
     for(i = 0, gp = x->x_gp, p = x->x_vec, ap = av; i < ac; i++, p++, ap++)
@@ -577,7 +623,9 @@ static void pipe_list(t_pipe *x, t_symbol *s, int ac, t_atom *av)
             case A_POINTER:
                 gpointer_unset(gp);
                 if(ap->a_type != A_POINTER)
+                {
                     pd_error(x, "pipe: bad pointer");
+                }
                 else
                 {
                     *gp = *(ap->a_w.w_gpointer);

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -244,7 +244,6 @@ int expr_donew(struct expr *expr, int ac, t_atom *av)
     char *exp_string;
     int exp_strlen;
     t_binbuf *b;
-    int i;
 
     memset(expr->exp_var, 0, MAX_VARS * sizeof(*expr->exp_var));
 #ifdef PD
@@ -343,7 +342,7 @@ int expr_donew(struct expr *expr, int ac, t_atom *av)
     t_freebytes(exp_string, exp_strlen + 1);
     return (0);
 error:
-    for(i = 0; i < expr->exp_nexpr; i++)
+    for(int i = 0; i < expr->exp_nexpr; i++)
     {
         fts_free(expr->exp_stack[i]);
         expr->exp_stack[i] = 0;
@@ -1462,7 +1461,6 @@ struct ex_ex *eval_func(
 /* the operation stack */
 /* the result pointer */
 {
-    int i;
     struct ex_ex args[MAX_ARGS];
     t_ex_func *f;
 
@@ -1484,7 +1482,7 @@ struct ex_ex *eval_func(
      */
     if(f->f_func != (void(*)) ex_if)
     {
-        for(i = 0; i < f->f_argc; i++)
+        for(int i = 0; i < f->f_argc; i++)
         {
             args[i].ex_type = 0;
             args[i].ex_int = 0;
@@ -1494,14 +1492,14 @@ struct ex_ex *eval_func(
     }
     else
     {
-        for(i = 0; i < f->f_argc; i++)
+        for(int i = 0; i < f->f_argc; i++)
         {
             args[i].ex_type = 0;
             args[i].ex_int = 0;
         }
         eptr = ex_if(expr, eptr, optr, args, idx);
     }
-    for(i = 0; i < f->f_argc; i++)
+    for(int i = 0; i < f->f_argc; i++)
     {
         if(args[i].ex_type == ET_VEC) fts_free(args[i].ex_vec);
     }

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1401,8 +1401,7 @@ struct ex_ex *ex_eval(
     if(right.ex_type == ET_VEC) fts_free(right.ex_vec);
     if(nullret)
         return (exNULL);
-    else
-        return (eptr);
+    return (eptr);
 }
 
 extern struct ex_ex *ex_if(t_expr *expr, struct ex_ex *eptr, struct ex_ex *optr,

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1,10 +1,9 @@
 /* Copyright (c) IRCAM.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* "expr" was written by Shahrokh Yadegari c. 1989. -msp */
 /* "expr~" and "fexpr~" conversion by Shahrokh Yadegari c. 1999,2000 */
-
 
 /*
  * Feb 2002 -   added access to variables
@@ -39,8 +38,10 @@
  * Oct 2020, Version 0.57
  *		- fixed a bug in fact()
  *		- fixed the bad lvalue bug - "4 + 5 = 3" was not caught before
- *		- fact() (factorial) now calculates and returns its value in double
- *		- Added mtof(), mtof(), dbtorms(), rmstodb(), powtodb(), dbtopow()
+ *		- fact() (factorial) now calculates and returns its value in
+ *double
+ *		- Added mtof(), mtof(), dbtorms(), rmstodb(), powtodb(),
+ *dbtopow()
  */
 
 /*
@@ -77,51 +78,50 @@
 #include <errno.h>
 #ifdef MSP
 #undef isdigit
-#define isdigit(x)      (x >= '0' && x <= '9')
+#define isdigit(x) (x >= '0' && x <= '9')
 #endif
 
 #if defined _MSC_VER && (_MSC_VER < 1800)
 #define strtof(a, b) _atoldbl(a, *b)
 #endif
 
-
 char *atoif(char *s, long int *value, long int *type);
 
 static struct ex_ex *ex_lex(struct expr *expr, long int *n);
 struct ex_ex *ex_match(struct ex_ex *eptr, long int op);
-struct ex_ex *ex_parse(struct expr *expr, struct ex_ex *iptr,
-                                        struct ex_ex *optr, long int *argc);
-static int ex_checklval (struct ex_ex *eptr);
-struct ex_ex *ex_eval(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
+struct ex_ex *ex_parse(
+    struct expr *expr, struct ex_ex *iptr, struct ex_ex *optr, long int *argc);
+static int ex_checklval(struct ex_ex *eptr);
+struct ex_ex *ex_eval(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
 
 int expr_donew(struct expr *exprr, int ac, t_atom *av);
-struct ex_ex *eval_func(struct expr *expr,struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
-struct ex_ex *eval_tab(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
-struct ex_ex *eval_var(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
-struct ex_ex *eval_store(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
-struct ex_ex *eval_sigidx(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
-static int cal_sigidx(struct ex_ex *optr,       /* The output value */
-           int i, t_float rem_i,      /* integer and fractinal part of index */
-           int idx,                  /* index of current fexpr~ processing */
-           int vsize,                                       /* vector size */
-           t_float *curvec, t_float *prevec);   /* current and previous table */
+struct ex_ex *eval_func(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
+struct ex_ex *eval_tab(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
+struct ex_ex *eval_var(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
+struct ex_ex *eval_store(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
+struct ex_ex *eval_sigidx(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
+static int cal_sigidx(struct ex_ex *optr, /* The output value */
+    int i, t_float rem_i,              /* integer and fractinal part of index */
+    int idx,                           /* index of current fexpr~ processing */
+    int vsize,                         /* vector size */
+    t_float *curvec, t_float *prevec); /* current and previous table */
 t_ex_func *find_func(char *s);
 void ex_dzdetect(struct expr *expr);
 
-#define MAX_ARGS        10
+#define MAX_ARGS 10
 extern t_ex_func ex_funcs[];
 
-struct ex_ex nullex = { 0 };
+struct ex_ex nullex = {0};
 
-void set_tokens (char *s);
-int getoken (struct expr *expr, struct ex_ex *eptr);
-void ex_print (struct ex_ex *eptr);
+void set_tokens(char *s);
+int getoken(struct expr *expr, struct ex_ex *eptr);
+void ex_print(struct ex_ex *eptr);
 #ifdef MSP
 void atom_string(t_atom *a, char *buf, unsigned int bufsize);
 
@@ -130,75 +130,88 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
     char tbuf[30];
     switch(a->a_type)
     {
-    case A_SEMI: strcpy(buf, ";"); break;
-    case A_COMMA: strcpy(buf, ","); break;
+        case A_SEMI:
+            strcpy(buf, ";");
+            break;
+        case A_COMMA:
+            strcpy(buf, ",");
+            break;
 #ifdef PD
-    case A_POINTER:
-        strcpy(buf, "(pointer)");
-        break;
+        case A_POINTER:
+            strcpy(buf, "(pointer)");
+            break;
 #endif
-    case A_FLOAT:
-        sprintf(tbuf, "%g", a->a_w.w_float);
-        if (strlen(tbuf) < bufsize-1) strcpy(buf, tbuf);
-        else if (a->a_w.w_float < 0) strcpy(buf, "-");
-        else  strcat(buf, "+");
-        break;
-    case A_LONG:
-        sprintf(tbuf, "%d", a->a_w.w_long);
-        if (strlen(tbuf) < bufsize-1) strcpy(buf, tbuf);
-        else if (a->a_w.w_float < 0) strcpy(buf, "-");
-        else  strcat(buf, "+");
-        break;
-    case A_SYMBOL:
-    {
-        char *sp;
-        unsigned int len;
-        int quote;
-        for (sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp; sp++, len++)
-            if (*sp == ';' || *sp == ',' || *sp == '\\' ||
-                (*sp == '$' && sp == a->a_w.w_symbol->s_name && sp[1] >= '0'
-                    && sp[1] <= '9'))
-                quote = 1;
-        if (quote)
+        case A_FLOAT:
+            sprintf(tbuf, "%g", a->a_w.w_float);
+            if(strlen(tbuf) < bufsize - 1)
+                strcpy(buf, tbuf);
+            else if(a->a_w.w_float < 0)
+                strcpy(buf, "-");
+            else
+                strcat(buf, "+");
+            break;
+        case A_LONG:
+            sprintf(tbuf, "%d", a->a_w.w_long);
+            if(strlen(tbuf) < bufsize - 1)
+                strcpy(buf, tbuf);
+            else if(a->a_w.w_float < 0)
+                strcpy(buf, "-");
+            else
+                strcat(buf, "+");
+            break;
+        case A_SYMBOL:
         {
-            char *bp = buf, *ep = buf + (bufsize-2);
-            sp = a->a_w.w_symbol->s_name;
-            while (bp < ep && *sp)
+            char *sp;
+            unsigned int len;
+            int quote;
+            for(sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp;
+                sp++, len++)
+                if(*sp == ';' || *sp == ',' || *sp == '\\' ||
+                    (*sp == '$' && sp == a->a_w.w_symbol->s_name &&
+                        sp[1] >= '0' && sp[1] <= '9'))
+                    quote = 1;
+            if(quote)
             {
-                if (*sp == ';' || *sp == ',' || *sp == '\\' ||
-                    (*sp == '$' && bp == buf && sp[1] >= '0' && sp[1] <= '9'))
+                char *bp = buf, *ep = buf + (bufsize - 2);
+                sp = a->a_w.w_symbol->s_name;
+                while(bp < ep && *sp)
+                {
+                    if(*sp == ';' || *sp == ',' || *sp == '\\' ||
+                        (*sp == '$' && bp == buf && sp[1] >= '0' &&
+                            sp[1] <= '9'))
                         *bp++ = '\\';
-                *bp++ = *sp++;
+                    *bp++ = *sp++;
+                }
+                if(*sp) *bp++ = '*';
+                *bp = 0;
+                /* post("quote %s -> %s", a->a_w.w_symbol->s_name, buf); */
             }
-            if (*sp) *bp++ = '*';
-            *bp = 0;
-            /* post("quote %s -> %s", a->a_w.w_symbol->s_name, buf); */
-        }
-        else
-        {
-            if (len < bufsize-1) strcpy(buf, a->a_w.w_symbol->s_name);
             else
             {
-                strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);
-                strcpy(buf + (bufsize - 2), "*");
+                if(len < bufsize - 1)
+                    strcpy(buf, a->a_w.w_symbol->s_name);
+                else
+                {
+                    strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);
+                    strcpy(buf + (bufsize - 2), "*");
+                }
             }
         }
-    }
         break;
 #ifdef PD
-    case A_DOLLAR:
-        sprintf(buf, "$%d", a->a_w.w_index);
-        break;
-    case A_DOLLSYM:
-        sprintf(buf, "$%s", a->a_w.w_symbol->s_name);
-                break;
+        case A_DOLLAR:
+            sprintf(buf, "$%d", a->a_w.w_index);
+            break;
+        case A_DOLLSYM:
+            sprintf(buf, "$%s", a->a_w.w_symbol->s_name);
+            break;
 #else /* MAX */
- case A_DOLLAR:
-        sprintf(buf, "$%s", a->a_w.w_symbol->s_name);
-        break;
+        case A_DOLLAR:
+            sprintf(buf, "$%s", a->a_w.w_symbol->s_name);
+            break;
 #endif
-    default:
-        post("atom_string bug");
+        default:
+            post("atom_string bug");
     }
 }
 #endif /* MSP */
@@ -206,115 +219,117 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
  * expr_donew -- create a new "expr" object.
  *           returns 1 on failure, 0 on success.
  */
-int
-expr_donew(struct expr *expr, int ac, t_atom *av)
+int expr_donew(struct expr *expr, int ac, t_atom *av)
 {
-        struct ex_ex *list;
-        struct ex_ex *ret;
-        long max_node = 0;              /* maximum number of nodes needed */
-        char *exp_string;
-        int exp_strlen;
-        t_binbuf *b;
-        int i;
+    struct ex_ex *list;
+    struct ex_ex *ret;
+    long max_node = 0; /* maximum number of nodes needed */
+    char *exp_string;
+    int exp_strlen;
+    t_binbuf *b;
+    int i;
 
-        memset(expr->exp_var, 0, MAX_VARS * sizeof (*expr->exp_var));
+    memset(expr->exp_var, 0, MAX_VARS * sizeof(*expr->exp_var));
 #ifdef PD
-        b = binbuf_new();
-        binbuf_add(b, ac, av);
-        binbuf_gettext(b, &exp_string, &exp_strlen);
-        binbuf_free(b);
+    b = binbuf_new();
+    binbuf_add(b, ac, av);
+    binbuf_gettext(b, &exp_string, &exp_strlen);
+    binbuf_free(b);
 #else /* MSP */
- {
-    char *buf = getbytes(0), *newbuf;
-    int length = 0;
-    char string[250];
-    t_atom *ap;
-    int indx;
+    {
+        char *buf = getbytes(0), *newbuf;
+        int length = 0;
+        char string[250];
+        t_atom *ap;
+        int indx;
 
-    for (ap = av, indx = 0; indx < ac; indx++, ap = ++av) {
-        int newlength;
-
-        if ((ap->a_type == A_SEMI || ap->a_type == A_COMMA) &&
-                length && buf[length-1] == ' ')
-                        length--;
-        atom_string(ap, string, 250);
-        newlength = length + strlen(string) + 1;
-        if (!(newbuf = t_resizebytes(buf, length, newlength)))
-                                break;
-        buf = newbuf;
-        strcpy(buf + length, string);
-        length = newlength;
-        if (ap->a_type == A_SEMI)
-                        buf[length-1] = '\n';
-        else
-                        buf[length-1] = ' ';
-    }
-
-    if (length && buf[length-1] == ' ') {
-        if (newbuf = t_resizebytes(buf, length, length-1))
+        for(ap = av, indx = 0; indx < ac; indx++, ap = ++av)
         {
+            int newlength;
+
+            if((ap->a_type == A_SEMI || ap->a_type == A_COMMA) && length &&
+                buf[length - 1] == ' ')
+                length--;
+            atom_string(ap, string, 250);
+            newlength = length + strlen(string) + 1;
+            if(!(newbuf = t_resizebytes(buf, length, newlength))) break;
             buf = newbuf;
-            length--;
+            strcpy(buf + length, string);
+            length = newlength;
+            if(ap->a_type == A_SEMI)
+                buf[length - 1] = '\n';
+            else
+                buf[length - 1] = ' ';
         }
+
+        if(length && buf[length - 1] == ' ')
+        {
+            if(newbuf = t_resizebytes(buf, length, length - 1))
+            {
+                buf = newbuf;
+                length--;
+            }
+        }
+        exp_string = buf;
+        exp_strlen = length;
     }
-    exp_string = buf;
-    exp_strlen  = length;
- }
 #endif
-        exp_string = (char *)t_resizebytes(exp_string, exp_strlen,exp_strlen+1);
-        exp_string[exp_strlen] = 0;
-        expr->exp_string = exp_string;
-        expr->exp_str = exp_string;
-        expr->exp_nexpr = 0;
-        ret = (struct ex_ex *) 0;
-        /*
-         * if ret == 0 it means that we have no expression
-         * so we let the pass go through to build a single null stack
-         */
-        while (*expr->exp_str || !ret) {
-                list = ex_lex(expr, &max_node);
-                if (!list) {            /* syntax error */
-                        goto error;
-                }
-                expr->exp_stack[expr->exp_nexpr] =
-                  (struct ex_ex *)fts_malloc(max_node * sizeof (struct ex_ex));
-                                if (!expr->exp_stack[expr->exp_nexpr]) {
-                                        post_error( (fts_object_t *) expr,
-                                                "expr: malloc for expr nodes failed\n");
-                                        goto error;
-                                }
-                                expr->exp_stack[expr->exp_nexpr][max_node-1].ex_type=0;
-                expr->exp_nexpr++;
-                ret = ex_match(list, (long)0);
-                if (expr->exp_nexpr  > MAX_VARS)
-                    /* we cannot exceed MAX_VARS '$' variables */
-                {
-                        post_error((fts_object_t *) expr,
-                            "expr: too many variables (maximum %d allowed)",
-                                MAX_VARS);
-                        goto error;
-                }
-                if (!ret)               /* syntax error */
-                        goto error;
-                ret = ex_parse(expr,
-                        list, expr->exp_stack[expr->exp_nexpr - 1], (long *)0);
-                if (!ret || ex_checklval(expr->exp_stack[expr->exp_nexpr - 1]))
-                        goto error;
-                fts_free(list);
+    exp_string = (char *) t_resizebytes(exp_string, exp_strlen, exp_strlen + 1);
+    exp_string[exp_strlen] = 0;
+    expr->exp_string = exp_string;
+    expr->exp_str = exp_string;
+    expr->exp_nexpr = 0;
+    ret = (struct ex_ex *) 0;
+    /*
+     * if ret == 0 it means that we have no expression
+     * so we let the pass go through to build a single null stack
+     */
+    while(*expr->exp_str || !ret)
+    {
+        list = ex_lex(expr, &max_node);
+        if(!list)
+        { /* syntax error */
+            goto error;
         }
-        *ret = nullex;
-        t_freebytes(exp_string, exp_strlen+1);
-        return (0);
+        expr->exp_stack[expr->exp_nexpr] =
+            (struct ex_ex *) fts_malloc(max_node * sizeof(struct ex_ex));
+        if(!expr->exp_stack[expr->exp_nexpr])
+        {
+            post_error(
+                (fts_object_t *) expr, "expr: malloc for expr nodes failed\n");
+            goto error;
+        }
+        expr->exp_stack[expr->exp_nexpr][max_node - 1].ex_type = 0;
+        expr->exp_nexpr++;
+        ret = ex_match(list, (long) 0);
+        if(expr->exp_nexpr > MAX_VARS)
+        /* we cannot exceed MAX_VARS '$' variables */
+        {
+            post_error((fts_object_t *) expr,
+                "expr: too many variables (maximum %d allowed)", MAX_VARS);
+            goto error;
+        }
+        if(!ret) /* syntax error */
+            goto error;
+        ret = ex_parse(
+            expr, list, expr->exp_stack[expr->exp_nexpr - 1], (long *) 0);
+        if(!ret || ex_checklval(expr->exp_stack[expr->exp_nexpr - 1]))
+            goto error;
+        fts_free(list);
+    }
+    *ret = nullex;
+    t_freebytes(exp_string, exp_strlen + 1);
+    return (0);
 error:
-        for (i = 0; i < expr->exp_nexpr; i++) {
-                fts_free(expr->exp_stack[i]);
-                expr->exp_stack[i] = 0;
-        }
-        expr->exp_nexpr = 0;
-        if (list)
-                fts_free(list);
-        t_freebytes(exp_string, exp_strlen+1);
-        return (1);
+    for(i = 0; i < expr->exp_nexpr; i++)
+    {
+        fts_free(expr->exp_stack[i]);
+        expr->exp_stack[i] = 0;
+    }
+    expr->exp_nexpr = 0;
+    if(list) fts_free(list);
+    t_freebytes(exp_string, exp_strlen + 1);
+    return (1);
 }
 
 /*
@@ -323,50 +338,52 @@ error:
  *           return a linked list of struct ex_ex.
  *           It will also put the number of the nodes in *n.
  */
-struct ex_ex *
-ex_lex(struct expr *expr, long int *n)
+struct ex_ex *ex_lex(struct expr *expr, long int *n)
 {
-        struct ex_ex *list_arr;
-        struct ex_ex *exptr;
-        long non = 0;           /* number of nodes */
-        long maxnode = 0;
+    struct ex_ex *list_arr;
+    struct ex_ex *exptr;
+    long non = 0; /* number of nodes */
+    long maxnode = 0;
 
-        list_arr = (struct ex_ex *)fts_malloc(sizeof (struct ex_ex) * MINODES);
-        if (! list_arr) {
-                post("ex_lex: no mem\n");
-                return ((struct ex_ex *)0);
-        }
-        exptr = list_arr;
-        maxnode = MINODES;
+    list_arr = (struct ex_ex *) fts_malloc(sizeof(struct ex_ex) * MINODES);
+    if(!list_arr)
+    {
+        post("ex_lex: no mem\n");
+        return ((struct ex_ex *) 0);
+    }
+    exptr = list_arr;
+    maxnode = MINODES;
 
-        while (8)
+    while(8)
+    {
+        if(non >= maxnode)
         {
-                if (non >= maxnode) {
-                        maxnode += MINODES;
+            maxnode += MINODES;
 
-                        list_arr = fts_realloc((void *)list_arr,
-                                        sizeof (struct ex_ex) * maxnode);
-                        if (!list_arr) {
-                                post("ex_lex: no mem\n");
-                                return ((struct ex_ex *)0);
-                        }
-                        exptr = &(list_arr)[non];
-                }
-
-                if (getoken(expr, exptr)) {
-                        fts_free(list_arr);
-                        return ((struct ex_ex *)0);
-                }
-                non++;
-
-                if (!exptr->ex_type)
-                        break;
-
-                exptr++;
+            list_arr =
+                fts_realloc((void *) list_arr, sizeof(struct ex_ex) * maxnode);
+            if(!list_arr)
+            {
+                post("ex_lex: no mem\n");
+                return ((struct ex_ex *) 0);
+            }
+            exptr = &(list_arr)[non];
         }
-        *n = non;
 
-        return list_arr;
+        if(getoken(expr, exptr))
+        {
+            fts_free(list_arr);
+            return ((struct ex_ex *) 0);
+        }
+        non++;
+
+        if(!exptr->ex_type) break;
+
+        exptr++;
+    }
+    *n = non;
+
+    return list_arr;
 }
 
 /*
@@ -376,151 +393,165 @@ ex_lex(struct expr *expr, long int *n)
  *             specified function
  */
 /* operator to match */
-struct ex_ex *
-ex_match(struct ex_ex *eptr, long int op)
+struct ex_ex *ex_match(struct ex_ex *eptr, long int op)
 {
-        int firstone = 1;
-        struct ex_ex *ret;
-        t_ex_func *fun;
+    int firstone = 1;
+    struct ex_ex *ret;
+    t_ex_func *fun;
 
-        for (; 8; eptr++, firstone = 0) {
-                switch (eptr->ex_type) {
-                case 0:
-                        if (!op)
-                                return (eptr);
-                        post("expr syntax error: an open %s not matched\n",
-                            op == OP_RP ? "parenthesis" : "bracket");
-                        return (exNULL);
-                case ET_INT:
-                case ET_FLT:
-                case ET_II:
-                case ET_FI:
-                case ET_SI:
-                case ET_VI:
-                case ET_SYM:
-                case ET_VSYM:
-                        continue;
-                case ET_YO:
-                        if (eptr[1].ex_type != ET_OP || eptr[1].ex_op != OP_LB)
-                                eptr->ex_type = ET_YOM1;
-                        continue;
-                case ET_XI:
-                        if (eptr[1].ex_type != ET_OP || eptr[1].ex_op != OP_LB)
-                                eptr->ex_type = ET_XI0;
-                        continue;
-                                /*
-                                 * tables, functions, parenthesis, and brackets, are marked as
-                                 * operations, and they are assigned their proper operation
-                                 * in this function. Thus, if we arrive to any of these in this
-                                 * type tokens at this location, we must have had some error
-                                 */
-                case ET_TBL:
-                case ET_FUNC:
-                case ET_LP:
-                case ET_LB:
-                        post("ex_match: unexpected type, %ld\n", eptr->ex_type);
-                        return (exNULL);
-                case ET_OP:
-                        if (op == eptr->ex_op)
-                                return (eptr);
-                        /*
-                         * if we are looking for a right peranthesis
-                         * or a right bracket and find the other kind,
-                         * it has to be a syntax error
-                         */
-                        if ((eptr->ex_op == OP_RP && op == OP_RB) ||
-                            (eptr->ex_op == OP_RB && op == OP_RP)) {
-                                post("expr syntax error: prenthesis or brackets not matched\n");
-                                return (exNULL);
-                        }
-                        /*
-                         * Up to now we have marked the unary minuses as
-                         * subrtacts.  Any minus that is the first one in
-                         * chain or is preceded by anything except ')' and
-                         * ']' is a unary minus.
-                         */
-                        if (eptr->ex_op == OP_SUB) {
-                                ret = eptr - 1;
-                                if (firstone ||  (ret->ex_type == ET_OP &&
-                                    ret->ex_op != OP_RB && ret->ex_op != OP_RP))
-                                        eptr->ex_op = OP_UMINUS;
-                        } else if (eptr->ex_op == OP_LP) {
-                                ret = ex_match(eptr + 1, OP_RP);
-                                if (!ret)
-                                        return (ret);
-                                eptr->ex_type = ET_LP;
-                                eptr->ex_ptr = (char *) ret;
-                                eptr = ret;
-                        } else if (eptr->ex_op == OP_LB) {
-                                ret = ex_match(eptr + 1, OP_RB);
-                                if (!ret)
-                                        return (ret);
-                                /*
-                                 * this is a special case handling
-                                 * for $1, $2 processing in Pd
-                                 *
-                                 * Pure data translates $#[x] (e.g. $1[x]) to 0[x]
-                                 * for abstracting patches so that later
-                                 * in the instantiation of the abstraction
-                                 * the $# is replaced with the proper argument
-                                 * of the abstraction
-                                 * so we change 0[x] to a special table pointing to null
-                                 * and catch errors in execution time
-                                 */
-                                if (!firstone && (eptr - 1)->ex_type == ET_INT &&
-                                    ((eptr - 1)->ex_int == 0)) {
-                                        (eptr - 1)->ex_type = ET_TBL;
-                                        (eptr - 1)->ex_ptr = (char *)0;
-                                }
-                                eptr->ex_type = ET_LB;
-                                eptr->ex_ptr = (char *) ret;
-                                eptr = ret;
-                        }
-                        continue;
-                case ET_STR:
-                        if (eptr[1].ex_op == OP_LB) {
-                                char *tmp;
-
-                                eptr->ex_type = ET_TBL;
-                                tmp = eptr->ex_ptr;
-                                if (ex_getsym(tmp, (t_symbol **)&(eptr->ex_ptr))) {
-                                        post("expr: syntax error: problms with ex_getsym\n");
-                                        return (exNULL);
-                                }
-                                fts_free((void *)tmp);
-                        } else if (eptr[1].ex_op == OP_LP) {
-                                fun = find_func(eptr->ex_ptr);
-                                if (!fun) {
-                                        post(
-                                         "expr: error: function %s not found\n",
-                                                                eptr->ex_ptr);
-                                        return (exNULL);
-                                }
-                                eptr->ex_type = ET_FUNC;
-                                eptr->ex_ptr = (char *) fun;
-                        } else {
-                                char *tmp;
-
-                                if (eptr[1].ex_type && eptr[1].ex_type!=ET_OP){
-                                        post("expr: syntax error: bad string '%s'\n", eptr->ex_ptr);
-                                        return (exNULL);
-                                }
-                                /* it is a variable */
-                                eptr->ex_type = ET_VAR;
-                                tmp = eptr->ex_ptr;
-                                if (ex_getsym(tmp,
-                                                (t_symbol **)&(eptr->ex_ptr))) {
-                                        post("expr: variable '%s' not found",tmp);
-                                        return (exNULL);
-                                }
-                        }
-                        continue;
-                default:
-                        post("ex_match: bad type\n");
-                        return (exNULL);
+    for(; 8; eptr++, firstone = 0)
+    {
+        switch(eptr->ex_type)
+        {
+            case 0:
+                if(!op) return (eptr);
+                post("expr syntax error: an open %s not matched\n",
+                    op == OP_RP ? "parenthesis" : "bracket");
+                return (exNULL);
+            case ET_INT:
+            case ET_FLT:
+            case ET_II:
+            case ET_FI:
+            case ET_SI:
+            case ET_VI:
+            case ET_SYM:
+            case ET_VSYM:
+                continue;
+            case ET_YO:
+                if(eptr[1].ex_type != ET_OP || eptr[1].ex_op != OP_LB)
+                    eptr->ex_type = ET_YOM1;
+                continue;
+            case ET_XI:
+                if(eptr[1].ex_type != ET_OP || eptr[1].ex_op != OP_LB)
+                    eptr->ex_type = ET_XI0;
+                continue;
+                /*
+                 * tables, functions, parenthesis, and brackets, are marked as
+                 * operations, and they are assigned their proper operation
+                 * in this function. Thus, if we arrive to any of these in this
+                 * type tokens at this location, we must have had some error
+                 */
+            case ET_TBL:
+            case ET_FUNC:
+            case ET_LP:
+            case ET_LB:
+                post("ex_match: unexpected type, %ld\n", eptr->ex_type);
+                return (exNULL);
+            case ET_OP:
+                if(op == eptr->ex_op) return (eptr);
+                /*
+                 * if we are looking for a right peranthesis
+                 * or a right bracket and find the other kind,
+                 * it has to be a syntax error
+                 */
+                if((eptr->ex_op == OP_RP && op == OP_RB) ||
+                    (eptr->ex_op == OP_RB && op == OP_RP))
+                {
+                    post("expr syntax error: prenthesis or brackets not "
+                         "matched\n");
+                    return (exNULL);
                 }
+                /*
+                 * Up to now we have marked the unary minuses as
+                 * subrtacts.  Any minus that is the first one in
+                 * chain or is preceded by anything except ')' and
+                 * ']' is a unary minus.
+                 */
+                if(eptr->ex_op == OP_SUB)
+                {
+                    ret = eptr - 1;
+                    if(firstone ||
+                        (ret->ex_type == ET_OP && ret->ex_op != OP_RB &&
+                            ret->ex_op != OP_RP))
+                        eptr->ex_op = OP_UMINUS;
+                }
+                else if(eptr->ex_op == OP_LP)
+                {
+                    ret = ex_match(eptr + 1, OP_RP);
+                    if(!ret) return (ret);
+                    eptr->ex_type = ET_LP;
+                    eptr->ex_ptr = (char *) ret;
+                    eptr = ret;
+                }
+                else if(eptr->ex_op == OP_LB)
+                {
+                    ret = ex_match(eptr + 1, OP_RB);
+                    if(!ret) return (ret);
+                    /*
+                     * this is a special case handling
+                     * for $1, $2 processing in Pd
+                     *
+                     * Pure data translates $#[x] (e.g. $1[x]) to 0[x]
+                     * for abstracting patches so that later
+                     * in the instantiation of the abstraction
+                     * the $# is replaced with the proper argument
+                     * of the abstraction
+                     * so we change 0[x] to a special table pointing to null
+                     * and catch errors in execution time
+                     */
+                    if(!firstone && (eptr - 1)->ex_type == ET_INT &&
+                        ((eptr - 1)->ex_int == 0))
+                    {
+                        (eptr - 1)->ex_type = ET_TBL;
+                        (eptr - 1)->ex_ptr = (char *) 0;
+                    }
+                    eptr->ex_type = ET_LB;
+                    eptr->ex_ptr = (char *) ret;
+                    eptr = ret;
+                }
+                continue;
+            case ET_STR:
+                if(eptr[1].ex_op == OP_LB)
+                {
+                    char *tmp;
+
+                    eptr->ex_type = ET_TBL;
+                    tmp = eptr->ex_ptr;
+                    if(ex_getsym(tmp, (t_symbol **) &(eptr->ex_ptr)))
+                    {
+                        post("expr: syntax error: problms with ex_getsym\n");
+                        return (exNULL);
+                    }
+                    fts_free((void *) tmp);
+                }
+                else if(eptr[1].ex_op == OP_LP)
+                {
+                    fun = find_func(eptr->ex_ptr);
+                    if(!fun)
+                    {
+                        post("expr: error: function %s not found\n",
+                            eptr->ex_ptr);
+                        return (exNULL);
+                    }
+                    eptr->ex_type = ET_FUNC;
+                    eptr->ex_ptr = (char *) fun;
+                }
+                else
+                {
+                    char *tmp;
+
+                    if(eptr[1].ex_type && eptr[1].ex_type != ET_OP)
+                    {
+                        post("expr: syntax error: bad string '%s'\n",
+                            eptr->ex_ptr);
+                        return (exNULL);
+                    }
+                    /* it is a variable */
+                    eptr->ex_type = ET_VAR;
+                    tmp = eptr->ex_ptr;
+                    if(ex_getsym(tmp, (t_symbol **) &(eptr->ex_ptr)))
+                    {
+                        post("expr: variable '%s' not found", tmp);
+                        return (exNULL);
+                    }
+                }
+                continue;
+            default:
+                post("ex_match: bad type\n");
+                return (exNULL);
         }
-        /* NOTREACHED */
+    }
+    /* NOTREACHED */
 }
 
 /*
@@ -540,205 +571,228 @@ ex_match(struct ex_ex *eptr, long int op)
  *             returns 0 on syntax error
  */
 /* number of argument separated by comma */
-struct ex_ex *
-ex_parse(struct expr *x, struct ex_ex *iptr, struct ex_ex *optr, long int *argc)
+struct ex_ex *ex_parse(
+    struct expr *x, struct ex_ex *iptr, struct ex_ex *optr, long int *argc)
 {
-        struct ex_ex *eptr;
-        struct ex_ex *lowpre = 0;       /* pointer to the lowest precedence */
-        struct ex_ex savex = { 0 };
-        struct ex_ex *tmpex;
-        long pre = HI_PRE;
-        long count;
+    struct ex_ex *eptr;
+    struct ex_ex *lowpre = 0; /* pointer to the lowest precedence */
+    struct ex_ex savex = {0};
+    struct ex_ex *tmpex;
+    long pre = HI_PRE;
+    long count;
 
-        if (!iptr) {
-                post("ex_parse: input is null, iptr = 0x%lx\n", iptr);
-                return (exNULL);
-        }
-        if (!iptr->ex_type)
-                return (exNULL);
+    if(!iptr)
+    {
+        post("ex_parse: input is null, iptr = 0x%lx\n", iptr);
+        return (exNULL);
+    }
+    if(!iptr->ex_type) return (exNULL);
 
-        /*
-         * the following loop finds the lowest precedence operator in the
-         * the input token list, comma is explicitly checked here since
-         * that is a special operator and is only legal in functions
-         */
-        for (eptr = iptr, count = 0; eptr->ex_type; eptr++, count++)
-                switch (eptr->ex_type) {
-                case ET_SYM:
-                case ET_VSYM:
-                        if (!argc) {
-                                post("expr: syntax error: symbols allowed for functions only\n");
-                                ex_print(eptr);
-                                return (exNULL);
-                        }   /* falls through */
-                case ET_INT:
-                case ET_FLT:
-                case ET_II:
-                case ET_FI:
-                case ET_XI0:
-                case ET_YOM1:
-                case ET_VI:
-                case ET_VAR:
-                        if (!count && !eptr[1].ex_type) {
-                                *optr = *eptr;
-                                                                tmpex = optr;
-                                                                tmpex->ex_end = ++optr;
-                                return (optr);
-                        }
-                        break;
-                case ET_XI:
-                case ET_YO:
-                case ET_SI:
-                case ET_TBL:
-                        if (eptr[1].ex_type != ET_LB) {
-                                post("expr: syntax error: brackets missing\n");
-                                ex_print(eptr);
-                                return (exNULL);
-                        }
-                        /* if this table is the only token, parse the table */
-                        if (!count &&
-                            !((struct ex_ex *) eptr[1].ex_ptr)[1].ex_type) {
-                                savex = *((struct ex_ex *) eptr[1].ex_ptr);
-                                *((struct ex_ex *) eptr[1].ex_ptr) = nullex;
-                                *optr = *eptr;
-                                lowpre = ex_parse(x, &eptr[2], optr + 1, (long *)0);
-                                *((struct ex_ex *) eptr[1].ex_ptr) = savex;
-                                                                optr->ex_end = lowpre;
-                                return(lowpre);
-                        }
-                        eptr = (struct ex_ex *) eptr[1].ex_ptr;
-                        break;
-                case ET_OP:
-                        if (eptr->ex_op == OP_COMMA) {
-                                if (!argc || !count || !eptr[1].ex_type) {
-                                        post("expr: syntax error: illegal comma\n");
-                                        ex_print(eptr[1].ex_type ? eptr : iptr);
-                                        return (exNULL);
-                                }
-                        }
-                        if (!eptr[1].ex_type) {
-                                post("expr: syntax error: missing operand\n");
-                                ex_print(iptr);
-                                return (exNULL);
-                        }
-                        if ((eptr->ex_op & PRE_MASK) <= pre) {
-                                pre = eptr->ex_op & PRE_MASK;
-                                lowpre = eptr;
-                        }
-                        break;
-                case ET_FUNC:
-                        if (eptr[1].ex_type != ET_LP) {
-                                post("expr: ex_parse: no parenthesis\n");
-                                return (exNULL);
-                        }
-                        /* if this function is the only token, parse it */
-                        if (!count &&
-                            !((struct ex_ex *) eptr[1].ex_ptr)[1].ex_type) {
-                                long ac;
+    /*
+     * the following loop finds the lowest precedence operator in the
+     * the input token list, comma is explicitly checked here since
+     * that is a special operator and is only legal in functions
+     */
+    for(eptr = iptr, count = 0; eptr->ex_type; eptr++, count++)
+        switch(eptr->ex_type)
+        {
+            case ET_SYM:
+            case ET_VSYM:
+                if(!argc)
+                {
+                    post("expr: syntax error: symbols allowed for functions "
+                         "only\n");
+                    ex_print(eptr);
+                    return (exNULL);
+                } /* falls through */
+            case ET_INT:
+            case ET_FLT:
+            case ET_II:
+            case ET_FI:
+            case ET_XI0:
+            case ET_YOM1:
+            case ET_VI:
+            case ET_VAR:
+                if(!count && !eptr[1].ex_type)
+                {
+                    *optr = *eptr;
+                    tmpex = optr;
+                    tmpex->ex_end = ++optr;
+                    return (optr);
+                }
+                break;
+            case ET_XI:
+            case ET_YO:
+            case ET_SI:
+            case ET_TBL:
+                if(eptr[1].ex_type != ET_LB)
+                {
+                    post("expr: syntax error: brackets missing\n");
+                    ex_print(eptr);
+                    return (exNULL);
+                }
+                /* if this table is the only token, parse the table */
+                if(!count && !((struct ex_ex *) eptr[1].ex_ptr)[1].ex_type)
+                {
+                    savex = *((struct ex_ex *) eptr[1].ex_ptr);
+                    *((struct ex_ex *) eptr[1].ex_ptr) = nullex;
+                    *optr = *eptr;
+                    lowpre = ex_parse(x, &eptr[2], optr + 1, (long *) 0);
+                    *((struct ex_ex *) eptr[1].ex_ptr) = savex;
+                    optr->ex_end = lowpre;
+                    return (lowpre);
+                }
+                eptr = (struct ex_ex *) eptr[1].ex_ptr;
+                break;
+            case ET_OP:
+                if(eptr->ex_op == OP_COMMA)
+                {
+                    if(!argc || !count || !eptr[1].ex_type)
+                    {
+                        post("expr: syntax error: illegal comma\n");
+                        ex_print(eptr[1].ex_type ? eptr : iptr);
+                        return (exNULL);
+                    }
+                }
+                if(!eptr[1].ex_type)
+                {
+                    post("expr: syntax error: missing operand\n");
+                    ex_print(iptr);
+                    return (exNULL);
+                }
+                if((eptr->ex_op & PRE_MASK) <= pre)
+                {
+                    pre = eptr->ex_op & PRE_MASK;
+                    lowpre = eptr;
+                }
+                break;
+            case ET_FUNC:
+                if(eptr[1].ex_type != ET_LP)
+                {
+                    post("expr: ex_parse: no parenthesis\n");
+                    return (exNULL);
+                }
+                /* if this function is the only token, parse it */
+                if(!count && !((struct ex_ex *) eptr[1].ex_ptr)[1].ex_type)
+                {
+                    long ac;
 
-                                if (eptr[1].ex_ptr == (char *) &eptr[2]) {
-                                        post("expr: syntax error: missing argument\n");
-                                        ex_print(eptr);
-                                        return (exNULL);
-                                }
-                                ac = 0;
-                                savex = *((struct ex_ex *) eptr[1].ex_ptr);
-                                *((struct ex_ex *) eptr[1].ex_ptr) = nullex;
-                                *optr = *eptr;
-                                lowpre = ex_parse(x, &eptr[2], optr + 1, &ac);
-                                if (!lowpre)
-                                        return (exNULL);
-                                ac++;
-                                if (ac !=
-                                    ((t_ex_func *)eptr->ex_ptr)->f_argc){
-                                        post("expr: syntax error: function '%s' needs %ld arguments\n",
-                                            ((t_ex_func *)eptr->ex_ptr)->f_name,
-                                            ((t_ex_func *)eptr->ex_ptr)->f_argc);
-                                        return (exNULL);
-                                }
-                                *((struct ex_ex *) eptr[1].ex_ptr) = savex;
-                                                                optr->ex_end = lowpre;
-                                return (lowpre);
-                        }
-                        eptr = (struct ex_ex *) eptr[1].ex_ptr;
-                        break;
-                case ET_LP:
-                case ET_LB:
-                        if (!count &&
-                            !((struct ex_ex *) eptr->ex_ptr)[1].ex_type) {
-                                if (eptr->ex_ptr == (char *)(&eptr[1])) {
-                                        post("expr: syntax error: empty '%s'\n",
-                                            eptr->ex_type==ET_LP?"()":"[]");
-                                        ex_print(eptr);
-                                        return (exNULL);
-                                }
-                                savex = *((struct ex_ex *) eptr->ex_ptr);
-                                *((struct ex_ex *) eptr->ex_ptr) = nullex;
-                                lowpre = ex_parse(x, &eptr[1], optr, (long *)0);
-                                *((struct ex_ex *) eptr->ex_ptr) = savex;
-                                                                optr->ex_end = lowpre;
-                                return (lowpre);
-                        }
-                        eptr = (struct ex_ex *)eptr->ex_ptr;
-                        break;
-                case ET_STR:
-                default:
+                    if(eptr[1].ex_ptr == (char *) &eptr[2])
+                    {
+                        post("expr: syntax error: missing argument\n");
                         ex_print(eptr);
-                        post("expr: ex_parse: type = 0x%lx\n", eptr->ex_type);
                         return (exNULL);
+                    }
+                    ac = 0;
+                    savex = *((struct ex_ex *) eptr[1].ex_ptr);
+                    *((struct ex_ex *) eptr[1].ex_ptr) = nullex;
+                    *optr = *eptr;
+                    lowpre = ex_parse(x, &eptr[2], optr + 1, &ac);
+                    if(!lowpre) return (exNULL);
+                    ac++;
+                    if(ac != ((t_ex_func *) eptr->ex_ptr)->f_argc)
+                    {
+                        post("expr: syntax error: function '%s' needs %ld "
+                             "arguments\n",
+                            ((t_ex_func *) eptr->ex_ptr)->f_name,
+                            ((t_ex_func *) eptr->ex_ptr)->f_argc);
+                        return (exNULL);
+                    }
+                    *((struct ex_ex *) eptr[1].ex_ptr) = savex;
+                    optr->ex_end = lowpre;
+                    return (lowpre);
                 }
+                eptr = (struct ex_ex *) eptr[1].ex_ptr;
+                break;
+            case ET_LP:
+            case ET_LB:
+                if(!count && !((struct ex_ex *) eptr->ex_ptr)[1].ex_type)
+                {
+                    if(eptr->ex_ptr == (char *) (&eptr[1]))
+                    {
+                        post("expr: syntax error: empty '%s'\n",
+                            eptr->ex_type == ET_LP ? "()" : "[]");
+                        ex_print(eptr);
+                        return (exNULL);
+                    }
+                    savex = *((struct ex_ex *) eptr->ex_ptr);
+                    *((struct ex_ex *) eptr->ex_ptr) = nullex;
+                    lowpre = ex_parse(x, &eptr[1], optr, (long *) 0);
+                    *((struct ex_ex *) eptr->ex_ptr) = savex;
+                    optr->ex_end = lowpre;
+                    return (lowpre);
+                }
+                eptr = (struct ex_ex *) eptr->ex_ptr;
+                break;
+            case ET_STR:
+            default:
+                ex_print(eptr);
+                post("expr: ex_parse: type = 0x%lx\n", eptr->ex_type);
+                return (exNULL);
+        }
 
-        if (pre == HI_PRE) {
-                post("expr: syntax error: missing operation\n");
-                ex_print(iptr);
-                return (exNULL);
+    if(pre == HI_PRE)
+    {
+        post("expr: syntax error: missing operation\n");
+        ex_print(iptr);
+        return (exNULL);
+    }
+    if(count < 2)
+    {
+        post("expr: syntax error: mission operand\n");
+        ex_print(iptr);
+        return (exNULL);
+    }
+    if(count == 2)
+    {
+        if(lowpre != iptr)
+        {
+            post("expr: ex_parse: unary operator should be first\n");
+            return (exNULL);
         }
-        if (count < 2) {
-                post("expr: syntax error: mission operand\n");
-                ex_print(iptr);
-                return (exNULL);
+        if(!unary_op(lowpre->ex_op))
+        {
+            post("expr: syntax error: not a uniary operator\n");
+            ex_print(iptr);
+            return (exNULL);
         }
-        if (count == 2) {
-                if (lowpre != iptr) {
-                        post("expr: ex_parse: unary operator should be first\n");
-                        return (exNULL);
-                }
-                if (!unary_op(lowpre->ex_op)) {
-                        post("expr: syntax error: not a uniary operator\n");
-                        ex_print(iptr);
-                        return (exNULL);
-                }
-                *optr = *lowpre;
-                eptr = ex_parse(x, &lowpre[1], optr + 1, argc);
-                                optr->ex_end = eptr;
-                return (eptr);
-        }
-        /* this is the case of using unary operator as a binary opetator */
-        if (count == 3 && unary_op(lowpre->ex_op)) {
-                post("expr: syntax error, missing operand before unary operator\n");
-                ex_print(iptr);
-                return (exNULL);
-        }
-        if (lowpre == iptr) {
-                post("expr: syntax error: mission operand\n");
-                ex_print(iptr);
-                return (exNULL);
-        }
-        savex = *lowpre;
-        *lowpre = nullex;
-        if (savex.ex_op != OP_COMMA) {
-            *optr = savex;
-                eptr = ex_parse(x, iptr, optr + 1, argc);
-                } else {
-            (*argc)++;
-                eptr = ex_parse(x, iptr, optr, argc);
-                }
-        if (eptr) {
-                eptr = ex_parse(x, &lowpre[1], eptr, argc);
-                *lowpre = savex;
-        }
-                optr->ex_end = eptr;
+        *optr = *lowpre;
+        eptr = ex_parse(x, &lowpre[1], optr + 1, argc);
+        optr->ex_end = eptr;
         return (eptr);
+    }
+    /* this is the case of using unary operator as a binary opetator */
+    if(count == 3 && unary_op(lowpre->ex_op))
+    {
+        post("expr: syntax error, missing operand before unary operator\n");
+        ex_print(iptr);
+        return (exNULL);
+    }
+    if(lowpre == iptr)
+    {
+        post("expr: syntax error: mission operand\n");
+        ex_print(iptr);
+        return (exNULL);
+    }
+    savex = *lowpre;
+    *lowpre = nullex;
+    if(savex.ex_op != OP_COMMA)
+    {
+        *optr = savex;
+        eptr = ex_parse(x, iptr, optr + 1, argc);
+    }
+    else
+    {
+        (*argc)++;
+        eptr = ex_parse(x, iptr, optr, argc);
+    }
+    if(eptr)
+    {
+        eptr = ex_parse(x, &lowpre[1], eptr, argc);
+        *lowpre = savex;
+    }
+    optr->ex_end = eptr;
+    return (eptr);
 }
 
 /*
@@ -748,273 +802,308 @@ ex_parse(struct expr *x, struct ex_ex *iptr, struct ex_ex *optr, long int *argc)
  *                 return 0 on success
  */
 
-static int
-ex_checklval(struct ex_ex *eptr)
+static int ex_checklval(struct ex_ex *eptr)
 {
-        struct ex_ex *extmp;
+    struct ex_ex *extmp;
 
-        extmp = eptr->ex_end;
-        while (eptr->ex_type && eptr != extmp) {
-				if (eptr->ex_type == ET_OP && eptr->ex_op == OP_STORE) {
-                        if (eptr[1].ex_type != ET_VAR &&
-                            eptr[1].ex_type != ET_SI &&
-                            eptr[1].ex_type != ET_TBL) {
-                                post("Bad left value: ");
-                                ex_print(eptr);
-                               return (1);
-                         }
-				}
-				eptr++;
+    extmp = eptr->ex_end;
+    while(eptr->ex_type && eptr != extmp)
+    {
+        if(eptr->ex_type == ET_OP && eptr->ex_op == OP_STORE)
+        {
+            if(eptr[1].ex_type != ET_VAR && eptr[1].ex_type != ET_SI &&
+                eptr[1].ex_type != ET_TBL)
+            {
+                post("Bad left value: ");
+                ex_print(eptr);
+                return (1);
+            }
         }
-        return (0);
+        eptr++;
+    }
+    return (0);
 }
-
 
 /*
  * this is the divide zero check for a non divide operator
  */
-#define DZC(ARG1,OPR,ARG2)      (ARG1 OPR ARG2)
+#define DZC(ARG1, OPR, ARG2) (ARG1 OPR ARG2)
 
-#define EVAL(OPR);                                                      \
-eptr = ex_eval(expr, ex_eval(expr, eptr, &left, idx), &right, idx);     \
-switch (left.ex_type) {                                                 \
-case ET_INT:                                                            \
-        switch(right.ex_type) {                                         \
-        case ET_INT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = (t_float)DZC(left.ex_int, OPR, right.ex_int); \
-                        for (j = 0; j < expr->exp_vsize; j++)           \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_INT;                         \
-                        optr->ex_int = DZC(left.ex_int, OPR, right.ex_int); \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = DZC(((t_float)left.ex_int), OPR, right.ex_flt);\
-                        for (j = 0; j < expr->exp_vsize; j++)           \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt = DZC(((t_float)left.ex_int), OPR,   \
-                                                        right.ex_flt);  \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                if (optr->ex_type != ET_VEC) {                          \
-                        if (optr->ex_type == ET_VI) {                   \
-                                post("expr~: Int. error %d", __LINE__); \
-                                abort();                                \
-                        }                                               \
-                        optr->ex_type = ET_VEC;                         \
-                        optr->ex_vec = (t_float *)                      \
-                          fts_malloc(sizeof (t_float)*expr->exp_vsize); \
-                }                                                       \
-                scalar = left.ex_int;                                   \
-                rp = right.ex_vec;                                      \
-                op = optr->ex_vec;                                      \
-                for (i = 0; i < expr->exp_vsize; i++) {                 \
-                        *op++ = DZC (scalar, OPR, *rp);                 \
-                        rp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) expr,                       \
-                      "expr: ex_eval(%d): bad right type %ld\n",        \
-                                              __LINE__, right.ex_type); \
-                nullret = 1;                                            \
-        }                                                               \
-        break;                                                          \
-case ET_FLT:                                                            \
-        switch(right.ex_type) {                                         \
-        case ET_INT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = DZC((t_float) left.ex_flt, OPR, right.ex_int); \
-                        for (j = 0; j < expr->exp_vsize; j++)           \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt = DZC(left.ex_flt, OPR, right.ex_int); \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = DZC(left.ex_flt, OPR, right.ex_flt);   \
-                        for (j = 0; j < expr->exp_vsize; j++)           \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt= DZC(left.ex_flt, OPR, right.ex_flt); \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                if (optr->ex_type != ET_VEC) {                          \
-                        if (optr->ex_type == ET_VI) {                   \
-                                post("expr~: Int. error %d", __LINE__); \
-                                abort();                                \
-                        }                                               \
-                        optr->ex_type = ET_VEC;                         \
-                        optr->ex_vec = (t_float *)                      \
-                          fts_malloc(sizeof (t_float)*expr->exp_vsize); \
-                }                                                       \
-                scalar = left.ex_flt;                                   \
-                rp = right.ex_vec;                                      \
-                op = optr->ex_vec;                                      \
-                for (i = 0; i < expr->exp_vsize; i++) {                 \
-                        *op++ = DZC(scalar, OPR, *rp);                  \
-                        rp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) expr,                       \
-                      "expr: ex_eval(%d): bad right type %ld\n",        \
-                                              __LINE__, right.ex_type); \
-                nullret = 1;                                            \
-        }                                                               \
-        break;                                                          \
-case ET_VEC:                                                            \
-case ET_VI:                                                             \
-        if (optr->ex_type != ET_VEC) {                                  \
-                if (optr->ex_type == ET_VI) {                           \
-                        post("expr~: Int. error %d", __LINE__);         \
-                        abort();                                        \
-                }                                                       \
-                optr->ex_type = ET_VEC;                                 \
-                optr->ex_vec = (t_float *)                              \
-                  fts_malloc(sizeof (t_float)*expr->exp_vsize);         \
-        }                                                               \
-        op = optr->ex_vec;                                              \
-        lp = left.ex_vec;                                               \
-        switch(right.ex_type) {                                         \
-        case ET_INT:                                                    \
-                scalar = right.ex_int;                                  \
-                for (i = 0; i < expr->exp_vsize; i++) {                 \
-                        *op++ = DZC(*lp, OPR, scalar);                  \
-                        lp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                scalar = right.ex_flt;                                  \
-                for (i = 0; i < expr->exp_vsize; i++) {                 \
-                        *op++ = DZC(*lp, OPR, scalar);                  \
-                        lp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                rp = right.ex_vec;                                      \
-                for (i = 0; i < expr->exp_vsize; i++) {                 \
-                        /*                                              \
-                         * on a RISC processor one could copy           \
-                         * 8 times in each round to get a considerable  \
-                         * improvement                                  \
-                         */                                             \
-                        *op++ = DZC(*lp, OPR, *rp);                     \
-                        rp++; lp++;                                     \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) expr,                       \
-                      "expr: ex_eval(%d): bad right type %ld\n",        \
-                                              __LINE__, right.ex_type); \
-                nullret = 1;                                            \
-        }                                                               \
-        break;                                                          \
-case ET_SYM:                                                            \
-default:                                                                \
-                post_error((fts_object_t *) expr,                       \
-                      "expr: ex_eval(%d): bad left type %ld\n",         \
-                                              __LINE__, left.ex_type);  \
-}                                                                       \
-break;
+#define EVAL(OPR)                                                              \
+    ;                                                                          \
+    eptr = ex_eval(expr, ex_eval(expr, eptr, &left, idx), &right, idx);        \
+    switch(left.ex_type)                                                       \
+    {                                                                          \
+        case ET_INT:                                                           \
+            switch(right.ex_type)                                              \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar =                                               \
+                            (t_float) DZC(left.ex_int, OPR, right.ex_int);     \
+                        for(j = 0; j < expr->exp_vsize; j++)                   \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_INT;                                \
+                        optr->ex_int = DZC(left.ex_int, OPR, right.ex_int);    \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar =                                               \
+                            DZC(((t_float) left.ex_int), OPR, right.ex_flt);   \
+                        for(j = 0; j < expr->exp_vsize; j++)                   \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt =                                         \
+                            DZC(((t_float) left.ex_int), OPR, right.ex_flt);   \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    if(optr->ex_type != ET_VEC)                                \
+                    {                                                          \
+                        if(optr->ex_type == ET_VI)                             \
+                        {                                                      \
+                            post("expr~: Int. error %d", __LINE__);            \
+                            abort();                                           \
+                        }                                                      \
+                        optr->ex_type = ET_VEC;                                \
+                        optr->ex_vec = (t_float *) fts_malloc(                 \
+                            sizeof(t_float) * expr->exp_vsize);                \
+                    }                                                          \
+                    scalar = left.ex_int;                                      \
+                    rp = right.ex_vec;                                         \
+                    op = optr->ex_vec;                                         \
+                    for(i = 0; i < expr->exp_vsize; i++)                       \
+                    {                                                          \
+                        *op++ = DZC(scalar, OPR, *rp);                         \
+                        rp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) expr,                          \
+                        "expr: ex_eval(%d): bad right type %ld\n", __LINE__,   \
+                        right.ex_type);                                        \
+                    nullret = 1;                                               \
+            }                                                                  \
+            break;                                                             \
+        case ET_FLT:                                                           \
+            switch(right.ex_type)                                              \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar =                                               \
+                            DZC((t_float) left.ex_flt, OPR, right.ex_int);     \
+                        for(j = 0; j < expr->exp_vsize; j++)                   \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt = DZC(left.ex_flt, OPR, right.ex_int);    \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar = DZC(left.ex_flt, OPR, right.ex_flt);          \
+                        for(j = 0; j < expr->exp_vsize; j++)                   \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt = DZC(left.ex_flt, OPR, right.ex_flt);    \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    if(optr->ex_type != ET_VEC)                                \
+                    {                                                          \
+                        if(optr->ex_type == ET_VI)                             \
+                        {                                                      \
+                            post("expr~: Int. error %d", __LINE__);            \
+                            abort();                                           \
+                        }                                                      \
+                        optr->ex_type = ET_VEC;                                \
+                        optr->ex_vec = (t_float *) fts_malloc(                 \
+                            sizeof(t_float) * expr->exp_vsize);                \
+                    }                                                          \
+                    scalar = left.ex_flt;                                      \
+                    rp = right.ex_vec;                                         \
+                    op = optr->ex_vec;                                         \
+                    for(i = 0; i < expr->exp_vsize; i++)                       \
+                    {                                                          \
+                        *op++ = DZC(scalar, OPR, *rp);                         \
+                        rp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) expr,                          \
+                        "expr: ex_eval(%d): bad right type %ld\n", __LINE__,   \
+                        right.ex_type);                                        \
+                    nullret = 1;                                               \
+            }                                                                  \
+            break;                                                             \
+        case ET_VEC:                                                           \
+        case ET_VI:                                                            \
+            if(optr->ex_type != ET_VEC)                                        \
+            {                                                                  \
+                if(optr->ex_type == ET_VI)                                     \
+                {                                                              \
+                    post("expr~: Int. error %d", __LINE__);                    \
+                    abort();                                                   \
+                }                                                              \
+                optr->ex_type = ET_VEC;                                        \
+                optr->ex_vec =                                                 \
+                    (t_float *) fts_malloc(sizeof(t_float) * expr->exp_vsize); \
+            }                                                                  \
+            op = optr->ex_vec;                                                 \
+            lp = left.ex_vec;                                                  \
+            switch(right.ex_type)                                              \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    scalar = right.ex_int;                                     \
+                    for(i = 0; i < expr->exp_vsize; i++)                       \
+                    {                                                          \
+                        *op++ = DZC(*lp, OPR, scalar);                         \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    scalar = right.ex_flt;                                     \
+                    for(i = 0; i < expr->exp_vsize; i++)                       \
+                    {                                                          \
+                        *op++ = DZC(*lp, OPR, scalar);                         \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    rp = right.ex_vec;                                         \
+                    for(i = 0; i < expr->exp_vsize; i++)                       \
+                    {                                                          \
+                        /*                                                     \
+                         * on a RISC processor one could copy                  \
+                         * 8 times in each round to get a considerable         \
+                         * improvement                                         \
+                         */                                                    \
+                        *op++ = DZC(*lp, OPR, *rp);                            \
+                        rp++;                                                  \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) expr,                          \
+                        "expr: ex_eval(%d): bad right type %ld\n", __LINE__,   \
+                        right.ex_type);                                        \
+                    nullret = 1;                                               \
+            }                                                                  \
+            break;                                                             \
+        case ET_SYM:                                                           \
+        default:                                                               \
+            post_error((fts_object_t *) expr,                                  \
+                "expr: ex_eval(%d): bad left type %ld\n", __LINE__,            \
+                left.ex_type);                                                 \
+    }                                                                          \
+    break;
 
 /*
  * evaluate a unary operator, TYPE is applied to float operands
  */
-#define EVAL_UNARY(OPR, TYPE)                                           \
-        eptr = ex_eval(expr, eptr, &left, idx);                         \
-        switch(left.ex_type) {                                          \
-        case ET_INT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        ex_mkvector(optr->ex_vec,(t_float)(OPR left.ex_int),\
-                                                        expr->exp_vsize);\
-                        break;                                          \
-                }                                                       \
-                optr->ex_type = ET_INT;                                 \
-                optr->ex_int = OPR left.ex_int;                         \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        ex_mkvector(optr->ex_vec, OPR (TYPE left.ex_flt),\
-                                                        expr->exp_vsize);\
-                        break;                                          \
-                }                                                       \
-                optr->ex_type = ET_FLT;                                 \
-                optr->ex_flt = OPR (TYPE left.ex_flt);                  \
-                break;                                                  \
-        case ET_VI:                                                     \
-        case ET_VEC:                                                    \
-                j = expr->exp_vsize;                                    \
-                if (optr->ex_type != ET_VEC) {                          \
-                        optr->ex_type = ET_VEC;                         \
-                        optr->ex_vec = (t_float *)                      \
-                          fts_malloc(sizeof (t_float)*expr->exp_vsize); \
-                }                                                       \
-                op = optr->ex_vec;                                      \
-                lp = left.ex_vec;                                       \
-                j = expr->exp_vsize;                                    \
-                for (i = 0; i < j; i++)                                 \
-                        *op++ = OPR (TYPE *lp++);                       \
-                break;                                                  \
-        default:                                                        \
-                post_error((fts_object_t *) expr,                       \
-                        "expr: ex_eval(%d): bad left type %ld\n",       \
-                                              __LINE__, left.ex_type);  \
-                nullret++;                                              \
-        }                                                               \
-        break;
+#define EVAL_UNARY(OPR, TYPE)                                                  \
+    eptr = ex_eval(expr, eptr, &left, idx);                                    \
+    switch(left.ex_type)                                                       \
+    {                                                                          \
+        case ET_INT:                                                           \
+            if(optr->ex_type == ET_VEC)                                        \
+            {                                                                  \
+                ex_mkvector(optr->ex_vec, (t_float) (OPR left.ex_int),         \
+                    expr->exp_vsize);                                          \
+                break;                                                         \
+            }                                                                  \
+            optr->ex_type = ET_INT;                                            \
+            optr->ex_int = OPR left.ex_int;                                    \
+            break;                                                             \
+        case ET_FLT:                                                           \
+            if(optr->ex_type == ET_VEC)                                        \
+            {                                                                  \
+                ex_mkvector(                                                   \
+                    optr->ex_vec, OPR(TYPE left.ex_flt), expr->exp_vsize);     \
+                break;                                                         \
+            }                                                                  \
+            optr->ex_type = ET_FLT;                                            \
+            optr->ex_flt = OPR(TYPE left.ex_flt);                              \
+            break;                                                             \
+        case ET_VI:                                                            \
+        case ET_VEC:                                                           \
+            j = expr->exp_vsize;                                               \
+            if(optr->ex_type != ET_VEC)                                        \
+            {                                                                  \
+                optr->ex_type = ET_VEC;                                        \
+                optr->ex_vec =                                                 \
+                    (t_float *) fts_malloc(sizeof(t_float) * expr->exp_vsize); \
+            }                                                                  \
+            op = optr->ex_vec;                                                 \
+            lp = left.ex_vec;                                                  \
+            j = expr->exp_vsize;                                               \
+            for(i = 0; i < j; i++)                                             \
+                *op++ = OPR(TYPE * lp++);                                      \
+            break;                                                             \
+        default:                                                               \
+            post_error((fts_object_t *) expr,                                  \
+                "expr: ex_eval(%d): bad left type %ld\n", __LINE__,            \
+                left.ex_type);                                                 \
+            nullret++;                                                         \
+    }                                                                          \
+    break;
 
-void
-ex_mkvector(t_float *fp, t_float x, int size)
+void ex_mkvector(t_float *fp, t_float x, int size)
 {
-        while (size--)
-                *fp++ = x;
+    while(size--)
+        *fp++ = x;
 }
 
 /*
  * ex_dzdetect -- divide by zero detected
  */
-void
-ex_dzdetect(struct expr *expr)
+void ex_dzdetect(struct expr *expr)
 {
-        char *etype;
+    char *etype;
 
-        if ((!expr->exp_error) & EE_DZ) {
-                if (IS_EXPR(expr))
-                        etype = "expr";
-                else if (IS_EXPR_TILDE(expr))
-                        etype = "expr~";
-                else if (IS_FEXPR_TILDE(expr))
-                        etype = "fexpr~";
-                else {
-                        post ("expr -- ex_dzdetect internal error");
-                        etype = "";
-                }
-                post ("%s divide by zero detected", etype);
-                expr->exp_error |= EE_DZ;
+    if((!expr->exp_error) & EE_DZ)
+    {
+        if(IS_EXPR(expr))
+            etype = "expr";
+        else if(IS_EXPR_TILDE(expr))
+            etype = "expr~";
+        else if(IS_FEXPR_TILDE(expr))
+            etype = "fexpr~";
+        else
+        {
+            post("expr -- ex_dzdetect internal error");
+            etype = "";
         }
+        post("%s divide by zero detected", etype);
+        expr->exp_error |= EE_DZ;
+    }
 }
-
 
 /*
  * ex_eval -- evaluate the array of prefix expression
@@ -1029,242 +1118,263 @@ need to be freed
 
 look into the variable nullret
 */
-struct ex_ex *
-ex_eval(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *ex_eval(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 /* the sample number processed for fexpr~ */
 {
-        int i, j;
-        t_float *lp, *rp, *op; /* left, right, and out pointer to vectors */
-        t_float scalar;
-        int nullret = 0;                /* did we have an error */
-        struct ex_ex left = { 0 }, right = { 0 };       /* left and right operands */
+    int i, j;
+    t_float *lp, *rp, *op; /* left, right, and out pointer to vectors */
+    t_float scalar;
+    int nullret = 0;                      /* did we have an error */
+    struct ex_ex left = {0}, right = {0}; /* left and right operands */
 
-        left.ex_type = 0;
-        left.ex_int = 0;
-        right.ex_type = 0;
-        right.ex_int = 0;
+    left.ex_type = 0;
+    left.ex_int = 0;
+    right.ex_type = 0;
+    right.ex_int = 0;
 
-        if (!eptr)
-                return (exNULL);
-        switch (eptr->ex_type) {
+    if(!eptr) return (exNULL);
+    switch(eptr->ex_type)
+    {
         case ET_INT:
-                if (optr->ex_type == ET_VEC)
-                        ex_mkvector(optr->ex_vec, (t_float) eptr->ex_int,
-                                                                expr->exp_vsize);
-                else
-                        *optr = *eptr;
-                return (++eptr);
+            if(optr->ex_type == ET_VEC)
+                ex_mkvector(
+                    optr->ex_vec, (t_float) eptr->ex_int, expr->exp_vsize);
+            else
+                *optr = *eptr;
+            return (++eptr);
 
         case ET_FLT:
 
-                if (optr->ex_type == ET_VEC)
-                        ex_mkvector(optr->ex_vec, eptr->ex_flt, expr->exp_vsize);
-                else
-                        *optr = *eptr;
-                return (++eptr);
+            if(optr->ex_type == ET_VEC)
+                ex_mkvector(optr->ex_vec, eptr->ex_flt, expr->exp_vsize);
+            else
+                *optr = *eptr;
+            return (++eptr);
 
         case ET_SYM:
-                if (optr->ex_type == ET_VEC) {
-                        post_error((fts_object_t *) expr,
-                              "expr: ex_eval: cannot turn string to vector\n");
-                        return (exNULL);
-                }
-                *optr = *eptr;
-                return (++eptr);
+            if(optr->ex_type == ET_VEC)
+            {
+                post_error((fts_object_t *) expr,
+                    "expr: ex_eval: cannot turn string to vector\n");
+                return (exNULL);
+            }
+            *optr = *eptr;
+            return (++eptr);
         case ET_II:
-                if (eptr->ex_int == -1) {
-                        post_error((fts_object_t *) expr,
-                            "expr: ex_eval: inlet number not set\n");
-                        return (exNULL);
-                }
-                if (optr->ex_type == ET_VEC) {
-                        ex_mkvector(optr->ex_vec,
-                               (t_float)expr->exp_var[eptr->ex_int].ex_int,
-                                                                expr->exp_vsize);
-                } else {
-                        optr->ex_type = ET_INT;
-                        optr->ex_int = expr->exp_var[eptr->ex_int].ex_int;
-                }
-                return (++eptr);
+            if(eptr->ex_int == -1)
+            {
+                post_error((fts_object_t *) expr,
+                    "expr: ex_eval: inlet number not set\n");
+                return (exNULL);
+            }
+            if(optr->ex_type == ET_VEC)
+            {
+                ex_mkvector(optr->ex_vec,
+                    (t_float) expr->exp_var[eptr->ex_int].ex_int,
+                    expr->exp_vsize);
+            }
+            else
+            {
+                optr->ex_type = ET_INT;
+                optr->ex_int = expr->exp_var[eptr->ex_int].ex_int;
+            }
+            return (++eptr);
         case ET_FI:
-                if (eptr->ex_int == -1) {
-                        post_error((fts_object_t *) expr,
-                            "expr: ex_eval: inlet number not set\n");
-                        return (exNULL);
-                }
-                if (optr->ex_type == ET_VEC) {
-                        ex_mkvector(optr->ex_vec,
-                             expr->exp_var[eptr->ex_int].ex_flt, expr->exp_vsize);
-                } else {
-                        optr->ex_type = ET_FLT;
-                        optr->ex_flt = expr->exp_var[eptr->ex_int].ex_flt;
-                }
-                return (++eptr);
+            if(eptr->ex_int == -1)
+            {
+                post_error((fts_object_t *) expr,
+                    "expr: ex_eval: inlet number not set\n");
+                return (exNULL);
+            }
+            if(optr->ex_type == ET_VEC)
+            {
+                ex_mkvector(optr->ex_vec, expr->exp_var[eptr->ex_int].ex_flt,
+                    expr->exp_vsize);
+            }
+            else
+            {
+                optr->ex_type = ET_FLT;
+                optr->ex_flt = expr->exp_var[eptr->ex_int].ex_flt;
+            }
+            return (++eptr);
 
         case ET_VSYM:
-                if (optr->ex_type == ET_VEC) {
-                        post_error((fts_object_t *) expr,
-                            "expr: IntErr. vsym in for vec out\n");
-                        return (exNULL);
-                }
-                if (eptr->ex_int == -1) {
-                        post_error((fts_object_t *) expr,
-                                "expr: ex_eval: inlet number not set\n");
-                        return (exNULL);
-                }
-                optr->ex_type = ET_SYM;
-                optr->ex_ptr = expr->exp_var[eptr->ex_int].ex_ptr;
-                return(++eptr);
+            if(optr->ex_type == ET_VEC)
+            {
+                post_error((fts_object_t *) expr,
+                    "expr: IntErr. vsym in for vec out\n");
+                return (exNULL);
+            }
+            if(eptr->ex_int == -1)
+            {
+                post_error((fts_object_t *) expr,
+                    "expr: ex_eval: inlet number not set\n");
+                return (exNULL);
+            }
+            optr->ex_type = ET_SYM;
+            optr->ex_ptr = expr->exp_var[eptr->ex_int].ex_ptr;
+            return (++eptr);
 
         case ET_VI:
-                if (optr->ex_type != ET_VEC)
-                        *optr = expr->exp_var[eptr->ex_int];
-                else if (optr->ex_vec != expr->exp_var[eptr->ex_int].ex_vec)
-                        memcpy(optr->ex_vec, expr->exp_var[eptr->ex_int].ex_vec,
-                                        expr->exp_vsize * sizeof (t_float));
-                return(++eptr);
+            if(optr->ex_type != ET_VEC)
+                *optr = expr->exp_var[eptr->ex_int];
+            else if(optr->ex_vec != expr->exp_var[eptr->ex_int].ex_vec)
+                memcpy(optr->ex_vec, expr->exp_var[eptr->ex_int].ex_vec,
+                    expr->exp_vsize * sizeof(t_float));
+            return (++eptr);
         case ET_VEC:
-                if (optr->ex_type != ET_VEC) {
-                        optr->ex_type = ET_VEC;
-                        optr->ex_vec = eptr->ex_vec;
-                        eptr->ex_type = ET_INT;
-                        eptr->ex_int = 0;
-                } else if (optr->ex_vec != eptr->ex_vec) {
-                        memcpy(optr->ex_vec, eptr->ex_vec,
-                                        expr->exp_vsize * sizeof (t_float));
-                        fts_free(eptr->ex_vec);
-                } else { /* this should not happen */
-                        post("expr int. error, optr->ex_vec = %d",optr->ex_vec);
-                        abort();
-                }
-                return(++eptr);
+            if(optr->ex_type != ET_VEC)
+            {
+                optr->ex_type = ET_VEC;
+                optr->ex_vec = eptr->ex_vec;
+                eptr->ex_type = ET_INT;
+                eptr->ex_int = 0;
+            }
+            else if(optr->ex_vec != eptr->ex_vec)
+            {
+                memcpy(optr->ex_vec, eptr->ex_vec,
+                    expr->exp_vsize * sizeof(t_float));
+                fts_free(eptr->ex_vec);
+            }
+            else
+            { /* this should not happen */
+                post("expr int. error, optr->ex_vec = %d", optr->ex_vec);
+                abort();
+            }
+            return (++eptr);
         case ET_XI0:
-                /* short hand for $x?[0] */
+            /* short hand for $x?[0] */
 
-                /* SDY delete the following check */
-                if (!IS_FEXPR_TILDE(expr) || optr->ex_type==ET_VEC) {
-                        post("%d:exp->exp_flags = %d", __LINE__,expr->exp_flags);
-                        abort();
-                }
-                optr->ex_type = ET_FLT;
-                optr->ex_flt = expr->exp_var[eptr->ex_int].ex_vec[idx];
-                return(++eptr);
+            /* SDY delete the following check */
+            if(!IS_FEXPR_TILDE(expr) || optr->ex_type == ET_VEC)
+            {
+                post("%d:exp->exp_flags = %d", __LINE__, expr->exp_flags);
+                abort();
+            }
+            optr->ex_type = ET_FLT;
+            optr->ex_flt = expr->exp_var[eptr->ex_int].ex_vec[idx];
+            return (++eptr);
         case ET_YOM1:
-                /*
-                 * short hand for $y?[-1]
-                 * if we are calculating the first sample of the vector
-                 * we need to look at the previous results buffer
-                 */
-                optr->ex_type = ET_FLT;
-                if (idx == 0)
-                        optr->ex_flt =
-                        expr->exp_p_res[eptr->ex_int][expr->exp_vsize - 1];
-                else
-                        optr->ex_flt=expr->exp_tmpres[eptr->ex_int][idx-1];
-                return(++eptr);
+            /*
+             * short hand for $y?[-1]
+             * if we are calculating the first sample of the vector
+             * we need to look at the previous results buffer
+             */
+            optr->ex_type = ET_FLT;
+            if(idx == 0)
+                optr->ex_flt =
+                    expr->exp_p_res[eptr->ex_int][expr->exp_vsize - 1];
+            else
+                optr->ex_flt = expr->exp_tmpres[eptr->ex_int][idx - 1];
+            return (++eptr);
 
         case ET_YO:
         case ET_XI:
-                /* SDY delete the following */
-                if (!IS_FEXPR_TILDE(expr) || optr->ex_type==ET_VEC) {
-                        post("%d:expr->exp_flags = %d", __LINE__,expr->exp_flags);
-                        abort();
-                }
-                return (eval_sigidx(expr, eptr, optr, idx));
+            /* SDY delete the following */
+            if(!IS_FEXPR_TILDE(expr) || optr->ex_type == ET_VEC)
+            {
+                post("%d:expr->exp_flags = %d", __LINE__, expr->exp_flags);
+                abort();
+            }
+            return (eval_sigidx(expr, eptr, optr, idx));
 
         case ET_TBL:
         case ET_SI:
-                return (eval_tab(expr, eptr, optr, idx));
+            return (eval_tab(expr, eptr, optr, idx));
         case ET_FUNC:
-                return (eval_func(expr, eptr, optr, idx));
+            return (eval_func(expr, eptr, optr, idx));
         case ET_VAR:
-                return (eval_var(expr, eptr, optr, idx));
+            return (eval_var(expr, eptr, optr, idx));
         case ET_OP:
-                break;
+            break;
         case ET_STR:
         case ET_LP:
         case ET_LB:
         default:
-                post_error((fts_object_t *) expr,
-                        "expr: ex_eval: unexpected type %d\n",
-                            (int)eptr->ex_type);
-                return (exNULL);
-        }
-        if (!eptr[1].ex_type) {
-                post_error((fts_object_t *) expr,
-                                        "expr: ex_eval: not enough nodes 1\n");
-                return (exNULL);
-        }
-        if (!unary_op(eptr->ex_op) && !eptr[2].ex_type) {
-                post_error((fts_object_t *) expr,
-                                        "expr: ex_eval: not enough nodes 2\n");
-                return (exNULL);
-        }
+            post_error((fts_object_t *) expr,
+                "expr: ex_eval: unexpected type %d\n", (int) eptr->ex_type);
+            return (exNULL);
+    }
+    if(!eptr[1].ex_type)
+    {
+        post_error(
+            (fts_object_t *) expr, "expr: ex_eval: not enough nodes 1\n");
+        return (exNULL);
+    }
+    if(!unary_op(eptr->ex_op) && !eptr[2].ex_type)
+    {
+        post_error(
+            (fts_object_t *) expr, "expr: ex_eval: not enough nodes 2\n");
+        return (exNULL);
+    }
 
-        switch((eptr++)->ex_op) {
+    switch((eptr++)->ex_op)
+    {
         case OP_STORE:
-                return (eval_store(expr, eptr, optr, idx));
+            return (eval_store(expr, eptr, optr, idx));
         case OP_NOT:
-                EVAL_UNARY(!, +);
+            EVAL_UNARY(!, +);
         case OP_NEG:
-                EVAL_UNARY(~, (long));
+            EVAL_UNARY(~, (long) );
         case OP_UMINUS:
-                EVAL_UNARY(-, +);
+            EVAL_UNARY(-, +);
         case OP_MUL:
-                EVAL(*);
+            EVAL(*);
         case OP_ADD:
-                EVAL(+);
+            EVAL(+);
         case OP_SUB:
-                EVAL(-);
+            EVAL(-);
         case OP_LT:
-                EVAL(<);
+            EVAL(<);
         case OP_LE:
-                EVAL(<=);
+            EVAL(<=);
         case OP_GT:
-                EVAL(>);
+            EVAL(>);
         case OP_GE:
-                EVAL(>=);
+            EVAL(>=);
         case OP_EQ:
-                EVAL(==);
+            EVAL(==);
         case OP_NE:
-                EVAL(!=);
+            EVAL(!=);
 /*
  * following operators convert their argument to integer
  */
 #undef DZC
-#define DZC(ARG1,OPR,ARG2)      (((int)ARG1) OPR ((int)ARG2))
+#define DZC(ARG1, OPR, ARG2) (((int) ARG1) OPR((int) ARG2))
         case OP_SL:
-                EVAL(<<);
+            EVAL(<<);
         case OP_SR:
-                EVAL(>>);
+            EVAL(>>);
         case OP_AND:
-                EVAL(&);
+            EVAL(&);
         case OP_XOR:
-                EVAL(^);
+            EVAL(^);
         case OP_OR:
-                EVAL(|);
+            EVAL(|);
         case OP_LAND:
-                EVAL(&&);
+            EVAL(&&);
         case OP_LOR:
-                EVAL(||);
+            EVAL(||);
 /*
  * for modulo we need to convert to integer and check for divide by zero
  */
 #undef DZC
-#define DZC(ARG1,OPR,ARG2)      ((((int)ARG2)?(((int)ARG1) OPR ((int)ARG2)) \
-                                                        : (ex_dzdetect(expr),0)))
+#define DZC(ARG1, OPR, ARG2) \
+    ((((int) ARG2) ? (((int) ARG1) OPR((int) ARG2)) : (ex_dzdetect(expr), 0)))
         case OP_MOD:
-                EVAL(%);
+            EVAL(%);
 /*
  * define the divide by zero check for divide
  */
 #undef DZC
-#define DZC(ARG1,OPR,ARG2)      (((ARG2)?(ARG1 OPR ARG2):(ex_dzdetect(expr),0)))
+#define DZC(ARG1, OPR, ARG2) \
+    (((ARG2) ? (ARG1 OPR ARG2) : (ex_dzdetect(expr), 0)))
         case OP_DIV:
-                EVAL(/);
+            EVAL(/);
         case OP_LP:
         case OP_RP:
         case OP_LB:
@@ -1272,348 +1382,381 @@ ex_eval(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
         case OP_COMMA:
         case OP_SEMI:
         default:
-                post_error((fts_object_t *) expr,
-                    "expr: ex_print: bad op 0x%x\n", (unsigned)eptr->ex_op);
-                return (exNULL);
-        }
+            post_error((fts_object_t *) expr, "expr: ex_print: bad op 0x%x\n",
+                (unsigned) eptr->ex_op);
+            return (exNULL);
+    }
 
-
-        /*
-         * the left and right nodes could have been transformed to vectors
-         * down the chain
-         */
-        if (left.ex_type == ET_VEC)
-                fts_free(left.ex_vec);
-        if (right.ex_type == ET_VEC)
-                fts_free(right.ex_vec);
-        if (nullret)
-                return (exNULL);
-        else
-                return (eptr);
+    /*
+     * the left and right nodes could have been transformed to vectors
+     * down the chain
+     */
+    if(left.ex_type == ET_VEC) fts_free(left.ex_vec);
+    if(right.ex_type == ET_VEC) fts_free(right.ex_vec);
+    if(nullret)
+        return (exNULL);
+    else
+        return (eptr);
 }
 
-extern struct ex_ex * ex_if(t_expr *expr,  struct ex_ex *eptr,
-                                struct ex_ex *optr,struct ex_ex *argv, int idx);
+extern struct ex_ex *ex_if(t_expr *expr, struct ex_ex *eptr, struct ex_ex *optr,
+    struct ex_ex *argv, int idx);
 
 /*
  * eval_func --  evaluate a function, call ex_eval() on all the arguments
  *               so that all of them are terminal nodes. The call the
  *               appropriate function
  */
-struct ex_ex *
-eval_func(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *eval_func(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 {
-        int i;
-        struct ex_ex args[MAX_ARGS];
-        t_ex_func *f;
+    int i;
+    struct ex_ex args[MAX_ARGS];
+    t_ex_func *f;
 
-        f = (t_ex_func *)(eptr++)->ex_ptr;
-        if (!f || !f->f_name) {
-                return (exNULL);
-        }
-        if (f->f_argc > MAX_ARGS) {
-                post_error((fts_object_t *) expr, "expr: eval_func: asking too many arguments\n");
-                return (exNULL);
-        }
+    f = (t_ex_func *) (eptr++)->ex_ptr;
+    if(!f || !f->f_name)
+    {
+        return (exNULL);
+    }
+    if(f->f_argc > MAX_ARGS)
+    {
+        post_error((fts_object_t *) expr,
+            "expr: eval_func: asking too many arguments\n");
+        return (exNULL);
+    }
 
-                /*
-                 * We treat the "if" function differently to be able to evaluate
-                 * the args selectively based on the truth value of the "condition"
-                 */
-                if (f->f_func != (void (*)) ex_if) {
-                        for (i = 0; i < f->f_argc; i++) {
-                args[i].ex_type = 0;
-                args[i].ex_int = 0;
-                eptr = ex_eval(expr, eptr, &args[i], idx);
-                        }
-                (*f->f_func)(expr, f->f_argc, args, optr);
-        } else {
-                        for (i = 0; i < f->f_argc; i++) {
-                args[i].ex_type = 0;
-                args[i].ex_int = 0;
-                        }
-                eptr = ex_if(expr, eptr, optr, args, idx);
-                }
-        for (i = 0; i < f->f_argc; i++) {
-                if (args[i].ex_type == ET_VEC)
-                        fts_free(args[i].ex_vec);
+    /*
+     * We treat the "if" function differently to be able to evaluate
+     * the args selectively based on the truth value of the "condition"
+     */
+    if(f->f_func != (void(*)) ex_if)
+    {
+        for(i = 0; i < f->f_argc; i++)
+        {
+            args[i].ex_type = 0;
+            args[i].ex_int = 0;
+            eptr = ex_eval(expr, eptr, &args[i], idx);
         }
-        return (eptr);
+        (*f->f_func)(expr, f->f_argc, args, optr);
+    }
+    else
+    {
+        for(i = 0; i < f->f_argc; i++)
+        {
+            args[i].ex_type = 0;
+            args[i].ex_int = 0;
+        }
+        eptr = ex_if(expr, eptr, optr, args, idx);
+    }
+    for(i = 0; i < f->f_argc; i++)
+    {
+        if(args[i].ex_type == ET_VEC) fts_free(args[i].ex_vec);
+    }
+    return (eptr);
 }
-
 
 /*
  * eval_store --  evaluate the '=' operator,
  *                make sure the first operator is a legal left operator
  *                and call ex_eval on the right operator
  */
-struct ex_ex *
-eval_store(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *eval_store(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 {
-        struct ex_ex arg = { 0 };
-        struct ex_ex rval = { 0 };
-        struct ex_ex *retp;
-        char *tbl = (char *) 0;
-        char *var = (char *) 0;
-        int badleft = 0;
-        int notable = 0;
+    struct ex_ex arg = {0};
+    struct ex_ex rval = {0};
+    struct ex_ex *retp;
+    char *tbl = (char *) 0;
+    char *var = (char *) 0;
+    int badleft = 0;
+    int notable = 0;
 
-        arg.ex_type = ET_INT;
-        arg.ex_int = 0;
+    arg.ex_type = ET_INT;
+    arg.ex_int = 0;
 
-        switch (eptr->ex_type) {
+    switch(eptr->ex_type)
+    {
         case ET_VAR:
-                var = (char *) eptr->ex_ptr;
-                eptr = ex_eval(expr, ++eptr, &arg, idx);
-                if (max_ex_var_store(expr, (t_symbol *)var, &arg, optr))
-                        retp = exNULL;
-                else
-                        retp = eptr;
+            var = (char *) eptr->ex_ptr;
+            eptr = ex_eval(expr, ++eptr, &arg, idx);
+            if(max_ex_var_store(expr, (t_symbol *) var, &arg, optr))
+                retp = exNULL;
+            else
+                retp = eptr;
 
-                if (arg.ex_type == ET_VEC)
-                        fts_free(arg.ex_vec);
-                return(retp);
+            if(arg.ex_type == ET_VEC) fts_free(arg.ex_vec);
+            return (retp);
         case ET_TBL:
-                tbl = (char *) eptr->ex_ptr;
-                break;
+            tbl = (char *) eptr->ex_ptr;
+            break;
         case ET_SI:
-                if (!expr->exp_var[eptr->ex_int].ex_ptr) {
-                        if (!(expr->exp_error & EE_NOTABLE)) {
-                                post("expr: syntax error: no string for inlet %d",
-                                                                                                                eptr->ex_int + 1);
-                                post("expr: No more table errors will be reported");
-                                post("expr: till the next reset");
-                                expr->exp_error |= EE_NOTABLE;
-                        }
-                        badleft++;
-                        post("Bad left value: ");
-                        /* report Error */
-                        ex_print(eptr);
-                        retp = exNULL;
-                        return (retp);
-                } else {
-                        tbl = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
+            if(!expr->exp_var[eptr->ex_int].ex_ptr)
+            {
+                if(!(expr->exp_error & EE_NOTABLE))
+                {
+                    post("expr: syntax error: no string for inlet %d",
+                        eptr->ex_int + 1);
+                    post("expr: No more table errors will be reported");
+                    post("expr: till the next reset");
+                    expr->exp_error |= EE_NOTABLE;
                 }
-                break;
-        default:
+                badleft++;
                 post("Bad left value: ");
                 /* report Error */
                 ex_print(eptr);
                 retp = exNULL;
                 return (retp);
-        }
-        arg.ex_type = 0;
-        arg.ex_int = 0;
-        /* evaluate the index of the table */
-        if (!(eptr = ex_eval(expr, ++eptr, &arg, idx)))
-                return (eptr);
+            }
+            else
+            {
+                tbl = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
+            }
+            break;
+        default:
+            post("Bad left value: ");
+            /* report Error */
+            ex_print(eptr);
+            retp = exNULL;
+            return (retp);
+    }
+    arg.ex_type = 0;
+    arg.ex_int = 0;
+    /* evaluate the index of the table */
+    if(!(eptr = ex_eval(expr, ++eptr, &arg, idx))) return (eptr);
 
-        /* evaluate the right index of the table */
-        if (!(eptr = ex_eval(expr, eptr, &rval, idx)))
-                return (eptr);
-        optr->ex_type = ET_INT;
-        optr->ex_int = 0;
-        if (!notable || badleft)
-                (void)max_ex_tab_store(expr, (t_symbol *)tbl, &arg, &rval, optr);
-        if (arg.ex_type == ET_VEC)
-                fts_free(arg.ex_vec);
-        return (eptr);
+    /* evaluate the right index of the table */
+    if(!(eptr = ex_eval(expr, eptr, &rval, idx))) return (eptr);
+    optr->ex_type = ET_INT;
+    optr->ex_int = 0;
+    if(!notable || badleft)
+        (void) max_ex_tab_store(expr, (t_symbol *) tbl, &arg, &rval, optr);
+    if(arg.ex_type == ET_VEC) fts_free(arg.ex_vec);
+    return (eptr);
 }
 
 /*
  * eval_tab -- evaluate a table operation
  */
-struct ex_ex *
-eval_tab(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *eval_tab(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 {
-        struct ex_ex arg = { 0 };
-        char *tbl = (char *) 0;
-        int notable = 0;
+    struct ex_ex arg = {0};
+    char *tbl = (char *) 0;
+    int notable = 0;
 
-        if (eptr->ex_type == ET_SI) {
-                if (!expr->exp_var[eptr->ex_int].ex_ptr) {
-                        if (!(expr->exp_error & EE_NOTABLE)) {
-                                post("expr: syntax error: no string for inlet %d",
-                                                                                                                        eptr->ex_int + 1);
-                                post("expr: No more table errors will be reported");
-                                post("expr: till the next reset");
-                                expr->exp_error |= EE_NOTABLE;
-                        }
-                        notable++;
-                } else
-                        tbl = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
-        } else if (eptr->ex_type == ET_TBL) {
-                tbl = (char *) eptr->ex_ptr;
-                if (!tbl) {
-                        post("expr: abstraction argument for table not set");
-                        notable++;
-                }
-
-        } else {
-                post_error((fts_object_t *) expr,"expr: eval_tbl: bad type %ld\n",eptr->ex_type);
-                notable++;
-
+    if(eptr->ex_type == ET_SI)
+    {
+        if(!expr->exp_var[eptr->ex_int].ex_ptr)
+        {
+            if(!(expr->exp_error & EE_NOTABLE))
+            {
+                post("expr: syntax error: no string for inlet %d",
+                    eptr->ex_int + 1);
+                post("expr: No more table errors will be reported");
+                post("expr: till the next reset");
+                expr->exp_error |= EE_NOTABLE;
+            }
+            notable++;
         }
-        arg.ex_type = 0;
-        arg.ex_int = 0;
-        if (!(eptr = ex_eval(expr, ++eptr, &arg, idx)))
-                return (eptr);
+        else
+            tbl = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
+    }
+    else if(eptr->ex_type == ET_TBL)
+    {
+        tbl = (char *) eptr->ex_ptr;
+        if(!tbl)
+        {
+            post("expr: abstraction argument for table not set");
+            notable++;
+        }
+    }
+    else
+    {
+        post_error((fts_object_t *) expr, "expr: eval_tbl: bad type %ld\n",
+            eptr->ex_type);
+        notable++;
+    }
+    arg.ex_type = 0;
+    arg.ex_int = 0;
+    if(!(eptr = ex_eval(expr, ++eptr, &arg, idx))) return (eptr);
 
-        optr->ex_type = ET_INT;
-        optr->ex_int = 0;
-        if (!notable)
-                (void)max_ex_tab(expr, (t_symbol *)tbl, &arg, optr);
-        if (arg.ex_type == ET_VEC)
-                fts_free(arg.ex_vec);
-        return (eptr);
+    optr->ex_type = ET_INT;
+    optr->ex_int = 0;
+    if(!notable) (void) max_ex_tab(expr, (t_symbol *) tbl, &arg, optr);
+    if(arg.ex_type == ET_VEC) fts_free(arg.ex_vec);
+    return (eptr);
 }
 
 /*
  * eval_var -- evaluate a variable
  */
-struct ex_ex *
-eval_var(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *eval_var(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 {
-        char *var = (char *) 0;
-        int novar = 0;
+    char *var = (char *) 0;
+    int novar = 0;
 
-        if (eptr->ex_type == ET_SI) {
-                if (!expr->exp_var[eptr->ex_int].ex_ptr) {
-                                if (!(expr->exp_error & EE_NOVAR)) {
-                                        post("expr: syntax error: no string for inlet %d", eptr->ex_int + 1);
-                                        post("expr: no more table errors will be reported");
-                                        post("expr: till the next reset");
-                                        expr->exp_error |= EE_NOVAR;
-                                }
-                                novar++;
-                } else
-                        var = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
-        } else if (eptr->ex_type == ET_VAR)
-                var = (char *) eptr->ex_ptr;
-        else {
-                post_error((fts_object_t *) expr, "expr: eval_tbl: bad type %ld\n", eptr->ex_type);
-                novar++;
-
+    if(eptr->ex_type == ET_SI)
+    {
+        if(!expr->exp_var[eptr->ex_int].ex_ptr)
+        {
+            if(!(expr->exp_error & EE_NOVAR))
+            {
+                post("expr: syntax error: no string for inlet %d",
+                    eptr->ex_int + 1);
+                post("expr: no more table errors will be reported");
+                post("expr: till the next reset");
+                expr->exp_error |= EE_NOVAR;
+            }
+            novar++;
         }
+        else
+            var = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
+    }
+    else if(eptr->ex_type == ET_VAR)
+        var = (char *) eptr->ex_ptr;
+    else
+    {
+        post_error((fts_object_t *) expr, "expr: eval_tbl: bad type %ld\n",
+            eptr->ex_type);
+        novar++;
+    }
 
-        optr->ex_type = ET_INT;
-        optr->ex_int = 0;
-        if (!novar)
-                (void)max_ex_var(expr, (t_symbol *)var, optr, idx);
-        return (++eptr);
+    optr->ex_type = ET_INT;
+    optr->ex_int = 0;
+    if(!novar) (void) max_ex_var(expr, (t_symbol *) var, optr, idx);
+    return (++eptr);
 }
 
 /*
  * eval_sigidx -- evaluate the value of an indexed signal for fexpr~
  */
-struct ex_ex *
-eval_sigidx(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
+struct ex_ex *eval_sigidx(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 /* the expr object data pointer */
 /* the operation stack */
 /* the result pointer */
 /* the index */
 {
-        struct ex_ex arg = { 0 };
-        struct ex_ex *reteptr;
-        int i = 0;
-        t_float fi = 0,         /* index in float */
-              rem_i = 0;        /* remains of the float */
+    struct ex_ex arg = {0};
+    struct ex_ex *reteptr;
+    int i = 0;
+    t_float fi = 0, /* index in float */
+        rem_i = 0;  /* remains of the float */
 
-        arg.ex_type = 0;
-        arg.ex_int = 0;
-        reteptr = ex_eval(expr, eptr + 1, &arg, idx);
-        if (arg.ex_type == ET_FLT) {
-                fi = arg.ex_flt;                /* float index */
-                i = (int) arg.ex_flt;           /* integer index */
-                rem_i =  arg.ex_flt - i;        /* remains of integer */
-        } else if (arg.ex_type == ET_INT) {
-                fi = arg.ex_int;                /* float index */
-                i = (int) arg.ex_int;           /* integer index */
-                rem_i = 0;
-        } else {
-                post("eval_sigidx: bad res type (%d)", arg.ex_type);
+    arg.ex_type = 0;
+    arg.ex_int = 0;
+    reteptr = ex_eval(expr, eptr + 1, &arg, idx);
+    if(arg.ex_type == ET_FLT)
+    {
+        fi = arg.ex_flt;        /* float index */
+        i = (int) arg.ex_flt;   /* integer index */
+        rem_i = arg.ex_flt - i; /* remains of integer */
+    }
+    else if(arg.ex_type == ET_INT)
+    {
+        fi = arg.ex_int;      /* float index */
+        i = (int) arg.ex_int; /* integer index */
+        rem_i = 0;
+    }
+    else
+    {
+        post("eval_sigidx: bad res type (%d)", arg.ex_type);
+    }
+    optr->ex_type = ET_FLT;
+    /*
+     * indexing an input vector
+     */
+    if(eptr->ex_type == ET_XI)
+    {
+        if(fi > 0)
+        {
+            if(!(expr->exp_error & EE_BI_INPUT))
+            {
+                expr->exp_error |= EE_BI_INPUT;
+                post("expr: input vector index > 0, (vector x%d[%f])",
+                    eptr->ex_int + 1, i + rem_i);
+                post("fexpr~: index assumed to be = 0");
+                post("fexpr~: no error report till next reset");
+                ex_print(eptr);
+            }
+            /* just replace it with zero */
+            i = 0;
+            rem_i = 0;
         }
-        optr->ex_type = ET_FLT;
-        /*
-         * indexing an input vector
-         */
-        if (eptr->ex_type == ET_XI) {
-                if (fi > 0) {
-                        if (!(expr->exp_error & EE_BI_INPUT)) {
-                                expr->exp_error |= EE_BI_INPUT;
-                          post("expr: input vector index > 0, (vector x%d[%f])",
-                                               eptr->ex_int + 1, i + rem_i);
-                                post("fexpr~: index assumed to be = 0");
-                                post("fexpr~: no error report till next reset");
-                                ex_print(eptr);
-                        }
-                        /* just replace it with zero */
-                        i = 0;
-                        rem_i = 0;
-                }
-                if (cal_sigidx(optr, i, rem_i, idx, expr->exp_vsize,
-                                        expr->exp_var[eptr->ex_int].ex_vec,
-                                                expr->exp_p_var[eptr->ex_int])) {
-                        if (!(expr->exp_error & EE_BI_INPUT)) {
-                                expr->exp_error |= EE_BI_INPUT;
-                                post("expr: input vector index <  -VectorSize, (vector x%d[%f])", eptr->ex_int + 1, fi);
-                                ex_print(eptr);
-                                post("fexpr~: index assumed to be = -%d",
-                                        expr->exp_vsize);
-                                post("fexpr~: no error report till next reset");
-                        }
-                }
+        if(cal_sigidx(optr, i, rem_i, idx, expr->exp_vsize,
+               expr->exp_var[eptr->ex_int].ex_vec,
+               expr->exp_p_var[eptr->ex_int]))
+        {
+            if(!(expr->exp_error & EE_BI_INPUT))
+            {
+                expr->exp_error |= EE_BI_INPUT;
+                post(
+                    "expr: input vector index <  -VectorSize, (vector x%d[%f])",
+                    eptr->ex_int + 1, fi);
+                ex_print(eptr);
+                post("fexpr~: index assumed to be = -%d", expr->exp_vsize);
+                post("fexpr~: no error report till next reset");
+            }
+        }
 
         /*
          * indexing an output vector
          */
-        } else if (eptr->ex_type == ET_YO) {
-                /* for output vectors index of zero is not legal */
-                if (fi >= 0) {
-                        if (!(expr->exp_error & EE_BI_OUTPUT)) {
-                                expr->exp_error |= EE_BI_OUTPUT;
-                                post("fexpr~: bad output index, (%f)", fi);
-                                ex_print(eptr);
-                                post("fexpr~: no error report till next reset");
-                                post("fexpr~: index assumed to be = -1");
-                        }
-                        i = -1;
-                }
-                if (eptr->ex_int >= expr->exp_nexpr) {
-                        post("fexpr~: $y%d illegal: not that many exprs",
-                                                                eptr->ex_int);
-                        optr->ex_flt = 0;
-                        return (reteptr);
-                }
-                if (cal_sigidx(optr, i, rem_i, idx, expr->exp_vsize,
-                             expr->exp_tmpres[eptr->ex_int],
-                                                expr->exp_p_res[eptr->ex_int])) {
-                        if (!(expr->exp_error & EE_BI_OUTPUT)) {
-                                expr->exp_error |= EE_BI_OUTPUT;
-                                post("fexpr~: bad output index, (%f)", fi);
-                                ex_print(eptr);
-                                post("fexpr~: index assumed to be = -%d",
-                                        expr->exp_vsize);
-                        }
-                }
-        } else {
-                optr->ex_flt = 0;
-                post("fexpr~:eval_sigidx: internal error - unknown vector (%d)",
-                                                                eptr->ex_type);
+    }
+    else if(eptr->ex_type == ET_YO)
+    {
+        /* for output vectors index of zero is not legal */
+        if(fi >= 0)
+        {
+            if(!(expr->exp_error & EE_BI_OUTPUT))
+            {
+                expr->exp_error |= EE_BI_OUTPUT;
+                post("fexpr~: bad output index, (%f)", fi);
+                ex_print(eptr);
+                post("fexpr~: no error report till next reset");
+                post("fexpr~: index assumed to be = -1");
+            }
+            i = -1;
         }
-        return (reteptr);
+        if(eptr->ex_int >= expr->exp_nexpr)
+        {
+            post("fexpr~: $y%d illegal: not that many exprs", eptr->ex_int);
+            optr->ex_flt = 0;
+            return (reteptr);
+        }
+        if(cal_sigidx(optr, i, rem_i, idx, expr->exp_vsize,
+               expr->exp_tmpres[eptr->ex_int], expr->exp_p_res[eptr->ex_int]))
+        {
+            if(!(expr->exp_error & EE_BI_OUTPUT))
+            {
+                expr->exp_error |= EE_BI_OUTPUT;
+                post("fexpr~: bad output index, (%f)", fi);
+                ex_print(eptr);
+                post("fexpr~: index assumed to be = -%d", expr->exp_vsize);
+            }
+        }
+    }
+    else
+    {
+        optr->ex_flt = 0;
+        post("fexpr~:eval_sigidx: internal error - unknown vector (%d)",
+            eptr->ex_type);
+    }
+    return (reteptr);
 }
 
 /*
@@ -1622,348 +1765,372 @@ eval_sigidx(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
  *               interpolation
  *              return 0 on success, 1 on failure (index out of bound)
  */
-static int
-cal_sigidx(struct ex_ex *optr,  /* The output value */
-           int i, t_float rem_i,/* integer and fractinal part of index */
-           int idx,             /* index of current fexpr~ processing */
-           int vsize,           /* vector size */
-           t_float *curvec, t_float *prevec)        /* current and previous table */
+static int cal_sigidx(struct ex_ex *optr, /* The output value */
+    int i, t_float rem_i,             /* integer and fractinal part of index */
+    int idx,                          /* index of current fexpr~ processing */
+    int vsize,                        /* vector size */
+    t_float *curvec, t_float *prevec) /* current and previous table */
 {
-        int n;
+    int n;
 
-        n = i + idx;
-        if (n > 0) {
-                /* from the curvec */
-                if (rem_i)
-                        optr->ex_flt = curvec[n] +
-                                        rem_i * (curvec[n] - curvec[n - 1]);
-                else
-                        optr->ex_flt = curvec[n];
-                return (0);
-        }
-        if (n == 0) {
-                /*
-                 * this is the case that the remaining float
-                 * is between two tables
-                 */
-                if (rem_i)
-                        optr->ex_flt = *curvec +
-                                        rem_i * (*curvec - prevec[vsize - 1]);
-                else
-                        optr->ex_flt = *curvec;
-                return (0);
-        }
-        /* find the index in the saved buffer */
-        n = vsize + n;
-        if (n > 0) {
-                if (rem_i)
-                        optr->ex_flt = prevec[n] +
-                                        rem_i * (prevec[n] - prevec[n - 1]);
-                else
-                        optr->ex_flt = prevec[n];
-                return (0);
-        }
-        /* out of bound */
-        optr->ex_flt = *prevec;
-        return (1);
+    n = i + idx;
+    if(n > 0)
+    {
+        /* from the curvec */
+        if(rem_i)
+            optr->ex_flt = curvec[n] + rem_i * (curvec[n] - curvec[n - 1]);
+        else
+            optr->ex_flt = curvec[n];
+        return (0);
+    }
+    if(n == 0)
+    {
+        /*
+         * this is the case that the remaining float
+         * is between two tables
+         */
+        if(rem_i)
+            optr->ex_flt = *curvec + rem_i * (*curvec - prevec[vsize - 1]);
+        else
+            optr->ex_flt = *curvec;
+        return (0);
+    }
+    /* find the index in the saved buffer */
+    n = vsize + n;
+    if(n > 0)
+    {
+        if(rem_i)
+            optr->ex_flt = prevec[n] + rem_i * (prevec[n] - prevec[n - 1]);
+        else
+            optr->ex_flt = prevec[n];
+        return (0);
+    }
+    /* out of bound */
+    optr->ex_flt = *prevec;
+    return (1);
 }
 
 /*
  * getoken -- return 1 on syntax error otherwise 0
  */
-int
-getoken(struct expr *expr, struct ex_ex *eptr)
+int getoken(struct expr *expr, struct ex_ex *eptr)
 {
-        char *p;
-        long i;
+    char *p;
+    long i;
 
-
-        if (!expr->exp_str) {
-                post("expr: getoken: expression string not set\n");
-                return (0);
-        }
+    if(!expr->exp_str)
+    {
+        post("expr: getoken: expression string not set\n");
+        return (0);
+    }
 retry:
-        if (!*expr->exp_str) {
-                eptr->ex_type = 0;
-                eptr->ex_int = 0;
-                return (0);
-        }
-        if (*expr->exp_str == ';') {
-                expr->exp_str++;
-                eptr->ex_type = 0;
-                eptr->ex_int = 0;
-                return (0);
-        }
-        eptr->ex_type = ET_OP;
-        switch (*expr->exp_str++) {
+    if(!*expr->exp_str)
+    {
+        eptr->ex_type = 0;
+        eptr->ex_int = 0;
+        return (0);
+    }
+    if(*expr->exp_str == ';')
+    {
+        expr->exp_str++;
+        eptr->ex_type = 0;
+        eptr->ex_int = 0;
+        return (0);
+    }
+    eptr->ex_type = ET_OP;
+    switch(*expr->exp_str++)
+    {
         case '\\':
         case ' ':
         case '\t':
-                goto retry;
+            goto retry;
         case ';':
-                post("expr: syntax error: ';' not implemented\n");
-                return (1);
+            post("expr: syntax error: ';' not implemented\n");
+            return (1);
         case ',':
-                eptr->ex_op = OP_COMMA;
-                break;
+            eptr->ex_op = OP_COMMA;
+            break;
         case '(':
-                eptr->ex_op = OP_LP;
-                break;
+            eptr->ex_op = OP_LP;
+            break;
         case ')':
-                eptr->ex_op = OP_RP;
-                break;
+            eptr->ex_op = OP_RP;
+            break;
         case ']':
-                eptr->ex_op = OP_RB;
-                break;
+            eptr->ex_op = OP_RB;
+            break;
         case '~':
-                eptr->ex_op = OP_NEG;
-                break;
-                /* we will take care of unary minus later */
+            eptr->ex_op = OP_NEG;
+            break;
+            /* we will take care of unary minus later */
         case '*':
-                eptr->ex_op = OP_MUL;
-                break;
+            eptr->ex_op = OP_MUL;
+            break;
         case '/':
-                eptr->ex_op = OP_DIV;
-                break;
+            eptr->ex_op = OP_DIV;
+            break;
         case '%':
-                eptr->ex_op = OP_MOD;
-                break;
+            eptr->ex_op = OP_MOD;
+            break;
         case '+':
-                eptr->ex_op = OP_ADD;
-                break;
+            eptr->ex_op = OP_ADD;
+            break;
         case '-':
-                eptr->ex_op = OP_SUB;
-                break;
+            eptr->ex_op = OP_SUB;
+            break;
         case '^':
-                eptr->ex_op = OP_XOR;
-                break;
+            eptr->ex_op = OP_XOR;
+            break;
         case '[':
-                eptr->ex_op = OP_LB;
-                break;
+            eptr->ex_op = OP_LB;
+            break;
         case '!':
-                if (*expr->exp_str == '=') {
-                        eptr->ex_op = OP_NE;
-                        expr->exp_str++;
-                } else
-                        eptr->ex_op = OP_NOT;
-                break;
+            if(*expr->exp_str == '=')
+            {
+                eptr->ex_op = OP_NE;
+                expr->exp_str++;
+            }
+            else
+                eptr->ex_op = OP_NOT;
+            break;
         case '<':
-                switch (*expr->exp_str) {
+            switch(*expr->exp_str)
+            {
                 case '<':
-                        eptr->ex_op = OP_SL;
-                        expr->exp_str++;
-                        break;
+                    eptr->ex_op = OP_SL;
+                    expr->exp_str++;
+                    break;
                 case '=':
-                        eptr->ex_op = OP_LE;
-                        expr->exp_str++;
-                        break;
+                    eptr->ex_op = OP_LE;
+                    expr->exp_str++;
+                    break;
                 default:
-                        eptr->ex_op = OP_LT;
-                        break;
-                }
-                break;
+                    eptr->ex_op = OP_LT;
+                    break;
+            }
+            break;
         case '>':
-                switch (*expr->exp_str) {
+            switch(*expr->exp_str)
+            {
                 case '>':
-                        eptr->ex_op = OP_SR;
-                        expr->exp_str++;
-                        break;
+                    eptr->ex_op = OP_SR;
+                    expr->exp_str++;
+                    break;
                 case '=':
-                        eptr->ex_op = OP_GE;
-                        expr->exp_str++;
-                        break;
+                    eptr->ex_op = OP_GE;
+                    expr->exp_str++;
+                    break;
                 default:
-                        eptr->ex_op = OP_GT;
-                        break;
-                }
-                break;
+                    eptr->ex_op = OP_GT;
+                    break;
+            }
+            break;
         case '=':
-                if (*expr->exp_str != '=')
-                        eptr->ex_op = OP_STORE;
-                else {
-                        expr->exp_str++;
-                        eptr->ex_op = OP_EQ;
-                }
-                break;
+            if(*expr->exp_str != '=')
+                eptr->ex_op = OP_STORE;
+            else
+            {
+                expr->exp_str++;
+                eptr->ex_op = OP_EQ;
+            }
+            break;
 
         case '&':
-                if (*expr->exp_str == '&') {
-                        expr->exp_str++;
-                        eptr->ex_op = OP_LAND;
-                } else
-                        eptr->ex_op = OP_AND;
-                break;
+            if(*expr->exp_str == '&')
+            {
+                expr->exp_str++;
+                eptr->ex_op = OP_LAND;
+            }
+            else
+                eptr->ex_op = OP_AND;
+            break;
 
         case '|':
-                if (*expr->exp_str == '|') {
-                        expr->exp_str++;
-                        eptr->ex_op = OP_LOR;
-                } else
-                        eptr->ex_op = OP_OR;
-                break;
+            if(*expr->exp_str == '|')
+            {
+                expr->exp_str++;
+                eptr->ex_op = OP_LOR;
+            }
+            else
+                eptr->ex_op = OP_OR;
+            break;
         case '$':
-                switch (*expr->exp_str++) {
+            switch(*expr->exp_str++)
+            {
                 case 'I':
                 case 'i':
-                        eptr->ex_type = ET_II;
-                        break;
+                    eptr->ex_type = ET_II;
+                    break;
                 case 'F':
                 case 'f':
-                        eptr->ex_type = ET_FI;
-                        break;
+                    eptr->ex_type = ET_FI;
+                    break;
                 case 'S':
                 case 's':
-                        eptr->ex_type = ET_SI;
-                        break;
+                    eptr->ex_type = ET_SI;
+                    break;
                 case 'V':
                 case 'v':
-                        if (IS_EXPR_TILDE(expr)) {
-                                eptr->ex_type = ET_VI;
-                                break;
-                        }
-                        post("$v? works only for expr~");
-                        post("expr: syntax error: %s\n", &expr->exp_str[-2]);
-                        return (1);
+                    if(IS_EXPR_TILDE(expr))
+                    {
+                        eptr->ex_type = ET_VI;
+                        break;
+                    }
+                    post("$v? works only for expr~");
+                    post("expr: syntax error: %s\n", &expr->exp_str[-2]);
+                    return (1);
                 case 'X':
                 case 'x':
-                        if (IS_FEXPR_TILDE(expr)) {
-                                eptr->ex_type = ET_XI;
-                                if (isdigit((int)(*expr->exp_str)))
-                                        break;
-                                /* for $x[] is a shorhand for $x1[] */
-                                /* eptr->ex_int = 0; */
-                                                                eptr->ex_op = 0;
-                                                                expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
-                                goto noinletnum;
-                        }
-                        post("$x? works only for fexpr~");
-                        post("expr: syntax error: %s\n", &expr->exp_str[-2]);
-                        return (1);
+                    if(IS_FEXPR_TILDE(expr))
+                    {
+                        eptr->ex_type = ET_XI;
+                        if(isdigit((int) (*expr->exp_str))) break;
+                        /* for $x[] is a shorhand for $x1[] */
+                        /* eptr->ex_int = 0; */
+                        eptr->ex_op = 0;
+                        expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
+                        goto noinletnum;
+                    }
+                    post("$x? works only for fexpr~");
+                    post("expr: syntax error: %s\n", &expr->exp_str[-2]);
+                    return (1);
                 case 'y':
                 case 'Y':
-                        if (IS_FEXPR_TILDE(expr)) {
-                                eptr->ex_type = ET_YO;
-                                /*$y takes no number */
-                                if (isdigit((int)(*expr->exp_str)))
-                                        break;
-                                /* for $y[] is a shorhand for $y1[] */
-                                /* eptr->ex_int = 0; */
-                                                                eptr->ex_op = 0;
-                                                                expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
-                                goto noinletnum;
-                        }
-                        post("$y works only for fexpr~");
-                                /* falls through */
-                                /*
-                                 * allow $# for abstraction argument substitution
-                                 *  $1+1 is translated to 0+1 and in abstraction substitution
-                                 *  the value is replaced with the new string
-                                 */
-                                case '0':
-                                case '1':
-                                case '2':
-                                case '3':
-                                case '4':
-                                case '5':
-                                case '6':
-                                case '7':
-                                case '8':
-                                case '9':
-                                        p = atoif(--expr->exp_str, &eptr->ex_op, &i);
-                        if (!p)
-                        return (1);
-                                        if (i != ET_INT) {
-                                                post("expr: syntax error: %s\n", expr->exp_str);
-                                                return (1);
-                                        }
-                        expr->exp_str = p;
-                                        eptr->ex_type = ET_INT;
-                                        eptr->ex_int = 0;
-                        return (0);
-                default:
-                        post("expr: syntax error: %s\n", &expr->exp_str[-2]);
-                        return (1);
-                }
-                p = atoif(expr->exp_str, &eptr->ex_op, &i);
-                if (!p) {
-                        post("expr: syntax error: %s\n", &expr->exp_str[-2]);
-                        return (1);
-                }
-                if (i != ET_INT) {
+                    if(IS_FEXPR_TILDE(expr))
+                    {
+                        eptr->ex_type = ET_YO;
+                        /*$y takes no number */
+                        if(isdigit((int) (*expr->exp_str))) break;
+                        /* for $y[] is a shorhand for $y1[] */
+                        /* eptr->ex_int = 0; */
+                        eptr->ex_op = 0;
+                        expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
+                        goto noinletnum;
+                    }
+                    post("$y works only for fexpr~");
+                /* falls through */
+                /*
+                 * allow $# for abstraction argument substitution
+                 *  $1+1 is translated to 0+1 and in abstraction substitution
+                 *  the value is replaced with the new string
+                 */
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    p = atoif(--expr->exp_str, &eptr->ex_op, &i);
+                    if(!p) return (1);
+                    if(i != ET_INT)
+                    {
                         post("expr: syntax error: %s\n", expr->exp_str);
                         return (1);
-                }
-                /*
-                 * make the user inlets one based rather than zero based
-                 * therefore we decrement the number that user has supplied
-                 */
-                if (!eptr->ex_op || (eptr->ex_op)-- > MAX_VARS) {
-                 post("expr: syntax error: inlet or outlet out of range: %s\n",
-                                                             expr->exp_str);
-                        return (1);
-                }
+                    }
+                    expr->exp_str = p;
+                    eptr->ex_type = ET_INT;
+                    eptr->ex_int = 0;
+                    return (0);
+                default:
+                    post("expr: syntax error: %s\n", &expr->exp_str[-2]);
+                    return (1);
+            }
+            p = atoif(expr->exp_str, &eptr->ex_op, &i);
+            if(!p)
+            {
+                post("expr: syntax error: %s\n", &expr->exp_str[-2]);
+                return (1);
+            }
+            if(i != ET_INT)
+            {
+                post("expr: syntax error: %s\n", expr->exp_str);
+                return (1);
+            }
+            /*
+             * make the user inlets one based rather than zero based
+             * therefore we decrement the number that user has supplied
+             */
+            if(!eptr->ex_op || (eptr->ex_op)-- > MAX_VARS)
+            {
+                post("expr: syntax error: inlet or outlet out of range: %s\n",
+                    expr->exp_str);
+                return (1);
+            }
 
-                /*
-                 * until we can change the input type of inlets on
-                 * the fly (at pd_new()
-                 * time) the first input to expr~ is always a vector
-                 * and $f1 or $i1 is
-                 * illegal for fexpr~
-                 */
-                if (eptr->ex_op == 0 &&
-                   (IS_FEXPR_TILDE(expr) ||  IS_EXPR_TILDE(expr)) &&
-                   (eptr->ex_type==ET_II || eptr->ex_type==ET_FI ||
-                                                        eptr->ex_type==ET_SI)) {
-                       post("first inlet of expr~/fexpr~ can only be a vector");
-                       return (1);
-                }
-                /* record the inlet or outlet type and check for consistency */
-                if (eptr->ex_type == ET_YO ) {
-                        /* it is an outlet  for fexpr~*/
-                        /* no need to do anything */
-                        ;
-                } else if (!expr->exp_var[eptr->ex_op].ex_type)
-                        expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
-                else if (expr->exp_var[eptr->ex_op].ex_type != eptr->ex_type) {
-                        post("expr: syntax error: inlets can only have one type: %s\n", expr->exp_str);
-                        return (1);
-                }
-                expr->exp_str = p;
-noinletnum:
-                break;
+            /*
+             * until we can change the input type of inlets on
+             * the fly (at pd_new()
+             * time) the first input to expr~ is always a vector
+             * and $f1 or $i1 is
+             * illegal for fexpr~
+             */
+            if(eptr->ex_op == 0 &&
+                (IS_FEXPR_TILDE(expr) || IS_EXPR_TILDE(expr)) &&
+                (eptr->ex_type == ET_II || eptr->ex_type == ET_FI ||
+                    eptr->ex_type == ET_SI))
+            {
+                post("first inlet of expr~/fexpr~ can only be a vector");
+                return (1);
+            }
+            /* record the inlet or outlet type and check for consistency */
+            if(eptr->ex_type == ET_YO)
+            {
+                /* it is an outlet  for fexpr~*/
+                /* no need to do anything */
+                ;
+            }
+            else if(!expr->exp_var[eptr->ex_op].ex_type)
+                expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
+            else if(expr->exp_var[eptr->ex_op].ex_type != eptr->ex_type)
+            {
+                post("expr: syntax error: inlets can only have one type: %s\n",
+                    expr->exp_str);
+                return (1);
+            }
+            expr->exp_str = p;
+        noinletnum:
+            break;
         case '"':
-                {
-                        struct ex_ex ex = { 0 };
+        {
+            struct ex_ex ex = {0};
 
-                        p = expr->exp_str;
-                        if (!*expr->exp_str || *expr->exp_str == '"') {
-                                post("expr: syntax error: empty symbol: %s\n", --expr->exp_str);
-                                return (1);
-                        }
-                        if (getoken(expr, &ex))
-                                return (1);
-                        switch (ex.ex_type) {
-                        case ET_STR:
-                                if (ex_getsym(ex.ex_ptr, (t_symbol **)&(eptr->ex_ptr))) {
-                                        post("expr: syntax error: getoken: problms with ex_getsym\n");
-                                        return (1);
-                                }
-                                eptr->ex_type = ET_SYM;
-                                break;
-                        case ET_SI:
-                                *eptr = ex;
-                                eptr->ex_type = ET_VSYM;
-                                break;
-                        default:
-                                post("expr: syntax error: bad symbol name: %s\n", p);
-                                return (1);
-                        }
-                        if (*expr->exp_str++ != '"') {
-                                post("expr: syntax error: missing '\"'\n");
-                                return (1);
-                        }
-                        break;
-                }
+            p = expr->exp_str;
+            if(!*expr->exp_str || *expr->exp_str == '"')
+            {
+                post("expr: syntax error: empty symbol: %s\n", --expr->exp_str);
+                return (1);
+            }
+            if(getoken(expr, &ex)) return (1);
+            switch(ex.ex_type)
+            {
+                case ET_STR:
+                    if(ex_getsym(ex.ex_ptr, (t_symbol **) &(eptr->ex_ptr)))
+                    {
+                        post("expr: syntax error: getoken: problms with "
+                             "ex_getsym\n");
+                        return (1);
+                    }
+                    eptr->ex_type = ET_SYM;
+                    break;
+                case ET_SI:
+                    *eptr = ex;
+                    eptr->ex_type = ET_VSYM;
+                    break;
+                default:
+                    post("expr: syntax error: bad symbol name: %s\n", p);
+                    return (1);
+            }
+            if(*expr->exp_str++ != '"')
+            {
+                post("expr: syntax error: missing '\"'\n");
+                return (1);
+            }
+            break;
+        }
         case '.':
         case '0':
         case '1':
@@ -1975,267 +2142,267 @@ noinletnum:
         case '7':
         case '8':
         case '9':
-                p = atoif(--expr->exp_str, &eptr->ex_int, &eptr->ex_type);
-                if (!p)
-                        return (1);
-                expr->exp_str = p;
-                break;
+            p = atoif(--expr->exp_str, &eptr->ex_int, &eptr->ex_type);
+            if(!p) return (1);
+            expr->exp_str = p;
+            break;
 
         default:
-                /*
-                 * has to be a string, it should either be a
-                 * function or a table
-                 */
-                p = --expr->exp_str;
-                for (i = 0; name_ok(*p); i++)
-                        p++;
-                if (!i) {
-                        post("expr: syntax error: %s\n", expr->exp_str);
-                        return (1);
-                }
-                eptr->ex_ptr = (char *)fts_malloc(i + 1);
-                strncpy(eptr->ex_ptr, expr->exp_str, (int) i);
-                (eptr->ex_ptr)[i] = 0;
-                expr->exp_str = p;
-                /*
-                 * we mark this as a string and later we will change this
-                 * to either a function or a table
-                 */
-                eptr->ex_type = ET_STR;
-                break;
-        }
-        return (0);
+            /*
+             * has to be a string, it should either be a
+             * function or a table
+             */
+            p = --expr->exp_str;
+            for(i = 0; name_ok(*p); i++)
+                p++;
+            if(!i)
+            {
+                post("expr: syntax error: %s\n", expr->exp_str);
+                return (1);
+            }
+            eptr->ex_ptr = (char *) fts_malloc(i + 1);
+            strncpy(eptr->ex_ptr, expr->exp_str, (int) i);
+            (eptr->ex_ptr)[i] = 0;
+            expr->exp_str = p;
+            /*
+             * we mark this as a string and later we will change this
+             * to either a function or a table
+             */
+            eptr->ex_type = ET_STR;
+            break;
+    }
+    return (0);
 }
 
 /*
- * atoif -- ascii to float or integer (strtof() understand exponential notations  ad strtod() understand hex numbers)
+ * atoif -- ascii to float or integer (strtof() understand exponential notations
+ * ad strtod() understand hex numbers)
  */
-char *
-atoif(char *s, long int *value, long int *type)
+char *atoif(char *s, long int *value, long int *type)
 {
-    const char*s0 = s;
+    const char *s0 = s;
     char *p;
-        long lval;
-        float fval;
+    long lval;
+    float fval;
 
-        lval = strtod(s, &p);
-        fval = strtof(s, &p);
-        if (lval != (int) fval) {
-                *type = ET_FLT;
-                *((t_float *) value) = fval;
-                return (p);
-        }
-        while (s != p) {
-                if (*s == 'x' || *s == 'X')
-                                break;
-                if (*s == '.' || *s == 'e' || *s == 'E') {
-                        *type = ET_FLT;
-                        *((t_float *) value) = fval;
-                        return (p);
-                }
-                s++;
-        }
-        if(s0 == p)
-            return 0;
-
-        *type = ET_INT;
-        *((t_int *) value) = lval;
+    lval = strtod(s, &p);
+    fval = strtof(s, &p);
+    if(lval != (int) fval)
+    {
+        *type = ET_FLT;
+        *((t_float *) value) = fval;
         return (p);
+    }
+    while(s != p)
+    {
+        if(*s == 'x' || *s == 'X') break;
+        if(*s == '.' || *s == 'e' || *s == 'E')
+        {
+            *type = ET_FLT;
+            *((t_float *) value) = fval;
+            return (p);
+        }
+        s++;
+    }
+    if(s0 == p) return 0;
+
+    *type = ET_INT;
+    *((t_int *) value) = lval;
+    return (p);
 }
 
 /*
  * find_func -- returns a pointer to the found function structure
  *              otherwise it returns 0
  */
-t_ex_func *
-find_func(char *s)
+t_ex_func *find_func(char *s)
 {
-        t_ex_func *f;
+    t_ex_func *f;
 
-        for (f = ex_funcs; f->f_name; f++)
-                if (!strcmp(f->f_name, s))
-                        return (f);
-        return ((t_ex_func *) 0);
+    for(f = ex_funcs; f->f_name; f++)
+        if(!strcmp(f->f_name, s)) return (f);
+    return ((t_ex_func *) 0);
 }
-
 
 /*
  * ex_print -- print an expression array
  */
 
-void
-ex_print(struct ex_ex *eptr)
+void ex_print(struct ex_ex *eptr)
 {
-                struct ex_ex *extmp;
+    struct ex_ex *extmp;
 
-                extmp = eptr->ex_end;
-        while (eptr->ex_type && eptr != extmp) {
-                switch (eptr->ex_type) {
-                case ET_INT:
-                        post("%ld ", eptr->ex_int);
-                        break;
-                case ET_FLT:
-                        post("%f ", eptr->ex_flt);
-                        break;
-                case ET_STR:
-                        post("%s ", eptr->ex_ptr);
-                        break;
-                case ET_TBL:
-                        if (!eptr->ex_ptr) { /* special case of $# processing */
-                                post("%s ", "$$");
-                            break;
-                        }
-                            /* falls through */
-                case ET_VAR:
-                        post("%s ", ex_symname((fts_symbol_t )eptr->ex_ptr));
-                        break;
-                case ET_SYM:
-                        post("\"%s\" ", ex_symname((fts_symbol_t )eptr->ex_ptr));
-                        break;
-                case ET_VSYM:
-                        post("\"$s%ld\" ", eptr->ex_int + 1);
-                        break;
-                case ET_FUNC:
-                        post("%s ",
-                            ((t_ex_func *)eptr->ex_ptr)->f_name);
-                        break;
-                case ET_LP:
+    extmp = eptr->ex_end;
+    while(eptr->ex_type && eptr != extmp)
+    {
+        switch(eptr->ex_type)
+        {
+            case ET_INT:
+                post("%ld ", eptr->ex_int);
+                break;
+            case ET_FLT:
+                post("%f ", eptr->ex_flt);
+                break;
+            case ET_STR:
+                post("%s ", eptr->ex_ptr);
+                break;
+            case ET_TBL:
+                if(!eptr->ex_ptr)
+                { /* special case of $# processing */
+                    post("%s ", "$$");
+                    break;
+                }
+                /* falls through */
+            case ET_VAR:
+                post("%s ", ex_symname((fts_symbol_t) eptr->ex_ptr));
+                break;
+            case ET_SYM:
+                post("\"%s\" ", ex_symname((fts_symbol_t) eptr->ex_ptr));
+                break;
+            case ET_VSYM:
+                post("\"$s%ld\" ", eptr->ex_int + 1);
+                break;
+            case ET_FUNC:
+                post("%s ", ((t_ex_func *) eptr->ex_ptr)->f_name);
+                break;
+            case ET_LP:
+                post("%c", '(');
+                break;
+                /* CHANGE
+         case ET_RP:
+                 post("%c ", ')');
+                 break;
+                 */
+            case ET_LB:
+                post("%c", '[');
+                break;
+                /* CHANGE
+        case ET_RB:
+                 post("%c ", ']');
+                 break;
+                 */
+            case ET_II:
+                post("$i%ld ", eptr->ex_int + 1);
+                break;
+            case ET_FI:
+                post("$f%ld ", eptr->ex_int + 1);
+                break;
+            case ET_SI:
+                post("$s%lx ", eptr->ex_ptr);
+                break;
+            case ET_VI:
+                post("$v%lx ", eptr->ex_vec);
+                break;
+            case ET_VEC:
+                post("vec = %ld ", eptr->ex_vec);
+                break;
+            case ET_YOM1:
+            case ET_YO:
+                post("$y%d", eptr->ex_int + 1);
+                break;
+            case ET_XI:
+            case ET_XI0:
+                post("$x%d", eptr->ex_int + 1);
+                break;
+            case ET_OP:
+                switch(eptr->ex_op)
+                {
+                    case OP_LP:
                         post("%c", '(');
                         break;
-                        /* CHANGE
-                 case ET_RP:
-                         post("%c ", ')');
-                         break;
-                         */
-                case ET_LB:
+                    case OP_RP:
+                        post("%c ", ')');
+                        break;
+                    case OP_LB:
                         post("%c", '[');
                         break;
-                        /* CHANGE
-                case ET_RB:
-                         post("%c ", ']');
-                         break;
-                         */
-                case ET_II:
-                        post("$i%ld ", eptr->ex_int + 1);
+                    case OP_RB:
+                        post("%c ", ']');
                         break;
-                case ET_FI:
-                        post("$f%ld ", eptr->ex_int + 1);
+                    case OP_NOT:
+                        post("%c", '!');
                         break;
-                case ET_SI:
-                        post("$s%lx ", eptr->ex_ptr);
+                    case OP_NEG:
+                        post("%c", '~');
                         break;
-                case ET_VI:
-                        post("$v%lx ", eptr->ex_vec);
+                    case OP_UMINUS:
+                        post("%c", '-');
                         break;
-                case ET_VEC:
-                        post("vec = %ld ", eptr->ex_vec);
+                    case OP_MUL:
+                        post("%c", '*');
                         break;
-                case ET_YOM1:
-                case ET_YO:
-                        post("$y%d", eptr->ex_int + 1);
+                    case OP_DIV:
+                        post("%c", '/');
                         break;
-                case ET_XI:
-                case ET_XI0:
-                        post("$x%d", eptr->ex_int + 1);
+                    case OP_MOD:
+                        post("%c", '%');
                         break;
-                case ET_OP:
-                        switch (eptr->ex_op) {
-                        case OP_LP:
-                                post("%c", '(');
-                                break;
-                        case OP_RP:
-                                post("%c ", ')');
-                                break;
-                        case OP_LB:
-                                post("%c", '[');
-                                break;
-                        case OP_RB:
-                                post("%c ", ']');
-                                break;
-                        case OP_NOT:
-                                post("%c", '!');
-                                break;
-                        case OP_NEG:
-                                post("%c", '~');
-                                break;
-                        case OP_UMINUS:
-                                post("%c", '-');
-                                break;
-                        case OP_MUL:
-                                post("%c", '*');
-                                break;
-                        case OP_DIV:
-                                post("%c", '/');
-                                break;
-                        case OP_MOD:
-                                post("%c", '%');
-                                break;
-                        case OP_ADD:
-                                post("%c", '+');
-                                break;
-                        case OP_SUB:
-                                post("%c", '-');
-                                break;
-                        case OP_SL:
-                                post("%s", "<<");
-                                break;
-                        case OP_SR:
-                                post("%s", ">>");
-                                break;
-                        case OP_LT:
-                                post("%c", '<');
-                                break;
-                        case OP_LE:
-                                post("%s", "<=");
-                                break;
-                        case OP_GT:
-                                post("%c", '>');
-                                break;
-                        case OP_GE:
-                                post("%s", ">=");
-                                break;
-                        case OP_EQ:
-                                post("%s", "==");
-                                break;
-                        case OP_STORE:
-                                post("%s", "=");
-                                break;
-                        case OP_NE:
-                                post("%s", "!=");
-                                break;
-                        case OP_AND:
-                                post("%c", '&');
-                                break;
-                        case OP_XOR:
-                                post("%c", '^');
-                                break;
-                        case OP_OR:
-                                post("%c", '|');
-                                break;
-                        case OP_LAND:
-                                post("%s", "&&");
-                                break;
-                        case OP_LOR:
-                                post("%s", "||");
-                                break;
-                        case OP_COMMA:
-                                post("%c", ',');
-                                break;
-                        case OP_SEMI:
-                                post("%c", ';');
-                                break;
-                        default:
-                                post("expr: ex_print: bad op 0x%lx\n", eptr->ex_op);
-                        }
+                    case OP_ADD:
+                        post("%c", '+');
                         break;
-                default:
-                        post("expr: ex_print: bad type 0x%lx\n", eptr->ex_type);
+                    case OP_SUB:
+                        post("%c", '-');
+                        break;
+                    case OP_SL:
+                        post("%s", "<<");
+                        break;
+                    case OP_SR:
+                        post("%s", ">>");
+                        break;
+                    case OP_LT:
+                        post("%c", '<');
+                        break;
+                    case OP_LE:
+                        post("%s", "<=");
+                        break;
+                    case OP_GT:
+                        post("%c", '>');
+                        break;
+                    case OP_GE:
+                        post("%s", ">=");
+                        break;
+                    case OP_EQ:
+                        post("%s", "==");
+                        break;
+                    case OP_STORE:
+                        post("%s", "=");
+                        break;
+                    case OP_NE:
+                        post("%s", "!=");
+                        break;
+                    case OP_AND:
+                        post("%c", '&');
+                        break;
+                    case OP_XOR:
+                        post("%c", '^');
+                        break;
+                    case OP_OR:
+                        post("%c", '|');
+                        break;
+                    case OP_LAND:
+                        post("%s", "&&");
+                        break;
+                    case OP_LOR:
+                        post("%s", "||");
+                        break;
+                    case OP_COMMA:
+                        post("%c", ',');
+                        break;
+                    case OP_SEMI:
+                        post("%c", ';');
+                        break;
+                    default:
+                        post("expr: ex_print: bad op 0x%lx\n", eptr->ex_op);
                 }
-                eptr++;
+                break;
+            default:
+                post("expr: ex_print: bad type 0x%lx\n", eptr->ex_type);
         }
-        post("\n");
+        eptr++;
+    }
+    post("\n");
 }
 
 #ifdef _WIN32
-void ABORT(void) {bug("expr");}
+void ABORT(void) { bug("expr"); }
 #endif

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -144,20 +144,32 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
         case A_FLOAT:
             sprintf(tbuf, "%g", a->a_w.w_float);
             if(strlen(tbuf) < bufsize - 1)
+            {
                 strcpy(buf, tbuf);
+            }
             else if(a->a_w.w_float < 0)
+            {
                 strcpy(buf, "-");
+            }
             else
+            {
                 strcat(buf, "+");
+            }
             break;
         case A_LONG:
             sprintf(tbuf, "%d", a->a_w.w_long);
             if(strlen(tbuf) < bufsize - 1)
+            {
                 strcpy(buf, tbuf);
+            }
             else if(a->a_w.w_float < 0)
+            {
                 strcpy(buf, "-");
+            }
             else
+            {
                 strcat(buf, "+");
+            }
             break;
         case A_SYMBOL:
         {
@@ -166,10 +178,12 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
             int quote;
             for(sp = a->a_w.w_symbol->s_name, len = 0, quote = 0; *sp;
                 sp++, len++)
+            {
                 if(*sp == ';' || *sp == ',' || *sp == '\\' ||
                     (*sp == '$' && sp == a->a_w.w_symbol->s_name &&
                         sp[1] >= '0' && sp[1] <= '9'))
                     quote = 1;
+            }
             if(quote)
             {
                 char *bp = buf;
@@ -190,7 +204,9 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
             else
             {
                 if(len < bufsize - 1)
+                {
                     strcpy(buf, a->a_w.w_symbol->s_name);
+                }
                 else
                 {
                     strncpy(buf, a->a_w.w_symbol->s_name, bufsize - 2);
@@ -259,9 +275,13 @@ int expr_donew(struct expr *expr, int ac, t_atom *av)
             strcpy(buf + length, string);
             length = newlength;
             if(ap->a_type == A_SEMI)
+            {
                 buf[length - 1] = '\n';
+            }
             else
+            {
                 buf[length - 1] = ' ';
+            }
         }
 
         if(length && buf[length - 1] == ' ')
@@ -596,6 +616,7 @@ struct ex_ex *ex_parse(
      * that is a special operator and is only legal in functions
      */
     for(eptr = iptr, count = 0; eptr->ex_type; eptr++, count++)
+    {
         switch(eptr->ex_type)
         {
             case ET_SYM:
@@ -732,6 +753,7 @@ struct ex_ex *ex_parse(
                 post("expr: ex_parse: type = 0x%lx\n", eptr->ex_type);
                 return (exNULL);
         }
+    }
 
     if(pre == HI_PRE)
     {
@@ -1092,11 +1114,17 @@ void ex_dzdetect(struct expr *expr)
     if((!expr->exp_error) & EE_DZ)
     {
         if(IS_EXPR(expr))
+        {
             etype = "expr";
+        }
         else if(IS_EXPR_TILDE(expr))
+        {
             etype = "expr~";
+        }
         else if(IS_FEXPR_TILDE(expr))
+        {
             etype = "fexpr~";
+        }
         else
         {
             post("expr -- ex_dzdetect internal error");
@@ -1147,18 +1175,26 @@ struct ex_ex *ex_eval(
     {
         case ET_INT:
             if(optr->ex_type == ET_VEC)
+            {
                 ex_mkvector(
                     optr->ex_vec, (t_float) eptr->ex_int, expr->exp_vsize);
+            }
             else
+            {
                 *optr = *eptr;
+            }
             return (++eptr);
 
         case ET_FLT:
 
             if(optr->ex_type == ET_VEC)
+            {
                 ex_mkvector(optr->ex_vec, eptr->ex_flt, expr->exp_vsize);
+            }
             else
+            {
                 *optr = *eptr;
+            }
             return (++eptr);
 
         case ET_SYM:
@@ -1227,10 +1263,14 @@ struct ex_ex *ex_eval(
 
         case ET_VI:
             if(optr->ex_type != ET_VEC)
+            {
                 *optr = expr->exp_var[eptr->ex_int];
+            }
             else if(optr->ex_vec != expr->exp_var[eptr->ex_int].ex_vec)
+            {
                 memcpy(optr->ex_vec, expr->exp_var[eptr->ex_int].ex_vec,
                     expr->exp_vsize * sizeof(t_float));
+            }
             return (++eptr);
         case ET_VEC:
             if(optr->ex_type != ET_VEC)
@@ -1272,10 +1312,14 @@ struct ex_ex *ex_eval(
              */
             optr->ex_type = ET_FLT;
             if(idx == 0)
+            {
                 optr->ex_flt =
                     expr->exp_p_res[eptr->ex_int][expr->exp_vsize - 1];
+            }
             else
+            {
                 optr->ex_flt = expr->exp_tmpres[eptr->ex_int][idx - 1];
+            }
             return (++eptr);
 
         case ET_YO:
@@ -1492,9 +1536,13 @@ struct ex_ex *eval_store(
             var = (char *) eptr->ex_ptr;
             eptr = ex_eval(expr, ++eptr, &arg, idx);
             if(max_ex_var_store(expr, (t_symbol *) var, &arg, optr))
+            {
                 retp = exNULL;
+            }
             else
+            {
                 retp = eptr;
+            }
 
             if(arg.ex_type == ET_VEC) fts_free(arg.ex_vec);
             return (retp);
@@ -1632,7 +1680,9 @@ struct ex_ex *eval_var(
             var = (char *) expr->exp_var[eptr->ex_int].ex_ptr;
     }
     else if(eptr->ex_type == ET_VAR)
+    {
         var = (char *) eptr->ex_ptr;
+    }
     else
     {
         post_error((fts_object_t *) expr, "expr: eval_tbl: bad type %ld\n",
@@ -1784,9 +1834,13 @@ static int cal_sigidx(struct ex_ex *optr, /* The output value */
     {
         /* from the curvec */
         if(rem_i)
+        {
             optr->ex_flt = curvec[n] + rem_i * (curvec[n] - curvec[n - 1]);
+        }
         else
+        {
             optr->ex_flt = curvec[n];
+        }
         return (0);
     }
     if(n == 0)
@@ -1796,9 +1850,13 @@ static int cal_sigidx(struct ex_ex *optr, /* The output value */
          * is between two tables
          */
         if(rem_i)
+        {
             optr->ex_flt = *curvec + rem_i * (*curvec - prevec[vsize - 1]);
+        }
         else
+        {
             optr->ex_flt = *curvec;
+        }
         return (0);
     }
     /* find the index in the saved buffer */
@@ -1806,9 +1864,13 @@ static int cal_sigidx(struct ex_ex *optr, /* The output value */
     if(n > 0)
     {
         if(rem_i)
+        {
             optr->ex_flt = prevec[n] + rem_i * (prevec[n] - prevec[n - 1]);
+        }
         else
+        {
             optr->ex_flt = prevec[n];
+        }
         return (0);
     }
     /* out of bound */
@@ -1933,7 +1995,9 @@ retry:
             break;
         case '=':
             if(*expr->exp_str != '=')
+            {
                 eptr->ex_op = OP_STORE;
+            }
             else
             {
                 expr->exp_str++;
@@ -2090,7 +2154,9 @@ retry:
                 ;
             }
             else if(!expr->exp_var[eptr->ex_op].ex_type)
+            {
                 expr->exp_var[eptr->ex_op].ex_type = eptr->ex_type;
+            }
             else if(expr->exp_var[eptr->ex_op].ex_type != eptr->ex_type)
             {
                 post("expr: syntax error: inlets can only have one type: %s\n",

--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -172,7 +172,8 @@ void atom_string(t_atom *a, char *buf, unsigned int bufsize)
                     quote = 1;
             if(quote)
             {
-                char *bp = buf, *ep = buf + (bufsize - 2);
+                char *bp = buf;
+                char *ep = buf + (bufsize - 2);
                 sp = a->a_w.w_symbol->s_name;
                 while(bp < ep && *sp)
                 {
@@ -237,7 +238,8 @@ int expr_donew(struct expr *expr, int ac, t_atom *av)
     binbuf_free(b);
 #else /* MSP */
     {
-        char *buf = getbytes(0), *newbuf;
+        char *buf = getbytes(0);
+        char *newbuf;
         int length = 0;
         char string[250];
         t_atom *ap;
@@ -1125,11 +1127,15 @@ struct ex_ex *ex_eval(
 /* the result pointer */
 /* the sample number processed for fexpr~ */
 {
-    int i, j;
-    t_float *lp, *rp, *op; /* left, right, and out pointer to vectors */
+    int i;
+    int j;
+    t_float *lp;
+    t_float *rp;
+    t_float *op; /* left, right, and out pointer to vectors */
     t_float scalar;
     int nullret = 0;                      /* did we have an error */
-    struct ex_ex left = {0}, right = {0}; /* left and right operands */
+    struct ex_ex left = {0};
+    struct ex_ex right = {0}; /* left and right operands */
 
     left.ex_type = 0;
     left.ex_int = 0;
@@ -1654,8 +1660,9 @@ struct ex_ex *eval_sigidx(
     struct ex_ex arg = {0};
     struct ex_ex *reteptr;
     int i = 0;
-    t_float fi = 0, /* index in float */
-        rem_i = 0;  /* remains of the float */
+    t_float fi = 0;
+    t_float        /* index in float */
+        rem_i = 0; /* remains of the float */
 
     arg.ex_type = 0;
     arg.ex_int = 0;

--- a/src/x_vexp.h
+++ b/src/x_vexp.h
@@ -1,6 +1,6 @@
 /* Copyright (c) IRCAM.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* "expr" was written by Shahrokh Yadegari c. 1989. -msp */
 /* "expr~" and "fexpr~" conversion by Shahrokh Yadegari c. 1999,2000 */
@@ -15,7 +15,7 @@
 #else /* MSP */
 #include "ext.h"
 #include "z_dsp.h"
-typedef float t_float;      // t_float is from m_pd.h
+typedef float t_float; // t_float is from m_pd.h
 #endif
 
 #define fts_malloc malloc
@@ -27,14 +27,14 @@ typedef float t_float;      // t_float is from m_pd.h
 typedef t_symbol *fts_symbol_t;
 
 #ifdef MSP
-#define t_atom          Atom
-#define t_symbol        Symbol
-#define pd_new(x)       newobject(x);
-#define pd_free(x)      freeobject(x);
-#define t_outlet        void
-#define t_binbuf        void
-typedef t_class         *t_pd;
-typedef float           t_floatarg;
+#define t_atom Atom
+#define t_symbol Symbol
+#define pd_new(x) newobject(x);
+#define pd_free(x) freeobject(x);
+#define t_outlet void
+#define t_binbuf void
+typedef t_class *t_pd;
+typedef float t_floatarg;
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -58,8 +58,8 @@ void pd_error(void *object, char *fmt, ...);
  * is 10.
  */
 
-#define MAX_VARS        100
-#define MINODES         10 /* was 200 */
+#define MAX_VARS 100
+#define MINODES 10 /* was 200 */
 
 /* terminal defines */
 
@@ -70,185 +70,198 @@ void pd_error(void *object, char *fmt, ...);
  * separators are defines as operators just for convenience
  */
 
-#define OP_SEMI         ((long)(1<<16|1))               /* ; */
-#define OP_COMMA        ((long)(2<<16|2))               /* , */
-#define OP_STORE        ((long)(3<<16|28))             /* = */
-#define OP_LOR          ((long)(4<<16|3))               /* || */
-#define OP_LAND         ((long)(5<<16|4))               /* && */
-#define OP_OR           ((long)(6<<16|5))               /* | */
-#define OP_XOR          ((long)(7<<16|6))               /* ^ */
-#define OP_AND          ((long)(8<<16|7))               /* & */
-#define OP_NE           ((long)(9<<16|8))               /* != */
-#define OP_EQ           ((long)(9<<16|9))               /* == */
-#define OP_GE           ((long)(10<<16|10))              /* >= */
-#define OP_GT           ((long)(10<<16|11))              /* > */
-#define OP_LE           ((long)(10<<16|12))              /* <= */
-#define OP_LT           ((long)(10<<16|13))              /* < */
-#define OP_SR           ((long)(11<<16|14))             /* >> */
-#define OP_SL           ((long)(11<<16|15))             /* << */
-#define OP_SUB          ((long)(12<<16|16))             /* - */
-#define OP_ADD          ((long)(12<<16|17))             /* + */
-#define OP_MOD          ((long)(13<<16|18))             /* % */
-#define OP_DIV          ((long)(13<<16|19))             /* / */
-#define OP_MUL          ((long)(13<<16|20))             /* * */
-#define OP_UMINUS       ((long)(14<<16|21))             /* - unary minus */
-#define OP_NEG          ((long)(14<<16|22))             /* ~ one complement */
-#define OP_NOT          ((long)(14<<16|23))             /* ! */
-#define OP_RB           ((long)(15<<16|24))             /* ] */
-#define OP_LB           ((long)(15<<16|25))             /* [ */
-#define OP_RP           ((long)(15<<16|26))             /* ) */
-#define OP_LP           ((long)(15<<16|27))             /* ( */
-#define HI_PRE          ((long)(100<<16))       /* infinite precedence */
-#define PRE_MASK        ((long)0xffff0000)      /* precedence level mask */
+#define OP_SEMI ((long) (1 << 16 | 1))     /* ; */
+#define OP_COMMA ((long) (2 << 16 | 2))    /* , */
+#define OP_STORE ((long) (3 << 16 | 28))   /* = */
+#define OP_LOR ((long) (4 << 16 | 3))      /* || */
+#define OP_LAND ((long) (5 << 16 | 4))     /* && */
+#define OP_OR ((long) (6 << 16 | 5))       /* | */
+#define OP_XOR ((long) (7 << 16 | 6))      /* ^ */
+#define OP_AND ((long) (8 << 16 | 7))      /* & */
+#define OP_NE ((long) (9 << 16 | 8))       /* != */
+#define OP_EQ ((long) (9 << 16 | 9))       /* == */
+#define OP_GE ((long) (10 << 16 | 10))     /* >= */
+#define OP_GT ((long) (10 << 16 | 11))     /* > */
+#define OP_LE ((long) (10 << 16 | 12))     /* <= */
+#define OP_LT ((long) (10 << 16 | 13))     /* < */
+#define OP_SR ((long) (11 << 16 | 14))     /* >> */
+#define OP_SL ((long) (11 << 16 | 15))     /* << */
+#define OP_SUB ((long) (12 << 16 | 16))    /* - */
+#define OP_ADD ((long) (12 << 16 | 17))    /* + */
+#define OP_MOD ((long) (13 << 16 | 18))    /* % */
+#define OP_DIV ((long) (13 << 16 | 19))    /* / */
+#define OP_MUL ((long) (13 << 16 | 20))    /* * */
+#define OP_UMINUS ((long) (14 << 16 | 21)) /* - unary minus */
+#define OP_NEG ((long) (14 << 16 | 22))    /* ~ one complement */
+#define OP_NOT ((long) (14 << 16 | 23))    /* ! */
+#define OP_RB ((long) (15 << 16 | 24))     /* ] */
+#define OP_LB ((long) (15 << 16 | 25))     /* [ */
+#define OP_RP ((long) (15 << 16 | 26))     /* ) */
+#define OP_LP ((long) (15 << 16 | 27))     /* ( */
+#define HI_PRE ((long) (100 << 16))        /* infinite precedence */
+#define PRE_MASK ((long) 0xffff0000)       /* precedence level mask */
 
-#define name_ok(c)      (((c)=='_') || ((c)>='a' && (c)<='z') || \
-                        ((c)>='A' && (c)<='Z') || ((c) >= '0' && (c) <= '9'))
-#define unary_op(x)     ((x) == OP_NOT || (x) == OP_NEG || (x) == OP_UMINUS)
+#define name_ok(c)                                 \
+    (((c) == '_') || ((c) >= 'a' && (c) <= 'z') || \
+        ((c) >= 'A' && (c) <= 'Z') || ((c) >= '0' && (c) <= '9'))
+#define unary_op(x) ((x) == OP_NOT || (x) == OP_NEG || (x) == OP_UMINUS)
 
-struct ex_ex {
-        union {
-                long v_int;
-                t_float v_flt;
-                t_float *v_vec;         /* this is an for allocated vector */
-                long op;
-                char *ptr;
-        } ex_cont;              /* content */
-#define ex_int          ex_cont.v_int
-#define ex_flt          ex_cont.v_flt
-#define ex_vec          ex_cont.v_vec
-#define ex_op           ex_cont.op
-#define ex_ptr          ex_cont.ptr
-        long ex_type;           /* type of the node */
-                struct ex_ex *ex_end;   /* the node after the end of this expression */
+struct ex_ex
+{
+    union
+    {
+        long v_int;
+        t_float v_flt;
+        t_float *v_vec; /* this is an for allocated vector */
+        long op;
+        char *ptr;
+    } ex_cont; /* content */
+
+#define ex_int ex_cont.v_int
+#define ex_flt ex_cont.v_flt
+#define ex_vec ex_cont.v_vec
+#define ex_op ex_cont.op
+#define ex_ptr ex_cont.ptr
+    long ex_type;         /* type of the node */
+    struct ex_ex *ex_end; /* the node after the end of this expression */
 };
-#define exNULL  ((struct ex_ex *)0)
+
+#define exNULL ((struct ex_ex *) 0)
 
 /* defines for ex_type */
-#define ET_INT          1               /* an int */
-#define ET_FLT          2               /* a float */
-#define ET_OP           3               /* operator */
-#define ET_STR          4               /* string */
-#define ET_TBL          5               /* a table, the content is a pointer */
-#define ET_FUNC         6               /* a function */
-#define ET_SYM          7               /* symbol ("string") */
-#define ET_VSYM         8               /* variable symbol ("$s?") */
-                                /* we treat parenthesis and brackets */
-                                /* special to keep a pointer to their */
-                                /* match in the content */
-#define ET_LP           9               /* left parenthesis */
-#define ET_LB           10              /* left bracket */
-#define ET_II           11              /* and integer inlet */
-#define ET_FI           12              /* float inlet */
-#define ET_SI           13              /* string inlet */
-#define ET_VI           14              /* signal inlet */
-#define ET_VEC          15              /* allocated signal vector */
-                                /* special types for fexpr~ */
-#define ET_YO           16              /* vector output for fexpr~ */
-#define ET_YOM1         17              /* shorthand for $y?[-1] */
-#define ET_XI           18              /* vector input for fexpr~ */
-#define ET_XI0          20              /* shorthand for $x?[0] */
-#define ET_VAR          21              /* variable */
+#define ET_INT 1   /* an int */
+#define ET_FLT 2   /* a float */
+#define ET_OP 3    /* operator */
+#define ET_STR 4   /* string */
+#define ET_TBL 5   /* a table, the content is a pointer */
+#define ET_FUNC 6  /* a function */
+#define ET_SYM 7   /* symbol ("string") */
+#define ET_VSYM 8  /* variable symbol ("$s?") */
+                   /* we treat parenthesis and brackets */
+                   /* special to keep a pointer to their */
+                   /* match in the content */
+#define ET_LP 9    /* left parenthesis */
+#define ET_LB 10   /* left bracket */
+#define ET_II 11   /* and integer inlet */
+#define ET_FI 12   /* float inlet */
+#define ET_SI 13   /* string inlet */
+#define ET_VI 14   /* signal inlet */
+#define ET_VEC 15  /* allocated signal vector */
+                   /* special types for fexpr~ */
+#define ET_YO 16   /* vector output for fexpr~ */
+#define ET_YOM1 17 /* shorthand for $y?[-1] */
+#define ET_XI 18   /* vector input for fexpr~ */
+#define ET_XI0 20  /* shorthand for $x?[0] */
+#define ET_VAR 21  /* variable */
 
 /* defines for ex_flags */
-#define EF_TYPE_MASK    0x07    /* first three bits define the type of expr */
-#define EF_EXPR         0x01    /* expr  - control in and out */
-#define EF_EXPR_TILDE   0x02    /* expr~ signal and control in, signal out */
-#define EF_FEXPR_TILDE  0x04    /* fexpr~ filter expression */
+#define EF_TYPE_MASK 0x07   /* first three bits define the type of expr */
+#define EF_EXPR 0x01        /* expr  - control in and out */
+#define EF_EXPR_TILDE 0x02  /* expr~ signal and control in, signal out */
+#define EF_FEXPR_TILDE 0x04 /* fexpr~ filter expression */
 
-#define EF_STOP         0x08    /* is it stopped used for expr~ and fexpr~ */
-#define EF_VERBOSE      0x10    /* verbose mode */
+#define EF_STOP 0x08    /* is it stopped used for expr~ and fexpr~ */
+#define EF_VERBOSE 0x10 /* verbose mode */
 
-#define IS_EXPR(x)        ((((x)->exp_flags&EF_TYPE_MASK)|EF_EXPR) == EF_EXPR)
-#define IS_EXPR_TILDE(x)  \
-                 ((((x)->exp_flags&EF_TYPE_MASK)|EF_EXPR_TILDE)==EF_EXPR_TILDE)
+#define IS_EXPR(x) ((((x)->exp_flags & EF_TYPE_MASK) | EF_EXPR) == EF_EXPR)
+#define IS_EXPR_TILDE(x) \
+    ((((x)->exp_flags & EF_TYPE_MASK) | EF_EXPR_TILDE) == EF_EXPR_TILDE)
 #define IS_FEXPR_TILDE(x) \
-               ((((x)->exp_flags&EF_TYPE_MASK)|EF_FEXPR_TILDE)==EF_FEXPR_TILDE)
+    ((((x)->exp_flags & EF_TYPE_MASK) | EF_FEXPR_TILDE) == EF_FEXPR_TILDE)
 
-#define SET_EXPR(x)     (x)->exp_flags |= EF_EXPR; \
-                        (x)->exp_flags &= ~EF_EXPR_TILDE;  \
-                        (x)->exp_flags &= ~EF_FEXPR_TILDE;
+#define SET_EXPR(x)                   \
+    (x)->exp_flags |= EF_EXPR;        \
+    (x)->exp_flags &= ~EF_EXPR_TILDE; \
+    (x)->exp_flags &= ~EF_FEXPR_TILDE;
 
-#define SET_EXPR_TILDE(x)       (x)->exp_flags &= ~EF_EXPR; \
-                                (x)->exp_flags |= EF_EXPR_TILDE;  \
-                                (x)->exp_flags &= ~EF_FEXPR_TILDE;
+#define SET_EXPR_TILDE(x)            \
+    (x)->exp_flags &= ~EF_EXPR;      \
+    (x)->exp_flags |= EF_EXPR_TILDE; \
+    (x)->exp_flags &= ~EF_FEXPR_TILDE;
 
-#define SET_FEXPR_TILDE(x)      (x)->exp_flags &= ~EF_EXPR; \
-                                (x)->exp_flags &= ~EF_EXPR_TILDE;  \
-                                (x)->exp_flags |= EF_FEXPR_TILDE;
+#define SET_FEXPR_TILDE(x)            \
+    (x)->exp_flags &= ~EF_EXPR;       \
+    (x)->exp_flags &= ~EF_EXPR_TILDE; \
+    (x)->exp_flags |= EF_FEXPR_TILDE;
 
 /*
  * defines for expr_error
  */
-#define EE_DZ           0x01    /* divide by zero error */
-#define EE_BI_OUTPUT    0x02    /* Bad output index */
-#define EE_BI_INPUT     0x04    /* Bad input index */
-#define EE_NOTABLE      0x08    /* NO TABLE */
-#define EE_NOVAR        0x10    /* NO VARIABLE */
+#define EE_DZ 0x01        /* divide by zero error */
+#define EE_BI_OUTPUT 0x02 /* Bad output index */
+#define EE_BI_INPUT 0x04  /* Bad input index */
+#define EE_NOTABLE 0x08   /* NO TABLE */
+#define EE_NOVAR 0x10     /* NO VARIABLE */
 
-typedef struct expr {
+typedef struct expr
+{
 #ifdef PD
-        t_object exp_ob;
+    t_object exp_ob;
 #else /* MSP */
-        t_pxobject exp_ob;
+    t_pxobject exp_ob;
 #endif
-        int     exp_flags;              /* are we expr~, fexpr~, or expr */
-        int     exp_error;              /* reported errors */
-        int     exp_nexpr;              /* number of expressions */
-        char    *exp_string;            /* the full expression string */
-        char    *exp_str;               /* current parsing position */
-        t_outlet *exp_outlet[MAX_VARS];
+    int exp_flags;    /* are we expr~, fexpr~, or expr */
+    int exp_error;    /* reported errors */
+    int exp_nexpr;    /* number of expressions */
+    char *exp_string; /* the full expression string */
+    char *exp_str;    /* current parsing position */
+    t_outlet *exp_outlet[MAX_VARS];
 #ifdef PD
-        struct _exprproxy *exp_proxy;
+    struct _exprproxy *exp_proxy;
 #else /* MAX */
-        void *exp_proxy[MAX_VARS];
-        long exp_proxy_id;
+    void *exp_proxy[MAX_VARS];
+    long exp_proxy_id;
 #endif
-        struct ex_ex *exp_stack[MAX_VARS];
-        struct ex_ex exp_var[MAX_VARS];
-        struct ex_ex exp_res[MAX_VARS]; /* the evluation result */
-        t_float *exp_p_var[MAX_VARS];
-        t_float *exp_p_res[MAX_VARS];   /* the previous evaluation result */
-        t_float *exp_tmpres[MAX_VARS];  /* temporty result for fexpr~ */
-        int exp_vsize;                  /* the size of the signal vector */
-        int exp_nivec;                  /* # of vector inlets */
-        t_float exp_f;          /* control value to be transformed to signal */
+    struct ex_ex *exp_stack[MAX_VARS];
+    struct ex_ex exp_var[MAX_VARS];
+    struct ex_ex exp_res[MAX_VARS]; /* the evluation result */
+    t_float *exp_p_var[MAX_VARS];
+    t_float *exp_p_res[MAX_VARS];  /* the previous evaluation result */
+    t_float *exp_tmpres[MAX_VARS]; /* temporty result for fexpr~ */
+    int exp_vsize;                 /* the size of the signal vector */
+    int exp_nivec;                 /* # of vector inlets */
+    t_float exp_f; /* control value to be transformed to signal */
 } t_expr;
 
-typedef struct ex_funcs {
-        char *f_name;                                   /* function name */
-        void (*f_func)(t_expr *, long, struct ex_ex *, struct ex_ex *);
-          /* the real function performing the function (void, no return!!!) */
-        long f_argc;                            /* number of arguments */
+typedef struct ex_funcs
+{
+    char *f_name; /* function name */
+    void (*f_func)(t_expr *, long, struct ex_ex *, struct ex_ex *);
+    /* the real function performing the function (void, no return!!!) */
+    long f_argc; /* number of arguments */
 } t_ex_func;
 
 /* function prototypes for pd-related functions called within vexp.h */
 
-extern int
-max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
-                                                                        struct ex_ex *rval, struct ex_ex *optr);
-extern int
-max_ex_tab(struct expr *expr, t_symbol *s, struct ex_ex *arg,
-                                                                                                                struct ex_ex *optr);
-extern int max_ex_var(struct expr *expr, t_symbol *s, struct ex_ex *optr,
-                                                                                                                                        int idx);
-extern int max_ex_var_store(struct expr *, t_symbol *, struct ex_ex *, struct ex_ex *);
+extern int max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
+    struct ex_ex *rval, struct ex_ex *optr);
+extern int max_ex_tab(
+    struct expr *expr, t_symbol *s, struct ex_ex *arg, struct ex_ex *optr);
+extern int max_ex_var(
+    struct expr *expr, t_symbol *s, struct ex_ex *optr, int idx);
+extern int max_ex_var_store(
+    struct expr *, t_symbol *, struct ex_ex *, struct ex_ex *);
 extern int ex_getsym(char *p, t_symbol **s);
 extern const char *ex_symname(t_symbol *s);
 void ex_mkvector(t_float *fp, t_float x, int size);
-extern void ex_size(t_expr *expr, long int argc, struct ex_ex *argv,
-                                                        struct ex_ex *optr);
-extern void ex_sum(t_expr *expr, long int argc, struct ex_ex *argv,                                                                     struct ex_ex *optr);
-extern void ex_Sum(t_expr *expr, long int argc, struct ex_ex *argv,                                                                     struct ex_ex *optr);
-extern void ex_avg(t_expr *expr, long int argc, struct ex_ex *argv,                                                                     struct ex_ex *optr);
-extern void ex_Avg(t_expr *expr, long int argc, struct ex_ex *argv,                                                                     struct ex_ex *optr);
-extern void ex_store(t_expr *expr, long int argc, struct ex_ex *argv,                                                                   struct ex_ex *optr);
+extern void ex_size(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+extern void ex_sum(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+extern void ex_Sum(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+extern void ex_avg(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+extern void ex_Avg(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+extern void ex_store(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
 
 int value_getonly(t_symbol *s, t_float *f);
 
-
 /* These pragmas are only used for MSVC, not MinGW or Cygwin <hans@at.or.at> */
 #ifdef _MSC_VER
-#pragma warning (disable: 4305 4244)
+#pragma warning(disable : 4305 4244)
 #endif
 
 #ifdef _WIN32

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -1,6 +1,6 @@
 /* Copyright (c) IRCAM.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* "expr" was written by Shahrokh Yadegari c. 1989. -msp
  *
@@ -51,12 +51,12 @@
  *
  *      - ex_if() is reworked to only evaluate either the left or the right arg
  *	October 2020 --sdy
- *		- fact() (factorial) now calculates and returns its value in double
- *		- Added mtof(), mtof(), dbtorms(), rmstodb(), powtodb(), dbtopow()
+ *		- fact() (factorial) now calculates and returns its value in
+ *double
+ *		- Added mtof(), mtof(), dbtorms(), rmstodb(), powtodb(),
+ *dbtopow()
  *
  */
-
-
 
 /*
  * vexp_func.c -- this file include all the functions for vexp.
@@ -84,437 +84,496 @@
 
 #include "x_vexp.h"
 
-struct ex_ex *ex_eval(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int i);
+struct ex_ex *ex_eval(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int i);
 
 /* forward declarations */
 
-static void ex_min(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_max(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_toint(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_rint(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_tofloat(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_pow(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_exp(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_log(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_ln(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_sin(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_cos(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_asin(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_acos(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_tan(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_atan(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_sinh(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_cosh(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_asinh(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_acosh(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_tanh(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_atanh(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_atan2(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_sqrt(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_fact(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_random(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_abs(t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_fmod(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_ceil(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_floor(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-struct ex_ex * ex_if(t_expr *expr, struct ex_ex *argv, struct ex_ex *optr,
-                                     struct ex_ex *args, int idx);
-static void ex_ldexp(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_imodf(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_modf(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_mtof(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_ftom(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_dbtorms(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_rmstodb(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_dbtopow(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_powtodb(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_min(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_max(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_toint(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_rint(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_tofloat(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_pow(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_exp(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_log(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_ln(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_sin(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_cos(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_asin(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_acos(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_tan(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_atan(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_sinh(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_cosh(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_asinh(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_acosh(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_tanh(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_atanh(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_atan2(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_sqrt(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_fact(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_random(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_abs(
+    t_expr *expr, long int argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_fmod(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_ceil(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_floor(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+struct ex_ex *ex_if(t_expr *expr, struct ex_ex *argv, struct ex_ex *optr,
+    struct ex_ex *args, int idx);
+static void ex_ldexp(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_imodf(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_modf(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_mtof(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_ftom(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_dbtorms(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_rmstodb(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_dbtopow(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_powtodb(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
 #if !defined(_MSC_VER) || (_MSC_VER >= 1700)
-static void ex_cbrt(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_erf(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_erfc(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_expm1(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_log1p(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_isinf(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_finite(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_isnan(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_copysign(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_drem(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_remainder(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_round(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_trunc(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
-static void ex_nearbyint(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_cbrt(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_erf(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_erfc(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_expm1(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_log1p(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_isinf(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_finite(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_isnan(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_copysign(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_drem(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_remainder(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_round(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_trunc(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_nearbyint(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
 
 #endif
 #ifdef notdef
 /* the following will be added once they are more popular in math libraries */
-static void ex_hypoth(t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
+static void ex_hypoth(
+    t_expr *expr, long argc, struct ex_ex *argv, struct ex_ex *optr);
 #endif
 
-
-t_ex_func ex_funcs[] = {
-        {"min",         ex_min,         2},
-        {"max",         ex_max,         2},
-        {"int",         ex_toint,       1},
-        {"rint",        ex_rint,        1},
-        {"float",       ex_tofloat,     1},
-        {"fmod",        ex_fmod,        2},
-        {"floor",       ex_floor,       1},
-        {"ceil",        ex_ceil,        1},
-        {"pow",         ex_pow,         2},
-        {"sqrt",        ex_sqrt,        1},
-        {"exp",         ex_exp,         1},
-        {"log10",       ex_log,         1},
-        {"ln",          ex_ln,          1},
-        {"log",         ex_ln,          1},
-        {"sin",         ex_sin,         1},
-        {"cos",         ex_cos,         1},
-        {"tan",         ex_tan,         1},
-        {"asin",        ex_asin,        1},
-        {"acos",        ex_acos,        1},
-        {"atan",        ex_atan,        1},
-        {"atan2",       ex_atan2,       2},
-        {"sinh",        ex_sinh,        1},
-        {"cosh",        ex_cosh,        1},
-        {"tanh",        ex_tanh,        1},
-        {"fact",        ex_fact,        1},
-        {"random",      ex_random,      2},     /* random number */
-        {"abs",         ex_abs,         1},
-        {"if",          (void (*))ex_if,          3},
-        {"ldexp",       ex_ldexp,       2},
-        {"imodf",       ex_imodf,       1},
-        {"modf",        ex_modf,        1},
-		{"mtof",		ex_mtof,		1},
-		{"ftom",		ex_ftom,		1},
-		{"dbtorms",		ex_dbtorms,		1},
-		{"rmstodb",		ex_rmstodb,		1},
-		{"dbtopow",		ex_dbtopow,		1},
-		{"powtodb",		ex_powtodb,		1},
+t_ex_func ex_funcs[] = {{"min", ex_min, 2}, {"max", ex_max, 2},
+    {"int", ex_toint, 1}, {"rint", ex_rint, 1}, {"float", ex_tofloat, 1},
+    {"fmod", ex_fmod, 2}, {"floor", ex_floor, 1}, {"ceil", ex_ceil, 1},
+    {"pow", ex_pow, 2}, {"sqrt", ex_sqrt, 1}, {"exp", ex_exp, 1},
+    {"log10", ex_log, 1}, {"ln", ex_ln, 1}, {"log", ex_ln, 1},
+    {"sin", ex_sin, 1}, {"cos", ex_cos, 1}, {"tan", ex_tan, 1},
+    {"asin", ex_asin, 1}, {"acos", ex_acos, 1}, {"atan", ex_atan, 1},
+    {"atan2", ex_atan2, 2}, {"sinh", ex_sinh, 1}, {"cosh", ex_cosh, 1},
+    {"tanh", ex_tanh, 1}, {"fact", ex_fact, 1},
+    {"random", ex_random, 2}, /* random number */
+    {"abs", ex_abs, 1}, {"if", (void(*)) ex_if, 3}, {"ldexp", ex_ldexp, 2},
+    {"imodf", ex_imodf, 1}, {"modf", ex_modf, 1}, {"mtof", ex_mtof, 1},
+    {"ftom", ex_ftom, 1}, {"dbtorms", ex_dbtorms, 1},
+    {"rmstodb", ex_rmstodb, 1}, {"dbtopow", ex_dbtopow, 1},
+    {"powtodb", ex_powtodb, 1},
 #if !defined(_MSC_VER) || (_MSC_VER >= 1700)
-        {"asinh",       ex_asinh,       1},
-        {"acosh",       ex_acosh,       1},
-        {"atanh",       ex_atanh,       1},     /* hyperbolic atan */
-        {"isnan",       ex_isnan,       1},
-        {"cbrt",        ex_cbrt,        1},
-        {"round",       ex_round,       1},
-        {"trunc",       ex_trunc,       1},
-        {"erf",         ex_erf,         1},
-        {"erfc",        ex_erfc,        1},
-        {"expm1",       ex_expm1,       1},
-        {"log1p",       ex_log1p,       1},
-        {"finite",      ex_finite,      1},
-        {"nearbyint",   ex_nearbyint,   1},
-        {"copysign",    ex_copysign,    2},
-        {"isinf",       ex_isinf,       1},
-        {"remainder",   ex_remainder,           2},
+    {"asinh", ex_asinh, 1}, {"acosh", ex_acosh, 1},
+    {"atanh", ex_atanh, 1}, /* hyperbolic atan */
+    {"isnan", ex_isnan, 1}, {"cbrt", ex_cbrt, 1}, {"round", ex_round, 1},
+    {"trunc", ex_trunc, 1}, {"erf", ex_erf, 1}, {"erfc", ex_erfc, 1},
+    {"expm1", ex_expm1, 1}, {"log1p", ex_log1p, 1}, {"finite", ex_finite, 1},
+    {"nearbyint", ex_nearbyint, 1}, {"copysign", ex_copysign, 2},
+    {"isinf", ex_isinf, 1}, {"remainder", ex_remainder, 2},
 #endif
 #ifdef PD
-        {"size",        ex_size,        1},
-        {"sum",         ex_sum,         1},
-        {"Sum",         ex_Sum,         3},
-        {"avg",         ex_avg,         1},
-        {"Avg",         ex_Avg,         3},
+    {"size", ex_size, 1}, {"sum", ex_sum, 1}, {"Sum", ex_Sum, 3},
+    {"avg", ex_avg, 1}, {"Avg", ex_Avg, 3},
 #endif
 #ifdef notdef
-/* the following will be added once they are more popular in math libraries */
-        {"hypoth",      ex_hypoth,      1},
+    /* the following will be added once they are more popular in math libraries
+     */
+    {"hypoth", ex_hypoth, 1},
 #endif
-        {0,             0,              0}
-};
+    {0, 0, 0}};
 
 /*
  * FUN_EVAL --  do type checking, evaluate a function,
  *              if fltret is set return float
  *              otherwise return value based on regular typechecking,
  */
-#define FUNC_EVAL(left, right, func, leftfuncast, rightfuncast, optr, fltret) \
-switch (left->ex_type) {                                                \
-case ET_INT:                                                            \
-        switch(right->ex_type) {                                        \
-        case ET_INT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = (t_float)func(leftfuncast left->ex_int,  \
-                                        rightfuncast right->ex_int);    \
-                        j = e->exp_vsize;                               \
-                        while (j--)                                     \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        if (fltret) {                                   \
-                                optr->ex_type = ET_FLT;                 \
-                                optr->ex_flt = (t_float)func(leftfuncast  \
-                                left->ex_int, rightfuncast right->ex_int); \
-                        } else {                                        \
-                                optr->ex_type = ET_INT;                 \
-                                optr->ex_int = (int)func(leftfuncast    \
-                                left->ex_int, rightfuncast right->ex_int); \
-                        }                                               \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = (t_float)func(leftfuncast left->ex_int,  \
-                                        rightfuncast right->ex_flt);    \
-                        j = e->exp_vsize;                               \
-                        while (j--)                                     \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt = (t_float)func(leftfuncast left->ex_int,  \
-                                        rightfuncast right->ex_flt);    \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                if (optr->ex_type != ET_VEC) {                          \
-                        if (optr->ex_type == ET_VI) {                   \
-                                post("expr~: Int. error %d", __LINE__); \
-                                abort();                                \
-                        }                                               \
-                        optr->ex_type = ET_VEC;                         \
-                        optr->ex_vec = (t_float *)                      \
-                          fts_malloc(sizeof (t_float)*e->exp_vsize);    \
-                }                                                       \
-                scalar = left->ex_int;                                  \
-                rp = right->ex_vec;                                     \
-                op = optr->ex_vec;                                      \
-                j = e->exp_vsize;                                       \
-                while (j--) {                                           \
-                        *op++ = (t_float)func(leftfuncast scalar,         \
-                                                rightfuncast *rp);      \
-                        rp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) e,                          \
-                      "expr: FUNC_EVAL(%d): bad right type %ld\n",      \
-                                              __LINE__, right->ex_type);\
-        }                                                               \
-        break;                                                          \
-case ET_FLT:                                                            \
-        switch(right->ex_type) {                                        \
-        case ET_INT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = (t_float)func(leftfuncast left->ex_flt,  \
-                                        rightfuncast right->ex_int);    \
-                        j = e->exp_vsize;                               \
-                        while (j--)                                     \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt = (t_float)func(leftfuncast left->ex_flt,  \
-                                        rightfuncast right->ex_int);    \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                if (optr->ex_type == ET_VEC) {                          \
-                        op = optr->ex_vec;                              \
-                        scalar = (t_float)func(leftfuncast left->ex_flt,  \
-                                        rightfuncast right->ex_flt);    \
-                        j = e->exp_vsize;                               \
-                        while (j--)                                     \
-                                *op++ = scalar;                         \
-                } else {                                                \
-                        optr->ex_type = ET_FLT;                         \
-                        optr->ex_flt = (t_float)func(leftfuncast left->ex_flt,  \
-                                        rightfuncast right->ex_flt);    \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                if (optr->ex_type != ET_VEC) {                          \
-                        if (optr->ex_type == ET_VI) {                   \
-                                post("expr~: Int. error %d", __LINE__); \
-                                abort();                                \
-                        }                                               \
-                        optr->ex_type = ET_VEC;                         \
-                        optr->ex_vec = (t_float *)                      \
-                          fts_malloc(sizeof (t_float) * e->exp_vsize);\
-                }                                                       \
-                scalar = left->ex_flt;                                  \
-                rp = right->ex_vec;                                     \
-                op = optr->ex_vec;                                      \
-                j = e->exp_vsize;                                       \
-                while (j--) {                                           \
-                        *op++ = (t_float)func(leftfuncast scalar,         \
-                                                rightfuncast *rp);      \
-                        rp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) e,                  \
-                      "expr: FUNC_EVAL(%d): bad right type %ld\n",      \
-                                              __LINE__, right->ex_type);\
-        }                                                               \
-        break;                                                          \
-case ET_VEC:                                                            \
-case ET_VI:                                                             \
-        if (optr->ex_type != ET_VEC) {                                  \
-                if (optr->ex_type == ET_VI) {                           \
-                        post("expr~: Int. error %d", __LINE__);         \
-                        abort();                                        \
-                }                                                       \
-                optr->ex_type = ET_VEC;                                 \
-                optr->ex_vec = (t_float *)                              \
-                  fts_malloc(sizeof (t_float) * e->exp_vsize);  \
-        }                                                               \
-        op = optr->ex_vec;                                              \
-        lp = left->ex_vec;                                              \
-        switch(right->ex_type) {                                        \
-        case ET_INT:                                                    \
-                scalar = right->ex_int;                                 \
-                j = e->exp_vsize;                                       \
-                while (j--) {                                           \
-                        *op++ = (t_float)func(leftfuncast *lp,            \
-                                                rightfuncast scalar);   \
-                        lp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_FLT:                                                    \
-                scalar = right->ex_flt;                                 \
-                j = e->exp_vsize;                                       \
-                while (j--) {                                           \
-                        *op++ = (t_float)func(leftfuncast *lp,            \
-                                                rightfuncast scalar);   \
-                        lp++;                                           \
-                }                                                       \
-                break;                                                  \
-        case ET_VEC:                                                    \
-        case ET_VI:                                                     \
-                rp = right->ex_vec;                                     \
-                j = e->exp_vsize;                                       \
-                while (j--) {                                           \
-                        /*                                              \
-                         * on a RISC processor one could copy           \
-                         * 8 times in each round to get a considerable  \
-                         * improvement                                  \
-                         */                                             \
-                        *op++ = (t_float)func(leftfuncast *lp,            \
-                                                rightfuncast *rp);      \
-                        rp++; lp++;                                     \
-                }                                                       \
-                break;                                                  \
-        case ET_SYM:                                                    \
-        default:                                                        \
-                post_error((fts_object_t *) e,                  \
-                      "expr: FUNC_EVAL(%d): bad right type %ld\n",      \
-                                              __LINE__, right->ex_type);\
-        }                                                               \
-        break;                                                          \
-case ET_SYM:                                                            \
-default:                                                                \
-                post_error((fts_object_t *) e,                  \
-                      "expr: FUNC_EVAL(%d): bad left type %ld\n",               \
-                                              __LINE__, left->ex_type); \
-}
+#define FUNC_EVAL(left, right, func, leftfuncast, rightfuncast, optr, fltret)  \
+    switch(left->ex_type)                                                      \
+    {                                                                          \
+        case ET_INT:                                                           \
+            switch(right->ex_type)                                             \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar = (t_float) func(leftfuncast left->ex_int,      \
+                            rightfuncast right->ex_int);                       \
+                        j = e->exp_vsize;                                      \
+                        while(j--)                                             \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        if(fltret)                                             \
+                        {                                                      \
+                            optr->ex_type = ET_FLT;                            \
+                            optr->ex_flt =                                     \
+                                (t_float) func(leftfuncast left->ex_int,       \
+                                    rightfuncast right->ex_int);               \
+                        }                                                      \
+                        else                                                   \
+                        {                                                      \
+                            optr->ex_type = ET_INT;                            \
+                            optr->ex_int =                                     \
+                                (int) func(leftfuncast left->ex_int,           \
+                                    rightfuncast right->ex_int);               \
+                        }                                                      \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar = (t_float) func(leftfuncast left->ex_int,      \
+                            rightfuncast right->ex_flt);                       \
+                        j = e->exp_vsize;                                      \
+                        while(j--)                                             \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt =                                         \
+                            (t_float) func(leftfuncast left->ex_int,           \
+                                rightfuncast right->ex_flt);                   \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    if(optr->ex_type != ET_VEC)                                \
+                    {                                                          \
+                        if(optr->ex_type == ET_VI)                             \
+                        {                                                      \
+                            post("expr~: Int. error %d", __LINE__);            \
+                            abort();                                           \
+                        }                                                      \
+                        optr->ex_type = ET_VEC;                                \
+                        optr->ex_vec = (t_float *) fts_malloc(                 \
+                            sizeof(t_float) * e->exp_vsize);                   \
+                    }                                                          \
+                    scalar = left->ex_int;                                     \
+                    rp = right->ex_vec;                                        \
+                    op = optr->ex_vec;                                         \
+                    j = e->exp_vsize;                                          \
+                    while(j--)                                                 \
+                    {                                                          \
+                        *op++ = (t_float) func(                                \
+                            leftfuncast scalar, rightfuncast * rp);            \
+                        rp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) e,                             \
+                        "expr: FUNC_EVAL(%d): bad right type %ld\n", __LINE__, \
+                        right->ex_type);                                       \
+            }                                                                  \
+            break;                                                             \
+        case ET_FLT:                                                           \
+            switch(right->ex_type)                                             \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar = (t_float) func(leftfuncast left->ex_flt,      \
+                            rightfuncast right->ex_int);                       \
+                        j = e->exp_vsize;                                      \
+                        while(j--)                                             \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt =                                         \
+                            (t_float) func(leftfuncast left->ex_flt,           \
+                                rightfuncast right->ex_int);                   \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    if(optr->ex_type == ET_VEC)                                \
+                    {                                                          \
+                        op = optr->ex_vec;                                     \
+                        scalar = (t_float) func(leftfuncast left->ex_flt,      \
+                            rightfuncast right->ex_flt);                       \
+                        j = e->exp_vsize;                                      \
+                        while(j--)                                             \
+                            *op++ = scalar;                                    \
+                    }                                                          \
+                    else                                                       \
+                    {                                                          \
+                        optr->ex_type = ET_FLT;                                \
+                        optr->ex_flt =                                         \
+                            (t_float) func(leftfuncast left->ex_flt,           \
+                                rightfuncast right->ex_flt);                   \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    if(optr->ex_type != ET_VEC)                                \
+                    {                                                          \
+                        if(optr->ex_type == ET_VI)                             \
+                        {                                                      \
+                            post("expr~: Int. error %d", __LINE__);            \
+                            abort();                                           \
+                        }                                                      \
+                        optr->ex_type = ET_VEC;                                \
+                        optr->ex_vec = (t_float *) fts_malloc(                 \
+                            sizeof(t_float) * e->exp_vsize);                   \
+                    }                                                          \
+                    scalar = left->ex_flt;                                     \
+                    rp = right->ex_vec;                                        \
+                    op = optr->ex_vec;                                         \
+                    j = e->exp_vsize;                                          \
+                    while(j--)                                                 \
+                    {                                                          \
+                        *op++ = (t_float) func(                                \
+                            leftfuncast scalar, rightfuncast * rp);            \
+                        rp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) e,                             \
+                        "expr: FUNC_EVAL(%d): bad right type %ld\n", __LINE__, \
+                        right->ex_type);                                       \
+            }                                                                  \
+            break;                                                             \
+        case ET_VEC:                                                           \
+        case ET_VI:                                                            \
+            if(optr->ex_type != ET_VEC)                                        \
+            {                                                                  \
+                if(optr->ex_type == ET_VI)                                     \
+                {                                                              \
+                    post("expr~: Int. error %d", __LINE__);                    \
+                    abort();                                                   \
+                }                                                              \
+                optr->ex_type = ET_VEC;                                        \
+                optr->ex_vec =                                                 \
+                    (t_float *) fts_malloc(sizeof(t_float) * e->exp_vsize);    \
+            }                                                                  \
+            op = optr->ex_vec;                                                 \
+            lp = left->ex_vec;                                                 \
+            switch(right->ex_type)                                             \
+            {                                                                  \
+                case ET_INT:                                                   \
+                    scalar = right->ex_int;                                    \
+                    j = e->exp_vsize;                                          \
+                    while(j--)                                                 \
+                    {                                                          \
+                        *op++ = (t_float) func(                                \
+                            leftfuncast * lp, rightfuncast scalar);            \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_FLT:                                                   \
+                    scalar = right->ex_flt;                                    \
+                    j = e->exp_vsize;                                          \
+                    while(j--)                                                 \
+                    {                                                          \
+                        *op++ = (t_float) func(                                \
+                            leftfuncast * lp, rightfuncast scalar);            \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_VEC:                                                   \
+                case ET_VI:                                                    \
+                    rp = right->ex_vec;                                        \
+                    j = e->exp_vsize;                                          \
+                    while(j--)                                                 \
+                    {                                                          \
+                        /*                                                     \
+                         * on a RISC processor one could copy                  \
+                         * 8 times in each round to get a considerable         \
+                         * improvement                                         \
+                         */                                                    \
+                        *op++ = (t_float) func(                                \
+                            leftfuncast * lp, rightfuncast * rp);              \
+                        rp++;                                                  \
+                        lp++;                                                  \
+                    }                                                          \
+                    break;                                                     \
+                case ET_SYM:                                                   \
+                default:                                                       \
+                    post_error((fts_object_t *) e,                             \
+                        "expr: FUNC_EVAL(%d): bad right type %ld\n", __LINE__, \
+                        right->ex_type);                                       \
+            }                                                                  \
+            break;                                                             \
+        case ET_SYM:                                                           \
+        default:                                                               \
+            post_error((fts_object_t *) e,                                     \
+                "expr: FUNC_EVAL(%d): bad left type %ld\n", __LINE__,          \
+                left->ex_type);                                                \
+    }
 
 /*
  * FUNC_EVAL_UNARY - evaluate a unary function,
  *              if fltret is set return t_float
  *              otherwise return value based on regular typechecking,
  */
-#define FUNC_EVAL_UNARY(left, func, leftcast, optr, fltret)             \
-switch(left->ex_type) {                                         \
-case ET_INT:                                                    \
-        if (optr->ex_type == ET_VEC) {                          \
-                ex_mkvector(optr->ex_vec,                       \
-                (t_float)(func (leftcast left->ex_int)), e->exp_vsize);\
-                break;                                          \
-        }                                                       \
-        if (fltret) {                                           \
-                optr->ex_type = ET_FLT;                         \
-                optr->ex_flt = (t_float) func(leftcast left->ex_int); \
-                break;                                          \
-        }                                                       \
-        optr->ex_type = ET_INT;                                 \
-        optr->ex_int = (int) func(leftcast left->ex_int);       \
-        break;                                                  \
-case ET_FLT:                                                    \
-        if (optr->ex_type == ET_VEC) {                          \
-                ex_mkvector(optr->ex_vec,                       \
-                (t_float)(func (leftcast left->ex_flt)), e->exp_vsize);\
-                break;                                          \
-        }                                                       \
-        optr->ex_type = ET_FLT;                                 \
-        optr->ex_flt = (t_float) func(leftcast left->ex_flt);     \
-        break;                                                  \
-case ET_VI:                                                     \
-case ET_VEC:                                                    \
-        if (optr->ex_type != ET_VEC) {                          \
-                optr->ex_type = ET_VEC;                         \
-                optr->ex_vec = (t_float *)                      \
-                  fts_malloc(sizeof (t_float)*e->exp_vsize);    \
-        }                                                       \
-        op = optr->ex_vec;                                      \
-        lp = left->ex_vec;                                      \
-        j = e->exp_vsize;                                       \
-        while (j--)                                             \
-                *op++ = (t_float)(func (leftcast *lp++));         \
-        break;                                                  \
-default:                                                        \
-        post_error((fts_object_t *) e,                          \
-                "expr: FUNV_EVAL_UNARY(%d): bad left type %ld\n",\
-                                      __LINE__, left->ex_type); \
-}
+#define FUNC_EVAL_UNARY(left, func, leftcast, optr, fltret)                 \
+    switch(left->ex_type)                                                   \
+    {                                                                       \
+        case ET_INT:                                                        \
+            if(optr->ex_type == ET_VEC)                                     \
+            {                                                               \
+                ex_mkvector(optr->ex_vec,                                   \
+                    (t_float) (func(leftcast left->ex_int)), e->exp_vsize); \
+                break;                                                      \
+            }                                                               \
+            if(fltret)                                                      \
+            {                                                               \
+                optr->ex_type = ET_FLT;                                     \
+                optr->ex_flt = (t_float) func(leftcast left->ex_int);       \
+                break;                                                      \
+            }                                                               \
+            optr->ex_type = ET_INT;                                         \
+            optr->ex_int = (int) func(leftcast left->ex_int);               \
+            break;                                                          \
+        case ET_FLT:                                                        \
+            if(optr->ex_type == ET_VEC)                                     \
+            {                                                               \
+                ex_mkvector(optr->ex_vec,                                   \
+                    (t_float) (func(leftcast left->ex_flt)), e->exp_vsize); \
+                break;                                                      \
+            }                                                               \
+            optr->ex_type = ET_FLT;                                         \
+            optr->ex_flt = (t_float) func(leftcast left->ex_flt);           \
+            break;                                                          \
+        case ET_VI:                                                         \
+        case ET_VEC:                                                        \
+            if(optr->ex_type != ET_VEC)                                     \
+            {                                                               \
+                optr->ex_type = ET_VEC;                                     \
+                optr->ex_vec =                                              \
+                    (t_float *) fts_malloc(sizeof(t_float) * e->exp_vsize); \
+            }                                                               \
+            op = optr->ex_vec;                                              \
+            lp = left->ex_vec;                                              \
+            j = e->exp_vsize;                                               \
+            while(j--)                                                      \
+                *op++ = (t_float) (func(leftcast * lp++));                  \
+            break;                                                          \
+        default:                                                            \
+            post_error((fts_object_t *) e,                                  \
+                "expr: FUNV_EVAL_UNARY(%d): bad left type %ld\n", __LINE__, \
+                left->ex_type);                                             \
+    }
 
 #undef min
 #undef max
-#define min(x,y)        (x > y ? y : x)
-#define max(x,y)        (x > y ? x : y)
+#define min(x, y) (x > y ? y : x)
+#define max(x, y) (x > y ? x : y)
 
-#define FUNC_DEF(ex_func, func, castleft, castright, fltret);                   \
-static void                                                             \
-ex_func(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)\
-{                                                                       \
-        struct ex_ex *left, *right;                                     \
-        t_float *op; /* output pointer */                                 \
-        t_float *lp, *rp;         /* left and right vector pointers */    \
+#define FUNC_DEF(ex_func, func, castleft, castright, fltret)              \
+    ;                                                                     \
+    static void ex_func(                                                  \
+        t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr) \
+    {                                                                     \
+        struct ex_ex *left, *right;                                       \
+        t_float *op;      /* output pointer */                            \
+        t_float *lp, *rp; /* left and right vector pointers */            \
         t_float scalar;                                                   \
-        int j;                                                          \
-                                                                        \
-        left = argv++;                                                  \
-        right = argv;                                                   \
-        FUNC_EVAL(left, right, func, castleft, castright, optr, fltret); \
-}
+        int j;                                                            \
+                                                                          \
+        left = argv++;                                                    \
+        right = argv;                                                     \
+        FUNC_EVAL(left, right, func, castleft, castright, optr, fltret);  \
+    }
 
-
-#define FUNC_DEF_UNARY(ex_func, func, cast, fltret);                    \
-static void                                                             \
-ex_func(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)\
-{                                                                       \
-        struct ex_ex *left;                                             \
-        t_float *op; /* output pointer */                                 \
-        t_float *lp, *rp;         /* left and right vector pointers */    \
+#define FUNC_DEF_UNARY(ex_func, func, cast, fltret)                       \
+    ;                                                                     \
+    static void ex_func(                                                  \
+        t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr) \
+    {                                                                     \
+        struct ex_ex *left;                                               \
+        t_float *op;      /* output pointer */                            \
+        t_float *lp, *rp; /* left and right vector pointers */            \
         t_float scalar;                                                   \
-        int j;                                                          \
-                                                                        \
-        left = argv++;                                                  \
-                                                                        \
-        FUNC_EVAL_UNARY(left, func, cast, optr, fltret);                \
-}
+        int j;                                                            \
+                                                                          \
+        left = argv++;                                                    \
+                                                                          \
+        FUNC_EVAL_UNARY(left, func, cast, optr, fltret);                  \
+    }
 
 /*
  * ex_min -- if any of the arguments are or the output are vectors, a vector
  *           of floats is generated otherwise the type of the result is the
  *           type of the smaller value
  */
-static void
-ex_min(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_min(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
+    left = argv++;
+    right = argv;
 
-        FUNC_EVAL(left, right, min, (double), (double), optr, 0);
+    FUNC_EVAL(left, right, min, (double), (double), optr, 0);
 }
 
 /*
@@ -522,752 +581,761 @@ ex_min(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
  *           of floats is generated otherwise the type of the result is the
  *           type of the larger value
  */
-static void
-ex_max(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_max(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
+    left = argv++;
+    right = argv;
 
-        FUNC_EVAL(left, right, max, (double), (double), optr, 0);
+    FUNC_EVAL(left, right, max, (double), (double), optr, 0);
 }
 
 /*
  * ex_toint -- convert to integer
  */
-static void
-ex_toint(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_toint(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-#define toint(x)        ((int)(x))
-                FUNC_EVAL_UNARY(left, toint, (int), optr, 0);
-        }
+#define toint(x) ((int) (x))
+    FUNC_EVAL_UNARY(left, toint, (int), optr, 0);
+}
 
 #if defined _MSC_VER && (_MSC_VER < 1800)
 /* rint is not available for Visual Studio Version < Visual Studio 2013 */
-static double rint(double x)
-{
-        return (floor(x + 0.5));
-}
+static double rint(double x) { return (floor(x + 0.5)); }
 #endif
 
 /*
  * ex_rint -- rint() round to the nearest int according to the common
  *            rounding mechanism
  */
-static void
-ex_rint(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_rint(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-
-        FUNC_EVAL_UNARY(left, rint, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, rint, (double), optr, 1);
 }
 
 /*
  * ex_tofloat -- convert to t_float
  */
-static void
-ex_tofloat(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_tofloat(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-#define tofloat(x)      ((t_float)(x))
-        FUNC_EVAL_UNARY(left, tofloat, (t_float), optr, 1);
+#define tofloat(x) ((t_float) (x))
+    FUNC_EVAL_UNARY(left, tofloat, (t_float), optr, 1);
 }
-
 
 /*
  * ex_pow -- the power of
  */
-static void
-ex_pow(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_pow(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
-        FUNC_EVAL(left, right, pow, (double), (double), optr, 1);
+    left = argv++;
+    right = argv;
+    FUNC_EVAL(left, right, pow, (double), (double), optr, 1);
 }
 
 /*
  * ex_sqrt -- square root
  */
-static void
-ex_sqrt(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_sqrt(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, sqrt, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, sqrt, (double), optr, 1);
 }
 
 /*
  * ex_exp -- e to the power of
  */
-static void
-ex_exp(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_exp(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, exp, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, exp, (double), optr, 1);
 }
 
 /*
  * ex_log -- 10 based logarithm
  */
-static void
-ex_log(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_log(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, log10, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, log10, (double), optr, 1);
 }
 
 /*
  * ex_ln -- natural log
  */
-static void
-ex_ln(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_ln(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, log, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, log, (double), optr, 1);
 }
 
-static void
-ex_sin(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_sin(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, sin, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, sin, (double), optr, 1);
 }
 
-static void
-ex_cos(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_cos(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, cos, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, cos, (double), optr, 1);
 }
 
-
-static void
-ex_tan(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_tan(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, tan, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, tan, (double), optr, 1);
 }
 
-static void
-ex_asin(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_asin(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, asin, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, asin, (double), optr, 1);
 }
 
-static void
-ex_acos(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_acos(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, acos, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, acos, (double), optr, 1);
 }
 
-
-static void
-ex_atan(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_atan(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, atan, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, atan, (double), optr, 1);
 }
 
 /*
  *ex_atan2 --
  */
-static void
-ex_atan2(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_atan2(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
-        FUNC_EVAL(left, right, atan2, (double), (double), optr, 1);
+    left = argv++;
+    right = argv;
+    FUNC_EVAL(left, right, atan2, (double), (double), optr, 1);
 }
 
 /*
  * ex_fmod -- floating point modulo
  */
-static void
-ex_fmod(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_fmod(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
-        FUNC_EVAL(left, right, fmod, (double), (double), optr, 1);
+    left = argv++;
+    right = argv;
+    FUNC_EVAL(left, right, fmod, (double), (double), optr, 1);
 }
-
 
 /*
  * ex_floor -- floor
  */
-static void
-ex_floor(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_floor(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        FUNC_EVAL_UNARY(left, floor, (double), optr, 1);
+    left = argv++;
+    FUNC_EVAL_UNARY(left, floor, (double), optr, 1);
 }
-
 
 /*
  * ex_ceil -- ceil
  */
-static void
-ex_ceil(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_ceil(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        FUNC_EVAL_UNARY(left, ceil, (double), optr, 1);
+    left = argv++;
+    FUNC_EVAL_UNARY(left, ceil, (double), optr, 1);
 }
 
-static void
-ex_sinh(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_sinh(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, sinh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, sinh, (double), optr, 1);
 }
 
-static void
-ex_cosh(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_cosh(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, cosh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, cosh, (double), optr, 1);
 }
 
-
-static void
-ex_tanh(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_tanh(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, tanh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, tanh, (double), optr, 1);
 }
-
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1700)
-static void
-ex_asinh(t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_asinh(
+    t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, asinh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, asinh, (double), optr, 1);
 }
 
-static void
-ex_acosh(t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_acosh(
+    t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, acosh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, acosh, (double), optr, 1);
 }
 
-static void
-ex_atanh(t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_atanh(
+    t_expr *e, long argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, atanh, (double), optr, 1);
+    FUNC_EVAL_UNARY(left, atanh, (double), optr, 1);
 }
 #endif
 
-static double
-ex_dofact(int i)
+static double ex_dofact(int i)
 {
-        float ret = 0;
+    float ret = 0;
 
-        if (i > 0)
-                ret = 1;
-        else
-                return (1);
+    if(i > 0)
+        ret = 1;
+    else
+        return (1);
 
-        do {
-                ret *= i;
-        } while (--i);
+    do
+    {
+        ret *= i;
+    } while(--i);
 
-        return(ret);
+    return (ret);
 }
 
-static void
-ex_fact(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_fact(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, ex_dofact,  (int), optr, 1);
+    FUNC_EVAL_UNARY(left, ex_dofact, (int), optr, 1);
 }
 
-static int
-ex_dorandom(int i1, int i2)
+static int ex_dorandom(int i1, int i2)
 {
-                int i;
-                int j;
+    int i;
+    int j;
 
-                j = rand() & 0x7fffL;
-                i = i1 + (int)((((float)(i2 - i1)) * (float)j) / pow (2, 15));
-                return (i);
+    j = rand() & 0x7fffL;
+    i = i1 + (int) ((((float) (i2 - i1)) * (float) j) / pow(2, 15));
+    return (i);
 }
+
 /*
  * ex_random -- return a random number
  */
-static void
-ex_random(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_random(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left, *right;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left, *right;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
-        right = argv;
-        FUNC_EVAL(left, right, ex_dorandom, (int), (int), optr, 0);
+    left = argv++;
+    right = argv;
+    FUNC_EVAL(left, right, ex_dorandom, (int), (int), optr, 0);
 }
 
-
-static void
-ex_abs(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+static void ex_abs(
+    t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        struct ex_ex *left;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float scalar;
-        int j;
+    struct ex_ex *left;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float scalar;
+    int j;
 
-        left = argv++;
+    left = argv++;
 
-        FUNC_EVAL_UNARY(left, fabs, (double), optr, 0);
+    FUNC_EVAL_UNARY(left, fabs, (double), optr, 0);
 }
 
 /*
  * ex_if -- if function
  */
-struct ex_ex *
-ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr, struct ex_ex *argv, int idx)
+struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
+    struct ex_ex *argv, int idx)
 {
-        struct ex_ex *left, *right, *cond, *res;
-        t_float *op; /* output pointer */
-        t_float *lp, *rp;         /* left and right vector pointers */
-        t_float *cp;              /* condition pointer */
-        t_float leftvalue, rightvalue;
-        int j;
-                int condtrue = 0;
+    struct ex_ex *left, *right, *cond, *res;
+    t_float *op;      /* output pointer */
+    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *cp;      /* condition pointer */
+    t_float leftvalue, rightvalue;
+    int j;
+    int condtrue = 0;
 
-                // evaluate the condition
-                eptr = ex_eval(e, eptr, argv, idx);
-        cond = argv++;
-                // only either the left or right will be evaluated depending
-                // on the truth value of the condition
-                // However, if the condition is a vector, both args will be evaluated
+    // evaluate the condition
+    eptr = ex_eval(e, eptr, argv, idx);
+    cond = argv++;
+    // only either the left or right will be evaluated depending
+    // on the truth value of the condition
+    // However, if the condition is a vector, both args will be evaluated
 
-        switch (cond->ex_type) {
+    switch(cond->ex_type)
+    {
         case ET_VEC:
         case ET_VI:
-                if (optr->ex_type != ET_VEC) {
-                        if (optr->ex_type == ET_VI) {
-                                /* SDY remove this test */
-                                post("expr~: Int. error %d", __LINE__);
-                                return (eptr);
-                        }
-                        optr->ex_type = ET_VEC;
-                        optr->ex_vec = (t_float *)
-                                  fts_malloc(sizeof (t_float) * e->exp_vsize);
-                                                if (!optr->ex_vec) {
-                                                        post("expr:if: no mem");
-                                                        /* pass over the left and right args */
-                                                        return(cond->ex_end->ex_end);
-                                                }
+            if(optr->ex_type != ET_VEC)
+            {
+                if(optr->ex_type == ET_VI)
+                {
+                    /* SDY remove this test */
+                    post("expr~: Int. error %d", __LINE__);
+                    return (eptr);
                 }
-                                /*
-                                 * if the condition is a vector
-                                 * the left and the right args both will get processed
-                                 */
-                                eptr = ex_eval(e, eptr, argv, idx);
-                                left = argv++;
-                                eptr = ex_eval(e, eptr, argv, idx);
-                                right = argv;
-                op = optr->ex_vec;
-                j = e->exp_vsize;
-                cp = cond->ex_vec;
-                switch (left->ex_type) {
+                optr->ex_type = ET_VEC;
+                optr->ex_vec =
+                    (t_float *) fts_malloc(sizeof(t_float) * e->exp_vsize);
+                if(!optr->ex_vec)
+                {
+                    post("expr:if: no mem");
+                    /* pass over the left and right args */
+                    return (cond->ex_end->ex_end);
+                }
+            }
+            /*
+             * if the condition is a vector
+             * the left and the right args both will get processed
+             */
+            eptr = ex_eval(e, eptr, argv, idx);
+            left = argv++;
+            eptr = ex_eval(e, eptr, argv, idx);
+            right = argv;
+            op = optr->ex_vec;
+            j = e->exp_vsize;
+            cp = cond->ex_vec;
+            switch(left->ex_type)
+            {
                 case ET_INT:
-                        leftvalue = left->ex_int;
-                        switch (right->ex_type) {
+                    leftvalue = left->ex_int;
+                    switch(right->ex_type)
+                    {
                         case ET_INT:
-                                rightvalue = right->ex_int;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = rightvalue;
-                                }
-                        return (eptr);
+                            rightvalue = right->ex_int;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = rightvalue;
+                            }
+                            return (eptr);
                         case ET_FLT:
-                                rightvalue = right->ex_flt;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = rightvalue;
-                                }
-                                return (eptr);
+                            rightvalue = right->ex_flt;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = rightvalue;
+                            }
+                            return (eptr);
                         case ET_VEC:
                         case ET_VI:
-                                rp = right->ex_vec;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = *rp;
-                                        rp++;
-                                }
-                                return (eptr);
+                            rp = right->ex_vec;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = *rp;
+                                rp++;
+                            }
+                            return (eptr);
                         case ET_SYM:
                         default:
-                                post_error((fts_object_t *) e,
-                              "expr: FUNC_EVAL(%d): bad right type %ld\n",
-                                                      __LINE__, right->ex_type);
-                                return (eptr);
-                        }
+                            post_error((fts_object_t *) e,
+                                "expr: FUNC_EVAL(%d): bad right type %ld\n",
+                                __LINE__, right->ex_type);
+                            return (eptr);
+                    }
                 case ET_FLT:
-                        leftvalue = left->ex_flt;
-                        switch (right->ex_type) {
+                    leftvalue = left->ex_flt;
+                    switch(right->ex_type)
+                    {
                         case ET_INT:
-                                rightvalue = right->ex_int;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = rightvalue;
-                                }
-                                return (eptr);
+                            rightvalue = right->ex_int;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = rightvalue;
+                            }
+                            return (eptr);
                         case ET_FLT:
-                                rightvalue = right->ex_flt;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = rightvalue;
-                                }
-                                return (eptr);
+                            rightvalue = right->ex_flt;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = rightvalue;
+                            }
+                            return (eptr);
                         case ET_VEC:
                         case ET_VI:
-                                rp = right->ex_vec;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = leftvalue;
-                                        else
-                                                *op++ = *rp;
-                                        rp++;
-                                }
-                                return (eptr);
+                            rp = right->ex_vec;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = leftvalue;
+                                else
+                                    *op++ = *rp;
+                                rp++;
+                            }
+                            return (eptr);
                         case ET_SYM:
                         default:
-                                post_error((fts_object_t *) e,
-                              "expr: FUNC_EVAL(%d): bad right type %ld\n",
-                                                      __LINE__, right->ex_type);
-                                return (eptr);
-                        }
+                            post_error((fts_object_t *) e,
+                                "expr: FUNC_EVAL(%d): bad right type %ld\n",
+                                __LINE__, right->ex_type);
+                            return (eptr);
+                    }
                 case ET_VEC:
                 case ET_VI:
-                        lp = left->ex_vec;
-                        switch (right->ex_type) {
+                    lp = left->ex_vec;
+                    switch(right->ex_type)
+                    {
                         case ET_INT:
-                                rightvalue = right->ex_int;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = *lp;
-                                        else
-                                                *op++ = rightvalue;
-                                        lp++;
-                                }
-                                return (eptr);
+                            rightvalue = right->ex_int;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = *lp;
+                                else
+                                    *op++ = rightvalue;
+                                lp++;
+                            }
+                            return (eptr);
                         case ET_FLT:
-                                rightvalue = right->ex_flt;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = *lp;
-                                        else
-                                                *op++ = rightvalue;
-                                        lp++;
-                                }
-                                return (eptr);
+                            rightvalue = right->ex_flt;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = *lp;
+                                else
+                                    *op++ = rightvalue;
+                                lp++;
+                            }
+                            return (eptr);
                         case ET_VEC:
                         case ET_VI:
-                                rp = right->ex_vec;
-                                while (j--) {
-                                        if (*cp++)
-                                                *op++ = *lp;
-                                        else
-                                                *op++ = *rp;
-                                        lp++; rp++;
-                                }
-                                return (eptr);
+                            rp = right->ex_vec;
+                            while(j--)
+                            {
+                                if(*cp++)
+                                    *op++ = *lp;
+                                else
+                                    *op++ = *rp;
+                                lp++;
+                                rp++;
+                            }
+                            return (eptr);
                         case ET_SYM:
                         default:
-                                post_error((fts_object_t *) e,
-                              "expr: FUNC_EVAL(%d): bad right type %ld\n",
-                                                      __LINE__, right->ex_type);
-                                return (eptr);
-                        }
+                            post_error((fts_object_t *) e,
+                                "expr: FUNC_EVAL(%d): bad right type %ld\n",
+                                __LINE__, right->ex_type);
+                            return (eptr);
+                    }
                 case ET_SYM:
                 default:
-                        post_error((fts_object_t *) e,
-                      "expr: FUNC_EVAL(%d): bad left type %ld\n",
-                                              __LINE__, left->ex_type);
-                        return (eptr);
-                }
+                    post_error((fts_object_t *) e,
+                        "expr: FUNC_EVAL(%d): bad left type %ld\n", __LINE__,
+                        left->ex_type);
+                    return (eptr);
+            }
         case ET_INT:
-                if (cond->ex_int)
-                        condtrue = 1;
-                else
-                        condtrue = 0;
-                break;
+            if(cond->ex_int)
+                condtrue = 1;
+            else
+                condtrue = 0;
+            break;
         case ET_FLT:
-                if (cond->ex_flt)
-                        condtrue = 1;
-                else
-                        condtrue = 0;
-                break;
+            if(cond->ex_flt)
+                condtrue = 1;
+            else
+                condtrue = 0;
+            break;
         case ET_SYM:
         default:
-                post_error((fts_object_t *) e,
-              "expr: FUNC_EVAL(%d): bad condition type %ld\n",
-                                      __LINE__, cond->ex_type);
-                return (eptr);
-        }
-                if (condtrue) {
-                        eptr = ex_eval(e, eptr, argv, idx);
-                        res = argv++;
-                        if (!eptr)
-                                return (exNULL);
-                        eptr = eptr->ex_end; /* no right processing */
-
-                } else {
-                        if (!eptr)
-                                return (exNULL);
-                        eptr = eptr->ex_end; /* no left rocessing */
-                        eptr = ex_eval(e, eptr, argv, idx);
-                        res = argv++;
-                }
-        switch(res->ex_type) {
+            post_error((fts_object_t *) e,
+                "expr: FUNC_EVAL(%d): bad condition type %ld\n", __LINE__,
+                cond->ex_type);
+            return (eptr);
+    }
+    if(condtrue)
+    {
+        eptr = ex_eval(e, eptr, argv, idx);
+        res = argv++;
+        if(!eptr) return (exNULL);
+        eptr = eptr->ex_end; /* no right processing */
+    }
+    else
+    {
+        if(!eptr) return (exNULL);
+        eptr = eptr->ex_end; /* no left rocessing */
+        eptr = ex_eval(e, eptr, argv, idx);
+        res = argv++;
+    }
+    switch(res->ex_type)
+    {
         case ET_INT:
-                if (optr->ex_type == ET_VEC) {
-                        ex_mkvector(optr->ex_vec, (t_float)res->ex_int,
-                                                                e->exp_vsize);
-                        return (eptr);
-                }
-                *optr = *res;
+            if(optr->ex_type == ET_VEC)
+            {
+                ex_mkvector(optr->ex_vec, (t_float) res->ex_int, e->exp_vsize);
                 return (eptr);
+            }
+            *optr = *res;
+            return (eptr);
         case ET_FLT:
-                if (optr->ex_type == ET_VEC) {
-                        ex_mkvector(optr->ex_vec, (t_float)res->ex_flt,
-                                                                e->exp_vsize);
-                        return (eptr);
-                }
-                *optr = *res;
+            if(optr->ex_type == ET_VEC)
+            {
+                ex_mkvector(optr->ex_vec, (t_float) res->ex_flt, e->exp_vsize);
                 return (eptr);
+            }
+            *optr = *res;
+            return (eptr);
         case ET_VEC:
         case ET_VI:
-                if (optr->ex_type != ET_VEC) {
-                        if (optr->ex_type == ET_VI) {
-                                /* SDY remove this test */
-                                post("expr~: Int. error %d", __LINE__);
-                                return (eptr);
-                        }
-                        optr->ex_type = ET_VEC;
-                        optr->ex_vec = (t_float *)
-                                  fts_malloc(sizeof (t_float) * e->exp_vsize);
-                                                if (!optr->ex_vec) {
-                                                        post("expr:if: no mem");
-                            return (eptr);
-                                                }
+            if(optr->ex_type != ET_VEC)
+            {
+                if(optr->ex_type == ET_VI)
+                {
+                    /* SDY remove this test */
+                    post("expr~: Int. error %d", __LINE__);
+                    return (eptr);
                 }
-                memcpy(optr->ex_vec, res->ex_vec, e->exp_vsize*sizeof(t_float));
-                return (eptr);
+                optr->ex_type = ET_VEC;
+                optr->ex_vec =
+                    (t_float *) fts_malloc(sizeof(t_float) * e->exp_vsize);
+                if(!optr->ex_vec)
+                {
+                    post("expr:if: no mem");
+                    return (eptr);
+                }
+            }
+            memcpy(optr->ex_vec, res->ex_vec, e->exp_vsize * sizeof(t_float));
+            return (eptr);
         case ET_SYM:
         default:
-                post_error((fts_object_t *) e,
-              "expr: FUNC_EVAL(%d): bad res type %ld\n",
-                                      __LINE__, res->ex_type);
-                return (eptr);
-        }
-
+            post_error((fts_object_t *) e,
+                "expr: FUNC_EVAL(%d): bad res type %ld\n", __LINE__,
+                res->ex_type);
+            return (eptr);
+    }
 }
 
 /*
  * ex_imodf -   extract signed integral value from floating-point number
  */
-static double
-imodf(double x)
+static double imodf(double x)
 {
-        double  xx;
+    double xx;
 
-        modf(x, &xx);
-        return (xx);
+    modf(x, &xx);
+    return (xx);
 }
+
 FUNC_DEF_UNARY(ex_imodf, imodf, (double), 1);
 
 /*
@@ -1275,15 +1343,14 @@ FUNC_DEF_UNARY(ex_imodf, imodf, (double), 1);
  *
  *  using fracmodf because fmodf() is already defined in a .h file
  */
-static double
-fracmodf(double x)
+static double fracmodf(double x)
 {
-        double  xx;
+    double xx;
 
-        return(modf(x, &xx));
+    return (modf(x, &xx));
 }
-FUNC_DEF_UNARY(ex_modf, fracmodf, (double), 1);
 
+FUNC_DEF_UNARY(ex_modf, fracmodf, (double), 1);
 
 FUNC_DEF_UNARY(ex_mtof, mtof, (double), 1);
 FUNC_DEF_UNARY(ex_ftom, ftom, (double), 1);

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -1012,9 +1012,13 @@ static double ex_dofact(int i)
     float ret = 0;
 
     if(i > 0)
+    {
         ret = 1;
+    }
     else
+    {
         return (1);
+    }
 
     do
     {
@@ -1153,9 +1157,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                             }
                             return (eptr);
                         case ET_FLT:
@@ -1163,9 +1171,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                             }
                             return (eptr);
                         case ET_VEC:
@@ -1174,9 +1186,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = *rp;
+                                }
                                 rp++;
                             }
                             return (eptr);
@@ -1196,9 +1212,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                             }
                             return (eptr);
                         case ET_FLT:
@@ -1206,9 +1226,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                             }
                             return (eptr);
                         case ET_VEC:
@@ -1217,9 +1241,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = leftvalue;
+                                }
                                 else
+                                {
                                     *op++ = *rp;
+                                }
                                 rp++;
                             }
                             return (eptr);
@@ -1240,9 +1268,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = *lp;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                                 lp++;
                             }
                             return (eptr);
@@ -1251,9 +1283,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = *lp;
+                                }
                                 else
+                                {
                                     *op++ = rightvalue;
+                                }
                                 lp++;
                             }
                             return (eptr);
@@ -1263,9 +1299,13 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
                             while(j--)
                             {
                                 if(*cp++)
+                                {
                                     *op++ = *lp;
+                                }
                                 else
+                                {
                                     *op++ = *rp;
+                                }
                                 lp++;
                                 rp++;
                             }
@@ -1286,15 +1326,23 @@ struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
             }
         case ET_INT:
             if(cond->ex_int)
+            {
                 condtrue = 1;
+            }
             else
+            {
                 condtrue = 0;
+            }
             break;
         case ET_FLT:
             if(cond->ex_flt)
+            {
                 condtrue = 1;
+            }
             else
+            {
                 condtrue = 0;
+            }
             break;
         case ET_SYM:
         default:

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -564,9 +564,11 @@ t_ex_func ex_funcs[] = {{"min", ex_min, 2}, {"max", ex_max, 2},
 static void ex_min(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -584,9 +586,11 @@ static void ex_min(
 static void ex_max(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -604,7 +608,8 @@ static void ex_toint(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -628,7 +633,8 @@ static void ex_rint(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -645,7 +651,8 @@ static void ex_tofloat(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -661,9 +668,11 @@ static void ex_tofloat(
 static void ex_pow(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -680,7 +689,8 @@ static void ex_sqrt(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -697,7 +707,8 @@ static void ex_exp(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -714,7 +725,8 @@ static void ex_log(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -731,7 +743,8 @@ static void ex_ln(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -745,7 +758,8 @@ static void ex_sin(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -759,7 +773,8 @@ static void ex_cos(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -773,7 +788,8 @@ static void ex_tan(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -787,7 +803,8 @@ static void ex_asin(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -801,7 +818,8 @@ static void ex_acos(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -815,7 +833,8 @@ static void ex_atan(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -830,9 +849,11 @@ static void ex_atan(
 static void ex_atan2(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -847,9 +868,11 @@ static void ex_atan2(
 static void ex_fmod(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -866,7 +889,8 @@ static void ex_floor(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -882,7 +906,8 @@ static void ex_ceil(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -895,7 +920,8 @@ static void ex_sinh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -909,7 +935,8 @@ static void ex_cosh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -923,7 +950,8 @@ static void ex_tanh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -938,7 +966,8 @@ static void ex_asinh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -952,7 +981,8 @@ static void ex_acosh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -966,7 +996,8 @@ static void ex_atanh(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -998,7 +1029,8 @@ static void ex_fact(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -1023,9 +1055,11 @@ static int ex_dorandom(int i1, int i2)
 static void ex_random(
     t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-    struct ex_ex *left, *right;
+    struct ex_ex *left;
+    struct ex_ex *right;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -1039,7 +1073,8 @@ static void ex_abs(
 {
     struct ex_ex *left;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp; /* left and right vector pointers */
     t_float scalar;
     int j;
 
@@ -1054,11 +1089,16 @@ static void ex_abs(
 struct ex_ex *ex_if(t_expr *e, struct ex_ex *eptr, struct ex_ex *optr,
     struct ex_ex *argv, int idx)
 {
-    struct ex_ex *left, *right, *cond, *res;
+    struct ex_ex *left;
+    struct ex_ex *right;
+    struct ex_ex *cond;
+    struct ex_ex *res;
     t_float *op;      /* output pointer */
-    t_float *lp, *rp; /* left and right vector pointers */
+    t_float *lp;
+    t_float *rp;      /* left and right vector pointers */
     t_float *cp;      /* condition pointer */
-    t_float leftvalue, rightvalue;
+    t_float leftvalue;
+    t_float rightvalue;
     int j;
     int condtrue = 0;
 

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -49,11 +49,9 @@ t_int *expr_perform(t_int *w);
 
 static void expr_list(t_expr *x, t_symbol *s, int argc, const fts_atom_t *argv)
 {
-    int i;
-
     if(argc > MAX_VARS) argc = MAX_VARS;
 
-    for(i = 0; i < argc; i++)
+    for(int i = 0; i < argc; i++)
     {
         if(argv[i].a_type == A_FLOAT)
         {
@@ -143,7 +141,6 @@ void exprproxy_float(t_exprproxy *p, t_floatarg f)
 static void expr_ff(t_expr *x)
 {
     t_exprproxy *y;
-    int i;
 
     y = x->exp_proxy;
     while(y)
@@ -157,13 +154,13 @@ static void expr_ff(t_expr *x)
 #endif
         y = x->exp_proxy;
     }
-    for(i = 0; i < x->exp_nexpr; i++)
+    for(int i = 0; i < x->exp_nexpr; i++)
         if(x->exp_stack[i]) fts_free(x->exp_stack[i]);
     /*
      * SDY free all the allocated buffers here for expr~ and fexpr~
      * check to see if there are others
      */
-    for(i = 0; i < MAX_VARS; i++)
+    for(int i = 0; i < MAX_VARS; i++)
     {
         if(x->exp_p_var[i]) fts_free(x->exp_p_var[i]);
         if(x->exp_p_res[i]) fts_free(x->exp_p_res[i]);
@@ -420,7 +417,6 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
 
 t_int *expr_perform(t_int *w)
 {
-    int i;
     int j;
     t_expr *x = (t_expr *) w[1];
     struct ex_ex res;
@@ -435,7 +431,7 @@ t_int *expr_perform(t_int *w)
 
     if(x->exp_flags & EF_STOP)
     {
-        for(i = 0; i < x->exp_nexpr; i++)
+        for(int i = 0; i < x->exp_nexpr; i++)
             memset(x->exp_res[i].ex_vec, 0, x->exp_vsize * sizeof(t_float));
         return (w + 2);
     }
@@ -455,13 +451,13 @@ t_int *expr_perform(t_int *w)
         else
         {
             res.ex_type = ET_VEC;
-            for(i = 0; i < x->exp_nexpr; i++)
+            for(int i = 0; i < x->exp_nexpr; i++)
             {
                 res.ex_vec = x->exp_tmpres[i];
                 ex_eval(x, x->exp_stack[i], &res, 0);
             }
             n = x->exp_vsize * sizeof(t_float);
-            for(i = 0; i < x->exp_nexpr; i++)
+            for(int i = 0; i < x->exp_nexpr; i++)
                 memcpy(x->exp_res[i].ex_vec, x->exp_tmpres[i], n);
         }
         return (w + 2);
@@ -477,7 +473,7 @@ t_int *expr_perform(t_int *w)
      * since the output buffer could be the same as one of the inputs
      * we need to keep the output in  a different buffer
      */
-    for(i = 0; i < x->exp_vsize; i++)
+    for(int i = 0; i < x->exp_vsize; i++)
     {
         for(j = 0; j < x->exp_nexpr; j++)
         {
@@ -503,12 +499,12 @@ t_int *expr_perform(t_int *w)
      * same as an input buffer
      */
     n = x->exp_vsize * sizeof(t_float);
-    for(i = 0; i < MAX_VARS; i++)
+    for(int i = 0; i < MAX_VARS; i++)
     {
         if(x->exp_var[i].ex_type == ET_XI)
             memcpy(x->exp_p_var[i], x->exp_var[i].ex_vec, n);
     }
-    for(i = 0; i < x->exp_nexpr; i++)
+    for(int i = 0; i < x->exp_nexpr; i++)
     {
         memcpy(x->exp_p_res[i], x->exp_tmpres[i], n);
         memcpy(x->exp_res[i].ex_vec, x->exp_tmpres[i], n);
@@ -645,7 +641,6 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sx;
     int vecno;
-    int i;
     int nargs;
 
     if(!argc) return;
@@ -692,7 +687,7 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
                     x->exp_vsize);
                 nargs = x->exp_vsize;
             }
-            for(i = 0; i < nargs; i++)
+            for(int i = 0; i < nargs; i++)
             {
                 x->exp_p_var[vecno][x->exp_vsize - i - 1] =
                     atom_getfloatarg(i + 1, argc, argv);
@@ -733,7 +728,7 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
                     x->exp_vsize);
                 nargs = x->exp_vsize;
             }
-            for(i = 0; i < nargs; i++)
+            for(int i = 0; i < nargs; i++)
             {
                 x->exp_p_res[vecno][x->exp_vsize - i - 1] =
                     atom_getfloatarg(i + 1, argc, argv);
@@ -745,7 +740,7 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
                 post("fexpr~.set: only %d outlets available", x->exp_nexpr);
                 post("fexpr~.set: the extra set values are ignored");
             }
-            for(i = 0; i < x->exp_nexpr && i < argc; i++)
+            for(int i = 0; i < x->exp_nexpr && i < argc; i++)
                 x->exp_p_res[i][x->exp_vsize - 1] =
                     atom_getfloatarg(i, argc, argv);
             return;
@@ -762,7 +757,6 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sx;
     int vecno;
-    int i;
     int nargs;
 
     /*
@@ -770,9 +764,9 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
      */
     if(!argc)
     {
-        for(i = 0; i < x->exp_nexpr; i++)
+        for(int i = 0; i < x->exp_nexpr; i++)
             memset(x->exp_p_res[i], 0, x->exp_vsize * sizeof(t_float));
-        for(i = 0; i < MAX_VARS; i++)
+        for(int i = 0; i < MAX_VARS; i++)
         {
             if(x->exp_var[i].ex_type == ET_XI)
                 memset(x->exp_p_var[i], 0, x->exp_vsize * sizeof(t_float));

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -1,6 +1,6 @@
 /* Copyright (c) IRCAM.
-* For information on usage and redistribution, and for a DISCLAIMER OF ALL
-* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
 
 /* "expr" was written by Shahrokh Yadegari c. 1989. -msp */
 /* "expr~" and "fexpr~" conversion by Shahrokh Yadegari c. 1999,2000 */
@@ -27,8 +27,8 @@
 
 static char *exp_version = "0.57";
 
-extern struct ex_ex *ex_eval(struct expr *expr, struct ex_ex *eptr,
-                                                struct ex_ex *optr, int n);
+extern struct ex_ex *ex_eval(
+    struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int n);
 
 #ifdef PD
 static t_class *expr_class;
@@ -37,7 +37,6 @@ static t_class *fexpr_tilde_class;
 #else /* MSP */
 void *expr_tilde_class;
 #endif
-
 
 /*------------------------- expr class -------------------------------------*/
 
@@ -48,182 +47,170 @@ extern int expr_donew(struct expr *expr, int ac, t_atom *av);
 static void expr_bang(t_expr *x);
 t_int *expr_perform(t_int *w);
 
-
-static void
-expr_list(t_expr *x, t_symbol *s, int argc, const fts_atom_t *argv)
+static void expr_list(t_expr *x, t_symbol *s, int argc, const fts_atom_t *argv)
 {
-        int i;
+    int i;
 
-        if (argc > MAX_VARS) argc = MAX_VARS;
+    if(argc > MAX_VARS) argc = MAX_VARS;
 
-        for (i = 0; i < argc; i++)
+    for(i = 0; i < argc; i++)
+    {
+        if(argv[i].a_type == A_FLOAT)
         {
-                if (argv[i].a_type == A_FLOAT)
-                {
-                        if (x->exp_var[i].ex_type == ET_FI)
-                                x->exp_var[i].ex_flt = argv[i].a_w.w_float;
-                        else if (x->exp_var[i].ex_type == ET_II)
-                                x->exp_var[i].ex_int = argv[i].a_w.w_float;
-                        else if (x->exp_var[i].ex_type)
-                            pd_error(x, "expr: type mismatch");
-                }
-                else if (argv[i].a_type == A_SYMBOL)
-                {
-                        if (x->exp_var[i].ex_type == ET_SI)
-                                x->exp_var[i].ex_ptr = (char *)argv[i].a_w.w_symbol;
-                        else if (x->exp_var[i].ex_type)
-                            pd_error(x, "expr: type mismatch");
-                }
+            if(x->exp_var[i].ex_type == ET_FI)
+                x->exp_var[i].ex_flt = argv[i].a_w.w_float;
+            else if(x->exp_var[i].ex_type == ET_II)
+                x->exp_var[i].ex_int = argv[i].a_w.w_float;
+            else if(x->exp_var[i].ex_type)
+                pd_error(x, "expr: type mismatch");
         }
-        expr_bang(x);
+        else if(argv[i].a_type == A_SYMBOL)
+        {
+            if(x->exp_var[i].ex_type == ET_SI)
+                x->exp_var[i].ex_ptr = (char *) argv[i].a_w.w_symbol;
+            else if(x->exp_var[i].ex_type)
+                pd_error(x, "expr: type mismatch");
+        }
+    }
+    expr_bang(x);
 }
 
-static void
-expr_flt(t_expr *x, t_float f, int in)
+static void expr_flt(t_expr *x, t_float f, int in)
 {
-        if (in >= MAX_VARS)
-                return;
+    if(in >= MAX_VARS) return;
 
-        if (x->exp_var[in].ex_type == ET_FI)
-                x->exp_var[in].ex_flt = f;
-        else if (x->exp_var[in].ex_type == ET_II)
-                x->exp_var[in].ex_int = f;
+    if(x->exp_var[in].ex_type == ET_FI)
+        x->exp_var[in].ex_flt = f;
+    else if(x->exp_var[in].ex_type == ET_II)
+        x->exp_var[in].ex_int = f;
 }
 
 static t_class *exprproxy_class;
 
-typedef struct _exprproxy {
-        t_pd p_pd;
-        int p_index;
-        t_expr *p_owner;
-        struct _exprproxy *p_next;
+typedef struct _exprproxy
+{
+    t_pd p_pd;
+    int p_index;
+    t_expr *p_owner;
+    struct _exprproxy *p_next;
 } t_exprproxy;
 
 t_exprproxy *exprproxy_new(t_expr *owner, int indx);
 void exprproxy_float(t_exprproxy *p, t_floatarg f);
 
-t_exprproxy *
-exprproxy_new(t_expr *owner, int indx)
+t_exprproxy *exprproxy_new(t_expr *owner, int indx)
 {
-        t_exprproxy *x = (t_exprproxy *)pd_new(exprproxy_class);
-        x->p_owner = owner;
-        x->p_index = indx;
-        x->p_next = owner->exp_proxy;
-        owner->exp_proxy = x;
-        return (x);
+    t_exprproxy *x = (t_exprproxy *) pd_new(exprproxy_class);
+    x->p_owner = owner;
+    x->p_index = indx;
+    x->p_next = owner->exp_proxy;
+    owner->exp_proxy = x;
+    return (x);
 }
 
-void
-exprproxy_float(t_exprproxy *p, t_floatarg f)
+void exprproxy_float(t_exprproxy *p, t_floatarg f)
 {
-        t_expr *x = p->p_owner;
-        int in = p->p_index;
+    t_expr *x = p->p_owner;
+    int in = p->p_index;
 
-        if (in >= MAX_VARS)
-                return;
+    if(in >= MAX_VARS) return;
 
-        if (x->exp_var[in].ex_type == ET_FI)
-                x->exp_var[in].ex_flt = f;
-        else if (x->exp_var[in].ex_type == ET_II)
-                x->exp_var[in].ex_int = f;
+    if(x->exp_var[in].ex_type == ET_FI)
+        x->exp_var[in].ex_flt = f;
+    else if(x->exp_var[in].ex_type == ET_II)
+        x->exp_var[in].ex_int = f;
 }
 
 /* method definitions */
-static void
-expr_ff(t_expr *x)
+static void expr_ff(t_expr *x)
 {
-        t_exprproxy *y;
-        int i;
+    t_exprproxy *y;
+    int i;
 
-        y = x->exp_proxy;
-        while (y)
-        {
-                x->exp_proxy = y->p_next;
+    y = x->exp_proxy;
+    while(y)
+    {
+        x->exp_proxy = y->p_next;
 #ifdef PD
-                pd_free(&y->p_pd);
+        pd_free(&y->p_pd);
 #else /*MSP */
         /* SDY find out what needs to be called for MSP */
 
 #endif
-                y = x->exp_proxy;
-        }
-        for (i = 0 ; i < x->exp_nexpr; i++)
-                if (x->exp_stack[i])
-                        fts_free(x->exp_stack[i]);
-/*
- * SDY free all the allocated buffers here for expr~ and fexpr~
- * check to see if there are others
- */
-        for (i = 0; i < MAX_VARS; i++) {
-                if (x->exp_p_var[i])
-                        fts_free(x->exp_p_var[i]);
-                if (x->exp_p_res[i])
-                        fts_free(x->exp_p_res[i]);
-                if (x->exp_tmpres[i])
-                        fts_free(x->exp_tmpres[i]);
-        }
-
-
+        y = x->exp_proxy;
+    }
+    for(i = 0; i < x->exp_nexpr; i++)
+        if(x->exp_stack[i]) fts_free(x->exp_stack[i]);
+    /*
+     * SDY free all the allocated buffers here for expr~ and fexpr~
+     * check to see if there are others
+     */
+    for(i = 0; i < MAX_VARS; i++)
+    {
+        if(x->exp_p_var[i]) fts_free(x->exp_p_var[i]);
+        if(x->exp_p_res[i]) fts_free(x->exp_p_res[i]);
+        if(x->exp_tmpres[i]) fts_free(x->exp_tmpres[i]);
+    }
 }
 
-static void
-expr_bang(t_expr *x)
+static void expr_bang(t_expr *x)
 {
-        int i;
+    int i;
 
 #ifdef EXPR_DEBUG
+    {
+        struct ex_ex *eptr;
+
+        for(i = 0, eptr = x->exp_var;; eptr++, i++)
         {
-                struct ex_ex *eptr;
+            if(!eptr->ex_type) break;
+            switch(eptr->ex_type)
+            {
+                case ET_II:
+                    fprintf(stderr, "ET_II: %d \n", eptr->ex_int);
+                    break;
 
-                for (i = 0, eptr = x->exp_var;  ; eptr++, i++)
-                {
-                        if (!eptr->ex_type)
-                                break;
-                        switch (eptr->ex_type)
-                        {
-                        case ET_II:
-                                fprintf(stderr,"ET_II: %d \n", eptr->ex_int);
-                                break;
-
-                        case ET_FI:
-                                fprintf(stderr,"ET_FT: %f \n", eptr->ex_flt);
-                                break;
-
-                        default:
-                                fprintf(stderr,"oups\n");
-                        }
-                }
-        }
-#endif
-        /* banging a signal or filter object means nothing */
-        if (!IS_EXPR(x))
-                return;
-
-        for (i = x->exp_nexpr - 1; i > -1 ; i--) {
-                if (!ex_eval(x, x->exp_stack[i], &x->exp_res[i], 0)) {
-                        /*fprintf(stderr,"expr_bang(error evaluation)\n"); */
-                /*  SDY now that we have multiple ones, on error we should
-                 * continue
-                        return;
-                 */
-                }
-                switch(x->exp_res[i].ex_type) {
-                case ET_INT:
-                        outlet_float(x->exp_outlet[i],
-                                        (t_float) x->exp_res[i].ex_int);
-                        break;
-
-                case ET_FLT:
-                        outlet_float(x->exp_outlet[i],  x->exp_res[i].ex_flt);
-                        break;
-
-                case ET_SYM:
-                        /* CHANGE this will have to be taken care of */
+                case ET_FI:
+                    fprintf(stderr, "ET_FT: %f \n", eptr->ex_flt);
+                    break;
 
                 default:
-                        post("expr: bang: unrecognized result %ld\n", x->exp_res[i].ex_type);
-                }
+                    fprintf(stderr, "oups\n");
+            }
         }
+    }
+#endif
+    /* banging a signal or filter object means nothing */
+    if(!IS_EXPR(x)) return;
+
+    for(i = x->exp_nexpr - 1; i > -1; i--)
+    {
+        if(!ex_eval(x, x->exp_stack[i], &x->exp_res[i], 0))
+        {
+            /*fprintf(stderr,"expr_bang(error evaluation)\n"); */
+            /*  SDY now that we have multiple ones, on error we should
+             * continue
+                    return;
+             */
+        }
+        switch(x->exp_res[i].ex_type)
+        {
+            case ET_INT:
+                outlet_float(x->exp_outlet[i], (t_float) x->exp_res[i].ex_int);
+                break;
+
+            case ET_FLT:
+                outlet_float(x->exp_outlet[i], x->exp_res[i].ex_flt);
+                break;
+
+            case ET_SYM:
+                /* CHANGE this will have to be taken care of */
+
+            default:
+                post("expr: bang: unrecognized result %ld\n",
+                    x->exp_res[i].ex_type);
+        }
+    }
 }
 
 static t_expr *
@@ -233,367 +220,382 @@ expr_new(t_symbol *s, int ac, t_atom *av)
 Nexpr_new(t_symbol *s, int ac, t_atom *av)
 #endif
 {
-        struct expr *x;
-        int i, ninlet;
-        struct ex_ex *eptr;
-        t_atom fakearg;
-        int dsp_index;  /* keeping track of the dsp inlets */
+    struct expr *x;
+    int i, ninlet;
+    struct ex_ex *eptr;
+    t_atom fakearg;
+    int dsp_index; /* keeping track of the dsp inlets */
 
+    /*
+     * SDY - we may need to call dsp_setup() in this function
+     */
 
-/*
- * SDY - we may need to call dsp_setup() in this function
- */
-
-        if (!ac)
-        {
-                ac = 1;
-                av = &fakearg;
-                SETFLOAT(&fakearg, 0);
-        }
+    if(!ac)
+    {
+        ac = 1;
+        av = &fakearg;
+        SETFLOAT(&fakearg, 0);
+    }
 
 #ifdef PD
-        /*
-         * figure out if we are expr, expr~, or fexpr~
-         */
-        if (!strcmp("expr", s->s_name)) {
-                x = (t_expr *)pd_new(expr_class);
-                SET_EXPR(x);
-        } else if (!strcmp("expr~", s->s_name)) {
-                x = (t_expr *)pd_new(expr_tilde_class);
-                SET_EXPR_TILDE(x);
-        } else if (!strcmp("fexpr~", s->s_name)) {
-                x = (t_expr *)pd_new(fexpr_tilde_class);
-                SET_FEXPR_TILDE(x);
-        } else {
-                post("expr_new: bad object name '%s'", s->s_name);
-                /* assume expr */
-                x = (t_expr *)pd_new(expr_class);
-                SET_EXPR(x);
-        }
-#else /* MSP */
-        /* for now assume an expr~ */
-        x = (t_expr *)pd_new(expr_tilde_class);
+    /*
+     * figure out if we are expr, expr~, or fexpr~
+     */
+    if(!strcmp("expr", s->s_name))
+    {
+        x = (t_expr *) pd_new(expr_class);
+        SET_EXPR(x);
+    }
+    else if(!strcmp("expr~", s->s_name))
+    {
+        x = (t_expr *) pd_new(expr_tilde_class);
         SET_EXPR_TILDE(x);
+    }
+    else if(!strcmp("fexpr~", s->s_name))
+    {
+        x = (t_expr *) pd_new(fexpr_tilde_class);
+        SET_FEXPR_TILDE(x);
+    }
+    else
+    {
+        post("expr_new: bad object name '%s'", s->s_name);
+        /* assume expr */
+        x = (t_expr *) pd_new(expr_class);
+        SET_EXPR(x);
+    }
+#else /* MSP */
+    /* for now assume an expr~ */
+    x = (t_expr *) pd_new(expr_tilde_class);
+    SET_EXPR_TILDE(x);
 #endif
 
+    /*
+     * initialize the newly allocated object
+     */
+    x->exp_proxy = 0;
+    x->exp_nivec = 0;
+    x->exp_nexpr = 0;
+    x->exp_error = 0;
+    for(i = 0; i < MAX_VARS; i++)
+    {
+        x->exp_stack[i] = (struct ex_ex *) 0;
+        x->exp_outlet[i] = (t_outlet *) 0;
+        x->exp_res[i].ex_type = 0;
+        x->exp_res[i].ex_int = 0;
+        x->exp_p_res[i] = (t_float *) 0;
+        x->exp_var[i].ex_type = 0;
+        x->exp_var[i].ex_int = 0;
+        x->exp_p_var[i] = (t_float *) 0;
+        x->exp_tmpres[i] = (t_float *) 0;
+        x->exp_vsize = 0;
+    }
+    x->exp_f = 0; /* save the control value to be transformed to signal */
+
+    if(expr_donew(x, ac, av))
+    {
+        pd_error(x, "expr: syntax error");
         /*
-         * initialize the newly allocated object
-         */
-        x->exp_proxy = 0;
-        x->exp_nivec = 0;
-        x->exp_nexpr = 0;
-        x->exp_error = 0;
-        for (i = 0; i < MAX_VARS; i++) {
-                x->exp_stack[i] = (struct ex_ex *)0;
-                x->exp_outlet[i] = (t_outlet *)0;
-                x->exp_res[i].ex_type = 0;
-                x->exp_res[i].ex_int = 0;
-                x->exp_p_res[i] = (t_float *)0;
-                x->exp_var[i].ex_type = 0;
-                x->exp_var[i].ex_int = 0;
-                x->exp_p_var[i] = (t_float *)0;
-                x->exp_tmpres[i] = (t_float *)0;
-                x->exp_vsize = 0;
-        }
-        x->exp_f = 0; /* save the control value to be transformed to signal */
+        SDY the following coredumps why?
+                        pd_free(&x->exp_ob.ob_pd);
+        */
+        return (0);
+    }
 
-
-        if (expr_donew(x, ac, av))
+    ninlet = 1;
+    for(i = 0, eptr = x->exp_var; i < MAX_VARS; i++, eptr++)
+        if(eptr->ex_type)
         {
-                pd_error(x, "expr: syntax error");
-/*
-SDY the following coredumps why?
-                pd_free(&x->exp_ob.ob_pd);
-*/
-                return (0);
+            ninlet = i + 1;
         }
 
-        ninlet = 1;
-        for (i = 0, eptr = x->exp_var; i < MAX_VARS ; i++, eptr++)
-                if (eptr->ex_type) {
-                        ninlet = i + 1;
-                }
-
-        /*
-         * create the new inlets
-         */
-        for (i = 1, eptr = x->exp_var + 1, dsp_index=1; i<ninlet ; i++, eptr++)
+    /*
+     * create the new inlets
+     */
+    for(i = 1, eptr = x->exp_var + 1, dsp_index = 1; i < ninlet; i++, eptr++)
+    {
+        t_exprproxy *p;
+        switch(eptr->ex_type)
         {
-                t_exprproxy *p;
-                switch (eptr->ex_type)
+            case 0:
+                /* nothing is using this inlet */
+                if(i < ninlet)
+#ifdef PD
+                    floatinlet_new(&x->exp_ob, &eptr->ex_flt);
+#else /* MSP */
+                    inlet_new(&x->exp_ob, "float");
+#endif
+                break;
+
+            case ET_II:
+            case ET_FI:
+                p = exprproxy_new(x, i);
+#ifdef PD
+                inlet_new(&x->exp_ob, &p->p_pd, &s_float, &s_float);
+#else /* MSP */
+                inlet_new(&x->exp_ob, "float");
+#endif
+                break;
+
+            case ET_SI:
+#ifdef PD
+                symbolinlet_new(&x->exp_ob, (t_symbol **) &eptr->ex_ptr);
+#else /* MSP */
+                inlet_new(&x->exp_ob, "symbol");
+#endif
+                break;
+
+            case ET_XI:
+            case ET_VI:
+                if(!IS_EXPR(x))
                 {
-                case 0:
-                        /* nothing is using this inlet */
-                        if (i < ninlet)
+                    dsp_index++;
 #ifdef PD
-                                floatinlet_new(&x->exp_ob, &eptr->ex_flt);
+                    inlet_new(
+                        &x->exp_ob, &x->exp_ob.ob_pd, &s_signal, &s_signal);
 #else /* MSP */
-                                inlet_new(&x->exp_ob, "float");
+                    inlet_new(&x->exp_ob, "signal");
 #endif
-                        break;
-
-                case ET_II:
-                case ET_FI:
-                        p = exprproxy_new(x, i);
-#ifdef PD
-                        inlet_new(&x->exp_ob, &p->p_pd, &s_float, &s_float);
-#else /* MSP */
-                        inlet_new(&x->exp_ob, "float");
-#endif
-                        break;
-
-                case ET_SI:
-#ifdef PD
-                        symbolinlet_new(&x->exp_ob, (t_symbol **)&eptr->ex_ptr);
-#else /* MSP */
-                        inlet_new(&x->exp_ob, "symbol");
-#endif
-                        break;
-
-                case ET_XI:
-                case ET_VI:
-                        if (!IS_EXPR(x)) {
-                                dsp_index++;
-#ifdef PD
-                                inlet_new(&x->exp_ob, &x->exp_ob.ob_pd,
-                                                        &s_signal, &s_signal);
-#else /* MSP */
-                                inlet_new(&x->exp_ob, "signal");
-#endif
-                                break;
-                        } else
-                                post("expr: internal error expr_new");
-                                /* falls through */
-                default:
-                        pd_error(x, "expr: bad type (%lx) inlet = %d\n",
-                                            eptr->ex_type, i + 1);
-                        break;
+                    break;
                 }
+                else
+                    post("expr: internal error expr_new");
+                /* falls through */
+            default:
+                pd_error(x, "expr: bad type (%lx) inlet = %d\n", eptr->ex_type,
+                    i + 1);
+                break;
         }
-        if (IS_EXPR(x)) {
-                for (i = 0; i < x->exp_nexpr; i++)
-                        x->exp_outlet[i] = outlet_new(&x->exp_ob, 0);
-        } else {
-                for (i = 0; i < x->exp_nexpr; i++)
-                        x->exp_outlet[i] = outlet_new(&x->exp_ob,
-                                                        gensym("signal"));
-                x->exp_nivec = dsp_index;
-        }
-        /*
-         * for now assume a 64 sample size block but this may change once
-         * expr_dsp is called
-         */
-        x->exp_vsize = 64;
-        for (i = 0; i < x->exp_nexpr; i++) {
-                x->exp_p_res[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
-                x->exp_tmpres[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
-        }
-        for (i = 0; i < MAX_VARS; i++)
-                x->exp_p_var[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
+    }
+    if(IS_EXPR(x))
+    {
+        for(i = 0; i < x->exp_nexpr; i++)
+            x->exp_outlet[i] = outlet_new(&x->exp_ob, 0);
+    }
+    else
+    {
+        for(i = 0; i < x->exp_nexpr; i++)
+            x->exp_outlet[i] = outlet_new(&x->exp_ob, gensym("signal"));
+        x->exp_nivec = dsp_index;
+    }
+    /*
+     * for now assume a 64 sample size block but this may change once
+     * expr_dsp is called
+     */
+    x->exp_vsize = 64;
+    for(i = 0; i < x->exp_nexpr; i++)
+    {
+        x->exp_p_res[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
+        x->exp_tmpres[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
+    }
+    for(i = 0; i < MAX_VARS; i++)
+        x->exp_p_var[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
 
-        return (x);
+    return (x);
 }
 
-t_int *
-expr_perform(t_int *w)
+t_int *expr_perform(t_int *w)
 {
-        int i, j;
-        t_expr *x = (t_expr *)w[1];
-        struct ex_ex res;
-        int n;
+    int i, j;
+    t_expr *x = (t_expr *) w[1];
+    struct ex_ex res;
+    int n;
 
-        /* sanity check */
-        if (IS_EXPR(x)) {
-                post("expr_perform: bad x->exp_flags = %d", x->exp_flags);
-                abort();
-        }
+    /* sanity check */
+    if(IS_EXPR(x))
+    {
+        post("expr_perform: bad x->exp_flags = %d", x->exp_flags);
+        abort();
+    }
 
-        if (x->exp_flags & EF_STOP) {
-                for (i = 0; i < x->exp_nexpr; i++)
-                        memset(x->exp_res[i].ex_vec, 0,
-                                        x->exp_vsize * sizeof (t_float));
-                return (w + 2);
-        }
+    if(x->exp_flags & EF_STOP)
+    {
+        for(i = 0; i < x->exp_nexpr; i++)
+            memset(x->exp_res[i].ex_vec, 0, x->exp_vsize * sizeof(t_float));
+        return (w + 2);
+    }
 
-        if (IS_EXPR_TILDE(x)) {
-                /*
-                 * if we have only one expression, we can right on
-                 * on the output directly, otherwise we have to copy
-                 * the data because, outputs could be the same buffer as
-                 * inputs
-                 */
-                if ( x->exp_nexpr == 1)
-                        ex_eval(x, x->exp_stack[0], &x->exp_res[0], 0);
-                else {
-                        res.ex_type = ET_VEC;
-                        for (i = 0; i < x->exp_nexpr; i++) {
-                                res.ex_vec = x->exp_tmpres[i];
-                                ex_eval(x, x->exp_stack[i], &res, 0);
-                        }
-                        n = x->exp_vsize * sizeof(t_float);
-                        for (i = 0; i < x->exp_nexpr; i++)
-                                memcpy(x->exp_res[i].ex_vec, x->exp_tmpres[i],
-                                                                        n);
-                }
-                return (w + 2);
-        }
-
-        if (!IS_FEXPR_TILDE(x)) {
-                post("expr_perform: bad x->exp_flags = %d - expecting fexpr",
-                                                                x->exp_flags);
-                return (w + 2);
-        }
+    if(IS_EXPR_TILDE(x))
+    {
         /*
-         * since the output buffer could be the same as one of the inputs
-         * we need to keep the output in  a different buffer
+         * if we have only one expression, we can right on
+         * on the output directly, otherwise we have to copy
+         * the data because, outputs could be the same buffer as
+         * inputs
          */
-        for (i = 0; i < x->exp_vsize; i++) for (j = 0; j < x->exp_nexpr; j++) {
-                res.ex_type = 0;
-                res.ex_int = 0;
-                ex_eval(x, x->exp_stack[j], &res, i);
-                switch (res.ex_type) {
-                case ET_INT:
-                        x->exp_tmpres[j][i] = (t_float) res.ex_int;
-                        break;
-                case ET_FLT:
-                        x->exp_tmpres[j][i] = res.ex_flt;
-                        break;
-                default:
-                        post("expr_perform: bad result type %d", res.ex_type);
-                }
-        }
-        /*
-         * copy inputs and results to the save buffers
-         * inputs need to be copied first as the output buffer can be
-         * same as an input buffer
-         */
-        n = x->exp_vsize * sizeof(t_float);
-        for (i = 0; i < MAX_VARS; i++)
-                if (x->exp_var[i].ex_type == ET_XI)
-                        memcpy(x->exp_p_var[i], x->exp_var[i].ex_vec, n);
-        for (i = 0; i < x->exp_nexpr; i++) {
-                memcpy(x->exp_p_res[i], x->exp_tmpres[i], n);
+        if(x->exp_nexpr == 1)
+            ex_eval(x, x->exp_stack[0], &x->exp_res[0], 0);
+        else
+        {
+            res.ex_type = ET_VEC;
+            for(i = 0; i < x->exp_nexpr; i++)
+            {
+                res.ex_vec = x->exp_tmpres[i];
+                ex_eval(x, x->exp_stack[i], &res, 0);
+            }
+            n = x->exp_vsize * sizeof(t_float);
+            for(i = 0; i < x->exp_nexpr; i++)
                 memcpy(x->exp_res[i].ex_vec, x->exp_tmpres[i], n);
         }
         return (w + 2);
+    }
+
+    if(!IS_FEXPR_TILDE(x))
+    {
+        post("expr_perform: bad x->exp_flags = %d - expecting fexpr",
+            x->exp_flags);
+        return (w + 2);
+    }
+    /*
+     * since the output buffer could be the same as one of the inputs
+     * we need to keep the output in  a different buffer
+     */
+    for(i = 0; i < x->exp_vsize; i++)
+        for(j = 0; j < x->exp_nexpr; j++)
+        {
+            res.ex_type = 0;
+            res.ex_int = 0;
+            ex_eval(x, x->exp_stack[j], &res, i);
+            switch(res.ex_type)
+            {
+                case ET_INT:
+                    x->exp_tmpres[j][i] = (t_float) res.ex_int;
+                    break;
+                case ET_FLT:
+                    x->exp_tmpres[j][i] = res.ex_flt;
+                    break;
+                default:
+                    post("expr_perform: bad result type %d", res.ex_type);
+            }
+        }
+    /*
+     * copy inputs and results to the save buffers
+     * inputs need to be copied first as the output buffer can be
+     * same as an input buffer
+     */
+    n = x->exp_vsize * sizeof(t_float);
+    for(i = 0; i < MAX_VARS; i++)
+        if(x->exp_var[i].ex_type == ET_XI)
+            memcpy(x->exp_p_var[i], x->exp_var[i].ex_vec, n);
+    for(i = 0; i < x->exp_nexpr; i++)
+    {
+        memcpy(x->exp_p_res[i], x->exp_tmpres[i], n);
+        memcpy(x->exp_res[i].ex_vec, x->exp_tmpres[i], n);
+    }
+    return (w + 2);
 }
 
-static void
-expr_dsp(t_expr *x, t_signal **sp)
+static void expr_dsp(t_expr *x, t_signal **sp)
 {
-        int i, nv;
-        int newsize;
+    int i, nv;
+    int newsize;
 
-        x->exp_error = 0;               /* reset all errors */
-        newsize = (x->exp_vsize !=  sp[0]->s_n);
-        x->exp_vsize = sp[0]->s_n;      /* record the vector size */
-        for (i = 0; i < x->exp_nexpr; i++) {
-                x->exp_res[i].ex_type = ET_VEC;
-                x->exp_res[i].ex_vec =  sp[x->exp_nivec + i]->s_vec;
-        }
-        for (i = 0, nv = 0; i < MAX_VARS; i++)
-                /*
-                 * the first inlet is always a signal
-                 *
-                 * SDY  We are warning the user till this limitation
-                 * is taken away from pd
-                 */
-                if (!i || x->exp_var[i].ex_type == ET_VI ||
-                                        x->exp_var[i].ex_type == ET_XI) {
-                        if (nv >= x->exp_nivec) {
-                          post("expr_dsp int. err nv = %d, x->exp_nive = %d",
-                                                          nv,  x->exp_nivec);
-                          abort();
-                        }
-                        x->exp_var[i].ex_vec  = sp[nv]->s_vec;
-                        nv++;
-                }
-        /* we always have one inlet but we may not use it */
-        if (nv != x->exp_nivec && (nv != 0 ||  x->exp_nivec != 1)) {
-                post("expr_dsp internal error 2 nv = %d, x->exp_nive = %d",
-                                                          nv,  x->exp_nivec);
+    x->exp_error = 0; /* reset all errors */
+    newsize = (x->exp_vsize != sp[0]->s_n);
+    x->exp_vsize = sp[0]->s_n; /* record the vector size */
+    for(i = 0; i < x->exp_nexpr; i++)
+    {
+        x->exp_res[i].ex_type = ET_VEC;
+        x->exp_res[i].ex_vec = sp[x->exp_nivec + i]->s_vec;
+    }
+    for(i = 0, nv = 0; i < MAX_VARS; i++)
+        /*
+         * the first inlet is always a signal
+         *
+         * SDY  We are warning the user till this limitation
+         * is taken away from pd
+         */
+        if(!i || x->exp_var[i].ex_type == ET_VI ||
+            x->exp_var[i].ex_type == ET_XI)
+        {
+            if(nv >= x->exp_nivec)
+            {
+                post("expr_dsp int. err nv = %d, x->exp_nive = %d", nv,
+                    x->exp_nivec);
                 abort();
+            }
+            x->exp_var[i].ex_vec = sp[nv]->s_vec;
+            nv++;
         }
+    /* we always have one inlet but we may not use it */
+    if(nv != x->exp_nivec && (nv != 0 || x->exp_nivec != 1))
+    {
+        post("expr_dsp internal error 2 nv = %d, x->exp_nive = %d", nv,
+            x->exp_nivec);
+        abort();
+    }
 
-        dsp_add(expr_perform, 1, (t_int *) x);
+    dsp_add(expr_perform, 1, (t_int *) x);
 
+    /*
+     * The buffer are now being allocated for expr~ and fexpr~
+     * because if we have more than one expression we need the
+     * temporary buffers, The save buffers are not really needed
+    if (!IS_FEXPR_TILDE(x))
+            return;
+     */
+    /*
+     * if we have already allocated the buffers and we have a
+     * new size free all the buffers
+     */
+    if(x->exp_p_res[0])
+    {
+        if(!newsize) return;
         /*
-         * The buffer are now being allocated for expr~ and fexpr~
-         * because if we have more than one expression we need the
-         * temporary buffers, The save buffers are not really needed
-        if (!IS_FEXPR_TILDE(x))
-                return;
+         * if new size, reallocate all the previous buffers for fexpr~
          */
-        /*
-         * if we have already allocated the buffers and we have a
-         * new size free all the buffers
-         */
-        if (x->exp_p_res[0]) {
-                if (!newsize)
-                        return;
-                /*
-                 * if new size, reallocate all the previous buffers for fexpr~
-                 */
-                for (i = 0; i < x->exp_nexpr; i++) {
-                        fts_free(x->exp_p_res[i]);
-                        fts_free(x->exp_tmpres[i]);
-                }
-                for (i = 0; i < MAX_VARS; i++)
-                        fts_free(x->exp_p_var[i]);
-
+        for(i = 0; i < x->exp_nexpr; i++)
+        {
+            fts_free(x->exp_p_res[i]);
+            fts_free(x->exp_tmpres[i]);
         }
-        for (i = 0; i < x->exp_nexpr; i++) {
-                x->exp_p_res[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
-                x->exp_tmpres[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
-        }
-        for (i = 0; i < MAX_VARS; i++)
-                x->exp_p_var[i] = fts_calloc(x->exp_vsize, sizeof (t_float));
+        for(i = 0; i < MAX_VARS; i++)
+            fts_free(x->exp_p_var[i]);
+    }
+    for(i = 0; i < x->exp_nexpr; i++)
+    {
+        x->exp_p_res[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
+        x->exp_tmpres[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
+    }
+    for(i = 0; i < MAX_VARS; i++)
+        x->exp_p_var[i] = fts_calloc(x->exp_vsize, sizeof(t_float));
 }
 
 /*
  * expr_verbose -- toggle the verbose switch
  */
-static void
-expr_verbose(t_expr *x)
+static void expr_verbose(t_expr *x)
 {
-        if (x->exp_flags & EF_VERBOSE) {
-                x->exp_flags &= ~EF_VERBOSE;
-                post ("verbose off");
-        } else {
-                x->exp_flags |= EF_VERBOSE;
-                post ("verbose on");
-        }
+    if(x->exp_flags & EF_VERBOSE)
+    {
+        x->exp_flags &= ~EF_VERBOSE;
+        post("verbose off");
+    }
+    else
+    {
+        x->exp_flags |= EF_VERBOSE;
+        post("verbose on");
+    }
 }
 
-
-static void
-expr_version(t_expr *x)
+static void expr_version(t_expr *x)
 {
-        post( "expr, expr~, fexpr~ version %s", exp_version);
+    post("expr, expr~, fexpr~ version %s", exp_version);
 }
 
 /*
  * expr_start -- turn on expr processing for now only used for fexpr~
  */
-static void
-expr_start(t_expr *x)
-{
-        x->exp_flags &= ~EF_STOP;
-}
+static void expr_start(t_expr *x) { x->exp_flags &= ~EF_STOP; }
 
 /*
  * expr_stop -- turn on expr processing for now only used for fexpr~
  */
-static void
-expr_stop(t_expr *x)
+static void expr_stop(t_expr *x) { x->exp_flags |= EF_STOP; }
+
+static void fexpr_set_usage(void)
 {
-        x->exp_flags |= EF_STOP;
-}
-static void
-fexpr_set_usage(void)
-{
-        post("fexpr~: set val ...");
-        post("fexpr~: set {xy}[#] val ...");
+    post("fexpr~: set val ...");
+    post("fexpr~: set {xy}[#] val ...");
 }
 
 /*
@@ -604,275 +606,275 @@ fexpr_set_usage(void)
  *              set y val ...   - sets the elements of the first output buffer
  *              set y# val ...  - sets the elements of the #th output buffers
  */
-static void
-fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
+static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
-        t_symbol *sx;
-        int vecno;
-        int i, nargs;
+    t_symbol *sx;
+    int vecno;
+    int i, nargs;
 
-        if (!argc)
-                return;
-        sx = atom_getsymbolarg(0, argc, argv);
-        switch(sx->s_name[0]) {
+    if(!argc) return;
+    sx = atom_getsymbolarg(0, argc, argv);
+    switch(sx->s_name[0])
+    {
         case 'x':
-                if (!sx->s_name[1])
-                        vecno = 0;
-                else {
-                        vecno = atoi(sx->s_name + 1);
-                        if (!vecno) {
-                                post("fexpr~.set: bad set x vector number");
-                                fexpr_set_usage();
-                                return;
-                        }
-                        if (vecno >= MAX_VARS) {
-                                post("fexpr~.set: no more than %d inlets",
-                                                                      MAX_VARS);
-                                return;
-                        }
-                        vecno--;
+            if(!sx->s_name[1])
+                vecno = 0;
+            else
+            {
+                vecno = atoi(sx->s_name + 1);
+                if(!vecno)
+                {
+                    post("fexpr~.set: bad set x vector number");
+                    fexpr_set_usage();
+                    return;
                 }
-                if (x->exp_var[vecno].ex_type != ET_XI) {
-                        post("fexpr~-set: no signal at inlet %d", vecno + 1);
-                        return;
+                if(vecno >= MAX_VARS)
+                {
+                    post("fexpr~.set: no more than %d inlets", MAX_VARS);
+                    return;
                 }
-                nargs = argc - 1;
-                if (!nargs) {
-                        post("fexpr~-set: no argument to set");
-                        return;
-                }
-                if (nargs > x->exp_vsize) {
-                   post("fexpr~.set: %d set values larger than vector size(%d)",
-                                                        nargs,  x->exp_vsize);
-                   post("fexpr~.set: only the first %d values will be set",
-                                                                x->exp_vsize);
-                   nargs = x->exp_vsize;
-                }
-                for (i = 0; i < nargs; i++) {
-                        x->exp_p_var[vecno][x->exp_vsize - i - 1] =
-                                        atom_getfloatarg(i + 1, argc, argv);
-                }
+                vecno--;
+            }
+            if(x->exp_var[vecno].ex_type != ET_XI)
+            {
+                post("fexpr~-set: no signal at inlet %d", vecno + 1);
                 return;
+            }
+            nargs = argc - 1;
+            if(!nargs)
+            {
+                post("fexpr~-set: no argument to set");
+                return;
+            }
+            if(nargs > x->exp_vsize)
+            {
+                post("fexpr~.set: %d set values larger than vector size(%d)",
+                    nargs, x->exp_vsize);
+                post("fexpr~.set: only the first %d values will be set",
+                    x->exp_vsize);
+                nargs = x->exp_vsize;
+            }
+            for(i = 0; i < nargs; i++)
+            {
+                x->exp_p_var[vecno][x->exp_vsize - i - 1] =
+                    atom_getfloatarg(i + 1, argc, argv);
+            }
+            return;
         case 'y':
-                if (!sx->s_name[1])
-                        vecno = 0;
-                else {
-                        vecno = atoi(sx->s_name + 1);
-                        if (!vecno) {
-                                post("fexpr~.set: bad set y vector number");
-                                fexpr_set_usage();
-                                return;
-                        }
-                        vecno--;
+            if(!sx->s_name[1])
+                vecno = 0;
+            else
+            {
+                vecno = atoi(sx->s_name + 1);
+                if(!vecno)
+                {
+                    post("fexpr~.set: bad set y vector number");
+                    fexpr_set_usage();
+                    return;
                 }
-                if (vecno >= x->exp_nexpr) {
-                        post("fexpr~.set: only %d outlets", x->exp_nexpr);
-                        return;
-                }
-                nargs = argc - 1;
-                if (!nargs) {
-                        post("fexpr~-set: no argument to set");
-                        return;
-                }
-                if (nargs > x->exp_vsize) {
-                   post("fexpr~-set: %d set values larger than vector size(%d)",
-                                                        nargs,  x->exp_vsize);
-                   post("fexpr~.set: only the first %d values will be set",
-                                                                x->exp_vsize);
-                   nargs = x->exp_vsize;
-                }
-                for (i = 0; i < nargs; i++) {
-                        x->exp_p_res[vecno][x->exp_vsize - i - 1] =
-                                        atom_getfloatarg(i + 1, argc, argv);
-                }
+                vecno--;
+            }
+            if(vecno >= x->exp_nexpr)
+            {
+                post("fexpr~.set: only %d outlets", x->exp_nexpr);
                 return;
+            }
+            nargs = argc - 1;
+            if(!nargs)
+            {
+                post("fexpr~-set: no argument to set");
+                return;
+            }
+            if(nargs > x->exp_vsize)
+            {
+                post("fexpr~-set: %d set values larger than vector size(%d)",
+                    nargs, x->exp_vsize);
+                post("fexpr~.set: only the first %d values will be set",
+                    x->exp_vsize);
+                nargs = x->exp_vsize;
+            }
+            for(i = 0; i < nargs; i++)
+            {
+                x->exp_p_res[vecno][x->exp_vsize - i - 1] =
+                    atom_getfloatarg(i + 1, argc, argv);
+            }
+            return;
         case 0:
-                if (argc >  x->exp_nexpr) {
-                        post("fexpr~.set: only %d outlets available",
-                                                                x->exp_nexpr);
-                        post("fexpr~.set: the extra set values are ignored");
-                }
-                for (i = 0; i < x->exp_nexpr && i < argc; i++)
-                        x->exp_p_res[i][x->exp_vsize - 1] =
-                                        atom_getfloatarg(i, argc, argv);
-                return;
+            if(argc > x->exp_nexpr)
+            {
+                post("fexpr~.set: only %d outlets available", x->exp_nexpr);
+                post("fexpr~.set: the extra set values are ignored");
+            }
+            for(i = 0; i < x->exp_nexpr && i < argc; i++)
+                x->exp_p_res[i][x->exp_vsize - 1] =
+                    atom_getfloatarg(i, argc, argv);
+            return;
         default:
-                fexpr_set_usage();
-                return;
-        }
-        return;
+            fexpr_set_usage();
+            return;
+    }
+    return;
 }
 
 /*
  * fexpr_tilde_clear - clear the past buffers
  */
-static void
-fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
+static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
-        t_symbol *sx;
-        int vecno;
-        int i, nargs;
+    t_symbol *sx;
+    int vecno;
+    int i, nargs;
 
-        /*
-         *  if no argument clear all input and output buffers
-         */
-        if (!argc) {
-                for (i = 0; i < x->exp_nexpr; i++)
-                        memset(x->exp_p_res[i], 0, x->exp_vsize*sizeof(t_float));
-                for (i = 0; i < MAX_VARS; i++)
-                        if (x->exp_var[i].ex_type == ET_XI)
-                                memset(x->exp_p_var[i], 0,
-                                                x->exp_vsize*sizeof(t_float));
-                return;
-        }
-        if (argc > 1) {
-                post("fexpr~ usage: 'clear' or 'clear {xy}[#]'");
-                return;
-        }
-
-        sx = atom_getsymbolarg(0, argc, argv);
-        switch(sx->s_name[0]) {
-        case 'x':
-                if (!sx->s_name[1])
-                        vecno = 0;
-                else {
-                        vecno = atoi(sx->s_name + 1);
-                        if (!vecno) {
-                                post("fexpr~.clear: bad clear x vector number");
-                                return;
-                        }
-                        if (vecno >= MAX_VARS) {
-                                post("fexpr~.clear: no more than %d inlets",
-                                                                      MAX_VARS);
-                                return;
-                        }
-                        vecno--;
-                }
-                if (x->exp_var[vecno].ex_type != ET_XI) {
-                        post("fexpr~-clear: no signal at inlet %d", vecno + 1);
-                        return;
-                }
-                memset(x->exp_p_var[vecno], 0, x->exp_vsize*sizeof(t_float));
-                return;
-        case 'y':
-                if (!sx->s_name[1])
-                        vecno = 0;
-                else {
-                        vecno = atoi(sx->s_name + 1);
-                        if (!vecno) {
-                                post("fexpr~.clear: bad clear y vector number");
-                                return;
-                        }
-                        vecno--;
-                }
-                if (vecno >= x->exp_nexpr) {
-                        post("fexpr~.clear: only %d outlets", x->exp_nexpr);
-                        return;
-                }
-                memset(x->exp_p_res[vecno], 0, x->exp_vsize*sizeof(t_float));
-                return;
-                return;
-        default:
-                post("fexpr~ usage: 'clear' or 'clear {xy}[#]'");
-                return;
-        }
+    /*
+     *  if no argument clear all input and output buffers
+     */
+    if(!argc)
+    {
+        for(i = 0; i < x->exp_nexpr; i++)
+            memset(x->exp_p_res[i], 0, x->exp_vsize * sizeof(t_float));
+        for(i = 0; i < MAX_VARS; i++)
+            if(x->exp_var[i].ex_type == ET_XI)
+                memset(x->exp_p_var[i], 0, x->exp_vsize * sizeof(t_float));
         return;
+    }
+    if(argc > 1)
+    {
+        post("fexpr~ usage: 'clear' or 'clear {xy}[#]'");
+        return;
+    }
+
+    sx = atom_getsymbolarg(0, argc, argv);
+    switch(sx->s_name[0])
+    {
+        case 'x':
+            if(!sx->s_name[1])
+                vecno = 0;
+            else
+            {
+                vecno = atoi(sx->s_name + 1);
+                if(!vecno)
+                {
+                    post("fexpr~.clear: bad clear x vector number");
+                    return;
+                }
+                if(vecno >= MAX_VARS)
+                {
+                    post("fexpr~.clear: no more than %d inlets", MAX_VARS);
+                    return;
+                }
+                vecno--;
+            }
+            if(x->exp_var[vecno].ex_type != ET_XI)
+            {
+                post("fexpr~-clear: no signal at inlet %d", vecno + 1);
+                return;
+            }
+            memset(x->exp_p_var[vecno], 0, x->exp_vsize * sizeof(t_float));
+            return;
+        case 'y':
+            if(!sx->s_name[1])
+                vecno = 0;
+            else
+            {
+                vecno = atoi(sx->s_name + 1);
+                if(!vecno)
+                {
+                    post("fexpr~.clear: bad clear y vector number");
+                    return;
+                }
+                vecno--;
+            }
+            if(vecno >= x->exp_nexpr)
+            {
+                post("fexpr~.clear: only %d outlets", x->exp_nexpr);
+                return;
+            }
+            memset(x->exp_p_res[vecno], 0, x->exp_vsize * sizeof(t_float));
+            return;
+            return;
+        default:
+            post("fexpr~ usage: 'clear' or 'clear {xy}[#]'");
+            return;
+    }
+    return;
 }
 
 #ifdef PD
 
-void
-expr_setup(void)
+void expr_setup(void)
 {
-        /*
-         * expr initialization
-         */
-        expr_class = class_new(gensym("expr"), (t_newmethod)expr_new,
-            (t_method)expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
-        class_addlist(expr_class, expr_list);
-        exprproxy_class = class_new(gensym("exprproxy"), 0,
-                                        0, sizeof(t_exprproxy), CLASS_PD, 0);
-        class_addfloat(exprproxy_class, exprproxy_float);
-        class_addmethod(expr_class,(t_method)expr_version,
-                                                        gensym("version"), 0);
+    /*
+     * expr initialization
+     */
+    expr_class = class_new(gensym("expr"), (t_newmethod) expr_new,
+        (t_method) expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
+    class_addlist(expr_class, expr_list);
+    exprproxy_class =
+        class_new(gensym("exprproxy"), 0, 0, sizeof(t_exprproxy), CLASS_PD, 0);
+    class_addfloat(exprproxy_class, exprproxy_float);
+    class_addmethod(expr_class, (t_method) expr_version, gensym("version"), 0);
 
-        /*
-         * expr~ initialization
-         */
-        expr_tilde_class = class_new(gensym("expr~"), (t_newmethod)expr_new,
-            (t_method)expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
-        class_addmethod(expr_tilde_class, nullfn, gensym("signal"), 0);
-        CLASS_MAINSIGNALIN(expr_tilde_class, t_expr, exp_f);
-        class_addmethod(expr_tilde_class,(t_method)expr_dsp, gensym("dsp"),
-                                                        A_CANT, 0);
-        class_sethelpsymbol(expr_tilde_class, gensym("expr"));
-        class_addmethod(expr_tilde_class,(t_method)expr_version,
-                                                        gensym("version"), 0);
-        /*
-         * fexpr~ initialization
-         */
-        fexpr_tilde_class = class_new(gensym("fexpr~"), (t_newmethod)expr_new,
-            (t_method)expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
-        class_addmethod(fexpr_tilde_class, nullfn, gensym("signal"), 0);
-        CLASS_MAINSIGNALIN(fexpr_tilde_class, t_expr, exp_f);
-        class_addmethod(fexpr_tilde_class,(t_method)expr_start,
-                                                        gensym("start"), 0);
-        class_addmethod(fexpr_tilde_class,(t_method)expr_stop,
-                                                        gensym("stop"), 0);
+    /*
+     * expr~ initialization
+     */
+    expr_tilde_class = class_new(gensym("expr~"), (t_newmethod) expr_new,
+        (t_method) expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
+    class_addmethod(expr_tilde_class, nullfn, gensym("signal"), 0);
+    CLASS_MAINSIGNALIN(expr_tilde_class, t_expr, exp_f);
+    class_addmethod(
+        expr_tilde_class, (t_method) expr_dsp, gensym("dsp"), A_CANT, 0);
+    class_sethelpsymbol(expr_tilde_class, gensym("expr"));
+    class_addmethod(
+        expr_tilde_class, (t_method) expr_version, gensym("version"), 0);
+    /*
+     * fexpr~ initialization
+     */
+    fexpr_tilde_class = class_new(gensym("fexpr~"), (t_newmethod) expr_new,
+        (t_method) expr_ff, sizeof(t_expr), 0, A_GIMME, 0);
+    class_addmethod(fexpr_tilde_class, nullfn, gensym("signal"), 0);
+    CLASS_MAINSIGNALIN(fexpr_tilde_class, t_expr, exp_f);
+    class_addmethod(
+        fexpr_tilde_class, (t_method) expr_start, gensym("start"), 0);
+    class_addmethod(fexpr_tilde_class, (t_method) expr_stop, gensym("stop"), 0);
 
-        class_addmethod(fexpr_tilde_class,(t_method)expr_dsp,gensym("dsp"),
-                                                        A_CANT, 0);
-        class_addmethod(fexpr_tilde_class, (t_method)fexpr_tilde_set,
-                        gensym("set"), A_GIMME, 0);
-        class_addmethod(fexpr_tilde_class, (t_method)fexpr_tilde_clear,
-                        gensym("clear"), A_GIMME, 0);
-        class_addmethod(fexpr_tilde_class,(t_method)expr_verbose,
-                                                        gensym("verbose"), 0);
-        class_addmethod(fexpr_tilde_class,(t_method)expr_version,
-                                                        gensym("version"), 0);
-        class_sethelpsymbol(fexpr_tilde_class, gensym("expr"));
-
+    class_addmethod(
+        fexpr_tilde_class, (t_method) expr_dsp, gensym("dsp"), A_CANT, 0);
+    class_addmethod(fexpr_tilde_class, (t_method) fexpr_tilde_set,
+        gensym("set"), A_GIMME, 0);
+    class_addmethod(fexpr_tilde_class, (t_method) fexpr_tilde_clear,
+        gensym("clear"), A_GIMME, 0);
+    class_addmethod(
+        fexpr_tilde_class, (t_method) expr_verbose, gensym("verbose"), 0);
+    class_addmethod(
+        fexpr_tilde_class, (t_method) expr_version, gensym("version"), 0);
+    class_sethelpsymbol(fexpr_tilde_class, gensym("expr"));
 }
 
-void
-expr_tilde_setup(void)
-{
-        expr_setup();
-}
+void expr_tilde_setup(void) { expr_setup(); }
 
-void
-fexpr_tilde_setup(void)
-{
-        expr_setup();
-}
+void fexpr_tilde_setup(void) { expr_setup(); }
 #else /* MSP */
-void
-main(void)
+void main(void)
 {
-        setup((t_messlist **)&expr_tilde_class, (method)Nexpr_new,
-                (method)expr_ff, (short)sizeof(t_expr), 0L, A_GIMME, 0);
-        addmess((method)expr_dsp, "dsp", A_CANT, 0); // dsp method
-        dsp_initclass();
+    setup((t_messlist **) &expr_tilde_class, (method) Nexpr_new,
+        (method) expr_ff, (short) sizeof(t_expr), 0L, A_GIMME, 0);
+    addmess((method) expr_dsp, "dsp", A_CANT, 0); // dsp method
+    dsp_initclass();
 }
 #endif
 
-
 /* -- the following functions use Pd internals and so are in the "if" file. */
 
-
-int
-ex_getsym(char *p, fts_symbol_t *s)
+int ex_getsym(char *p, fts_symbol_t *s)
 {
-        *s = gensym(p);
-        return (0);
+    *s = gensym(p);
+    return (0);
 }
 
-const char *
-ex_symname(fts_symbol_t s)
+const char *ex_symname(fts_symbol_t s)
 {
-        if (!s)
-            return (0);
-        return (fts_symbol_name(s));
+    if(!s) return (0);
+    return (fts_symbol_name(s));
 }
 
 /*
@@ -887,51 +889,54 @@ ex_symname(fts_symbol_t s)
  *  the argument
  *  the result pointer
  */
-int
-max_ex_tab(struct expr *expr, fts_symbol_t s, struct ex_ex *arg,
-    struct ex_ex *optr)
+int max_ex_tab(
+    struct expr *expr, fts_symbol_t s, struct ex_ex *arg, struct ex_ex *optr)
 {
 #ifdef PD
-        t_garray *garray;
-        int size;
-        long indx;
-        t_word *wvec;
+    t_garray *garray;
+    int size;
+    long indx;
+    t_word *wvec;
 
-        if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||
-            !garray_getfloatwords(garray, &size, &wvec))
-        {
-                optr->ex_type = ET_FLT;
-                optr->ex_flt = 0;
-                pd_error(expr, "no such table '%s'", ex_symname(s));
-                return (1);
-        }
-        optr->ex_type = ET_FLT;
-
-        switch (arg->ex_type) {
-        case ET_INT:
-                indx = arg->ex_int;
-                break;
-        case ET_FLT:
-                /* strange interpolation code deleted here -msp */
-                indx = arg->ex_flt;
-                break;
-
-        default:        /* do something with strings */
-                pd_error(expr, "expr: bad argument for table '%s'\n", fts_symbol_name(s));
-                indx = 0;
-        }
-        if (indx < 0) indx = 0;
-        else if (indx >= size) indx = size - 1;
-        optr->ex_flt = wvec[indx].w_float;
-#else /* MSP */
-        /*
-         * table lookup not done for MSP yet
-         */
-        post("max_ex_tab: not complete for MSP yet!");
+    if(!s || !(garray = (t_garray *) pd_findbyclass(s, garray_class)) ||
+        !garray_getfloatwords(garray, &size, &wvec))
+    {
         optr->ex_type = ET_FLT;
         optr->ex_flt = 0;
+        pd_error(expr, "no such table '%s'", ex_symname(s));
+        return (1);
+    }
+    optr->ex_type = ET_FLT;
+
+    switch(arg->ex_type)
+    {
+        case ET_INT:
+            indx = arg->ex_int;
+            break;
+        case ET_FLT:
+            /* strange interpolation code deleted here -msp */
+            indx = arg->ex_flt;
+            break;
+
+        default: /* do something with strings */
+            pd_error(expr, "expr: bad argument for table '%s'\n",
+                fts_symbol_name(s));
+            indx = 0;
+    }
+    if(indx < 0)
+        indx = 0;
+    else if(indx >= size)
+        indx = size - 1;
+    optr->ex_flt = wvec[indx].w_float;
+#else /* MSP */
+    /*
+     * table lookup not done for MSP yet
+     */
+    post("max_ex_tab: not complete for MSP yet!");
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = 0;
 #endif
-        return (0);
+    return (0);
 }
 
 /*
@@ -948,356 +953,353 @@ max_ex_tab(struct expr *expr, fts_symbol_t s, struct ex_ex *arg,
  *  value to be stored
  *  the result pointer
  */
-int
-max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
-                                                                        struct ex_ex *rval, struct ex_ex *optr)
+int max_ex_tab_store(struct expr *expr, t_symbol *s, struct ex_ex *arg,
+    struct ex_ex *rval, struct ex_ex *optr)
 {
 #ifdef PD
-        t_garray *garray;
-        int size;
-        long indx;
-        t_word *wvec;
+    t_garray *garray;
+    int size;
+    long indx;
+    t_word *wvec;
 
-        if (!s || !(garray = (t_garray *)pd_findbyclass(s, garray_class)) ||
-                !garray_getfloatwords(garray, &size, &wvec)) {
-                optr->ex_type = ET_FLT;
-                optr->ex_flt = 0;
-                if (s)
-                    pd_error(expr, "no such table to store '%s'", s->s_name);
-                else
-                    pd_error(expr, "cannot store in unnamed table");
-                return (1);
-        }
-        optr->ex_type = ET_FLT;
-
-        switch (arg->ex_type) {
-        case ET_INT:
-                indx = arg->ex_int;
-                break;
-        case ET_FLT:
-                /* strange interpolation code deleted here -msp */
-                indx = arg->ex_flt;
-                break;
-
-        default:        /* do something with strings */
-                pd_error(expr, "expr: bad argument for table store '%s'\n",
-                        fts_symbol_name(s));
-                indx = 0;
-        }
-        if (indx < 0)
-                indx = 0;
-        else if (indx >= size)
-                indx = size - 1;
-        *optr = *rval;
-        switch (rval->ex_type) {
-        case ET_INT:
-                wvec[indx].w_float = rval->ex_int;
-                                break;
-        case ET_FLT:
-                wvec[indx].w_float = rval->ex_flt;
-                                break;
-        default:
-                pd_error(expr, "expr:bad right value type '%ld'", rval->ex_type);
-                optr->ex_type = ET_FLT;
-                optr->ex_flt = 0;
-                return (1);
-        }
-                garray_redraw(garray);
-                return(0);
-
-#else /* MSP */
-        /*
-         * table lookup not done for MSP yet
-         */
-        post("max_ex_tab: not complete for MSP yet!");
+    if(!s || !(garray = (t_garray *) pd_findbyclass(s, garray_class)) ||
+        !garray_getfloatwords(garray, &size, &wvec))
+    {
         optr->ex_type = ET_FLT;
         optr->ex_flt = 0;
+        if(s)
+            pd_error(expr, "no such table to store '%s'", s->s_name);
+        else
+            pd_error(expr, "cannot store in unnamed table");
+        return (1);
+    }
+    optr->ex_type = ET_FLT;
+
+    switch(arg->ex_type)
+    {
+        case ET_INT:
+            indx = arg->ex_int;
+            break;
+        case ET_FLT:
+            /* strange interpolation code deleted here -msp */
+            indx = arg->ex_flt;
+            break;
+
+        default: /* do something with strings */
+            pd_error(expr, "expr: bad argument for table store '%s'\n",
+                fts_symbol_name(s));
+            indx = 0;
+    }
+    if(indx < 0)
+        indx = 0;
+    else if(indx >= size)
+        indx = size - 1;
+    *optr = *rval;
+    switch(rval->ex_type)
+    {
+        case ET_INT:
+            wvec[indx].w_float = rval->ex_int;
+            break;
+        case ET_FLT:
+            wvec[indx].w_float = rval->ex_flt;
+            break;
+        default:
+            pd_error(expr, "expr:bad right value type '%ld'", rval->ex_type);
+            optr->ex_type = ET_FLT;
+            optr->ex_flt = 0;
+            return (1);
+    }
+    garray_redraw(garray);
+    return (0);
+
+#else /* MSP */
+    /*
+     * table lookup not done for MSP yet
+     */
+    post("max_ex_tab: not complete for MSP yet!");
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = 0;
 #endif
-        return (0);
+    return (0);
 }
 
-int
-max_ex_var(struct expr *expr, t_symbol *var, struct ex_ex *optr, int idx)
+int max_ex_var(struct expr *expr, t_symbol *var, struct ex_ex *optr, int idx)
 {
-        optr->ex_type = ET_FLT;
-                if (!strcmp(var->s_name, "sys_idx")) {
-                        optr->ex_flt = idx;
-                        return (0);
-                }
-        if (value_getfloat(var, &(optr->ex_flt))) {
-                optr->ex_type = ET_FLT;
-                optr->ex_flt = 0;
-                pd_error(expr, "no such var '%s'", var->s_name);
-                return (1);
-        }
+    optr->ex_type = ET_FLT;
+    if(!strcmp(var->s_name, "sys_idx"))
+    {
+        optr->ex_flt = idx;
         return (0);
+    }
+    if(value_getfloat(var, &(optr->ex_flt)))
+    {
+        optr->ex_type = ET_FLT;
+        optr->ex_flt = 0;
+        pd_error(expr, "no such var '%s'", var->s_name);
+        return (1);
+    }
+    return (0);
 }
 
-#ifdef PD /* this goes to the end of this file as the following functions
-           * should be defined in the expr object in MSP
+#ifdef PD /* this goes to the end of this file as the following functions \
+           * should be defined in the expr object in MSP                  \
            */
-#define ISTABLE(sym, garray, size, vec)                               \
-if (!sym || !(garray = (t_garray *)pd_findbyclass(sym, garray_class)) || \
-                !garray_getfloatwords(garray, &size, &vec))  {          \
-        optr->ex_type = ET_FLT;                                         \
-        optr->ex_int = 0;                                               \
-        pd_error(0, "no such table '%s'", sym?(sym->s_name):"(null)");                       \
-        return;                                                         \
-}
+#define ISTABLE(sym, garray, size, vec)                                      \
+    if(!sym || !(garray = (t_garray *) pd_findbyclass(sym, garray_class)) || \
+        !garray_getfloatwords(garray, &size, &vec))                          \
+    {                                                                        \
+        optr->ex_type = ET_FLT;                                              \
+        optr->ex_int = 0;                                                    \
+        pd_error(0, "no such table '%s'", sym ? (sym->s_name) : "(null)");   \
+        return;                                                              \
+    }
 
 /*
  * ex_size -- find the size of a table
  */
-void
-ex_size(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_size(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        t_symbol *s;
-        t_garray *garray;
-        int size;
-        t_word *wvec;
+    t_symbol *s;
+    t_garray *garray;
+    int size;
+    t_word *wvec;
 
-        if (argv->ex_type != ET_SYM)
-        {
-                post("expr: size: need a table name\n");
-                optr->ex_type = ET_INT;
-                optr->ex_int = 0;
-                return;
-        }
-
-        s = (fts_symbol_t ) argv->ex_ptr;
-
-        ISTABLE(s, garray, size, wvec);
-
+    if(argv->ex_type != ET_SYM)
+    {
+        post("expr: size: need a table name\n");
         optr->ex_type = ET_INT;
-        optr->ex_int = size;
+        optr->ex_int = 0;
+        return;
+    }
+
+    s = (fts_symbol_t) argv->ex_ptr;
+
+    ISTABLE(s, garray, size, wvec);
+
+    optr->ex_type = ET_INT;
+    optr->ex_int = size;
 }
 
 /*
  * ex_sum -- calculate the sum of all elements of a table
  */
 
-void
-ex_sum(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_sum(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        t_symbol *s;
-        t_garray *garray;
-        int size;
-        t_word *wvec;
-        t_float sum;
-        int indx;
+    t_symbol *s;
+    t_garray *garray;
+    int size;
+    t_word *wvec;
+    t_float sum;
+    int indx;
 
-        if (argv->ex_type != ET_SYM)
-        {
-                post("expr: sum: need a table name\n");
-                optr->ex_type = ET_INT;
-                optr->ex_int = 0;
-                return;
-        }
+    if(argv->ex_type != ET_SYM)
+    {
+        post("expr: sum: need a table name\n");
+        optr->ex_type = ET_INT;
+        optr->ex_int = 0;
+        return;
+    }
 
-        s = (fts_symbol_t ) argv->ex_ptr;
+    s = (fts_symbol_t) argv->ex_ptr;
 
-        ISTABLE(s, garray, size, wvec);
+    ISTABLE(s, garray, size, wvec);
 
-        for (indx = 0, sum = 0; indx < size; indx++)
-                sum += wvec[indx].w_float;
+    for(indx = 0, sum = 0; indx < size; indx++)
+        sum += wvec[indx].w_float;
 
-        optr->ex_type = ET_FLT;
-        optr->ex_flt = sum;
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = sum;
 }
-
 
 /*
  * ex_Sum -- calculate the sum of table with the given boundaries
  */
 
-void
-ex_Sum(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_Sum(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        t_symbol *s;
-        t_garray *garray;
-        int size;
-        t_word *wvec;
-        t_float sum;
-        long indx, n1, n2;
+    t_symbol *s;
+    t_garray *garray;
+    int size;
+    t_word *wvec;
+    t_float sum;
+    long indx, n1, n2;
 
-        if (argv->ex_type != ET_SYM)
-        {
-                post("expr: sum: need a table name\n");
-                optr->ex_type = ET_INT;
-                optr->ex_int = 0;
-                return;
-        }
+    if(argv->ex_type != ET_SYM)
+    {
+        post("expr: sum: need a table name\n");
+        optr->ex_type = ET_INT;
+        optr->ex_int = 0;
+        return;
+    }
 
-        s = (fts_symbol_t ) argv->ex_ptr;
+    s = (fts_symbol_t) argv->ex_ptr;
 
-        ISTABLE(s, garray, size, wvec);
+    ISTABLE(s, garray, size, wvec);
 
-                switch((++argv)->ex_type) {
-                case ET_INT:
-                n1 = argv->ex_int;
-                        break;
-                case ET_FLT:
-                n1 = argv->ex_flt;
-                        break;
-                default:
-                        post("expr: Sum: boundaries have to be fix values\n");
-                        optr->ex_type = ET_INT;
-                        optr->ex_int = 0;
-                        return;
-                }
-                if (n1 < 0)
-                        n1 = 0;
+    switch((++argv)->ex_type)
+    {
+        case ET_INT:
+            n1 = argv->ex_int;
+            break;
+        case ET_FLT:
+            n1 = argv->ex_flt;
+            break;
+        default:
+            post("expr: Sum: boundaries have to be fix values\n");
+            optr->ex_type = ET_INT;
+            optr->ex_int = 0;
+            return;
+    }
+    if(n1 < 0) n1 = 0;
 
-                switch((++argv)->ex_type) {
-                case ET_INT:
-                n2 = argv->ex_int;
-                        break;
-                case ET_FLT:
-                n2 = argv->ex_flt;
-                        break;
-                default:
-                        post("expr: Sum: boundaries have to be fix values\n");
-                        optr->ex_type = ET_INT;
-                        optr->ex_int = 0;
-                        return;
-                }
-                if (n2 > size)
-                        n2 = size;
+    switch((++argv)->ex_type)
+    {
+        case ET_INT:
+            n2 = argv->ex_int;
+            break;
+        case ET_FLT:
+            n2 = argv->ex_flt;
+            break;
+        default:
+            post("expr: Sum: boundaries have to be fix values\n");
+            optr->ex_type = ET_INT;
+            optr->ex_int = 0;
+            return;
+    }
+    if(n2 > size) n2 = size;
 
-        for (indx = n1, sum = 0; indx <= n2; indx++)
-                        if (indx >= 0 && indx < size)
-                                sum += wvec[indx].w_float;
+    for(indx = n1, sum = 0; indx <= n2; indx++)
+        if(indx >= 0 && indx < size) sum += wvec[indx].w_float;
 
-        optr->ex_type = ET_FLT;
-        optr->ex_flt = sum;
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = sum;
 }
 
 /*
  * ex_avg -- calculate the average of a table
  */
 
-void
-ex_avg(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_avg(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        t_symbol *s;
-        t_garray *garray;
-        int size;
-        t_word *wvec;
-        t_float sum;
-        int indx;
+    t_symbol *s;
+    t_garray *garray;
+    int size;
+    t_word *wvec;
+    t_float sum;
+    int indx;
 
-        if (argv->ex_type != ET_SYM)
-        {
-                post("expr: avg: need a table name\n");
-                optr->ex_type = ET_INT;
-                optr->ex_int = 0;
-                return;
-        }
+    if(argv->ex_type != ET_SYM)
+    {
+        post("expr: avg: need a table name\n");
+        optr->ex_type = ET_INT;
+        optr->ex_int = 0;
+        return;
+    }
 
-        s = (fts_symbol_t ) argv->ex_ptr;
+    s = (fts_symbol_t) argv->ex_ptr;
 
-        ISTABLE(s, garray, size, wvec);
+    ISTABLE(s, garray, size, wvec);
 
-        for (indx = 0, sum = 0; indx < size; indx++)
-                sum += wvec[indx].w_float;
+    for(indx = 0, sum = 0; indx < size; indx++)
+        sum += wvec[indx].w_float;
 
-        optr->ex_type = ET_FLT;
-        optr->ex_flt = sum / size;
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = sum / size;
 }
-
 
 /*
  * ex_Avg -- calculate the average of table with the given boundaries
  */
 
-void
-ex_Avg(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_Avg(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
-        t_symbol *s;
-        t_garray *garray;
-        int size;
-        t_word *wvec;
-        t_float sum;
-        long indx, n1, n2;
+    t_symbol *s;
+    t_garray *garray;
+    int size;
+    t_word *wvec;
+    t_float sum;
+    long indx, n1, n2;
 
-        if (argv->ex_type != ET_SYM)
-        {
-                post("expr: sum: need a table name\n");
-                optr->ex_type = ET_INT;
-                optr->ex_int = 0;
-                return;
-        }
+    if(argv->ex_type != ET_SYM)
+    {
+        post("expr: sum: need a table name\n");
+        optr->ex_type = ET_INT;
+        optr->ex_int = 0;
+        return;
+    }
 
-        s = (fts_symbol_t ) argv->ex_ptr;
+    s = (fts_symbol_t) argv->ex_ptr;
 
-        ISTABLE(s, garray, size, wvec);
+    ISTABLE(s, garray, size, wvec);
 
-                switch((++argv)->ex_type) {
-                case ET_INT:
-                n1 = argv->ex_int;
-                        break;
-                case ET_FLT:
-                n1 = argv->ex_flt;
-                        break;
-                default:
-                        post("expr: Avg: boundaries have to be fix values\n");
-                        optr->ex_type = ET_INT;
-                        optr->ex_int = 0;
-                        return;
-                }
-                if (n1 < 0)
-                        n1 = 0;
+    switch((++argv)->ex_type)
+    {
+        case ET_INT:
+            n1 = argv->ex_int;
+            break;
+        case ET_FLT:
+            n1 = argv->ex_flt;
+            break;
+        default:
+            post("expr: Avg: boundaries have to be fix values\n");
+            optr->ex_type = ET_INT;
+            optr->ex_int = 0;
+            return;
+    }
+    if(n1 < 0) n1 = 0;
 
-                switch((++argv)->ex_type) {
-                case ET_INT:
-                n2 = argv->ex_int;
-                        break;
-                case ET_FLT:
-                n2 = argv->ex_flt;
-                        break;
-                default:
-                        post("expr: Avg: boundaries have to be fix values\n");
-                        optr->ex_type = ET_INT;
-                        optr->ex_int = 0;
-                        return;
-                }
-                if (n2 >= size)
-                        n2 = size - 1;
+    switch((++argv)->ex_type)
+    {
+        case ET_INT:
+            n2 = argv->ex_int;
+            break;
+        case ET_FLT:
+            n2 = argv->ex_flt;
+            break;
+        default:
+            post("expr: Avg: boundaries have to be fix values\n");
+            optr->ex_type = ET_INT;
+            optr->ex_int = 0;
+            return;
+    }
+    if(n2 >= size) n2 = size - 1;
 
-        for (indx = n1, sum = 0; indx <= n2; indx++)
-                if (indx >= 0 && indx < size)
-                        sum += wvec[indx].w_float;
+    for(indx = n1, sum = 0; indx <= n2; indx++)
+        if(indx >= 0 && indx < size) sum += wvec[indx].w_float;
 
-        optr->ex_type = ET_FLT;
-        optr->ex_flt = sum / (n2 - n1 + 1);
+    optr->ex_type = ET_FLT;
+    optr->ex_flt = sum / (n2 - n1 + 1);
 }
 
 /*
  * max_ex_store --- store a value in a variable or table
  */
-int
-max_ex_var_store(struct expr *expr, t_symbol * var, struct ex_ex *eptr, struct ex_ex *optr)
+int max_ex_var_store(
+    struct expr *expr, t_symbol *var, struct ex_ex *eptr, struct ex_ex *optr)
 {
-                t_float value = 0.;
+    t_float value = 0.;
 
-                *optr = *eptr;
-                switch (eptr->ex_type) {
-                case ET_INT:
-                        value = eptr->ex_int;
-                        break;
-                case ET_FLT:
-                        value = eptr->ex_flt;
-                        break;
-                default:
-                        post("do not know yet\n");
-                }
+    *optr = *eptr;
+    switch(eptr->ex_type)
+    {
+        case ET_INT:
+            value = eptr->ex_int;
+            break;
+        case ET_FLT:
+            value = eptr->ex_flt;
+            break;
+        default:
+            post("do not know yet\n");
+    }
 
-        if (value_setfloat(var, value)) {
-                optr->ex_flt = 0;
-                pd_error(expr, "no such var '%s'", var->s_name);
-                return (1);
-        }
-        return (0);
+    if(value_setfloat(var, value))
+    {
+        optr->ex_flt = 0;
+        pd_error(expr, "no such var '%s'", var->s_name);
+        return (1);
+    }
+    return (0);
 }
 
 /*
@@ -1306,8 +1308,7 @@ max_ex_var_store(struct expr *expr, t_symbol * var, struct ex_ex *eptr, struct e
  *             we will make a modulo the size of the table
  */
 
-void
-ex_store(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
+void ex_store(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 {
 /* SDY - look into this function */
 #if 0
@@ -1345,23 +1346,23 @@ ex_store(t_expr *e, long int argc, struct ex_ex *argv, struct ex_ex *optr)
 
 #else /* MSP */
 
-void
-pd_error(void *object, char *fmt, ...)
+void pd_error(void *object, char *fmt, ...)
 {
     va_list ap;
     t_int arg[8];
     int i;
     static int saidit = 0;
     va_start(ap, fmt);
-/* SDY
-    vsprintf(error_string, fmt, ap);
-*/ post(fmt, ap);
-        va_end(ap);
-/* SDY
-    fprintf(stderr, "error: %s\n", error_string);
-    error_object = object;
-*/
-    if (!saidit)
+    /* SDY
+        vsprintf(error_string, fmt, ap);
+    */
+    post(fmt, ap);
+    va_end(ap);
+    /* SDY
+        fprintf(stderr, "error: %s\n", error_string);
+        error_object = object;
+    */
+    if(!saidit)
     {
         post("... you might be able to track this down from the Find menu.");
         saidit = 1;

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -58,18 +58,28 @@ static void expr_list(t_expr *x, t_symbol *s, int argc, const fts_atom_t *argv)
         if(argv[i].a_type == A_FLOAT)
         {
             if(x->exp_var[i].ex_type == ET_FI)
+            {
                 x->exp_var[i].ex_flt = argv[i].a_w.w_float;
+            }
             else if(x->exp_var[i].ex_type == ET_II)
+            {
                 x->exp_var[i].ex_int = argv[i].a_w.w_float;
+            }
             else if(x->exp_var[i].ex_type)
+            {
                 pd_error(x, "expr: type mismatch");
+            }
         }
         else if(argv[i].a_type == A_SYMBOL)
         {
             if(x->exp_var[i].ex_type == ET_SI)
+            {
                 x->exp_var[i].ex_ptr = (char *) argv[i].a_w.w_symbol;
+            }
             else if(x->exp_var[i].ex_type)
+            {
                 pd_error(x, "expr: type mismatch");
+            }
         }
     }
     expr_bang(x);
@@ -80,9 +90,13 @@ static void expr_flt(t_expr *x, t_float f, int in)
     if(in >= MAX_VARS) return;
 
     if(x->exp_var[in].ex_type == ET_FI)
+    {
         x->exp_var[in].ex_flt = f;
+    }
     else if(x->exp_var[in].ex_type == ET_II)
+    {
         x->exp_var[in].ex_int = f;
+    }
 }
 
 static t_class *exprproxy_class;
@@ -116,9 +130,13 @@ void exprproxy_float(t_exprproxy *p, t_floatarg f)
     if(in >= MAX_VARS) return;
 
     if(x->exp_var[in].ex_type == ET_FI)
+    {
         x->exp_var[in].ex_flt = f;
+    }
     else if(x->exp_var[in].ex_type == ET_II)
+    {
         x->exp_var[in].ex_int = f;
+    }
 }
 
 /* method definitions */
@@ -304,10 +322,12 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
 
     ninlet = 1;
     for(i = 0, eptr = x->exp_var; i < MAX_VARS; i++, eptr++)
+    {
         if(eptr->ex_type)
         {
             ninlet = i + 1;
         }
+    }
 
     /*
      * create the new inlets
@@ -320,11 +340,13 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
             case 0:
                 /* nothing is using this inlet */
                 if(i < ninlet)
+                {
 #ifdef PD
                     floatinlet_new(&x->exp_ob, &eptr->ex_flt);
 #else /* MSP */
                     inlet_new(&x->exp_ob, "float");
 #endif
+                }
                 break;
 
             case ET_II:
@@ -359,7 +381,9 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
                     break;
                 }
                 else
+                {
                     post("expr: internal error expr_new");
+                }
                 /* falls through */
             default:
                 pd_error(x, "expr: bad type (%lx) inlet = %d\n", eptr->ex_type,
@@ -425,7 +449,9 @@ t_int *expr_perform(t_int *w)
          * inputs
          */
         if(x->exp_nexpr == 1)
+        {
             ex_eval(x, x->exp_stack[0], &x->exp_res[0], 0);
+        }
         else
         {
             res.ex_type = ET_VEC;
@@ -452,6 +478,7 @@ t_int *expr_perform(t_int *w)
      * we need to keep the output in  a different buffer
      */
     for(i = 0; i < x->exp_vsize; i++)
+    {
         for(j = 0; j < x->exp_nexpr; j++)
         {
             res.ex_type = 0;
@@ -469,6 +496,7 @@ t_int *expr_perform(t_int *w)
                     post("expr_perform: bad result type %d", res.ex_type);
             }
         }
+    }
     /*
      * copy inputs and results to the save buffers
      * inputs need to be copied first as the output buffer can be
@@ -476,8 +504,10 @@ t_int *expr_perform(t_int *w)
      */
     n = x->exp_vsize * sizeof(t_float);
     for(i = 0; i < MAX_VARS; i++)
+    {
         if(x->exp_var[i].ex_type == ET_XI)
             memcpy(x->exp_p_var[i], x->exp_var[i].ex_vec, n);
+    }
     for(i = 0; i < x->exp_nexpr; i++)
     {
         memcpy(x->exp_p_res[i], x->exp_tmpres[i], n);
@@ -501,6 +531,7 @@ static void expr_dsp(t_expr *x, t_signal **sp)
         x->exp_res[i].ex_vec = sp[x->exp_nivec + i]->s_vec;
     }
     for(i = 0, nv = 0; i < MAX_VARS; i++)
+    {
         /*
          * the first inlet is always a signal
          *
@@ -519,6 +550,7 @@ static void expr_dsp(t_expr *x, t_signal **sp)
             x->exp_var[i].ex_vec = sp[nv]->s_vec;
             nv++;
         }
+    }
     /* we always have one inlet but we may not use it */
     if(nv != x->exp_nivec && (nv != 0 || x->exp_nivec != 1))
     {
@@ -622,7 +654,9 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
     {
         case 'x':
             if(!sx->s_name[1])
+            {
                 vecno = 0;
+            }
             else
             {
                 vecno = atoi(sx->s_name + 1);
@@ -666,7 +700,9 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
             return;
         case 'y':
             if(!sx->s_name[1])
+            {
                 vecno = 0;
+            }
             else
             {
                 vecno = atoi(sx->s_name + 1);
@@ -737,8 +773,10 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
         for(i = 0; i < x->exp_nexpr; i++)
             memset(x->exp_p_res[i], 0, x->exp_vsize * sizeof(t_float));
         for(i = 0; i < MAX_VARS; i++)
+        {
             if(x->exp_var[i].ex_type == ET_XI)
                 memset(x->exp_p_var[i], 0, x->exp_vsize * sizeof(t_float));
+        }
         return;
     }
     if(argc > 1)
@@ -752,7 +790,9 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
     {
         case 'x':
             if(!sx->s_name[1])
+            {
                 vecno = 0;
+            }
             else
             {
                 vecno = atoi(sx->s_name + 1);
@@ -777,7 +817,9 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
             return;
         case 'y':
             if(!sx->s_name[1])
+            {
                 vecno = 0;
+            }
             else
             {
                 vecno = atoi(sx->s_name + 1);

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -221,7 +221,8 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
 #endif
 {
     struct expr *x;
-    int i, ninlet;
+    int i;
+    int ninlet;
     struct ex_ex *eptr;
     t_atom fakearg;
     int dsp_index; /* keeping track of the dsp inlets */
@@ -395,7 +396,8 @@ Nexpr_new(t_symbol *s, int ac, t_atom *av)
 
 t_int *expr_perform(t_int *w)
 {
-    int i, j;
+    int i;
+    int j;
     t_expr *x = (t_expr *) w[1];
     struct ex_ex res;
     int n;
@@ -486,7 +488,8 @@ t_int *expr_perform(t_int *w)
 
 static void expr_dsp(t_expr *x, t_signal **sp)
 {
-    int i, nv;
+    int i;
+    int nv;
     int newsize;
 
     x->exp_error = 0; /* reset all errors */
@@ -610,7 +613,8 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sx;
     int vecno;
-    int i, nargs;
+    int i;
+    int nargs;
 
     if(!argc) return;
     sx = atom_getsymbolarg(0, argc, argv);
@@ -723,7 +727,8 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
 {
     t_symbol *sx;
     int vecno;
-    int i, nargs;
+    int i;
+    int nargs;
 
     /*
      *  if no argument clear all input and output buffers

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -717,7 +717,6 @@ static void fexpr_tilde_set(t_expr *x, t_symbol *s, int argc, t_atom *argv)
             fexpr_set_usage();
             return;
     }
-    return;
 }
 
 /*
@@ -801,7 +800,6 @@ static void fexpr_tilde_clear(t_expr *x, t_symbol *s, int argc, t_atom *argv)
             post("fexpr~ usage: 'clear' or 'clear {xy}[#]'");
             return;
     }
-    return;
 }
 
 #ifdef PD

--- a/src/z_libpd.c
+++ b/src/z_libpd.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <limits.h>
 #ifndef LIBPD_NO_NUMERIC
-# include <locale.h>
+#include <locale.h>
 #endif
 #include "z_libpd.h"
 #include "x_libpdreceive.h"
@@ -25,13 +25,13 @@
 #include "g_all_guis.h"
 
 #if PD_MINOR_VERSION < 46
-# define HAVE_SCHED_TICK_ARG
+#define HAVE_SCHED_TICK_ARG
 #endif
 
 #ifdef HAVE_SCHED_TICK_ARG
-# define SCHED_TICK(x) sched_tick(x)
+#define SCHED_TICK(x) sched_tick(x)
 #else
-# define SCHED_TICK(x) sched_tick()
+#define SCHED_TICK(x) sched_tick()
 #endif
 
 // forward declares
@@ -42,16 +42,16 @@ int sys_pollgui(void);
 
 // (optional) setup functions for built-in "extra" externals
 #ifdef LIBPD_EXTRA
-  void bob_tilde_setup(void);
-  void bonk_tilde_setup(void);
-  void choice_setup(void);
-  void fiddle_tilde_setup(void);
-  void loop_tilde_setup(void);
-  void lrshift_tilde_setup(void);
-  void pd_tilde_setup(void);
-  void pique_setup(void);
-  void sigmund_tilde_setup(void);
-  void stdout_setup(void);
+void bob_tilde_setup(void);
+void bonk_tilde_setup(void);
+void choice_setup(void);
+void fiddle_tilde_setup(void);
+void loop_tilde_setup(void);
+void lrshift_tilde_setup(void);
+void pd_tilde_setup(void);
+void pique_setup(void);
+void sigmund_tilde_setup(void);
+void stdout_setup(void);
 #endif
 
 static PERTHREAD t_atom *s_argv = NULL;
@@ -59,607 +59,678 @@ static PERTHREAD t_atom *s_curr = NULL;
 static PERTHREAD int s_argm = 0;
 static PERTHREAD int s_argc = 0;
 
-static void *get_object(const char *s) {
-  t_pd *x = gensym(s)->s_thing;
-  return x;
+static void *get_object(const char *s)
+{
+    t_pd *x = gensym(s)->s_thing;
+    return x;
 }
 
 // this is called instead of sys_main() to start things
-int libpd_init(void) {
-  static int s_initialized = 0;
-  if (s_initialized) return -1; // only allow init once (for now)
-  s_initialized = 1;
-  signal(SIGFPE, SIG_IGN);
-  libpd_start_message(32); // allocate array for message assembly
-  sys_externalschedlib = 0;
-  sys_printtostderr = 0;
-  sys_usestdpath = 0; // don't use pd_extrapath, only sys_searchpath
-  sys_debuglevel = 0;
-  sys_noloadbang = 0;
-  sys_hipriority = 0;
-  sys_nmidiin = 0;
-  sys_nmidiout = 0;
+int libpd_init(void)
+{
+    static int s_initialized = 0;
+    if(s_initialized) return -1; // only allow init once (for now)
+    s_initialized = 1;
+    signal(SIGFPE, SIG_IGN);
+    libpd_start_message(32); // allocate array for message assembly
+    sys_externalschedlib = 0;
+    sys_printtostderr = 0;
+    sys_usestdpath = 0; // don't use pd_extrapath, only sys_searchpath
+    sys_debuglevel = 0;
+    sys_noloadbang = 0;
+    sys_hipriority = 0;
+    sys_nmidiin = 0;
+    sys_nmidiout = 0;
 #ifdef HAVE_SCHED_TICK_ARG
-  sys_time = 0;
+    sys_time = 0;
 #endif
-  pd_init();
-  STUFF->st_soundin = NULL;
-  STUFF->st_soundout = NULL;
-  STUFF->st_schedblocksize = DEFDACBLKSIZE;
-  sys_init_fdpoll();
-  libpdreceive_setup();
-  STUFF->st_searchpath = NULL;
-  sys_libdir = gensym("");
-  post("pd %d.%d.%d%s", PD_MAJOR_VERSION, PD_MINOR_VERSION,
-    PD_BUGFIX_VERSION, PD_TEST_VERSION);
+    pd_init();
+    STUFF->st_soundin = NULL;
+    STUFF->st_soundout = NULL;
+    STUFF->st_schedblocksize = DEFDACBLKSIZE;
+    sys_init_fdpoll();
+    libpdreceive_setup();
+    STUFF->st_searchpath = NULL;
+    sys_libdir = gensym("");
+    post("pd %d.%d.%d%s", PD_MAJOR_VERSION, PD_MINOR_VERSION, PD_BUGFIX_VERSION,
+        PD_TEST_VERSION);
 #ifdef LIBPD_EXTRA
-  bob_tilde_setup();
-  bonk_tilde_setup();
-  choice_setup();
-  fiddle_tilde_setup();
-  loop_tilde_setup();
-  lrshift_tilde_setup();
-  pd_tilde_setup();
-  pique_setup();
-  sigmund_tilde_setup();
-  stdout_setup();
+    bob_tilde_setup();
+    bonk_tilde_setup();
+    choice_setup();
+    fiddle_tilde_setup();
+    loop_tilde_setup();
+    lrshift_tilde_setup();
+    pd_tilde_setup();
+    pique_setup();
+    sigmund_tilde_setup();
+    stdout_setup();
 #endif
 #ifndef LIBPD_NO_NUMERIC
-  setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C");
 #endif
-  return 0;
+    return 0;
 }
 
-void libpd_clear_search_path(void) {
-  sys_lock();
-  namelist_free(STUFF->st_searchpath);
-  STUFF->st_searchpath = NULL;
-  sys_unlock();
+void libpd_clear_search_path(void)
+{
+    sys_lock();
+    namelist_free(STUFF->st_searchpath);
+    STUFF->st_searchpath = NULL;
+    sys_unlock();
 }
 
-void libpd_add_to_search_path(const char *path) {
-  sys_lock();
-  STUFF->st_searchpath = namelist_append(STUFF->st_searchpath, path, 0);
-  sys_unlock();
+void libpd_add_to_search_path(const char *path)
+{
+    sys_lock();
+    STUFF->st_searchpath = namelist_append(STUFF->st_searchpath, path, 0);
+    sys_unlock();
 }
 
-void *libpd_openfile(const char *name, const char *dir) {
-  void *retval;
-  sys_lock();
-  pd_globallock();
-  retval = (void *)glob_evalfile(NULL, gensym(name), gensym(dir));
-  pd_globalunlock();
-  sys_unlock();
-  return retval;
+void *libpd_openfile(const char *name, const char *dir)
+{
+    void *retval;
+    sys_lock();
+    pd_globallock();
+    retval = (void *) glob_evalfile(NULL, gensym(name), gensym(dir));
+    pd_globalunlock();
+    sys_unlock();
+    return retval;
 }
 
-void libpd_closefile(void *p) {
-  sys_lock();
-  pd_free((t_pd *)p);
-  sys_unlock();
+void libpd_closefile(void *p)
+{
+    sys_lock();
+    pd_free((t_pd *) p);
+    sys_unlock();
 }
 
-int libpd_getdollarzero(void *p) {
-  sys_lock();
-  pd_pushsym((t_pd *)p);
-  int dzero = canvas_getdollarzero();
-  pd_popsym((t_pd *)p);
-  sys_unlock();
-  return dzero;
+int libpd_getdollarzero(void *p)
+{
+    sys_lock();
+    pd_pushsym((t_pd *) p);
+    int dzero = canvas_getdollarzero();
+    pd_popsym((t_pd *) p);
+    sys_unlock();
+    return dzero;
 }
 
-int libpd_blocksize(void) {
-  return DEFDACBLKSIZE;
-}
+int libpd_blocksize(void) { return DEFDACBLKSIZE; }
 
-int libpd_init_audio(int inChannels, int outChannels, int sampleRate) {
-  t_audiosettings as;
-  as.a_indevvec[0] = as.a_outdevvec[0] = DEFAULTAUDIODEV;
-  as.a_nindev = as.a_noutdev = as.a_nchindev = as.a_nchoutdev = 1;
-  as.a_chindevvec[0] = inChannels;
-  as.a_choutdevvec[0] = outChannels;
-  as.a_srate = sampleRate;
-  as.a_blocksize = DEFDACBLKSIZE;
-  as.a_callback = 0;
-  as.a_advance = -1;
-  as.a_api = API_DUMMY;
-  sys_lock();
-  sys_set_audio_settings(&as);
-  sched_set_using_audio(SCHED_AUDIO_CALLBACK);
-  sys_reopen_audio();
-  sys_unlock();
-  return 0;
+int libpd_init_audio(int inChannels, int outChannels, int sampleRate)
+{
+    t_audiosettings as;
+    as.a_indevvec[0] = as.a_outdevvec[0] = DEFAULTAUDIODEV;
+    as.a_nindev = as.a_noutdev = as.a_nchindev = as.a_nchoutdev = 1;
+    as.a_chindevvec[0] = inChannels;
+    as.a_choutdevvec[0] = outChannels;
+    as.a_srate = sampleRate;
+    as.a_blocksize = DEFDACBLKSIZE;
+    as.a_callback = 0;
+    as.a_advance = -1;
+    as.a_api = API_DUMMY;
+    sys_lock();
+    sys_set_audio_settings(&as);
+    sched_set_using_audio(SCHED_AUDIO_CALLBACK);
+    sys_reopen_audio();
+    sys_unlock();
+    return 0;
 }
 
 static const t_sample sample_to_short = SHRT_MAX,
                       short_to_sample = 1.0 / (t_sample) SHRT_MAX;
 
-#define PROCESS(_x, _y) \
-  int i, j, k; \
-  t_sample *p0, *p1; \
-  sys_lock(); \
-  sys_pollgui(); \
-  for (i = 0; i < ticks; i++) { \
-    for (j = 0, p0 = STUFF->st_soundin; j < DEFDACBLKSIZE; j++, p0++) { \
-      for (k = 0, p1 = p0; k < STUFF->st_inchannels; k++, p1 += DEFDACBLKSIZE) \
-        { \
-        *p1 = *inBuffer++ _x; \
-      } \
-    } \
-    memset(STUFF->st_soundout, 0, \
-        STUFF->st_outchannels*DEFDACBLKSIZE*sizeof(t_sample)); \
+#define PROCESS(_x, _y)                                                   \
+    int i, j, k;                                                          \
+    t_sample *p0, *p1;                                                    \
+    sys_lock();                                                           \
+    sys_pollgui();                                                        \
+    for(i = 0; i < ticks; i++)                                            \
+    {                                                                     \
+        for(j = 0, p0 = STUFF->st_soundin; j < DEFDACBLKSIZE; j++, p0++)  \
+        {                                                                 \
+            for(k = 0, p1 = p0; k < STUFF->st_inchannels;                 \
+                k++, p1 += DEFDACBLKSIZE)                                 \
+            {                                                             \
+                *p1 = *inBuffer++ _x;                                     \
+            }                                                             \
+        }                                                                 \
+        memset(STUFF->st_soundout, 0,                                     \
+            STUFF->st_outchannels *DEFDACBLKSIZE * sizeof(t_sample));     \
+        SCHED_TICK(pd_this->pd_systime + STUFF->st_time_per_dsp_tick);    \
+        for(j = 0, p0 = STUFF->st_soundout; j < DEFDACBLKSIZE; j++, p0++) \
+        {                                                                 \
+            for(k = 0, p1 = p0; k < STUFF->st_outchannels;                \
+                k++, p1 += DEFDACBLKSIZE)                                 \
+            {                                                             \
+                *outBuffer++ = *p1 _y;                                    \
+            }                                                             \
+        }                                                                 \
+    }                                                                     \
+    sys_unlock();                                                         \
+    return 0;
+
+int libpd_process_short(
+    const int ticks, const short *inBuffer, short *outBuffer)
+{
+    PROCESS(*short_to_sample, *sample_to_short)
+}
+
+int libpd_process_float(
+    const int ticks, const float *inBuffer, float *outBuffer)
+{
+    PROCESS(, )
+}
+
+int libpd_process_double(
+    const int ticks, const double *inBuffer, double *outBuffer)
+{
+    PROCESS(, )
+}
+
+#define PROCESS_RAW(_x, _y)                                        \
+    size_t n_in = STUFF->st_inchannels * DEFDACBLKSIZE;            \
+    size_t n_out = STUFF->st_outchannels * DEFDACBLKSIZE;          \
+    t_sample *p;                                                   \
+    size_t i;                                                      \
+    sys_lock();                                                    \
+    sys_pollgui();                                                 \
+    for(p = STUFF->st_soundin, i = 0; i < n_in; i++)               \
+    {                                                              \
+        *p++ = *inBuffer++ _x;                                     \
+    }                                                              \
+    memset(STUFF->st_soundout, 0, n_out * sizeof(t_sample));       \
     SCHED_TICK(pd_this->pd_systime + STUFF->st_time_per_dsp_tick); \
-    for (j = 0, p0 = STUFF->st_soundout; j < DEFDACBLKSIZE; j++, p0++) { \
-      for (k = 0, p1 = p0; k < STUFF->st_outchannels; k++, p1 += DEFDACBLKSIZE) \
-        { \
-        *outBuffer++ = *p1 _y; \
-      } \
-    } \
-  } \
-  sys_unlock(); \
-  return 0;
+    for(p = STUFF->st_soundout, i = 0; i < n_out; i++)             \
+    {                                                              \
+        *outBuffer++ = *p++ _y;                                    \
+    }                                                              \
+    sys_unlock();                                                  \
+    return 0;
 
-int libpd_process_short(const int ticks, const short *inBuffer, short *outBuffer) {
-  PROCESS(* short_to_sample, * sample_to_short)
+int libpd_process_raw(const float *inBuffer, float *outBuffer)
+{
+    PROCESS_RAW(, )
 }
 
-int libpd_process_float(const int ticks, const float *inBuffer, float *outBuffer) {
-  PROCESS(,)
+int libpd_process_raw_short(const short *inBuffer, short *outBuffer)
+{
+    PROCESS_RAW(*short_to_sample, *sample_to_short)
 }
 
-int libpd_process_double(const int ticks, const double *inBuffer, double *outBuffer) {
-  PROCESS(,)
+int libpd_process_raw_double(const double *inBuffer, double *outBuffer)
+{
+    PROCESS_RAW(, )
 }
 
-#define PROCESS_RAW(_x, _y) \
-  size_t n_in = STUFF->st_inchannels * DEFDACBLKSIZE; \
-  size_t n_out = STUFF->st_outchannels * DEFDACBLKSIZE; \
-  t_sample *p; \
-  size_t i; \
-  sys_lock(); \
-  sys_pollgui(); \
-  for (p = STUFF->st_soundin, i = 0; i < n_in; i++) { \
-    *p++ = *inBuffer++ _x; \
-  } \
-  memset(STUFF->st_soundout, 0, n_out * sizeof(t_sample)); \
-  SCHED_TICK(pd_this->pd_systime + STUFF->st_time_per_dsp_tick); \
-  for (p = STUFF->st_soundout, i = 0; i < n_out; i++) { \
-    *outBuffer++ = *p++ _y; \
-  } \
-  sys_unlock(); \
-  return 0;
-
-int libpd_process_raw(const float *inBuffer, float *outBuffer) {
-  PROCESS_RAW(,)
-}
-
-int libpd_process_raw_short(const short *inBuffer, short *outBuffer) {
-  PROCESS_RAW(* short_to_sample, * sample_to_short)
-}
-
-int libpd_process_raw_double(const double *inBuffer, double *outBuffer) {
-  PROCESS_RAW(,)
-}
-
-#define GETARRAY \
-  t_garray *garray = (t_garray *) pd_findbyclass(gensym(name), garray_class); \
-  if (!garray) {sys_unlock(); return -1;} \
-
-int libpd_arraysize(const char *name) {
-  int retval;
-  sys_lock();
-  GETARRAY
-  retval = garray_npoints(garray);
-  sys_unlock();
-  return retval;
-}
-
-int libpd_resize_array(const char *name, long size) {
-  sys_lock();
-  GETARRAY
-  garray_resize_long(garray, size);
-  sys_unlock();
-  return 0;
-}
-
-#define MEMCPY(_x, _y) \
-  GETARRAY \
-  if (n < 0 || offset < 0 || offset + n > garray_npoints(garray)) return -2; \
-  t_word *vec = ((t_word *) garray_vec(garray)) + offset; \
-  int i; \
-  for (i = 0; i < n; i++) _x = _y;
-
-int libpd_read_array(float *dest, const char *name, int offset, int n) {
-  sys_lock();
-  MEMCPY(*dest++, (vec++)->w_float)
-  sys_unlock();
-  return 0;
-}
-
-int libpd_write_array(const char *name, int offset, const float *src, int n) {
-  sys_lock();
-  MEMCPY((vec++)->w_float, *src++)
-  sys_unlock();
-  return 0;
-}
-
-int libpd_bang(const char *recv) {
-  void *obj;
-  sys_lock();
-  obj = get_object(recv);
-  if (obj == NULL)
-  {
-    sys_unlock();
-    return -1;
-  }
-  pd_bang(obj);
-  sys_unlock();
-  return 0;
-}
-
-int libpd_float(const char *recv, float x) {
-  void *obj;
-  sys_lock();
-  obj = get_object(recv);
-  if (obj == NULL)
-  {
-    sys_unlock();
-    return -1;
-  }
-  pd_float(obj, x);
-  sys_unlock();
-  return 0;
-}
-
-int libpd_symbol(const char *recv, const char *symbol) {
-  void *obj;
-  sys_lock();
-  obj = get_object(recv);
-  if (obj == NULL)
-  {
-    sys_unlock();
-    return -1;
-  }
-  pd_symbol(obj, gensym(symbol));
-  sys_unlock();
-  return 0;
-}
-
-int libpd_start_message(int maxlen) {
-  if (maxlen > s_argm) {
-    t_atom *v = realloc(s_argv, maxlen * sizeof(t_atom));
-    if (v) {
-      s_argv = v;
-      s_argm = maxlen;
-    } else {
-      return -1;
+#define GETARRAY                                                 \
+    t_garray *garray =                                           \
+        (t_garray *) pd_findbyclass(gensym(name), garray_class); \
+    if(!garray)                                                  \
+    {                                                            \
+        sys_unlock();                                            \
+        return -1;                                               \
     }
-  }
-  s_argc = 0;
-  s_curr = s_argv;
-  return 0;
-}
 
-#define ADD_ARG(f) f(s_curr, x); s_curr++; s_argc++;
-
-void libpd_add_float(float x) {
-  ADD_ARG(SETFLOAT);
-}
-
-void libpd_add_symbol(const char *symbol) {
-  t_symbol *x;
-  sys_lock();
-  x = gensym(symbol);
-  sys_unlock();
-  ADD_ARG(SETSYMBOL);
-}
-
-int libpd_finish_list(const char *recv) {
-  return libpd_list(recv, s_argc, s_argv);
-}
-
-int libpd_finish_message(const char *recv, const char *msg) {
-  return libpd_message(recv, msg, s_argc, s_argv);
-}
-
-void libpd_set_float(t_atom *a, float x) {
-  SETFLOAT(a, x);
-}
-
-void libpd_set_symbol(t_atom *a, const char *symbol) {
-  SETSYMBOL(a, gensym(symbol));
-}
-
-int libpd_list(const char *recv, int argc, t_atom *argv) {
-  t_pd *obj;
-  sys_lock();
-  obj = get_object(recv);
-  if (obj == NULL)
-  {
+int libpd_arraysize(const char *name)
+{
+    int retval;
+    sys_lock();
+    GETARRAY
+    retval = garray_npoints(garray);
     sys_unlock();
-    return -1;
-  }
-  pd_list(obj, &s_list, argc, argv);
-  sys_unlock();
-  return 0;
+    return retval;
 }
 
-int libpd_message(const char *recv, const char *msg, int argc, t_atom *argv) {
-  t_pd *obj;
-  sys_lock();
-  obj = get_object(recv);
-  if (obj == NULL)
-  {
+int libpd_resize_array(const char *name, long size)
+{
+    sys_lock();
+    GETARRAY
+    garray_resize_long(garray, size);
     sys_unlock();
-    return -1;
-  }
-  pd_typedmess(obj, gensym(msg), argc, argv);
-  sys_unlock();
-  return 0;
+    return 0;
 }
 
-void *libpd_bind(const char *recv) {
-  t_symbol *x;
-  sys_lock();
-  x = gensym(recv);
-  sys_unlock();
-  return libpdreceive_new(x);
+#define MEMCPY(_x, _y)                                                        \
+    GETARRAY                                                                  \
+    if(n < 0 || offset < 0 || offset + n > garray_npoints(garray)) return -2; \
+    t_word *vec = ((t_word *) garray_vec(garray)) + offset;                   \
+    int i;                                                                    \
+    for(i = 0; i < n; i++)                                                    \
+        _x = _y;
+
+int libpd_read_array(float *dest, const char *name, int offset, int n)
+{
+    sys_lock();
+    MEMCPY(*dest++, (vec++)->w_float)
+    sys_unlock();
+    return 0;
 }
 
-void libpd_unbind(void *p) {
-  sys_lock();
-  pd_free((t_pd *)p);
-  sys_unlock();
+int libpd_write_array(const char *name, int offset, const float *src, int n)
+{
+    sys_lock();
+    MEMCPY((vec++)->w_float, *src++)
+    sys_unlock();
+    return 0;
 }
 
-int libpd_exists(const char *recv) {
-  int retval;
-  sys_lock();
-  retval = (get_object(recv) != NULL);
-  sys_unlock();
-  return retval;
+int libpd_bang(const char *recv)
+{
+    void *obj;
+    sys_lock();
+    obj = get_object(recv);
+    if(obj == NULL)
+    {
+        sys_unlock();
+        return -1;
+    }
+    pd_bang(obj);
+    sys_unlock();
+    return 0;
 }
 
-void libpd_set_printhook(const t_libpd_printhook hook) {
-  sys_printhook = (t_printhook) hook;
+int libpd_float(const char *recv, float x)
+{
+    void *obj;
+    sys_lock();
+    obj = get_object(recv);
+    if(obj == NULL)
+    {
+        sys_unlock();
+        return -1;
+    }
+    pd_float(obj, x);
+    sys_unlock();
+    return 0;
 }
 
-void libpd_set_banghook(const t_libpd_banghook hook) {
-  libpd_banghook = hook;
+int libpd_symbol(const char *recv, const char *symbol)
+{
+    void *obj;
+    sys_lock();
+    obj = get_object(recv);
+    if(obj == NULL)
+    {
+        sys_unlock();
+        return -1;
+    }
+    pd_symbol(obj, gensym(symbol));
+    sys_unlock();
+    return 0;
 }
 
-void libpd_set_floathook(const t_libpd_floathook hook) {
-  libpd_floathook = hook;
+int libpd_start_message(int maxlen)
+{
+    if(maxlen > s_argm)
+    {
+        t_atom *v = realloc(s_argv, maxlen * sizeof(t_atom));
+        if(v)
+        {
+            s_argv = v;
+            s_argm = maxlen;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    s_argc = 0;
+    s_curr = s_argv;
+    return 0;
 }
 
-void libpd_set_symbolhook(const t_libpd_symbolhook hook) {
-  libpd_symbolhook = hook;
+#define ADD_ARG(f) \
+    f(s_curr, x);  \
+    s_curr++;      \
+    s_argc++;
+
+void libpd_add_float(float x) { ADD_ARG(SETFLOAT); }
+
+void libpd_add_symbol(const char *symbol)
+{
+    t_symbol *x;
+    sys_lock();
+    x = gensym(symbol);
+    sys_unlock();
+    ADD_ARG(SETSYMBOL);
 }
 
-void libpd_set_listhook(const t_libpd_listhook hook) {
-  libpd_listhook = hook;
+int libpd_finish_list(const char *recv)
+{
+    return libpd_list(recv, s_argc, s_argv);
 }
 
-void libpd_set_messagehook(const t_libpd_messagehook hook) {
-  libpd_messagehook = hook;
+int libpd_finish_message(const char *recv, const char *msg)
+{
+    return libpd_message(recv, msg, s_argc, s_argv);
 }
 
-int libpd_is_float(t_atom *a) {
-  return (a)->a_type == A_FLOAT;
+void libpd_set_float(t_atom *a, float x) { SETFLOAT(a, x); }
+
+void libpd_set_symbol(t_atom *a, const char *symbol)
+{
+    SETSYMBOL(a, gensym(symbol));
 }
 
-int libpd_is_symbol(t_atom *a) {
-  return (a)->a_type == A_SYMBOL;
+int libpd_list(const char *recv, int argc, t_atom *argv)
+{
+    t_pd *obj;
+    sys_lock();
+    obj = get_object(recv);
+    if(obj == NULL)
+    {
+        sys_unlock();
+        return -1;
+    }
+    pd_list(obj, &s_list, argc, argv);
+    sys_unlock();
+    return 0;
 }
 
-float libpd_get_float(t_atom *a) {
-  return (a)->a_w.w_float;
+int libpd_message(const char *recv, const char *msg, int argc, t_atom *argv)
+{
+    t_pd *obj;
+    sys_lock();
+    obj = get_object(recv);
+    if(obj == NULL)
+    {
+        sys_unlock();
+        return -1;
+    }
+    pd_typedmess(obj, gensym(msg), argc, argv);
+    sys_unlock();
+    return 0;
 }
 
-const char *libpd_get_symbol(t_atom *a) {
-  return (a)->a_w.w_symbol->s_name;
+void *libpd_bind(const char *recv)
+{
+    t_symbol *x;
+    sys_lock();
+    x = gensym(recv);
+    sys_unlock();
+    return libpdreceive_new(x);
 }
 
-t_atom *libpd_next_atom(t_atom *a) {
-  return a + 1;
+void libpd_unbind(void *p)
+{
+    sys_lock();
+    pd_free((t_pd *) p);
+    sys_unlock();
 }
 
-#define CHECK_CHANNEL if (channel < 0) return -1;
-#define CHECK_PORT if (port < 0 || port > 0x0fff) return -1;
-#define CHECK_RANGE_7BIT(v) if (v < 0 || v > 0x7f) return -1;
-#define CHECK_RANGE_8BIT(v) if (v < 0 || v > 0xff) return -1;
+int libpd_exists(const char *recv)
+{
+    int retval;
+    sys_lock();
+    retval = (get_object(recv) != NULL);
+    sys_unlock();
+    return retval;
+}
+
+void libpd_set_printhook(const t_libpd_printhook hook)
+{
+    sys_printhook = (t_printhook) hook;
+}
+
+void libpd_set_banghook(const t_libpd_banghook hook) { libpd_banghook = hook; }
+
+void libpd_set_floathook(const t_libpd_floathook hook)
+{
+    libpd_floathook = hook;
+}
+
+void libpd_set_symbolhook(const t_libpd_symbolhook hook)
+{
+    libpd_symbolhook = hook;
+}
+
+void libpd_set_listhook(const t_libpd_listhook hook) { libpd_listhook = hook; }
+
+void libpd_set_messagehook(const t_libpd_messagehook hook)
+{
+    libpd_messagehook = hook;
+}
+
+int libpd_is_float(t_atom *a) { return (a)->a_type == A_FLOAT; }
+
+int libpd_is_symbol(t_atom *a) { return (a)->a_type == A_SYMBOL; }
+
+float libpd_get_float(t_atom *a) { return (a)->a_w.w_float; }
+
+const char *libpd_get_symbol(t_atom *a) { return (a)->a_w.w_symbol->s_name; }
+
+t_atom *libpd_next_atom(t_atom *a) { return a + 1; }
+
+#define CHECK_CHANNEL \
+    if(channel < 0) return -1;
+#define CHECK_PORT \
+    if(port < 0 || port > 0x0fff) return -1;
+#define CHECK_RANGE_7BIT(v) \
+    if(v < 0 || v > 0x7f) return -1;
+#define CHECK_RANGE_8BIT(v) \
+    if(v < 0 || v > 0xff) return -1;
 #define PORT (channel >> 4)
 #define CHANNEL (channel & 0x0f)
 
-int libpd_noteon(int channel, int pitch, int velocity) {
-  CHECK_CHANNEL
-  CHECK_RANGE_7BIT(pitch)
-  CHECK_RANGE_7BIT(velocity)
-  sys_lock();
-  inmidi_noteon(PORT, CHANNEL, pitch, velocity);
-  sys_unlock();
-  return 0;
+int libpd_noteon(int channel, int pitch, int velocity)
+{
+    CHECK_CHANNEL
+    CHECK_RANGE_7BIT(pitch)
+    CHECK_RANGE_7BIT(velocity)
+    sys_lock();
+    inmidi_noteon(PORT, CHANNEL, pitch, velocity);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_controlchange(int channel, int controller, int value) {
-  CHECK_CHANNEL
-  CHECK_RANGE_7BIT(controller)
-  CHECK_RANGE_7BIT(value)
-  sys_lock();
-  inmidi_controlchange(PORT, CHANNEL, controller, value);
-  sys_unlock();
-  return 0;
+int libpd_controlchange(int channel, int controller, int value)
+{
+    CHECK_CHANNEL
+    CHECK_RANGE_7BIT(controller)
+    CHECK_RANGE_7BIT(value)
+    sys_lock();
+    inmidi_controlchange(PORT, CHANNEL, controller, value);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_programchange(int channel, int value) {
-  CHECK_CHANNEL
-  CHECK_RANGE_7BIT(value)
-  sys_lock();
-  inmidi_programchange(PORT, CHANNEL, value);
-  sys_unlock();
-  return 0;
+int libpd_programchange(int channel, int value)
+{
+    CHECK_CHANNEL
+    CHECK_RANGE_7BIT(value)
+    sys_lock();
+    inmidi_programchange(PORT, CHANNEL, value);
+    sys_unlock();
+    return 0;
 }
 
 // note: for consistency with Pd, we center the output of [pitchin] at 8192
-int libpd_pitchbend(int channel, int value) {
-  CHECK_CHANNEL
-  if (value < -8192 || value > 8191) return -1;
-  sys_lock();
-  inmidi_pitchbend(PORT, CHANNEL, value + 8192);
-  sys_unlock();
-  return 0;
+int libpd_pitchbend(int channel, int value)
+{
+    CHECK_CHANNEL
+    if(value < -8192 || value > 8191) return -1;
+    sys_lock();
+    inmidi_pitchbend(PORT, CHANNEL, value + 8192);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_aftertouch(int channel, int value) {
-  CHECK_CHANNEL
-  CHECK_RANGE_7BIT(value)
-  sys_lock();
-  inmidi_aftertouch(PORT, CHANNEL, value);
-  sys_unlock();
-  return 0;
+int libpd_aftertouch(int channel, int value)
+{
+    CHECK_CHANNEL
+    CHECK_RANGE_7BIT(value)
+    sys_lock();
+    inmidi_aftertouch(PORT, CHANNEL, value);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_polyaftertouch(int channel, int pitch, int value) {
-  CHECK_CHANNEL
-  CHECK_RANGE_7BIT(pitch)
-  CHECK_RANGE_7BIT(value)
-  sys_lock();
-  inmidi_polyaftertouch(PORT, CHANNEL, pitch, value);
-  sys_unlock();
-  return 0;
+int libpd_polyaftertouch(int channel, int pitch, int value)
+{
+    CHECK_CHANNEL
+    CHECK_RANGE_7BIT(pitch)
+    CHECK_RANGE_7BIT(value)
+    sys_lock();
+    inmidi_polyaftertouch(PORT, CHANNEL, pitch, value);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_midibyte(int port, int byte) {
-  CHECK_PORT
-  CHECK_RANGE_8BIT(byte)
-  sys_lock();
-  inmidi_byte(port, byte);
-  sys_unlock();
-  return 0;
+int libpd_midibyte(int port, int byte)
+{
+    CHECK_PORT
+    CHECK_RANGE_8BIT(byte)
+    sys_lock();
+    inmidi_byte(port, byte);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_sysex(int port, int byte) {
-  CHECK_PORT
-  CHECK_RANGE_8BIT(byte)
-  sys_lock();
-  inmidi_sysex(port, byte);
-  sys_unlock();
-  return 0;
+int libpd_sysex(int port, int byte)
+{
+    CHECK_PORT
+    CHECK_RANGE_8BIT(byte)
+    sys_lock();
+    inmidi_sysex(port, byte);
+    sys_unlock();
+    return 0;
 }
 
-int libpd_sysrealtime(int port, int byte) {
-  CHECK_PORT
-  CHECK_RANGE_8BIT(byte)
-  sys_lock();
-  inmidi_realtimein(port, byte);
-  sys_unlock();
-  return 0;
+int libpd_sysrealtime(int port, int byte)
+{
+    CHECK_PORT
+    CHECK_RANGE_8BIT(byte)
+    sys_lock();
+    inmidi_realtimein(port, byte);
+    sys_unlock();
+    return 0;
 }
 
-void libpd_set_noteonhook(const t_libpd_noteonhook hook) {
-  libpd_noteonhook = hook;
+void libpd_set_noteonhook(const t_libpd_noteonhook hook)
+{
+    libpd_noteonhook = hook;
 }
 
-void libpd_set_controlchangehook(const t_libpd_controlchangehook hook) {
-  libpd_controlchangehook = hook;
+void libpd_set_controlchangehook(const t_libpd_controlchangehook hook)
+{
+    libpd_controlchangehook = hook;
 }
 
-void libpd_set_programchangehook(const t_libpd_programchangehook hook) {
-  libpd_programchangehook = hook;
+void libpd_set_programchangehook(const t_libpd_programchangehook hook)
+{
+    libpd_programchangehook = hook;
 }
 
-void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook) {
-  libpd_pitchbendhook = hook;
+void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook)
+{
+    libpd_pitchbendhook = hook;
 }
 
-void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook) {
-  libpd_aftertouchhook = hook;
+void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook)
+{
+    libpd_aftertouchhook = hook;
 }
 
-void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook) {
-  libpd_polyaftertouchhook = hook;
+void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook)
+{
+    libpd_polyaftertouchhook = hook;
 }
 
-void libpd_set_midibytehook(const t_libpd_midibytehook hook) {
-  libpd_midibytehook = hook;
+void libpd_set_midibytehook(const t_libpd_midibytehook hook)
+{
+    libpd_midibytehook = hook;
 }
 
-int libpd_start_gui(const char *path) {
-  int retval;
-  sys_lock();
-  retval = sys_startgui(path);
-  sys_unlock();
-  return retval;
+int libpd_start_gui(const char *path)
+{
+    int retval;
+    sys_lock();
+    retval = sys_startgui(path);
+    sys_unlock();
+    return retval;
 }
 
-void libpd_stop_gui(void) {
-  sys_lock();
-  sys_stopgui();
-  sys_unlock();
+void libpd_stop_gui(void)
+{
+    sys_lock();
+    sys_stopgui();
+    sys_unlock();
 }
 
-int libpd_poll_gui(void) {
-  int retval;
-  sys_lock();
-  retval = sys_pollgui();
-  sys_unlock();
-  return (retval);
+int libpd_poll_gui(void)
+{
+    int retval;
+    sys_lock();
+    retval = sys_pollgui();
+    sys_unlock();
+    return (retval);
 }
 
-t_pdinstance *libpd_new_instance(void) {
+t_pdinstance *libpd_new_instance(void)
+{
 #ifdef PDINSTANCE
-  return pdinstance_new();
+    return pdinstance_new();
 #else
-  return 0;
+    return 0;
 #endif
 }
 
-void libpd_set_instance(t_pdinstance *p) {
+void libpd_set_instance(t_pdinstance *p)
+{
 #ifdef PDINSTANCE
-  pd_setinstance(p);
+    pd_setinstance(p);
 #endif
 }
 
-void libpd_free_instance(t_pdinstance *p) {
+void libpd_free_instance(t_pdinstance *p)
+{
 #ifdef PDINSTANCE
-  pdinstance_free(p);
+    pdinstance_free(p);
 #endif
 }
 
-t_pdinstance *libpd_this_instance(void) {
-  return pd_this;
-}
+t_pdinstance *libpd_this_instance(void) { return pd_this; }
 
-t_pdinstance *libpd_get_instance(int index) {
+t_pdinstance *libpd_get_instance(int index)
+{
 #ifdef PDINSTANCE
-  if(index < 0 || index >= pd_ninstances) {return 0;}
-  return pd_instances[index];
+    if(index < 0 || index >= pd_ninstances)
+    {
+        return 0;
+    }
+    return pd_instances[index];
 #else
-  return pd_this;
+    return pd_this;
 #endif
 }
 
-int libpd_num_instances(void) {
+int libpd_num_instances(void)
+{
 #ifdef PDINSTANCE
-  return pd_ninstances;
+    return pd_ninstances;
 #else
-  return 1;
+    return 1;
 #endif
 }
 
-void libpd_set_verbose(int verbose) {
-  if (verbose < 0) verbose = 0;
-  sys_verbose = verbose;
+void libpd_set_verbose(int verbose)
+{
+    if(verbose < 0) verbose = 0;
+    sys_verbose = verbose;
 }
 
-int libpd_get_verbose(void) {
-  return sys_verbose;
-}
+int libpd_get_verbose(void) { return sys_verbose; }
 
 // dummy routines needed because we don't use s_file.c
 void glob_loadpreferences(t_pd *dummy, t_symbol *s) {}
+
 void glob_savepreferences(t_pd *dummy, t_symbol *s) {}
+
 void glob_forgetpreferences(t_pd *dummy) {}
+
 void sys_loadpreferences(const char *filename, int startingup) {}
-int sys_oktoloadfiles(int done) {return 1;}
+
+int sys_oktoloadfiles(int done) { return 1; }
+
 void sys_savepreferences(const char *filename) {} // used in s_path.c

--- a/src/z_libpd.c
+++ b/src/z_libpd.c
@@ -181,12 +181,12 @@ static const t_sample sample_to_short = SHRT_MAX,
                       short_to_sample = 1.0 / (t_sample) SHRT_MAX;
 
 #define PROCESS(_x, _y)                                                   \
-    int i, j, k;                                                          \
-    t_sample *p0, *p1;                                                    \
     sys_lock();                                                           \
     sys_pollgui();                                                        \
-    for(i = 0; i < ticks; i++)                                            \
+    for(int i = 0; i < ticks; i++)                                        \
     {                                                                     \
+        int j, k;                                                         \
+        t_sample *p0, *p1;                                                \
         for(j = 0, p0 = STUFF->st_soundin; j < DEFDACBLKSIZE; j++, p0++)  \
         {                                                                 \
             for(k = 0, p1 = p0; k < STUFF->st_inchannels;                 \
@@ -295,8 +295,7 @@ int libpd_resize_array(const char *name, long size)
     GETARRAY                                                                  \
     if(n < 0 || offset < 0 || offset + n > garray_npoints(garray)) return -2; \
     t_word *vec = ((t_word *) garray_vec(garray)) + offset;                   \
-    int i;                                                                    \
-    for(i = 0; i < n; i++)                                                    \
+    for(int i = 0; i < n; i++)                                                \
         _x = _y;
 
 int libpd_read_array(float *dest, const char *name, int offset, int n)

--- a/src/z_libpd.h
+++ b/src/z_libpd.h
@@ -19,492 +19,504 @@ extern "C"
 
 #include "m_pd.h"
 
-/* initializing pd */
-
-/// initialize libpd; it is safe to call this more than once
-/// returns 0 on success or -1 if libpd was already initialized
-/// note: sets SIGFPE handler to keep bad pd patches from crashing due to divide
-///       by 0, set any custom handling after calling this function
-EXTERN int libpd_init(void);
-
-/// clear the libpd search path for abstractions and externals
-/// note: this is called by libpd_init()
-EXTERN void libpd_clear_search_path(void);
-
-/// add a path to the libpd search paths
-/// relative paths are relative to the current working directory
-/// unlike desktop pd, *no* search paths are set by default (ie. extra)
-EXTERN void libpd_add_to_search_path(const char *path);
-
-/* opening patches */
-
-/// open a patch by filename and parent dir path
-/// returns an opaque patch handle pointer or NULL on failure
-EXTERN void *libpd_openfile(const char *name, const char *dir);
-
-/// close a patch by patch handle pointer
-EXTERN void libpd_closefile(void *p);
-
-/// get the $0 id of the patch handle pointer
-/// returns $0 value or 0 if the patch is non-existent
-EXTERN int libpd_getdollarzero(void *p);
-
-/* audio processing */
-
-/// return pd's fixed block size: the number of sample frames per 1 pd tick
-EXTERN int libpd_blocksize(void);
-
-/// initialize audio rendering
-/// returns 0 on success
-EXTERN int libpd_init_audio(int inChannels, int outChannels, int sampleRate);
-
-/// process interleaved float samples from inBuffer -> libpd -> outBuffer
-/// buffer sizes are based on # of ticks and channels where:
-///     size = ticks * libpd_blocksize() * (in/out)channels
-/// returns 0 on success
-EXTERN int libpd_process_float(const int ticks,
-    const float *inBuffer, float *outBuffer);
-
-/// process interleaved short samples from inBuffer -> libpd -> outBuffer
-/// buffer sizes are based on # of ticks and channels where:
-///     size = ticks * libpd_blocksize() * (in/out)channels
-/// float samples are converted to short by multiplying by 32767 and casting,
-/// so any values received from pd patches beyond -1 to 1 will result in garbage
-/// note: for efficiency, does *not* clip input
-/// returns 0 on success
-EXTERN int libpd_process_short(const int ticks,
-    const short *inBuffer, short *outBuffer);
-
-/// process interleaved double samples from inBuffer -> libpd -> outBuffer
-/// buffer sizes are based on # of ticks and channels where:
-///     size = ticks * libpd_blocksize() * (in/out)channels
-/// returns 0 on success
-EXTERN int libpd_process_double(const int ticks,
-    const double *inBuffer, double *outBuffer);
-
-/// process non-interleaved float samples from inBuffer -> libpd -> outBuffer
-/// copies buffer contents to/from libpd without striping
-/// buffer sizes are based on a single tick and # of channels where:
-///     size = libpd_blocksize() * (in/out)channels
-/// returns 0 on success
-EXTERN int libpd_process_raw(const float *inBuffer, float *outBuffer);
-
-/// process non-interleaved short samples from inBuffer -> libpd -> outBuffer
-/// copies buffer contents to/from libpd without striping
-/// buffer sizes are based on a single tick and # of channels where:
-///     size = libpd_blocksize() * (in/out)channels
-/// float samples are converted to short by multiplying by 32767 and casting,
-/// so any values received from pd patches beyond -1 to 1 will result in garbage
-/// note: for efficiency, does *not* clip input
-/// returns 0 on success
-EXTERN int libpd_process_raw_short(const short *inBuffer, short *outBuffer);
-
-/// process non-interleaved double samples from inBuffer -> libpd -> outBuffer
-/// copies buffer contents to/from libpd without striping
-/// buffer sizes are based on a single tick and # of channels where:
-///     size = libpd_blocksize() * (in/out)channels
-/// returns 0 on success
-EXTERN int libpd_process_raw_double(const double *inBuffer, double *outBuffer);
-
-/* array access */
-
-/// get the size of an array by name
-/// returns size or negative error code if non-existent
-EXTERN int libpd_arraysize(const char *name);
-
-/// (re)size an array by name; sizes <= 0 are clipped to 1
-/// returns 0 on success or negative error code if non-existent
-EXTERN int libpd_resize_array(const char *name, long size);
-
-/// read n values from named src array and write into dest starting at an offset
-/// note: performs no bounds checking on dest
-/// returns 0 on success or a negative error code if the array is non-existent
-/// or offset + n exceeds range of array
-EXTERN int libpd_read_array(float *dest, const char *name, int offset, int n);
-
-/// read n values from src and write into named dest array starting at an offset
-/// note: performs no bounds checking on src
-/// returns 0 on success or a negative error code if the array is non-existent
-/// or offset + n exceeds range of array
-EXTERN int libpd_write_array(const char *name, int offset,
-	const float *src, int n);
-
-/* sending messages to pd */
-
-/// send a bang to a destination receiver
-/// ex: libpd_bang("foo") will send a bang to [s foo] on the next tick
-/// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_bang(const char *recv);
-
-/// send a float to a destination receiver
-/// ex: libpd_float("foo", 1) will send a 1.0 to [s foo] on the next tick
-/// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_float(const char *recv, float x);
-
-/// send a symbol to a destination receiver
-/// ex: libpd_symbol("foo", "bar") will send "bar" to [s foo] on the next tick
-/// returns 0 on success or -1 if receiver name is non-existent
-EXTERN int libpd_symbol(const char *recv, const char *symbol);
-
-/* sending compound messages: sequenced function calls */
-
-/// start composition of a new list or typed message of up to max element length
-/// messages can be of a smaller length as max length is only an upper bound
-/// note: no cleanup is required for unfinished messages
-/// returns 0 on success or nonzero if the length is too large
-EXTERN int libpd_start_message(int maxlen);
-
-/// add a float to the current message in progress
-EXTERN void libpd_add_float(float x);
-
-/// add a symbol to the current message in progress
-EXTERN void libpd_add_symbol(const char *symbol);
-
-/// finish current message and send as a list to a destination receiver
-/// returns 0 on success or -1 if receiver name is non-existent
-/// ex: send [list 1 2 bar( to [s foo] on the next tick with:
-///     libpd_start_message(3);
-///     libpd_add_float(1);
-///     libpd_add_float(2);
-///     libpd_add_symbol("bar");
-///     libpd_finish_list("foo");
-EXTERN int libpd_finish_list(const char *recv);
-
-/// finish current message and send as a typed message to a destination receiver
-/// note: typed message handling currently only supports up to 4 elements
-///       internally, additional elements may be ignored
-/// returns 0 on success or -1 if receiver name is non-existent
-/// ex: send [; pd dsp 1( on the next tick with:
-///     libpd_start_message(1);
-///     libpd_add_float(1);
-///     libpd_finish_message("pd", "dsp");
-EXTERN int libpd_finish_message(const char *recv, const char *msg);
-
-/* sending compound messages: atom array */
-
-/// write a float value to the given atom
-EXTERN void libpd_set_float(t_atom *a, float x);
-
-/// write a symbol value to the given atom
-EXTERN void libpd_set_symbol(t_atom *a, const char *symbol);
-
-/// send an atom array of a given length as a list to a destination receiver
-/// returns 0 on success or -1 if receiver name is non-existent
-/// ex: send [list 1 2 bar( to [r foo] on the next tick with:
-///     t_atom v[3];
-///     libpd_set_float(v, 1);
-///     libpd_set_float(v + 1, 2);
-///     libpd_set_symbol(v + 2, "bar");
-///     libpd_list("foo", 3, v);
-EXTERN int libpd_list(const char *recv, int argc, t_atom *argv);
-
-/// send a atom array of a given length as a typed message to a destination
-/// receiver, returns 0 on success or -1 if receiver name is non-existent
-/// ex: send [; pd dsp 1( on the next tick with:
-///     t_atom v[1];
-///     libpd_set_float(v, 1);
-///     libpd_message("pd", "dsp", 1, v);
-EXTERN int libpd_message(const char *recv, const char *msg,
-	int argc, t_atom *argv);
-
-/* receiving messages from pd */
-
-/// subscribe to messages sent to a source receiver
-/// ex: libpd_bind("foo") adds a "virtual" [r foo] which forwards messages to
-///     the libpd message hooks
-/// returns an opaque receiver pointer or NULL on failure
-EXTERN void *libpd_bind(const char *recv);
-
-/// unsubscribe and free a source receiver object created by libpd_bind()
-EXTERN void libpd_unbind(void *p);
-
-/// check if a source receiver object exists with a given name
-/// returns 1 if the receiver exists, otherwise 0
-EXTERN int libpd_exists(const char *recv);
-
-/// print receive hook signature, s is the string to be printed
-/// note: default behavior returns individual words and spaces:
-///     line "hello 123" is received in 4 parts -> "hello", " ", "123\n"
-typedef void (*t_libpd_printhook)(const char *s);
-
-/// bang receive hook signature, recv is the source receiver name
-typedef void (*t_libpd_banghook)(const char *recv);
-
-/// float receive hook signature, recv is the source receiver name
-typedef void (*t_libpd_floathook)(const char *recv, float x);
-
-/// symbol receive hook signature, recv is the source receiver name
-typedef void (*t_libpd_symbolhook)(const char *recv, const char *symbol);
-
-/// list receive hook signature, recv is the source receiver name
-/// argc is the list length and vector argv contains the list elements
-/// which can be accessed using the atom accessor functions, ex:
-///     int i;
-///     for (i = 0; i < argc; i++) {
-///       t_atom *a = &argv[n];
-///       if (libpd_is_float(a)) {
-///         float x = libpd_get_float(a);
-///         // do something with float x
-///       } else if (libpd_is_symbol(a)) {
-///         char *s = libpd_get_symbol(a);
-///         // do something with c string s
-///       }
-///     }
-/// note: check for both float and symbol types as atom may also be a pointer
-typedef void (*t_libpd_listhook)(const char *recv, int argc, t_atom *argv);
-
-/// typed message hook signature, recv is the source receiver name and msg is
-/// the typed message name: a message like [; foo bar 1 2 a b( will trigger a
-/// function call like libpd_messagehook("foo", "bar", 4, argv)
-/// argc is the list length and vector argv contains the
-/// list elements which can be accessed using the atom accessor functions, ex:
-///     int i;
-///     for (i = 0; i < argc; i++) {
-///       t_atom *a = &argv[n];
-///       if (libpd_is_float(a)) {
-///         float x = libpd_get_float(a);
-///         // do something with float x
-///       } else if (libpd_is_symbol(a)) {
-///         char *s = libpd_get_symbol(a);
-///         // do something with c string s
-///       }
-///     }
-/// note: check for both float and symbol types as atom may also be a pointer
-typedef void (*t_libpd_messagehook)(const char *recv, const char *msg,
-    int argc, t_atom *argv);
-
-/// set the print receiver hook, prints to stdout by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_printhook(const t_libpd_printhook hook);
-
-/// set the bang receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_banghook(const t_libpd_banghook hook);
-
-/// set the float receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_floathook(const t_libpd_floathook hook);
-
-/// set the symbol receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_symbolhook(const t_libpd_symbolhook hook);
-
-/// set the list receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_listhook(const t_libpd_listhook hook);
-
-/// set the message receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_messagehook(const t_libpd_messagehook hook);
-
-/// check if an atom is a float type: 0 or 1
-/// note: no NULL check is performed
-EXTERN int libpd_is_float(t_atom *a);
-
-/// check if an atom is a symbol type: 0 or 1
-/// note: no NULL check is performed
-EXTERN int libpd_is_symbol(t_atom *a);
-
-/// get the float value of an atom
-/// note: no NULL or type checks are performed
-EXTERN float libpd_get_float(t_atom *a);
-
-/// note: no NULL or type checks are performed
-/// get symbol value of an atom
-EXTERN const char *libpd_get_symbol(t_atom *a);
-
-/// increment to the next atom in an atom vector
-/// returns next atom or NULL, assuming the atom vector is NULL-terminated
-EXTERN t_atom *libpd_next_atom(t_atom *a);
-
-/* sending MIDI messages to pd */
-
-/// send a MIDI note on message to [notein] objects
-/// channel is 0-indexed, pitch is 0-127, and velocity is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: there is no note off message, send a note on with velocity = 0 instead
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_noteon(int channel, int pitch, int velocity);
-
-/// send a MIDI control change message to [ctlin] objects
-/// channel is 0-indexed, controller is 0-127, and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_controlchange(int channel, int controller, int value);
-
-/// send a MIDI program change message to [pgmin] objects
-/// channel is 0-indexed and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_programchange(int channel, int value);
-
-/// send a MIDI pitch bend message to [bendin] objects
-/// channel is 0-indexed and value is -8192-8192
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: [bendin] outputs 0-16383 while [bendout] accepts -8192-8192
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_pitchbend(int channel, int value);
-
-/// send a MIDI after touch message to [touchin] objects
-/// channel is 0-indexed and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_aftertouch(int channel, int value);
-
-/// send a MIDI poly after touch message to [polytouchin] objects
-/// channel is 0-indexed, pitch is 0-127, and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_polyaftertouch(int channel, int pitch, int value);
-
-/// send a raw MIDI byte to [midiin] objects
-/// port is 0-indexed and byte is 0-256
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_midibyte(int port, int byte);
-
-/// send a raw MIDI byte to [sysexin] objects
-/// port is 0-indexed and byte is 0-256
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_sysex(int port, int byte);
-
-/// send a raw MIDI byte to [realtimein] objects
-/// port is 0-indexed and byte is 0-256
-/// returns 0 on success or -1 if an argument is out of range
-EXTERN int libpd_sysrealtime(int port, int byte);
-
-/* receiving MIDI messages from pd */
-
-/// MIDI note on receive hook signature
-/// channel is 0-indexed, pitch is 0-127, and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: there is no note off message, note on w/ velocity = 0 is used instead
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_noteonhook)(int channel, int pitch, int velocity);
-
-/// MIDI control change receive hook signature
-/// channel is 0-indexed, controller is 0-127, and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_controlchangehook)(int channel,
-    int controller, int value);
-
-/// MIDI program change receive hook signature
-/// channel is 0-indexed and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_programchangehook)(int channel, int value);
-
-/// MIDI pitch bend receive hook signature
-/// channel is 0-indexed and value is -8192-8192
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: [bendin] outputs 0-16383 while [bendout] accepts -8192-8192
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_pitchbendhook)(int channel, int value);
-
-/// MIDI after touch receive hook signature
-/// channel is 0-indexed and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_aftertouchhook)(int channel, int value);
-
-/// MIDI poly after touch receive hook signature
-/// channel is 0-indexed, pitch is 0-127, and value is 0-127
-/// channels encode MIDI ports via: libpd_channel = pd_channel + 16 * pd_port
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_polyaftertouchhook)(int channel, int pitch, int value);
-
-/// raw MIDI byte receive hook signature
-/// port is 0-indexed and byte is 0-256
-/// note: out of range values from pd are clamped
-typedef void (*t_libpd_midibytehook)(int port, int byte);
-
-/// set the MIDI note on hook to receive from [noteout] objects, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_noteonhook(const t_libpd_noteonhook hook);
-
-/// set the MIDI control change hook to receive from [ctlout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_controlchangehook(const t_libpd_controlchangehook hook);
-
-/// set the MIDI program change hook to receive from [pgmout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_programchangehook(const t_libpd_programchangehook hook);
-
-/// set the MIDI pitch bend hook to receive from [bendout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook);
-
-/// set the MIDI after touch hook to receive from [touchout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
-
-/// set the MIDI poly after touch hook to receive from [polytouchout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
-
-/// set the raw MIDI byte hook to receive from [midiout] objects,
-/// NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
-
-/* GUI */
-
-/// open the current patches within a pd vanilla GUI
-/// requires the path to pd's main folder that contains bin/, tcl/, etc
-/// for a macOS .app bundle: /path/to/Pd-#.#-#.app/Contents/Resources
-/// returns 0 on success
-EXTERN int libpd_start_gui(const char *path);
-
-/// stop the pd vanilla GUI
-EXTERN void libpd_stop_gui(void);
-
-/// manually update and handle any GUI messages
-/// this is called automatically when using a libpd_process function,
-/// note: this also facilitates network message processing, etc so it can be
-///       useful to call repeatedly when idle for more throughput
-/// returns 1 if the poll found something, in which case it might be desirable
-/// to poll again, up to some reasonable limit
-EXTERN int libpd_poll_gui(void);
-
-/* multiple instances */
-
-/// create a new pd instance
-/// returns new instance or NULL when libpd is not compiled with PDINSTANCE
-EXTERN t_pdinstance *libpd_new_instance(void);
-
-/// set the current pd instance
-/// subsequent libpd calls will affect this instance only
-/// does nothing when libpd is not compiled with PDINSTANCE
-EXTERN void libpd_set_instance(t_pdinstance *p);
-
-/// free a pd instance
-/// does nothing when libpd is not compiled with PDINSTANCE
-EXTERN void libpd_free_instance(t_pdinstance *p);
-
-/// get the current pd instance
-EXTERN t_pdinstance *libpd_this_instance(void);
-
-/// get a pd instance by index
-/// returns NULL if index is out of bounds or "this" instance when libpd is not
-/// compiled with PDINSTANCE
-EXTERN t_pdinstance *libpd_get_instance(int index);
-
-/// get the number of pd instances
-/// returns number or 1 when libpd is not compiled with PDINSTANCE
-EXTERN int libpd_num_instances(void);
-
-/* log level */
-
-/// set verbose print state: 0 or 1
-EXTERN void libpd_set_verbose(int verbose);
-
-/// get the verbose print state: 0 or 1
-EXTERN int libpd_get_verbose(void);
+    /* initializing pd */
+
+    /// initialize libpd; it is safe to call this more than once
+    /// returns 0 on success or -1 if libpd was already initialized
+    /// note: sets SIGFPE handler to keep bad pd patches from crashing due to
+    /// divide
+    ///       by 0, set any custom handling after calling this function
+    EXTERN int libpd_init(void);
+
+    /// clear the libpd search path for abstractions and externals
+    /// note: this is called by libpd_init()
+    EXTERN void libpd_clear_search_path(void);
+
+    /// add a path to the libpd search paths
+    /// relative paths are relative to the current working directory
+    /// unlike desktop pd, *no* search paths are set by default (ie. extra)
+    EXTERN void libpd_add_to_search_path(const char *path);
+
+    /* opening patches */
+
+    /// open a patch by filename and parent dir path
+    /// returns an opaque patch handle pointer or NULL on failure
+    EXTERN void *libpd_openfile(const char *name, const char *dir);
+
+    /// close a patch by patch handle pointer
+    EXTERN void libpd_closefile(void *p);
+
+    /// get the $0 id of the patch handle pointer
+    /// returns $0 value or 0 if the patch is non-existent
+    EXTERN int libpd_getdollarzero(void *p);
+
+    /* audio processing */
+
+    /// return pd's fixed block size: the number of sample frames per 1 pd tick
+    EXTERN int libpd_blocksize(void);
+
+    /// initialize audio rendering
+    /// returns 0 on success
+    EXTERN int libpd_init_audio(
+        int inChannels, int outChannels, int sampleRate);
+
+    /// process interleaved float samples from inBuffer -> libpd -> outBuffer
+    /// buffer sizes are based on # of ticks and channels where:
+    ///     size = ticks * libpd_blocksize() * (in/out)channels
+    /// returns 0 on success
+    EXTERN int libpd_process_float(
+        const int ticks, const float *inBuffer, float *outBuffer);
+
+    /// process interleaved short samples from inBuffer -> libpd -> outBuffer
+    /// buffer sizes are based on # of ticks and channels where:
+    ///     size = ticks * libpd_blocksize() * (in/out)channels
+    /// float samples are converted to short by multiplying by 32767 and
+    /// casting, so any values received from pd patches beyond -1 to 1 will
+    /// result in garbage note: for efficiency, does *not* clip input returns 0
+    /// on success
+    EXTERN int libpd_process_short(
+        const int ticks, const short *inBuffer, short *outBuffer);
+
+    /// process interleaved double samples from inBuffer -> libpd -> outBuffer
+    /// buffer sizes are based on # of ticks and channels where:
+    ///     size = ticks * libpd_blocksize() * (in/out)channels
+    /// returns 0 on success
+    EXTERN int libpd_process_double(
+        const int ticks, const double *inBuffer, double *outBuffer);
+
+    /// process non-interleaved float samples from inBuffer -> libpd ->
+    /// outBuffer copies buffer contents to/from libpd without striping buffer
+    /// sizes are based on a single tick and # of channels where:
+    ///     size = libpd_blocksize() * (in/out)channels
+    /// returns 0 on success
+    EXTERN int libpd_process_raw(const float *inBuffer, float *outBuffer);
+
+    /// process non-interleaved short samples from inBuffer -> libpd ->
+    /// outBuffer copies buffer contents to/from libpd without striping buffer
+    /// sizes are based on a single tick and # of channels where:
+    ///     size = libpd_blocksize() * (in/out)channels
+    /// float samples are converted to short by multiplying by 32767 and
+    /// casting, so any values received from pd patches beyond -1 to 1 will
+    /// result in garbage note: for efficiency, does *not* clip input returns 0
+    /// on success
+    EXTERN int libpd_process_raw_short(const short *inBuffer, short *outBuffer);
+
+    /// process non-interleaved double samples from inBuffer -> libpd ->
+    /// outBuffer copies buffer contents to/from libpd without striping buffer
+    /// sizes are based on a single tick and # of channels where:
+    ///     size = libpd_blocksize() * (in/out)channels
+    /// returns 0 on success
+    EXTERN int libpd_process_raw_double(
+        const double *inBuffer, double *outBuffer);
+
+    /* array access */
+
+    /// get the size of an array by name
+    /// returns size or negative error code if non-existent
+    EXTERN int libpd_arraysize(const char *name);
+
+    /// (re)size an array by name; sizes <= 0 are clipped to 1
+    /// returns 0 on success or negative error code if non-existent
+    EXTERN int libpd_resize_array(const char *name, long size);
+
+    /// read n values from named src array and write into dest starting at an
+    /// offset note: performs no bounds checking on dest returns 0 on success or
+    /// a negative error code if the array is non-existent or offset + n exceeds
+    /// range of array
+    EXTERN int libpd_read_array(
+        float *dest, const char *name, int offset, int n);
+
+    /// read n values from src and write into named dest array starting at an
+    /// offset note: performs no bounds checking on src returns 0 on success or
+    /// a negative error code if the array is non-existent or offset + n exceeds
+    /// range of array
+    EXTERN int libpd_write_array(
+        const char *name, int offset, const float *src, int n);
+
+    /* sending messages to pd */
+
+    /// send a bang to a destination receiver
+    /// ex: libpd_bang("foo") will send a bang to [s foo] on the next tick
+    /// returns 0 on success or -1 if receiver name is non-existent
+    EXTERN int libpd_bang(const char *recv);
+
+    /// send a float to a destination receiver
+    /// ex: libpd_float("foo", 1) will send a 1.0 to [s foo] on the next tick
+    /// returns 0 on success or -1 if receiver name is non-existent
+    EXTERN int libpd_float(const char *recv, float x);
+
+    /// send a symbol to a destination receiver
+    /// ex: libpd_symbol("foo", "bar") will send "bar" to [s foo] on the next
+    /// tick returns 0 on success or -1 if receiver name is non-existent
+    EXTERN int libpd_symbol(const char *recv, const char *symbol);
+
+    /* sending compound messages: sequenced function calls */
+
+    /// start composition of a new list or typed message of up to max element
+    /// length messages can be of a smaller length as max length is only an
+    /// upper bound note: no cleanup is required for unfinished messages returns
+    /// 0 on success or nonzero if the length is too large
+    EXTERN int libpd_start_message(int maxlen);
+
+    /// add a float to the current message in progress
+    EXTERN void libpd_add_float(float x);
+
+    /// add a symbol to the current message in progress
+    EXTERN void libpd_add_symbol(const char *symbol);
+
+    /// finish current message and send as a list to a destination receiver
+    /// returns 0 on success or -1 if receiver name is non-existent
+    /// ex: send [list 1 2 bar( to [s foo] on the next tick with:
+    ///     libpd_start_message(3);
+    ///     libpd_add_float(1);
+    ///     libpd_add_float(2);
+    ///     libpd_add_symbol("bar");
+    ///     libpd_finish_list("foo");
+    EXTERN int libpd_finish_list(const char *recv);
+
+    /// finish current message and send as a typed message to a destination
+    /// receiver note: typed message handling currently only supports up to 4
+    /// elements
+    ///       internally, additional elements may be ignored
+    /// returns 0 on success or -1 if receiver name is non-existent
+    /// ex: send [; pd dsp 1( on the next tick with:
+    ///     libpd_start_message(1);
+    ///     libpd_add_float(1);
+    ///     libpd_finish_message("pd", "dsp");
+    EXTERN int libpd_finish_message(const char *recv, const char *msg);
+
+    /* sending compound messages: atom array */
+
+    /// write a float value to the given atom
+    EXTERN void libpd_set_float(t_atom *a, float x);
+
+    /// write a symbol value to the given atom
+    EXTERN void libpd_set_symbol(t_atom *a, const char *symbol);
+
+    /// send an atom array of a given length as a list to a destination receiver
+    /// returns 0 on success or -1 if receiver name is non-existent
+    /// ex: send [list 1 2 bar( to [r foo] on the next tick with:
+    ///     t_atom v[3];
+    ///     libpd_set_float(v, 1);
+    ///     libpd_set_float(v + 1, 2);
+    ///     libpd_set_symbol(v + 2, "bar");
+    ///     libpd_list("foo", 3, v);
+    EXTERN int libpd_list(const char *recv, int argc, t_atom *argv);
+
+    /// send a atom array of a given length as a typed message to a destination
+    /// receiver, returns 0 on success or -1 if receiver name is non-existent
+    /// ex: send [; pd dsp 1( on the next tick with:
+    ///     t_atom v[1];
+    ///     libpd_set_float(v, 1);
+    ///     libpd_message("pd", "dsp", 1, v);
+    EXTERN int libpd_message(
+        const char *recv, const char *msg, int argc, t_atom *argv);
+
+    /* receiving messages from pd */
+
+    /// subscribe to messages sent to a source receiver
+    /// ex: libpd_bind("foo") adds a "virtual" [r foo] which forwards messages
+    /// to
+    ///     the libpd message hooks
+    /// returns an opaque receiver pointer or NULL on failure
+    EXTERN void *libpd_bind(const char *recv);
+
+    /// unsubscribe and free a source receiver object created by libpd_bind()
+    EXTERN void libpd_unbind(void *p);
+
+    /// check if a source receiver object exists with a given name
+    /// returns 1 if the receiver exists, otherwise 0
+    EXTERN int libpd_exists(const char *recv);
+
+    /// print receive hook signature, s is the string to be printed
+    /// note: default behavior returns individual words and spaces:
+    ///     line "hello 123" is received in 4 parts -> "hello", " ", "123\n"
+    typedef void (*t_libpd_printhook)(const char *s);
+
+    /// bang receive hook signature, recv is the source receiver name
+    typedef void (*t_libpd_banghook)(const char *recv);
+
+    /// float receive hook signature, recv is the source receiver name
+    typedef void (*t_libpd_floathook)(const char *recv, float x);
+
+    /// symbol receive hook signature, recv is the source receiver name
+    typedef void (*t_libpd_symbolhook)(const char *recv, const char *symbol);
+
+    /// list receive hook signature, recv is the source receiver name
+    /// argc is the list length and vector argv contains the list elements
+    /// which can be accessed using the atom accessor functions, ex:
+    ///     int i;
+    ///     for (i = 0; i < argc; i++) {
+    ///       t_atom *a = &argv[n];
+    ///       if (libpd_is_float(a)) {
+    ///         float x = libpd_get_float(a);
+    ///         // do something with float x
+    ///       } else if (libpd_is_symbol(a)) {
+    ///         char *s = libpd_get_symbol(a);
+    ///         // do something with c string s
+    ///       }
+    ///     }
+    /// note: check for both float and symbol types as atom may also be a
+    /// pointer
+    typedef void (*t_libpd_listhook)(const char *recv, int argc, t_atom *argv);
+
+    /// typed message hook signature, recv is the source receiver name and msg
+    /// is the typed message name: a message like [; foo bar 1 2 a b( will
+    /// trigger a function call like libpd_messagehook("foo", "bar", 4, argv)
+    /// argc is the list length and vector argv contains the
+    /// list elements which can be accessed using the atom accessor functions,
+    /// ex:
+    ///     int i;
+    ///     for (i = 0; i < argc; i++) {
+    ///       t_atom *a = &argv[n];
+    ///       if (libpd_is_float(a)) {
+    ///         float x = libpd_get_float(a);
+    ///         // do something with float x
+    ///       } else if (libpd_is_symbol(a)) {
+    ///         char *s = libpd_get_symbol(a);
+    ///         // do something with c string s
+    ///       }
+    ///     }
+    /// note: check for both float and symbol types as atom may also be a
+    /// pointer
+    typedef void (*t_libpd_messagehook)(
+        const char *recv, const char *msg, int argc, t_atom *argv);
+
+    /// set the print receiver hook, prints to stdout by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_printhook(const t_libpd_printhook hook);
+
+    /// set the bang receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_banghook(const t_libpd_banghook hook);
+
+    /// set the float receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_floathook(const t_libpd_floathook hook);
+
+    /// set the symbol receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_symbolhook(const t_libpd_symbolhook hook);
+
+    /// set the list receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_listhook(const t_libpd_listhook hook);
+
+    /// set the message receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_messagehook(const t_libpd_messagehook hook);
+
+    /// check if an atom is a float type: 0 or 1
+    /// note: no NULL check is performed
+    EXTERN int libpd_is_float(t_atom *a);
+
+    /// check if an atom is a symbol type: 0 or 1
+    /// note: no NULL check is performed
+    EXTERN int libpd_is_symbol(t_atom *a);
+
+    /// get the float value of an atom
+    /// note: no NULL or type checks are performed
+    EXTERN float libpd_get_float(t_atom *a);
+
+    /// note: no NULL or type checks are performed
+    /// get symbol value of an atom
+    EXTERN const char *libpd_get_symbol(t_atom *a);
+
+    /// increment to the next atom in an atom vector
+    /// returns next atom or NULL, assuming the atom vector is NULL-terminated
+    EXTERN t_atom *libpd_next_atom(t_atom *a);
+
+    /* sending MIDI messages to pd */
+
+    /// send a MIDI note on message to [notein] objects
+    /// channel is 0-indexed, pitch is 0-127, and velocity is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: there is no note off message, send a note on with velocity
+    /// = 0 instead returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_noteon(int channel, int pitch, int velocity);
+
+    /// send a MIDI control change message to [ctlin] objects
+    /// channel is 0-indexed, controller is 0-127, and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_controlchange(int channel, int controller, int value);
+
+    /// send a MIDI program change message to [pgmin] objects
+    /// channel is 0-indexed and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_programchange(int channel, int value);
+
+    /// send a MIDI pitch bend message to [bendin] objects
+    /// channel is 0-indexed and value is -8192-8192
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: [bendin] outputs 0-16383 while [bendout] accepts
+    /// -8192-8192 returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_pitchbend(int channel, int value);
+
+    /// send a MIDI after touch message to [touchin] objects
+    /// channel is 0-indexed and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_aftertouch(int channel, int value);
+
+    /// send a MIDI poly after touch message to [polytouchin] objects
+    /// channel is 0-indexed, pitch is 0-127, and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_polyaftertouch(int channel, int pitch, int value);
+
+    /// send a raw MIDI byte to [midiin] objects
+    /// port is 0-indexed and byte is 0-256
+    /// returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_midibyte(int port, int byte);
+
+    /// send a raw MIDI byte to [sysexin] objects
+    /// port is 0-indexed and byte is 0-256
+    /// returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_sysex(int port, int byte);
+
+    /// send a raw MIDI byte to [realtimein] objects
+    /// port is 0-indexed and byte is 0-256
+    /// returns 0 on success or -1 if an argument is out of range
+    EXTERN int libpd_sysrealtime(int port, int byte);
+
+    /* receiving MIDI messages from pd */
+
+    /// MIDI note on receive hook signature
+    /// channel is 0-indexed, pitch is 0-127, and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: there is no note off message, note on w/ velocity = 0 is
+    /// used instead note: out of range values from pd are clamped
+    typedef void (*t_libpd_noteonhook)(int channel, int pitch, int velocity);
+
+    /// MIDI control change receive hook signature
+    /// channel is 0-indexed, controller is 0-127, and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: out of range values from pd are clamped
+    typedef void (*t_libpd_controlchangehook)(
+        int channel, int controller, int value);
+
+    /// MIDI program change receive hook signature
+    /// channel is 0-indexed and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: out of range values from pd are clamped
+    typedef void (*t_libpd_programchangehook)(int channel, int value);
+
+    /// MIDI pitch bend receive hook signature
+    /// channel is 0-indexed and value is -8192-8192
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: [bendin] outputs 0-16383 while [bendout] accepts
+    /// -8192-8192 note: out of range values from pd are clamped
+    typedef void (*t_libpd_pitchbendhook)(int channel, int value);
+
+    /// MIDI after touch receive hook signature
+    /// channel is 0-indexed and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: out of range values from pd are clamped
+    typedef void (*t_libpd_aftertouchhook)(int channel, int value);
+
+    /// MIDI poly after touch receive hook signature
+    /// channel is 0-indexed, pitch is 0-127, and value is 0-127
+    /// channels encode MIDI ports via: libpd_channel = pd_channel + 16 *
+    /// pd_port note: out of range values from pd are clamped
+    typedef void (*t_libpd_polyaftertouchhook)(
+        int channel, int pitch, int value);
+
+    /// raw MIDI byte receive hook signature
+    /// port is 0-indexed and byte is 0-256
+    /// note: out of range values from pd are clamped
+    typedef void (*t_libpd_midibytehook)(int port, int byte);
+
+    /// set the MIDI note on hook to receive from [noteout] objects, NULL by
+    /// default note: do not call this while DSP is running
+    EXTERN void libpd_set_noteonhook(const t_libpd_noteonhook hook);
+
+    /// set the MIDI control change hook to receive from [ctlout] objects,
+    /// NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_controlchangehook(
+        const t_libpd_controlchangehook hook);
+
+    /// set the MIDI program change hook to receive from [pgmout] objects,
+    /// NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_programchangehook(
+        const t_libpd_programchangehook hook);
+
+    /// set the MIDI pitch bend hook to receive from [bendout] objects,
+    /// NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_pitchbendhook(const t_libpd_pitchbendhook hook);
+
+    /// set the MIDI after touch hook to receive from [touchout] objects,
+    /// NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_aftertouchhook(const t_libpd_aftertouchhook hook);
+
+    /// set the MIDI poly after touch hook to receive from [polytouchout]
+    /// objects, NULL by default note: do not call this while DSP is running
+    EXTERN void libpd_set_polyaftertouchhook(
+        const t_libpd_polyaftertouchhook hook);
+
+    /// set the raw MIDI byte hook to receive from [midiout] objects,
+    /// NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_midibytehook(const t_libpd_midibytehook hook);
+
+    /* GUI */
+
+    /// open the current patches within a pd vanilla GUI
+    /// requires the path to pd's main folder that contains bin/, tcl/, etc
+    /// for a macOS .app bundle: /path/to/Pd-#.#-#.app/Contents/Resources
+    /// returns 0 on success
+    EXTERN int libpd_start_gui(const char *path);
+
+    /// stop the pd vanilla GUI
+    EXTERN void libpd_stop_gui(void);
+
+    /// manually update and handle any GUI messages
+    /// this is called automatically when using a libpd_process function,
+    /// note: this also facilitates network message processing, etc so it can be
+    ///       useful to call repeatedly when idle for more throughput
+    /// returns 1 if the poll found something, in which case it might be
+    /// desirable to poll again, up to some reasonable limit
+    EXTERN int libpd_poll_gui(void);
+
+    /* multiple instances */
+
+    /// create a new pd instance
+    /// returns new instance or NULL when libpd is not compiled with PDINSTANCE
+    EXTERN t_pdinstance *libpd_new_instance(void);
+
+    /// set the current pd instance
+    /// subsequent libpd calls will affect this instance only
+    /// does nothing when libpd is not compiled with PDINSTANCE
+    EXTERN void libpd_set_instance(t_pdinstance *p);
+
+    /// free a pd instance
+    /// does nothing when libpd is not compiled with PDINSTANCE
+    EXTERN void libpd_free_instance(t_pdinstance *p);
+
+    /// get the current pd instance
+    EXTERN t_pdinstance *libpd_this_instance(void);
+
+    /// get a pd instance by index
+    /// returns NULL if index is out of bounds or "this" instance when libpd is
+    /// not compiled with PDINSTANCE
+    EXTERN t_pdinstance *libpd_get_instance(int index);
+
+    /// get the number of pd instances
+    /// returns number or 1 when libpd is not compiled with PDINSTANCE
+    EXTERN int libpd_num_instances(void);
+
+    /* log level */
+
+    /// set verbose print state: 0 or 1
+    EXTERN void libpd_set_verbose(int verbose);
+
+    /// get the verbose print state: 0 or 1
+    EXTERN int libpd_get_verbose(void);
 
 #ifdef __cplusplus
 }

--- a/src/z_print_util.c
+++ b/src/z_print_util.c
@@ -18,34 +18,38 @@ t_libpd_printhook libpd_concatenated_printhook = NULL;
 
 #define PRINT_LINE_SIZE 2048
 
-void libpd_set_concatenated_printhook(const t_libpd_printhook hook) {
-  libpd_concatenated_printhook = hook;
+void libpd_set_concatenated_printhook(const t_libpd_printhook hook)
+{
+    libpd_concatenated_printhook = hook;
 }
 
-void libpd_print_concatenator(const char *s) {
-  if (!libpd_concatenated_printhook) return;
+void libpd_print_concatenator(const char *s)
+{
+    if(!libpd_concatenated_printhook) return;
 
-  static char concatenated_print_line[PRINT_LINE_SIZE];
-  static int len_line = 0;
-  concatenated_print_line[len_line] = '\0';
+    static char concatenated_print_line[PRINT_LINE_SIZE];
+    static int len_line = 0;
+    concatenated_print_line[len_line] = '\0';
 
-  int len = (int) strlen(s);
-  while (len_line + len >= PRINT_LINE_SIZE) {
-    int d = PRINT_LINE_SIZE - 1 - len_line;
-    strncat(concatenated_print_line, s, d);
-    libpd_concatenated_printhook(concatenated_print_line);
-    s += d;
-    len -= d;
-    len_line = 0;
-    concatenated_print_line[0] = '\0';
-  }
+    int len = (int) strlen(s);
+    while(len_line + len >= PRINT_LINE_SIZE)
+    {
+        int d = PRINT_LINE_SIZE - 1 - len_line;
+        strncat(concatenated_print_line, s, d);
+        libpd_concatenated_printhook(concatenated_print_line);
+        s += d;
+        len -= d;
+        len_line = 0;
+        concatenated_print_line[0] = '\0';
+    }
 
-  strncat(concatenated_print_line, s, len);
-  len_line += len;
+    strncat(concatenated_print_line, s, len);
+    len_line += len;
 
-  if (len_line > 0 && concatenated_print_line[len_line - 1] == '\n') {
-    concatenated_print_line[len_line - 1] = '\0';
-    libpd_concatenated_printhook(concatenated_print_line);
-    len_line = 0;
-  }
+    if(len_line > 0 && concatenated_print_line[len_line - 1] == '\n')
+    {
+        concatenated_print_line[len_line - 1] = '\0';
+        libpd_concatenated_printhook(concatenated_print_line);
+        len_line = 0;
+    }
 }

--- a/src/z_print_util.h
+++ b/src/z_print_util.h
@@ -19,26 +19,28 @@ extern "C"
 {
 #endif
 
-/// concatenate print messages into single lines before returning them to the
-/// print hook:
-///    ie. line "hello 123\n" is received in 1 part -> "hello 123"
-/// for comparison, the default behavior receives individual words and spaces:
-///
-/// ie. line "hello 123" is sent in 3 parts -> "hello", " ", "123\n"
+    /// concatenate print messages into single lines before returning them to
+    /// the print hook:
+    ///    ie. line "hello 123\n" is received in 1 part -> "hello 123"
+    /// for comparison, the default behavior receives individual words and
+    /// spaces:
+    ///
+    /// ie. line "hello 123" is sent in 3 parts -> "hello", " ", "123\n"
 
-/// assign the pointer to your print handler
-EXTERN void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
+    /// assign the pointer to your print handler
+    EXTERN void libpd_set_concatenated_printhook(const t_libpd_printhook hook);
 
-/// assign this function pointer to libpd_printhook or libpd_queued_printhook,
-/// depending on whether you're using queued messages, to intercept and
-/// concatenate print messages:
-///     libpd_set_printhook(libpd_print_concatenator);
-///     or
-///     libpd_set_concatenated_printhook(your_print_handler);
-/// note: the char pointer argument is only good for the duration of the print
-///       callback; if you intend to use the argument after the callback has
-///       returned, you need to make a defensive copy
-EXTERN void libpd_print_concatenator(const char *s);
+    /// assign this function pointer to libpd_printhook or
+    /// libpd_queued_printhook, depending on whether you're using queued
+    /// messages, to intercept and concatenate print messages:
+    ///     libpd_set_printhook(libpd_print_concatenator);
+    ///     or
+    ///     libpd_set_concatenated_printhook(your_print_handler);
+    /// note: the char pointer argument is only good for the duration of the
+    /// print
+    ///       callback; if you intend to use the argument after the callback has
+    ///       returned, you need to make a defensive copy
+    EXTERN void libpd_print_concatenator(const char *s);
 
 #ifdef __cplusplus
 }

--- a/src/z_queued.c
+++ b/src/z_queued.c
@@ -30,25 +30,40 @@ t_libpd_aftertouchhook libpd_queued_aftertouchhook = NULL;
 t_libpd_polyaftertouchhook libpd_queued_polyaftertouchhook = NULL;
 t_libpd_midibytehook libpd_queued_midibytehook = NULL;
 
-typedef struct _pd_params {
-  enum {
-    LIBPD_PRINT, LIBPD_BANG, LIBPD_FLOAT,
-    LIBPD_SYMBOL, LIBPD_LIST, LIBPD_MESSAGE,
-  } type;
-  const char *src;
-  float x;
-  const char *sym;
-  int argc;
+typedef struct _pd_params
+{
+    enum
+    {
+        LIBPD_PRINT,
+        LIBPD_BANG,
+        LIBPD_FLOAT,
+        LIBPD_SYMBOL,
+        LIBPD_LIST,
+        LIBPD_MESSAGE,
+    } type;
+
+    const char *src;
+    float x;
+    const char *sym;
+    int argc;
 } pd_params;
 
-typedef struct _midi_params {
-  enum {
-    LIBPD_NOTEON, LIBPD_CONTROLCHANGE, LIBPD_PROGRAMCHANGE, LIBPD_PITCHBEND,
-    LIBPD_AFTERTOUCH, LIBPD_POLYAFTERTOUCH, LIBPD_MIDIBYTE
-  } type;
-  int midi1;
-  int midi2;
-  int midi3;
+typedef struct _midi_params
+{
+    enum
+    {
+        LIBPD_NOTEON,
+        LIBPD_CONTROLCHANGE,
+        LIBPD_PROGRAMCHANGE,
+        LIBPD_PITCHBEND,
+        LIBPD_AFTERTOUCH,
+        LIBPD_POLYAFTERTOUCH,
+        LIBPD_MIDIBYTE
+    } type;
+
+    int midi1;
+    int midi2;
+    int midi3;
 } midi_params;
 
 #define BUFFER_SIZE 16384
@@ -59,364 +74,464 @@ typedef struct _midi_params {
 static ring_buffer *pd_receive_buffer = NULL;
 static ring_buffer *midi_receive_buffer = NULL;
 
-static void receive_print(pd_params *p, char **buffer) {
-  if (libpd_queued_printhook) {
-    libpd_queued_printhook(*buffer);
-  }
-  *buffer += p->argc;
+static void receive_print(pd_params *p, char **buffer)
+{
+    if(libpd_queued_printhook)
+    {
+        libpd_queued_printhook(*buffer);
+    }
+    *buffer += p->argc;
 }
 
-static void receive_bang(pd_params *p, char **buffer) {
-  if (libpd_queued_banghook) {
-    libpd_queued_banghook(p->src);
-  }
+static void receive_bang(pd_params *p, char **buffer)
+{
+    if(libpd_queued_banghook)
+    {
+        libpd_queued_banghook(p->src);
+    }
 }
 
-static void receive_float(pd_params *p, char **buffer) {
-  if (libpd_queued_floathook) {
-    libpd_queued_floathook(p->src, p->x);
-  }
+static void receive_float(pd_params *p, char **buffer)
+{
+    if(libpd_queued_floathook)
+    {
+        libpd_queued_floathook(p->src, p->x);
+    }
 }
 
-static void receive_symbol(pd_params *p, char **buffer) {
-  if (libpd_queued_symbolhook) {
-    libpd_queued_symbolhook(p->src, p->sym);
-  }
+static void receive_symbol(pd_params *p, char **buffer)
+{
+    if(libpd_queued_symbolhook)
+    {
+        libpd_queued_symbolhook(p->src, p->sym);
+    }
 }
 
-static void receive_list(pd_params *p, char **buffer) {
-  if (libpd_queued_listhook) {
-    libpd_queued_listhook(p->src, p->argc, (t_atom *) *buffer);
-  }
-  *buffer += p->argc * S_ATOM;
+static void receive_list(pd_params *p, char **buffer)
+{
+    if(libpd_queued_listhook)
+    {
+        libpd_queued_listhook(p->src, p->argc, (t_atom *) *buffer);
+    }
+    *buffer += p->argc * S_ATOM;
 }
 
-static void receive_message(pd_params *p, char **buffer) {
-  if (libpd_queued_messagehook) {
-    libpd_queued_messagehook(p->src, p->sym, p->argc, (t_atom *) *buffer);
-  }
-  *buffer += p->argc * S_ATOM;
+static void receive_message(pd_params *p, char **buffer)
+{
+    if(libpd_queued_messagehook)
+    {
+        libpd_queued_messagehook(p->src, p->sym, p->argc, (t_atom *) *buffer);
+    }
+    *buffer += p->argc * S_ATOM;
 }
 
 #define LIBPD_WORD_ALIGN 8
 
-static void internal_printhook(const char *s) {
-  static char padding[LIBPD_WORD_ALIGN];
-  int len = (int) strlen(s) + 1; // remember terminating null char
-  int rest = len % LIBPD_WORD_ALIGN;
-  if (rest) rest = LIBPD_WORD_ALIGN - rest;
-  int total = len + rest;
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + total) {
-    pd_params p = {LIBPD_PRINT, NULL, 0.0f, NULL, total};
-    rb_write_to_buffer(pd_receive_buffer, 3,
-        (const char *)&p, S_PD_PARAMS, s, len, padding, rest);
-  }
-}
-
-static void internal_banghook(const char *src) {
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS) {
-    pd_params p = {LIBPD_BANG, src, 0.0f, NULL, 0};
-    rb_write_to_buffer(pd_receive_buffer, 1, (const char *)&p, S_PD_PARAMS);
-  }
-}
-
-static void internal_floathook(const char *src, float x) {
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS) {
-    pd_params p = {LIBPD_FLOAT, src, x, NULL, 0};
-    rb_write_to_buffer(pd_receive_buffer, 1, (const char *)&p, S_PD_PARAMS);
-  }
-}
-
-static void internal_symbolhook(const char *src, const char *sym) {
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS) {
-    pd_params p = {LIBPD_SYMBOL, src, 0.0f, sym, 0};
-    rb_write_to_buffer(pd_receive_buffer, 1, (const char *)&p, S_PD_PARAMS);
-  }
-}
-
-static void internal_listhook(const char *src, int argc, t_atom *argv) {
-  int n = argc * S_ATOM;
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n) {
-    pd_params p = {LIBPD_LIST, src, 0.0f, NULL, argc};
-    rb_write_to_buffer(pd_receive_buffer, 2,
-        (const char *)&p, S_PD_PARAMS, (const char *)argv, n);
-  }
-}
-
-static void internal_messagehook(const char *src, const char* sym,
-    int argc, t_atom *argv) {
-  int n = argc * S_ATOM;
-  if (rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n) {
-    pd_params p = {LIBPD_MESSAGE, src, 0.0f, sym, argc};
-    rb_write_to_buffer(pd_receive_buffer, 2,
-        (const char *)&p, S_PD_PARAMS, (const char *)argv, n);
-  }
-}
-
-static void receive_noteon(midi_params *p, char **buffer) {
-  if (libpd_queued_noteonhook) {
-    libpd_queued_noteonhook(p->midi1, p->midi2, p->midi3);
-  }
-}
-
-static void receive_controlchange(midi_params *p, char **buffer) {
-  if (libpd_queued_controlchangehook) {
-    libpd_queued_controlchangehook(p->midi1, p->midi2, p->midi3);
-  }
-}
-
-static void receive_programchange(midi_params *p, char **buffer) {
-  if (libpd_queued_programchangehook) {
-    libpd_queued_programchangehook(p->midi1, p->midi2);
-  }
-}
-
-static void receive_pitchbend(midi_params *p, char **buffer) {
-  if (libpd_queued_pitchbendhook) {
-    libpd_queued_pitchbendhook(p->midi1, p->midi2);
-  }
-}
-
-static void receive_aftertouch(midi_params *p, char **buffer) {
-  if (libpd_queued_aftertouchhook) {
-    libpd_queued_aftertouchhook(p->midi1, p->midi2);
-  }
-}
-
-static void receive_polyaftertouch(midi_params *p, char **buffer) {
-  if (libpd_queued_polyaftertouchhook) {
-    libpd_queued_polyaftertouchhook(p->midi1, p->midi2, p->midi3);
-  }
-}
-
-static void receive_midibyte(midi_params *p, char **buffer) {
-  if (libpd_queued_midibytehook) {
-    libpd_queued_midibytehook(p->midi1, p->midi2);
-  }
-}
-
-static void internal_noteonhook(int channel, int pitch, int velocity) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_NOTEON, channel, pitch, velocity};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_controlchangehook(int channel, int controller, int value) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_CONTROLCHANGE, channel, controller, value};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_programchangehook(int channel, int value) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_PROGRAMCHANGE, channel, value, 0};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_pitchbendhook(int channel, int value) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_PITCHBEND, channel, value, 0};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_aftertouchhook(int channel, int value) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_AFTERTOUCH, channel, value, 0};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_polyaftertouchhook(int channel, int pitch, int value) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_POLYAFTERTOUCH, channel, pitch, value};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-static void internal_midibytehook(int port, int byte) {
-  if (rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS) {
-    midi_params p = {LIBPD_MIDIBYTE, port, byte, 0};
-    rb_write_to_buffer(midi_receive_buffer, 1, (const char *)&p, S_MIDI_PARAMS);
-  }
-}
-
-void libpd_set_queued_printhook(const t_libpd_printhook hook) {
-  libpd_queued_printhook = hook;
-}
-
-void libpd_set_queued_banghook(const t_libpd_banghook hook) {
-  libpd_queued_banghook = hook;
-}
-
-void libpd_set_queued_floathook(const t_libpd_floathook hook) {
-  libpd_queued_floathook = hook;
-}
-
-void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook) {
-  libpd_queued_symbolhook = hook;
-}
-
-void libpd_set_queued_listhook(const t_libpd_listhook hook) {
-  libpd_queued_listhook = hook;
-}
-
-void libpd_set_queued_messagehook(const t_libpd_messagehook hook) {
-  libpd_queued_messagehook = hook;
-}
-
-void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook) {
-  libpd_queued_noteonhook = hook;
-}
-
-void libpd_set_queued_controlchangehook(const t_libpd_controlchangehook hook) {
-  libpd_queued_controlchangehook = hook;
-}
-
-void libpd_set_queued_programchangehook(const t_libpd_programchangehook hook) {
-  libpd_queued_programchangehook = hook;
-}
-
-void libpd_set_queued_pitchbendhook(const t_libpd_pitchbendhook hook) {
-  libpd_queued_pitchbendhook = hook;
-}
-
-void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook) {
-  libpd_queued_aftertouchhook = hook;
-}
-
-void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook) {
-  libpd_queued_polyaftertouchhook = hook;
-}
-
-void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook) {
-  libpd_queued_midibytehook = hook;
-}
-
-int libpd_queued_init() {
-  if (!pd_receive_buffer) {
-    pd_receive_buffer = rb_create(BUFFER_SIZE);
-    if (!pd_receive_buffer) return -2;
-  }
-  if (!midi_receive_buffer) {
-    midi_receive_buffer = rb_create(BUFFER_SIZE);
-    if (!midi_receive_buffer) return -2;
-  }
-
-  libpd_set_printhook(internal_printhook);
-  libpd_set_banghook(internal_banghook);
-  libpd_set_floathook(internal_floathook);
-  libpd_set_symbolhook(internal_symbolhook);
-  libpd_set_listhook(internal_listhook);
-  libpd_set_messagehook(internal_messagehook);
-
-  libpd_set_noteonhook(internal_noteonhook);
-  libpd_set_controlchangehook(internal_controlchangehook);
-  libpd_set_programchangehook(internal_programchangehook);
-  libpd_set_pitchbendhook(internal_pitchbendhook);
-  libpd_set_aftertouchhook(internal_aftertouchhook);
-  libpd_set_polyaftertouchhook(internal_polyaftertouchhook);
-  libpd_set_midibytehook(internal_midibytehook);
-
-  return libpd_init();
-}
-
-void libpd_queued_release() {
-  if (pd_receive_buffer) {
-    rb_free(pd_receive_buffer);
-    pd_receive_buffer = NULL;
-  }
-  if (midi_receive_buffer) {
-    rb_free(midi_receive_buffer);
-    midi_receive_buffer = NULL;
-  }
-}
-
-void libpd_queued_receive_pd_messages() {
-  size_t available = rb_available_to_read(pd_receive_buffer);
-  if (!available) return;
-  static char temp_buffer[BUFFER_SIZE];
-  rb_read_from_buffer(pd_receive_buffer, temp_buffer, (int) available);
-  char *end = temp_buffer + available;
-  char *buffer = temp_buffer;
-  while (buffer < end) {
-    pd_params *p = (pd_params *)buffer;
-    buffer += S_PD_PARAMS;
-    switch (p->type) {
-      case LIBPD_PRINT: {
-        receive_print(p, &buffer);
-        break;
-      }
-      case LIBPD_BANG: {
-        receive_bang(p, &buffer);
-        break;
-      }
-      case LIBPD_FLOAT: {
-        receive_float(p, &buffer);
-        break;
-      }
-      case LIBPD_SYMBOL: {
-        receive_symbol(p, &buffer);
-        break;
-      }
-      case LIBPD_LIST: {
-        receive_list(p, &buffer);
-        break;
-      }
-      case LIBPD_MESSAGE: {
-        receive_message(p, &buffer);
-        break;
-      }
-      default:
-        break;
+static void internal_printhook(const char *s)
+{
+    static char padding[LIBPD_WORD_ALIGN];
+    int len = (int) strlen(s) + 1; // remember terminating null char
+    int rest = len % LIBPD_WORD_ALIGN;
+    if(rest) rest = LIBPD_WORD_ALIGN - rest;
+    int total = len + rest;
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + total)
+    {
+        pd_params p = {LIBPD_PRINT, NULL, 0.0f, NULL, total};
+        rb_write_to_buffer(pd_receive_buffer, 3, (const char *) &p, S_PD_PARAMS,
+            s, len, padding, rest);
     }
-  }
 }
 
-void libpd_queued_receive_midi_messages() {
-  size_t available = rb_available_to_read(midi_receive_buffer);
-  if (!available) return;
-  static char temp_buffer[BUFFER_SIZE];
-  rb_read_from_buffer(midi_receive_buffer, temp_buffer, (int) available);
-  char *end = temp_buffer + available;
-  char *buffer = temp_buffer;
-  while (buffer < end) {
-    midi_params *p = (midi_params *)buffer;
-    buffer += S_MIDI_PARAMS;
-    switch (p->type) {
-      case LIBPD_NOTEON: {
-        receive_noteon(p, &buffer);
-        break;
-      }
-      case LIBPD_CONTROLCHANGE: {
-        receive_controlchange(p, &buffer);
-        break;
-      }
-      case LIBPD_PROGRAMCHANGE: {
-        receive_programchange(p, &buffer);
-        break;
-      }
-      case LIBPD_PITCHBEND: {
-        receive_pitchbend(p, &buffer);
-        break;
-      }
-      case LIBPD_AFTERTOUCH: {
-        receive_aftertouch(p, &buffer);
-        break;
-      }
-      case LIBPD_POLYAFTERTOUCH: {
-        receive_polyaftertouch(p, &buffer);
-        break;
-      }
-      case LIBPD_MIDIBYTE: {
-        receive_midibyte(p, &buffer);
-        break;
-      }
-      default:
-        break;
+static void internal_banghook(const char *src)
+{
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS)
+    {
+        pd_params p = {LIBPD_BANG, src, 0.0f, NULL, 0};
+        rb_write_to_buffer(
+            pd_receive_buffer, 1, (const char *) &p, S_PD_PARAMS);
     }
-  }
+}
+
+static void internal_floathook(const char *src, float x)
+{
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS)
+    {
+        pd_params p = {LIBPD_FLOAT, src, x, NULL, 0};
+        rb_write_to_buffer(
+            pd_receive_buffer, 1, (const char *) &p, S_PD_PARAMS);
+    }
+}
+
+static void internal_symbolhook(const char *src, const char *sym)
+{
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS)
+    {
+        pd_params p = {LIBPD_SYMBOL, src, 0.0f, sym, 0};
+        rb_write_to_buffer(
+            pd_receive_buffer, 1, (const char *) &p, S_PD_PARAMS);
+    }
+}
+
+static void internal_listhook(const char *src, int argc, t_atom *argv)
+{
+    int n = argc * S_ATOM;
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n)
+    {
+        pd_params p = {LIBPD_LIST, src, 0.0f, NULL, argc};
+        rb_write_to_buffer(pd_receive_buffer, 2, (const char *) &p, S_PD_PARAMS,
+            (const char *) argv, n);
+    }
+}
+
+static void internal_messagehook(
+    const char *src, const char *sym, int argc, t_atom *argv)
+{
+    int n = argc * S_ATOM;
+    if(rb_available_to_write(pd_receive_buffer) >= S_PD_PARAMS + n)
+    {
+        pd_params p = {LIBPD_MESSAGE, src, 0.0f, sym, argc};
+        rb_write_to_buffer(pd_receive_buffer, 2, (const char *) &p, S_PD_PARAMS,
+            (const char *) argv, n);
+    }
+}
+
+static void receive_noteon(midi_params *p, char **buffer)
+{
+    if(libpd_queued_noteonhook)
+    {
+        libpd_queued_noteonhook(p->midi1, p->midi2, p->midi3);
+    }
+}
+
+static void receive_controlchange(midi_params *p, char **buffer)
+{
+    if(libpd_queued_controlchangehook)
+    {
+        libpd_queued_controlchangehook(p->midi1, p->midi2, p->midi3);
+    }
+}
+
+static void receive_programchange(midi_params *p, char **buffer)
+{
+    if(libpd_queued_programchangehook)
+    {
+        libpd_queued_programchangehook(p->midi1, p->midi2);
+    }
+}
+
+static void receive_pitchbend(midi_params *p, char **buffer)
+{
+    if(libpd_queued_pitchbendhook)
+    {
+        libpd_queued_pitchbendhook(p->midi1, p->midi2);
+    }
+}
+
+static void receive_aftertouch(midi_params *p, char **buffer)
+{
+    if(libpd_queued_aftertouchhook)
+    {
+        libpd_queued_aftertouchhook(p->midi1, p->midi2);
+    }
+}
+
+static void receive_polyaftertouch(midi_params *p, char **buffer)
+{
+    if(libpd_queued_polyaftertouchhook)
+    {
+        libpd_queued_polyaftertouchhook(p->midi1, p->midi2, p->midi3);
+    }
+}
+
+static void receive_midibyte(midi_params *p, char **buffer)
+{
+    if(libpd_queued_midibytehook)
+    {
+        libpd_queued_midibytehook(p->midi1, p->midi2);
+    }
+}
+
+static void internal_noteonhook(int channel, int pitch, int velocity)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_NOTEON, channel, pitch, velocity};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_controlchangehook(int channel, int controller, int value)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_CONTROLCHANGE, channel, controller, value};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_programchangehook(int channel, int value)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_PROGRAMCHANGE, channel, value, 0};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_pitchbendhook(int channel, int value)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_PITCHBEND, channel, value, 0};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_aftertouchhook(int channel, int value)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_AFTERTOUCH, channel, value, 0};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_polyaftertouchhook(int channel, int pitch, int value)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_POLYAFTERTOUCH, channel, pitch, value};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+static void internal_midibytehook(int port, int byte)
+{
+    if(rb_available_to_write(midi_receive_buffer) >= S_MIDI_PARAMS)
+    {
+        midi_params p = {LIBPD_MIDIBYTE, port, byte, 0};
+        rb_write_to_buffer(
+            midi_receive_buffer, 1, (const char *) &p, S_MIDI_PARAMS);
+    }
+}
+
+void libpd_set_queued_printhook(const t_libpd_printhook hook)
+{
+    libpd_queued_printhook = hook;
+}
+
+void libpd_set_queued_banghook(const t_libpd_banghook hook)
+{
+    libpd_queued_banghook = hook;
+}
+
+void libpd_set_queued_floathook(const t_libpd_floathook hook)
+{
+    libpd_queued_floathook = hook;
+}
+
+void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook)
+{
+    libpd_queued_symbolhook = hook;
+}
+
+void libpd_set_queued_listhook(const t_libpd_listhook hook)
+{
+    libpd_queued_listhook = hook;
+}
+
+void libpd_set_queued_messagehook(const t_libpd_messagehook hook)
+{
+    libpd_queued_messagehook = hook;
+}
+
+void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook)
+{
+    libpd_queued_noteonhook = hook;
+}
+
+void libpd_set_queued_controlchangehook(const t_libpd_controlchangehook hook)
+{
+    libpd_queued_controlchangehook = hook;
+}
+
+void libpd_set_queued_programchangehook(const t_libpd_programchangehook hook)
+{
+    libpd_queued_programchangehook = hook;
+}
+
+void libpd_set_queued_pitchbendhook(const t_libpd_pitchbendhook hook)
+{
+    libpd_queued_pitchbendhook = hook;
+}
+
+void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook)
+{
+    libpd_queued_aftertouchhook = hook;
+}
+
+void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook)
+{
+    libpd_queued_polyaftertouchhook = hook;
+}
+
+void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook)
+{
+    libpd_queued_midibytehook = hook;
+}
+
+int libpd_queued_init()
+{
+    if(!pd_receive_buffer)
+    {
+        pd_receive_buffer = rb_create(BUFFER_SIZE);
+        if(!pd_receive_buffer) return -2;
+    }
+    if(!midi_receive_buffer)
+    {
+        midi_receive_buffer = rb_create(BUFFER_SIZE);
+        if(!midi_receive_buffer) return -2;
+    }
+
+    libpd_set_printhook(internal_printhook);
+    libpd_set_banghook(internal_banghook);
+    libpd_set_floathook(internal_floathook);
+    libpd_set_symbolhook(internal_symbolhook);
+    libpd_set_listhook(internal_listhook);
+    libpd_set_messagehook(internal_messagehook);
+
+    libpd_set_noteonhook(internal_noteonhook);
+    libpd_set_controlchangehook(internal_controlchangehook);
+    libpd_set_programchangehook(internal_programchangehook);
+    libpd_set_pitchbendhook(internal_pitchbendhook);
+    libpd_set_aftertouchhook(internal_aftertouchhook);
+    libpd_set_polyaftertouchhook(internal_polyaftertouchhook);
+    libpd_set_midibytehook(internal_midibytehook);
+
+    return libpd_init();
+}
+
+void libpd_queued_release()
+{
+    if(pd_receive_buffer)
+    {
+        rb_free(pd_receive_buffer);
+        pd_receive_buffer = NULL;
+    }
+    if(midi_receive_buffer)
+    {
+        rb_free(midi_receive_buffer);
+        midi_receive_buffer = NULL;
+    }
+}
+
+void libpd_queued_receive_pd_messages()
+{
+    size_t available = rb_available_to_read(pd_receive_buffer);
+    if(!available) return;
+    static char temp_buffer[BUFFER_SIZE];
+    rb_read_from_buffer(pd_receive_buffer, temp_buffer, (int) available);
+    char *end = temp_buffer + available;
+    char *buffer = temp_buffer;
+    while(buffer < end)
+    {
+        pd_params *p = (pd_params *) buffer;
+        buffer += S_PD_PARAMS;
+        switch(p->type)
+        {
+            case LIBPD_PRINT:
+            {
+                receive_print(p, &buffer);
+                break;
+            }
+            case LIBPD_BANG:
+            {
+                receive_bang(p, &buffer);
+                break;
+            }
+            case LIBPD_FLOAT:
+            {
+                receive_float(p, &buffer);
+                break;
+            }
+            case LIBPD_SYMBOL:
+            {
+                receive_symbol(p, &buffer);
+                break;
+            }
+            case LIBPD_LIST:
+            {
+                receive_list(p, &buffer);
+                break;
+            }
+            case LIBPD_MESSAGE:
+            {
+                receive_message(p, &buffer);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+}
+
+void libpd_queued_receive_midi_messages()
+{
+    size_t available = rb_available_to_read(midi_receive_buffer);
+    if(!available) return;
+    static char temp_buffer[BUFFER_SIZE];
+    rb_read_from_buffer(midi_receive_buffer, temp_buffer, (int) available);
+    char *end = temp_buffer + available;
+    char *buffer = temp_buffer;
+    while(buffer < end)
+    {
+        midi_params *p = (midi_params *) buffer;
+        buffer += S_MIDI_PARAMS;
+        switch(p->type)
+        {
+            case LIBPD_NOTEON:
+            {
+                receive_noteon(p, &buffer);
+                break;
+            }
+            case LIBPD_CONTROLCHANGE:
+            {
+                receive_controlchange(p, &buffer);
+                break;
+            }
+            case LIBPD_PROGRAMCHANGE:
+            {
+                receive_programchange(p, &buffer);
+                break;
+            }
+            case LIBPD_PITCHBEND:
+            {
+                receive_pitchbend(p, &buffer);
+                break;
+            }
+            case LIBPD_AFTERTOUCH:
+            {
+                receive_aftertouch(p, &buffer);
+                break;
+            }
+            case LIBPD_POLYAFTERTOUCH:
+            {
+                receive_polyaftertouch(p, &buffer);
+                break;
+            }
+            case LIBPD_MIDIBYTE:
+            {
+                receive_midibyte(p, &buffer);
+                break;
+            }
+            default:
+                break;
+        }
+    }
 }

--- a/src/z_queued.h
+++ b/src/z_queued.h
@@ -18,72 +18,77 @@ extern "C"
 {
 #endif
 
-/// set the queued print receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_printhook(const t_libpd_printhook hook);
+    /// set the queued print receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_printhook(const t_libpd_printhook hook);
 
-/// set the queued bang receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_banghook(const t_libpd_banghook hook);
+    /// set the queued bang receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_banghook(const t_libpd_banghook hook);
 
-/// set the queued float receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_floathook(const t_libpd_floathook hook);
+    /// set the queued float receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_floathook(const t_libpd_floathook hook);
 
-/// set the queued symbol receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook);
+    /// set the queued symbol receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_symbolhook(const t_libpd_symbolhook hook);
 
-/// set the queued list receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_listhook(const t_libpd_listhook hook);
+    /// set the queued list receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_listhook(const t_libpd_listhook hook);
 
-/// set the queued typed message receiver hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_messagehook(const t_libpd_messagehook hook);
+    /// set the queued typed message receiver hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_messagehook(const t_libpd_messagehook hook);
 
-/// set the queued MIDI note on hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook);
+    /// set the queued MIDI note on hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_noteonhook(const t_libpd_noteonhook hook);
 
-/// set the queued MIDI control change hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_controlchangehook(const t_libpd_controlchangehook hook);
+    /// set the queued MIDI control change hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_controlchangehook(
+        const t_libpd_controlchangehook hook);
 
-/// set the queued MIDI program change hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_programchangehook(const t_libpd_programchangehook hook);
+    /// set the queued MIDI program change hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_programchangehook(
+        const t_libpd_programchangehook hook);
 
-/// set the queued MIDI pitch bend hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_pitchbendhook(const t_libpd_pitchbendhook hook);
+    /// set the queued MIDI pitch bend hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_pitchbendhook(
+        const t_libpd_pitchbendhook hook);
 
-/// set the queued MIDI after touch hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_aftertouchhook(const t_libpd_aftertouchhook hook);
+    /// set the queued MIDI after touch hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_aftertouchhook(
+        const t_libpd_aftertouchhook hook);
 
-/// set the queued MIDI poly after touch hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_polyaftertouchhook(const t_libpd_polyaftertouchhook hook);
+    /// set the queued MIDI poly after touch hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_polyaftertouchhook(
+        const t_libpd_polyaftertouchhook hook);
 
-/// set the queued raw MIDI byte hook, NULL by default
-/// note: do not call this while DSP is running
-EXTERN void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook);
+    /// set the queued raw MIDI byte hook, NULL by default
+    /// note: do not call this while DSP is running
+    EXTERN void libpd_set_queued_midibytehook(const t_libpd_midibytehook hook);
 
-/// initialize libpd and the queued ringbuffers, use in place of libpd_init()
-/// this is safe to call more than once
-/// returns 0 on success, -1 if libpd was already initialized, or -2 if ring
-/// buffer allocation failed
-EXTERN int libpd_queued_init();
+    /// initialize libpd and the queued ringbuffers, use in place of
+    /// libpd_init() this is safe to call more than once returns 0 on success,
+    /// -1 if libpd was already initialized, or -2 if ring buffer allocation
+    /// failed
+    EXTERN int libpd_queued_init();
 
-/// free the queued ringbuffers
-EXTERN void libpd_queued_release();
+    /// free the queued ringbuffers
+    EXTERN void libpd_queued_release();
 
-/// process and dispatch received messages in message ringbuffer
-EXTERN void libpd_queued_receive_pd_messages();
+    /// process and dispatch received messages in message ringbuffer
+    EXTERN void libpd_queued_receive_pd_messages();
 
-/// process and dispatch receive midi messages in MIDI message ringbuffer
-EXTERN void libpd_queued_receive_midi_messages();
+    /// process and dispatch receive midi messages in MIDI message ringbuffer
+    EXTERN void libpd_queued_receive_midi_messages();
 
 #ifdef __cplusplus
 }

--- a/src/z_ringbuffer.c
+++ b/src/z_ringbuffer.c
@@ -15,140 +15,166 @@
 #include <string.h>
 
 #if __STDC_VERSION__ >= 201112L // use stdatomic if C11 is available
-  #include <stdatomic.h>
-  #define SYNC_FETCH(ptr) atomic_fetch_or((_Atomic int *)ptr, 0)
-  #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-          atomic_compare_exchange_strong((_Atomic int *)ptr, &oldval, newval)
-#else // use platform specfics
-  #ifdef __APPLE__ // apple atomics
-    #include <libkern/OSAtomic.h>
-    #define SYNC_FETCH(ptr) OSAtomicOr32Barrier(0, (volatile uint32_t *)ptr)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            OSAtomicCompareAndSwap32Barrier(oldval, newval, ptr)
-  #elif defined(_WIN32) || defined(_WIN64) // win api atomics
-    #include <windows.h>
-    #define SYNC_FETCH(ptr) InterlockedOr(ptr, 0)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            InterlockedCompareExchange(ptr, oldval, newval)
-  #else // gcc atomics
-    #define SYNC_FETCH(ptr) __sync_fetch_and_or(ptr, 0)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            __sync_val_compare_and_swap(ptr, oldval, newval)
-  #endif
+#include <stdatomic.h>
+#define SYNC_FETCH(ptr) atomic_fetch_or((_Atomic int *) ptr, 0)
+#define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
+    atomic_compare_exchange_strong((_Atomic int *) ptr, &oldval, newval)
+#else            // use platform specfics
+#ifdef __APPLE__ // apple atomics
+#include <libkern/OSAtomic.h>
+#define SYNC_FETCH(ptr) OSAtomicOr32Barrier(0, (volatile uint32_t *) ptr)
+#define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
+    OSAtomicCompareAndSwap32Barrier(oldval, newval, ptr)
+#elif defined(_WIN32) || defined(_WIN64) // win api atomics
+#include <windows.h>
+#define SYNC_FETCH(ptr) InterlockedOr(ptr, 0)
+#define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
+    InterlockedCompareExchange(ptr, oldval, newval)
+#else // gcc atomics
+#define SYNC_FETCH(ptr) __sync_fetch_and_or(ptr, 0)
+#define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
+    __sync_val_compare_and_swap(ptr, oldval, newval)
+#endif
 #endif
 
-ring_buffer *rb_create(int size) {
-  if (size & 0xff) return NULL;  // size must be a multiple of 256
-  ring_buffer *buffer = malloc(sizeof(ring_buffer));
-  if (!buffer) return NULL;
-  buffer->buf_ptr = calloc(size, sizeof(char));
-  if (!buffer->buf_ptr) {
-    free(buffer);
-    return NULL;
-  }
-  buffer->size = size;
-  buffer->write_idx = 0;
-  buffer->read_idx = 0;
-  return buffer;
-}
-
-void rb_free(ring_buffer *buffer) {
-  free(buffer->buf_ptr);
-  free(buffer);
-}
-
-int rb_available_to_write(ring_buffer *buffer) {
-  if (buffer) {
-    // note: the largest possible result is buffer->size - 1 because
-    // we adopt the convention that read_idx == write_idx means that the
-    // buffer is empty
-    int read_idx = SYNC_FETCH(&(buffer->read_idx));
-    int write_idx = SYNC_FETCH(&(buffer->write_idx));
-    return (buffer->size + read_idx - write_idx - 1) % buffer->size;
-  } else {
-    return 0;
-  }
-}
-
-int rb_available_to_read(ring_buffer *buffer) {
-  if (buffer) {
-    int read_idx = SYNC_FETCH(&(buffer->read_idx));
-    int write_idx = SYNC_FETCH(&(buffer->write_idx));
-    return (buffer->size + write_idx - read_idx) % buffer->size;
-  } else {
-    return 0;
-  }
-}
-
-int rb_write_to_buffer(ring_buffer *buffer, int n, ...) {
-  if (!buffer) return -1;
-  int write_idx = buffer->write_idx;  // no need for sync in writer thread
-  int available = rb_available_to_write(buffer);
-  va_list args;
-  va_start(args, n);
-  int i;
-  for (i = 0; i < n; ++i) {
-    const char* src = va_arg(args, const char*);
-    int len = va_arg(args, int);
-    available -= len;
-    if (len < 0 || available < 0) return -1;
-    if (write_idx + len <= buffer->size) {
-      memcpy(buffer->buf_ptr + write_idx, src, len);
-    } else {
-      int d = buffer->size - write_idx;
-      memcpy(buffer->buf_ptr + write_idx, src, d);
-      memcpy(buffer->buf_ptr, src + d, len - d);
+ring_buffer *rb_create(int size)
+{
+    if(size & 0xff) return NULL; // size must be a multiple of 256
+    ring_buffer *buffer = malloc(sizeof(ring_buffer));
+    if(!buffer) return NULL;
+    buffer->buf_ptr = calloc(size, sizeof(char));
+    if(!buffer->buf_ptr)
+    {
+        free(buffer);
+        return NULL;
     }
-    write_idx = (write_idx + len) % buffer->size;
-  }
-  va_end(args);
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
-      write_idx);  // includes memory barrier
-  return 0;
+    buffer->size = size;
+    buffer->write_idx = 0;
+    buffer->read_idx = 0;
+    return buffer;
 }
 
-int rb_write_value_to_buffer(ring_buffer *buffer, int value, int n) {
-  if (!buffer) return -1;
-  int write_idx = buffer->write_idx;  // No need for sync in writer thread.
-  int available = rb_available_to_write(buffer);
-  available -= n;
-  if (n < 0 || available < 0) return -1;
-  if (write_idx + n <= buffer->size) {
-    memset(buffer->buf_ptr + write_idx, value, n);
-  } else {
-    int d = buffer->size - write_idx;
-    memset(buffer->buf_ptr + write_idx, value, d);
-    memset(buffer->buf_ptr, value, n - d);
-  }
-  write_idx = (write_idx + n) % buffer->size;
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
-    write_idx);  // includes memory barrier
-  return 0;
+void rb_free(ring_buffer *buffer)
+{
+    free(buffer->buf_ptr);
+    free(buffer);
 }
 
-int rb_read_from_buffer(ring_buffer *buffer, char *dest, int len) {
-  if (len == 0) return 0;
-  if (!buffer || len < 0 || len > rb_available_to_read(buffer)) return -1;
-  // note that rb_available_to_read also serves as a memory barrier, and so any
-  // writes to buffer->buf_ptr that precede the update of buffer->write_idx are
-  // visible to us now
-  int read_idx = buffer->read_idx;  // no need for sync in reader thread
-  if (read_idx + len <= buffer->size) {
-    memcpy(dest, buffer->buf_ptr + read_idx, len);
-  } else {
-    int d = buffer->size - read_idx;
-    memcpy(dest, buffer->buf_ptr + read_idx, d);
-    memcpy(dest + d, buffer->buf_ptr, len - d);
-  }
-  SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx,
-       (read_idx + len) % buffer->size);  // includes memory barrier
-  return 0;
+int rb_available_to_write(ring_buffer *buffer)
+{
+    if(buffer)
+    {
+        // note: the largest possible result is buffer->size - 1 because
+        // we adopt the convention that read_idx == write_idx means that the
+        // buffer is empty
+        int read_idx = SYNC_FETCH(&(buffer->read_idx));
+        int write_idx = SYNC_FETCH(&(buffer->write_idx));
+        return (buffer->size + read_idx - write_idx - 1) % buffer->size;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+int rb_available_to_read(ring_buffer *buffer)
+{
+    if(buffer)
+    {
+        int read_idx = SYNC_FETCH(&(buffer->read_idx));
+        int write_idx = SYNC_FETCH(&(buffer->write_idx));
+        return (buffer->size + write_idx - read_idx) % buffer->size;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+int rb_write_to_buffer(ring_buffer *buffer, int n, ...)
+{
+    if(!buffer) return -1;
+    int write_idx = buffer->write_idx; // no need for sync in writer thread
+    int available = rb_available_to_write(buffer);
+    va_list args;
+    va_start(args, n);
+    int i;
+    for(i = 0; i < n; ++i)
+    {
+        const char *src = va_arg(args, const char *);
+        int len = va_arg(args, int);
+        available -= len;
+        if(len < 0 || available < 0) return -1;
+        if(write_idx + len <= buffer->size)
+        {
+            memcpy(buffer->buf_ptr + write_idx, src, len);
+        }
+        else
+        {
+            int d = buffer->size - write_idx;
+            memcpy(buffer->buf_ptr + write_idx, src, d);
+            memcpy(buffer->buf_ptr, src + d, len - d);
+        }
+        write_idx = (write_idx + len) % buffer->size;
+    }
+    va_end(args);
+    SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
+        write_idx); // includes memory barrier
+    return 0;
+}
+
+int rb_write_value_to_buffer(ring_buffer *buffer, int value, int n)
+{
+    if(!buffer) return -1;
+    int write_idx = buffer->write_idx; // No need for sync in writer thread.
+    int available = rb_available_to_write(buffer);
+    available -= n;
+    if(n < 0 || available < 0) return -1;
+    if(write_idx + n <= buffer->size)
+    {
+        memset(buffer->buf_ptr + write_idx, value, n);
+    }
+    else
+    {
+        int d = buffer->size - write_idx;
+        memset(buffer->buf_ptr + write_idx, value, d);
+        memset(buffer->buf_ptr, value, n - d);
+    }
+    write_idx = (write_idx + n) % buffer->size;
+    SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
+        write_idx); // includes memory barrier
+    return 0;
+}
+
+int rb_read_from_buffer(ring_buffer *buffer, char *dest, int len)
+{
+    if(len == 0) return 0;
+    if(!buffer || len < 0 || len > rb_available_to_read(buffer)) return -1;
+    // note that rb_available_to_read also serves as a memory barrier, and so
+    // any writes to buffer->buf_ptr that precede the update of
+    // buffer->write_idx are visible to us now
+    int read_idx = buffer->read_idx; // no need for sync in reader thread
+    if(read_idx + len <= buffer->size)
+    {
+        memcpy(dest, buffer->buf_ptr + read_idx, len);
+    }
+    else
+    {
+        int d = buffer->size - read_idx;
+        memcpy(dest, buffer->buf_ptr + read_idx, d);
+        memcpy(dest + d, buffer->buf_ptr, len - d);
+    }
+    SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx,
+        (read_idx + len) % buffer->size); // includes memory barrier
+    return 0;
 }
 
 // simply reset the indices
-void rb_clear_buffer(ring_buffer *buffer) {
-  if (buffer) {
-  SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx, 0);
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx, 0);
-  }
+void rb_clear_buffer(ring_buffer *buffer)
+{
+    if(buffer)
+    {
+        SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx, 0);
+        SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx, 0);
+    }
 }

--- a/src/z_ringbuffer.c
+++ b/src/z_ringbuffer.c
@@ -94,8 +94,7 @@ int rb_write_to_buffer(ring_buffer *buffer, int n, ...)
     int available = rb_available_to_write(buffer);
     va_list args;
     va_start(args, n);
-    int i;
-    for(i = 0; i < n; ++i)
+    for(int i = 0; i < n; ++i)
     {
         const char *src = va_arg(args, const char *);
         int len = va_arg(args, int);

--- a/src/z_ringbuffer.c
+++ b/src/z_ringbuffer.c
@@ -71,10 +71,8 @@ int rb_available_to_write(ring_buffer *buffer)
         int write_idx = SYNC_FETCH(&(buffer->write_idx));
         return (buffer->size + read_idx - write_idx - 1) % buffer->size;
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }
 
 int rb_available_to_read(ring_buffer *buffer)
@@ -85,10 +83,8 @@ int rb_available_to_read(ring_buffer *buffer)
         int write_idx = SYNC_FETCH(&(buffer->write_idx));
         return (buffer->size + write_idx - read_idx) % buffer->size;
     }
-    else
-    {
-        return 0;
-    }
+
+    return 0;
 }
 
 int rb_write_to_buffer(ring_buffer *buffer, int n, ...)

--- a/src/z_ringbuffer.h
+++ b/src/z_ringbuffer.h
@@ -13,7 +13,8 @@
 
 /// simple lock-free ring buffer implementation for one writer thread
 /// and one consumer thread
-typedef struct ring_buffer {
+typedef struct ring_buffer
+{
     int size;
     char *buf_ptr;
     int write_idx;


### PR DESCRIPTION
Hi !

I'm working on a fork of the codebase, in an attempt to make it easier to read, learn, and contribute for new and current C programmers.

Current goals : 

 - Consistent formatting, enforced with clang-format/tidy
 - More descriptive variable names
 - Top-to-bottom reading flow for algorithms :     
	 - Moving away from multiple-pointers to single-index loops, whenever possible
	 - Limit variable reuse
	 - Localization of variables, especially loop indices. (dropping C90)

I don't expect this fork to be merged ever, but I would encourage maintainers to attempt something like this. Pure-data is a gateway into visual programming, and the codebase could be a gateway into C and DSP. The algorithms could be treated as reference implementations and learning resources, especially since it's so widely used in education.