### PR TITLE
Bugfix/tcl window positioning (#1805)

### DIFF
--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -63,10 +63,10 @@ if {[tk windowingsystem] eq "win32" || \
             set y $::menubarsize
         }
 
-        set x [ expr $x % $width]
-        set y [ expr $y % $height]
-        if {$x < 0} {set x 0}
-        if {$y < 0} {set y 0}
+        set xmin [winfo vrootx .]
+        set ymin [winfo vrooty .]
+        set x [expr ($x - $xmin) % $width + $xmin] 
+        set y [expr ($y - $ymin) % $height + $ymin] 
 
         return [list ${x} ${y} ${w} ${h}]
     }


### PR DESCRIPTION
Fix window positioning according to discussion in #1805.

Windows that were saved with negative positions (caused by multiscreen setups with a secondary screen on the left or on top of the primary screen for example) were placed in an invisible area on reload because the wrapping of the position did not consider legitimate negative coordinates.

This PR is to be merged into `develop` branch.

Closes: #1805