### PR TITLE
Some missing multichannel objects

### DIFF
--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -388,52 +388,80 @@ static t_class *snapshot_tilde_class;
 typedef struct _snapshot
 {
     t_object x_obj;
-    t_sample x_value;
     t_float x_f;
+    int x_n;
+    t_atom *x_vec;
 } t_snapshot;
 
 static void *snapshot_tilde_new(void)
 {
     t_snapshot *x = (t_snapshot *)pd_new(snapshot_tilde_class);
-    x->x_value = 0;
-    outlet_new(&x->x_obj, &s_float);
+    x->x_vec = getbytes(sizeof(t_atom));
+    SETFLOAT(x->x_vec, 0);
+    x->x_n = 1;
     x->x_f = 0;
+    outlet_new(&x->x_obj, &s_float);
     return (x);
+}
+
+static void snapshot_tilde_free(t_snapshot *x)
+{
+    freebytes(x->x_vec, x->x_n * sizeof(t_atom));
 }
 
 static t_int *snapshot_tilde_perform(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
-    t_sample *out = (t_sample *)(w[2]);
-    *out = *in;
-    return (w+3);
+    t_atom *out = (t_atom *)(w[2]);
+    int nchans = (int)(w[3]);
+    int n = (int)(w[4]), i;
+    for (i = 0; i < nchans; i++)
+        SETFLOAT(out + i, in[i * n]);
+    return (w+5);
 }
 
 static void snapshot_tilde_dsp(t_snapshot *x, t_signal **sp)
 {
-    dsp_add(snapshot_tilde_perform, 2, sp[0]->s_vec + (sp[0]->s_n-1),
-        &x->x_value);
+    int i, nchans = sp[0]->s_nchans;
+    if (nchans != x->x_n)
+    {
+        x->x_vec = (t_atom *)resizebytes(x->x_vec,
+            x->x_n * sizeof(t_atom), nchans * sizeof(t_atom));
+        for (i = x->x_n; i < nchans; i++)
+            SETFLOAT(x->x_vec + i, 0);
+        x->x_n = nchans;
+    }
+    dsp_add(snapshot_tilde_perform, 4, sp[0]->s_vec + (sp[0]->s_n-1),
+        x->x_vec, (t_int)nchans, (t_int)sp[0]->s_n);
 }
 
 static void snapshot_tilde_bang(t_snapshot *x)
 {
-    outlet_float(x->x_obj.ob_outlet, x->x_value);
+    outlet_list(x->x_obj.ob_outlet, &s_list, x->x_n, x->x_vec);
 }
 
-static void snapshot_tilde_set(t_snapshot *x, t_floatarg f)
+static void snapshot_tilde_set(t_snapshot *x, t_symbol *s, int argc, t_atom *argv)
 {
-    x->x_value = f;
+    int i;
+    if (argc > 0)
+    {
+        for (i = 0; i < argc && i < x->x_n; i++)
+            SETFLOAT(x->x_vec + i, atom_getfloat(argv + i));
+    }
+    else /* emulate previous A_DEFFLOAT behavior */
+        SETFLOAT(x->x_vec, 0);
 }
 
 static void snapshot_tilde_setup(void)
 {
-    snapshot_tilde_class = class_new(gensym("snapshot~"), snapshot_tilde_new, 0,
-        sizeof(t_snapshot), 0, 0);
+    snapshot_tilde_class = class_new(gensym("snapshot~"),
+        snapshot_tilde_new, (t_method)snapshot_tilde_free,
+            sizeof(t_snapshot), CLASS_MULTICHANNEL, 0);
     CLASS_MAINSIGNALIN(snapshot_tilde_class, t_snapshot, x_f);
     class_addmethod(snapshot_tilde_class, (t_method)snapshot_tilde_dsp,
         gensym("dsp"), A_CANT, 0);
     class_addmethod(snapshot_tilde_class, (t_method)snapshot_tilde_set,
-        gensym("set"), A_DEFFLOAT, 0);
+        gensym("set"), A_GIMME, 0);
     class_addbang(snapshot_tilde_class, snapshot_tilde_bang);
 }
 

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -23,24 +23,35 @@ static t_int *print_perform(t_int *w)
 {
     t_print *x = (t_print *)(w[1]);
     t_sample *in = (t_sample *)(w[2]);
-    int n = (int)(w[3]);
+    int nchans = (int)(w[3]);
+    int n = (int)(w[4]);
     if (x->x_count)
     {
-        int i=0;
+        int i, j;
         startpost("%s:", x->x_sym->s_name);
-        for(i=0; i<n; i++) {
-          if(i%8==0)endpost();
-          startpost("%.4g  ", in[i]);
+        for (j = 0; j < nchans; j++)
+        {
+            if (nchans > 1)
+            {
+                endpost();
+                startpost("channel %d:", j + 1);
+            }
+            for (i = 0; i < n; i++) {
+                if (i % 8 == 0)
+                    endpost();
+                startpost("%.4g  ", in[j * n + i]);
+            }
         }
         endpost();
         x->x_count--;
     }
-    return (w+4);
+    return (w+5);
 }
 
 static void print_dsp(t_print *x, t_signal **sp)
 {
-    dsp_add(print_perform, 3, x, sp[0]->s_vec, (t_int)sp[0]->s_n);
+    dsp_add(print_perform, 4, x, sp[0]->s_vec,
+        (t_int)sp[0]->s_nchans, (t_int)sp[0]->s_n);
 }
 
 static void print_float(t_print *x, t_float f)
@@ -66,7 +77,7 @@ static void *print_new(t_symbol *s)
 static void print_setup(void)
 {
     print_class = class_new(gensym("print~"), (t_newmethod)print_new, 0,
-        sizeof(t_print), 0, A_DEFSYM, 0);
+        sizeof(t_print), CLASS_MULTICHANNEL, A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(print_class, t_print, x_f);
     class_addmethod(print_class, (t_method)print_dsp, gensym("dsp"), A_CANT, 0);
     class_addbang(print_class, print_bang);


### PR DESCRIPTION
* `[print~]`: print multichannel signals:
    ```
    <symbol>:
    channel 1:
    <data>
    channel 2:
    <data>
    ...
    ```
* `[snapshot~]`: handle multichannels signals by outputting a list

* `[sig~]`: multiple creation arguments generate a multichannel signal; each scalar value gets a float inlet.