### PR TITLE
improve scheduler

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1459,14 +1459,17 @@ void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv)
         int newstate = atom_getfloat(argv);
         if (newstate && !THISGUI->i_dspstate)
         {
-            sys_set_audio_state(1);
+                /* if audio should be kept open, we don't reopen the device,
+                unless it really has been closed (for whatever reason) */
+            if (!audio_shouldkeepopen() || !audio_isopen())
+                sys_reopen_audio();
             canvas_start_dsp();
         }
         else if (!newstate && THISGUI->i_dspstate)
         {
             canvas_stop_dsp();
             if (!audio_shouldkeepopen())
-                sys_set_audio_state(0);
+                sys_close_audio();
         }
     }
     else post("dsp state %d", THISGUI->i_dspstate);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1443,20 +1443,20 @@ void canvas_update_dsp(void)
 }
 
 /* the "dsp" message to pd starts and stops DSP computation, and, if
-appropriate, also opens and closes the audio device.  On exclusive-access
+appropriate, also opens and closes the audio device. On exclusive-access
 APIs such as ALSA, MMIO, and ASIO (I think) it's appropriate to close the
 audio devices when not using them; but jack behaves better if audio I/O
-simply keeps running.  This is wasteful of CPU cycles but we do it anyway
+simply keeps running. Also, we want to preserve any connections made between
+Pd and other Jack clients. This is wasteful of CPU cycles but we do it anyway
 and can perhaps regard this is a design flaw in jack that we're working around
-here.  The function audio_shouldkeepopen() is provided by s_audio.c to tell
-us that we should elide the step of closing audio when DSP is turned off.*/
+here. The function audio_shouldkeepopen() is provided by s_audio.c to tell us
+that we should elide the step of closing audio when DSP is turned off.*/
 
 void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv)
 {
-    int newstate;
     if (argc)
     {
-        newstate = atom_getfloatarg(0, argc, argv);
+        int newstate = atom_getfloat(argv);
         if (newstate && !THISGUI->i_dspstate)
         {
             sys_set_audio_state(1);

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -304,6 +304,7 @@ void pd_anything(t_pd *x, t_symbol *s, int argc, t_atom *argv)
 }
 
 void mess_init(void);
+void sched_init(void);
 void obj_init(void);
 void conf_init(void);
 void glob_init(void);
@@ -347,6 +348,7 @@ void pd_term(void)
 void pd_init_systems(void)
 {
     mess_init();
+    sched_init();
     sys_lock();
     obj_init();
     conf_init();

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -327,7 +327,25 @@ void pd_init(void)
     pd_init_systems();
 }
 
-void pd_init_systems(void) {
+void pd_term(void)
+{
+    t_glist *c;
+    for (c = pd_getcanvaslist(); c; c = c->gl_next)
+        canvas_closebang(c);
+#if 0
+        /* Canvases may be slow to close and as a workaround people
+        may want Pd to shutdown quickly. Conversely, others might
+        prefer it if canvases (and all their containing objects) are
+        always freed properly. For now let's exit quickly and LATER
+        figure out a way to handle this. */
+    while ((c = pd_getcanvaslist()))
+        pd_free((t_pd *)c);
+#endif
+    pd_term_systems();
+}
+
+void pd_init_systems(void)
+{
     mess_init();
     sys_lock();
     obj_init();
@@ -337,9 +355,9 @@ void pd_init_systems(void) {
     sys_unlock();
 }
 
-void pd_term_systems(void) {
-    sys_lock();
-    sys_unlock();
+void pd_term_systems(void)
+{
+        /* TODO free resources */
 }
 
 t_canvas *pd_getcanvaslist(void)

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -9,7 +9,12 @@
 #include "s_stuff.h"
 #ifdef _WIN32
 #include <windows.h>
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
 #endif
+#include <errno.h>
+#include <pthread.h>
 
     /* LATER consider making this variable.  It's now the LCM of all sample
     rates we expect to see: 32000, 44100, 48000, 88200, 96000. */
@@ -21,8 +26,14 @@
     ((int)(STUFF->st_dacsr /(double)STUFF->st_schedblocksize))
 
 #define SYS_QUIT_QUIT 1
-#define SYS_QUIT_RESTART 2
+#define SYS_QUIT_REOPEN 2
+#define SYS_QUIT_CLOSE 3
 static int sys_quit;
+static pthread_cond_t sched_cond;
+static pthread_mutex_t sched_mutex;
+static int sched_useaudio = SCHED_AUDIO_NONE;
+static double sched_referencerealtime, sched_referencelogicaltime;
+
 static int sys_exitcode;
 extern int sys_nosleep;
 
@@ -210,19 +221,38 @@ void glob_fastforward(void *dummy, t_floatarg f)
 
 void dsp_tick(void);
 
-static int sched_useaudio = SCHED_AUDIO_NONE;
-static double sched_referencerealtime, sched_referencelogicaltime;
+    /* ask the scheduler to quit; this is thread-safe, so it
+       can be safely called from within the audio callback. */
 void sys_exit(int status)
 {
+    pthread_mutex_lock(&sched_mutex);
     sys_exitcode = status;
     sys_quit = SYS_QUIT_QUIT;
+    pthread_cond_signal(&sched_cond);
+    pthread_mutex_unlock(&sched_mutex);
 }
 
-void sched_reopenmeplease(void)   /* request from s_audio for deferred reopen */
+    /* ask the scheduler to (re)open the audio system; thread-safe! */
+void sys_reopen_audio(void)
 {
-    sys_quit = SYS_QUIT_RESTART;
+    pthread_mutex_lock(&sched_mutex);
+    if (sys_quit != SYS_QUIT_QUIT)
+        sys_quit = SYS_QUIT_REOPEN;
+    pthread_cond_signal(&sched_cond);
+    pthread_mutex_unlock(&sched_mutex);
 }
 
+    /* ask the scheduler to close the audio system; thread-safe! */
+void sys_close_audio(void)
+{
+    pthread_mutex_lock(&sched_mutex);
+    if (sys_quit != SYS_QUIT_QUIT)
+        sys_quit = SYS_QUIT_CLOSE;
+    pthread_cond_signal(&sched_cond);
+    pthread_mutex_unlock(&sched_mutex);
+}
+
+    /* called by sys_do_reopen_audio() and sys_do_close_audio() */
 void sched_set_using_audio(int flag)
 {
     sched_useaudio = flag;
@@ -231,13 +261,6 @@ void sched_set_using_audio(int flag)
         sched_referencerealtime = sys_getrealtime();
         sched_referencelogicaltime = clock_getlogicaltime();
     }
-        if (flag == SCHED_AUDIO_CALLBACK &&
-            sched_useaudio != SCHED_AUDIO_CALLBACK)
-                sys_quit = SYS_QUIT_RESTART;
-        if (flag != SCHED_AUDIO_CALLBACK &&
-            sched_useaudio == SCHED_AUDIO_CALLBACK)
-                post("sorry, can't turn off callbacks yet; restart Pd");
-                    /* not right yet! */
 
     pdgui_vmess("pdtk_pd_audio", "r", flag ? "on" : "off");
 }
@@ -335,6 +358,8 @@ static void m_pollingscheduler(void)
 {
     sys_lock();
     sys_initmidiqueue();
+        /* NB: we don't need to lock the scheduler mutex because sys_quit
+        will only be modified from this thread */
     while (!sys_quit)   /* outer loop runs once per tick */
     {
         sys_addhist(0);
@@ -351,6 +376,8 @@ static void m_pollingscheduler(void)
             sched_referencelogicaltime = pd_this->pd_systime;
             continue;
         }
+            /* do at least one GUI update per DSP tick, so that Pd stays responsive
+             * if the scheduler can't keep up with the audio callback */
         sys_pollgui();
         sys_pollmidiqueue();
         sys_addhist(2);
@@ -392,8 +419,11 @@ static void m_pollingscheduler(void)
     sys_unlock();
 }
 
+static volatile int callback_inprogress;
+
 void sched_audio_callbackfn(void)
 {
+    callback_inprogress = 1;
     sys_lock();
     sys_addhist(0);
     sched_tick();
@@ -403,55 +433,100 @@ void sched_audio_callbackfn(void)
     sys_unlock();
     (void)sched_idletask();
     sys_addhist(3);
+    callback_inprogress = 0;
 }
+
+    /* callback scheduler timeout in seconds */
+#define CALLBACK_TIMEOUT 2.0
+
+int sys_try_reopen_audio(void);
 
 static void m_callbackscheduler(void)
 {
+    sys_lock();
     sys_initmidiqueue();
+    sys_unlock();
+        /* wait in a loop until the audio callback asks us to quit. */
+    pthread_mutex_lock(&sched_mutex);
     while (!sys_quit)
     {
-        double timewas = pd_this->pd_systime;
-#ifdef _WIN32
-        Sleep(1000);
-#else
-        sleep(1);
-#endif
-        if (pd_this->pd_systime == timewas)
+        int wasinprogress;
+            /* get current system time and add timeout */
+        double timewas, timeout = CALLBACK_TIMEOUT;
+        struct timespec ts;
+    #ifdef _WIN32
+        struct __timeb64 tb;
+        _ftime64(&tb);
+            /* add fractional part to timeout */
+        timeout += tb.millitm * 0.001;
+        ts.tv_sec = tb.time + (time_t)timeout;
+        ts.tv_nsec = (timeout - (time_t)timeout) * 1000000000;
+    #else
+        struct timeval now;
+        gettimeofday(&now, 0);
+            /* add fractional part to timeout */
+        timeout += now.tv_usec * 0.000001;
+        ts.tv_sec = now.tv_sec + (time_t)timeout;
+        ts.tv_nsec = (timeout - (time_t)timeout) * 1000000000;
+    #endif
+            /* wait for semaphore (with timeout) */
+        timewas = pd_this->pd_systime;
+        wasinprogress = callback_inprogress;
+        if (pthread_cond_timedwait(&sched_cond, &sched_mutex, &ts) == ETIMEDOUT)
         {
-            sys_lock();
-            (void)sys_pollgui();
-            sched_tick();
-            sys_unlock();
+                /* check if the schedular has advanced since the last time
+                   we checked (while it was not in progress) */
+            if (!sys_quit && !wasinprogress && (pd_this->pd_systime == timewas))
+            {
+                pthread_mutex_unlock(&sched_mutex);
+                    /* if the scheduler has not advanced, but the callback is
+                       still in progress, it just blocks on some Pd message.
+                       Otherwise, the audio device got stuck or disconnected. */
+                if (!callback_inprogress && !sys_try_reopen_audio())
+                    return;
+                pthread_mutex_lock(&sched_mutex);
+            }
         }
-        if (sys_idlehook)
-            sys_idlehook();
     }
+    pthread_mutex_unlock(&sched_mutex);
 }
+
+void sys_do_reopen_audio(void);
+void sys_do_close_audio(void);
 
 int m_mainloop(void)
 {
+    pthread_mutex_init(&sched_mutex, 0);
+    pthread_cond_init(&sched_cond, 0);
+
         /* open audio and MIDI */
     sys_reopen_midi();
     if (audio_shouldkeepopen())
         sys_reopen_audio();
+
+        /* run the scheduler until it quits. */
     while (sys_quit != SYS_QUIT_QUIT)
     {
+            /* check if we should close/reopen the audio device. */
+        if (sys_quit != 0)
+        {
+            int reopen = sys_quit == SYS_QUIT_REOPEN;
+            sys_quit = 0;
+            sys_do_close_audio();
+            if (reopen)
+                sys_do_reopen_audio();
+        }
         if (sched_useaudio == SCHED_AUDIO_CALLBACK)
             m_callbackscheduler();
-        else m_pollingscheduler();
-        if (sys_quit == SYS_QUIT_RESTART)
-        {
-            sys_quit = 0;
-            if (audio_isopen())
-            {
-                sys_close_audio();
-                sys_reopen_audio();
-            }
-        }
+        else
+            m_pollingscheduler();
     }
 
-    sys_close_audio();
+    sys_do_close_audio();
     sys_close_midi();
+
+    pthread_mutex_destroy(&sched_mutex);
+    pthread_cond_destroy(&sched_cond);
     return (sys_exitcode);
 }
 

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -216,7 +216,10 @@ static float sched_fastforward;
 
 void glob_fastforward(void *dummy, t_floatarg f)
 {
-    sched_fastforward = TIMEUNITPERMSEC * f;
+    if (sched_useaudio == SCHED_AUDIO_CALLBACK)
+        pd_error(0, "'fast-forward' does not work with 'callbacks' (yet)");
+    else
+        sched_fastforward = TIMEUNITPERMSEC * f;
 }
 
 void dsp_tick(void);

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -222,6 +222,18 @@ void glob_fastforward(void *dummy, t_floatarg f)
         sched_fastforward = TIMEUNITPERMSEC * f;
 }
 
+void sched_init(void)
+{
+    pthread_mutex_init(&sched_mutex, 0);
+    pthread_cond_init(&sched_cond, 0);
+}
+
+void sched_term(void)
+{
+    pthread_mutex_destroy(&sched_mutex);
+    pthread_cond_destroy(&sched_cond);
+}
+
 void dsp_tick(void);
 
     /* ask the scheduler to quit; this is thread-safe, so it
@@ -513,9 +525,6 @@ void sys_do_close_audio(void);
 
 int m_mainloop(void)
 {
-    pthread_mutex_init(&sched_mutex, 0);
-    pthread_cond_init(&sched_cond, 0);
-
         /* open audio and MIDI */
     sys_reopen_midi();
     if (audio_shouldkeepopen())
@@ -545,8 +554,6 @@ int m_mainloop(void)
     sys_do_close_audio();
     sys_close_midi();
 
-    pthread_mutex_destroy(&sched_mutex);
-    pthread_cond_destroy(&sched_cond);
     return (sys_exitcode);
 }
 

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -372,14 +372,16 @@ static void m_pollingscheduler(void)
                 }
                 timeforward = (lateness > 0 ? SENDDACS_YES : SENDDACS_NO);
             }
