### PR TITLE
toolkit-agnostic Core->GUI Communication - WIP

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 #endif
 
-#define USE_PDTK_CANVAS_CREATE
+#define USE_PDTK_CANVAS_PROC
 
 typedef struct _iemgui_private {
     int p_prevX, p_prevY;
@@ -932,14 +932,14 @@ static void iemgui_draw_move(t_iemgui *x, t_glist *glist)
     char tag_object[128];
     sprintf(tag_object, "%lxOBJ", x);
 
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "rr c rii",
         "::pdtk_canvas::move", "tag",
         canvas,
         tag_object, dx, dy);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "crs ii", canvas, "move", tag_object, dx, dy);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
 }
 
 static void iemgui_draw(t_iemgui *x, t_glist *glist, int mode)

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -487,9 +487,15 @@ void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av
         sprintf(tag, "%lxLABEL", x);
         int x0 = text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom;
         int y0 = text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom;
+#ifdef USE_PDTK_CANVAS_PROC
+        pdgui_vmess("::pdtk_canvas::iemgui_label_pos", "rcr ii",
+            "tag", glist_getcanvas(iemgui->x_glist), tag,
+            x0, y0);
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crs ii",
             glist_getcanvas(iemgui->x_glist), "coords", tag,
             x0, y0);
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 
@@ -518,9 +524,15 @@ void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *a
         SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
         SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
         SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
+#ifdef USE_PDTK_CANVAS_PROC
+        pdgui_vmess("::pdtk_canvas::iemgui_label_font", "rcs A",
+            "tag", glist_getcanvas(iemgui->x_glist), tag,
+            3, fontatoms);
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crs rA",
             glist_getcanvas(iemgui->x_glist), "itemconfigure", tag,
             "-font", 3, fontatoms);
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -484,10 +484,11 @@ void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av
     {
         char tag[128];
         sprintf(tag, "%lxLABEL", x);
+        int x0 = text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom;
+        int y0 = text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom;
         pdgui_vmess(0, "crs ii",
             glist_getcanvas(iemgui->x_glist), "coords", tag,
-            text_xpix((t_object *)x, iemgui->x_glist) + iemgui->x_ldx*zoom,
-            text_ypix((t_object *)x, iemgui->x_glist) + iemgui->x_ldy*zoom);
+            x0, y0);
     }
 }
 

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #endif
 
+#define USE_PDTK_CANVAS_CREATE
 
 typedef struct _iemgui_private {
     int p_prevX, p_prevY;
@@ -931,7 +932,14 @@ static void iemgui_draw_move(t_iemgui *x, t_glist *glist)
     char tag_object[128];
     sprintf(tag_object, "%lxOBJ", x);
 
+#ifdef USE_PDTK_CANVAS_CREATE
+    pdgui_vmess(0, "rr c rii",
+        "::pdtk_canvas::move", "tag",
+        canvas,
+        tag_object, dx, dy);
+#else // USE_PDTK_CANVAS_CREATE
     pdgui_vmess(0, "crs ii", canvas, "move", tag_object, dx, dy);
+#endif // USE_PDTK_CANVAS_CREATE
 }
 
 static void iemgui_draw(t_iemgui *x, t_glist *glist, int mode)

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -891,6 +891,13 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
     sprintf(tag, "%lxOUT%d", x, 0);
     canvas_deletefromtag(canvas, tag);
     if(!x->x_fsf.x_snd_able) {
+#ifdef USE_PDTK_CANVAS_PROC
+        pdgui_vmess("::pdtk_canvas::create", "r c iiii Ss",
+            "iemgui_outlet",
+            canvas,
+            xpos, ypos + x->x_h + zoom - ioh, xpos + iow, ypos + x->x_h,
+            2, tags, tag_label);
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crr iiii rs rS",
             canvas, "create", "rectangle",
             xpos, ypos + x->x_h + zoom - ioh, xpos + iow, ypos + x->x_h,
@@ -898,12 +905,20 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
             "-tags", 2, tags);
         /* keep label above outlet */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);
