### PR TITLE
A few multi-channel bugfixes and improvements

### DIFF
--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -119,7 +119,7 @@ static void plus_dsp(t_plus *x, t_signal **sp)
     else if (bign0 > 1)
         outchans = sp[0]->s_nchans;
     else outchans = 1;
-    signal_setchansout(&sp[2], outchans);
+    signal_setoutchans(&sp[2], outchans);
     if (bign0 > 1) /* first input is a vector */
     {
         if (bign1 > 1)
@@ -152,7 +152,7 @@ static void plus_dsp(t_plus *x, t_signal **sp)
 static void scalarplus_dsp(t_scalarplus *x, t_signal **sp)
 {
     t_int bign = sp[0]->s_length * sp[0]->s_nchans;
-    signal_setchansout(&sp[1], sp[0]->s_nchans);
+    signal_setoutchans(&sp[1], sp[0]->s_nchans);
     dsp_add((bign & 7 ? scalarplus_perform : scalarplus_perf8),
         4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec, bign);
 }
@@ -305,7 +305,7 @@ static void minus_dsp(t_minus *x, t_signal **sp)
     else if (bign0 > 1)
         outchans = sp[0]->s_nchans;
     else outchans = 1;
-    signal_setchansout(&sp[2], outchans);
+    signal_setoutchans(&sp[2], outchans);
     if (bign0 > 1) /* first input is a vector */
     {
         if (bign1 > 1)
@@ -337,7 +337,7 @@ static void minus_dsp(t_minus *x, t_signal **sp)
 static void scalarminus_dsp(t_scalarminus *x, t_signal **sp)
 {
     t_int bign = sp[0]->s_length * sp[0]->s_nchans;
-    signal_setchansout(&sp[1], sp[0]->s_nchans);
+    signal_setoutchans(&sp[1], sp[0]->s_nchans);
     dsp_add((bign & 7 ? scalarminus_perform : scalarminus_perf8),
         4, sp[0]->s_vec, &x->x_g, sp[1]->s_vec, bign);
 }

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -190,7 +190,7 @@ static void sigreceive_dsp(t_sigreceive *x, t_signal **sp)
 {
     x->x_length = sp[0]->s_length;
     sigreceive_set(x, x->x_sym);
-    signal_setchansout(&sp[0], x->x_nchans);
+    signal_setoutchans(&sp[0], x->x_nchans);
     if ((x->x_length * x->x_nchans) & 7)
         dsp_add(sigreceive_perform, 3,
             x, sp[0]->s_vec, (t_int)(x->x_length * x->x_nchans));
@@ -268,7 +268,7 @@ static t_int *sigcatch_perform(t_int *w)
 static void sigcatch_dsp(t_sigcatch *x, t_signal **sp)
 {
     sigcatch_fixbuf(x, sp[0]->s_length);
-    signal_setchansout(&sp[0], x->x_nchans);
+    signal_setoutchans(&sp[0], x->x_nchans);
     dsp_add(sigcatch_perform, 3, x->x_vec, sp[0]->s_vec,
         x->x_length * x->x_nchans);
 }

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -136,7 +136,7 @@ static void pack_tilde_dsp(t_pack *x, t_signal **sp)
 {
     int i;
         /* create an n-channel output signal. sp has n+1 elements. */
-    signal_setchansout(&sp[x->x_nchans], x->x_nchans);
+    signal_setoutchans(&sp[x->x_nchans], x->x_nchans);
         /* add n copy operations to the DSP chain, one from each input */
     for (i = 0; i < x->x_nchans; i++)
          dsp_add_copy(sp[i]->s_vec,
@@ -185,7 +185,7 @@ static void unpack_tilde_dsp(t_unpack *x, t_signal **sp)
         for each one tothe DSP chain */
     for (i = 0; i < x->x_nchans; i++)
     {
-        signal_setchansout(&sp[i+1], 1);
+        signal_setoutchans(&sp[i+1], 1);
         if (i < usenchans)
             dsp_add_copy(sp[0]->s_vec + i * sp[0]->s_length,
                 sp[i+1]->s_vec, sp[0]->s_length);

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -575,7 +575,7 @@ void signal_setborrowed(t_signal *sig, t_signal *sig2)
 
     /* only use this in the context of dsp routines to set number of channels
     on output signal - we assume it's currently a pointer to the null signal */
-void signal_setchansout(t_signal **sig, int nchans)
+void signal_setoutchans(t_signal **sig, int nchans)
 {
     *sig = signal_new((*sig)->s_length, nchans, (*sig)->s_sr, 0);
 }

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -866,8 +866,8 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
             t_float *scalar = obj_findsignalscalar(u->u_obj, i);
                 /* if the object can deal with it, we generate a signal that
                 consists only of a pointer to a scalar. */
-            if (i && (flags & CLASS_NOPROMOTESIG) ||
-                !i && (flags & CLASS_NOPROMOTELEFT))
+            if ((i && (flags & CLASS_NOPROMOTESIG)) ||
+                (!i && (flags & CLASS_NOPROMOTELEFT)))
                     uin->i_signal = signal_new(1, 1, DC_SR(dc), scalar);
             else
             {       /* otherwise we have to add a call to the DSP chain to
@@ -968,7 +968,8 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
                         class_getname(u->u_obj->ob_pd),
                             s1->s_nchans, s1->s_length,
                             s2->s_nchans, s2->s_length);
-                    dsp_add_copy(s1->s_vec, s3->s_vec, s1->s_n);
+                    dsp_add_copy(s1->s_vec, s3->s_vec,
+                        s1->s_length * s1->s_nchans);
                 }
                 else
                 {

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -644,7 +644,7 @@ typedef t_int *(*t_perfroutine)(t_int *args);
 
 EXTERN t_signal *signal_new(int length, int nchans, t_float sr,
     t_sample *scalarptr);
-EXTERN void signal_setchansout(t_signal **sig, int nchans);
+EXTERN void signal_setoutchans(t_signal **sig, int nchans);
 
 EXTERN t_int *plus_perform(t_int *args);
 EXTERN t_int *plus_perf8(t_int *args);


### PR DESCRIPTION
1. fix scalar-scalar versions of `[+~]` and `[-~]`

2. fix DSP flags for `scalarminus` class to prevent bogus output

3. small fixes in `ugen_doit` (parenthesis and a wrong calc size)

4. use a dedicated free-list for scalar signals.
Currently, scalar signals are allocated from the vector free-list and returned to the "borrowed" free-list... Of course, it should really use the same free-list for both operations.
We can't use the vector free-list because it can cause memory leaks. (We overwrite `s_vec` - which might point to an actual 1-sample buffer!)
We *could* use the "borrowed" list, but I'm not sure about the implications. This can be potentially dangerous because both scalar and "borrowed" signals mess with `s_vec` in their own ways.
I think the safest - and clearest - solution is to use a dedicated free-list for scalar signals.

6. rename `signal_setchansout` to `signal_setoutchans`.
Maybe it is just me, but IMO `signal_setchansout` looks really strange. Also, I think "set out(put) channels" makes more sense than "set channels out(put)". @millerpuckette If you don't want this, just merge up to the previous commit :-)