-            else timeforward = sys_send_dacs();
+            else
+                timeforward = sys_send_dacs();
             sys_addhist(3);
                 /* test for idle; if so, do graphics updates. */
-            if (timeforward != SENDDACS_YES && !sched_idletask() && !sys_nosleep)
+            if (timeforward != SENDDACS_YES && !sched_idletask())
             {
                 /* if even that had nothing to do, sleep. */
                 sys_addhist(4);
-                sys_microsleep();
+                if (!sys_nosleep && timeforward != SENDDACS_SLEPT)
+                    sys_microsleep();
             }
             sys_addhist(5);
             sys_lock();

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -294,15 +294,27 @@ void sched_tick(void)
     sched_counter++;
 }
 
-int sched_get_sleepgrain( void)
+int sched_get_sleepgrain(void)
 {
-    return (sys_sleepgrain > 0 ? sys_sleepgrain :
-        (sys_schedadvance/4 > 5000 ? 5000 : (sys_schedadvance/4 < 100 ? 100 :
-            sys_schedadvance/4)));
+    if (sys_sleepgrain > 0)
+        return sys_sleepgrain;
+    else if (sched_useaudio == SCHED_AUDIO_POLL)
+    {
+        int sleepgrain = sys_schedadvance / 4;
+        if (sleepgrain > 5000)
+            sleepgrain = 5000;
+        else if (sleepgrain < 100)
+            sleepgrain = 100;
+        return sleepgrain;
+    }
+    else return 1000; /* default */
 }
 
     /* old stuff for extern binary compatibility -- remove someday */