+#endif // USE_PDTK_CANVAS_PROC
     }
 
     /* re-create inlet */
     sprintf(tag, "%lxIN%d", x, 0);
     canvas_deletefromtag(canvas, tag);
     if(!x->x_fsf.x_rcv_able) {
+#ifdef USE_PDTK_CANVAS_PROC
+        pdgui_vmess("::pdtk_canvas::create", "r c iiii Ss",
+            "iemgui_inlet",
+            canvas,
+            xpos, ypos, xpos + iow, ypos - zoom + ioh,
+            2, tags, tag_label);
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crr iiii rs rS",
             canvas, "create", "rectangle",
             xpos, ypos, xpos + iow, ypos - zoom + ioh,
@@ -911,6 +926,7 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
             "-tags", 2, tags);
         /* keep label above inlet */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -933,8 +933,8 @@ static void iemgui_draw_move(t_iemgui *x, t_glist *glist)
     sprintf(tag_object, "%lxOBJ", x);
 
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess(0, "rr c rii",
-        "::pdtk_canvas::move", "tag",
+    pdgui_vmess("::pdtk_canvas::move", "r c rii",
+        "tag",
         canvas,
         tag_object, dx, dy);
 #else // USE_PDTK_CANVAS_PROC

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -888,7 +888,7 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
 
     /* re-create outlet */
     sprintf(tag, "%lxOUT%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_fsf.x_snd_able) {
         pdgui_vmess(0, "crr iiii rs rS",
             canvas, "create", "rectangle",
@@ -901,7 +901,7 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
 
     /* re-create inlet */
     sprintf(tag, "%lxIN%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_fsf.x_rcv_able) {
         pdgui_vmess(0, "crr iiii rs rS",
             canvas, "create", "rectangle",
@@ -919,7 +919,7 @@ static void iemgui_draw_erase(t_iemgui* x, t_glist* glist)
     char tag_object[128];
     sprintf(tag_object, "%lxOBJ", x);
 
-    pdgui_vmess(0, "crs", canvas, "delete", tag_object);
+    canvas_deletefromtag(canvas, tag_object);
 }
 
 static void iemgui_draw_move(t_iemgui *x, t_glist *glist)

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -35,9 +35,10 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess("::pdtk_canvas::create", "r c iiii o ikk ii A k",
+    pdgui_vmess("::pdtk_canvas::config", "r c iiii o ikk ii A k",
         "bang",
-        canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
+        canvas,
+        xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
         x, // used to generate various tags
         zoom, x->x_gui.x_bcol, x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom, // label coord
@@ -70,10 +71,11 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
 
 static void bng_draw_new(t_bng *x, t_glist *glist)
 {
-#ifdef USE_PDTK_CANVAS_PROC
-    // deferred till bng_draw_config()
-#else // USE_PDTK_CANVAS_PROC
     t_canvas *canvas = glist_getcanvas(glist);
+#ifdef USE_PDTK_CANVAS_PROC
+    pdgui_vmess("::pdtk_canvas::create", "rco",
+        "bang", canvas, x);
+#else // USE_PDTK_CANVAS_PROC
     char tag[128], tag_object[128];
     char*tags[] = {tag_object, tag, "label", "text"};
     sprintf(tag_object, "%lxOBJ", x);

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -11,7 +11,7 @@
 
 #include "g_all_guis.h"
 
-#define USE_PDTK_CANVAS_CREATE
+#define USE_PDTK_CANVAS_PROC
 /* --------------- bng     gui-bang ------------------------- */
 
 t_widgetbehavior bng_widgetbehavior;
@@ -34,7 +34,7 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "rr c iiii o ikk ii A k",
         "::pdtk_canvas::create", "bang",
         canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
@@ -44,7 +44,7 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
         3, fontatoms,
         x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol);
 
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     sprintf(tag, "%lxBASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
@@ -64,15 +64,15 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
         "-fill", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol));
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
 static void bng_draw_new(t_bng *x, t_glist *glist)
 {
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     // deferred till bng_draw_config()
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128], tag_object[128];
     char*tags[] = {tag_object, tag, "label", "text"};
@@ -89,7 +89,7 @@ static void bng_draw_new(t_bng *x, t_glist *glist)
     sprintf(tag, "%lxLABEL", x);
     pdgui_vmess(0, "crr ii rs rS", canvas, "create", "text",
         0, 0, "-anchor", "w", "-tags", 4, tags);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
 
     bng_draw_config(x, glist);
     (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_IO);
@@ -104,19 +104,19 @@ static void bng_draw_select(t_bng* x, t_glist* glist)
     if(x->x_gui.x_fsf.x_selected)
         col = lcol = IEM_GUI_COLOR_SELECTED;
 
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "rr co kk",
         "::pdtk_canvas::select", "bang",
         canvas, x,
         col, lcol);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     sprintf(tag, "%lxBASE", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%lxBUT", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%lxLABEL", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
 }
 
 static void bng_draw_update(t_bng *x, t_glist *glist)
@@ -124,17 +124,17 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
     if(glist_isvisible(glist))
     {
         int col = (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol);
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "rr co k",
             "::pdtk_canvas::update", "bang",
             glist_getcanvas(glist), x,
             col);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
         char tag[128];
         sprintf(tag, "%lxBUT", x);
         pdgui_vmess(0, "crs rk", glist_getcanvas(glist), "itemconfigure", tag,
             "-fill", col);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -124,10 +124,17 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
     if(glist_isvisible(glist))
     {
         int col = (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol);
+#ifdef USE_PDTK_CANVAS_CREATE
+        pdgui_vmess(0, "rr co k",
+            "::pdtk_canvas::update", "bang",
+            glist_getcanvas(glist), x,
+            col);
+#else // USE_PDTK_CANVAS_CREATE
         char tag[128];
         sprintf(tag, "%lxBUT", x);
         pdgui_vmess(0, "crs rk", glist_getcanvas(glist), "itemconfigure", tag,
             "-fill", col);
+#endif // USE_PDTK_CANVAS_CREATE
     }
 }
 

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -99,10 +99,11 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
 {
     if(glist_isvisible(glist))
     {
+        int col = (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol);
         char tag[128];
         sprintf(tag, "%lxBUT", x);
         pdgui_vmess(0, "crs rk", glist_getcanvas(glist), "itemconfigure", tag,
-            "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
+            "-fill", col);
     }
 }
 

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -35,8 +35,8 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess(0, "rr c iiii o ikk ii A k",
-        "::pdtk_canvas::create", "bang",
+    pdgui_vmess("::pdtk_canvas::create", "r c iiii o ikk ii A k",
+        "bang",
         canvas, xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h,
         x, // used to generate various tags
         zoom, x->x_gui.x_bcol, x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol,
@@ -105,8 +105,8 @@ static void bng_draw_select(t_bng* x, t_glist* glist)
         col = lcol = IEM_GUI_COLOR_SELECTED;
 
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess(0, "rr co kk",
-        "::pdtk_canvas::select", "bang",
+    pdgui_vmess("::pdtk_canvas::select", "r co kk",
+        "bang",
         canvas, x,
         col, lcol);
 #else // USE_PDTK_CANVAS_PROC
@@ -125,8 +125,8 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
     {
         int col = (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol);
 #ifdef USE_PDTK_CANVAS_PROC
-        pdgui_vmess(0, "rr co k",
-            "::pdtk_canvas::update", "bang",
+        pdgui_vmess("::pdtk_canvas::update", "r co k",
+            "bang",
             glist_getcanvas(glist), x,
             col);
 #else // USE_PDTK_CANVAS_PROC

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -779,7 +779,7 @@ void canvas_drawredrect(t_canvas *x, int doit)
             "-tags", "GOP"); /* better: "-tags", 1, &"GOP" */
     }
     else
-        pdgui_vmess(0, "crs", glist_getcanvas(x), "delete", "GOP");
+        glist_deletefromtag(x, "GOP");
 }
 
     /* the window becomes "mapped" (visible and not miniaturized) or
@@ -820,7 +820,7 @@ void canvas_map(t_canvas *x, t_floatarg f)
                 return;
             }
                 /* just clear out the whole canvas */
-            pdgui_vmess(0, "crs", x, "delete", "all");
+            canvas_deletefromtag(x, "all");
             x->gl_mapped = 0;
         }
     }
@@ -978,7 +978,17 @@ static void _canvas_delete_line(t_canvas*x, t_outconnect *oc)
     if (!glist_isvisible(x))
         return;
     sprintf(tag, "l%lx", oc);
-    pdgui_vmess(0, "crs", glist_getcanvas(x), "delete", tag);
+    glist_deletefromtag(x, tag);
+}
+
+void canvas_deletefromtag(t_canvas* x, const char* tag)
+{
+    pdgui_vmess(0, "crs", x, "delete", tag);
+}
+
+void glist_deletefromtag(t_canvas* x, const char* tag)
+{
+    canvas_deletefromtag(glist_getcanvas(x), tag);
 }
 
     /* kill all lines for the object */

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -15,7 +15,7 @@ to be different but are now unified except for some fossilized names.) */
 #include <string.h>
 #include "g_undo.h"
 
-#define USE_PDTK_CANVAS_CREATE
+#define USE_PDTK_CANVAS_PROC
 
 #ifdef _WIN32
 #include <io.h>
@@ -985,13 +985,13 @@ static void _canvas_delete_line(t_canvas*x, t_outconnect *oc)
 
 void canvas_deletefromtag(t_canvas* x, const char* tag)
 {
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "r cs",
         "::pdtk_canvas::delete",
             x, tag);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "crs", x, "delete", tag);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
 }
 
 void glist_deletefromtag(t_canvas* x, const char* tag)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -986,8 +986,7 @@ static void _canvas_delete_line(t_canvas*x, t_outconnect *oc)
 void canvas_deletefromtag(t_canvas* x, const char* tag)
 {
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess(0, "r cs",
-        "::pdtk_canvas::delete",
+    pdgui_vmess("::pdtk_canvas::delete", "cs",
             x, tag);
 #else // USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "crs", x, "delete", tag);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -15,6 +15,8 @@ to be different but are now unified except for some fossilized names.) */
 #include <string.h>
 #include "g_undo.h"
 
+#define USE_PDTK_CANVAS_CREATE
+
 #ifdef _WIN32
 #include <io.h>
 #endif
@@ -983,7 +985,13 @@ static void _canvas_delete_line(t_canvas*x, t_outconnect *oc)
 
 void canvas_deletefromtag(t_canvas* x, const char* tag)
 {
+#ifdef USE_PDTK_CANVAS_CREATE
+    pdgui_vmess(0, "r cs",
+        "::pdtk_canvas::delete",
+            x, tag);
+#else // USE_PDTK_CANVAS_CREATE
     pdgui_vmess(0, "crs", x, "delete", tag);
+#endif // USE_PDTK_CANVAS_CREATE
 }
 
 void glist_deletefromtag(t_canvas* x, const char* tag)

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -410,6 +410,7 @@ EXTERN void glist_deselect(t_glist *x, t_gobj *y);
 EXTERN void glist_noselect(t_glist *x);
 EXTERN void glist_selectall(t_glist *x);
 EXTERN void glist_delete(t_glist *x, t_gobj *y);
+EXTERN void glist_deletefromtag(t_glist *x, const char* tag);
 EXTERN void glist_retext(t_glist *x, t_text *y);
 EXTERN void glist_grab(t_glist *x, t_gobj *y, t_glistmotionfn motionfn,
     t_glistkeyfn keyfn, int xpos, int ypos);
@@ -489,6 +490,7 @@ EXTERN t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv);
 EXTERN t_symbol *canvas_makebindsym(t_symbol *s);
 EXTERN void canvas_fixlinesfor(t_canvas *x, t_text *text);
 EXTERN void canvas_deletelinesfor(t_canvas *x, t_text *text);
+EXTERN void canvas_deletefromtag(t_canvas *x, const char *tag);
 EXTERN void canvas_stowconnections(t_canvas *x);
 EXTERN void canvas_restoreconnections(t_canvas *x);
 EXTERN void canvas_redraw(t_canvas *x);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -466,7 +466,7 @@ void canvas_disconnect(t_canvas *x,
         {
             char tag[128];
             sprintf(tag, "l%lx", oc);
-            pdgui_vmess(0, "crs", x, "delete", tag);
+            canvas_deletefromtag(x, tag);
             obj_disconnect(t.tr_ob, t.tr_outno, t.tr_ob2, t.tr_inno);
             break;
         }
@@ -2631,7 +2631,7 @@ static void canvas_doconnect(t_canvas *x, int xpos, int ypos, int mod, int doit)
 #endif
     if (doit) {
         pdgui_vmess("::pdtk_canvas::cords_to_foreground", "ci", x, 1);
-        pdgui_vmess(0, "crs", x, "delete", "x");
+        canvas_deletefromtag(x, "x");
     }
     else
         pdgui_vmess(0, "crs iiii",
@@ -2854,7 +2854,7 @@ static void canvas_doregion(t_canvas *x, int xpos, int ypos, int doit)
             loy = x->gl_editor->e_ywas, hiy = ypos;
         else hiy = x->gl_editor->e_ywas, loy = ypos;
         canvas_selectinrect(x, lox, loy, hix, hiy);
-        pdgui_vmess(0, "crs", x, "delete", "x");
+        canvas_deletefromtag(x, "x");
         x->gl_editor->e_onmotion = MA_NONE;
     }
     else
@@ -4800,8 +4800,7 @@ void canvas_editmode(t_canvas *x, t_floatarg state)
         if (glist_isvisible(x) && glist_istoplevel(x))
         {
             canvas_setcursor(x, CURSOR_RUNMODE_NOTHING);
-            pdgui_vmess(0, "crs",
-                glist_getcanvas(x), "delete", "commentbar");
+            glist_deletefromtag(x, "commentbar");
         }
     }
     if (glist_isvisible(x) && x->gl_havewindow)

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -757,8 +757,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
                 "-joinstyle", "miter",
                 "-tags", 2, tags2);
         else
-            pdgui_vmess(0, "crs",
-                glist_getcanvas(x->gl_owner), "delete", tag);
+            glist_deletefromtag(x->gl_owner, tag);
         return;
     }
         /* otherwise draw (or erase) us as a graph inside another glist. */
@@ -894,7 +893,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
     }
     else
     {
-        pdgui_vmess(0, "crs", glist_getcanvas(x->gl_owner), "delete", tag);
+        glist_deletefromtag(x->gl_owner, tag);
         for (g = x->gl_list; g; g = g->g_next)
             gobj_vis(g, x, 0);
     }

