### PR TITLE
set vector length of a new throw~ to 64

### DIFF
--- a/src/d_global.c
+++ b/src/d_global.c
@@ -307,7 +307,7 @@ static void *sigthrow_new(t_symbol *s)
     t_sigthrow *x = (t_sigthrow *)pd_new(sigthrow_class);
     x->x_sym = s;
     x->x_whereto  = 0;
-    x->x_length = 1;
+    x->x_length = 64;
     x->x_f = 0;
     return (x);
 }


### PR DESCRIPTION
If we're going to initialize it to some random value, then at least to one that doesn't trigger error messages in most cases.


fixes #1901