### PR TITLE
multichannel support for delay objects

### DIFF
--- a/src/d_delay.c
+++ b/src/d_delay.c
@@ -14,6 +14,7 @@ static t_class *sigdelwrite_class;
 typedef struct delwritectl
 {
     int c_n;
+    int c_nchans;
     t_sample *c_vec;
     int c_phase;
 } t_delwritectl;
@@ -27,6 +28,7 @@ typedef struct _sigdelwrite
     int x_sortno;   /* DSP sort number at which this was last put on chain */
     int x_rsortno;  /* DSP sort # for first delread or write in chain */
     int x_vecsize;  /* vector size for delread~ to use */
+    int x_nchans;
     t_float x_sr;
     t_float x_f;
 } t_sigdelwrite;
@@ -40,25 +42,21 @@ static void sigdelwrite_update(t_sigdelwrite *x) /* added by Mathieu Bouchard */
     if (nsamps < 1) nsamps = 1;
     nsamps += ((- nsamps) & (SAMPBLK - 1));
     nsamps += x->x_vecsize;
-    if (x->x_cspace.c_n != nsamps)
+    if (x->x_cspace.c_n != nsamps || x->x_cspace.c_nchans != x->x_nchans)
     {
+        int oldsize = (x->x_cspace.c_n + XTRASAMPS) * x->x_cspace.c_nchans;
+        int newsize = (nsamps + XTRASAMPS) * x->x_nchans;
         x->x_cspace.c_vec = (t_sample *)resizebytes(x->x_cspace.c_vec,
-            (x->x_cspace.c_n + XTRASAMPS) * sizeof(t_sample),
-            (nsamps + XTRASAMPS) * sizeof(t_sample));
+             oldsize * sizeof(t_sample), newsize * sizeof(t_sample));
+        memset(x->x_cspace.c_vec, 0, newsize * sizeof(t_sample));
         x->x_cspace.c_n = nsamps;
+        x->x_cspace.c_nchans = x->x_nchans;
         x->x_cspace.c_phase = XTRASAMPS;
     #if 0
         post("delay line resized to %d samples", nsamps);
     #endif
     }
 }
-
-static void sigdelwrite_clear (t_sigdelwrite *x) /* added by Orm Finnendahl */
-{
-  if (x->x_cspace.c_n > 0)
-    memset(x->x_cspace.c_vec, 0, sizeof(t_sample)*(x->x_cspace.c_n + XTRASAMPS));
-}
-
 
     /* routine to check that all delwrites/delreads/vds have same vecsize */
 static void sigdelwrite_check(t_sigdelwrite *x, int vecsize, t_float sr)
@@ -89,7 +87,7 @@ static void sigdelwrite_check(t_sigdelwrite *x, int vecsize, t_float sr)
 #endif
 }
 
