### PR TITLE
Fix signal message crash

### DIFF
--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -184,7 +184,15 @@ static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 static void inlet_anything(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
     if (x->i_symfrom == s)
-        typedmess(x->i_dest, x->i_symto, argc, argv);
+    {
+        /* the "symto" field is undefined for signal inlets, so we don't
+         attempt to translate the selector, just forward the original msg. */
+        
+        if (x->i_symfrom == &s_signal)
+            typedmess(x->i_dest, s, argc, argv);
+        else
+            typedmess(x->i_dest, x->i_symto, argc, argv);
+    }
     else if (!x->i_symfrom)
         typedmess(x->i_dest, s, argc, argv);
     else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -187,14 +187,8 @@ static void inlet_anything(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
         typedmess(x->i_dest, x->i_symto, argc, argv);
     else if (!x->i_symfrom)
         typedmess(x->i_dest, s, argc, argv);
-    else if (x->i_symfrom == &s_signal)
-    {
-        if (zgetfn(x->i_dest, gensym("fwd")))
-            inlet_fwd(x, s, argc, argv);
-                /* the "symto" field is undefined, so we don't attempt
-                to translate the selector, just forward the original msg. */
-        else typedmess(x->i_dest, &s_signal, argc, argv);
-    }
+    else if (x->i_symfrom == &s_signal && zgetfn(x->i_dest, gensym("fwd")))
+        inlet_fwd(x, s, argc, argv);
     else inlet_wrong(x, s);
 }
 


### PR DESCRIPTION
This fix correctly fixes a crash when sending the message "signal" to signal inlets, which is caused by access to the iu_symto value of the inletunion union when it is not correctly defined.

It is intended to correct 6aaa6f7d2c5133b848e5fcd66d7f030eb79b85fb which seems to have been applied to the wrong place (where iu_symto is not accessed). *This* fix looks for places where the incoming symbol matches the inlet symbol and is also "signal" and avoids the dereference at that point. The crash itself is caused by a dereference that is typically a NULL and thus typically the code ends up calling through to a point where that NULL symbol is then dereferenced in order to print an error to the console, at which point pd crashes.

The crash and fix can be tested with the attached patch. Before applying this PR pd will crash.

[signal_crash.pd.zip](https://github.com/pure-data/pure-data/files/9332748/signal_crash.pd.zip)
 