### PR TITLE
indicate nbx activation as with gatom

### DIFF
--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -42,6 +42,8 @@ static void my_numbox_calc_fontwidth(t_my_numbox *x)
     x->x_gui.x_w = (w + (x->x_gui.x_h/2)/IEMGUI_ZOOM(x) + 4) * IEMGUI_ZOOM(x);
 }
 
+/* gatom_float_sizelimit() from g_rtext.c */
+const char* gatom_float_sizelimit(char*buf, int bufsize, int maxsize);
 static void my_numbox_ftoa(t_my_numbox *x)
 {
     double f = x->x_val;
@@ -49,54 +51,8 @@ static void my_numbox_ftoa(t_my_numbox *x)
 
     sprintf(x->x_buf, "%g", f);
     bufsize = (int)strlen(x->x_buf);
-    if(bufsize >= 5)/* if it is in exponential mode */
-    {
-        i = bufsize - 4;
-        if((x->x_buf[i] == 'e') || (x->x_buf[i] == 'E'))
-            is_exp = 1;
-    }
-    if(bufsize > x->x_numwidth)/* if to reduce */
-    {
-        if(is_exp)
-        {
-            if(x->x_numwidth <= 5)
-            {
-                x->x_buf[0] = (f < 0.0 ? '-' : '+');
-                x->x_buf[1] = 0;
-            }
-            i = bufsize - 4;
-            for(idecimal = 0; idecimal < i; idecimal++)
-                if(x->x_buf[idecimal] == '.')
-                    break;
-            if(idecimal > (x->x_numwidth - 4))
-            {
-                x->x_buf[0] = (f < 0.0 ? '-' : '+');
-                x->x_buf[1] = 0;
-            }
-            else
-            {
-                int new_exp_index = x->x_numwidth - 4;
-                int old_exp_index = bufsize - 4;
 
-                for(i = 0; i < 4; i++, new_exp_index++, old_exp_index++)
-                    x->x_buf[new_exp_index] = x->x_buf[old_exp_index];
-                x->x_buf[x->x_numwidth] = 0;
-            }
-        }
-        else
-        {
-            for(idecimal = 0; idecimal < bufsize; idecimal++)
-                if(x->x_buf[idecimal] == '.')
-                    break;
-            if(idecimal > x->x_numwidth)
-            {
-                x->x_buf[0] = (f < 0.0 ? '-' : '+');
-                x->x_buf[1] = 0;
-            }
-            else
-                x->x_buf[x->x_numwidth] = 0;
-        }
-    }
+    gatom_float_sizelimit(x->x_buf, bufsize, x->x_numwidth);
 }
 
 /* ------------ nbx gui-my number box ----------------------- */
@@ -250,7 +206,6 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
             { /* while typing */
                 char *cp = x->x_buf;
                 int sl = (int)strlen(x->x_buf);
-
                 x->x_buf[sl] = '>';
                 x->x_buf[sl+1] = 0;
                 if(sl >= x->x_numwidth)

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -118,6 +118,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     int corner = x->x_gui.x_h/4;
     int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     char tag[128];
+    int borderwidth = zoom * (1+!!x->x_gui.x_fsf.x_change);
 
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
@@ -145,7 +146,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
         xpos,              ypos + x->x_gui.x_h,
         xpos,              ypos);
     pdgui_vmess(0, "crs  ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom,
+        "-width", borderwidth,
         "-outline", THISGUI->i_foregroundcolor,
         "-fill", x->x_gui.x_bcol);
 
@@ -240,12 +241,13 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
     if(glist_isvisible(glist))
     {
         t_canvas *canvas = glist_getcanvas(glist);
+        int borderwidth = IEMGUI_ZOOM(x) * (1+!!x->x_gui.x_fsf.x_change);
         char tag[128];
         sprintf(tag, "%p_NUMBER", x);
         if(x->x_gui.x_fsf.x_change)
         {
             if(x->x_buf[0])
-            {
+            { /* while typing */
                 char *cp = x->x_buf;
                 int sl = (int)strlen(x->x_buf);
 
@@ -253,15 +255,15 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
                 x->x_buf[sl+1] = 0;
                 if(sl >= x->x_numwidth)
                     cp += sl - x->x_numwidth + 1;
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_gopcolor, "-text", cp);
+                pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag,
+                    "-text", cp);
                 x->x_buf[sl] = 0;
             }
             else
-            {
+            { /* when activated */
                 my_numbox_ftoa(x);
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_gopcolor, "-text", x->x_buf);
+                pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag,
+                    "-text", x->x_buf);
                 x->x_buf[0] = 0;
             }
         }