-static void *sigdelwrite_new(t_symbol *s, t_floatarg msec)
+static void *sigdelwrite_new(t_symbol *s, t_floatarg msec, t_floatarg nchans)
 {
     t_sigdelwrite *x = (t_sigdelwrite *)pd_new(sigdelwrite_class);
     if (!*s->s_name) s = gensym("delwrite~");
@@ -97,68 +95,113 @@ static void *sigdelwrite_new(t_symbol *s, t_floatarg msec)
     x->x_sym = s;
     x->x_deltime = msec;
     x->x_cspace.c_n = 0;
+    x->x_cspace.c_nchans = 1;
     x->x_cspace.c_vec = getbytes(XTRASAMPS * sizeof(t_sample));
     x->x_sortno = 0;
     x->x_vecsize = 0;
+    x->x_nchans = nchans > 0 ? nchans : 1;
     x->x_sr = 0;
     x->x_f = 0;
     return (x);
+}
+
+static void sigdelwrite_clear (t_sigdelwrite *x) /* added by Orm Finnendahl */
+{
+    if (x->x_cspace.c_n > 0)
+        memset(x->x_cspace.c_vec, 0,
+            (x->x_cspace.c_n + XTRASAMPS) * x->x_cspace.c_nchans * sizeof(t_sample));
+}
+
+static void sigdelwrite_channels(t_sigdelwrite *x, t_floatarg nchans)
+{
+    x->x_nchans = nchans > 0 ? nchans : 1;
+    canvas_update_dsp();
 }
 
 static t_int *sigdelwrite_perform(t_int *w)
 {
     t_sample *in = (t_sample *)(w[1]);
     t_delwritectl *c = (t_delwritectl *)(w[2]);
-    int n = (int)(w[3]);
-    int phase = c->c_phase, nsamps = c->c_n;
-    t_sample *vp = c->c_vec, *bp = vp + phase, *ep = vp + (c->c_n + XTRASAMPS);
-    phase += n;
-
-    while (n--)
+    int nchans = (int)(w[3]);
+    int n = (int)(w[4]);
+    int i, phase, nsamps = c->c_n;
+    for (i = 0; i < c->c_nchans; i++)
     {
-        t_sample f = *in++;
-        if (PD_BIGORSMALL(f))
-            f = 0;
-        *bp++ = f;
-        if (bp == ep)
-        {
-            vp[0] = ep[-4];
-            vp[1] = ep[-3];
-            vp[2] = ep[-2];
-            vp[3] = ep[-1];
-            bp = vp + XTRASAMPS;
-            phase -= nsamps;
-        }
+        t_sample *vp = c->c_vec + i * (nsamps + XTRASAMPS), *bp, *ep;
+        int k = n;
+        phase = c->c_phase;
+        bp = vp + phase;
+        ep = vp + (nsamps + XTRASAMPS);
+        phase += k;
+
+        if (i < nchans)
+            while (k--)
+            {
+                t_sample f = *in++;
+                if (PD_BIGORSMALL(f))
+                    f = 0;
+                *bp++ = f;
+                if (bp == ep)
+                {
+                    vp[0] = ep[-4];
+                    vp[1] = ep[-3];
+                    vp[2] = ep[-2];
+                    vp[3] = ep[-1];
+                    bp = vp + XTRASAMPS;
+                    phase -= nsamps;
+                }
+            }
+        else    /* fill missing channel with silence */
+            while (k--)
+            {
+                *bp++ = 0;
+                if (bp == ep)
+                {
+                    vp[0] = ep[-4];
+                    vp[1] = ep[-3];
+                    vp[2] = ep[-2];
+                    vp[3] = ep[-1];
+                    bp = vp + XTRASAMPS;
+                    phase -= nsamps;
+                }
+            }
     }
+        /* store phase from last iteration */
     c->c_phase = phase;
-    return (w+4);
+    return (w+5);
 }
 
 static void sigdelwrite_dsp(t_sigdelwrite *x, t_signal **sp)
 {
-    dsp_add(sigdelwrite_perform, 3, sp[0]->s_vec, &x->x_cspace, (t_int)sp[0]->s_n);
     x->x_sortno = ugen_getsortno();
-    sigdelwrite_check(x, sp[0]->s_n, sp[0]->s_sr);
+    sigdelwrite_check(x, sp[0]->s_length, sp[0]->s_sr);
     sigdelwrite_update(x);
+        /* NB: do not pass a direct pointer to the delay buffer because
+        it might get resized by another object, see sigdelwrite_update() */
+    dsp_add(sigdelwrite_perform, 4, sp[0]->s_vec,
+        &x->x_cspace, (t_int)sp[0]->s_nchans, (t_int)sp[0]->s_length);
 }
 
 static void sigdelwrite_free(t_sigdelwrite *x)
 {
     pd_unbind(&x->x_obj.ob_pd, x->x_sym);
     freebytes(x->x_cspace.c_vec,
-        (x->x_cspace.c_n + XTRASAMPS) * sizeof(t_sample));
+        (x->x_cspace.c_n + XTRASAMPS) * x->x_cspace.c_nchans * sizeof(t_sample));
 }
 
 static void sigdelwrite_setup(void)
 {
     sigdelwrite_class = class_new(gensym("delwrite~"),
         (t_newmethod)sigdelwrite_new, (t_method)sigdelwrite_free,
-        sizeof(t_sigdelwrite), 0, A_DEFSYM, A_DEFFLOAT, 0);
+        sizeof(t_sigdelwrite), CLASS_MULTICHANNEL,
+        A_DEFSYM, A_DEFFLOAT, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(sigdelwrite_class, t_sigdelwrite, x_f);
     class_addmethod(sigdelwrite_class, (t_method)sigdelwrite_dsp,
         gensym("dsp"), A_CANT, 0);
     class_addmethod(sigdelwrite_class, (t_method)sigdelwrite_clear,
-                    gensym("clear"), 0);
+        gensym("clear"), 0);
+    class_addmethod(sigdelwrite_class, (t_method)sigdelwrite_channels,
+        gensym("channels"), A_FLOAT, 0);
     class_sethelpsymbol(sigdelwrite_class, gensym("delay-tilde-objects"));
 }
 