-int *get_sys_sleepgrain(void) {return(&sys_sleepgrain);}
+int *get_sys_sleepgrain(void)
+{
+    return(&sys_sleepgrain);
+}
 
 /*
 Here is Pd's "main loop."  This routine dispatches clock timeouts and DSP

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -291,7 +291,8 @@ void sched_tick(void)
             countdown = 5000;
             (void)sys_pollgui();
         }
-        if (sys_quit)
+            /* ignore SYS_QUIT_REOPEN and SYS_QUIT_CLOSE! */
+        if (sys_quit == SYS_QUIT_QUIT)
             return;
     }
     pd_this->pd_systime = next_sys_time;

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -268,6 +268,11 @@ void sched_set_using_audio(int flag)
     pdgui_vmess("pdtk_pd_audio", "r", flag ? "on" : "off");
 }
 
+int sched_get_using_audio(void)
+{
+    return sched_useaudio;
+}
+
     /* take the scheduler forward one DSP tick, also handling clock timeouts */
 void sched_tick(void)
 {
@@ -372,7 +377,6 @@ int sched_idletask(void)
 static void m_pollingscheduler(void)
 {
     sys_lock();
-    sys_initmidiqueue();
         /* NB: we don't need to lock the scheduler mutex because sys_quit
         will only be modified from this thread */
     while (!sys_quit)   /* outer loop runs once per tick */
@@ -458,9 +462,6 @@ int sys_try_reopen_audio(void);
 
 static void m_callbackscheduler(void)
 {
-    sys_lock();
-    sys_initmidiqueue();
-    sys_unlock();
         /* wait in a loop until the audio callback asks us to quit. */
     pthread_mutex_lock(&sched_mutex);
     while (!sys_quit)
@@ -531,6 +532,9 @@ int m_mainloop(void)
             if (reopen)
                 sys_do_reopen_audio();
         }
+        sys_lock();
+        sys_initmidiqueue();
+        sys_unlock();
         if (sched_useaudio == SCHED_AUDIO_CALLBACK)
             m_callbackscheduler();
         else

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -292,7 +292,7 @@ will now sleep. */
 int (*sys_idlehook)(void);
 
     /* when audio is idle, see to GUI and other stuff */
-static int sched_idletask( void)
+int sched_idletask(void)
 {
     static int sched_nextmeterpolltime, sched_nextpingtime;
     int rtn = 0;

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -485,7 +485,7 @@ static void m_callbackscheduler(void)
         ts.tv_sec = now.tv_sec + (time_t)timeout;
         ts.tv_nsec = (timeout - (time_t)timeout) * 1000000000;
     #endif
-            /* wait for semaphore (with timeout) */
+            /* sleep on condition variable (with timeout) */
         timewas = pd_this->pd_systime;
         wasinprogress = callback_inprogress;
         if (pthread_cond_timedwait(&sched_cond, &sched_mutex, &ts) == ETIMEDOUT)

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -742,7 +742,8 @@ void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
             as.a_blocksize = DEFDACBLKSIZE;
 
     sys_set_audio_settings(&as);
-    sys_reopen_audio();
+    if (canvas_dspstate || audio_shouldkeepopen())
+        sys_reopen_audio();
 }
 
 void sys_listdevs(void)
@@ -794,12 +795,7 @@ void glob_audio_setapi(void *dummy, t_floatarg f)
     int newapi = f;
     if (newapi)
     {
-        if (newapi == audio_nextsettings.a_api)
-        {
-            if (!audio_isopen() && audio_shouldkeepopen())
-                sys_reopen_audio();
-        }
-        else
+        if (newapi != audio_nextsettings.a_api)
         {
             audio_nextsettings.a_api = newapi;
                 /* bash device params back to default */
@@ -812,7 +808,8 @@ void glob_audio_setapi(void *dummy, t_floatarg f)
                 audio_nextsettings.a_choutdevvec[0] = SYS_DEFAULTCH;
             audio_nextsettings.a_blocksize = DEFDACBLKSIZE;
             audio_nextsettings.a_callback = 0;
-            sys_reopen_audio();
+            if (canvas_dspstate || audio_shouldkeepopen())
+                sys_reopen_audio();
         }
         glob_audio_properties(0, 0);
     }

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -535,7 +535,10 @@ int sys_get_inchannels(void)
 keep jack audio open but close unused audio devices for any other API */
 int audio_shouldkeepopen(void)
 {
-    return (sys_audioapiopened == API_JACK);
+    if (sys_audioapiopened == API_NONE)
+        return (audio_nextsettings.a_api == API_JACK);
+    else
+        return (sys_audioapiopened == API_JACK);
 }
 
     /* get names of available audio devices for the specified API */

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -361,7 +361,10 @@ void sys_do_reopen_audio(void)
         as.a_chindevvec, &totalinchans, MAXAUDIOINDEV);
     audio_compact_and_count_channels(&as.a_noutdev, as.a_outdevvec,
         as.a_choutdevvec, &totaloutchans, MAXAUDIOOUTDEV);
+        /* NB: sys_setchsr() may update the DSP graph, so we need to lock Pd! */
+    sys_lock();
     sys_setchsr(totalinchans, totaloutchans, as.a_srate);
+    sys_unlock();
     if (!as.a_nindev && !as.a_noutdev)
     {
         sched_set_using_audio(SCHED_AUDIO_NONE);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -520,10 +520,7 @@ void sys_get_audio_devs(char *indevlist, int *nindevs,
     {
         pa_getdevs(indevlist, nindevs, outdevlist, noutdevs, canmulti,
             maxndev, devdescsize);
-        /* portaudio officially allows callbacks but it hangs Pd on MacOS
-        and perhaps on other platforms too - this would potentially reduce
-        latency but doesn't appear to be worth the danger. */
-        *cancallback = 0;
+        *cancallback = 1;
     }
     else
 #endif

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -449,6 +449,10 @@ int sys_try_reopen_audio(void)
     if (sys_audioapiopened == API_PORTAUDIO)
         return pa_reopen_audio();
 #endif
+#ifdef USEAPI_JACK
+    if (sys_audioapiopened == API_JACK)
+        return jack_reopen_audio();
+#endif
         /* generic implementation: close audio and try to reopen it */
     sys_do_close_audio();
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -803,6 +803,7 @@ void glob_audio_setapi(void *dummy, t_floatarg f)
             audio_nextsettings.a_chindevvec[0] =
                 audio_nextsettings.a_choutdevvec[0] = SYS_DEFAULTCH;
             audio_nextsettings.a_blocksize = DEFDACBLKSIZE;
+            audio_nextsettings.a_callback = 0;
             sys_reopen_audio();
         }
         glob_audio_properties(0, 0);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -819,17 +819,6 @@ void glob_audio_setapi(void *dummy, t_floatarg f)
     }
 }
 