@@ -278,6 +280,11 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
                     "-text", x->x_buf);
             x->x_buf[0] = 0;
         }
+        /* highlight border */
+        sprintf(tag, "%p_BASE1", x);
+        pdgui_vmess(0, "crs ri", canvas, "itemconfigure", tag,
+            "-width", borderwidth);
+
     }
 }
 

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -654,7 +654,7 @@ static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
 static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_my_numbox *x = (t_my_numbox *)iemgui_new(my_numbox_class);
-    int w = 5, h = 14 * IEM_GUI_DEFAULTSIZE_SCALE;
+    int w = 5, h = IEM_GUI_DEFAULTSIZE;
     int lilo = 0, ldx = 0, ldy = -8 * IEM_GUI_DEFAULTSIZE_SCALE;
     int fs = x->x_gui.x_fontsize;
     int log_height = 256;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -8,12 +8,75 @@
 #include <string.h>
 #include <stdio.h>
 #include "m_pd.h"
+#include "s_stuff.h"
 
 #include "g_all_guis.h"
 #include <math.h>
 
 #define MINDIGITS 1
 #define MINFONT   4
+
+/* helpers */
+#if NO_ISNAN
+PD_INLINE int my_isnan(t_float f) { return ((f) != (f)); }
+# undef isnan
+# define isnan my_isnan
+#endif
+
+#if NO_ISINF
+# ifndef INFINITY
+#  define INFINITY (1.0/0.0)
+# endif
+PD_INLINE int my_isinf(t_float f) { return f == INFINITY || f == -INFINITY; }
+# undef isinf
+# define isinf my_isinf
+#endif
+
+#if NO_ISFINITE
+PD_INLINE int my_isfinite(t_float f) { return !isinf(f) && !isnan(f); }
+# undef isfinite
+# define isfinite my_isfinite
+#endif
+
+PD_INLINE t_float _getfloat(const t_atom* a)
+{
+    char*endptr = 0;
+    static t_float f_nan = 1;
+    if (f_nan > 0)
+        f_nan = strtod("NAN", NULL);
+    t_float f;
+    if(!a) return f_nan;
+    switch(a->a_type) {
+    case A_FLOAT:
+        return a->a_w.w_float;
+    case A_SYMBOL:
+        f = strtod(a->a_w.w_symbol->s_name, &endptr);
+        if(endptr != a->a_w.w_symbol->s_name)
+            return f;
+            /* falls through */
+    default:
+        break;
+    }
+    return f_nan;
+}
+
+PD_INLINE t_float _getfloatarg(int which, int argc, const t_atom *argv) {
+
+    return _getfloat((argc > which)?(argv+which):0);
+}
+
+PD_INLINE t_symbol *_float2symbol(const t_float f) {
+    const int compat = (pd_compatibilitylevel <= 56);
+    char buf[30];
+
+    if(f == -INFINITY) return gensym(compat?"-1e37":"-1e999");
+    if(f == INFINITY) return gensym(compat?"1e37":"1e999");
+
+    pd_snprintf(buf, 30, "%g", f);
+    buf[29] = 0;
+    return gensym(buf);
+
+}
 
 /*------------------ global functions -------------------------*/
 
@@ -292,10 +355,10 @@ static void my_numbox_save(t_gobj *z, t_binbuf *b)
         x->x_gui.x_fsf.x_change = 0;
         sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
     }
