### PR TITLE
clone multi-channel fixes

### DIFF
--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -339,13 +339,17 @@ static void clone_dsp(t_clone *x, t_signal **sp)
             {
                 if (x->x_distributein)
                 {
+                        /* distribute multi-channel signal over instances;
+                        wrap around if channel count is lower than instance count */
+                    int offset = j % sp[i]->s_nchans;
                     tempio[i] = signal_new(0, 1, sp[i]->s_sr, 0);
                     signal_setborrowed(tempio[i], sp[i]);
                     tempio[i]->s_nchans = 1;
-                    tempio[i]->s_vec = sp[i]->s_vec + j * sp[i]->s_length;
+                    tempio[i]->s_vec = sp[i]->s_vec + offset * sp[i]->s_length;
                     tempio[i]->s_refcount = 1;
                 }
-                else  tempio[i] = sp[i];
+                else
+                    tempio[i] = sp[i];
                 sp[i]->s_refcount++;
             }
             for (i = 0; i < nout; i++)
@@ -379,13 +383,17 @@ static void clone_dsp(t_clone *x, t_signal **sp)
             {
                 if (x->x_distributein)
                 {
+                        /* distribute multi-channel signal over instances;
+                        wrap around if channel count is lower than instance count */
+                    int offset = j % sp[i]->s_nchans;
                     tempio[i] = signal_new(0, 1, sp[i]->s_sr, 0);
                     signal_setborrowed(tempio[i], sp[i]);
                     tempio[i]->s_nchans = 1;
-                    tempio[i]->s_vec = sp[i]->s_vec + j * sp[i]->s_length;
+                    tempio[i]->s_vec = sp[i]->s_vec + offset * sp[i]->s_length;
                     tempio[i]->s_refcount = 1;
                 }
-                else  tempio[i] = sp[i];
+                else
+                    tempio[i] = sp[i];
                 sp[i]->s_refcount++;
             }
             for (i = 0; i < nout; i++)


### PR DESCRIPTION
1. If input channels are distributed over instances and the input channel count is smaller than the number of instances, the inputs wrap around. In particular, if you pass a single-channel signal, it is passed to all instances. This matches the behavior of other multi-channel objects, such as `[+~]` or [-~]`.

2. Properly handle multi-channel outputs.
a) no flags: multi-channel outputs are summed channel-wise, just as you would expect.
b) `-d` or `-do` now also work with multi-channel outputs; the total channel count of each output is the channel count of the (first) instance output times the number of instances.

In both cases, we always use the channel counts of the *first* instance for each outlet. If other instances have different channel counts - unusual, but possible! -, we post a warning and take the necessary measures (ignore extra channels resp. fill missing channels with zeros).

Here's a test patch: [clone-mc-test.zip](https://github.com/pure-data/pure-data/files/10540249/clone-mc-test.zip)