-    /* start or stop the audio hardware */
-void sys_set_audio_state(int onoff)
-{
-        /* NB: only reopen audio if it has been closed, so we don't
-        interfere with audio_shouldkeepopen()! See also glob_dsp(). */
-    if (onoff && !audio_isopen())  /* start */
-        sys_reopen_audio();
-    else if (!onoff && audio_isopen())
-        sys_close_audio();
-}
-
 #define MAXAPIENTRY 10
 typedef struct _apientry
 {

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -95,7 +95,7 @@ void sys_setchsr(int chin, int chout, int sr)
 
         /* NB: reallocating the input/output channel arrays requires a DSP
         graph update, so we only do it if the channel count has changed! */
-    if (chin != oldchin)
+    if (!STUFF->st_soundin || chin != oldchin)
     {
         if (STUFF->st_soundin)
             freebytes(STUFF->st_soundin, oldinbytes);
@@ -105,7 +105,7 @@ void sys_setchsr(int chin, int chout, int sr)
     }
     memset(STUFF->st_soundin, 0, inbytes);
 
-    if (chout != oldchout)
+    if (!STUFF->st_soundout || chout != oldchout)
     {
         if (STUFF->st_soundout)
             freebytes(STUFF->st_soundout, oldoutbytes);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -244,6 +244,8 @@ void sys_set_audio_settings(t_audiosettings *a)
     a->a_blocksize = 1 << ilog2(a->a_blocksize);
     if (a->a_blocksize < DEFDACBLKSIZE || a->a_blocksize > MAXBLOCKSIZE)
         a->a_blocksize = DEFDACBLKSIZE;
+    if (a->a_callback && !cancallback)
+        a->a_callback = 0;
 
     audio_make_sane(&a->a_noutdev, a->a_outdevvec,
         &a->a_nchoutdev, a->a_choutdevvec, MAXAUDIOOUTDEV);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -352,8 +352,9 @@ void sys_do_reopen_audio(void)
     {
         int blksize = (as.a_blocksize ? as.a_blocksize : 64);
         int nbufs = (double)sys_schedadvance / 1000000. * as.a_srate / blksize;
-            /* make sure that the delay is not smaller than the hardware blocksize */
-        if (nbufs < 1)
+            /* make sure that the delay is not smaller than the hardware blocksize.
+            NB: nbufs has no effect if callbacks are enabled. */
+        if (nbufs < 1 && !as.a_callback)
         {
             int delay = ((double)sys_schedadvance / 1000.) + 0.5;
             int limit = ceil(blksize * 1000. / (double)as.a_srate);
@@ -363,11 +364,11 @@ void sys_do_reopen_audio(void)
                  delay, blksize, limit);
         }
         outcome = pa_open_audio((as.a_nindev > 0 ? as.a_chindevvec[0] : 0),
-        (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0), as.a_srate,
+            (as.a_noutdev > 0 ? as.a_choutdevvec[0] : 0), as.a_srate,
             STUFF->st_soundin, STUFF->st_soundout, blksize, nbufs,
-             (as.a_nindev > 0 ? as.a_indevvec[0] : 0),
-              (as.a_noutdev > 0 ? as.a_outdevvec[0] : 0),
-               (as.a_callback ? sched_audio_callbackfn : 0));
+            (as.a_nindev > 0 ? as.a_indevvec[0] : 0),
+            (as.a_noutdev > 0 ? as.a_outdevvec[0] : 0),
+            (as.a_callback ? sched_audio_callbackfn : 0));
     }
     else
 #endif

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -186,10 +186,13 @@ static int callbackprocess(jack_nframes_t nframes, void *arg)
 
 static int jack_srate(jack_nframes_t srate, void *arg)
 {
-    const t_float oldrate = STUFF->st_dacsr;
-    STUFF->st_dacsr = srate;
-    if (oldrate != STUFF->st_dacsr)
+    sys_lock();
+    if (srate != STUFF->st_dacsr)
+    {
+        STUFF->st_dacsr = srate;
         canvas_update_dsp();
+    }
+    sys_unlock();
     return 0;
 }
 
@@ -332,7 +335,9 @@ static int jack_connect_ports(char* client)
 
 static void pd_jack_error_callback(const char *desc)
 {
-    pd_error(0, "JACKerror: %s", desc);
+    sys_lock();
+    logpost(0, PD_DEBUG, "JACK error: %s", desc);
+    sys_unlock();
     return;
 }
 

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -444,7 +444,7 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     advance_samples = sys_schedadvance * (double)STUFF->st_dacsr / 1.e6;
     advance_samples -= (advance_samples % DEFDACBLKSIZE);
         /* make sure that the delay is not smaller than the Jack blocksize! */
-    if (advance_samples < jack_blocksize)
+    if (!callback && advance_samples < jack_blocksize)
     {
         int delay = ((double)sys_schedadvance / 1000.) + 0.5;
         int limit = ceil(jack_blocksize * 1000. / (double)STUFF->st_dacsr);

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -50,7 +50,7 @@
 #define MAX_ALLOCA_SAMPLES 16*1024
 
 /* enable thread signaling instead of polling */
-#if 0
+#if 1
 #define THREADSIGNAL
 #endif
 

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -542,6 +542,8 @@ void jack_close_audio(void)
 #endif
 }
 
