### PR TITLE
bob~: outstate should be FLOAT not double

### DIFF
--- a/extra/bob~/bob~.c
+++ b/extra/bob~/bob~.c
@@ -210,7 +210,7 @@ static t_int *bob_perform(t_int *w)
     t_float *resonancein = (t_float *)(w[4]);
     t_float *out = (t_float *)(w[5]);
         /* bug fix: output is last state variable, not first */
-    double *outstate =
+    FLOAT *outstate =
         (pd_compatibilitylevel > 51? &x->x_state[3] : &x->x_state[0]);
     int n = (int)(w[6]), i, j;
     FLOAT stepsize = 1./(x->x_oversample * x->x_sr);


### PR DESCRIPTION
As it is, it fails if one changes the definition of `FLOAT`