### PR TITLE
add unique seed according to system time in peudo-random generators

### DIFF
--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -22,12 +22,6 @@
 #include <endian.h>
 #endif
 
-#ifdef _WIN32
-#include <time.h>
-#else
-#include <sys/time.h>
-#endif
-
 #ifdef __MINGW32__
 #include <sys/param.h>
 #endif
@@ -473,21 +467,13 @@ void sigvcf_setup(void)
 /* -------------------------- noise~ ------------------------------ */
 static t_class *noise_class;
 
-static int instanceindex = 0;
-
 typedef struct _noise
 {
     t_object x_obj;
     int x_val;
 } t_noise;
 
-static int makeseed(void)
-{
-    /* seed each instance differently.  Once in a blue moon two threads
-    could grab the same seed value.  We can live with that. */
-    int init = time(NULL) * ++instanceindex;
-    return (init *= 1319);
-}
+int makeseed(){};
 
 static void *noise_new(void)
 {

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -473,7 +473,7 @@ typedef struct _noise
     int x_val;
 } t_noise;
 
-int makeseed(){};
+int makeseed(void);
 
 static void *noise_new(void)
 {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -713,7 +713,7 @@ typedef struct _array_random   /* any operation meaningful on a subrange */
     unsigned int x_state;
 } t_array_random;
 
-int makeseed();
+int makeseed(void);
 
 static void *array_random_new(t_symbol *s, int argc, t_atom *argv)
 {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -13,9 +13,6 @@
 #endif
 #ifdef _WIN32
 #include <io.h>
-#include <time.h>
-#else
-#include <sys/time.h>
 #endif
 
 #ifdef _WIN32
@@ -710,20 +707,13 @@ static void array_quantile_float(t_array_rangeop *x, t_floatarg f)
 /* ----  array random -- output random value with array as distribution ---- */
 static t_class *array_random_class;
 
-static int instanceindex = 0;
-
 typedef struct _array_random   /* any operation meaningful on a subrange */
 {
     t_array_rangeop x_r;
     unsigned int x_state;
 } t_array_random;
 
-static int makeseed(void)
-{
-    unsigned int random_nextseed = time(NULL) * ++instanceindex * 151;
-    random_nextseed = random_nextseed * 435898247 + 938284287;
-    return (random_nextseed & 0x7fffffff);
-}
+int makeseed();
 
 static void *array_random_new(t_symbol *s, int argc, t_atom *argv)
 {

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -13,6 +13,9 @@
 #endif
 #ifdef _WIN32
 #include <io.h>
+#include <time.h>
+#else
+#include <sys/time.h>
 #endif
 
 #ifdef _WIN32
@@ -707,26 +710,36 @@ static void array_quantile_float(t_array_rangeop *x, t_floatarg f)
 /* ----  array random -- output random value with array as distribution ---- */
 static t_class *array_random_class;
 
+static int instanceindex = 0;
+
 typedef struct _array_random   /* any operation meaningful on a subrange */
 {
     t_array_rangeop x_r;
     unsigned int x_state;
 } t_array_random;
 
+static int makeseed(void)
+{
+    unsigned int random_nextseed = time(NULL) * ++instanceindex * 151;
+    random_nextseed = random_nextseed * 435898247 + 938284287;
+    return (random_nextseed & 0x7fffffff);
+}
+
 static void *array_random_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_array_random *x = array_rangeop_new(array_random_class, s,
         &argc, &argv, 0, 1, 1);
-    static unsigned int random_nextseed = 584926371;
-    random_nextseed = random_nextseed * 435898247 + 938284287;
-    x->x_state = random_nextseed;
+    x->x_state = makeseed();
     outlet_new(&x->x_r.x_tc.tc_obj, &s_float);
     return (x);
 }
 
-static void array_random_seed(t_array_random *x, t_floatarg f)
+static void array_random_seed(t_array_random *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_state = f;
+    if(!argc)
+        x->x_state = makeseed();
+    else
+        x->x_state = (unsigned int)(atom_getfloat(argv));
 }
 
 static void array_random_bang(t_array_random *x)
@@ -925,7 +938,7 @@ void x_array_setup(void)
         (t_newmethod)array_random_new, (t_method)array_client_free,
             sizeof(t_array_random), 0, A_GIMME, 0);
     class_addmethod(array_random_class, (t_method)array_random_seed,
-        gensym("seed"), A_FLOAT, 0);
+        gensym("seed"), A_GIMME, 0);
     class_addfloat(array_random_class, array_random_float);
     class_addbang(array_random_class, array_random_bang);
     class_sethelpsymbol(array_random_class, gensym("array-object"));

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -46,8 +46,6 @@
 
 static t_class *random_class;
 
-static int instanceindex = 0;
-
 typedef struct _random
 {
     t_object x_obj;
@@ -58,7 +56,9 @@ typedef struct _random
 
 static int makeseed(void)
 {
-    unsigned int random_nextseed = time(NULL) * ++instanceindex * 151;
+    static PERTHREAD unsigned int random_nextseed = 0;
+    if (!random_nextseed)
+        random_nextseed = time(NULL);
     random_nextseed = random_nextseed * 435898247 + 938284287;
     return (random_nextseed & 0x7fffffff);
 }

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -46,6 +46,8 @@
 
 static t_class *random_class;
 
+static int instanceindex = 0;
+
 typedef struct _random
 {
     t_object x_obj;
@@ -56,7 +58,7 @@ typedef struct _random
 
 static int makeseed(void)
 {
-    static unsigned int random_nextseed = 1489853723;
+    unsigned int random_nextseed = time(NULL) * ++instanceindex * 151;
     random_nextseed = random_nextseed * 435898247 + 938284287;
     return (random_nextseed & 0x7fffffff);
 }
@@ -83,9 +85,12 @@ static void random_bang(t_random *x)
     outlet_float(x->x_obj.ob_outlet, nval);
 }
 
-static void random_seed(t_random *x, t_float f, t_float glob)
+static void random_seed(t_random *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_state = f;
+    if(!argc)
+        x->x_state = makeseed();
+    else
+        x->x_state = (unsigned int)(atom_getfloat(argv));
 }
 
 static void random_setup(void)
@@ -94,7 +99,7 @@ static void random_setup(void)
         sizeof(t_random), 0, A_DEFFLOAT, 0);
     class_addbang(random_class, random_bang);
     class_addmethod(random_class, (t_method)random_seed,
-        gensym("seed"), A_FLOAT, 0);
+        gensym("seed"), A_GIMME, 0);
 }
 
 


### PR DESCRIPTION
This closes https://github.com/pure-data/pure-data/issues/1717 and takes care of [random], [array random] and [noise~].

Now the seed is set via system time when you load the patch/object at creation time. A _static int instanceindex_ is used to provide a different seed for each instance.

A seed message without arguments set unique seeds according to system time again.