### PR TITLE
stable development branch

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -206,7 +206,8 @@ need. For example, to install the autotools & gettext using Homebrew:
 By default, Pd is built for the current system architecture, usually 64 bit. If
 you want to override this you can use the --enable-universal configure option
 which allows you to specify the desired architecture(s) when building Pd. For
-Intel/AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". By
+Intel/AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". For Apple
+Silicon processors (M1, M2, etc), the 64 bit archotecture is called "arm64". By
 default, Pd is built for the architecture of the current system, however you may
 want a 32 bit Pd to work with existing 32 bit externals on a 64 bit system. You
 can override the defaults with --enable-universal:
@@ -218,11 +219,12 @@ compiler:
 * macOS 10.6: i386, x86_64, ppc
 * macOS 10.7+: i386, x86_64
 * macOS 10.15: x86_64
+* macOS 11+: x86_64, arm64
 
 Note: a "fat" Pd may not work on all systems and/or be able to load both 32 or
 64 bit externals. Additionally, you can specify multiple architectures directly:
 
-    # build a "fat" Pd for both 32 and 64 bit
+    # build a "fat" Pd for both 32 and 64 bit Intel
     # may not work on all systems
     ./configure --enable-universal=i386,x86_64
 
@@ -230,10 +232,11 @@ Note: a "fat" Pd may not work on all systems and/or be able to load both 32 or
     # may not work on all systems
     ./configure --enable-universal
 
-The JACK audio server is supported by Pd on macOS. By default, Pd can use the
-Jack OS X runtime framework from http://www.jackosx.com if it is installed on
-the system. Optionally, Pd can also be built with Jack installed via Homebrew or
-Macports, however the runtime framework support must be disabled:
+The JACK audio server is supported by Pd on macOS. By default, Pd can use either
+the offical 64-bit builds for macOS 10.12+ from https://jackaudio.org or the
+older, 32-bit Jack OS X runtime framework if one is installed on the system.
+Optionally, Pd can also be built with Jack installed via Homebrew or Macports,
+however the runtime framework support must be disabled:
 
     brew install jack
     ./configure --disable-jack-framework --enable-jack

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -207,7 +207,7 @@ By default, Pd is built for the current system architecture, usually 64 bit. If
 you want to override this you can use the --enable-universal configure option
 which allows you to specify the desired architecture(s) when building Pd. For
 Intel/AMD processors, 32 bit is called "i386" and 64 bit is "x86_64". For Apple
-Silicon processors (M1, M2, etc), the 64 bit archotecture is called "arm64". By
+Silicon processors (M1, M2, etc), the 64 bit architecture is called "arm64". By
 default, Pd is built for the architecture of the current system, however you may
 want a 32 bit Pd to work with existing 32 bit externals on a 64 bit system. You
 can override the defaults with --enable-universal:

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,7 @@ AC_SUBST(EXTERNAL_EXTENSION)
 AC_SUBST(EXTERNAL_CFLAGS)
 AC_SUBST(EXTERNAL_LDFLAGS)
 AC_SUBST([ALSA_LIBS])
+AC_SUBST([JACK_CFLAGS])
 AC_SUBST([JACK_LIBS])
 
 # pass include paths down to all Makefiles
@@ -373,11 +374,18 @@ AC_ARG_ENABLE([jack],
     [AS_HELP_STRING([--enable-jack], [use JACK audio server])],
     [jack=$enableval], [jack=no])
 AS_IF([test x$jack_framework != xyes -a x$jack = xyes],[
-    AC_CHECK_LIB([rt], [shm_open], [LIBS="$LIBS -lrt"])
-    AC_CHECK_LIB([jack], [jack_set_xrun_callback], [JACK_LIBS="-ljack" ; jack=xrun])
-    AC_CHECK_LIB([jack], [jack_set_error_function], [JACK_LIBS="-ljack" ; jack=yes],
-        [AC_MSG_WARN([JACK development files not found... skipping (See INSTALL.txt)])
-        jack=no])
+    AS_IF([pkg-config --exists jack],[
+        AC_MSG_NOTICE([Using JACK as specified by pkg-config])
+        JACK_CFLAGS=$(pkg-config --cflags jack)
+        JACK_LIBS=$(pkg-config --libs jack)
+        jack=yes
+        ],[
+        AC_CHECK_LIB([rt], [shm_open], [LIBS="$LIBS -lrt"])
+        AC_CHECK_LIB([jack], [jack_set_xrun_callback], [JACK_LIBS="-ljack" ; jack=xrun])
+        AC_CHECK_LIB([jack], [jack_set_error_function], [JACK_LIBS="-ljack" ; jack=yes],
+            [AC_MSG_WARN([JACK development files not found... skipping (See INSTALL.txt)])
+            jack=no])
+        ])
 ])
 
 ##### MMIO #####

--- a/libpd/Makefile
+++ b/libpd/Makefile
@@ -76,12 +76,11 @@ LDFLAGS = $(PLATFORM_LDFLAGS) $(MORELDFLAGS)
 
 PDSRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     g_scalar.c g_traversal.c g_guiconnect.c g_readwrite.c g_editor.c g_clone.c \
