### PR TITLE
Feature/msw compile for debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,6 @@ PD_LDFLAGS=""
 PD_CHECK_IPHONE(IPHONEOS=yes, IPHONEOS=no, AC_MSG_ERROR([iOS SDK not available]))
 PD_CHECK_ANDROID(ANDROID=yes, ANDROID=no, AC_MSG_ERROR([Android SDK not available]))
 
-
 AS_CASE([$host],
 [*darwin*],[
     AS_IF([test "x${IPHONEOS}" = "xno"],[
@@ -134,6 +133,7 @@ AS_CASE([$host],
 
     # externals are dynamically linked to pd.dll in their individual automake files
     EXTERNAL_CFLAGS="-mms-bitfields"
+    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -lpd"
     EXTERNAL_EXTENSION=dll
 
     # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling
@@ -274,6 +274,7 @@ AC_SUBST([ALSA_LIBS])
 AC_SUBST([JACK_CFLAGS])
 AC_SUBST([JACK_LIBS])
 
+# Whether to strip symbol from binaries (msw_strip="") or not (msw_strip="-n") on windows. Used in msw/Makefile
 AC_SUBST([msw_strip])
 
 # pass include paths down to all Makefiles
@@ -292,10 +293,8 @@ AS_IF([test x$debug = xyes],[
 
 AS_IF([test "x${debug}" = "xyes" -a "x${WINDOWS}" = "xyes" ],[
     msw_strip="-n"
-    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -lpd"
     ],[
     msw_strip=""
-    EXTERNAL_LDFLAGS="-s -Wl,--enable-auto-import -no-undefined -lpd"
     ])
 
 ##### macOS version min #####

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,7 @@ PD_LDFLAGS=""
 PD_CHECK_IPHONE(IPHONEOS=yes, IPHONEOS=no, AC_MSG_ERROR([iOS SDK not available]))
 PD_CHECK_ANDROID(ANDROID=yes, ANDROID=no, AC_MSG_ERROR([Android SDK not available]))
 
+
 AS_CASE([$host],
 [*darwin*],[
     AS_IF([test "x${IPHONEOS}" = "xno"],[
@@ -133,7 +134,6 @@ AS_CASE([$host],
 
     # externals are dynamically linked to pd.dll in their individual automake files
     EXTERNAL_CFLAGS="-mms-bitfields"
-    EXTERNAL_LDFLAGS="-s -Wl,--enable-auto-import -no-undefined -lpd"
     EXTERNAL_EXTENSION=dll
 
     # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling
@@ -274,6 +274,8 @@ AC_SUBST([ALSA_LIBS])
 AC_SUBST([JACK_CFLAGS])
 AC_SUBST([JACK_LIBS])
 
+AC_SUBST([msw_strip])
+
 # pass include paths down to all Makefiles
 AC_SUBST([AM_CPPFLAGS], [$AM_CPPFLAGS])
 
@@ -287,6 +289,14 @@ AS_IF([test x$debug = xyes],[
     PD_CFLAGS="$RELEASE_CFLAGS $PD_CFLAGS"
     PD_CPPFLAGS="-DNDEBUG $PD_CPPFLAGS"
 ])
+
+AS_IF([test "x${debug}" = "xyes" -a "x${WINDOWS}" = "xyes" ],[
+    msw_strip="-n"
+    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -lpd"
+    ],[
+    msw_strip=""
+    EXTERNAL_LDFLAGS="-s -Wl,--enable-auto-import -no-undefined -lpd"
+    ])
 
 ##### macOS version min #####
 AS_IF([test "x$macos_version_min" != "x"],[

--- a/msw/Makefile.am
+++ b/msw/Makefile.am
@@ -11,7 +11,7 @@ if WINDOWS
 # build a standalone application directory on Windows
 app:
 	rm -rf $(top_builddir)/pd-$(VERSION)
-	$(SH) $(top_srcdir)/msw/msw-app.sh --sources --builddir $(top_builddir) $(VERSION)
+	$(SH) $(top_srcdir)/msw/msw-app.sh ${msw_strip} --sources --builddir $(top_builddir) $(VERSION)
 	mv $(top_builddir)/msw/pd-$(VERSION) $(top_builddir)
 
 else

--- a/msw/README.txt
+++ b/msw/README.txt
@@ -145,14 +145,11 @@ source.
 
 ## debug
 
-To avoid stripping symbols out of libtool pre-binaries and debug pd,call configure with --enable-debug and CFLAGS=-g :
+If you intend to debug Pd, you probably want an unoptimized build with debug symbols. This can be achieved with the following flags:
 
-./configure --enable-debug CFLAGS=-g
+./configure --enable-debug CFLAGS="-g -O0"
 make
 make app
 
-This will call msw-app.sh with the -n flag (through msw_strip variable)
-
-The call to gdb shall be perform using libtool mode execute :
-libtool --mode=execute gdb --args pd-0.53.1/bin/pd.exe
+This will call msw-app.sh with the -n flag, preventing it from stripping the debug symbols
 

--- a/msw/README.txt
+++ b/msw/README.txt
@@ -142,3 +142,17 @@ Pd font.
 Currently, pdfontloader.dll is pre-built and included within the pdprototype.tgz
 tarball. To build pdfontloader, see https://github.com/pure-data/pdfontloader
 source.
+
+## debug
+
+To avoid stripping symbols out of libtool pre-binaries and debug pd,call configure with --enable-debug and CFLAGS=-g :
+
+./configure --enable-debug CFLAGS=-g
+make
+make app
+
+This will call msw-app.sh with the -n flag (through msw_strip variable)
+
+The call to gdb shall be perform using libtool mode execute :
+libtool --mode=execute gdb --args pd-0.53.1/bin/pd.exe
+


### PR DESCRIPTION
This pull request propose to be able to build on mingw64 in debug mode (i.e. with symbols findable by gdb) as discussed in #1961  .
It adds the -n flag on the call to msw-app.sh when configure is called with --enable-debug and also remove -s on the EXTERNAL_LDFLAGS.

Note that the modification around EXTERNAL_LDFLAGS is not tested and should be removed from the patch (I can correct it on a subsequent commit).

Also add some details in the README.txt

I tested this sequence on mingw64 :

```
mkdir build
cd build
../configure --enable-debug CFLAGS=-g
make
make app
libtool --mode=execute gdb --args pd-0.53.1/bin/pd.exe
```

I have been able to test modification proposal of #1960 with it.

Thx for your attention.