### PR TITLE
enlarge hot area for outlets

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2390,22 +2390,20 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
                 int iow = IOWIDTH * x->gl_zoom;
                 int nout1 = (noutlet > 1 ? noutlet - 1 : 1);
                 int closest = ((xpos-x1) * (nout1) + width/2)/width;
-                int hotspot = x1 +
-                    (width - iow) * closest / (nout1);
-                if (closest < noutlet &&
-                    xpos >= (hotspot - x->gl_zoom) &&
-                    xpos <= hotspot + (iow + x->gl_zoom))
+                if (noutlet == 1 || closest < noutlet)
                 {
                     if (doit)
                     {
                         int issignal = obj_issignaloutlet(hitobj, closest);
+                        int xout = x1 + IOMIDDLE * x->gl_zoom +
+                            (noutlet > 1 ? ((width - iow) * closest)/nout1 : 0);
                         x->gl_editor->e_onmotion = MA_CONNECT;
-                        x->gl_editor->e_xwas = xpos;
-                        x->gl_editor->e_ywas = ypos;
+                        x->gl_editor->e_xwas = xout;
+                        x->gl_editor->e_ywas = y2;
                         pdgui_vmess("::pdtk_canvas::cords_to_foreground", "ci", x, 0);
                         pdgui_vmess(0, "crr iiii ri rs",
                             x, "create", "line",
-                            xpos,ypos, xpos,ypos,
+                            x->gl_editor->e_xwas,x->gl_editor->e_ywas, xpos,ypos,
                             "-width", (issignal ? 2 : 1) * x->gl_zoom,
                             "-tags", "x");
                     }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2359,6 +2359,11 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
         else
         {
             int noutlet;
+            int out_activeminh = (OHEIGHT + 1)  * x->gl_zoom;
+            int out_activemaxh = (y2 - y1) / 4;
+            int out_activeheight = OHEIGHT * 2 * x->gl_zoom;
+            if (out_activeheight > out_activemaxh) out_activeheight = out_activemaxh;
+            if (out_activeheight < out_activeminh) out_activeheight = out_activeminh;
                 /* resize? only for "true" text boxes or canvases */
             if (xpos >= x2-4 && ypos < y2-4 && hitobj &&
                     (hitobj->te_pd->c_wb == &text_widgetbehavior ||
@@ -2384,7 +2389,7 @@ static void canvas_doclick(t_canvas *x, int xpos, int ypos, int which,
             }
                 /* look for an outlet */
             else if (hitobj && (noutlet = obj_noutlets(hitobj)) &&
-                ypos >= y2 - (OHEIGHT*x->gl_zoom) + x->gl_zoom)
+                ypos >= y2 - out_activeheight)
             {
                 int width = x2 - x1;
                 int iow = IOWIDTH * x->gl_zoom;


### PR DESCRIPTION
people keep complaining about not being able to create a connection on HiDPI screens, because the hotspot for starting a connection is too small.

while "intelligent patching" addresses some of these problems (e.g. by being able to <kbd>Tab</kbd>-cycle the outlets until you find the one you want), it requires a change in workflow.

This PR simply enlargens the outlet hotspot:
- the height of the hotspot is raised to the double size of the outlet. however it will not cover more than ¼ of the entire object height (typically this means that the height of the hotspot is ¼ if the object height)
- the width of the hotspots is no longer limited. instead you always get the *nearest* outlet (similar to how inlets are currently selected)
- the pending connection line will always start in the center of the chosen outlet (as opposed to now, where it starts at whichever position the mouse was on)

![test](https://user-images.githubusercontent.com/214034/226576578-3b4dfbc8-d890-4d75-8056-4e884c6891c3.gif)


I can see a small drawback though: the outlet hotarea takes precedence over the "edit click" (that is clicking into an object box to change its contents). with the enlarged hotarea, this means that when you want to edit an object chances are now higher that you accidentally click into the outlet hotarea (which will start a new connection, rather than put the object into text edit mode).
This is the reason why I've used a relatively small height-enlargment (for a 20pix object - the default at 12pt fonts) the new hot area is now 5 pixes instead of 4. I think together with the larger width, this is already an improvement for HiDPI screens.
With larger objects (fontsizes) the active area grows in absolute height (while previously it was constant), which is another improvement for HiDPI, where typically larger fontsizes need to be used.

(This small drawback is the reason why I have not committed this directly to the `develop` branch)

- Closes: https://github.com/pure-data/pure-data/issues/1926