--- a/src/g_radio.c
+++ b/src/g_radio.c
@@ -40,7 +40,7 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     sprintf(tag_but, "%lxBUT", x);
 
     sprintf(tag, "%lxOUT%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_gui.x_fsf.x_snd_able)
     {
         int height = x->x_gui.x_h * ((x->x_orientation == horizontal)? 1: x->x_number);
@@ -55,7 +55,7 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     }
 
     sprintf(tag, "%lxIN%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
         pdgui_vmess(0, "crr iiii rs rS", canvas, "create", "rectangle",

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -526,8 +526,8 @@ void rtext_erase(t_rtext *x)
 void rtext_displace(t_rtext *x, int dx, int dy)
 {
 #ifdef USE_PDTK_CANVAS_PROC
-    pdgui_vmess(0, "rr c rii",
-        "::pdtk_canvas::move", "tag",
+    pdgui_vmess("::pdtk_canvas::move", "r c rii",
+        "tag",
         glist_getcanvas(x->x_glist),
         x->x_tag, dx, dy);
 #else // USE_PDTK_CANVAS_PROC

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -9,6 +9,8 @@
 #include "g_canvas.h"
 #include "s_utf8.h"
 
+#define USE_PDTK_CANVAS_CREATE
+
 #define LMARGIN 2
 #define RMARGIN 2
 #define TMARGIN 3
@@ -523,8 +525,15 @@ void rtext_erase(t_rtext *x)
 
 void rtext_displace(t_rtext *x, int dx, int dy)
 {
+#ifdef USE_PDTK_CANVAS_CREATE
+    pdgui_vmess(0, "rr c rii",
+        "::pdtk_canvas::move", "tag",
+        glist_getcanvas(x->x_glist),
+        x->x_tag, dx, dy);
+#else // USE_PDTK_CANVAS_CREATE
     pdgui_vmess(0, "crs ii", glist_getcanvas(x->x_glist), "move", x->x_tag,
         dx, dy);
+#endif // USE_PDTK_CANVAS_CREATE
 }
 
 void rtext_select(t_rtext *x, int state)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -9,7 +9,7 @@
 #include "g_canvas.h"
 #include "s_utf8.h"
 
-#define USE_PDTK_CANVAS_CREATE
+#define USE_PDTK_CANVAS_PROC
 
 #define LMARGIN 2
 #define RMARGIN 2
@@ -525,15 +525,15 @@ void rtext_erase(t_rtext *x)
 
 void rtext_displace(t_rtext *x, int dx, int dy)
 {
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "rr c rii",
         "::pdtk_canvas::move", "tag",
         glist_getcanvas(x->x_glist),
         x->x_tag, dx, dy);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
     pdgui_vmess(0, "crs ii", glist_getcanvas(x->x_glist), "move", x->x_tag,
         dx, dy);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
 }
 
 void rtext_select(t_rtext *x, int state)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -518,7 +518,7 @@ void rtext_draw(t_rtext *x)
 
 void rtext_erase(t_rtext *x)
 {
-    pdgui_vmess(0, "crs", glist_getcanvas(x->x_glist), "delete", x->x_tag);
+    glist_deletefromtag(x->x_glist, x->x_tag);
 }
 
 void rtext_displace(t_rtext *x, int dx, int dy)

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -397,7 +397,7 @@ static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
                   "-fill", "blue",
                   "-tags", tag);
     } else {
-        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
+        glist_deletefromtag(glist, tag);
     }
 }
 
@@ -489,7 +489,7 @@ static void scalar_vis(t_gobj *z, t_glist *owner, int vis)
                       "-tags", tag);
         }
         else
-            pdgui_vmess(0, "crs", glist_getcanvas(owner), "delete", tag);
+            glist_deletefromtag(owner, tag);
         return;
     }
 

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -59,7 +59,7 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     }
 
     sprintf(tag, "%lxOUT%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_gui.x_fsf.x_snd_able)
     {
         pdgui_vmess(0, "crr iiii rs rS", canvas, "create", "rectangle",
@@ -73,7 +73,7 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     }
 
     sprintf(tag, "%lxIN%d", x, 0);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
         pdgui_vmess(0, "crr iiii rs rS", canvas, "create", "rectangle",

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1279,7 +1279,7 @@ static void curve_vis(t_gobj *z, t_glist *glist,
     else
     {
         if (n > 1)
-            pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
+            glist_deletefromtag(glist, tag);
     }
 }
 
@@ -2094,7 +2094,7 @@ static void plot_vis(t_gobj *z, t_glist *glist,
             }
         }
             /* and then the trace */
-        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
+        glist_deletefromtag(glist, tag);
     }
 }
 
@@ -2746,7 +2746,7 @@ static void drawnumber_vis(t_gobj *z, t_glist *glist,
             "-tags", 2, tags);
     }
     else
-        pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);
+        glist_deletefromtag(glist, tag);
 }
 
 static void drawnumber_motionfn(void *z, t_floatarg dx, t_floatarg dy,

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -22,7 +22,7 @@
 #define ATOM_BMARGIN 4 /* 1 pixel smaller than object TMARGIN+BMARGIN */
 
 #define MESSAGE_CLICK_WIDTH 5
-#define USE_PDTK_CANVAS_CREATE
+#define USE_PDTK_CANVAS_PROC
 
 t_class *text_class;
 static t_class *message_class;
@@ -1083,18 +1083,18 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
         int mdy = dy * glist->gl_zoom;
         char buf[MAXPDSTRING];
         sprintf(buf, "%lx.l", x);
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "rr c rii",
             "::pdtk_canvas::move", "tag",
             glist_getcanvas(glist),
             buf, mdx, mdy);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crs ii",
             glist_getcanvas(glist),
             "move",
             buf,
             mdx, mdy);
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 
@@ -1318,17 +1318,17 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
     {
         char buf[MAXPDSTRING];
         sprintf(buf, "%sR", rtext_gettag(y));
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "rr csr",
             "::pdtk_canvas::select", "tag",
             glist, buf, (state ? "blue" : "black"));
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crs rr",
             glist,
             "itemconfigure",
             buf,
             "-fill", (state? "blue" : "black"));
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     }
 }
 
