### PR TITLE
fix crash in dsp method of [outlet~] when it is located in toplevel patch

### DIFF
--- a/src/g_io.c
+++ b/src/g_io.c
@@ -471,7 +471,7 @@ void voutlet_dspprolog(struct _voutlet *x, t_signal **parentsigs,
 
 static void voutlet_dsp(t_voutlet *x, t_signal **sp)
 {
-    if (!x->x_buf) return;
+    if (!x->x_buf || !x->x_parentsignal) return;
     if (x->x_borrowed)
     {
             /* if we're just going to make the signal available on the


### PR DESCRIPTION
Fix #1894.
When the [outlet~] is created in a toplevel patch, `x_parentsignal` is NULL, so `voutlet_dsp()` must be aborted.