### PR TITLE
Add wm_state in pd files updated by setbounds

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -685,7 +685,6 @@ static void canvas_dosetbounds(t_canvas *x, t_symbol * wm_state, int x1, int y1,
         pd_error(0, "Error recording wm_state");
     }
 
-
     if (!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
     {
             /* if it's flipped so that y grows upward,
@@ -1177,7 +1176,7 @@ static void canvas_relocate(t_canvas *x, t_symbol *canvasgeom,
             we just suppress that here. */
     if (cw > 5 && ch > 5)
         canvas_dosetbounds(x, gensym("normal"), txpix, typix,
-                           txpix + cw, typix + ch);
+            txpix + cw, typix + ch);
 }
 
 void canvas_popabstraction(t_canvas *x)
@@ -2039,9 +2038,9 @@ void g_canvas_setup(void)
         /* we prevent the user from typing "canvas" in an object box
         by sending 0 for a creator function. */
     canvas_class = class_new(gensym("canvas"), 0,
-                             (t_method)canvas_free, sizeof(t_canvas),
-                             CLASS_NOINLET | CLASS_MULTICHANNEL, 0);
-        /* here is the real creator function, invoked in patch files
+        (t_method)canvas_free, sizeof(t_canvas),
+            CLASS_NOINLET | CLASS_MULTICHANNEL, 0);
+            /* here is the real creator function, invoked in patch files
             by sending the "canvas" message to #N, which is bound
             to pd_camvasmaker. */
     class_addmethod(pd_canvasmaker, (t_method)canvas_new, gensym("canvas"),
@@ -2051,7 +2050,7 @@ void g_canvas_setup(void)
     class_addmethod(canvas_class, (t_method)canvas_coords,
         gensym("coords"), A_GIMME, 0);
 
-        /* -------------------------- objects ----------------------------- */
+/* -------------------------- objects ----------------------------- */
     class_addmethod(canvas_class, (t_method)canvas_obj,
         gensym("obj"), A_GIMME, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_msg,
@@ -2104,7 +2103,7 @@ void g_canvas_setup(void)
     class_addmethod(canvas_class, (t_method)canvas_loadbang,
         gensym("loadbang"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_setbounds,
-                    gensym("setbounds"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+        gensym("setbounds"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_relocate,
         gensym("relocate"), A_SYMBOL, A_SYMBOL, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_vis,
@@ -2164,7 +2163,7 @@ void canvas_add_for_class(t_class *c)
     class_addmethod(c, (t_method)canvas_map,
         gensym("map"), A_FLOAT, A_NULL);
     class_addmethod(c, (t_method)canvas_setbounds,
-                    gensym("setbounds"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+        gensym("setbounds"), A_SYMBOL, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
     canvas_editor_for_class(c);
     canvas_readwrite_for_class(c);
     /* g_graph_setup_class(c); */

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -176,9 +176,7 @@ struct _glist
     int gl_screeny1;
     int gl_screenx2;
     int gl_screeny2;
-
     t_symbol * gl_wm_state;     /* wm state */
-
     int gl_xmargin;                /* origin for GOP rectangle */
     int gl_ymargin;
     t_tick gl_xtick;            /* ticks marking X values */

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -176,6 +176,9 @@ struct _glist
     int gl_screeny1;
     int gl_screenx2;
     int gl_screeny2;
+
+    t_symbol * gl_wm_state;     /* wm state */
+
     int gl_xmargin;                /* origin for GOP rectangle */
     int gl_ymargin;
     t_tick gl_xtick;            /* ticks marking X values */

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1254,6 +1254,7 @@ typedef struct _undo_canvas_properties
     int gl_screeny1;
     int gl_screenx2;
     int gl_screeny2;
+    t_symbol * gl_wm_state;
     int gl_xmargin;             /* origin for GOP rectangle */
     int gl_ymargin;
 
@@ -1279,6 +1280,7 @@ void *canvas_undo_set_canvas(t_canvas *x)
     buf->gl_screeny1 = x->gl_screeny1;
     buf->gl_screenx2 = x->gl_screenx2;
     buf->gl_screeny2 = x->gl_screeny2;
+    buf->gl_wm_state = x->gl_wm_state;
     buf->gl_xmargin = x->gl_xmargin;
     buf->gl_ymargin = x->gl_ymargin;
     buf->gl_goprect = x->gl_goprect;
@@ -1316,6 +1318,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         tmp.gl_screeny1 = x->gl_screeny1;
         tmp.gl_screenx2 = x->gl_screenx2;
         tmp.gl_screeny2 = x->gl_screeny2;
+        tmp.gl_wm_state = x->gl_wm_state;
         tmp.gl_xmargin = x->gl_xmargin;
         tmp.gl_ymargin = x->gl_ymargin;
         tmp.gl_goprect = x->gl_goprect;
@@ -1333,6 +1336,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         x->gl_screeny1 = buf->gl_screeny1;
         x->gl_screenx2 = buf->gl_screenx2;
         x->gl_screeny2 = buf->gl_screeny2;
+        x->gl_wm_state = buf->gl_wm_state;
         x->gl_xmargin = buf->gl_xmargin;
         x->gl_ymargin = buf->gl_ymargin;
         x->gl_goprect = buf->gl_goprect;
@@ -1350,6 +1354,7 @@ int canvas_undo_canvas_apply(t_canvas *x, void *z, int action)
         buf->gl_screeny1 = tmp.gl_screeny1;
         buf->gl_screenx2 = tmp.gl_screenx2;
         buf->gl_screeny2 = tmp.gl_screeny2;
+        buf->gl_wm_state = tmp.gl_wm_state;
         buf->gl_xmargin = tmp.gl_xmargin;
         buf->gl_ymargin = tmp.gl_ymargin;
         buf->gl_goprect = tmp.gl_goprect;
@@ -1900,10 +1905,10 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 sprintf(winpos, "+%d+%d", (int)(x->gl_screenx1), (int)(x->gl_screeny1));
             }
 
-            pdgui_vmess("pdtk_canvas_new", "^ ii si", x,
+            pdgui_vmess("pdtk_canvas_new", "^ ii si s", x,
                 (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1),
-                winpos, x->gl_edit);
+                        winpos, x->gl_edit, x->gl_wm_state->s_name);
 
             numparents = 0;
             while (c->gl_owner && !c->gl_isclone) {

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1908,7 +1908,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             pdgui_vmess("pdtk_canvas_new", "^ ii si s", x,
                 (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1),
-                        winpos, x->gl_edit, x->gl_wm_state->s_name);
+                winpos, x->gl_edit, x->gl_wm_state->s_name);
 
             numparents = 0;
             while (c->gl_owner && !c->gl_isclone) {

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -687,12 +687,13 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
         /* root or abstraction */
     else
     {
-        binbuf_addv(b, "ssiiiii;", gensym("#N"), gensym("canvas"),
+        binbuf_addv(b, "ssiiiiis;", gensym("#N"), gensym("canvas"),
             (int)(x->gl_screenx1),
             (int)(x->gl_screeny1),
             (int)(x->gl_screenx2 - x->gl_screenx1),
             (int)(x->gl_screeny2 - x->gl_screeny1),
-                (int)x->gl_font);
+            (int)x->gl_font,
+            x->gl_wm_state);
         canvas_savedeclarationsto(x, b);
     }
     for (y = x->gl_list; y; y = y->g_next)

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -1477,7 +1477,7 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
         pd_error(0, "%s: read failed; %s", name->s_name, strerror(errno));
     else
     {
-        /* save bindings of symbols #N, #A (and restore afterward) */
+            /* save bindings of symbols #N, #A (and restore afterward) */
         t_pd *bounda = gensym("#A")->s_thing, *boundn = s__N.s_thing;
         gensym("#A")->s_thing = 0;
         s__N.s_thing = &pd_canvasmaker;

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -1477,7 +1477,7 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
         pd_error(0, "%s: read failed; %s", name->s_name, strerror(errno));
     else
     {
-            /* save bindings of symbols #N, #A (and restore afterward) */
+        /* save bindings of symbols #N, #A (and restore afterward) */
         t_pd *bounda = gensym("#A")->s_thing, *boundn = s__N.s_thing;
         gensym("#A")->s_thing = 0;
         s__N.s_thing = &pd_canvasmaker;

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -362,10 +362,8 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
 
     pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
-
     # send the size/location status of the window and canvas to 'pd' in the form of:
-    #    left top right bottom status
-
+    #    status left top right bottom 
     pdsend "$mytoplevel setbounds $wm_state $x $y [expr $x + $width] [expr $y + $height]"
 }
 

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -349,18 +349,24 @@ proc ::pd_bindings::patch_unmap {mytoplevel} {
 }
 
 proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
+    set wm_state [wm state $mytoplevel]
+
     if {$width == 1 || $height == 1} {
         # make sure the window is fully created
         update idletasks
     }
+
     # the geometry we receive from the callback is really for the frame
     # however, we need position including the border decoration
     # as this is how we restore the position
     scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
+
     pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
-    # send the size/location of the window and canvas to 'pd' in the form of:
-    #    left top right bottom
-    pdsend "$mytoplevel setbounds $x $y [expr $x + $width] [expr $y + $height]"
+
+    # send the size/location status of the window and canvas to 'pd' in the form of:
+    #    left top right bottom status
+
+    pdsend "$mytoplevel setbounds $wm_state $x $y [expr $x + $width] [expr $y + $height]"
 }
 
 proc ::pd_bindings::patch_destroy {window} {

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -95,7 +95,7 @@ proc pdtk_canvas_place_window {width height geometry} {
 #------------------------------------------------------------------------------#
 # canvas new/saveas
 
-proc pdtk_canvas_new {mytoplevel width height geometry editable} {
+proc pdtk_canvas_new {mytoplevel width height geometry editable wm_state} {
     if { "" eq $geometry } {
         # no position set: this is a new window (rather than one loaded from file)
         # we set a flag here, so we can query (and report) the actual geometry,
@@ -124,6 +124,10 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable} {
     if { "" != ${geometry} } {
         wm geometry $mytoplevel $geometry
     }
+    if { "" != ${wm_state} } {
+        wm state $mytoplevel $wm_state
+    }
+
     wm minsize $mytoplevel $::canvas_minwidth $::canvas_minheight
 
     set tkcanvas [tkcanvas_name $mytoplevel]
@@ -340,6 +344,7 @@ proc ::pdtk_canvas::finished_loading_file {mytoplevel} {
     if { "" ne [array names ::pdtk_canvas::geometry_needs_init $mytoplevel ] } {
         array unset ::pdtk_canvas::geometry_needs_init $mytoplevel
         scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
+        set wm_state [wm state $mytoplevel]
         # on X11, 'wm geometry' won't report a useful position until the window was moved
         # but 'winfo geometry' does (though slightly off, but we ignore this offset
         # for newly created, never moved windows)
@@ -347,7 +352,7 @@ proc ::pdtk_canvas::finished_loading_file {mytoplevel} {
         # they report the same for 'wm geometry' and 'winfo geometry'
         if { "+$x+$y" eq "+0+0" } {
             scan [winfo geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
-            pdsend "$mytoplevel setbounds $x $y [expr $x + $width] [expr $y + $height]"
+            pdsend "$mytoplevel setbounds ${wm_state} $x $y [expr $x + $width] [expr $y + $height]"
         }
     }
 }


### PR DESCRIPTION
This pull request intends to add the wm state (zoomed / normal) in the pd file as set when user save its pd file.
Reading a pd file without this state set it to normal.
See #1959 

I tested it on mingw64 host with both save/load of new .pd file and former ones.

A clear limitation of this patch is that it may leads to regression with other gui than the default tcl tk one (i.e. modification of pd communication protocol on "setbounds" command) .