@@ -1532,19 +1532,19 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
             sprintf(tagbuf, "%s%c%d", tag, c, i);
             tags[0] = tagbuf;
             if (firsttime)
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
                 pdgui_vmess(0, "rr c iiii s",
                     "::pdtk_canvas::create", tags[1],
                     glist_getcanvas(glist),
                     iox1, ioy1, iox2, ioy2,
                     tags[0]);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
                 pdgui_vmess(0, "crr iiii rS rr",
                     glist_getcanvas(glist), "create", "rectangle",
                     iox1, ioy1, iox2, ioy2,
                     "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
                     "-fill", "black");
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
             else
                 pdgui_vmess(0, "crs iiii",
                     glist_getcanvas(glist), "coords", tagbuf,
@@ -1567,7 +1567,7 @@ void text_drawborder(t_text *x, t_glist *glist,
     {
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
         char *tags[] = {tagR, "obj"};
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
         pdgui_vmess(0, "rr c iiii r i s",
             cmd, tags[1],
@@ -1576,7 +1576,7 @@ void text_drawborder(t_text *x, t_glist *glist,
             pattern,
             glist->gl_zoom, // unused when !firsttime
             tags[0]);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
         if (firsttime)
         {
             pdgui_vmess(0, "crr iiiiiiiiii rr ri rr rS",
@@ -1596,7 +1596,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 glist_getcanvas(glist), "itemconfigure", tagR,
                 "-dash", pattern);
         }
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     }
     else if (x->te_type == T_MESSAGE)
     {
@@ -1624,7 +1624,7 @@ void text_drawborder(t_text *x, t_glist *glist,
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
-#ifdef USE_PDTK_CANVAS_CREATE
+#ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
         pdgui_vmess(0, "rr c iiii i i s",
             cmd, tags[1],
@@ -1633,7 +1633,7 @@ void text_drawborder(t_text *x, t_glist *glist,
             corner,
             glist->gl_zoom+grabbed,
             tags[0]);
-#else // USE_PDTK_CANVAS_CREATE
+#else // USE_PDTK_CANVAS_PROC
         if (firsttime)
             pdgui_vmess(0, "crr iiiiiiiiiiii ri rr rS",
                 glist_getcanvas(glist), "create", "line",
@@ -1650,7 +1650,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 glist_getcanvas(glist), "itemconfigure", tagR,
                 "-width", glist->gl_zoom+grabbed);
         }
-#endif // USE_PDTK_CANVAS_CREATE
+#endif // USE_PDTK_CANVAS_PROC
     }
     else if (x->te_type == T_ATOM ) /* list (ATOM but not float or symbol) */
     {

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1569,13 +1569,13 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "obj"};
 #ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
-        pdgui_vmess(cmd, "r c iiii r i s",
-            tags[1],
+        pdgui_vmess(cmd, "r c iiii r i S",
+            "obj",
             glist_getcanvas(glist),
             x1, y1, x2, y2,
             pattern,
             glist->gl_zoom, // unused when !firsttime
-            tags[0]);
+            2, tags);
 #else // USE_PDTK_CANVAS_PROC
         if (firsttime)
         {
@@ -1604,6 +1604,16 @@ void text_drawborder(t_text *x, t_glist *glist,
         corner = ((y2-y1)/4);
         if (corner > 10*glist->gl_zoom)
             corner = 10*glist->gl_zoom; /* looks bad if too big */
+#ifdef USE_PDTK_CANVAS_PROC
+        const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
+        pdgui_vmess(cmd, "r c iiii i i S",
+            "msg",
+            glist_getcanvas(glist),
+            x1, y1, x2, y2,
+            corner,
+            glist->gl_zoom, // unused when !firsttime
+            2, tags);
+#else // USE_PDTK_CANVAS_PROC
         if (firsttime)
             pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rr rS",
                 glist_getcanvas(glist), "create", "line",
@@ -1615,6 +1625,7 @@ void text_drawborder(t_text *x, t_glist *glist,
             pdgui_vmess(0, "crs iiiiiiiiiiiiii",
                 glist_getcanvas(glist), "coords", tagR,
                 x1, y1,  x2+corner, y1,  x2, y1+corner,  x2, y2-corner,  x2+corner, y2,  x1, y2,  x1, y1);
+#endif // USE_PDTK_CANVAS_PROC
     }
     else if (x->te_type == T_ATOM && (((t_gatom *)x)->a_flavor == A_FLOAT ||
            ((t_gatom *)x)->a_flavor == A_SYMBOL))
@@ -1626,13 +1637,14 @@ void text_drawborder(t_text *x, t_glist *glist,
         corner = ((y2-y1)/4);
 #ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
-        pdgui_vmess(cmd, "r c iiii i i s",
-            tags[1],
+        const char* type = ((t_gatom *)x)->a_flavor == A_FLOAT ? "floatatom" : "symbolatom";
+        pdgui_vmess(cmd, "r c iiii i i S",
+            type,
             glist_getcanvas(glist),
             x1p, y1p, x2, y2,
             corner,
             glist->gl_zoom+grabbed,
-            tags[0]);
+            2, tags);
 #else // USE_PDTK_CANVAS_PROC
         if (firsttime)
             pdgui_vmess(0, "crr iiiiiiiiiiii ri rr rS",
@@ -1658,6 +1670,16 @@ void text_drawborder(t_text *x, t_glist *glist,
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
+#ifdef USE_PDTK_CANVAS_PROC
+        const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
+        pdgui_vmess(cmd, "r c iiii i i S",
+            "listbox",
+            glist_getcanvas(glist),
+            x1p, y1p, x2, y2,
+            corner,
+            glist->gl_zoom+grabbed,
+            2, tags);
+#else // USE_PDTK_CANVAS_PROC
         if (firsttime)
             pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rr rS",
                 glist_getcanvas(glist),
@@ -1675,6 +1697,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 glist_getcanvas(glist), "itemconfigure", tagR,
                 "-width", glist->gl_zoom+grabbed);
         }
+#endif // USE_PDTK_CANVAS_PROC
     }
         /* for comments, just draw a bar on RHS if unlocked; when a visible
         canvas is unlocked we have to call this anew on all comments, and when

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1115,7 +1115,7 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
                 gatom_fontsize(x) * glist_getzoom(glist), "black");
         }
         else
-            pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", buf);
+            glist_deletefromtag(glist, buf);
     }
 }
 
@@ -1666,8 +1666,7 @@ void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)
         {
             char tagbuf[MAXPDSTRING];
             sprintf(tagbuf, "%s%c%d", tag, c, i);
-            pdgui_vmess(0, "crs",
-                glist_getcanvas(glist), "delete", tagbuf);
+            glist_deletefromtag(glist, tagbuf);
         }
     }
 }
@@ -1677,8 +1676,7 @@ void text_eraseborder(t_text *x, t_glist *glist, const char *tag)
     char tagbuf[MAXPDSTRING];
     if (x->te_type == T_TEXT && !glist->gl_edit) return;
     sprintf(tagbuf, "%sR", tag);
-    pdgui_vmess(0, "crs",
-        glist_getcanvas(glist), "delete", tagbuf);
+    glist_deletefromtag(glist, tagbuf);
     glist_eraseiofor(glist, x, tag);
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1705,6 +1705,14 @@ void text_drawborder(t_text *x, t_glist *glist,
     else if (x->te_type == T_TEXT && glist->gl_edit)
     {
         char *tags[] = {tagR, "commentbar"};
+#ifdef USE_PDTK_CANVAS_PROC
+        const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
+        pdgui_vmess(cmd, "r c iiii S",
+            "commentbar",
+            glist_getcanvas(glist),
+            x2, y1, x2, y2, // x2...x2 : a vertical line
+            2, tags);
+#else // USE_PDTK_CANVAS_PROC
         if (firsttime)
             pdgui_vmess(0, "crr iiii rS",
                 glist_getcanvas(glist), "create", "line",
@@ -1714,6 +1722,7 @@ void text_drawborder(t_text *x, t_glist *glist,
             pdgui_vmess(0, "crs iiii",
                 glist_getcanvas(glist), "coords", tagR,
                 x2, y1,  x2, y2);
+#endif // USE_PDTK_CANVAS_PROC
     }
         /* draw inlets/outlets */
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1319,10 +1319,8 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
         char buf[MAXPDSTRING];
         sprintf(buf, "%sR", rtext_gettag(y));
 #ifdef USE_PDTK_CANVAS_CREATE
-        // TODO: this case also covers atoms, so maybe obj is not the best type
-        // name?
         pdgui_vmess(0, "rr csr",
-            "::pdtk_canvas::select", "obj",
+            "::pdtk_canvas::select", "tag",
             glist, buf, (state ? "blue" : "black"));
 #else // USE_PDTK_CANVAS_CREATE
         pdgui_vmess(0, "crs rr",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1533,11 +1533,11 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
             tags[0] = tagbuf;
             if (firsttime)
 #ifdef USE_PDTK_CANVAS_PROC
-                pdgui_vmess("::pdtk_canvas::create", "r c iiii s",
+                pdgui_vmess("::pdtk_canvas::create", "r c iiii S",
                     tags[1],
                     glist_getcanvas(glist),
                     iox1, ioy1, iox2, ioy2,
-                    tags[0]);
+                    2, tags);
 #else // USE_PDTK_CANVAS_PROC
                 pdgui_vmess(0, "crr iiii rS rr",
                     glist_getcanvas(glist), "create", "rectangle",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -22,6 +22,7 @@
 #define ATOM_BMARGIN 4 /* 1 pixel smaller than object TMARGIN+BMARGIN */
 
 #define MESSAGE_CLICK_WIDTH 5
+#define USE_PDTK_CANVAS_CREATE
 
 t_class *text_class;
 static t_class *message_class;
@@ -1546,6 +1547,16 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
         char *tags[] = {tagR, "obj"};
         if (firsttime)
+        {
+#ifdef USE_PDTK_CANVAS_CREATE
+            pdgui_vmess(0, "rr c iiii r i s",
+                "::pdtk_canvas::create", tags[1],
+                glist_getcanvas(glist),
+                x1, y1,  x2, y2,
+                pattern,
+                glist->gl_zoom,
+                tags[0]);
+#else // USE_PDTK_CANVAS_CREATE
             pdgui_vmess(0, "crr iiiiiiiiii rr ri rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1,
@@ -1553,6 +1564,8 @@ void text_drawborder(t_text *x, t_glist *glist,
                 "-width", glist->gl_zoom,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
+#endif // USE_PDTK_CANVAS_CREATE
+        }
         else
         {
             pdgui_vmess(0, "crs iiiiiiiiii",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1083,11 +1083,18 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
         int mdy = dy * glist->gl_zoom;
         char buf[MAXPDSTRING];
         sprintf(buf, "%lx.l", x);
+#ifdef USE_PDTK_CANVAS_CREATE
+        pdgui_vmess(0, "rr c rii",
+            "::pdtk_canvas::move", "tag",
+            glist_getcanvas(glist),
+            buf, mdx, mdy);
+#else // USE_PDTK_CANVAS_CREATE
         pdgui_vmess(0, "crs ii",
             glist_getcanvas(glist),
             "move",
             buf,
             mdx, mdy);
+#endif // USE_PDTK_CANVAS_CREATE
     }
 }
 
@@ -1562,17 +1569,18 @@ void text_drawborder(t_text *x, t_glist *glist,
     {
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
         char *tags[] = {tagR, "obj"};
+#ifdef USE_PDTK_CANVAS_CREATE
+        const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
+        pdgui_vmess(0, "rr c iiii r i s",
+            cmd, tags[1],
+            glist_getcanvas(glist),
+            x1, y1, x2, y2,
+            pattern,
+            glist->gl_zoom, // unused when !firsttime
+            tags[0]);
+#else // USE_PDTK_CANVAS_CREATE
         if (firsttime)
         {
-#ifdef USE_PDTK_CANVAS_CREATE
-            pdgui_vmess(0, "rr c iiii r i s",
-                "::pdtk_canvas::create", tags[1],
-                glist_getcanvas(glist),
-                x1, y1,  x2, y2,
-                pattern,
-                glist->gl_zoom,
-                tags[0]);
-#else // USE_PDTK_CANVAS_CREATE
             pdgui_vmess(0, "crr iiiiiiiiii rr ri rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1,
@@ -1580,7 +1588,6 @@ void text_drawborder(t_text *x, t_glist *glist,
                 "-width", glist->gl_zoom,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
-#endif // USE_PDTK_CANVAS_CREATE
         }
         else
         {
@@ -1591,6 +1598,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 glist_getcanvas(glist), "itemconfigure", tagR,
                 "-dash", pattern);
         }
+#endif // USE_PDTK_CANVAS_CREATE
     }
     else if (x->te_type == T_MESSAGE)
     {
@@ -1618,23 +1626,23 @@ void text_drawborder(t_text *x, t_glist *glist,
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
-        if (firsttime)
 #ifdef USE_PDTK_CANVAS_CREATE
-            pdgui_vmess(0, "rr c iiii i i s",
-                "::pdtk_canvas::create", tags[1],
-                glist_getcanvas(glist),
-                x1p, y1p, x2, y2,
-                corner,
-                glist->gl_zoom+grabbed,
-                tags[0]);
+        const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
+        pdgui_vmess(0, "rr c iiii i i s",
+            cmd, tags[1],
+            glist_getcanvas(glist),
+            x1p, y1p, x2, y2,
+            corner,
+            glist->gl_zoom+grabbed,
+            tags[0]);
 #else // USE_PDTK_CANVAS_CREATE
+        if (firsttime)
             pdgui_vmess(0, "crr iiiiiiiiiiii ri rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner, x2, y2,  x1p, y2,  x1p, y1p,
                 "-width", glist->gl_zoom+grabbed,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
-#endif // USE_PDTK_CANVAS_CREATE
         else
         {
             pdgui_vmess(0, "crs iiiiiiiiiiii",
@@ -1644,6 +1652,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 glist_getcanvas(glist), "itemconfigure", tagR,
                 "-width", glist->gl_zoom+grabbed);
         }
+#endif // USE_PDTK_CANVAS_CREATE
     }
     else if (x->te_type == T_ATOM ) /* list (ATOM but not float or symbol) */
     {

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1311,11 +1311,19 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
     {
         char buf[MAXPDSTRING];
         sprintf(buf, "%sR", rtext_gettag(y));
+#ifdef USE_PDTK_CANVAS_CREATE
+        // TODO: this case also covers atoms, so maybe obj is not the best type
+        // name?
+        pdgui_vmess(0, "rr csr",
+            "::pdtk_canvas::select", "obj",
+            glist, buf, (state ? "blue" : "black"));
+#else // USE_PDTK_CANVAS_CREATE
         pdgui_vmess(0, "crs rr",
             glist,
             "itemconfigure",
             buf,
             "-fill", (state? "blue" : "black"));
+#endif // USE_PDTK_CANVAS_CREATE
     }
 }
 
@@ -1611,12 +1619,22 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
         if (firsttime)
+#ifdef USE_PDTK_CANVAS_CREATE
+            pdgui_vmess(0, "rr c iiii i i s",
+                "::pdtk_canvas::create", tags[1],
+                glist_getcanvas(glist),
+                x1p, y1p, x2, y2,
+                corner,
+                glist->gl_zoom+grabbed,
+                tags[0]);
+#else // USE_PDTK_CANVAS_CREATE
             pdgui_vmess(0, "crr iiiiiiiiiiii ri rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner, x2, y2,  x1p, y2,  x1p, y1p,
                 "-width", glist->gl_zoom+grabbed,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
+#endif // USE_PDTK_CANVAS_CREATE
         else
         {
             pdgui_vmess(0, "crs iiiiiiiiiiii",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1481,7 +1481,7 @@ static const t_widgetbehavior gatom_widgetbehavior =
 void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     const char *tag, int x1, int y1, int x2, int y2)
 {
-    int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
+    int isInlet, i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;
     int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
@@ -1489,42 +1489,43 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     char tagbuf[128];
 
     /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
-    for (i = 0; i < n; i++)
+    for (isInlet = 0; isInlet < 2; isInlet++)
     {
-        int onset = x1 + (width - iow) * i / nplus;
-        sprintf(tagbuf, "%so%d", tag, i);
-        tags[0] = tagbuf;
-        tags[1] = "outlet";
-        if (firsttime)
-            pdgui_vmess(0, "crr iiii rS rr",
-                glist_getcanvas(glist), "create", "rectangle",
-                onset, y2 - oh + glist->gl_zoom, onset + iow, y2,
-                "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", "black");
-        else
-            pdgui_vmess(0, "crs iiii",
-                glist_getcanvas(glist), "coords", tagbuf,
-                onset, y2 - oh + glist->gl_zoom, onset + iow, y2);
-    }
-    n = obj_ninlets(ob);
-    nplus = (n == 1 ? 1 : n-1);
-    for (i = 0; i < n; i++)
-    {
-        int onset = x1 + (width - iow) * i / nplus;
-        sprintf(tagbuf, "%si%d", tag, i);
-        tags[0] = tagbuf;
-        tags[1] = "inlet";
-        if (firsttime)
-            pdgui_vmess(0, "crr iiii rS rr",
-                glist_getcanvas(glist),
-                "create", "rectangle",
-                onset, y1, onset + iow, y1 + ih - glist->gl_zoom,
-                "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", "black");
-        else
-            pdgui_vmess(0, "crs iiii",
-                glist_getcanvas(glist), "coords", tagbuf,
-                onset, y1, onset + iow, y1 + ih - glist->gl_zoom);
+        int n = isInlet ? obj_ninlets(ob) : obj_noutlets(ob);
+        int nplus = (n == 1 ? 1 : n-1), i;
+        for (i = 0; i < n; i++)
+        {
+            int iox1, iox2, ioy1, ioy2;
+            char c;
+            iox1 = x1 + (width - iow) * i / nplus;
+            iox2 = iox1 + iow;
+            if(isInlet)
+            {
+                ioy1 = y1;
+                ioy2 = y1 + ih - glist->gl_zoom;
+                c = 'i';
+                tags[1] = "inlet";
+            }
+            else
+            {
+                ioy1 = y2 - oh + glist->gl_zoom;
+                ioy2 = y2;
+                c = 'o';
+                tags[1] = "outlet";
+            }
+            sprintf(tagbuf, "%s%c%d", tag, c, i);
+            tags[0] = tagbuf;
+            if (firsttime)
+                pdgui_vmess(0, "crr iiii rS rr",
+                    glist_getcanvas(glist), "create", "rectangle",
+                    iox1, ioy1, iox2, ioy2,
+                    "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
+                    "-fill", "black");
+            else
+                pdgui_vmess(0, "crs iiii",
+                    glist_getcanvas(glist), "coords", tagbuf,
+                    iox1, ioy1, iox2, ioy2);
+        }
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1654,21 +1654,19 @@ void text_drawborder(t_text *x, t_glist *glist,
 
 void glist_eraseiofor(t_glist *glist, t_object *ob, const char *tag)
 {
-    int i, n;
-    n = obj_noutlets(ob);
-    char tagbuf[MAXPDSTRING];
-    for (i = 0; i < n; i++)
+    int isInlet;
+    for(isInlet = 0; isInlet < 2; isInlet++)
     {
-        sprintf(tagbuf, "%so%d", tag, i);
-        pdgui_vmess(0, "crs",
-            glist_getcanvas(glist), "delete", tagbuf);
-    }
-    n = obj_ninlets(ob);
-    for (i = 0; i < n; i++)
-    {
-        sprintf(tagbuf, "%si%d", tag, i);
-        pdgui_vmess(0, "crs",
-            glist_getcanvas(glist), "delete", tagbuf);
+        int n = isInlet ? obj_ninlets(ob) : obj_noutlets(ob);
+        char c = isInlet ? 'i' : 'o';
+        int i;
+        for (i = 0; i < n; i++)
+        {
+            char tagbuf[MAXPDSTRING];
+            sprintf(tagbuf, "%s%c%d", tag, c, i);
+            pdgui_vmess(0, "crs",
+                glist_getcanvas(glist), "delete", tagbuf);
+        }
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1519,11 +1519,19 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
             sprintf(tagbuf, "%s%c%d", tag, c, i);
             tags[0] = tagbuf;
             if (firsttime)
+#ifdef USE_PDTK_CANVAS_CREATE
+                pdgui_vmess(0, "rr c iiii s",
+                    "::pdtk_canvas::create", tags[1],
+                    glist_getcanvas(glist),
+                    iox1, ioy1, iox2, ioy2,
+                    tags[0]);
+#else // USE_PDTK_CANVAS_CREATE
                 pdgui_vmess(0, "crr iiii rS rr",
                     glist_getcanvas(glist), "create", "rectangle",
                     iox1, ioy1, iox2, ioy2,
                     "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
                     "-fill", "black");
+#endif // USE_PDTK_CANVAS_CREATE
             else
                 pdgui_vmess(0, "crs iiii",
                     glist_getcanvas(glist), "coords", tagbuf,

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1078,13 +1078,15 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
     text_displace(z, glist, dx, dy);
     if (glist_isvisible(glist))
     {
+        int mdx = dx * glist->gl_zoom;
+        int mdy = dy * glist->gl_zoom;
         char buf[MAXPDSTRING];
         sprintf(buf, "%lx.l", x);
         pdgui_vmess(0, "crs ii",
             glist_getcanvas(glist),
             "move",
             buf,
-            dx * glist->gl_zoom, dy * glist->gl_zoom);
+            mdx, mdy);
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1084,8 +1084,8 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
         char buf[MAXPDSTRING];
         sprintf(buf, "%lx.l", x);
 #ifdef USE_PDTK_CANVAS_PROC
-        pdgui_vmess(0, "rr c rii",
-            "::pdtk_canvas::move", "tag",
+        pdgui_vmess("::pdtk_canvas::move", "r c rii",
+            "tag",
             glist_getcanvas(glist),
             buf, mdx, mdy);
 #else // USE_PDTK_CANVAS_PROC
@@ -1319,8 +1319,8 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
         char buf[MAXPDSTRING];
         sprintf(buf, "%sR", rtext_gettag(y));
 #ifdef USE_PDTK_CANVAS_PROC
-        pdgui_vmess(0, "rr csr",
-            "::pdtk_canvas::select", "tag",
+        pdgui_vmess("::pdtk_canvas::select", "r csr",
+            "tag",
             glist, buf, (state ? "blue" : "black"));
 #else // USE_PDTK_CANVAS_PROC
         pdgui_vmess(0, "crs rr",
@@ -1533,8 +1533,8 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
             tags[0] = tagbuf;
             if (firsttime)
 #ifdef USE_PDTK_CANVAS_PROC
-                pdgui_vmess(0, "rr c iiii s",
-                    "::pdtk_canvas::create", tags[1],
+                pdgui_vmess("::pdtk_canvas::create", "r c iiii s",
+                    tags[1],
                     glist_getcanvas(glist),
                     iox1, ioy1, iox2, ioy2,
                     tags[0]);
@@ -1569,8 +1569,8 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "obj"};
 #ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
-        pdgui_vmess(0, "rr c iiii r i s",
-            cmd, tags[1],
+        pdgui_vmess(cmd, "r c iiii r i s",
+            tags[1],
             glist_getcanvas(glist),
             x1, y1, x2, y2,
             pattern,
@@ -1626,8 +1626,8 @@ void text_drawborder(t_text *x, t_glist *glist,
         corner = ((y2-y1)/4);
 #ifdef USE_PDTK_CANVAS_PROC
         const char* cmd = firsttime ? "::pdtk_canvas::create" : "::pdtk_canvas::move";
-        pdgui_vmess(0, "rr c iiii i i s",
-            cmd, tags[1],
+        pdgui_vmess(cmd, "r c iiii i i s",
+            tags[1],
             glist_getcanvas(glist),
             x1p, y1p, x2, y2,
             corner,

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -98,7 +98,7 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
 
     /* re-create outlets */
     sprintf(tag, "%lxOUT", x);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!snd_able)
     {
         sprintf(tag_n, "%lxOUT%d", x, 0);
@@ -119,7 +119,7 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     }
 
     sprintf(tag, "%lxIN", x);
-    pdgui_vmess(0, "crs", canvas, "delete", tag);
+    canvas_deletefromtag(canvas, tag);
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
         sprintf(tag_n, "%lxIN%d", x, 0);

--- a/tcl/pd_connect.tcl
+++ b/tcl/pd_connect.tcl
@@ -100,6 +100,9 @@ proc ::pd_connect::assemble_cmd {A B} {
 }
 
 proc ::pd_connect::pd_docmds {docmds} {
+    puts stderr "START_DOCMDS"
+    puts stderr [string trim "$docmds"]
+    puts stderr "STOP_DOCMDS"
     if {![catch {uplevel #0 $docmds} errorname]} {
         # we ran the command block without error
     } else {

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -668,6 +668,38 @@ proc ::pdtk_canvas::select {args} {
     }
 }
 
+proc ::pdtk_canvas::move {args} {
+    set docmds ""
+    check_argc_least 2 [llength $args]
+    set type [lindex $args 0]
+    set args [lrange $args 1 end]
+    set argc [llength $args]
+    if { $type in [list atom obj]} {
+        parse_cnv_coords $args $argc p
+        parse_obj_atom_args $args $argc $type p
+        append docmds "$p(cnv) coords $p(tag) [get_poly_coords p];\n"
+        if { "obj" eq $type } {
+            # this is for backwards compatibility in order to ensure the exact
+            # same command as before get executed. It can be removed later, as
+            # there is no effect in an additional `-width` property with the
+            # same width as in create()
+            set p(width) ""
+        }
+        append docmds "$p(cnv) itemconfigure $p(tag) $p(pattern) $p(width);\n"
+    }
+    if { "tag" eq $type} { ;#meta-type for those commands that call tk's "move" directly
+        check_argc_exact 4 $argc $type
+        set cnv [lindex $args 0]
+        set tag [lindex $args 1]
+        set dx [lindex $args 2]
+        set dy [lindex $args 3]
+        set docmds "$cnv move $tag $dx $dy"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}
+
 proc ::pdtk_canvas::delete {args} {
     set docmds ""
     check_argc_exact 2 [llength $args]

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -778,11 +778,7 @@ proc ::pdtk_canvas::move {args} {
     }
 }
 
-proc ::pdtk_canvas::delete {args} {
-    set docmds ""
-    check_argc_exact 2 [llength $args]
-    set cnv [lindex $args 0]
-    set tag [lindex $args 1]
+proc ::pdtk_canvas::delete {cnv tag} {
     set docmds "$cnv delete $tag"
     if { [string length $docmds] > 0 } {
         ::pd_connect::pd_docmds "$docmds"

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -648,3 +648,17 @@ proc ::pdtk_canvas::select {args} {
         ::pd_connect::pd_docmds "$docmds"
     }
 }
+
+proc ::pdtk_canvas::delete {args} {
+    set docmds ""
+    if {[llength $args] < 2} {
+        puts "ERROR: ::pdtk_canvas::delete: not enough arguments"
+        return
+    }
+    set cnv [lindex $args 0]
+    set tag [lindex $args 1]
+    set docmds "$cnv delete $tag"
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -504,6 +504,14 @@ proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
     }
 }
 
+proc get_rect_coords {x1 y1 x2 y2} {
+    return "$x1 $y1 $x2 $y1 $x2 $y2 $x1 $y2 $x1 $y1"
+}
+
+proc get_atom_coords {x1 y1 x2 y2 corner} {
+    return "$x1 $y1 [expr $x2 - $corner] $y1 $x2 [expr $y1 + $corner] $x2 $y2 $x1 $y2 $x1 $y1"
+}
+
 proc ::pdtk_canvas::create {args} {
     #puts "pdtk_canvas::create got: $args"
     set docmds ""
@@ -534,7 +542,7 @@ proc ::pdtk_canvas::create {args} {
         set pattern [lindex $args 5]
         set width [lindex $args 6]
         set tag [lindex $args 7]
-        set docmds "$cnv create line $x1 $y1 $x2 $y1 $x2 $y2 $x1 $y2 $x1 $y1 -dash \"$pattern\" -width $width -capstyle projecting -tags {{$tag} {$type} }"
+        set docmds "$cnv create line [get_rect_coords $x1 $y1 $x2 $y2] -dash \"$pattern\" -width $width -capstyle projecting -tags {{$tag} {$type} }"
     }
     if {$type eq "outlet" || $type eq "inlet"} {
         if { $argc != 6 } {
@@ -552,7 +560,7 @@ proc ::pdtk_canvas::create {args} {
         set corner [lindex $args 5]
         set width [lindex $args 6]
         set tag [lindex $args 7]
-        set docmds "$cnv create line $x1 $y1 [expr $x2 - $corner] $y1 $x2 [expr $y1 + $corner] $x2 $y2 $x1 $y2 $x1 $y1 -width $width -capstyle projecting -tags {{$tag} {$type}}"
+        set docmds "$cnv create line [get_atom_coords $x1 $y1 $x2 $y2 $corner] -width $width -capstyle projecting -tags {{$tag} {$type}}"
     }
     if {"bang" eq $type} {
         if { $argc != 13 } {

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -503,3 +503,40 @@ proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
         }
     }
 }
+
+proc ::pdtk_canvas::create {args} {
+    #puts "pdtk_canvas::create got: $args"
+    set docmds ""
+    if {[llength $args] < 1} {
+        puts "ERROR: ::pdtk_canvas::create: no arguments"
+        return
+    }
+    set type [lindex $args 0]
+    set args [lrange $args 1 end]
+    set argc [llength $args]
+    set cnvCoordsTypes { obj }
+    if { $type in $cnvCoordsTypes} {
+        if { $argc < 5 } {
+            puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
+            return
+        }
+        set cnv [lindex $args 0]
+        set x1 [lindex $args 1]
+        set y1 [lindex $args 2]
+        set x2 [lindex $args 3]
+        set y2 [lindex $args 4]
+    }
+    if {$type eq "obj"} {
+        if { $argc != 8 } {
+            puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
+            return
+        }
+        set pattern [lindex $args 5]
+        set width [lindex $args 6]
+        set tag [lindex $args 7]
+        set docmds "$cnv create line $x1 $y1 $x2 $y1 $x2 $y2 $x1 $y2 $x1 $y1 -dash \"$pattern\" -width $width -capstyle projecting -tags {{$tag} {$type} }"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -788,3 +788,34 @@ proc ::pdtk_canvas::delete {args} {
         ::pd_connect::pd_docmds "$docmds"
     }
 }
+
+proc ::pdtk_canvas::iemgui_label_pos {args} {
+    set docmds ""
+    check_argc_exact 5 [llength $args]
+    set type [lindex $args 0]
+    set cnv [lindex $args 1]
+    if {"tag" eq $type} {
+        set tag [lindex $args 2]
+        set x0 [lindex $args 3]
+        set y0 [lindex $args 4]
+        set docmds "$cnv coords $tag $x0 $y0"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}
+
+proc ::pdtk_canvas::iemgui_label_font {args} {
+    set docmds ""
+    check_argc_exact 4 [llength $args]
+    set type [lindex $args 0]
+    set cnv [lindex $args 1]
+    if {"tag" eq $type} {
+        set tag [lindex $args 2]
+        set font [lindex $args 3]
+        set docmds "$cnv itemconfigure $tag -font {$font}"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -636,7 +636,7 @@ proc ::pdtk_canvas::select {args} {
     set type [lindex $args 0]
     set args [lrange $args 1 end]
     set argc [llength $args]
-    if {"obj" eq $type} {
+    if {$type eq "tag"} {
         check_argc_exact 3 $argc
         set glist [lindex $args 0]
         set buf [lindex $args 1]

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -671,6 +671,26 @@ proc ::pdtk_canvas::select {args} {
     }
 }
 
+proc ::pdtk_canvas::update {args} {
+    set docmds ""
+    check_argc_least 2 [llength $args]
+    set type [lindex $args 0]
+    set args [lrange $args 1 end]
+    set argc [llength $args]
+    if { "bang" eq $type} {
+        check_argc_exact 3 $argc $type
+        set cnv [lindex $args 0]
+        set obj [lindex $args 1]
+        set col [lindex $args 2]
+        set obj [string replace $obj 0 1 "" ]; # same as above
+        append tag_button $obj BUT
+        set docmds "$cnv itemconfigure $tag_button -fill $col"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}
+
 proc ::pdtk_canvas::move {args} {
     set docmds ""
     check_argc_least 2 [llength $args]

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -514,7 +514,7 @@ proc ::pdtk_canvas::create {args} {
     set type [lindex $args 0]
     set args [lrange $args 1 end]
     set argc [llength $args]
-    set cnvCoordsTypes { obj }
+    set cnvCoordsTypes { obj inlet outlet }
     if { $type in $cnvCoordsTypes} {
         if { $argc < 5 } {
             puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
@@ -535,6 +535,14 @@ proc ::pdtk_canvas::create {args} {
         set width [lindex $args 6]
         set tag [lindex $args 7]
         set docmds "$cnv create line $x1 $y1 $x2 $y1 $x2 $y2 $x1 $y2 $x1 $y1 -dash \"$pattern\" -width $width -capstyle projecting -tags {{$tag} {$type} }"
+    }
+    if {$type eq "outlet" || $type eq "inlet"} {
+        if { $argc != 6 } {
+            puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
+            return
+        }
+        set tag [lindex $args 5]
+        set docmds "$cnv create rectangle $x1 $y1 $x2 $y2 -tags {{$tag} {$type}} -fill black"
     }
     if { [string length $docmds] > 0 } {
         ::pd_connect::pd_docmds "$docmds"

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -607,13 +607,16 @@ proc ::pdtk_canvas::create {args} {
         append tag_label $obj LABEL
         set inset $zoom
 
-        #bng_draw_new()
-        set cmd "$cnv create rectangle 0 0 0 0 -tags {$tag_object $tag_base}"
-        append docmds "$cmd;\n"
-        set cmd "$cnv create oval 0 0 0 0 -tags {$tag_object $tag_button}"
-        append docmds "$cmd;\n"
-        set cmd "$cnv create text 0 0 -anchor w -tags {$tag_object $tag_label label text}"
-        append docmds "$cmd;\n"
+        if { ![llength [$cnv coords $tag_base]] } {
+            # if item doesn't exist, create it first
+            #bang_draw_new()
+            set cmd "$cnv create rectangle 0 0 0 0 -tags {$tag_object $tag_base}"
+            append docmds "$cmd;\n"
+            set cmd "$cnv create oval 0 0 0 0 -tags {$tag_object $tag_button}"
+            append docmds "$cmd;\n"
+            set cmd "$cnv create text 0 0 -anchor w -tags {$tag_object $tag_label label text}"
+            append docmds "$cmd;\n"
+        }
 
         #bng_draw_config()
         append docmds "$cnv coords $tag_base $x1 $y1 $x2 $y2;\n"

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -530,6 +530,15 @@ proc check_argc_least {count argc {type {}} } {
 
 set cnv_coords_types { obj inlet outlet atom }
 
+# expand array to variables named after the array members in the caller's scope
+proc array_to_vars {arrPtr} {
+    upvar 1 $arrPtr arr
+    foreach name [array names arr] {
+        upvar 1 $name $name
+        set $name $arr($name)
+    }
+}
+
 proc parse_cnv_coords {args argc outPtr} {
     check_argc_least 5 $argc
     upvar 1 $outPtr out
@@ -557,7 +566,7 @@ proc parse_obj_atom_args {args argc type outPtr} {
 
 proc get_poly_coords {pPtr} {
     upvar 1 $pPtr p
-    foreach name [array names p] { set $name $p($name) }
+    array_to_vars p
     if [info exists corner] {
         return "$x1 $y1 [expr $x2 - $corner] $y1 $x2 [expr $y1 + $corner] $x2 $y2 $x1 $y2 $x1 $y1"
     } else {
@@ -587,7 +596,7 @@ proc ::pdtk_canvas::create {args} {
     set argc [llength $args]
     if { $type in $::cnv_coords_types} {
         parse_cnv_coords $args $argc p
-        foreach name [array names p] { set $name $p($name) }
+        array_to_vars p
     }
     if {"obj" eq $type || "atom" eq $type} {
         parse_obj_atom_args $args $argc $type p
@@ -663,7 +672,7 @@ proc ::pdtk_canvas::config {args} {
     if { "bang" eq $type} {
         check_argc_exact 13 $argc $type
         parse_cnv_coords $args $argc p
-        foreach name [array names p] { set $name $p($name) }
+        array_to_vars p
         set obj [lindex $args 5]
         set zoom [lindex $args 6]
         set bcol [lindex $args 7]

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -604,8 +604,8 @@ proc ::pdtk_canvas::create {args} {
     }
     if {$type eq "outlet" || $type eq "inlet"} {
         check_argc_exact 6 $argc $type
-        set tag [lindex $args 5]
-        set docmds "$cnv create rectangle $x1 $y1 $x2 $y2 -tags {{$tag} {$type}} -fill black"
+        set tags [lindex $args 5]
+        set docmds "$cnv create rectangle $x1 $y1 $x2 $y2 -tags {$tags} -fill black"
     }
     if {"bang" eq $type} {
         check_argc_exact 2 $argc

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -507,14 +507,14 @@ proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
 proc ::pdtk_canvas::create {args} {
     #puts "pdtk_canvas::create got: $args"
     set docmds ""
-    if {[llength $args] < 1} {
-        puts "ERROR: ::pdtk_canvas::create: no arguments"
+    if {[llength $args] < 2} {
+        puts "ERROR: ::pdtk_canvas::create: not enough arguments"
         return
     }
     set type [lindex $args 0]
     set args [lrange $args 1 end]
     set argc [llength $args]
-    set cnvCoordsTypes { obj inlet outlet }
+    set cnvCoordsTypes { obj inlet outlet atom }
     if { $type in $cnvCoordsTypes} {
         if { $argc < 5 } {
             puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
@@ -543,6 +543,41 @@ proc ::pdtk_canvas::create {args} {
         }
         set tag [lindex $args 5]
         set docmds "$cnv create rectangle $x1 $y1 $x2 $y2 -tags {{$tag} {$type}} -fill black"
+    }
+    if {"atom" eq $type} {
+        if { $argc != 8 } {
+            puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
+            return
+        }
+        set corner [lindex $args 5]
+        set width [lindex $args 6]
+        set tag [lindex $args 7]
+        set docmds "$cnv create line $x1 $y1 [expr $x2 - $corner] $y1 $x2 [expr $y1 + $corner] $x2 $y2 $x1 $y2 $x1 $y1 -width $width -capstyle projecting -tags {{$tag} {$type}}"
+    }
+    if { [string length $docmds] > 0 } {
+        ::pd_connect::pd_docmds "$docmds"
+    }
+}
+
+proc ::pdtk_canvas::select {args} {
+    #puts "pdtk_canvas::select got: $args"
+    set docmds ""
+    if {[llength $args] < 2} {
+        puts "ERROR: ::pdtk_canvas::select: not enough arguments"
+        return
+    }
+    set type [lindex $args 0]
+    set args [lrange $args 1 end]
+    set argc [llength $args]
+    if {"obj" eq $type} {
+        if { $argc != 3} {
+            puts "ERROR: ::pdtk_canvas::select: only $argc arguments for $type"
+            return
+        }
+        set glist [lindex $args 0]
+        set buf [lindex $args 1]
+        set state [lindex $args 2]
+        set docmds "$glist itemconfigure $buf -fill $state"
     }
     if { [string length $docmds] > 0 } {
         ::pd_connect::pd_docmds "$docmds"

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -514,7 +514,7 @@ proc ::pdtk_canvas::create {args} {
     set type [lindex $args 0]
     set args [lrange $args 1 end]
     set argc [llength $args]
-    set cnvCoordsTypes { obj inlet outlet atom }
+    set cnvCoordsTypes { obj inlet outlet atom bang }
     if { $type in $cnvCoordsTypes} {
         if { $argc < 5 } {
             puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
@@ -554,6 +554,48 @@ proc ::pdtk_canvas::create {args} {
         set tag [lindex $args 7]
         set docmds "$cnv create line $x1 $y1 [expr $x2 - $corner] $y1 $x2 [expr $y1 + $corner] $x2 $y2 $x1 $y2 $x1 $y1 -width $width -capstyle projecting -tags {{$tag} {$type}}"
     }
+    if {"bang" eq $type} {
+        if { $argc != 13 } {
+            puts "ERROR: ::pdtk_canvas::create: only $argc arguments for $type"
+            return
+        }
+        set obj [lindex $args 5]
+        set zoom [lindex $args 6]
+        set bcol [lindex $args 7]
+        set fcol [lindex $args 8]
+        set ldx [lindex $args 9]
+        set ldy [lindex $args 10]
+        set fontatoms [lindex $args 11]
+        set lcol [lindex $args 12]
+
+        #The C backend sends $obj with trailing 0x, however the legacy version
+        #would create tags with sprintf(...%lx..)(i.e.: no leading 0x). Here we
+        #remove the trailing 0x.
+        #TODO: better options would be to find a a better type from C instead
+        set obj [string replace $obj 0 1 "" ];
+        append tag_object $obj OBJ
+        append tag_base $obj BASE
+        append tag_button $obj BUT
+        append tag_label $obj LABEL
+        set inset $zoom
+
+        #bng_draw_new()
+        set cmd "$cnv create rectangle 0 0 0 0 -tags {$tag_object $tag_base}"
+        append docmds "$cmd;\n"
+        set cmd "$cnv create oval 0 0 0 0 -tags {$tag_object $tag_button}"
+        append docmds "$cmd;\n"
+        set cmd "$cnv create text 0 0 -anchor w -tags {$tag_object $tag_label label text}"
+        append docmds "$cmd;\n"
+
+        #bng_draw_config()
+        append docmds "$cnv coords $tag_base $x1 $y1 $x2 $y2;\n"
+        append docmds "$cnv itemconfigure $tag_base -width $zoom -fill $bcol;\n"
+        append docmds "$cnv coords $tag_button [expr $x1 + $inset] \
+            [expr $y1 + $inset] [expr $x2 - $inset] [expr $y2 - $inset];\n"
+        append docmds "$cnv itemconfigure $tag_button -width $zoom -fill $fcol;\n"
+        append docmds "$cnv coords $tag_label $ldx $ldy;\n"
+        append docmds "$cnv itemconfigure $tag_label -font {$fontatoms} -fill $lcol;\n"
+    }
     if { [string length $docmds] > 0 } {
         ::pd_connect::pd_docmds "$docmds"
     }
@@ -578,6 +620,29 @@ proc ::pdtk_canvas::select {args} {
         set buf [lindex $args 1]
         set state [lindex $args 2]
         set docmds "$glist itemconfigure $buf -fill $state"
+    }
+    if {"bang" eq $type} {
+        if { $argc != 4 } {
+            puts "ERROR: ::pdtk_canvas::select: only $argc arguments for $type"
+            return
+        }
+        set cnv [lindex $args 0]
+        set obj [lindex $args 1]
+        set col [lindex $args 2]
+        set lcol [lindex $args 3]
+        #The C backend sends $obj with trailing 0x, however the legacy version
+        #would create tags with sprintf(...%lx..)(i.e.: no leading 0x). Here we
+        #remove the trailing 0x.
+        #TODO: better options would be to find a a better type from C instead
+        set obj [string replace $obj 0 1 "" ];
+        append tag_object $obj OBJ
+        append tag_base $obj BASE
+        append tag_button $obj BUT
+        append tag_label $obj LABEL
+
+        append docmds "$cnv itemconfigure $tag_base -outline $col;\n"
+        append docmds "$cnv itemconfigure $tag_button -outline $col;\n"
+        append docmds "$cnv itemconfigure $tag_label -fill $lcol;\n"
     }
     if { [string length $docmds] > 0 } {
         ::pd_connect::pd_docmds "$docmds"


### PR DESCRIPTION
I have done a first pass at implementing some tcl procs as discussed in https://github.com/pure-data/pure-data/discussions/1695 to move away from passing tk commands. It is my first time at tcl and I don't have a deep understanding of the inner works of Pd, so please bare with me if anything about the style is not ideal. I ` #define USE_PDTK_CANVAS_PROC` in any relevant file. This should be done through configure, but honestly this is easier for developing/debugging so I can switch it off/on per file as needed.

The code can be found here https://github.com/giuliomoro/pure-data-1/tree/1695-tests

I made a few NIT commits to begin with which helped me minimse the `diff` later on. Two commits are meant to be reverted later on as they are used only to log the actual docmds executed by the frontend in such a way that they can be used for automated testing:
  a2f07d98 tcl: print docmds as they get executed. This is for testing purposes (i.e.: to produce consistent logs that are convenient to compare with pure-data-gui-tester) and should not be used in production without a switch to manually enable it
  f227d05b tcl: evaluate one command at a time. This is mainly for testing purposes (i.e.: to produce consistent logs that are convenient to compare with pure-data-gui-tester and not thoroughly tested)

Throughout, I have been testing this with my [pure-data-gui-testing](https://github.com/giuliomoro/pure-data-gui-testing), whose [test patch](https://github.com/giuliomoro/pure-data-gui-testing/blob/main/test-gui.pd) has been extended to include coverage to all (I think) the tcl calls that have been affected by the commits on this branch (incl e.g.: deleting, selecting and moving objects). Where appropriate, I added workarounds in the tcl code to ensure that the tcl command being generated is exactly the same as in the code I am comparing against (a2f07d98). These can be removed at a later date.

What has been migrated:
- create, select, move, delete: plain objects, symbolatom, floatatom, listbox, commentbar, msg, bang and inlets/outlets. This doesn't include the actual text, which is created via the `pdtk_text_*` procedures.
- config, update: bang
- all iemguis: iemgui_label_font, iemgui_label_pos, iemgui_draw_iolets, iemgui_draw_move, 
- all delete operations 
- some move operations
- all text is still generated via existing - unmodified - calls to `pdtk_text_*`

I tried to stay reasonably close to the existing C functions. This means that I have all of the following procs on the tcl side: config create delete iemgui_label_font iemgui_label_pos move select update. This could surely be rationalised further (e.g.: config and update I think are only iemgui-specific). However in some cases I rationalised it a bit more. E.g.: `text_drawborder()`'s `firsttime` flag distinguishes between what semantically are a `create` and a `move` operation and so I made that explicit in the code.
I am minimising the number of arguments to be passed to the GUI, but still recreate the same pixel-accurate drawing. E.g.: creating a `T_OBJECT` passes the x1,y1,x2,y2 coordinates, creating a `T_ATOM` (float or symbol) passes those plus `corner`. In order to allow this, a minimal amount of the logic that is in the C data which is needed to draw the shapes from this data has been duplicated in tcl (see `get_poly_coords()`).  Another example of what is needed to minimise the number of parameters passed is that only the obj's ID (ptr) is passed to the GUI in several bang methods, where it is then manipulated to generate the various OBJ, BASE, BUT, LABEL tags (see bang_get_tags()). On this note, `pdgui_vmess` doesn't seem to allow to pass a plain `%lx` which would be needed for this case, but only `%p` or `.x%lx`, so I have to trim the leading `0x` from the argument in the GUI. It would be great if a type could be added that allows us to pass `%lx` without further processing needed on the front end.

I am currently not following the recommendation above 

> ideally the syntax would be closely modelled after how objects are stored on the disk.

This is in the first instance because I tried to keep the same argument order as the `pdgui_vmess()` calls I am replacing (weeding out unnecessary arguments), in order to facilitate my work. Furthermore, most of these calls (all except for `create`) do not really have a "stored on the disk" counterpart. The parameters I am passing to `create` include more details than what is stored to disk. E.g.: in the case above of `floatatom` with a `-width` of `5`, the actual box's coordinates are computed in the backed based on font size and "width". This logic could be moved to the frontend if desired but it's not there yet.  To complicate the matter further (at least for me), in order to send the object name's (or analogously the atom's or message's or comment's content) alongside the `create()` call would need some refactoring on the core side, as `::create()` is called e.g.: in text_drawborder() while  the text is set created in `rtext_senditup()`. Also keep in mind that if the call to `create()` looks more similar to how the object is stored on disk (e.g.: passing x0 and y0 coordinates and text), then the computation of the size of the box (`rtext_width()`, `rtext_height()`) moves to the frontend and so the hit detection problem manifests itself and needs to be dealt with.

Before doing any further work, I wanted to stop and check in first. Feel free to comment on all of this and the code: this was mostly a time-limited attempt I made in order for me to better understand the issues at hand, but I am not strongly attached to any of the code I wrote.

 I thought I'd make a comment here instead of opening a PR because this is veeery far from being mergeable and this is more of a contribution to the discussion that is ongoing here, but let me know if a PR would be a better approach for this and I can do that.

Not sure whether the conversation is best continued her or on https://github.com/pure-data/pure-data/discussions/1695