### PR TITLE
fix empty list input for list box (should be treated as a bang)

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -771,8 +771,8 @@ static void gatom_symbol(t_gatom *x, t_symbol *s)
     "nofirstin" flag, the standard list behavior gets confused. */
 static void gatom_list(t_gatom *x, t_symbol *s, int argc, t_atom *argv)
 {
-    /* empty lists are like bang and output value for float and symbol, but clears list */
-    if (argc || x->a_flavor == A_LIST)
+    /* empty lists is like a bang */
+    if (argc)
         gatom_set(x, s, argc, argv);
     gatom_bang(x);
 }


### PR DESCRIPTION
This closes #1682

Currently, if you send an empty list to a list box it has a distinct behaviour than a bang as it sets and outputs an empty list. This was considered a bug as discussed in #1682