@@ -210,9 +253,11 @@ static t_int *sigdelread_perform(t_int *w)
     t_sample *out = (t_sample *)(w[1]);
     t_delwritectl *c = (t_delwritectl *)(w[2]);
     int delsamps = *(int *)(w[3]);
-    int n = (int)(w[4]);
+    int chn = (int)(w[4]);
+    int n = (int)(w[5]);
     int phase = c->c_phase - delsamps, nsamps = c->c_n;
-    t_sample *vp = c->c_vec, *bp, *ep = vp + (c->c_n + XTRASAMPS);
+    t_sample *vp = c->c_vec + chn * (nsamps + XTRASAMPS),
+        *bp, *ep = vp + (nsamps + XTRASAMPS);
     if (phase < 0) phase += nsamps;
     bp = vp + phase;
 
@@ -221,37 +266,48 @@ static t_int *sigdelread_perform(t_int *w)
         *out++ = *bp++;
         if (bp == ep) bp -= nsamps;
     }
-    return (w+5);
+    return (w+6);
 }
 
 static void sigdelread_dsp(t_sigdelread *x, t_signal **sp)
 {
     t_sigdelwrite *delwriter =
         (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
+    int i, length = sp[0]->s_length;
     x->x_sr = sp[0]->s_sr * 0.001;
-    x->x_n = sp[0]->s_n;
+    x->x_n = length;
     if (delwriter)
     {
-        sigdelwrite_check(delwriter, sp[0]->s_n, sp[0]->s_sr);
+        signal_setmultiout(&sp[0], delwriter->x_nchans);
+        sigdelwrite_check(delwriter, length, sp[0]->s_sr);
         sigdelwrite_update(delwriter);
         x->x_zerodel = (delwriter->x_sortno == ugen_getsortno() ?
             0 : delwriter->x_vecsize);
         sigdelread_float(x, x->x_deltime);
-        dsp_add(sigdelread_perform, 4,
-            sp[0]->s_vec, &delwriter->x_cspace, &x->x_delsamps, (t_int)sp[0]->s_n);
+            /* NB: do not pass a direct pointer to the delay buffer because
+            it might get resized by another object, see sigdelwrite_update() */
+        for (i = 0; i < delwriter->x_nchans; i++)
+            dsp_add(sigdelread_perform, 5,
+                sp[0]->s_vec + i * length, &delwriter->x_cspace,
+                    &x->x_delsamps, (t_int)i, (t_int)length);
         /* check block size - but only if delwriter has been initialized */
-        if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+        if (delwriter->x_cspace.c_n > 0 && length > delwriter->x_cspace.c_n)
             pd_error(x, "delread~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);
     }
-    else if (*x->x_sym->s_name)
-        pd_error(x, "delread~: %s: no such delwrite~",x->x_sym->s_name);
+    else
+    {
+        if (*x->x_sym->s_name)
+            pd_error(x, "delread~: %s: no such delwrite~", x->x_sym->s_name);
+        signal_setmultiout(&sp[0], 1);
+        dsp_add_zero(sp[0]->s_vec, length);
+    }
 }
 
 static void sigdelread_setup(void)
 {
     sigdelread_class = class_new(gensym("delread~"),
         (t_newmethod)sigdelread_new, 0,
-        sizeof(t_sigdelread), 0, A_DEFSYM, A_DEFFLOAT, 0);
+        sizeof(t_sigdelread), CLASS_MULTICHANNEL, A_DEFSYM, A_DEFFLOAT, 0);
     class_addmethod(sigdelread_class, (t_method)sigdelread_dsp,
         gensym("dsp"), A_CANT, 0);
     class_addfloat(sigdelread_class, (t_method)sigdelread_float);
@@ -288,22 +344,25 @@ static t_int *sigvd_perform(t_int *w)
     t_sample *out = (t_sample *)(w[2]);
     t_delwritectl *ctl = (t_delwritectl *)(w[3]);
     t_sigvd *x = (t_sigvd *)(w[4]);
-    int n = (int)(w[5]);
+    int chn = (int)(w[5]);
+    int n = (int)(w[6]);
 
     int nsamps = ctl->c_n;
+    t_sample sr = x->x_sr;
     t_sample limit = nsamps - n;
     t_sample fn = n-1;
-    t_sample *vp = ctl->c_vec, *bp, *wp = vp + ctl->c_phase;
+    t_sample *vp = ctl->c_vec + chn * (nsamps + XTRASAMPS),
+        *bp, *wp = vp + ctl->c_phase;
     t_sample zerodel = x->x_zerodel;
     if (limit < 0) /* blocksize is larger than delread~ buffer size */
     {
         while (n--)
             *out++ = 0;
-        return (w+6);
+        return (w+7);
     }
     while (n--)
     {
-        t_sample delsamps = x->x_sr * *in++ - zerodel, frac;
+        t_sample delsamps = sr * (*in++) - zerodel, frac;
         int idelsamps;
         t_sample a, b, c, d, cminusb;
         if (!(delsamps >= 1.00001f))    /* too small or NAN */
@@ -327,35 +386,46 @@ static t_int *sigvd_perform(t_int *w)
             )
         );
     }
