### PR TITLE
html: fix broken explanation of how to use pd commandline on macOS

### DIFF
--- a/doc/1.manual/x6.htm
+++ b/doc/1.manual/x6.htm
@@ -256,7 +256,12 @@ brew link --force gettext</pre>
 
 <h4 id="pd-commandline">pd commandline</h4>
 
-<p>WHICHPD=&quot;Pd-0.47-1&quot; alias pd=&quot;/Applications/<span class="math">$WHICHPD.app/Contents/Resources/bin/pd&quot; alias pdsend=&quot;/Applications/$</span>WHICHPD.app/Contents/Resources/bin/pdsend&quot; alias pdreceive=&quot;/Applications/$WHICHPD.app/Contents/Resources/bin/pdreceive&quot;</p>
+
+<pre><code>WHICHPD=&quot;Pd-0.47-1&quot;
+alias pd=&quot;/Applications/$WHICHPD.app/Contents/Resources/bin/pd&quot;
+alias pdsend=&quot;/Applications/$WHICHPD.app/Contents/Resources/bin/pdsend&quot;
+alias pdreceive=&quot;/Applications/$WHICHPD.app/Contents/Resources/bin/pdreceive&quot;
+</code></pre>
 
 <p>Next, reload the profile by either opening a new Terminal window or running:</p>
 


### PR DESCRIPTION
html: fix broken explanation of how to use pd commandline on macOS