-    binbuf_addv(b, "ssiisiiffiisssiiiisssfi", gensym("#X"), gensym("obj"),
+    binbuf_addv(b, "ssiisiissiisssiiiisssfi", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
                 gensym("nbx"), x->x_numwidth, x->x_gui.x_h/IEMGUI_ZOOM(x),
-                (t_float)x->x_min, (t_float)x->x_max,
+                _float2symbol(x->x_min), _float2symbol(x->x_max),
                 x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
@@ -374,8 +437,8 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     t_symbol *srl[3];
     int w = (int)atom_getfloatarg(0, argc, argv);
     int h = (int)atom_getfloatarg(1, argc, argv);
-    double min = (double)atom_getfloatarg(2, argc, argv);
-    double max = (double)atom_getfloatarg(3, argc, argv);
+    double min = (double)_getfloatarg(2, argc, argv);
+    double max = (double)_getfloatarg(3, argc, argv);
     int lilo = (int)atom_getfloatarg(4, argc, argv);
     int log_height = (int)atom_getfloatarg(6, argc, argv);
     int sr_flags;
@@ -658,12 +721,12 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     int lilo = 0, ldx = 0, ldy = -8 * IEM_GUI_DEFAULTSIZE_SCALE;
     int fs = x->x_gui.x_fontsize;
     int log_height = 256;
-    double min = -1.0e+37, max = 1.0e+37, v = 0.0;
+    double min = -INFINITY, max = INFINITY, v = 0.0;
 
     IEMGUI_SETDRAWFUNCTIONS(x, my_numbox);
 
     if((argc >= 17)&&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)
-       &&IS_A_FLOAT(argv,2)&&IS_A_FLOAT(argv,3)
+       &&!isnan(_getfloat(argv+2))&&!isnan(_getfloat(argv+3))
        &&IS_A_FLOAT(argv,4)&&IS_A_FLOAT(argv,5)
        &&(IS_A_SYMBOL(argv,6)||IS_A_FLOAT(argv,6))
        &&(IS_A_SYMBOL(argv,7)||IS_A_FLOAT(argv,7))
@@ -673,8 +736,8 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     {
         w = (int)atom_getfloatarg(0, argc, argv);
         h = (int)atom_getfloatarg(1, argc, argv);
-        min = (double)atom_getfloatarg(2, argc, argv);
-        max = (double)atom_getfloatarg(3, argc, argv);
+        min = _getfloat(argv+2);
+        max = _getfloat(argv+3);
         lilo = (int)atom_getfloatarg(4, argc, argv);
         iem_inttosymargs(&x->x_gui.x_isa, atom_getfloatarg(5, argc, argv));
         iemgui_new_getnames(&x->x_gui, 6, argv);
@@ -685,7 +748,12 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
         iemgui_all_loadcolors(&x->x_gui, argv+13, argv+14, argv+15);
         v = atom_getfloatarg(16, argc, argv);
     }
-    else iemgui_new_getnames(&x->x_gui, 6, 0);
+    else
+    {
+        min = -INFINITY;
+        max = INFINITY;
+        iemgui_new_getnames(&x->x_gui, 6, 0);
+    }
     if((argc == 18)&&IS_A_FLOAT(argv,17))
     {
         log_height = (int)atom_getfloatarg(17, argc, argv);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -124,9 +124,10 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
 
 
     sprintf(tag, "%p_BASE2", x);
-    pdgui_vmess(0, "crs  ii ii ii", canvas, "coords", tag,
+    pdgui_vmess(0, "crs  ii ii ii ii", canvas, "coords", tag,
         xpos + zoom, ypos + zoom,
         xpos + half, ypos + half,
+        xpos + half, ypos + half + x->x_gui.x_h%2,
         xpos + zoom, ypos + x->x_gui.x_h - zoom);
     pdgui_vmess(0, "crs  ri rk", canvas, "itemconfigure", tag,
         "-width", zoom,

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -455,6 +455,39 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
         (x->x_text? (TMARGIN + BMARGIN) * glist_getzoom(x->x_glist) : 0);
 }
 
+/* reduce a formatted number (in <buf>) to not exceed <maxsize> chars
+ * the result in <buf> is 0-terminated
+ */
+const char* gatom_float_sizelimit(char*buf, int bufsize, int maxsize) {
+    int wantreduce = bufsize - maxsize;
+    char *decimal = 0, *nextchar, *ebuf = buf + bufsize,
+        *s1, *s2;
+    int ndecimals;
+    if(maxsize >= bufsize)
+        return buf;
+    buf[bufsize] = 0;
+    for (decimal = buf; decimal < ebuf; decimal++)
+        if (*decimal == '.')
+            break;
+    if (decimal >= ebuf)
+        goto giveup;
+    for (nextchar = decimal + 1; nextchar < ebuf; nextchar++)
+        if (*nextchar < '0' || *nextchar > '9')
+            break;
+    if (nextchar - decimal - 1 < wantreduce)
+        goto giveup;
+    for (s1 = nextchar - wantreduce, s2 = s1 + wantreduce;
+         s2 < ebuf; s1++, s2++)
+        *s1 = *s2;
+    buf[maxsize-0] = 0;
+    return buf;
+ giveup:
+        /* give up and bash last char to '>' */
+    buf[maxsize-1] = '>';
+    buf[maxsize-0] = 0;
+    return buf;
+}
+
     /* same as above, but for atom boxes, which are always on one line. */
 static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp,
     int *indexp,  char *tempbuf, int *outchars_b_p, int *selstart_b_p,
@@ -469,35 +502,12 @@ static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp,
         binbuf_getvec(x->x_text->te_binbuf)->a_type == A_FLOAT &&
         x->x_bufsize > charwidth)
     {
-            /* try to reduce size by dropping decimal digits */
-        int wantreduce = x->x_bufsize - charwidth;
-        char *decimal = 0, *nextchar, *ebuf = x->x_buf + x->x_bufsize,
-            *s1, *s2;
-        int ndecimals;
+        t_float f = atom_getfloat(binbuf_getvec(x->x_text->te_binbuf));
         strncpy(tempbuf, x->x_buf, x->x_bufsize);
-        tempbuf[x->x_bufsize] = 0;
-        ebuf = tempbuf + x->x_bufsize;
-        for (decimal = tempbuf; decimal < ebuf; decimal++)
-            if (*decimal == '.')
-                break;
-        if (decimal >= ebuf)
-            goto giveup;
-        for (nextchar = decimal + 1; nextchar < ebuf; nextchar++)
-            if (*nextchar < '0' || *nextchar > '9')
-                break;
-        if (nextchar - decimal - 1 < wantreduce)
-            goto giveup;
-        for (s1 = nextchar - wantreduce, s2 = s1 + wantreduce;
-            s2 < ebuf; s1++, s2++)
-                *s1 = *s2;
+            // 3rd argument should be charwidth
+        gatom_float_sizelimit(tempbuf, x->x_bufsize, charwidth);
+
         *outchars_b_p = charwidth;
-        goto done;
-    giveup:
-            /* give up and bash last char to '>' */
-        tempbuf[charwidth-1] = '>';
-        tempbuf[charwidth] = 0;
-        *outchars_b_p = charwidth;
-    done: ;
         *indexp = findx;
         *widthp = charwidth * fontwidth;
     }


### PR DESCRIPTION
### activation indicator

this simply uses the border width to indicate whether an iemgui `[nbx]` is active or not, similar as the ordinary gatoms do it (which is nice as it doesn't clash with any color concepts)

![active-nbx](https://user-images.githubusercontent.com/214034/189349142-f49860d4-6a79-41ea-b58f-b82dfdeb61dd.png)

- Closes: #1690 

### streamlined number shortening algorithm

at also uses the same float-shortening algorithm as the number gatom (so if the number is too big, it displays a trailing `>` rather than replacing the entire number with a `+`

![nbx-shortener](https://user-images.githubusercontent.com/214034/189909949-3578a7dc-3be7-413b-8744-fc5dab7df22d.png)

- Closes: #1753 

### improved fontwidth calculation
the new calculation uses the system fontspecs (as other objects/gatoms do), getting rid of the empty space on the right hand of the nbx.
for backwards compatibility, we make sure that the new width is not bigger than it used to be (so objects on GOPs will always be visible). this shouldn't be an issue with the default fonts, but might be one, if a weird non-standard font is used).
it's possible to force the old behaviour by setting the compat-level to `<0.53`

![nbx-width](https://user-images.githubusercontent.com/214034/189909855-91f863f0-9beb-473e-aae9-c7de90589ea8.png)

- Closes: #1755

### reduce anti-aliasing artifacts with odd heights

previously, the triangle on the left-hand would show an ugly artifact if the nbx2-height was odd. this is now fixed:

<img width="326" height="71" alt="image" src="https://github.com/user-attachments/assets/1f3be76a-1842-45de-b576-e9aa3da7a42f" />


### use `±inf` as unbound limits

originally, the object used some "very large numbers" (namely `±1e37`) for "virtually no limit".
such large numbers are seldomly encountered in practice.
nevertheless, the limit is arbitrary, and when using Pd64 it is far from the actual minimum/maximum numbers (doubles are in the range of `±1e308`).
i think the proper fix is to use `±inf` to indicate that there is no upper (or lower) limit.

