### PR TITLE
retext msgboxes and comments so we always see the binbuf representation

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1768,7 +1768,12 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
            (void *)canvas_undo_set_recreate(glist_getcanvas(glist),
             &x->te_g, pos));
         binbuf_text(x->te_binbuf, buf, bufsize);
-
+            /* retext, so we see the binbuf representation
+             * rather than the literal text.
+             * otherwise, we are in for a surprise when the
+             * patch is reloaded/copied/duplicated/...
+             */
+        glist_retext(glist, x);
     }
 }
 


### PR DESCRIPTION
this changes what is displayed right after you've typed something into a comment or a msgbox (or anything except objects; but i think comments and msgboxes are the only actually affected thingies).

right now, you can type something into a msgbox (or comment) like this:

```
this text deliberately uses
linebreaks; it also uses multiple representations
of numbers, like 10 or 10.0000 or 1e1 or 10.
```

Once the msgbox is instantiated, it keeps the formatting as is.

![msgbox0](https://user-images.githubusercontent.com/214034/226571197-910ef76d-efea-4f55-9413-86eb3accf611.jpg)


However, when the patch is saved and reloaded, or when duplicating the msgbox or copy/pasting it, the contents will be reformatted to match the standard binbuf representation:

![msgbox1](https://user-images.githubusercontent.com/214034/226571470-af8da738-9e9d-45ec-8d4c-c21aecefbc81.jpg)

This is weird and leads to an inconsistent experience.

What makes matters even more inconsistent is, that normal objectboxes behave differently, as they always show the binbuf representation (that is: you can create an object `[float 3.141592654]` but as soon as the object is instantiated it will be displayed as `[float 3.14159]`.

This PR tries to make the experience more consistent by transforming  the raw input string into its binbuf representation also for comments and msgboxes.
In practice this means that while you can fill a msgbox with the content as shown in fig.1, as soon as you leave the msgbox it will reformat itself immediately so it looks like fig.2

Closes: https://github.com/pure-data/pure-data/issues/1925