-    return (w+6);
+    return (w+7);
 }
 
 static void sigvd_dsp(t_sigvd *x, t_signal **sp)
 {
     t_sigdelwrite *delwriter =
         (t_sigdelwrite *)pd_findbyclass(x->x_sym, sigdelwrite_class);
+    int i, length = sp[0]->s_length;
     x->x_sr = sp[0]->s_sr * 0.001;
     if (delwriter)
     {
-        sigdelwrite_check(delwriter, sp[0]->s_n, sp[0]->s_sr);
+        signal_setmultiout(&sp[1], delwriter->x_nchans);
+        sigdelwrite_check(delwriter, length, sp[0]->s_sr);
         sigdelwrite_update(delwriter);
         x->x_zerodel = (delwriter->x_sortno == ugen_getsortno() ?
             0 : delwriter->x_vecsize);
-        dsp_add(sigvd_perform, 5,
-            sp[0]->s_vec, sp[1]->s_vec,
-                &delwriter->x_cspace, x, (t_int)sp[0]->s_n);
+            /* NB: do not pass a direct pointer to the delay buffer because
+            it might get resized by another object, see sigdelwrite_update() */
+        for (i = 0; i < delwriter->x_nchans; i++)
+            dsp_add(sigvd_perform, 6,
+                sp[0]->s_vec + (i % sp[0]->s_nchans) * length,
+                    sp[1]->s_vec + i * length, &delwriter->x_cspace,
+                        x, (t_int)i, (t_int)length);
         /* check block size - but only if delwriter has been initialized */
-        if (delwriter->x_cspace.c_n > 0 && sp[0]->s_n > delwriter->x_cspace.c_n)
+        if (delwriter->x_cspace.c_n > 0 && length > delwriter->x_cspace.c_n)
             pd_error(x, "delread4~ %s: blocksize larger than delwrite~ buffer", x->x_sym->s_name);
     }
-    else if (*x->x_sym->s_name)
-        pd_error(x, "delread4~: %s: no such delwrite~",x->x_sym->s_name);
+    else
+    {
+        if (*x->x_sym->s_name)
+            pd_error(x, "delread4~: %s: no such delwrite~",x->x_sym->s_name);
+        signal_setmultiout(&sp[1], 1);
+        dsp_add_zero(sp[1]->s_vec, length);
+    }
 }
 
 static void sigvd_setup(void)
 {
     sigvd_class = class_new(gensym("delread4~"), (t_newmethod)sigvd_new, 0,
-        sizeof(t_sigvd), 0, A_DEFSYM, 0);
+        sizeof(t_sigvd), CLASS_MULTICHANNEL, A_DEFSYM, 0);
     class_addcreator((t_newmethod)sigvd_new, gensym("vd~"), A_DEFSYM, 0);
     class_addmethod(sigvd_class, (t_method)sigvd_dsp, gensym("dsp"), A_CANT, 0);
     CLASS_MAINSIGNALIN(sigvd_class, t_sigvd, x_f);


### PR DESCRIPTION
`[delwrite~]` and `[delread~]` are conceptually very similar to `[send~]` and `[receive~]` resp. `[tabsend~]` and `[tabreceive~]`, so it would make sense if they also had multichannel support.

---

`[delwrite~]` now has an optionional third creation argument that sets the number of channels. This can also be changed dynamically with the `[channels(` message (requiring a DSP graph update), similar to `[send~]`.

`[delread~]` and `[delread4~]` automatically take the channel count from the corresponding `[delwrite~]` object, similar to `[receive~]`.