### PR TITLE
stable development branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -829,3 +829,13 @@ AS_IF([test x$enable_asio = xyes -a x$asio = xno ],
 
 AS_IF([test x$enable_fftw = xyes -a x$fftw = xno ],
  AC_MSG_WARN([FFTW requested but no development files found... disabled]))
+
+AS_CASE([${floatsize}],
+    [""],[],
+    [32],[],
+    [
+      AS_IF([test "${pd_transformed}" = "pd"],[
+        AC_MSG_WARN([Using a non-standard floatsize without name-mangling.
+        Did you forget to specify "--program-transform-name='s/pd$/pd${floatsize}/'"?
+        ])
+      ])])

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -483,12 +483,13 @@ static void *tabread4_tilde_new(t_symbol *s, int argc, t_atom *argv)
 static t_int *tabread4_tilde_perform(t_int *w)
 {
     t_dsparray *d = (t_dsparray *)(w[1]);
-    t_sample onset = *(t_sample *)(w[2]);
+    double onset = *(t_float *)(w[2]);
     t_sample *in = (t_sample *)(w[3]);
     t_sample *out = (t_sample *)(w[4]);
     int n = (int)(w[5]);
     int maxindex, i;
     t_word *buf, *wp;
+    const t_sample one_over_six = 1./6.;
 
     if (!dsparray_get_array(d, &maxindex, &buf, 0))
         goto zero;
@@ -515,8 +516,9 @@ static t_int *tabread4_tilde_perform(t_int *w)
         d = wp[2].w_float;
         cminusb = c-b;
         *out++ = b + frac * (
-            cminusb - 0.1666667f * (1.-frac) * (
-                (d - a - 3.0f * cminusb) * frac + (d + 2.0f*a - 3.0f*b)
+            cminusb - one_over_six * ((t_sample)1.-frac) * (
+                (d - a - (t_sample)3.0 * cminusb) * frac +
+                (d + a*(t_sample)2.0 - b*(t_sample)3.0)
             )
         );
     }

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -226,10 +226,15 @@ static void tabwrite_tilde_stop(t_tabwrite_tilde *x)
     }
 }
 
