### PR TITLE
Fixed regression: Apple Silicon compilation

### DIFF
--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -919,7 +919,7 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
         routine must fill in "borrowed" signal outputs in case it's either
         a subcanvas or a signal inlet. */
     mess1(&u->u_obj->ob_pd, gensym("dsp"), insig);
-    
+
     for (sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
     {
         uout->o_signal = *sig;

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -918,8 +918,8 @@ static void ugen_doit(t_dspcontext *dc, t_ugenbox *u)
         /* now call the DSP scheduling routine for the ugen.  This
         routine must fill in "borrowed" signal outputs in case it's either
         a subcanvas or a signal inlet. */
-    (*getfn(&u->u_obj->ob_pd, gensym("dsp")))(&u->u_obj->ob_pd, insig);
-
+    mess1(&u->u_obj->ob_pd, gensym("dsp"), insig);
+    
     for (sig = outsig, uout = u->u_out, i = u->u_nout; i--; sig++, uout++)
     {
         uout->o_signal = *sig;


### PR DESCRIPTION
By replacing getfn with mess1, it will compile again on macOS/iOS.