### PR TITLE
Update deken to 0.9.4

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -3555,7 +3555,7 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
                 if(argc>0 && A_SYMBOL == argv[0].a_type) {
                     t_symbol*s = atom_getsymbol(argv);
                     if (s && s->s_name && *s->s_name)
-                        sys_vgui("::deken::open_search_objects {%s}\n", s->s_name);
+                        pdgui_vmess("::deken::open_search_objects", "s", s->s_name);
                 }
             }
             return (1);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -3532,6 +3532,7 @@ static void canvas_find_parent(t_canvas *x)
 }
 
 extern t_pd *message_get_responder(t_gobj *x);
+extern t_class *text_class;
 
 static int glist_dofinderror(t_glist *gl, const void *error_object)
 {
@@ -3547,6 +3548,16 @@ static int glist_dofinderror(t_glist *gl, const void *error_object)
             canvas_vis((t_canvas *)gl, 1);
             canvas_editmode((t_canvas *)gl, 1.);
             glist_select(gl, g);
+            if (pd_class(&g->g_pd) == text_class) {
+                t_text* x = (t_text*)g;
+                int argc = binbuf_getnatom(x->te_binbuf);
+                t_atom*argv = binbuf_getvec(x->te_binbuf);
+                if(argc>0 && A_SYMBOL == argv[0].a_type) {
+                    t_symbol*s = atom_getsymbol(argv);
+                    if (s && s->s_name && *s->s_name)
+                        sys_vgui("::deken::open_search_objects {%s}\n", s->s_name);
+                }
+            }
             return (1);
         }
         else if (g->g_pd == canvas_class)
@@ -4336,8 +4347,6 @@ static void canvas_reselect(t_canvas *x)
             /* otherwise activate first item in selection */
         gobj_activate(x->gl_editor->e_selection->sel_what, x, 1);
 }
-
-extern t_class *text_class;
 
 void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
     t_floatarg fwhoin, t_floatarg finno)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -105,6 +105,20 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
 
 void canvas_getargs(int *argcp, t_atom **argvp);
 
+static void canvas_error_couldntcreate(void*x, t_binbuf*b, const char*errmsg)
+{
+    char *buf=0;
+    int bufsize=0;
+    if (!binbuf_getnatom(b))
+        return;
+    binbuf_gettext(b, &buf, &bufsize);
+    buf = resizebytes(buf, bufsize, bufsize+1);
+    buf[bufsize] = 0;
+    logpost(x, PD_CRITICAL, "%s", buf);
+    logpost(x, PD_ERROR, "%s", errmsg);
+    freebytes(buf, bufsize);
+}
+
 static void canvas_objtext(t_glist *gl, int xpix, int ypix, int width,
     int selected, t_binbuf *b)
 {
@@ -121,19 +135,14 @@ static void canvas_objtext(t_glist *gl, int xpix, int ypix, int width,
             x = 0;
         else if (!(x = pd_checkobject(pd_this->pd_newest)))
         {
-            binbuf_print(b);
-            pd_error(0, "... didn't return a patchable object");
+            canvas_error_couldntcreate(0, b, "... didn't return a patchable object");
         }
     }
     else x = 0;
     if (!x)
     {
         x = (t_text *)pd_new(text_class);
-        if (binbuf_getnatom(b))
-        {
-            binbuf_print(b);
-            pd_error(x, "... couldn't create");
-        }
+        canvas_error_couldntcreate(x, b, "... couldn't create");
     }
     x->te_binbuf = b;
     x->te_xpix = xpix;

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -309,13 +309,19 @@ void glob_findinstance(t_pd *dummy, t_symbol*s)
 {
     // revert s to (potential) pointer to object
     PD_LONGINTTYPE obj = 0;
-    if (sscanf(s->s_name, ".x%lx", &obj))
-    {
-        if (obj)
-        {
-            canvas_finderror((void *)obj);
-        }
-    }
+    const char*addr;
+    if(!s || !s->s_name)
+        return;
+    addr = s->s_name;
+    if (('.' != addr[0]) && ('0' != addr[0]))
+        return;
+    if (!sscanf(addr+1, "x%lx", &obj))
+        return;
+
+    if(!obj)
+        return;
+
+    canvas_finderror((void *)obj);
 }
 
 void bug(const char *fmt, ...)


### PR DESCRIPTION
from the announcement on Pd-list

deken-plugin ("Find externals" within Pd)
=========================================

- brand-new excel-like interface
- sort by library/version/uploader/date
- quick link from a package to it's deken homepage (which features objectlists and more)
- simple selection of multiple packages
- INSTALL button
- watch the installation as it unfolds
- proper menu for installing pre-downloaded package files
- fast SHA256 verification on all platforms
- option to uninstall packages
- proper menu for proper ties
- advertise https://deken.puredata.info/
- better feedback if search returned no result
- tooltip
- balloons
- improve guessing of deken architecture
- fix version sorting
- fix all bugs
- fix some more bugs
- implement many bugs

additionally, this PR allows the user to easily search for objects that failed to create by right-clicking the error-message (as it includes #1547)