### PR TITLE
stable development branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,14 @@ AS_IF([test "$( (echo 1.16; echo ${am__api_version}) | sort -t. -k 1,1n -k 2,2n 
 	       ])
 ])
 
+# check whether the user has provided --program-transform-name
+# we need this so we can fall back to a default transformation
+# in case the user passed --with-floatsize
+AS_CASE([$ac_configure_args],
+        [*\'--program-transform-name*], [have_program_transform_name=yes],
+        [*\'--program-prefix*], [have_program_transform_name=yes],
+        [*\'--program-suffix*], [have_program_transform_name=yes],
+        [have_program_transform_name=no])
 
 #########################################
 ##### Default values #####
@@ -59,9 +67,6 @@ PD_CPPFLAGS=""
 PD_CFLAGS=""
 PD_LDFLAGS=""
 
-
-pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
-pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
 
 #########################################
 ##### OS Detection #####
@@ -151,9 +156,10 @@ AS_CASE([$host],
     # this mirrors the default windows WISH define in s_inter.c
     wish="wish85.exe"
 
-    # externals are dynamically linked to pd.dll in their individual automake files
+    # externals need to be dynamically linked to pd.dll,
+    # but we need to check for --with-floatsize first (see below)
     EXTERNAL_CFLAGS="-mms-bitfields"
-    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined -l${pd_transformed}"
+    EXTERNAL_LDFLAGS="-Wl,--enable-auto-import -no-undefined"
     EXTERNAL_EXTENSION=dll
 
     # workaround for rpl_malloc/rpl_realloc bug in autoconf when cross-compiling
@@ -173,7 +179,8 @@ AS_CASE([$host],
     # this mirrors the default windows WISH define in s_inter.c
     wish="wish85.exe"
 
-    # externals are dynamically linked to pd.dll in their individual automake files
+    # externals need to be dynamically linked to pd.dll,
+    # but we need to check for --with-floatsize first (see below)
     EXTERNAL_CFLAGS=
     EXTERNAL_LDFLAGS="-Wl,--export-dynamic"
     EXTERNAL_EXTENSION=dll
@@ -385,7 +392,7 @@ AC_ARG_ENABLE([watchdog],
 AS_IF([test "x$enable_watchdog" != "xyes"],[enable_watchdog=no])
 AM_CONDITIONAL(PD_WATCHDOG, test x$enable_watchdog = xyes)
 
-
+###### floatsize ########
 AC_ARG_WITH([floatsize],
     [AS_HELP_STRING([--with-floatsize=<SIZE>],
     [build binaries for the given floatsize;
@@ -400,7 +407,7 @@ AS_CASE([${floatsize}],
     [64],[],
     [""],[],
     [
-        AC_MSG_WARN([${floatsize}bit floats not supported..fallback to default])
+        AC_MSG_WARN([${floatsize}bit floats not supported...use fallback])
         floatsize=""
     ])
 AS_IF([test "x${floatsize}" != "x" ],
@@ -414,6 +421,26 @@ AS_IF([test "x${floatsize}" = "x64" && test "x${deken_cpu}" != "x" && test "x${d
       EXTERNAL_EXTENSION="${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}"
       AC_MSG_NOTICE([default external extension...${EXTERNAL_EXTENSION}])
       ])
+
+pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
+pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
+
+AS_CASE([${floatsize}],
+    [""],[],
+    [32],[],
+    [
+      # if we specify a non-standard floatsize, make sure that the the program is also transformed.
+      # this is especially important on Windows (where we link against a pd.dll variant)
+      AS_IF([test "${pd_transformed}" = "pd" && test "${have_program_transform_name}" = "no"],[
+        program_transform_name="s/pd\$\$/pd${floatsize}/"
+        pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
+        pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
+      ])])
+
+# on Windows, we need to link against a (floatsize-decorated) pd.dll
+AS_IF([test "x${WINDOWS}" = "xyes" ],[
+   EXTERNAL_LDFLAGS="${EXTERNAL_LDFLAGS} -l${pd_transformed}"
+])
 
 ##### libpd #####
 AC_ARG_ENABLE([libpd],
@@ -836,6 +863,6 @@ AS_CASE([${floatsize}],
     [
       AS_IF([test "${pd_transformed}" = "pd"],[
         AC_MSG_WARN([Using a non-standard floatsize without name-mangling.
-        Did you forget to specify "--program-transform-name='s/pd$/pd${floatsize}/'"?
+        You should use something like "--program-suffix=${floatsize}"?
         ])
       ])])

--- a/configure.ac
+++ b/configure.ac
@@ -780,54 +780,54 @@ AC_OUTPUT
 
 AC_MSG_NOTICE([
 
-    $PACKAGE $VERSION is now configured
+    ${PACKAGE} ${VERSION} is now configured
 
-    Platform:             $platform
+    Platform:             ${platform}
     Float size:           ${floatsize:-default}
-    Debug build:          $debug
-    Universal build:      $universal
-    Localizations:        $locales
-    Source directory:     $srcdir
-    Installation prefix:  $prefix
+    Debug build:          ${debug}
+    Universal build:      ${universal}
+    Localizations:        ${locales}
+    Source directory:     ${srcdir}
+    Installation prefix:  ${prefix}
 
-    Compiler:             $CC
-    CPPFLAGS:             $PD_CPPFLAGS $CPPFLAGS
-    CFLAGS:               $PD_CFLAGS $CFLAGS
-    LDFLAGS:              $PD_LDFLAGS $LDFLAGS
-    INCLUDES:             $AM_CPPFLAGS
-    LIBS:                 $LIBS
+    Compiler:             ${CC}
+    CPPFLAGS:             ${PD_CPPFLAGS} ${CPPFLAGS}
+    CFLAGS:               ${PD_CFLAGS} ${CFLAGS}
+    LDFLAGS:              ${PD_LDFLAGS} ${LDFLAGS}
+    INCLUDES:             ${AM_CPPFLAGS}
+    LIBS:                 ${LIBS}
 
-    External extension:   $EXTERNAL_EXTENSION
-    External CFLAGS:      $EXTERNAL_CFLAGS
-    External LDFLAGS:     $EXTERNAL_LDFLAGS
+    External extension:   ${EXTERNAL_EXTENSION}
+    External CFLAGS:      ${EXTERNAL_CFLAGS}
+    External LDFLAGS:     ${EXTERNAL_LDFLAGS}
     Deken identifier:     ${deken_os:-???}-${deken_cpu:-???}
 
-    fftw:                 $fftw
-    wish(tcl/tk):         $wish
-    watchdog:             $enable_watchdog
-    audio APIs:           $audio_backends
-    midi APIs:            $midi_backends
-    libpd:                $libpd
+    fftw:                 ${fftw}
+    wish(tcl/tk):         ${wish}
+    watchdog:             ${enable_watchdog}
+    audio APIs:           ${audio_backends}
+    midi APIs:            ${midi_backends}
+    libpd:                ${libpd}
 ])
 
-AS_IF([test x$enable_locales = xyes -a x$locales = xno ],
+AS_IF([test "x${enable_locales}" = xyes -a "x${locales}" = xno ],
  AC_MSG_WARN([localization requested but no GNU gettext with msgfmt found... disabled]))
-AS_IF([test x$enable_oss = xyes -a x$oss = xno ],
+AS_IF([test "x${enable_oss}" = xyes -a "x${oss}" = xno ],
  AC_MSG_WARN([OSS requested but no development files found... disabled]))
-AS_IF([test x$enable_alsa = xyes -a x$alsa = xno ],
+AS_IF([test "x${enable_alsa}" = xyes -a "x${alsa}" = xno ],
  AC_MSG_WARN([ALSA requested but no development files found... disabled (See INSTALL.txt)]))
-AS_IF([test x$enable_jack = xyes -a x$jack = xno ],
+AS_IF([test "x${enable_jack}" = xyes -a "x${jack}" = xno ],
  AC_MSG_WARN([JACK requested but no development files found... disabled (See INSTALL.txt)]))
-AS_IF([test x$enable_jack_framework = xyes -a x$jack_jack != xyes ],
+AS_IF([test "x${enable_jack_framework}" = xyes -a "x${jack_jack}" != xyes ],
  AC_MSG_WARN([JACK-Framework requested but no development files found... disabled (See INSTALL.txt)]))
-AS_IF([test x$enable_mmio = xyes -a x$mmio = xno ],
+AS_IF([test "x${enable_mmio}" = xyes -a "x${mmio}" = xno ],
  AC_MSG_WARN([MMIO requested but not available... disabled (requires Windows)]))
-AS_IF([test x$enable_asio = xyes -a x$asio = xno ],
+AS_IF([test "x${enable_asio}" = xyes -a "x${asio}" = xno ],
  AC_MSG_WARN([ASIO requested but no SDK found... disabled (see asio/README.txt)]))
 
 # TODO portaudio
 
-AS_IF([test x$enable_fftw = xyes -a x$fftw = xno ],
+AS_IF([test "x${enable_fftw}" = xyes -a "x${fftw}" = xno ],
  AC_MSG_WARN([FFTW requested but no development files found... disabled]))
 
 AS_CASE([${floatsize}],

--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -141,10 +141,15 @@ if ! [ -d "${PDWINDIR}" ]
 then
   error "'${PDWINDIR}' is not a directory"
   cleanup 1
-elif ! [ -f "${PDWINDIR}/bin/pd.exe" ]
-then
-  error "Could not find bin/pd.exe. Is this a Windows build?"
-  cleanup 1
+else
+  for f in pd.exe pd.com pd64.exe pd64.com pd32.exe pd32.com pd.exe; do
+    pd_exe="${PDWINDIR}/bin/${f}"
+    [ -f "${pd_exe}" ] && break
+  done
+  if ! [ -f "${pd_exe}" ]; then
+	  error "Could not find ${f}. Is this a Windows build?"
+	  cleanup 1
+  fi
 fi
 
 if [  -z "${PDVERSION}" ]; then
@@ -167,9 +172,9 @@ fi
 
 # autodetect architecture if not given on the cmdline
 if [  "${PDARCH}" = "" ]; then
-    if file -b "${PDWINDIR}/bin/pd.exe" | grep -E "^PE32 .* 80386 " >/dev/null; then
+    if file -b "${pd_exe}" | grep -E "^PE32 .* 80386 " >/dev/null; then
         PDARCH=32
-    elif file -b "${PDWINDIR}/bin/pd.exe" | grep -E "^PE32\+ .* x86-64 " >/dev/null; then
+    elif file -b "${pd_exe}" | grep -E "^PE32\+ .* x86-64 " >/dev/null; then
         PDARCH=64
     fi
 fi

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -285,7 +285,7 @@ static t_int *tabplay_tilde_perform(t_int *w)
 
     if (!dsparray_get_array(d, &endphase, &buf, 0) || phase >= endphase)
         goto zero;
-    if (endphase < x->x_limit)
+    if (endphase > x->x_limit)
         endphase = x->x_limit;
     nxfer = endphase - phase;
     wp = buf + phase;

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -297,10 +297,14 @@ static t_int *tabplay_tilde_perform(t_int *w)
         *out++ = (wp++)->w_float;
     if (phase >= endphase)
     {
-            /* set the clock when the first channel runs out */
-        if (d == x->x_v.v_vec)
-            clock_delay(x->x_clock, 0);
+        int i, playing = 0;
         d->d_phase = 0x7fffffff;
+            /* set the clock when all channels have run out */
+        for (i = 0; i < x->x_v.v_n; i++)
+            if (x->x_v.v_vec[i].d_phase < 0x7fffffff)
+                playing = 1;
+        if (!playing)
+            clock_delay(x->x_clock, 0);
         while (n3--)
             *out++ = 0;
     }

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -152,10 +152,9 @@ static void tabwrite_tilde_redraw(t_symbol *arraysym)
 
 static t_int *tabwrite_tilde_perform(t_int *w)
 {
-    t_tabwrite_tilde *x = (t_tabwrite_tilde *)(w[1]);
-    t_dsparray *d = (t_dsparray *)(w[2]);
-    t_sample *in = (t_sample *)(w[3]);
-    int n = (int)(w[4]), phase = d->d_phase, endphase;
+    t_dsparray *d = (t_dsparray *)(w[1]);
+    t_sample *in = (t_sample *)(w[2]);
+    int n = (int)(w[3]), phase = d->d_phase, endphase;
     t_word *buf;
 
     if (!dsparray_get_array(d, &endphase, &buf, 0))
@@ -184,7 +183,7 @@ static t_int *tabwrite_tilde_perform(t_int *w)
     }
     else d->d_phase = 0x7fffffff;
 noop:
-    return (w+5);
+    return (w+4);
 }
 
 static void tabwrite_tilde_set(t_tabwrite_tilde *x, t_symbol *s,
@@ -199,7 +198,7 @@ static void tabwrite_tilde_dsp(t_tabwrite_tilde *x, t_signal **sp)
         sp[0]->s_nchans : x->x_v.v_n);
     arrayvec_testvec(&x->x_v, x);
     for (i = 0; i < nchans; i++)
-        dsp_add(tabwrite_tilde_perform, 4, x, x->x_v.v_vec+i,
+        dsp_add(tabwrite_tilde_perform, 3, x->x_v.v_vec+i,
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
 }
 

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -76,7 +76,7 @@ static void arrayvec_testvec(t_arrayvec *v)
 static void arrayvec_set(t_arrayvec *v, int argc, t_atom *argv)
 {
     int i;
-    for (i = 0; i < v->v_n; i++)
+    for (i = 0; i < v->v_n && i < argc; i++)
     {
         gpointer_unset(&v->v_vec[i].d_gp); /* reset the pointer */
         if (argv[i].a_type != A_SYMBOL)

--- a/src/d_fft.c
+++ b/src/d_fft.c
@@ -108,6 +108,16 @@ static void sigfft_dspx(t_sigfft *x, t_signal **sp, t_int *(*f)(t_int *w))
             "FFT inputs have different channel counts - ignoring extras");
     signal_setmultiout(&sp[2], nchans);
     signal_setmultiout(&sp[3], nchans);
+    if (length < 4 || (length != (1 << ilog2(length))))
+    {
+        if (length < 4)
+            pd_error(x, "fft: minimum 4 points");
+        else
+            pd_error(x, "fft: blocksize (%d) not a power of 2", length);
+        dsp_add_zero(sp[2]->s_vec, length * nchans);
+        dsp_add_zero(sp[3]->s_vec, length * nchans);
+        return;
+    }
     for (ch = 0; ch < nchans; ch++)
     {
         t_sample *in1 = sp[0]->s_vec + ch * length;
@@ -193,16 +203,21 @@ static void sigrfft_dsp(t_sigrfft *x, t_signal **sp)
     int nchans = sp[0]->s_nchans;
     signal_setmultiout(&sp[1], nchans);
     signal_setmultiout(&sp[2], nchans);
+    if (length < 4 || (length != (1 << ilog2(length))))
+    {
+        if (length < 4)
+            pd_error(x, "fft: minimum 4 points");
+        else
+            pd_error(x, "fft: blocksize (%d) not a power of 2", length);
+        dsp_add_zero(sp[1]->s_vec, length * nchans);
+        dsp_add_zero(sp[2]->s_vec, length * nchans);
+        return;
+    }
     for (ch = 0; ch < nchans; ch++)
     {
         t_sample *in1 = sp[0]->s_vec + ch * length;
         t_sample *out1 = sp[1]->s_vec + ch * length;
         t_sample *out2 = sp[2]->s_vec + ch * length;
-        if (length < 4)
-        {
-            pd_error(0, "fft: minimum 4 points");
-            return;
-        }
         if (in1 != out1)
             dsp_add(copy_perform, 3, in1, out1, (t_int)length);
         dsp_add(sigrfft_perform, 2, out1, (t_int)length);
@@ -262,16 +277,20 @@ static void sigrifft_dsp(t_sigrifft *x, t_signal **sp)
         pd_error(x,
             "rifft~ inputs have different channel counts - ignoring extras");
     signal_setmultiout(&sp[2], nchans);
+    if (length < 4 || (length != (1 << ilog2(length))))
+    {
+        if (length < 4)
+            pd_error(x, "fft: minimum 4 points");
+        else
+            pd_error(x, "fft: blocksize (%d) not a power of 2", length);
+        dsp_add_zero(sp[2]->s_vec, length * nchans);
+        return;
+    }
     for (ch = 0; ch < nchans; ch++)
     {
         t_sample *in1 = sp[0]->s_vec + ch * length;
         t_sample *in2 = sp[1]->s_vec + ch * length;
         t_sample *out1 = sp[2]->s_vec + ch * length;
-        if (length < 4)
-        {
-            pd_error(0, "fft: minimum 4 points");
-            return;
-        }
         if (in2 == out1)
         {
             dsp_add(sigrfft_flip, 3, out1+1, out1 + length, (t_int)(n2-1));

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -24,7 +24,8 @@ typedef struct _sigsend
 static void *sigsend_new(t_symbol *s, t_floatarg fnchans)
 {
     t_sigsend *x = (t_sigsend *)pd_new(sigsend_class);
-    pd_bind(&x->x_obj.ob_pd, s);
+    if (*s->s_name)
+        pd_bind(&x->x_obj.ob_pd, s);
     x->x_sym = s;
     if ((x->x_nchans = fnchans) < 1)
         x->x_nchans = 1;
@@ -81,7 +82,8 @@ static void sigsend_dsp(t_sigsend *x, t_signal **sp)
 
 static void sigsend_free(t_sigsend *x)
 {
-    pd_unbind(&x->x_obj.ob_pd, x->x_sym);
+    if (*x->x_sym->s_name)
+        pd_unbind(&x->x_obj.ob_pd, x->x_sym);
     freebytes(x->x_vec, x->x_length * sizeof(t_sample));
 }
 
@@ -198,7 +200,8 @@ static void sigreceive_set(t_sigreceive *x, t_symbol *s)
                     sender->x_nchans, sender->x_length);
         }
     }
-    else pd_error(x, "receive~ %s: no matching send", x->x_sym->s_name);
+    else if (*x->x_sym->s_name)
+        pd_error(x, "receive~ %s: no matching send", x->x_sym->s_name);
 }
 
 static void sigreceive_dsp(t_sigreceive *x, t_signal **sp)
@@ -244,7 +247,8 @@ typedef struct _sigcatch
 static void *sigcatch_new(t_symbol *s, t_floatarg fnchans)
 {
     t_sigcatch *x = (t_sigcatch *)pd_new(sigcatch_class);
-    pd_bind(&x->x_obj.ob_pd, s);
+    if (*s->s_name)
+        pd_bind(&x->x_obj.ob_pd, s);
     x->x_sym = s;
     x->x_canvas = canvas_getcurrent();
     x->x_length = 1;     /* replaced later */
@@ -297,7 +301,8 @@ static void sigcatch_dsp(t_sigcatch *x, t_signal **sp)
 
 static void sigcatch_free(t_sigcatch *x)
 {
-    pd_unbind(&x->x_obj.ob_pd, x->x_sym);
+    if (*x->x_sym->s_name)
+        pd_unbind(&x->x_obj.ob_pd, x->x_sym);
     freebytes(x->x_vec, x->x_length * sizeof(t_sample));
 }
 

--- a/src/d_osc.c
+++ b/src/d_osc.c
@@ -602,7 +602,6 @@ static void tabosc4_tilde_set(t_tabosc4_tilde *x, t_symbol *s)
         pd_error(x, "%s: number of points (%d) not a power of 2 plus three",
             x->x_arrayname->s_name, pointsinarray);
         x->x_vec = 0;
-        garray_usedindsp(a);
     }
     else
     {

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -394,10 +394,29 @@ static void sys_doneloadpreferences(void)
         sys_doneloadpreferences_file();
 }
 
+static int sys_deletepreference(const char *key);
+
 static void sys_initsavepreferences(void)
 {
     if (sys_prefsavefp)
         bug("sys_initsavepreferences");
+    else    /* delete audio and MIDI device keys */
+    {
+        int i, j;
+        char dev[MAXPDSTRING], devname[MAXPDSTRING];
+        const char *key[4] = { "audioin", "audioout", "midiin", "midiout" };
+        int maxnum[4] = { MAXAUDIOINDEV, MAXAUDIOOUTDEV, MAXMIDIINDEV, MAXMIDIOUTDEV };
+        for (i = 0; i < 4; i++)
+        {
+            for (j = 0; j < maxnum[i]; j++)
+            {
+                snprintf(dev, sizeof(dev), "%sdev%d", key[i], j + 1);
+                snprintf(devname, sizeof(devname), "%sdevname%d", key[i], j + 1);
+                if (!sys_deletepreference(dev) || !sys_deletepreference(devname))
+                    break;
+            }
+        }
+    }
 }
 
 static void sys_donesavepreferences(void)
@@ -418,7 +437,7 @@ static int sys_getpreference(const char *key, char *value, int size)
             "Software\\Pure-Data", 0,  KEY_QUERY_VALUE, &hkey);
         if (err != ERROR_SUCCESS)
             return (0);
-        err = RegQueryValueEx(hkey, key, 0, 0, value, &bigsize);
+        err = RegQueryValueEx(hkey, key, 0, 0, (LPBYTE)value, &bigsize);
         if (err != ERROR_SUCCESS)
         {
             RegCloseKey(hkey);
@@ -444,10 +463,37 @@ static void sys_putpreference(const char *key, const char *value)
             pd_error(0, "unable to create registry entry: %s\n", key);
             return;
         }
-        err = RegSetValueEx(hkey, key, 0, REG_EXPAND_SZ, value, strlen(value)+1);
+        err = RegSetValueEx(hkey, key, 0, REG_EXPAND_SZ, (const LPBYTE)value, strlen(value)+1);
         if (err != ERROR_SUCCESS)
             pd_error(0, "unable to set registry entry: %s\n", key);
         RegCloseKey(hkey);
+    }
+}
+
+static int sys_deletepreference(const char *key)
+{
+    if (sys_prefsavefp)
+    {
+        bug("sys_deletepreference");
+        return 0;
+    }
+    else
+    {
+        HKEY hkey;
+        LONG err;
+        err = RegOpenKeyEx(HKEY_CURRENT_USER,
+            "Software\\Pure-Data", 0, KEY_SET_VALUE, &hkey);
+        if (err != ERROR_SUCCESS)
+            return 0;
+        err = RegDeleteValue(hkey, key);
+        if (err == ERROR_SUCCESS)
+        {
+            RegCloseKey(hkey);
+            return 1;
+        } else if (err != ERROR_FILE_NOT_FOUND)
+            pd_error(0, "unable to delete registry entry: %s\n", key);
+        RegCloseKey(hkey);
+        return 0;
     }
 }
 

--- a/tcl/dialog_midi.tcl
+++ b/tcl/dialog_midi.tcl
@@ -116,6 +116,7 @@ proc ::dialog_midi::fill_frame_device {frame direction port} {
     pack $frame.l1 -side left
     pack $frame.x1 -side left -fill x -expand 1
 }
+
 proc ::dialog_midi::fill_frame_devices {frame direction maxports} {
     ## create a list of device pull-downs (one for each port)
 
@@ -123,7 +124,8 @@ proc ::dialog_midi::fill_frame_devices {frame direction maxports} {
     ## ro: devlist_midi_${direction}devlist
 
     upvar ::midi_${direction}devlist devlist
-    set numdevs [llength $devlist]
+    # NB: don't create entry for 'none' device
+    set numdevs [expr [llength $devlist] - 1]
     if { $maxports > $numdevs } { set maxports $numdevs }
     for {set p 1} {$p <= $maxports} {incr p} {
         set w ${frame}.${p}f


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch develop that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with unresolvable file conflicts)

it supersedes https://github.com/pure-data/pure-data/pull/2020

---

### core
- Closes: https://github.com/pure-data/pure-data/issues/2017
- get rid of unused arguments in `d_array.c` and `d_osc.c`
- fix possible out-of-bound access and bogus limit-check in `d_array.c`
- Closes: https://github.com/pure-data/pure-data/issues/1974
- Closes: https://github.com/pure-data/pure-data/issues/1988
- Closes: https://github.com/pure-data/pure-data/issues/2024
- clone: fix missing loadbangs on resize + fix duplicate closebangs

### gui
- MIDI dialog: fix number of device slots and "no available devices" label

### buildsystem
- by default, add the `64` suffix to the programname (and accompanying `pd.dll`) when building double-precision Pd
  see https://github.com/pure-data/pure-data/pull/1995#issuecomment-1609316224
- windows-installer: handle the case when no`pd.exe` is present (e.g. a pure Pd-double build)