### PR TITLE
only redraw all scalars when template's owning canvas is in edit mode

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -45,9 +45,10 @@ void glist_add(t_glist *x, t_gobj *y)
     }
     if (glist_isvisible(x))
         gobj_vis(y, x, 1);
-    if (class_isdrawcommand(y->g_pd))
+    t_canvas *c = glist_getcanvas(x);
+    if (class_isdrawcommand(y->g_pd) && c->gl_edit)
         canvas_redrawallfortemplate(template_findbyname(canvas_makebindsym(
-            glist_getcanvas(x)->gl_name)), 0);
+            c->gl_name)), 0);
 }
 
     /* this is to protect against a hairy problem in which deleting


### PR DESCRIPTION
This is an attempt to address #1918. 

Apparently, redraws are only necessary when editing templates so that changes to the templates are reflected in all scalars. As long as the template is not edited, redrawing all scalars seems superfluous.

This PR suppresses redraws normally and enables them for structs in canvasses that are in edit mode.  I couldn't spot any regression after testing all kinds of patches using data structures. 