### PR TITLE
Co-installable double-builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,12 @@ LIBPD_DIST = libpd/Makefile libpd/README.txt libpd/test_libpd/Makefile \
 # files that are included but not built
 EXTRA_DIST = LICENSE.txt README.txt INSTALL.txt $(LIBPD_DIST)
 
+pkgdata_DATA = \
+    LICENSE.txt \
+    README.txt \
+    $(empty)
+
+
 # subdirs that are built,
 # mac before src due to uninstall target order kludge (see mac/Makefile.am)
 SUBDIRS = $(EXTRA_SUBDIRS) linux mac msw src man doc tcl extra font

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,12 @@ wish="wish"
 audio_backends=""
 midi_backends=""
 
+# deken information
+deken_os=""
+deken_cpu=""
+deken_ext="so"
+floatsize=""
+
 # debug/release defaults
 DEBUG_CFLAGS="-O0"
 RELEASE_CFLAGS="-ffast-math -fno-finite-math-only -funroll-loops -fomit-frame-pointer -O3"
@@ -69,6 +75,7 @@ AS_CASE([$host],
     AS_IF([test "x${IPHONEOS}" = "xno"],[
         MACOSX=yes
         platform="Mac OSX"
+        deken_os=darwin
         coreaudio=yes
         portaudio=yes
         portmidi=yes
@@ -112,6 +119,7 @@ AS_CASE([$host],
     AS_IF([test "x${ANDROID}" = "xno"],[
         LINUX=yes
         platform=Linux
+        deken_os=linux
         portaudio=yes
         watchdog=yes
         EXTERNAL_CFLAGS="-fPIC"
@@ -119,10 +127,12 @@ AS_CASE([$host],
         EXTERNAL_EXTENSION=pd_linux
     ],[
         platform=Android
+        EXTERNAL_EXTENSION=so
     ])
 ],[*-*-gnu*],[
     HURD=yes
     platform=Hurd
+    deken_os=linux
     watchdog=yes
     EXTERNAL_CFLAGS="-fPIC"
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic -fPIC"
@@ -131,6 +141,7 @@ AS_CASE([$host],
     WINDOWS=yes
     MINGW=yes
     platform=MinGW
+    deken_os=windows
     mmio=yes
     asio=yes
     wasapi=yes
@@ -152,6 +163,7 @@ AS_CASE([$host],
     WINDOWS=yes
     CYGWIN=yes
     platform=Cygwin
+    deken_os=windows
     mmio=yes
     asio=yes
     wasapi=yes
@@ -172,6 +184,20 @@ AS_CASE([$host],
     platform=Unknown
     EXTERNAL_EXTENSION=so
 ])
+
+AS_IF([test "x${deken_os}" = "xwindows"],[deken_ext=dll])
+
+
+AS_CASE([$host_cpu],
+    [x86_64|amd64],[deken_cpu=amd64],
+    [i386|i486|i586|i686],[deken_cpu=i386],
+    [aarch64],[deken_cpu=arm64],
+    [armv*l],[deken_cpu=${host_cpu%l}],
+    [armv*b],[deken_cpu=${host_cpu}],
+    [powerpc64],[deken_cpu=ppc64],
+    [powerpc],[deken_cpu=ppc],
+    [])
+
 
 AM_CONDITIONAL(ANDROID, test x$ANDROID = xyes)
 AM_CONDITIONAL(IPHONEOS, test x$IPHONEOS = xyes)
@@ -359,6 +385,35 @@ AC_ARG_ENABLE([watchdog],
 AS_IF([test "x$enable_watchdog" != "xyes"],[enable_watchdog=no])
 AM_CONDITIONAL(PD_WATCHDOG, test x$enable_watchdog = xyes)
 
+
+AC_ARG_WITH([floatsize],
+    [AS_HELP_STRING([--with-floatsize=<SIZE>],
+    [build binaries for the given floatsize;
+    SIZE can be 32 (single precision) or 64 (double precision)
+    ]
+    )],
+    [floatsize=${withval}]
+    )
+AC_MSG_CHECKING([float size])
+AS_CASE([${floatsize}],
+    [32],[],
+    [64],[],
+    [""],[],
+    [
+        AC_MSG_WARN([${floatsize}bit floats not supported..fallback to default])
+        floatsize=""
+    ])
+AS_IF([test "x${floatsize}" != "x" ],
+   [
+    PD_CPPFLAGS="-DPD_FLOATSIZE=${floatsize} $PD_CPPFLAGS"
+    AC_MSG_RESULT([${floatsize}])
+   ],[AC_MSG_RESULT([default])
+   ])
+
+AS_IF([test "x${floatsize}" = "x64" && test "x${deken_cpu}" != "x" && test "x${deken_os}" != "x" && test "x${deken_ext}" != "x"],[
+      EXTERNAL_EXTENSION="${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}"
+      AC_MSG_NOTICE([default external extension...${EXTERNAL_EXTENSION}])
+      ])
 
 ##### libpd #####
 AC_ARG_ENABLE([libpd],
@@ -556,7 +611,6 @@ AS_IF([test "x${WISH}" = "xyes" -o "x${WISH}" = "xno"],
 AC_SUBST([WISH])
 
 ##### Deken OS and CPU #####
-deken_id=""
 AC_ARG_WITH([deken-os],
     [AS_HELP_STRING([--with-deken-os=<OS>],
         [Operating System string to use for externals (e.g. Linux, Windows, Darwin,...)])],
@@ -565,7 +619,7 @@ AS_IF([test "x${DEKEN_OS}" = "xyes" -o "x${DEKEN_OS}" = "xno"],
     [AC_MSG_NOTICE([--with-deken-os requires an Operating System, ignoring '${DEKEN_OS}'])
     DEKEN_OS=""])
 AC_SUBST([DEKEN_OS])
-AS_IF([test "x${DEKEN_OS}" = "x"], [deken_id="???"], [deken_id="${DEKEN_OS}"])
+AS_IF([test "x${DEKEN_OS}" != "x"], [deken_os="${DEKEN_OS}"])
 
 AC_ARG_WITH([deken-cpu],
     [AS_HELP_STRING([--with-deken-cpu=<CPU>],
@@ -575,7 +629,7 @@ AS_IF([test "x${DEKEN_CPU}" = "xyes" -o "x${DEKEN_CPU}" = "xno"],
     [AC_MSG_NOTICE([--with-deken-cpu requires a CPU, ignoring '${DEKEN_CPU}'])
     DEKEN_CPU=""])
 AC_SUBST([DEKEN_CPU])
-AS_IF([test "x${DEKEN_CPU}" = "x"], [deken_id="${deken_id}-???"], [deken_id="${deken_id}-${DEKEN_CPU}"])
+AS_IF([test "x${DEKEN_CPU}" != "x"], [deken_cpu="${DEKEN_CPU}"])
 
 AC_ARG_WITH([external-extension],
     [AS_HELP_STRING([--with-external-extension=<EXT>],
@@ -729,6 +783,7 @@ AC_MSG_NOTICE([
     $PACKAGE $VERSION is now configured
 
     Platform:             $platform
+    Float size:           ${floatsize:-default}
     Debug build:          $debug
     Universal build:      $universal
     Localizations:        $locales
@@ -745,7 +800,7 @@ AC_MSG_NOTICE([
     External extension:   $EXTERNAL_EXTENSION
     External CFLAGS:      $EXTERNAL_CFLAGS
     External LDFLAGS:     $EXTERNAL_LDFLAGS
-    Deken identifier:     ${deken_id}
+    Deken identifier:     ${deken_os:-???}-${deken_cpu:-???}
 
     fftw:                 $fftw
     wish(tcl/tk):         $wish

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ local_portaudio=yes
 local_portmidi=yes
 mmio=no
 asio=no
+wasapi=no
 jack_framework=no
 locales=yes
 
@@ -128,6 +129,7 @@ AS_CASE([$host],
     platform=MinGW
     mmio=yes
     asio=yes
+    wasapi=yes
     portaudio=yes
     portmidi=yes
 
@@ -148,6 +150,7 @@ AS_CASE([$host],
     platform=Cygwin
     mmio=yes
     asio=yes
+    wasapi=yes
     portaudio=yes
     portmidi=yes
 
@@ -464,6 +467,12 @@ AS_IF([test x$asio = xyes],
         AC_MSG_WARN([ASIO SDK not found... skipping (See asio/README.txt)]))
 )
 
+#### WASAPI ####
+AC_ARG_ENABLE([wasapi],
+    [AS_HELP_STRING([--disable-wasapi], [do not use WASAPI backend])],
+    [wasapi=$enableval])
+test x$WINDOWS = xyes || wasapi=no
+
 ##### Apple's CoreAudio #####
 # not used directly, implicitly needed when using PortAudio on OSX
 AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [coreaudio=yes], [coreaudio=no])
@@ -605,6 +614,10 @@ dnl AS_IF([test x$mmio = xyes], [midi_backends="MMIO ${midi_backends}"])
 ##### ASIO #####
 AM_CONDITIONAL(ASIO, test x$asio = xyes)
 AS_IF([test x$asio = xyes], [audio_backends="ASIO ${audio_backends}"])
+
+##### WASAPI #####
+AM_CONDITIONAL(WASAPI, test x$wasapi = xyes)
+AS_IF([test x$wasapi = xyes], [audio_backends="WASAPI ${audio_backends}"])
 
 ##### CoreAudio #####
 # portaudio doesn't work with iOS, so don't bother with CoreAudio

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,10 @@ PD_CPPFLAGS=""
 PD_CFLAGS=""
 PD_LDFLAGS=""
 
+
+pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
+pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
+
 #########################################
 ##### OS Detection #####
 
@@ -138,7 +142,7 @@ AS_CASE([$host],
 
     # externals are dynamically linked to pd.dll in their individual automake files
     EXTERNAL_CFLAGS="-mms-bitfields"
-    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -lpd"
+    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -l${pd_transformed}"
     EXTERNAL_EXTENSION=dll
 
     # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling

--- a/font/Makefile.am
+++ b/font/Makefile.am
@@ -1,11 +1,22 @@
 #########################################
 ##### Files, Binaries, & Libs #####
 
-# files that are included but not built
 EXTRA_DIST = \
+	$(fontdata_DATA) \
+	$(empty)
+
+fontdatadir = $(pkgdatadir)/font
+fontdata_DATA =
+
+# files that are included but not built
+fontdata_DATA += \
     DejaVuSansMono.ttf \
     DejaVuSansMono-Oblique.ttf \
     DejaVuSansMono-Bold.ttf \
     DejaVuSansMono-BoldOblique.ttf \
+    $(data)
+
+fontdata_DATA += \
     LICENSE \
-    README.txt
+    README.txt \
+    $(data)

--- a/mac/osx-app.sh
+++ b/mac/osx-app.sh
@@ -21,6 +21,7 @@ TK=
 SYS_TK=Current
 WISH=
 PD_VERSION=
+RUNDIR="$(pwd)"
 
 # ad hoc by default
 SIGNATURE_ID="-"
@@ -31,6 +32,15 @@ SRC=..
 # build dir, relative to working directory
 custom_builddir=false
 BUILD=..
+
+# which installation method to chose
+# either 'manually' or 'make'
+# per default we use 'make' for custom-builddirs
+# and 'manually' otherwise
+install_type=
+
+
+
 
 # PlistBuddy command for editing app bundle Info.plist from template
 PLIST_BUDDY=/usr/libexec/PlistBuddy
@@ -66,7 +76,13 @@ Options:
                       a combination of ppc, i386, x86_64, and/or arm64
                       depending on detected macOS SDK
 
-  --builddir          set pd build directory path
+  --builddir DIR      set pd build directory path
+
+  --installtype TYP   select how files are collected into the .app bundle
+                      "manually" - use builtin logic to determine files
+                      "make" - use 'make install'
+                      not setting this value, will use 'make' if you set
+                      the '--builddir', and 'manually' otherwise
 
 Arguments:
 
@@ -96,6 +112,99 @@ Examples:
     osx-app.sh --wish Wish-8.6.5 0.47-0
 
 EOF
+}
+
+install_manually() {
+    # pd app bundle destination path
+    local DEST="${APP}/Contents/Resources"
+
+    # install binaries
+    mkdir -p "${DEST}/bin"
+    cp -R $verbose "${BUILD}/src/pd"          "${DEST}/bin/"
+    cp -R $verbose "${BUILD}/src/pdsend"      "${DEST}/bin/"
+    cp -R $verbose "${BUILD}/src/pdreceive"   "${DEST}/bin/"
+    cp -R $verbose "${BUILD}/src/pd-watchdog" "${DEST}/bin/" || true
+
+    # install resources
+    mkdir -p "${DEST}/po"
+    cp -R $verbose "${SRC}/doc"         "${DEST}/"
+    cp -R $verbose "${SRC}/extra"       "${DEST}/"
+    cp -R $verbose "${SRC}/tcl"         "${DEST}/"
+    rm -f "${DEST}/tcl/pd.ico" "${DEST}/tcl/pd-gui.in"
+    if [ ! "${BUILD}" -ef "${SRC}" ] ; then # are src and build dirs not the same?
+        # compiled externals are in the build dir
+        cp -R $verbose "${BUILD}/extra" "${DEST}/"
+    fi
+
+    # install translations if they were built
+    if [ -e "${BUILD}/po/es.msg" ] ; then
+        mkdir -p "${DEST}/po"
+        cp $verbose "${BUILD}/po"/*.msg "${DEST}/po/"
+        # add locale entries to the plist based on available .msg files
+        # commented out for 0.48-1 because it seems to misbehave - open/save dialogs
+        # are opening in a random language (and meanwhile Pd doesn't yet respect
+        # current language setting - I don't know what's going on here.  -msp
+        # LOCALES=$(find ${BUILD}/po -name "*.msg" -exec basename {} .msg \;)
+        # $PLIST_BUDDY \
+            #     -c "Add:CFBundleLocalizations array \"$PLIST_VERSION\"" $INFO_PLIST
+        # for locale in $LOCALES ; do
+        #     $PLIST_BUDDY \
+            #         -c "Add:CFBundleLocalizations: string \"$locale\"" $INFO_PLIST
+        # done
+    else
+        echo "No localizations found. Skipping po dir..."
+    fi
+
+    # install headers
+    mkdir -p "${DEST}/src"
+    cp $verbose "${SRC}/src"/*.h "${DEST}/src/"
+
+    # clean extra folders
+    cd "${DEST}/extra"
+    rm -f makefile.subdir
+    find ./* -prune -type d | while read ext; do
+        ext_lib="${ext}.${EXTERNAL_EXT}"
+        if [ -e "${ext}/.libs/${ext_lib}" ] ; then
+
+            # remove any symlinks to the compiled external
+            rm -f "${ext}"/*."${EXTERNAL_EXT}"
+
+            # mv compiled external into main folder
+            mv "${ext}"/.libs/*."${EXTERNAL_EXT}" "${ext}/"
+
+            # remove libtool build folders & unneeded build files
+            rm -rf "${ext}/.libs"
+            rm -rf "${ext}/.deps"
+            rm -f "${ext}"/*.c "${ext}"/*.o "${ext}"/*.lo "${ext}"/*.la
+            rm -f "${ext}"/GNUmakefile* "${ext}"/makefile*
+        fi
+    done
+    cd - > /dev/null # quiet
+
+    cp stuff/pd.icns "${DEST}/"
+    cp stuff/pd-file.icns "${DEST}/"
+    cp -R "${SRC}/font" "${DEST}/"
+
+    # install licenses
+    cp $verbose "${SRC}/README.txt"  "${DEST}/"
+    cp $verbose "${SRC}/LICENSE.txt" "${DEST}/"
+
+
+    # clean Makefiles
+    find "${DEST}" -name "Makefile*" -type f -delete
+
+    # create any needed symlinks
+    ln -s tcl "${DEST}/Scripts"
+}
+
+install_make() {
+    local DEST="${APP}/Contents/Resources"
+    make install -C "${BUILD}" DESTDIR="${DEST}" prefix=/ libdir=/ pkglibdir=/ datarootdir=/ pkgdatadir=/ includedir=/src pkgincludedir=/src
+
+    find "${DEST}" -type f -name "*.la" -delete
+
+    # create any needed symlinks
+    ln -s tcl "${DEST}/Scripts"
 }
 
 # Parse command line arguments
@@ -147,6 +256,25 @@ while [ "$1" != "" ] ; do
             BUILD=${1%/} # remove trailing slash
             custom_builddir=true
             ;;
+        --installtype)
+            if [ $# = 0 ] ; then
+                echo "--installtype option requires a TYPE argument"
+                exit 1
+            fi
+            shift 1
+            case "$1" in
+                manual|manually)
+                    install_type=manual
+                    ;;
+                make)
+                    install_type=make
+                    ;;
+                *)
+                    echo "invalid installtype (must be 'manually' or 'make')"
+                    exit 1
+                    ;;
+            esac
+            ;;
         -v|--verbose)
             verbose=-v
             ;;
@@ -162,49 +290,55 @@ done
 
 # check for version argument and set app path in the dir the script is run from
 if [ "$1" != "" ] ; then
-    APP=$(pwd)/Pd-$1.app
+    APP="$(pwd)/Pd-${1}.app"
 else
     # version not specified
-    APP=$(pwd)/Pd.app
+    APP="$(pwd)/Pd.app"
 fi
 
 # Go
 #----------------------------------------------------------
 
+# use a default install-type if none was requested
+if [ "x${install_type}" = "x" ] ; then
+   if [ "${custom_builddir}" = true ] ; then
+       install_type=make
+   else
+       install_type=manual
+   fi
+fi
+
 # make sure custom build directory is an absolute path
-if [ $custom_builddir = true ] ; then
+if [ "${custom_builddir}" = true ] ; then
     if [ "${BUILD}" = "${BUILD#/}" ] ; then
-       BUILD=$(pwd)/$BUILD
+       BUILD="$(pwd)/${BUILD}"
     fi
 fi
 
 # change to the dir of this script
-cd $(dirname $0)
+cd $(dirname "$0")
 
 # grab package version from configure --version output: line 1, word 3
 # aka "pd configure 0.47.1" -> "0.47.1"
-PD_VERSION=$(../configure --version | head -n 1 | cut -d " " -f 3)
-
-# pd app bundle destination path
-DEST=$APP/Contents/Resources
+PD_VERSION=$(${SRC}/configure --version | head -n 1 | cut -d " " -f 3)
 
 # remove old app if found
-if [ -d $APP ] ; then
-    rm -rf $APP
+if [ -d "${APP}" ] ; then
+    rm -rf "${APP}"
 fi
 
 # check if pd is already built
-if [ ! -e "$BUILD/src/pd" ] ; then
+if [ ! -e "${BUILD}/src/pd" ] ; then
     echo "Looks like pd hasn't been built yet. Maybe run make first?"
     exit 1
 fi
 
 if [ "$verbose" != "" ] ; then
-    echo "==== Creating $APP"
+    echo "==== Creating ${APP}"
 fi
 
 # extract included Wish app
-if [ $included_wish = true ] ; then
+if [ "${included_wish}" = true ] ; then
     tar xzf stuff/wish-shell.tgz
     if [ -e "Wish Shell.app" ] ; then
         mv "Wish Shell.app" Wish.app
@@ -212,23 +346,23 @@ if [ $included_wish = true ] ; then
     WISH=Wish.app
 
 # build Wish or use the system Wish
-elif [ "$WISH" = "" ] ; then
-    if [ "$TK" != "" ] ; then
-        echo "Using custom $TK Wish.app"
-        ./tcltk-wish.sh $universal $TK
-        WISH=Wish-${TK}.app
-    elif [ "$SYS_TK" != "" ] ; then
-        echo "Using system $SYS_TK Wish.app"
+elif [ "${WISH}" = "" ] ; then
+    if [ "${TK}" != "" ] ; then
+        echo "Using custom ${TK} Wish.app"
+        ./tcltk-wish.sh ${universal} "${TK}"
+        WISH="Wish-${TK}.app"
+    elif [ "${SYS_TK}" != "" ] ; then
+        echo "Using system ${SYS_TK} Wish.app"
         tk_path=/Library/Frameworks/Tk.framework/Versions
         # check /Library first, then fall back to /System/Library
-        if [ ! -e $tk_path/$SYS_TK/Resources/Wish.app ] ; then
-            tk_path=/System${tk_path}
-            if [ ! -e $tk_path/$SYS_TK/Resources/Wish.app ] ; then
+        if [ ! -e "${tk_path}/${SYS_TK}/Resources/Wish.app" ] ; then
+            tk_path="/System${tk_path}"
+            if [ ! -e "${tk_path}/${SYS_TK}/Resources/Wish.app" ] ; then
                 echo "Wish.app not found"
                 exit 1
             fi
         fi
-        cp -R $verbose $tk_path/$SYS_TK/Resources/Wish.app .
+        cp -R $verbose "${tk_path}/${SYS_TK}/Resources/Wish.app" .
         WISH=Wish.app
     fi
 
@@ -237,143 +371,75 @@ else
 
     # get absolute path in original location
     cd - > /dev/null # quiet
-    WISH=$(cd "$(dirname "$WISH")"; pwd)/$(basename "$WISH")
+    WISH=$(cd "$(dirname "${WISH}")"; pwd)/$(basename "${WISH}")
     cd - > /dev/null # quiet
-    if [ ! -e $WISH ] ; then
+    if [ ! -e "${WISH}" ] ; then
         [ ! -e "${WISH}.app" ] || WISH="${WISH}.app"
     fi
-    if [ ! -e $WISH ] ; then
-        echo "$WISH not found"
+    if [ ! -e "${WISH}" ] ; then
+        echo "${WISH} not found"
         exit 1
     fi
-    echo "Using $(basename $WISH)"
+    echo "Using $(basename ${WISH})"
 
     # copy
-    WISH_TMP=$(basename $WISH)-tmp
-    cp -R $WISH $WISH_TMP
-    WISH=$WISH_TMP
+    WISH_TMP=$(basename "${WISH}")-tmp
+    cp -R "${WISH}" "${WISH_TMP}"
+    WISH="${WISH_TMP}"
 fi
 
 # sanity check
-if [ ! -e $WISH ] ; then
-    echo "$WISH not found"
+if [ ! -e "${WISH}" ] ; then
+    echo "${WISH} not found"
     exit 1
 fi
 
 # change app name and rename resources
 # try to handle both older "Wish Shell.app" & newer "Wish.app"
-mv "$WISH" $APP
-chmod -R u+w $APP
-if [ -e $APP/Contents/version.plist ] ; then
-    rm $APP/Contents/version.plist
+mv "${WISH}" "${APP}"
+chmod -R u+w "${APP}"
+
+if [ -e "${APP}/Contents/version.plist" ] ; then
+    rm "${APP}/Contents/version.plist"
 fi
 # older "Wish Shell.app" does not have a symlink but a real file
-if [ -f $APP/Contents/MacOS/Wish\ Shell ] && \
-   [ ! -L $APP/Contents/MacOS/Wish\ Shell ] ; then
-    mv $APP/Contents/MacOS/Wish\ Shell $APP/Contents/MacOS/Pd
-    mv $APP/Contents/Resources/Wish\ Shell.rsrc $APP/Contents/Resources/Pd.rsrc
+if [ -f "${APP}/Contents/MacOS/Wish Shell" ] && \
+   [ ! -L "${APP}/Contents/MacOS/Wish Shell" ] ; then
+    mv "${APP}/Contents/MacOS/Wish Shell" "${APP}/Contents/MacOS/Pd"
+    mv "${APP}/Contents/Resources/Wish Shell.rsrc" "${APP}/Contents/Resources/Pd.rsrc"
 else
-    mv $APP/Contents/MacOS/Wish $APP/Contents/MacOS/Pd
-    if [ -e $APP/Contents/Resources/Wish.rsrc ] ; then
-        mv $APP/Contents/Resources/Wish.rsrc $APP/Contents/Resources/Pd.rsrc
+    mv "${APP}/Contents/MacOS/Wish" "${APP}/Contents/MacOS/Pd"
+    if [ -e "${APP}/Contents/Resources/Wish.rsrc" ] ; then
+        mv "${APP}/Contents/Resources/Wish.rsrc" "${APP}/Contents/Resources/Pd.rsrc"
     else
-        mv $APP/Contents/Resources/Wish.sdef $APP/Contents/Resources/Pd.sdef
+        mv "${APP}/Contents/Resources/Wish.sdef" "${APP}/Contents/Resources/Pd.sdef"
     fi
 fi
-rm -f $APP/Contents/MacOS/Wish
-rm -f $APP/Contents/MacOS/Wish\ Shell
+rm -f "${APP}/Contents/MacOS/Wish"
+rm -f "${APP}/Contents/MacOS/Wish Shell"
 
 # prepare bundle resources
-cp stuff/Info.plist $APP/Contents/
-rm $APP/Contents/Resources/Wish.icns
-cp stuff/pd.icns $APP/Contents/Resources/
-cp stuff/pd-file.icns $APP/Contents/Resources/
-cp -R ../font $APP/Contents/Resources/
+cp stuff/Info.plist "${APP}/Contents/"
+rm "${APP}/Contents/Resources/Wish.icns"
 
-INFO_PLIST=$APP/Contents/Info.plist
+INFO_PLIST="${APP}/Contents/Info.plist"
 
 # set version identifiers & contextual strings in Info.plist,
 # version strings can only use 0-9 and periods, so replace "-" & "test" with "."
-PLIST_VERSION=$(echo ${PD_VERSION} | sed -e 's/[^0-9]/./g' -e 's/\.\.*/./g' -e 's/^\.//' -e 's/\.$//')
-$PLIST_BUDDY -c "Set:CFBundleVersion \"$PLIST_VERSION\"" $INFO_PLIST
-$PLIST_BUDDY -c "Set:CFBundleShortVersionString \"$PLIST_VERSION\"" $INFO_PLIST
+PLIST_VERSION=$(echo "${PD_VERSION}" | sed -e 's/[^0-9]/./g' -e 's/\.\.*/./g' -e 's/^\.//' -e 's/\.$//')
+"${PLIST_BUDDY}" -c "Set:CFBundleVersion \"$PLIST_VERSION\"" "${INFO_PLIST}"
+"${PLIST_BUDDY}" -c "Set:CFBundleShortVersionString \"$PLIST_VERSION\"" "${INFO_PLIST}"
 # remove deprecated key as this will display in Finder instead of the version
-$PLIST_BUDDY -c "Delete:CFBundleGetInfoString" $INFO_PLIST
+"${PLIST_BUDDY}" -c "Delete:CFBundleGetInfoString" "${INFO_PLIST}"
 
-# install binaries
-mkdir -p $DEST/bin
-cp -R $verbose $BUILD/src/pd          $DEST/bin/
-cp -R $verbose $BUILD/src/pdsend      $DEST/bin/
-cp -R $verbose $BUILD/src/pdreceive   $DEST/bin/
-cp -R $verbose $BUILD/src/pd-watchdog $DEST/bin/ || true
-
-# install resources
-mkdir -p $DEST/po
-cp -R $verbose $SRC/doc         $DEST/
-cp -R $verbose $SRC/extra       $DEST/
-cp -R $verbose $SRC/tcl         $DEST/
-rm -f $DEST/tcl/pd.ico $DEST/tcl/pd-gui.in
-if [ ! $BUILD -ef $SRC ] ; then # are src and build dirs not the same?
-    # compiled externals are in the build dir
-    cp -R $verbose $BUILD/extra $DEST/
-fi
-
-# install licenses
-cp $verbose $SRC/README.txt  $DEST/
-cp $verbose $SRC/LICENSE.txt $DEST/
-
-# install translations if they were built
-if [ -e $BUILD/po/es.msg ] ; then
-    mkdir -p $DEST/po
-    cp $verbose $BUILD/po/*.msg $DEST/po/
-    # add locale entries to the plist based on available .msg files
-    # commented out for 0.48-1 because it seems to misbehave - open/save dialogs
-    # are opening in a random language (and meanwhile Pd doesn't yet respect
-    # current language setting - I don't know what's going on here.  -msp
-    # LOCALES=$(find $BUILD/po -name "*.msg" -exec basename {} .msg \;)
-    # $PLIST_BUDDY \
-    #     -c "Add:CFBundleLocalizations array \"$PLIST_VERSION\"" $INFO_PLIST
-    # for locale in $LOCALES ; do
-    #     $PLIST_BUDDY \
-    #         -c "Add:CFBundleLocalizations: string \"$locale\"" $INFO_PLIST
-    # done
-else
-    echo "No localizations found. Skipping po dir..."
-fi
-
-# install headers
-mkdir -p $DEST/src
-cp $verbose $SRC/src/*.h $DEST/src/
-
-# clean extra folders
-cd $DEST/extra
-rm -f makefile.subdir
-find * -prune -type d | while read ext; do
-    ext_lib=$ext.$EXTERNAL_EXT
-    if [ -e $ext/.libs/$ext_lib ] ; then
-
-        # remove any symlinks to the compiled external
-        rm -f $ext/*.$EXTERNAL_EXT
-
-        # mv compiled external into main folder
-        mv $ext/.libs/*.$EXTERNAL_EXT $ext/
-
-        # remove libtool build folders & unneeded build files
-        rm -rf $ext/.libs
-        rm -rf $ext/.deps
-        rm -f $ext/*.c $ext/*.o $ext/*.lo $ext/*.la
-        rm -f $ext/GNUmakefile* $ext/makefile*
-    fi
-done
-cd - > /dev/null # quiet
-
-# clean Makefiles
-find $DEST -name "Makefile*" -type f -delete
-
-# create any needed symlinks
-cd $DEST
-ln -s tcl Scripts
-cd - > /dev/null # quiet
+case "${install_type}" in
+    make)
+        install_make
+        ;;
+    *)
+        install_manually
+        ;;
+esac
 
 # "code signing" which also sets entitlements
 # note: "-" identity results in "ad-hoc signing" aka no signing is performed
@@ -387,8 +453,8 @@ codesign $verbose --deep  --sign "${SIGNATURE_ID}" --entitlements stuff/pd.entit
     "${APP}"
 
 # finish up
-touch $APP
+touch "${APP}"
 
 if [ "$verbose" != "" ] ; then
-    echo  "==== Finished $APP"
+    echo  "==== Finished ${APP}"
 fi

--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -47,21 +47,22 @@ file pd.nsi.
 
 # Set some defaults
 SCRIPTDIR=${0%/*}
-OUTDIR=$(mktemp -d || echo /tmp)
-INSTALLFILE="${OUTDIR}/install_files_list.nsh"
-UNINSTALLFILE="${OUTDIR}/uninstall_files_list.nsh"
-LICENSEFILE="${OUTDIR}/license_page.nsh"
-NSIFILE="${OUTDIR}/pd.nsi"
+OUTDIR=/tmp
+WORKDIR=$(mktemp -d || echo /tmp)
+INSTALLFILE="${WORKDIR}/install_files_list.nsh"
+UNINSTALLFILE="${WORKDIR}/uninstall_files_list.nsh"
+LICENSEFILE="${WORKDIR}/license_page.nsh"
+NSIFILE="${WORKDIR}/pd.nsi"
 
 error() {
   echo "$@" 1>&2
 }
 
 cleanup() {
- if [ "x${OUTDIR}" != "x/tmp" ]; then
-    rm -rf "${OUTDIR}"
+ if [ "${WORKDIR}" != "/tmp" ]; then
+    rm -rf "${WORKDIR}"
  fi
- exit $1
+ exit "$1"
 }
 
 usage() {
@@ -70,38 +71,85 @@ Helper script to build a proper Windows installer out of a
 Pd build tree.
 
 Usage:
-$0 <path_to_pd_build> <version> [<wish-exec-name> [<arch>]]
+$0 [ OPTIONS ] <path_to_pd_build> [<version> [<wish-exec-name> [<arch>]]]
 
-   <path_to_pd_build>   input directory (containing 'bin/pd.exe')
-   <version>            Pd-version to create installer for (e.g. '0.32-8')
-   <wish-exec-name>     name of wish executable (e.g., 'wish85.exe')
-   <arch>               architecture of Pd ('32' or '64')
+ Options:
+
+  -o,--outdir DIR      Output directory (where the generated installer binary
+                       can be found after a succesfull run)
+
+  -h,--help            Print this help
+
+ Arguments:
+
+  <path_to_pd_build>   input directory (containing 'bin/pd.exe')
+                       such as created by 'make app'
+  <version>            Pd-version to create installer for (e.g. '0.32-8')
+                       DEFAULT: autodetect from <path_to_pd_build>
+  <wish-exec-name>     name of the Tcl/Tk interpreter executable
+                       e.g., 'wish85.exe'
+                       DEFAULT: use a "bin/wish*.exe" in <path_to_pd_build>
+  <ARCH>               architecture of the Pd executable.
+                       valid values are '32' for x86 and '64' for x86_64
+                       DEFAULT: autodetect from "bin/pd.exe" in <path_to_pd_build>
 EOF
   cleanup 1
 }
 
+
+# Parse command line arguments
+#----------------------------------------------------------
+while [ "$1" != "" ] ; do
+    case $1 in
+        -o|--outdir)
+            if [  $# = 0 ]; then
+                error "-o,--outdir requires a DIR argument"
+                cleanup 1
+            fi
+            shift 1
+            OUTDIR="$1"
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            break ;;
+    esac
+    shift 1
+done
+
 # show usage when invoked without args
-if [ "$#" -lt "2" ]
+if [ $# -lt 1 ]
 then
     usage
 fi
 
 PDWINDIR=$(realpath "$1")
-PDVERSION=$2
-WISHNAME=$3
-PDARCH=$4
+PDVERSION="$2"
+WISHNAME="$3"
+PDARCH="$4"
 
-
+if [ -z "${PDVERSION}" ]; then
+    ver=${PDWINDIR##*/}
+    if [ -n "${ver}" ] && [ "${ver}" != "${ver#*-}" ]; then
+        PDVERSION="${ver#*-}"
+    fi
+fi
 
 # Check validity of specified PDWINDIR
-if ! [ -d "$PDWINDIR" ]
+if ! [ -d "${PDWINDIR}" ]
 then
-  error "'$PDWINDIR' is not a directory"
+  error "'${PDWINDIR}' is not a directory"
   cleanup 1
-elif ! [ -f "$PDWINDIR/bin/pd.exe" ]
+elif ! [ -f "${PDWINDIR}/bin/pd.exe" ]
 then
   error "Could not find bin/pd.exe. Is this a Windows build?"
   cleanup 1
+fi
+
+if [  -z "${PDVERSION}" ]; then
+    error "could not auto-detect the version from ${PDWINDIR}"
+    cleanup 1
 fi
 
 # autodetect wishname if none is given
@@ -118,20 +166,22 @@ if [ -z "${WISHNAME}" ]; then
 fi
 
 # autodetect architecture if not given on the cmdline
-if [  "x$PDARCH" = "x" ]; then
-    if file -b "$PDWINDIR/bin/pd.exe" | egrep "^PE32 .* 80386 " >/dev/null; then
+if [  "${PDARCH}" = "" ]; then
+    if file -b "${PDWINDIR}/bin/pd.exe" | grep -E "^PE32 .* 80386 " >/dev/null; then
         PDARCH=32
-    elif file -b "$PDWINDIR/bin/pd.exe" | egrep "^PE32\+ .* x86-64 " >/dev/null; then
+    elif file -b "${PDWINDIR}/bin/pd.exe" | grep -E "^PE32\+ .* x86-64 " >/dev/null; then
         PDARCH=64
     fi
 fi
-if [  "x$PDARCH" = "x" ]; then
+if [  "${PDARCH}" = "" ]; then
     error "Unable to automatically determine <arch>."
     cleanup 1
 fi
 
+OUTDIR=$(realpath "${OUTDIR}")
+
 #### WRITE INSTALL LIST #########################################
-find "$PDWINDIR" \
+find "${PDWINDIR}" \
   -mindepth 0 \
   -type d \
   -printf 'SetOutPath "$INSTDIR/%P"\n' \
@@ -146,37 +196,36 @@ find "$PDWINDIR" \
 
 #### WRITE UNINSTALL FILE LIST ###################################
 # clear
-> "${UNINSTALLFILE}"
+echo > "${UNINSTALLFILE}"
 
 # delete files
-find "$PDWINDIR" -type f -printf 'Delete "$INSTDIR/%P"\n' \
+find "${PDWINDIR}" -type f -printf 'Delete "$INSTDIR/%P"\n' \
   -not -name "*.o" \
   | sed 's|/|\\|g' \
   >> "${UNINSTALLFILE}"
 
 # delete directories
 # tac is used to reverse order so that dirs are removed in depth-first order
-find "$PDWINDIR" -type d -printf 'RMDir "$INSTDIR/%P"\n' \
+find "${PDWINDIR}" -type d -printf 'RMDir "$INSTDIR/%P"\n' \
   | tac \
   | sed 's|/|\\|g' \
   >> "${UNINSTALLFILE}"
 
 #### WRITE LICENSE INCLUDE ######################################
-echo "!insertmacro MUI_PAGE_LICENSE \"$PDWINDIR/LICENSE.txt\"" \
+echo "!insertmacro MUI_PAGE_LICENSE \"${PDWINDIR}/LICENSE.txt\"" \
   > "${LICENSEFILE}"
 
-# stick version number in pd.nsi script
+# uninstall/license/... information into pd.nsi script
 cat "${SCRIPTDIR}/pd.nsi" | sed \
-	-e "s/PDVERSION/${PDVERSION}/" \
-	-e "s/WISHNAME/${WISHNAME}/" \
-	-e "s|include \"/tmp/|include \"${OUTDIR}/|" \
+	-e "s|include \"/tmp/|include \"${WORKDIR}/|" \
+	-e "s|OutFile \"/tmp/|OutFile \"${OUTDIR}/|" \
 	> "${NSIFILE}"
 
 # check if we have nsis compiler
 nsis_version=$(makensis -version)
 nsis_exit=$?
 case $nsis_exit in
-  0) echo "Found NSIS version $nsis_version"
+  0) error "Found NSIS version $nsis_version"
      ;;
   1) error "makensis returned error. What's the problem?"
      cleanup 1
@@ -190,16 +239,19 @@ case $nsis_exit in
 esac
 
 # copy installer custom artwork
-cp "${SCRIPTDIR}/installer-art/big.bmp" "${OUTDIR}/big.bmp"
-cp "${SCRIPTDIR}/installer-art/small.bmp" "${OUTDIR}/small.bmp"
-cp "${SCRIPTDIR}/../tcl/pd.ico" "${OUTDIR}/pd.ico"
+cp "${SCRIPTDIR}/installer-art/big.bmp" "${WORKDIR}/big.bmp"
+cp "${SCRIPTDIR}/installer-art/small.bmp" "${WORKDIR}/small.bmp"
+cp "${SCRIPTDIR}/../tcl/pd.ico" "${WORKDIR}/pd.ico"
 
 # run the build
-if makensis -DPDVER=${PDVERSION} -DWISHN=${WISHNAME} -DARCHI=${PDARCH} ${NSIFILE}
+mkdir -p "${OUTDIR}"
+if makensis -DPDVER="${PDVERSION}" -DWISHN="${WISHNAME}" -DARCHI="${PDARCH}" "${NSIFILE}" 1>&2
 then
-  echo "Build successful"
+  error "Build successful"
+  echo "${OUTDIR}/pd-${PDVERSION}.windows-installer.exe"
 else
   error "Some error occurred during compilation of ${NSIFILE}"
+  error "(files are not cleaned up so you can inspect them)"
   exit 1
 fi
 cleanup 0

--- a/msw/msw-app.sh
+++ b/msw/msw-app.sh
@@ -218,10 +218,16 @@ fi
 # * Linux cross-compile: $MINGW_PREFIX/lib
 if [ "x${MINGW_PREFIX}" != "x" ] ; then
     if [ -e $MINGW_PREFIX/bin/$PTHREAD_DLL ] ; then
-        cp -v $MINGW_PREFIX/bin/$PTHREAD_DLL $APP/bin
+        pthread_dll="${MINGW_PREFIX}/bin/${PTHREAD_DLL}"
     elif [ -e $MINGW_PREFIX/lib/$PTHREAD_DLL ] ; then
-        cp -v $MINGW_PREFIX/lib/$PTHREAD_DLL $APP/bin
+        pthread_dll="${MINGW_PREFIX}/lib/${PTHREAD_DLL}"
     fi
+fi
+
+if [  -e "${pthread_dll}" ]; then
+    find "${APP}" -type f '(' -name "pd.dll" -o -name "pd64.dll" -o -name "pd32.dll" ')' -exec dirname {} ";" | sort -u | while read dir ; do
+    cp -v "${pthread_dll}" "${dir}/"
+    done
 fi
 
 # copy info and resources not handled via "make install"

--- a/portaudio/Makefile.am
+++ b/portaudio/Makefile.am
@@ -62,10 +62,13 @@ AM_CFLAGS += -Wno-error -Wno-deprecated
 endif
 
 if WINDOWS
+libportaudio_a_SOURCES += \
+    portaudio/src/hostapi/wmme/pa_win_wmme.c
+if WASAPI
 AM_CFLAGS += -DPA_USE_WASAPI
 libportaudio_a_SOURCES += \
-    portaudio/src/hostapi/wmme/pa_win_wmme.c \
     portaudio/src/hostapi/wasapi/pa_win_wasapi.c
+endif
 if ASIO
 AM_CFLAGS += -DPA_USE_ASIO
 if MINGW

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,7 @@ libpd_la_CPPFLAGS = -DPD -DPD_INTERNAL -DUSEAPI_DUMMY @PD_CPPFLAGS@
 libpd_la_CFLAGS = @PD_CFLAGS@
 libpd_la_LIBADD =
 libpd_la_LDFLAGS = @PD_LDFLAGS@
-libpdincludedir = $(includedir)/libpd
+libpdincludedir = $(pkgincludedir)
 libpdinclude_HEADERS =
 
 libpdbin_PROGRAMS =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,6 +45,9 @@ SUFFIXES = .@EXTENSION@ .@SHARED_LIB@
 pd_LDADD_core += $(LIBM)
 libpd_la_LIBADD += $(LIBM)
 
+# in case somebody passes '--program-transform-name' to configure
+pd_transformed=$(shell echo pd | sed -e '$(transform)')
+
 #########################################
 ##### Files, Binaries, & Libs #####
 
@@ -390,16 +393,16 @@ if WINDOWS
 # win32 sockets 2, multimedia, and all that
 LIBS += -lws2_32 -lwinmm -lole32 -static-libgcc -static-libstdc++
 
-bin_SCRIPTS += pd.dll pd.lib pd.def pd.com
-CLEANFILES += pd.dll pd.lib pd.def pd.com
-noinst_SCRIPTS += libpd.a
-CLEANFILES += libpd.a
+bin_SCRIPTS += $(pd_transformed).dll $(pd_transformed).lib $(pd_transformed).def $(pd_transformed).com
+CLEANFILES += $(pd_transformed).dll $(pd_transformed).lib $(pd_transformed).def $(pd_transformed).com
+noinst_SCRIPTS += lib$(pd_transformed).a
+CLEANFILES += lib$(pd_transformed).a
 CLEANFILES += pd.res
 
 # hide the console
 pd_LDFLAGS += -mwindows
 # link with resources and pd.dll import library
-pd_LDADD += pd.res pd.lib
+pd_LDADD += pd.res $(pd_transformed).lib
 
 libpd_la_LDFLAGS += -Wl,--export-all-symbols -static-libgcc
 libpd_la_LIBADD += -lws2_32 -lkernel32
@@ -416,28 +419,28 @@ pd.res: pd.rc
 	$(WINDRES) $< -O coff -o $@
 
 # import library for pd.dll. also works with MSVC!
-pd.lib: pd.dll
+$(pd_transformed).lib: $(pd_transformed).dll
+$(pd_transformed).def: $(pd_transformed).dll
 
 # another import library (when linking with -lpd), the same as pd.lib.
-libpd.a: pd.lib
+lib$(pd_transformed).a: $(pd_transformed).lib
 	cp $< $@
 
-pd.def: pd.dll
-
-pd.dll: $(pd_OBJECTS_core) $(pd_OBJECTS_standalone)
+$(pd_transformed).dll: $(pd_OBJECTS_core) $(pd_OBJECTS_standalone)
 	$(CXX) -shared \
 	$(pd_LDFLAGS_core) $(pd_LDFLAGS_standalone) \
-	-o pd.dll \
+	-o $@ \
 	$(pd_OBJECTS_core) $(pd_OBJECTS_standalone) \
 	$(pd_LDADD_core) $(pd_LDADD_standalone) \
 	$(LIBS) \
-	-Wl,--export-all-symbols -Wl,--out-implib=pd.lib -Wl,--output-def=pd.def
+	-Wl,--export-all-symbols \
+    -Wl,--out-implib=$(patsubst %.dll,%.lib,$@) -Wl,--output-def=$(patsubst %.dll,%.def,$@)
 
 # same as pd.exe but without -mwindows and resources
 # NOTE: this is a bit ugly. I couldn't figure out how to get automake to build
 # two programs with the same basename but different suffix.
-pd.com: pd-s_entry.o pd.lib
-	$(CXX) $(LDFLAGS) -o pd.com pd-s_entry.o $(LIBS) pd.lib
+$(pd_transformed).com: pd-s_entry.o $(pd_transformed).lib
+	$(CXX) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 else
 # for other OS, join pd_* with pd_*_core
@@ -486,8 +489,7 @@ clean-local:
 # we remove any existing symlink if doing a repeated install.
 install-exec-hook:
 	$(MKDIR_P) $(DESTDIR)$(libpdbindir)
-	rm -f $(DESTDIR)$(libpdbindir)/pd
-	$(LN_S) $(DESTDIR)$(bindir)/pd $(DESTDIR)$(libpdbindir)/pd
+	test "$(bindir)" = "$(libpdbindir)" || $(LN_S) -f $(DESTDIR)$(bindir)/$(pd_transformed)$(EXEEXT) $(DESTDIR)$(libpdbindir)/$(pd_transformed)$(EXEEXT)
 
 # remove the $(libdir)/pd/bin link
 # &

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -490,6 +490,8 @@ clean-local:
 install-exec-hook:
 	$(MKDIR_P) $(DESTDIR)$(libpdbindir)
 	test "$(bindir)" = "$(libpdbindir)" || $(LN_S) -f $(DESTDIR)$(bindir)/$(pd_transformed)$(EXEEXT) $(DESTDIR)$(libpdbindir)/$(pd_transformed)$(EXEEXT)
+#  try to create relative symlinks (doesn't work on macOS)
+	-test "$(bindir)" = "$(libpdbindir)" || $(LN_S) -f --relative $(DESTDIR)$(bindir)/$(pd_transformed)$(EXEEXT) $(DESTDIR)$(libpdbindir)/$(pd_transformed)$(EXEEXT)
 
 # remove the $(libdir)/pd/bin link
 # &

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -289,7 +289,7 @@ static void sigrifft_dsp(t_sigrifft *x, t_signal **sp)
 static void sigrifft_setup(void)
 {
     sigrifft_class = class_new(gensym("rifft~"), sigrifft_new, 0,
-        sizeof(t_sigrifft), 0, 0);
+        sizeof(t_sigrifft), CLASS_MULTICHANNEL, 0);
     class_setfreefn(sigrifft_class, fftclass_cleanup);
     CLASS_MAINSIGNALIN(sigrifft_class, t_sigrifft, x_f);
     class_addmethod(sigrifft_class, (t_method)sigrifft_dsp,

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -207,3 +207,8 @@ void sys_getversion(int *major, int *minor, int *bugfix)
     if (bugfix)
         *bugfix = PD_BUGFIX_VERSION;
 }
+
+unsigned int sys_getfloatsize()
+{
+    return sizeof(t_float);
+}

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -906,6 +906,9 @@ static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-512,512) */
     /* get version number at run time */
 EXTERN void sys_getversion(int *major, int *minor, int *bugfix);
 
+    /* get floatsize at run time */
+EXTERN unsigned int sys_getfloatsize(void);
+
 EXTERN_STRUCT _instancemidi;
 #define t_instancemidi struct _instancemidi
 

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -602,8 +602,8 @@ void sys_gui_audiopreferences(void) {
     char indevlist[MAXNDEV*DEVDESCSIZE], outdevlist[MAXNDEV*DEVDESCSIZE];
     char srate[80], callback[80], blocksize[80];
     const char *devicesI[MAXNDEV], *devicesO[MAXNDEV];
-    float usedevsI[MAXAUDIOINDEV], devchansI[MAXAUDIOINDEV];
-    float usedevsO[MAXAUDIOOUTDEV], devchansO[MAXAUDIOOUTDEV];
+    t_float usedevsI[MAXAUDIOINDEV], devchansI[MAXAUDIOINDEV];
+    t_float usedevsO[MAXAUDIOOUTDEV], devchansO[MAXAUDIOOUTDEV];
     int num_usedevsI, num_devchansI, num_usedevsO, num_devchansO;
     int num_devicesI = 0, num_devicesO = 0, canmulti = 0, cancallback = 0;
     int i;

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -733,7 +733,6 @@ void sys_listdevs(void)
 #if 0
         /* To agree with command line flags, normally start at 1 */
         /* But microsoft "MMIO" device list starts at 0 (the "mapper"). */
-        /* (see also sys_mmio variable in s_main.c)  */
 
        /* JMZ: otoh, it seems that the '-audiodev' flags 0-based
         * indices on ALSA and PORTAUDIO as well,

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -201,12 +201,14 @@ const char**sys_get_dllextensions(void)
         if(extraext)
             add_dllextension(extraext);
 
+#if PD_FLOATSIZE == 32
             /* and add the legacy extensions */
         for(i=0; i<sizeof(sys_dllextent_base)/sizeof(*sys_dllextent_base); i++)
         {
             if(sys_dllextent_base[i])
                 add_dllextension(sys_dllextent_base[i]);
         }
+#endif
             /* 0-terminate the extension list */
         add_dllextension(0);
     }

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -718,12 +718,6 @@ void sys_findprogdir(const char *progname)
 #endif
 }
 
-#ifdef _WIN32
-static int sys_mmio = 1;
-#else
-static int sys_mmio = 0;
-#endif
-
 int sys_argparse(int argc, const char **argv)
 {
     t_audiosettings as;
@@ -910,7 +904,6 @@ int sys_argparse(int argc, const char **argv)
             || !strcmp(*argv, "-asio"))
         {
             as.a_api = API_PORTAUDIO;
-            sys_mmio = 0;
             argc--; argv++;
         }
 #else
@@ -929,7 +922,6 @@ int sys_argparse(int argc, const char **argv)
         else if (!strcmp(*argv, "-mmio"))
         {
             as.a_api = API_MMIO;
-            sys_mmio = 1;
             argc--; argv++;
         }
 #else

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -696,7 +696,7 @@ void sys_gui_midipreferences(void) {
         /* these are the devices you're using: */
     int nindev, midiindev[MAXMIDIINDEV];
     int noutdev, midioutdev[MAXMIDIOUTDEV];
-    float midiindevf[MAXMIDIINDEV], midioutdevf[MAXMIDIOUTDEV];
+    t_float midiindevf[MAXMIDIINDEV], midioutdevf[MAXMIDIOUTDEV];
 
         /* query the current MIDI settings */
     sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -98,7 +98,7 @@ proc ::dialog_startup::fill_frame {frame} {
 
     checkbutton $frame.optionframe.verbose  -anchor w \
         -text [_ "Verbose"] \
-        -variable verbose_button
+        -variable ::sys_verbose
     pack $frame.optionframe.verbose -side top -anchor w -expand 1
 
     if {$::windowingsystem ne "win32"} {

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -93,24 +93,14 @@ proc ::dialog_startup::fill_frame {frame} {
         {} {} \
         [_ "Pd libraries to load on startup"]
 
-    labelframe $frame.optionframe -text [_ "Startup options" ]
-    pack $frame.optionframe -side top -anchor s -fill x -padx 2m -pady 5
-
-    checkbutton $frame.optionframe.verbose  -anchor w \
-        -text [_ "Verbose"] \
-        -variable ::sys_verbose
-    pack $frame.optionframe.verbose -side top -anchor w -expand 1
-
-    if {$::windowingsystem ne "win32"} {
-        checkbutton $frame.optionframe.defeatrt -anchor w \
-            -text [_ "Defeat real-time scheduling"] \
-            -variable ::sys_defeatrt
-        pack $frame.optionframe.defeatrt -side top -anchor w -expand 1
-    }
+    ## GUI options
+    labelframe $frame.guiframe -text [_ "GUI options" ]
+    set f $frame.guiframe
+    pack $f -side top -anchor s -fill x -padx 2m -pady 5
 
     # language selection
-    frame $frame.optionframe.langframe
-    set w $frame.optionframe.langframe.language
+    frame $f.langframe
+    set w $f.langframe.language
     menubutton $w -indicatoron 1 -menu $w.menu \
         -text [_ "language" ] \
             -relief raised -highlightthickness 1 -anchor c \
@@ -130,14 +120,28 @@ proc ::dialog_startup::fill_frame {frame} {
             }
         }
     }
-    pack $w -side left
-
-    set w $frame.optionframe.langframe.langlabel
-    label $w -text [_ "Menu language" ]
     pack $w -side right
-    pack $frame.optionframe.langframe -side top -anchor w -expand 1
 
+    set w $f.langframe.langlabel
+    label $w -text [_ "Menu language" ]
+    pack $w -side left
+    pack $f.langframe -side top -anchor w -expand 1
 
+    # Startup options and flags
+    labelframe $frame.optionframe -text [_ "Startup options" ]
+    pack $frame.optionframe -side top -anchor s -fill x -padx 2m -pady 5
+
+    checkbutton $frame.optionframe.verbose  -anchor w \
+        -text [_ "Verbose"] \
+        -variable ::sys_verbose
+    pack $frame.optionframe.verbose -side top -anchor w -expand 1
+
+    if {$::windowingsystem ne "win32"} {
+        checkbutton $frame.optionframe.defeatrt -anchor w \
+            -text [_ "Defeat real-time scheduling"] \
+            -variable ::sys_defeatrt
+        pack $frame.optionframe.defeatrt -side top -anchor w -expand 1
+    }
 
     labelframe $frame.flags -text [_ "Startup flags:" ]
     pack $frame.flags -side top -anchor s -fill x -padx 2m


### PR DESCRIPTION
this PR deals with the idea that both a single-precision Pd and a double-precision Pd can be installed at the same time (with the same package/installer/...).

The PR mostly fixes bugs with the buildsystem, that prevent the creation of co-installable binaries.

from a "new feature" perspective, I think the sole new feature is that 
- the GUI now has a preference to select which variant is to be launched
- and some accompanying code to actually launch that variant (either "pd" or "pd64")
- this "new feature" has been added as the last commit (https://github.com/pure-data/pure-data/pull/1995/commits/4036292a69b6c598408cf07df54a4780103413cf), so if it is unfit for inclusion in Pd-0.54-0, it can be easily left out)

after a lot of discussing and experimenting (see below), it also turned out that it's best that **double-precision and single-precision do not share the same filename space** (that is: they should use different file-extensions as a way to never accidentally try to load a double-precision external into a single-precision runtime; this was mostly problematic on Windows, where a single-precision library would force a single-precision runtime by means of loading the single-precision `pd.dll`).
the simple solution for that was to not use the good ole' library extensions (e.g. `.pd_linux`) for double-precision externals *at all*.

the remainder is really
- bug fixes in the build system that prevented building a `pd64.exe` (or rather: to allow mangling the name of the main binary, something that autotools does provide infrastructure for, but our Windows and macOS specific quirks did not take into account)

- Closes: https://github.com/pure-data/pure-data/issues/1992
- Closes: https://github.com/pure-data/pure-data/issues/2000
- Closes: https://github.com/pure-data/pure-data/issues/2006

for practical reasons (to resolve a merge conflict), this includes the (current) `develop` branch...

---
the main idea was laid out by @danomatika [on the mailinglist](https://lists.puredata.info/pipermail/pd-dev/2023-06/023409.html) and expanded by @Lucarda [later on](https://lists.puredata.info/pipermail/pd-dev/2023-06/023412.html):

- ship both `pd.exe` (for the single-precision build) and `pd64.exe` (for the double-precision build)
- have a single Pd-GUI
  - but have some option in the Pd-GUI preferences to tell it which variant of Pd to launch (if Pd is started via the GUI)

this PR doesn't automatically build double-precision binaries (this still has to be done explicitly by whoever creates the packages)