+int sched_idletask(void);
+
 int jack_send_dacs(void)
 {
     t_sample *muxbuffer;
@@ -562,6 +564,9 @@ int jack_send_dacs(void)
             (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(t_sample))))
     {
 #ifdef THREADSIGNAL
+        if (sched_idletask())
+            continue;
+            /* only go to sleep if there is nothing else to do. */
         sys_semaphore_wait(jack_sem);
         retval = SENDDACS_SLEPT;
 #else

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -94,7 +94,7 @@ static int jack_polling_callback(jack_nframes_t nframes, void *unused)
     if (infiforoom < nframes * STUFF->st_inchannels * sizeof(t_sample) ||
         outfiforoom < nframes * STUFF->st_outchannels * sizeof(t_sample))
     {
-        /* data late: output zeros, drop inputs, and leave FIFos untouched */
+        /* data late: output zeros, drop inputs, and leave FIFOs untouched */
         if (jack_started)
             jack_dio_error = 1;
         for (j = 0; j < STUFF->st_outchannels; j++)
@@ -184,8 +184,7 @@ static int callbackprocess(jack_nframes_t nframes, void *arg)
     return 0;
 }
 
-static int
-jack_srate (jack_nframes_t srate, void *arg)
+static int jack_srate(jack_nframes_t srate, void *arg)
 {
     const t_float oldrate = STUFF->st_dacsr;
     STUFF->st_dacsr = srate;
@@ -194,8 +193,7 @@ jack_srate (jack_nframes_t srate, void *arg)
     return 0;
 }
 
-static int
-jack_bsize (jack_nframes_t bufsize, void *arg)
+static int jack_bsize(jack_nframes_t bufsize, void *arg)
 {
     jack_blocksize = bufsize;
     return 0;
@@ -203,61 +201,60 @@ jack_bsize (jack_nframes_t bufsize, void *arg)
 
 void glob_audio_setapi(void *dummy, t_floatarg f);
 
-static void
-jack_shutdown (void *arg)
+static void jack_shutdown(void *arg)
 {
-  pd_error(0, "JACK: server shut down");
+    pd_error(0, "JACK: server shut down");
 
-  jack_deactivate (jack_client);
-  jack_client = NULL;
-  jack_blocksize = 0;
+    jack_deactivate (jack_client);
+    jack_client = NULL;
+    jack_blocksize = 0;
 
-  glob_audio_setapi(NULL, API_NONE); // set pd_whichapi 0
+    glob_audio_setapi(NULL, API_NONE); // set pd_whichapi 0
 }
 
-static int jack_xrun(void* arg) {
-  jack_dio_error = 1;
-  return 0;
+static int jack_xrun(void* arg)
+{
+    jack_dio_error = 1;
+    return 0;
 }
-
 
 static char** jack_get_clients(void)
 {
     const char **jack_ports;
-    int tmp_client_name_size = jack_client_name_size ? jack_client_name_size() : CLIENT_NAME_SIZE_FALLBACK;
+    int tmp_client_name_size = jack_client_name_size ?
+        jack_client_name_size() : CLIENT_NAME_SIZE_FALLBACK;
     char* tmp_client_name = (char*)getbytes(tmp_client_name_size);
     int i,j;
     int num_clients = 0;
     regex_t port_regex;
-    jack_ports = jack_get_ports( jack_client, "", "", 0 );
-    regcomp( &port_regex, "^[^:]*", REG_EXTENDED );
+    jack_ports = jack_get_ports(jack_client, "", "", 0);
+    regcomp(&port_regex, "^[^:]*", REG_EXTENDED);
 
     jack_client_names[0] = NULL;
 
     /* Build a list of clients from the list of ports */
-    for( i = 0; jack_ports[i] != NULL; i++ )
+    for (i = 0; jack_ports[i] != NULL; i++)
     {
         int client_seen;
         regmatch_t match_info;
 
-        if(num_clients>=MAX_CLIENTS)break;
-
+        if (num_clients >= MAX_CLIENTS) break;
 
         /* extract the client name from the port name, using a regex
          * that parses the clientname:portname syntax */
-        regexec( &port_regex, jack_ports[i], 1, &match_info, 0 );
-        memcpy( tmp_client_name, &jack_ports[i][match_info.rm_so],
-                match_info.rm_eo - match_info.rm_so );
+        regexec(&port_regex, jack_ports[i], 1, &match_info, 0);
+        memcpy(tmp_client_name, &jack_ports[i][match_info.rm_so],
+            match_info.rm_eo - match_info.rm_so);
         tmp_client_name[ match_info.rm_eo - match_info.rm_so ] = '\0';
 
         /* do we know about this port's client yet? */
         client_seen = 0;
 
-        for( j = 0; j < num_clients; j++ )
-            if( strcmp( tmp_client_name, jack_client_names[j] ) == 0 )
+        for (j = 0; j < num_clients; j++)
+            if (strcmp(tmp_client_name, jack_client_names[j]) == 0)
                 client_seen = 1;
 
-        if( client_seen == 0 )
+        if (client_seen == 0)
         {
             jack_client_names[num_clients] = (char*)getbytes(strlen(tmp_client_name) + 1);
 
@@ -266,19 +263,19 @@ static char** jack_get_clients(void)
              * it in spot 0 put it in spot 0 and move whatever
              * was already in spot 0 to the end. */
 
-            if( strcmp( "alsa_pcm", tmp_client_name ) == 0 && num_clients > 0 )
+            if (strcmp("alsa_pcm", tmp_client_name) == 0 && num_clients > 0)
             {
-              char* tmp;
-                /* alsa_pcm goes in spot 0 */
-              tmp = jack_client_names[ num_clients ];
-              jack_client_names[ num_clients ] = jack_client_names[0];
-              jack_client_names[0] = tmp;
-              strcpy( jack_client_names[0], tmp_client_name);
+                char* tmp;
+                    /* alsa_pcm goes in spot 0 */
+                tmp = jack_client_names[num_clients];
+                jack_client_names[num_clients] = jack_client_names[0];
+                jack_client_names[0] = tmp;
+                strcpy( jack_client_names[0], tmp_client_name);
             }
             else
             {
                 /* put the new client at the end of the client list */
-                strcpy( jack_client_names[ num_clients ], tmp_client_name );
+                strcpy(jack_client_names[num_clients], tmp_client_name);
             }
             num_clients++;
         }
@@ -286,8 +283,8 @@ static char** jack_get_clients(void)
 
     /*    for (i=0;i<num_clients;i++) post("client: %s",jack_client_names[i]); */
 
-    freebytes( tmp_client_name, tmp_client_name_size );
-    free( jack_ports );
+    freebytes(tmp_client_name, tmp_client_name_size);
+    free(jack_ports);
     return jack_client_names;
 }
 
@@ -304,28 +301,28 @@ static int jack_connect_ports(char* client)
 
     if (strlen(client) > 96)  return -1;
 
-    sprintf( regex_pattern, "%s:.*", client );
+    sprintf(regex_pattern, "%s:.*", client);
 
-    jack_ports = jack_get_ports( jack_client, regex_pattern,
-                                 NULL, JackPortIsOutput);
+    jack_ports = jack_get_ports(jack_client, regex_pattern,
+                                NULL, JackPortIsOutput);
     if (jack_ports)
     {
         for (i=0;jack_ports[i] != NULL && i < STUFF->st_inchannels;i++)
             if (jack_connect (jack_client, jack_ports[i],
-               jack_port_name (input_port[i])))
-                  pd_error(0, "JACK: cannot connect input ports %s -> %s",
-                      jack_ports[i],jack_port_name (input_port[i]));
+                jack_port_name (input_port[i])))
+                    pd_error(0, "JACK: cannot connect input ports %s -> %s",
+                        jack_ports[i],jack_port_name (input_port[i]));
         free(jack_ports);
     }
-    jack_ports = jack_get_ports( jack_client, regex_pattern,
-                                 NULL, JackPortIsInput);
+    jack_ports = jack_get_ports(jack_client, regex_pattern,
+                                NULL, JackPortIsInput);
     if (jack_ports)
     {
         for (i=0;jack_ports[i] != NULL && i < STUFF->st_outchannels;i++)
-          if (jack_connect (jack_client, jack_port_name (output_port[i]),
-            jack_ports[i]))
-              pd_error(0,  "JACK: cannot connect output ports %s -> %s",
-                jack_port_name (output_port[i]),jack_ports[i]);
+            if (jack_connect (jack_client, jack_port_name(output_port[i]),
+                jack_ports[i]))
+                    pd_error(0,  "JACK: cannot connect output ports %s -> %s",
+                        jack_port_name (output_port[i]),jack_ports[i]);
 
         free(jack_ports);
     }
@@ -333,9 +330,10 @@ static int jack_connect_ports(char* client)
 }
 
 
-static void pd_jack_error_callback(const char *desc) {
-  pd_error(0, "JACKerror: %s", desc);
-  return;
+static void pd_jack_error_callback(const char *desc)
+{
+    pd_error(0, "JACKerror: %s", desc);
+    return;
 }
 
 int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
@@ -479,10 +477,10 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
             port_name, JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
         if (!output_port[j])
         {
-          pd_error(0, "JACK: can only register %d output ports (of %d requested)",
-            j, outchans);
-          STUFF->st_outchannels = outchans = j;
-          break;
+            pd_error(0, "JACK: can only register %d output ports (of %d requested)",
+                j, outchans);
+            STUFF->st_outchannels = outchans = j;
+            break;
         }
     }
 

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -492,6 +492,8 @@ void pa_close_audio(void)
 #endif
 }
 
