### PR TITLE
Do not save template structs at the head of patch files (fixes #772)

### DIFF
--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -750,46 +750,6 @@ static void canvas_collecttemplatesfor(t_canvas *x, int *ntemplatesp,
     }
 }
 
-    /* save the templates needed by a canvas to a binbuf. */
-static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
-{
-    t_symbol **templatevec = getbytes(0);
-    int i, ntemplates = 0;
-    canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
-    for (i = 0; i < ntemplates; i++)
-    {
-        t_template *template = template_findbyname(templatevec[i]);
-        int j, m;
-        if (!template)
-        {
-            bug("canvas_savetemplatesto");
-            continue;
-        }
-        m = template->t_n;
-            /* drop "pd-" prefix from template symbol to print */
-        binbuf_addv(b, "sss", &s__N, gensym("struct"),
-            gensym(templatevec[i]->s_name + 3));
-        for (j = 0; j < m; j++)
-        {
-            t_symbol *type;
-            switch (template->t_vec[j].ds_type)
-            {
-                case DT_FLOAT: type = &s_float; break;
-                case DT_SYMBOL: type = &s_symbol; break;
-                case DT_ARRAY: type = gensym("array"); break;
-                case DT_TEXT: type = gensym("text"); break;
-                default: type = &s_float; bug("canvas_write");
-            }
-            if (template->t_vec[j].ds_type == DT_ARRAY)
-                binbuf_addv(b, "sss", type, template->t_vec[j].ds_name,
-                    gensym(template->t_vec[j].ds_arraytemplate->s_name + 3));
-            else binbuf_addv(b, "ss", type, template->t_vec[j].ds_name);
-        }
-        binbuf_addsemi(b);
-    }
-    freebytes(templatevec, ntemplates * sizeof(*templatevec));
-}
-
 void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except);
 
     /* save a "root" canvas to a file; cf. canvas_saveto() which saves the
@@ -798,7 +758,6 @@ static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
     float fdestroy)
 {
     t_binbuf *b = binbuf_new();
-    canvas_savetemplatesto(x, b, 1);
     canvas_saveto(x, b);
     errno = 0;
     if (binbuf_write(b, filename->s_name, dir->s_name, 0))


### PR DESCRIPTION
This addresses #772.

The function `canvas_savetemplatesto`  scans current and all child canvases recursively and writes the structs it finds to the head of the patchfile. This "taints" the current canvas with structs from all its children with no apparent reason. Templates still load fine without the `#N struct ` lines in the beginning of Pd files. 