-    g_all_guis.c g_bang.c g_hdial.c g_hslider.c g_mycanvas.c g_numbox.c \
-    g_toggle.c g_undo.c g_vdial.c g_vslider.c g_vumeter.c \
-    g_editor_extras.c \
+    g_all_guis.c g_bang.c g_mycanvas.c g_numbox.c g_radio.c g_slider.c \
+    g_toggle.c g_undo.c g_vumeter.c g_editor_extras.c \
     m_pd.c m_class.c m_obj.c m_atom.c m_memory.c m_binbuf.c \
     m_conf.c m_glob.c m_sched.c \
-    s_main.c s_inter.c s_print.c \
+    s_main.c s_inter.c s_inter_gui.c s_print.c \
     s_loader.c s_path.c s_entry.c s_audio.c s_midi.c s_net.c s_utf8.c \
     s_audio_paring.c \
     d_ugen.c d_ctl.c d_arithmetic.c d_osc.c d_filter.c d_dac.c d_misc.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -230,7 +230,7 @@ endif
 ##### Jack Audio Connection Kit #####
 # TODO support Jack xrun
 if JACK
-pd_CFLAGS += -DUSEAPI_JACK -DJACK_XRUN
+pd_CFLAGS += -DUSEAPI_JACK -DJACK_XRUN @JACK_CFLAGS@
 pd_SOURCES_standalone += s_audio_jack.c
 
 if JACK_FRAMEWORK

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -400,6 +400,9 @@ void iemgui_send(void *x, t_iemgui *iemgui, t_symbol *s)
     if(iemgui->x_fsf.x_snd_able)
         oldsndrcvable |= IEM_GUI_OLD_SND_FLAG;
 
+    if(s && gensym("empty") == s)
+        s = 0;
+
     if(s) {
         iemgui->x_snd_unexpanded = s;
         iemgui->x_snd = canvas_realizedollar(iemgui->x_glist, s);
@@ -422,6 +425,9 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
         oldsndrcvable |= IEM_GUI_OLD_RCV_FLAG;
     if(iemgui->x_fsf.x_snd_able)
         oldsndrcvable |= IEM_GUI_OLD_SND_FLAG;
+
+    if(s && gensym("empty") == s)
+        s = 0;
 
     if(s) {
         iemgui->x_rcv_unexpanded = s;

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -431,7 +431,7 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
     }
     if(s)
     {
-        if(strcmp(s->s_name, iemgui->x_rcv->s_name))
+        if(!iemgui->x_rcv || strcmp(s->s_name, iemgui->x_rcv->s_name))
         {
             if(iemgui->x_fsf.x_rcv_able)
                 pd_unbind(&iemgui->x_obj.ob_pd, iemgui->x_rcv);

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -529,6 +529,7 @@ static void slider_set(t_slider *x, t_floatarg f)
     else
         g = (f - x->x_min) / x->x_k;
     x->x_val = (int)(100.0*g + 0.49999);
+    x->x_pos = x->x_val;
     if(x->x_val != old)
         (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
 }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -63,10 +63,10 @@ if {[tk windowingsystem] eq "win32" || \
             set y $::menubarsize
         }
 
-        set x [ expr $x % $width]
-        set y [ expr $y % $height]
-        if {$x < 0} {set x 0}
-        if {$y < 0} {set y 0}
+        set xmin [winfo vrootx .]
+        set ymin [winfo vrooty .]
+        set x [expr ($x - $xmin) % $width + $xmin] 
+        set y [expr ($y - $ymin) % $height + $ymin] 
 
         return [list ${x} ${y} ${w} ${h}]
     }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -64,8 +64,8 @@ if {[tk windowingsystem] eq "win32" || \
 
         set xmin [winfo vrootx .]
         set ymin [winfo vrooty .]
-        set x [expr ($x - $xmin) % $width + $xmin] 
-        set y [expr ($y - $ymin) % $height + $ymin] 
+        set x [expr ($x - $xmin) % $width + $xmin]
+        set y [expr ($y - $ymin) % $height + $ymin]
 
         return [list ${x} ${y} ${w} ${h}]
     }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -50,8 +50,7 @@ if {[tk windowingsystem] eq "win32" || \
     # also check for Tk Cocoa backend on macOS which is only stable in 8.5.13+;
     # newer versions of Tk can handle multiple monitors so allow negative pos
     proc pdtk_canvas_wrap_window {x y w h} {
-        set width [lindex [wm maxsize .] 0]
-        set height [lindex [wm maxsize .] 1]
+        foreach {width height} [wm maxsize .] {break}
 
         if {$w > $width} {
             set w $width


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with unresolvable file conflicts)

it supersedes https://github.com/pure-data/pure-data/pull/1797

---


## bugs

### GUI
- Closes: https://github.com/pure-data/pure-data/issues/1805 (the never-ending story of placing windows on odd desktop layouts)
- Closes: https://github.com/pure-data/pure-data/issues/1826 (crashing regression when setting iemgui receivers)
- Closes: https://github.com/pure-data/pure-data/issues/1827 (regression that prohibits unsetting iemgui send/receive)
- Closes: https://github.com/pure-data/pure-data/issues/1831 (another iemgui regression that would ignore `[set(` messages while dragging sliders)

### build system

- Closes: https://github.com/pure-data/pure-data/issues/1799 (building against pipewire-jack on Fedora)
- Update the non-autotools `libpd` buildsystem

### Documentation
- Updated notes for macOS/arm64