+int sched_idletask(void);
+
 int pa_send_dacs(void)
 {
     PaError err;
@@ -501,7 +503,7 @@ int pa_send_dacs(void)
     int j, k;
     int retval = SENDDACS_YES;
     double timeref = sys_getrealtime();
-
+        /* this shouldn't really happen... */
     if (!pa_stream || (!STUFF->st_inchannels && !STUFF->st_outchannels))
         return (SENDDACS_NO);
 
@@ -516,6 +518,9 @@ int pa_send_dacs(void)
             (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(t_sample))))
     {
 #ifdef THREADSIGNAL
+        if (sched_idletask())
+            continue;
+            /* only go to sleep if there is nothing else to do. */
         if (!sys_semaphore_waitfor(pa_sem, POLL_TIMEOUT))
         {
                 /* timed out -> check stream */

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -44,7 +44,7 @@
 #endif
 
 /* enable thread signaling instead of polling */
-#if 0
+#if 1
 #define THREADSIGNAL
 #endif
 

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -432,7 +432,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     {
         pa_callback = callbackfn;
         err = pa_open_callback(rate, inchans, outchans,
-            framesperbuf, nbuffers, pa_indev, pa_outdev, pa_lowlevel_callback);
+            framesperbuf, 0, pa_indev, pa_outdev, pa_lowlevel_callback);
     }
     else
     {
@@ -451,7 +451,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
                 nbuffers*framesperbuf*pa_outchans*sizeof(float), pa_outbuf, 0);
         }
         err = pa_open_callback(rate, inchans, outchans,
-            framesperbuf, nbuffers, pa_indev, pa_outdev, pa_fifo_callback);
+            framesperbuf, 0, pa_indev, pa_outdev, pa_fifo_callback);
 #else
         err = pa_open_callback(rate, inchans, outchans,
             framesperbuf, nbuffers, pa_indev, pa_outdev, 0);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -61,7 +61,7 @@ static t_audiocallback pa_callback;
 
 static int pa_started;
 static int pa_nbuffers;
-static int pa_dio_error;
+static volatile int pa_dio_error;
 
 #ifdef FAKEBLOCKING
 #include "s_audio_paring.h"
@@ -458,6 +458,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
 #endif
     }
     pa_started = 0;
