### PR TITLE
load seeds based on system time for pseudo random number generators

### DIFF
--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -473,13 +473,12 @@ typedef struct _noise
     int x_val;
 } t_noise;
 
+int makeseed(void);
+
 static void *noise_new(void)
 {
     t_noise *x = (t_noise *)pd_new(noise_class);
-        /* seed each instance differently.  Once in a blue moon two threads
-        could grab the same seed value.  We can live with that. */
-    static int init = 307;
-    x->x_val = (init *= 1319);
+    x->x_val = makeseed();
     outlet_new(&x->x_obj, gensym("signal"));
     return (x);
 }
@@ -505,10 +504,12 @@ static void noise_dsp(t_noise *x, t_signal **sp)
     dsp_add(noise_perform, 3, sp[0]->s_vec, &x->x_val, (t_int)sp[0]->s_n);
 }
 
-static void noise_float(t_noise *x, t_float f)
+static void noise_seed(t_noise *x, t_symbol *s, int argc, t_atom *argv)
 {
-    /* set the seed */
-    x->x_val = (int)f;
+    if(!argc)
+        x->x_val = makeseed();
+    else
+        x->x_val = (int)(atom_getfloat(argv));
 }
 
 static void noise_setup(void)
@@ -517,8 +518,8 @@ static void noise_setup(void)
         sizeof(t_noise), 0, A_DEFFLOAT, 0);
     class_addmethod(noise_class, (t_method)noise_dsp,
         gensym("dsp"), A_CANT, 0);
-    class_addmethod(noise_class, (t_method)noise_float,
-        gensym("seed"), A_FLOAT, 0);
+    class_addmethod(noise_class, (t_method)noise_seed,
+        gensym("seed"), A_GIMME, 0);
 }
 
 /* ----------------------- global setup routine ---------------- */

--- a/src/x_array.c
+++ b/src/x_array.c
@@ -713,20 +713,23 @@ typedef struct _array_random   /* any operation meaningful on a subrange */
     unsigned int x_state;
 } t_array_random;
 
+int makeseed(void);
+
 static void *array_random_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_array_random *x = array_rangeop_new(array_random_class, s,
         &argc, &argv, 0, 1, 1);
-    static unsigned int random_nextseed = 584926371;
-    random_nextseed = random_nextseed * 435898247 + 938284287;
-    x->x_state = random_nextseed;
+    x->x_state = makeseed();
     outlet_new(&x->x_r.x_tc.tc_obj, &s_float);
     return (x);
 }
 
-static void array_random_seed(t_array_random *x, t_floatarg f)
+static void array_random_seed(t_array_random *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_state = f;
+    if(!argc)
+        x->x_state = makeseed();
+    else
+        x->x_state = (unsigned int)(atom_getfloat(argv));
 }
 
 static void array_random_bang(t_array_random *x)
@@ -925,7 +928,7 @@ void x_array_setup(void)
         (t_newmethod)array_random_new, (t_method)array_client_free,
             sizeof(t_array_random), 0, A_GIMME, 0);
     class_addmethod(array_random_class, (t_method)array_random_seed,
-        gensym("seed"), A_FLOAT, 0);
+        gensym("seed"), A_GIMME, 0);
     class_addfloat(array_random_class, array_random_float);
     class_addbang(array_random_class, array_random_bang);
     class_sethelpsymbol(array_random_class, gensym("array-object"));

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -54,9 +54,11 @@ typedef struct _random
 } t_random;
 
 
-static int makeseed(void)
+int makeseed(void)
 {
-    static unsigned int random_nextseed = 1489853723;
+    static PERTHREAD unsigned int random_nextseed = 0;
+    if (!random_nextseed)
+        random_nextseed = time(NULL);
     random_nextseed = random_nextseed * 435898247 + 938284287;
     return (random_nextseed & 0x7fffffff);
 }
@@ -83,9 +85,12 @@ static void random_bang(t_random *x)
     outlet_float(x->x_obj.ob_outlet, nval);
 }
 
-static void random_seed(t_random *x, t_float f, t_float glob)
+static void random_seed(t_random *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_state = f;
+    if(!argc)
+        x->x_state = makeseed();
+    else
+        x->x_state = (unsigned int)(atom_getfloat(argv));
 }
 
 static void random_setup(void)
@@ -94,7 +99,7 @@ static void random_setup(void)
         sizeof(t_random), 0, A_DEFFLOAT, 0);
     class_addbang(random_class, random_bang);
     class_addmethod(random_class, (t_method)random_seed,
-        gensym("seed"), A_FLOAT, 0);
+        gensym("seed"), A_GIMME, 0);
 }
 
 


### PR DESCRIPTION
this is a reboot of https://github.com/pure-data/pure-data/pull/1718

This closes #1717 and takes care of [random], [array random] and [noise~].

Now the seed is set via system time when you load the patch/object at creation time.

A seed message without arguments set unique seeds according to system time again.

In the previous PR we discussed and decided to use the same "makeseed" function for all objects - [noise~] did use a different code to generate the first seed, but now this is unified.