### PR TITLE
load accompanying GUI-plugin for library

### DIFF
--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -473,6 +473,9 @@ int sys_loadlib_iter(const char *path, struct _loadlib_data *data)
     for(q = &loaders; q; q = q->next)
         if ((ok = q->loader(data->canvas, data->classname, path)))
             break;
+    if(ok)
+        pdgui_vmess("::pdgui::load_plugin", "ss", data->classname, path);
+
     /* if all loaders failed, try to load as abstraction */
     if (!ok)
         ok = sys_do_load_abs(data->canvas, data->classname, path);


### PR DESCRIPTION
This PR simplifies distributing libraries with accompanying GUI-plugins.

Whenever a Pd-library is loaded, Pd-core signals the GUI to load a GUI-plugin of the same name and in the same path as the loaded external.

### example
1. user loads `zexy`
2. Pd-core finds it in `~/.local/lib/pd/extra/` (the real path being `~/.local/lib/pd/extra/zexy/zexy.pd_linux`) and loads it
3. Pd-core tells Pd-GUI to load a GUI-plugin `zexy` in `~/.local/lib/pd/extra/`
4. The GUI finds the GUI-plugin as `~/.local/lib/pd/extra/zexy/zexy-plugin.tcl` and loads it.
5. zexy can now use all the nifty features provided by its GUI-plugin

### why is this useful?
some libraries come with a considerable amount of GUI code.
E.g. `else` comes with a lot of GUI objects, and implements them as tons of Tcl/Tk code that is compiled into the external itself (and then sent to the GUI).
Others, like `patcherize` ship both a compiled object and a GUI-plugin, and go through hoops and loops to automatically load the external when the GUI-plugin is autoloaded (abusing hidden canvases and what not).

Neither solution is good: `else`'s GUI-objects have hardcoded their Tcl/Tk dependency (and we want to get rid of it - at least theoretically); and the user has no way to *not* load `patcherize` once it's installed.

With this PR, the GUI-part of a library is separated from the core (and theoretically the library could provide multiple GUI-implementations - one for each GUI-frontend), and the user has full control over what they load (using the trusted library loading features)


Closes: https://github.com/pure-data/pure-data/issues/1555