+    pa_dio_error = 0;
     pa_nbuffers = nbuffers;
     if (err != paNoError)
     {
@@ -625,6 +626,11 @@ int pa_send_dacs(void)
     if ((sys_getrealtime() - timeref) > 0.002)
         retval = SENDDACS_SLEPT;
 #endif /* FAKEBLOCKING */
+    if (pa_dio_error)
+    {
+        sys_log_error(ERR_RESYNC);
+        pa_dio_error = 0;
+    }
     pa_started = 1;
 
     memset(STUFF->st_soundout, 0,

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -48,17 +48,20 @@
 #else /* _WIN32 */
 #include <sys/time.h>
 #include <errno.h>
-#if defined(__linux__) || defined(__FreeBSD__) || \
+#if defined(__APPLE__) && defined(__MACH__)
+/* macOS does not support unnamed posix semaphores,
+ * so we use Mach semaphores instead. */
+#include <mach/mach.h>
+#define HAVE_MACH_SEMAPHORE
+#elif defined(__linux__) || defined(__FreeBSD__) || \
     defined(__NetBSD__) || defined(__OpenBSD__)
-#define HAVE_POSIX_SEMAPHORE
 #include <semaphore.h>
+#define HAVE_POSIX_SEMAPHORE
 #else
 /* Some platforms (including Apple) do not support unnamed posix semaphores,
  * others might not implement sem_timedwait(); to be on the safe side, we
  * we simply emulate it with a counter, mutex and condition variable.
  * The critical section is so short that there should not be any locking.
- * NOTE: we cannot use Mach semaphores for Apple because they do not have
- * a wait function with time-out...
  */
 #include <pthread.h>
 #endif
@@ -281,7 +284,9 @@ long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
 #ifndef _WIN32
 struct _semaphore
 {
-#ifdef HAVE_POSIX_SEMAPHORE
+#ifdef HAVE_MACH_SEMAPHORE
+    semaphore_t sem;
+#elif defined(HAVE_POSIX_SEMAPHORE)
     sem_t sem;
 #else
     pthread_mutex_t mutex;
@@ -297,7 +302,9 @@ t_semaphore * sys_semaphore_create(void)
     return (t_semaphore *)CreateSemaphoreA(0, 0, LONG_MAX, 0);
 #else /* _WIN32 */
     t_semaphore *sem = (t_semaphore *)malloc(sizeof(t_semaphore));
-#ifdef HAVE_POSIX_SEMAPHORE
+#ifdef HAVE_MACH_SEMAPHORE
+    semaphore_create(mach_task_self(), &sem->sem, SYNC_POLICY_FIFO, 0);
+#elif defined(HAVE_POSIX_SEMAPHORE)
     sem_init(&sem->sem, 0, 0);
 #else
     pthread_cond_init(&sem->condvar, 0);
@@ -305,7 +312,7 @@ t_semaphore * sys_semaphore_create(void)
     sem->count = 0;
 #endif
     return sem;
-#endif
+#endif /* _WIN32 */
 }
 
 void sys_semaphore_destroy(t_semaphore *sem)
@@ -313,20 +320,24 @@ void sys_semaphore_destroy(t_semaphore *sem)
 #ifdef _WIN32
     CloseHandle((HANDLE)sem);
 #else /* _WIN32 */
-#ifdef HAVE_POSIX_SEMAPHORE
+#ifdef HAVE_MACH_SEMAPHORE
+    semaphore_destroy(mach_task_self(), sem->sem);
+#elif defined(HAVE_POSIX_SEMAPHORE)
     sem_destroy(&sem->sem);
 #else
     pthread_mutex_destroy(&sem->mutex);
     pthread_cond_destroy(&sem->condvar);
 #endif
     free(sem);
-#endif
+#endif /* _WIN32 */
 }
 
 void sys_semaphore_wait(t_semaphore *sem)
 {
 #if defined(_WIN32)
     WaitForSingleObject((HANDLE)sem, INFINITE);
+#elif defined(HAVE_MACH_SEMAPHORE)
+    semaphore_wait(sem->sem);
 #elif defined(HAVE_POSIX_SEMAPHORE)
     while (sem_wait(&sem->sem) == -1 && errno == EINTR) continue;
 #else
@@ -342,7 +353,27 @@ int sys_semaphore_waitfor(t_semaphore *sem, double seconds)
 {
 #ifdef _WIN32
     return WaitForSingleObject((HANDLE)sem, seconds * 1000.0) != WAIT_TIMEOUT;
+#elif defined(HAVE_MACH_SEMAPHORE)
+    mach_timespec_t ts;
+    ts.tv_sec = (unsigned int)seconds;
+    ts.tv_nsec = (seconds - ts.tv_sec) * 1000000000;
+    return semaphore_timedwait(sem->sem, ts) != KERN_OPERATION_TIMED_OUT;
+#else /* Posix semaphore and pthreads */
+        /* first check if the semaphore is available */
+#ifdef HAVE_POSIX_SEMAPHORE
+    if (sem_trywait(&sem->sem) == 0)
+        return 1;
 #else
+    pthread_mutex_lock(&sem->mutex);
+    if (sem->count > 0)
+    {
+        sem->count--;
+        pthread_mutex_unlock(&sem->mutex);
+        return 1;
+    }
+    pthread_mutex_unlock(&sem->mutex);
+#endif
+        /* otherwise wait for it to become available */
     struct timespec ts;
     struct timeval now;
     gettimeofday(&now, 0);
@@ -378,6 +409,8 @@ void sys_semaphore_post(t_semaphore *sem)
 {
 #if defined(_WIN32)
     ReleaseSemaphore((HANDLE)sem, 1, NULL);
+#elif defined(HAVE_MACH_SEMAPHORE)
+    semaphore_signal(sem->sem);
 #elif defined(HAVE_POSIX_SEMAPHORE)
     sem_post(&sem->sem);
 #else

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -37,9 +37,32 @@
  *
  */
 
-#include <stdio.h>
 #include "s_audio_paring.h"
+
+#include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else /* _WIN32 */
+#include <sys/time.h>
+#include <errno.h>
+#if defined(__linux__) || defined(__FreeBSD__) || \
+    defined(__NetBSD__) || defined(__OpenBSD__)
+#define HAVE_POSIX_SEMAPHORE
+#include <semaphore.h>
+#else
+/* Some platforms (including Apple) do not support unnamed posix semaphores,
+ * others might not implement sem_timedwait(); to be on the safe side, we
+ * we simply emulate it with a counter, mutex and condition variable.
+ * The critical section is so short that there should not be any locking.
+ * NOTE: we cannot use Mach semaphores for Apple because they do not have
+ * a wait function with time-out...
+ */
+#include <pthread.h>
+#endif
+#endif /* _WIN32 */
 
 /* Clear buffer. Should only be called when buffer is NOT being read. */
 static void sys_ringbuf_Flush(PA_VOLATILE sys_ringbuf *rbuf,
@@ -250,4 +273,117 @@ long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
     }
     sys_ringbuf_AdvanceReadIndex( rbuf, numRead );
     return numRead;
+}
+
+/***************************************************************************
+** t_semaphore */
+
+#ifndef _WIN32
+struct _semaphore
+{
+#ifdef HAVE_POSIX_SEMAPHORE
+    sem_t sem;
+#else
+    pthread_mutex_t mutex;
+    pthread_cond_t condvar;
+    int count;
+#endif
+};
+#endif
+
+t_semaphore * sys_semaphore_create(void)
+{
+#ifdef _WIN32
+    return (t_semaphore *)CreateSemaphoreA(0, 0, LONG_MAX, 0);
+#else /* _WIN32 */
+    t_semaphore *sem = (t_semaphore *)malloc(sizeof(t_semaphore));
+#ifdef HAVE_POSIX_SEMAPHORE
+    sem_init(&sem->sem, 0, 0);
+#else
+    pthread_cond_init(&sem->condvar, 0);
+    pthread_mutex_init(&sem->mutex, 0);
+    sem->count = 0;
+#endif
+    return sem;
+#endif
+}
+
+void sys_semaphore_destroy(t_semaphore *sem)
+{
+#ifdef _WIN32
+    CloseHandle((HANDLE)sem);
+#else /* _WIN32 */
+#ifdef HAVE_POSIX_SEMAPHORE
+    sem_destroy(&sem->sem);
+#else
+    pthread_mutex_destroy(&sem->mutex);
+    pthread_cond_destroy(&sem->condvar);
+#endif
+    free(sem);
+#endif
+}
+
+void sys_semaphore_wait(t_semaphore *sem)
+{
+#if defined(_WIN32)
+    WaitForSingleObject((HANDLE)sem, INFINITE);
+#elif defined(HAVE_POSIX_SEMAPHORE)
+    while (sem_wait(&sem->sem) == -1 && errno == EINTR) continue;
+#else
+    pthread_mutex_lock(&sem->mutex);
+    while (sem->count == 0)
+        pthread_cond_wait(&sem->condvar, &sem->mutex);
+    sem->count--;
+    pthread_mutex_unlock(&sem->mutex);
+#endif
+}
+
+int sys_semaphore_waitfor(t_semaphore *sem, double seconds)
+{
+#ifdef _WIN32
+    return WaitForSingleObject((HANDLE)sem, seconds * 1000.0) != WAIT_TIMEOUT;
+#else
+    struct timespec ts;
+    struct timeval now;
+    gettimeofday(&now, 0);
+        /* add fractional part to timeout */
+    seconds += now.tv_usec * 0.000001;
+    ts.tv_sec = now.tv_sec + (time_t)seconds;
+    ts.tv_nsec = (seconds - (time_t)seconds) * 1000000000;
+#ifdef HAVE_POSIX_SEMAPHORE
+    while (sem_timedwait(&sem->sem, &ts) == -1)
+    {
+        if (errno != EINTR) /* ETIMEDOUT */
+            return 0;
+    }
+    return 1;
+#else
+    pthread_mutex_lock(&sem->mutex);
+    while (sem->count == 0)
+    {
+        if (pthread_cond_timedwait(&sem->condvar, &sem->mutex, &ts) == ETIMEDOUT)
+        {
+            pthread_mutex_unlock(&sem->mutex);
+            return 0;
+        }
+    }
+    sem->count--;
+    pthread_mutex_unlock(&sem->mutex);
+    return 1;
+#endif
+#endif
+}
+
+void sys_semaphore_post(t_semaphore *sem)
+{
+#if defined(_WIN32)
+    ReleaseSemaphore((HANDLE)sem, 1, NULL);
+#elif defined(HAVE_POSIX_SEMAPHORE)
+    sem_post(&sem->sem);
+#else
+    pthread_mutex_lock(&sem->mutex);
+    sem->count++;
+    pthread_mutex_unlock(&sem->mutex);
+    pthread_cond_signal(&sem->condvar);
+#endif
 }

--- a/src/s_audio_paring.h
+++ b/src/s_audio_paring.h
@@ -69,6 +69,17 @@ long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
 long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
     PA_VOLATILE char *buffer);
 
+/* semaphore for signaling the consumer thread */
+struct _semaphore;
+typedef struct _semaphore t_semaphore;
+
+t_semaphore * sys_semaphore_create(void);
+void sys_semaphore_destroy(t_semaphore *sem);
+void sys_semaphore_wait(t_semaphore *sem);
+/* wait with timeout (in seconds) */
+int sys_semaphore_waitfor(t_semaphore *sem, double seconds);
+void sys_semaphore_post(t_semaphore *sem);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -869,15 +869,14 @@ void sys_savepreferences(const char *filename)
 
     sys_donesavepreferences();
 }
-
     /* calls from GUI to load/save from/to a file */
 void glob_loadpreferences(t_pd *dummy, t_symbol *filesym)
 {
     sys_loadpreferences(filesym->s_name, 0);
-    sys_close_audio();
-    sys_reopen_audio();
     sys_close_midi();
     sys_reopen_midi();
+    if (audio_isopen())
+        sys_reopen_audio();
 }
 
 void glob_savepreferences(t_pd *dummy, t_symbol *filesym)

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1728,6 +1728,8 @@ void sys_setrealtime(const char *libdir)
 #endif /* __APPLE__ */
 }
 
+void sys_do_close_audio(void);
+
 /* This is called when something bad has happened, like a segfault.
 Call glob_quit() below to exit cleanly.
 LATER try to save dirty documents even in the bad case. */
@@ -1741,7 +1743,7 @@ void sys_bail(int n)
             /* sys_close_audio() hangs if you're in a signal? */
         fprintf(stderr ,"gui socket %d - \n", INTER->i_guisock);
         fprintf(stderr, "closing audio...\n");
-        sys_close_audio();
+        sys_do_close_audio();
         fprintf(stderr, "closing MIDI...\n");
         sys_close_midi();
         fprintf(stderr, "... done.\n");

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1751,20 +1751,11 @@ void sys_bail(int n)
     else _exit(1);
 }
 