+static void tabwrite_tilde_free(t_tabwrite_tilde *x)
+{
+    arrayvec_free(&x->x_v);
+}
+
 static void tabwrite_tilde_setup(void)
 {
     tabwrite_tilde_class = class_new(gensym("tabwrite~"),
-        (t_newmethod)tabwrite_tilde_new, 0,
+        (t_newmethod)tabwrite_tilde_new, (t_method)tabwrite_tilde_free,
         sizeof(t_tabwrite_tilde), CLASS_MULTICHANNEL, A_GIMME, 0);
     CLASS_MAINSIGNALIN(tabwrite_tilde_class, t_tabwrite_tilde, x_f);
     class_addmethod(tabwrite_tilde_class, (t_method)tabwrite_tilde_dsp,
@@ -633,10 +638,16 @@ static void tabsend_dsp(t_tabsend *x, t_signal **sp)
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
 }
 
+static void tabsend_free(t_tabsend *x)
+{
+    arrayvec_free(&x->x_v);
+}
+
 static void tabsend_setup(void)
 {
-    tabsend_class = class_new(gensym("tabsend~"), (t_newmethod)tabsend_new,
-        0, sizeof(t_tabsend), CLASS_MULTICHANNEL, A_GIMME, 0);
+    tabsend_class = class_new(gensym("tabsend~"),
+        (t_newmethod)tabsend_new, (t_method)tabsend_free,
+        sizeof(t_tabsend), CLASS_MULTICHANNEL, A_GIMME, 0);
     CLASS_MAINSIGNALIN(tabsend_class, t_tabsend, x_f);
     class_addmethod(tabsend_class, (t_method)tabsend_dsp,
         gensym("dsp"), A_CANT, 0);
@@ -703,10 +714,15 @@ static void tabreceive_dsp(t_tabreceive *x, t_signal **sp)
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
 }
 
+static void tabreceive_free(t_tabreceive *x)
+{
+    arrayvec_free(&x->x_v);
+}
+
 static void tabreceive_setup(void)
 {
     tabreceive_class = class_new(gensym("tabreceive~"),
-        (t_newmethod)tabreceive_new, 0,
+        (t_newmethod)tabreceive_new, (t_method)tabreceive_free,
         sizeof(t_tabreceive), CLASS_MULTICHANNEL, A_GIMME, 0);
     class_addmethod(tabreceive_class, (t_method)tabreceive_dsp,
         gensym("dsp"), A_CANT, 0);

--- a/src/s_audio.c
+++ b/src/s_audio.c
@@ -856,6 +856,9 @@ static t_apientry audio_apilist[] = {
 
 void sys_get_audio_apis(char *buf)
 {
+        /* FIXXME: this returns a raw Tcl-list!
+         *  instead it should return something we can use with pdgui_vmess()
+         */
     unsigned int n;
     if (sizeof(audio_apilist)/sizeof(t_apientry) < 2)
         strcpy(buf, "{}");

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -880,33 +880,13 @@ void sys_gui(const char *s)
     sys_vgui("%s", s);
 }
 
-void sys_gui_namelist(const char*varname, t_namelist *nl)
+static void sys_gui_namelist(const char*varname, t_namelist *nl)
 {
     char obuf[MAXPDSTRING];
 
     sys_vgui("set_escaped %s ", varname);
     for (; nl; nl = nl->nl_next)
         sys_vgui("{%s} ", pdgui_strnescape(obuf, MAXPDSTRING, nl->nl_string, 0));
-    sys_gui("\n");
-}
-void sys_gui_strarray(const char*varname, const char*strarray[], unsigned int size)
-{
-    char obuf[MAXPDSTRING];
-    unsigned int i;
-
-    sys_vgui("set_escaped %s ", varname);
-    for (i=0; i<size; i++)
-        sys_vgui("{%s} ", pdgui_strnescape(obuf, MAXPDSTRING, strarray[i], 0));
-    sys_gui("\n");
-}
-void sys_gui_intarray(const char*varname, const int*intarray, unsigned int size)
-{
-    char obuf[MAXPDSTRING];
-    unsigned int i;
-
-    sys_vgui("set_escaped %s", varname);
-    for (i=0; i<size; i++)
-        sys_vgui(" %d", intarray[i]);
     sys_gui("\n");
 }
 

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -38,7 +38,6 @@ int sys_argparse(int argc, const char **argv);
 void sys_findprogdir(const char *progname);
 void sys_setsignalhandlers(void);
 int sys_startgui(const char *guipath);
-void sys_gui_namelist(const char*varname, t_namelist *nl);
 void sys_setrealtime(const char *guipath);
 int m_mainloop(void);
 int m_batchmain(void);

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -711,9 +711,9 @@ void sys_gui_midipreferences(void) {
 
         /* notify GUI of used input/output devices */
     for (i=0; i<nindev; i++)
-        midiindevf[i] = (t_float)midiindev[i];
+        midiindevf[i] = (t_float)midiindev[i] + 1;
     for (i=0; i<noutdev; i++)
-        midioutdevf[i] = (t_float)midioutdev[i];
+        midioutdevf[i] = (t_float)midioutdev[i] + 1;
 
     pdgui_vmess("::dialog_midi::set_configuration", "i SF SF",
                 sys_midiapi,

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -527,6 +527,9 @@ static char midi_outdevnames[MAXMIDIINDEV * DEVDESCSIZE];
 
 void sys_get_midi_apis(char *buf)
 {
+        /* FIXXME: this returns a raw Tcl-list!
+         *  instead it should return something we can use with pdgui_vmess()
+         */
     int n = 0;
     strcpy(buf, "{ ");
 #ifdef USEAPI_OSS

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -528,7 +528,7 @@ static void list_store_delete(t_list_store *x, t_floatarg f1, t_floatarg f2)
     x->x_alist.l_n -= n;
 }
 
-static void list_store_get(t_list_store *x, float f1, float f2)
+static void list_store_get(t_list_store *x, t_floatarg f1, t_floatarg f2)
 {
     t_atom *outv;
     int onset = f1, outc = f2;

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -259,3 +259,11 @@ proc ::dialog_path::commit {new_path} {
         ::pd_docsdir::update_path $::dialog_path::docspath
     }
 }
+
+
+# procs for setting variables from the Pd-core
+proc ::dialog_path::set_paths {searchpath temppath staticpath} {
+    set ::sys_searchpath $searchpath
+    set ::sys_temppath $temppath
+    set ::sys_staticpath $staticpath
+}

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -65,13 +65,13 @@ proc ::dialog_startup::commit { new_startup } {
     set ::pd_i18n::language $::dialog_startup::language
     ::pd_guiprefs::write "gui_language" $::dialog_startup::language
     set ::startup_libraries $new_startup
-    pdsend "pd startup-dialog $::sys_defeatrt [pdtk_encodedialog $::startup_flags] [pdtk_encode $::startup_libraries]"
+    pdsend "pd startup-dialog $::sys_defeatrt [pdtk_encodedialog $::sys_flags] [pdtk_encode $::startup_libraries]"
 }
 
 # set up the panel with the info from pd
 proc ::dialog_startup::pdtk_startup_dialog {mytoplevel defeatrt flags} {
     set ::sys_defeatrt $defeatrt
-    if {$flags ne ""} {variable ::startup_flags [subst -nocommands $flags]}
+    if {$flags ne ""} {variable ::sys_flags [subst -nocommands $flags]}
 
     if {[winfo exists $mytoplevel]} {
         wm deiconify $mytoplevel
@@ -141,7 +141,7 @@ proc ::dialog_startup::fill_frame {frame} {
 
     labelframe $frame.flags -text [_ "Startup flags:" ]
     pack $frame.flags -side top -anchor s -fill x -padx 2m
-    entry $frame.flags.entry -textvariable ::startup_flags
+    entry $frame.flags.entry -textvariable ::sys_flags
     pack $frame.flags.entry -side right -expand 1 -fill x
 
     ::preferencewindow::entryfocus $frame.flags.entry

--- a/tcl/dialog_startup.tcl
+++ b/tcl/dialog_startup.tcl
@@ -285,3 +285,11 @@ proc ::dialog_startup::unbind_return {mytoplevel} {
     bind $mytoplevel <KeyPress-Return> break
     return 1
 }
+
+# procs for setting variables from the Pd-core
+proc ::dialog_startup::set_flags {flags} {
+    set ::sys_flags [subst -nocommands -novariables ${flags}]
+}
+proc ::dialog_startup::set_libraries {libraries} {
+    set ::startup_libraries $libraries
+}

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -172,7 +172,7 @@ set current_plugin_loadpath {}
 # a list of plugins that were loaded
 set loaded_plugins {}
 # list of command line flags set at startup
-set startup_flags {}
+set sys_flags {}
 # list of libraries loaded on startup
 set startup_libraries {}
 # start dirs for new files and open panels

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -837,11 +837,20 @@ proc main {argc argv} {
         set exe_floatsize [::pd_guiprefs::read "pdcore_precision_binary" ]
         set pid ""
         set stderr ""
+
+        # the second-from-last and next-to-last entries are just fallbacks
+        # in case there's no 'pd'
+        # the very last entry is repeating a previous one,
+        # in order to have 'catch' emit a less confusing error message into $stderr
         foreach {bindir              exe} [list \
                  bin${exe_floatsize} pd${exe_floatsize} \
                  bin${exe_floatsize} pd \
                  bin                 pd${exe_floatsize} \
-                 bin                 pd ] {
+                 bin                 pd \
+                 bin                 pd32 \
+                 bin                 pd64 \
+                 bin                 pd \
+                ] {
             set pd_exec [file join $basedir $bindir $exe]
             catch {
                 set pid ""

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -1173,6 +1173,8 @@ proc ::deken::platform2string {{verbose 0}} {
 
 # allow overriding deken platform from Pd-core
 proc ::deken::set_platform {os machine bits floatsize} {
+    set bits [expr int($bits)]
+    set floatsize [expr int($floatsize)]
     if { $os != $::deken::platform(os) ||
          $machine != $::deken::platform(machine) ||
          $bits != $::deken::platform(bits) ||

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -1185,6 +1185,9 @@ proc ::deken::set_platform {os machine bits floatsize} {
         set msg [format [_ "Platform re-detected: %s" ] [::deken::platform2string 1] ]
         ::pdwindow::verbose 0 "\[deken\] ${msg}\n"
     }
+    if { [info procs ::pdwindow::update_title] ne ""} {
+        after idle {::pdwindow::update_title .pdwindow}
+    }
 }
 
 proc ::deken::versioncompare {a b} {

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -371,6 +371,28 @@ proc ::pdwindow::set_findinstance_cursor {widget key state} {
 }
 
 #--create the window-----------------------------------------------------------#
+proc ::pdwindow::update_title {w} {
+    set title [_ "Pd" ]
+    set version "${::PD_MAJOR_VERSION}.${::PD_MINOR_VERSION}.${::PD_BUGFIX_VERSION}${::PD_TEST_VERSION}"
+    set fulltitle "${title} ${version}"
+    if { [info exists ::deken::platform(floatsize)] } {
+        switch -- ${::deken::platform(floatsize)} {
+            32 { set floatsize "" }
+            64 { set floatsize [_ "EXPERIMENTAL double (64bit) precision"] }
+            default  { set floatsize [format [_ "%dbit-floats EXPERIMENTAL" ]  ${::deken::platform(floatsize)}]}
+        }
+        if { ${floatsize} ne "" } {
+            set fulltitle "${fulltitle} - ${floatsize}"
+        }
+    }
+
+    if { [winfo exists ${w} ] } {
+        wm title ${w} "${fulltitle}"
+    }
+    set ::windowname($w) $title
+
+    return ${fulltitle}
+}
 
 proc ::pdwindow::create_window {} {
     variable logmenuitems
@@ -386,8 +408,8 @@ proc ::pdwindow::create_window {} {
     option add *PdWindow*Entry.background "white" startupFile
 
     toplevel .pdwindow -class PdWindow
-    wm title .pdwindow [_ "Pd"]
-    set ::windowname(.pdwindow) [_ "Pd"]
+    ::pdwindow::update_title .pdwindow
+
     if {$::windowingsystem eq "x11"} {
         wm minsize .pdwindow 400 75
     } else {

--- a/tcl/preferencewindow.tcl
+++ b/tcl/preferencewindow.tcl
@@ -270,9 +270,9 @@ if {[tk windowingsystem] eq "aqua"} {
         }
 
         # call apply on Return in entry boxes that are in focus & rebind Return to ok button
-        bind $id <KeyPress-Return> "::dialog_audio::rebind_return $mytoplevel $okbutton \"$okaction\" \"cancelaction\""
+        bind $id <KeyPress-Return> "::preferencewindow::rebind_return $mytoplevel $okbutton \"$okaction\" \"cancelaction\""
         # unbind Return from ok button when an entry takes focus
-        $id config -validate focusin -vcmd "::dialog_audio::unbind_return $mytoplevel"
+        $id config -validate focusin -vcmd "::preferencewindow::unbind_return $mytoplevel"
     }
 
     # for focus handling on OSX

--- a/tcl/preferencewindow.tcl
+++ b/tcl/preferencewindow.tcl
@@ -116,7 +116,8 @@ proc ::preferencewindow::create {winid title {dimen {0 0}}} {
             [::deken::versioncompare 8.6.12 [info patchlevel]] > 0
          } {
             # some versions of Tcl/Tk on macOS just crash with ttk::notebook
-            ::pdwindow::error [_ "Disabling tabbed view: incompatible Tcl/Tk detected"]
+            set msg [_ "Disabling tabbed view: incompatible Tcl/Tk detected"]
+            ::pdwindow::error "${msg}\n"
             fail "Tcl/Tk request to not use ttk::notebook"
         }
         ttk::notebook ${winid}.content.frames


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch develop that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with unresolvable file conflicts)

it supersedes https://github.com/pure-data/pure-data/pull/2003

---

### core

- Closes: https://github.com/pure-data/pure-data/issues/2013
- Add missing destructors for `tabwrite~`, `tabsend~` and `tabreceive~`

### GUI
- Closes: https://github.com/pure-data/pure-data/issues/2005
- Closes: https://github.com/pure-data/pure-data/issues/2010
- Closes: https://github.com/pure-data/pure-data/issues/2016
- Closes: https://github.com/pure-data/pure-data/issues/2021
- Closes: https://github.com/pure-data/pure-data/issues/2022
- make it obvious if (by chance) you are running a double-precision Pd
  - by displaying the Pd-version and the float-precision (if not the default single-precision) in the title of the Pd-window
- if Pd-GUI couldn't launch Pd, open a messagebox telling the user so and perform an orderly exit (rather than crashing)
- fall back to `pd32` and `pd64` if no `pd` executable can be found 