-extern void sys_exit(void);
+void sys_exit(int status);
 
 void glob_exit(void *dummy, t_float status)
 {
-        /* sys_exit() sets the sys_quit flag, so all loops end */
-    sys_exit();
-    sys_close_audio();
-    sys_close_midi();
-    if (sys_havegui())
-    {
-        sys_closesocket(INTER->i_guisock);
-        sys_rmpollfn(INTER->i_guisock);
-    }
-    exit((int)status);
+    sys_exit(status);
 }
 void glob_quit(void *dummy)
 {

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -37,10 +37,12 @@ char pd_compiletime[] = __TIME__;
 char pd_compiledate[] = __DATE__;
 
 void pd_init(void);
+void pd_term(void);
 int sys_argparse(int argc, const char **argv);
 void sys_findprogdir(const char *progname);
 void sys_setsignalhandlers(void);
 int sys_startgui(const char *guipath);
+void sys_stopgui(void);
 void sys_setrealtime(const char *guipath);
 int m_mainloop(void);
 int m_batchmain(void);
@@ -367,7 +369,7 @@ static void sys_printusage(void);
 /* this is called from main() in s_entry.c */
 int sys_main(int argc, const char **argv)
 {
-    int i, noprefs;
+    int i, noprefs, ret;
     const char *prefsfile = "";
     sys_externalschedlib = 0;
     sys_extraflags = 0;
@@ -453,19 +455,15 @@ int sys_main(int argc, const char **argv)
     if (sys_hipriority)
         sys_setrealtime(sys_libdir->s_name); /* set desired process priority */
     if (sys_externalschedlib)
-        return (sys_run_scheduler(sys_externalschedlibname,
+        ret = (sys_run_scheduler(sys_externalschedlibname,
             sys_extraflagsstring));
     else if (sys_batch)
-        return (m_batchmain());
+        ret = m_batchmain();
     else
-    {
-            /* open audio and MIDI */
-        sys_reopen_midi();
-        if (audio_shouldkeepopen())
-            sys_reopen_audio();
-            /* run scheduler until it quits */
-        return (m_mainloop());
-    }
+        ret = m_mainloop();
+    sys_stopgui();
+    pd_term();
+    return (ret);
 }
 
 static char *(usagemessage[]) = {

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -313,6 +313,7 @@ EXTERN void sys_log_error(int type);
 #define SCHED_AUDIO_POLL 1
 #define SCHED_AUDIO_CALLBACK 2
 void sched_set_using_audio(int flag);
+int sched_get_using_audio(void);
 extern int sys_sleepgrain;      /* override value set in command line */
 EXTERN int sched_get_sleepgrain( void);     /* returns actual value */
 

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -148,7 +148,6 @@ typedef void (*t_audiocallback)(void);
 
 extern int sys_schedadvance;
 
-void sys_set_audio_state(int onoff);
 int sys_send_dacs(void);
 void sys_reportidle(void);
 void sys_listdevs(void);

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -174,6 +174,7 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     int indeviceno, int outdeviceno, t_audiocallback callback);
 void pa_close_audio(void);
 int pa_send_dacs(void);
+int pa_reopen_audio(void);
 void pa_listdevs(void);
 void pa_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti,

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -203,6 +203,7 @@ void alsa_getdevs(char *indevlist, int *nindevs,
 int jack_open_audio(int inchans, int outchans, t_audiocallback callback);
 void jack_close_audio(void);
 int jack_send_dacs(void);
+int jack_reopen_audio(void);
 void jack_reportidle(void);
 void jack_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti,

--- a/src/z_libpd.c
+++ b/src/z_libpd.c
@@ -36,6 +36,7 @@
 
 // forward declares
 void pd_init(void);
+void sys_setchsr(int chin, int chout, int sr);
 int sys_startgui(const char *libdir);
 void sys_stopgui(void);
 int sys_pollgui(void);
@@ -153,20 +154,9 @@ int libpd_blocksize(void) {
 }
 
 int libpd_init_audio(int inChannels, int outChannels, int sampleRate) {
-  t_audiosettings as;
-  as.a_indevvec[0] = as.a_outdevvec[0] = DEFAULTAUDIODEV;
-  as.a_nindev = as.a_noutdev = as.a_nchindev = as.a_nchoutdev = 1;
-  as.a_chindevvec[0] = inChannels;
-  as.a_choutdevvec[0] = outChannels;
-  as.a_srate = sampleRate;
-  as.a_blocksize = DEFDACBLKSIZE;
-  as.a_callback = 0;
-  as.a_advance = -1;
-  as.a_api = API_DUMMY;
   sys_lock();
-  sys_set_audio_settings(&as);
   sched_set_using_audio(SCHED_AUDIO_CALLBACK);
-  sys_reopen_audio();
+  sys_setchsr(inChannels, outChannels, sampleRate);
   sys_unlock();
   return 0;
 }


### PR DESCRIPTION
General:
* `glob_exit` breaks from the scheduler loop, instead of calling `exit`, and thus allows for proper cleanup in `sys_main`.
* `sys_main` calls a new function `pd_term` (counterpart to `pd_init`) before returning. Currently, `pd_term` just destroys the root canvases, but LATER it should free *all* resources. Ideally, Pd should not leak any memory on shutdown.
* fix `audio_shouldkeepopen` for the case where no audio backend has actually been opened (yet). Now `pd -jack` immediately connects to the Jack server; before you had to turn on DSP first.
* if the user switches backends or applies audio settings, only open audio if DSP is on or audio should be kept open
* only derive sleep grain from `sys_schedadvance` if we are in the polling scheduler and DSP is turned on, otherwise use a fixed (default) sleep grain of 1 ms.

Callback scheduler:
* allow to toggle DSP
* allow to switch to the polling scheduler
* check if audio device got stuck
* fix high CPU usage with portaudio

Polling scheduler:
* don't sleep if we already slept in `sys_send_dacs` (= `SENDDACS_SLEPT`)

Jack/portaudio
* enable `THREADSIGNAL` by default
* use a semaphore instead of a condition variable to get rid of unnecessary locking
* only sleep on the semaphore when really idle

Portaudio
* rewrote `pa_send_dacs` to match the much simpler `jack_send_dacs`
* show audio I/O error if we have been late and the audio callback had to drop samples (just like the Jack backend already does)
* remove unused code (`FAKEBLOCKING` not defined) to improve readability

Jack
* gracefully handle server shutdown
* log Jack errors with `PD_DEBUG` to avoid spamming the console

MIDI
* only delay outgoing MIDI messages if audio is delayed (= polling scheduler with DSP on)

---

`sys_reopen_audio` and `sys_close_audio` now only notify the scheduler, therefore they can be safely called anywhere, including the audio callback. The actual implementation has been moved to *private* functions (`sys_do_reopen_audio` and `sys_do_close_audio`)

At least here on Windows, the (new) `THREADSIGNAL` implementation allows for significantly lower latency.

- Closes https://github.com/pure-data/pure-data/issues/550
- Closes https://github.com/pure-data/pure-data/issues/1554 
- Closes https://github.com/pure-data/pure-data/issues/1703
- Closes https://github.com/pure-data/pure-data/issues/1930

This branch has been successfully tested with the following configurations:

* Windows / portaudio (ASIO) / polling scheduler + callback scheduler
* macOS / portaudio (CoreAudio) / polling scheduler + callback scheduler
* macOS / Jack / polling scheduler + callback scheduler
* Linux / Jack / polling scheduler + callback scheduler