### PR TITLE
allow to unset receive~, throw~ and table DSP objects

### DIFF
--- a/src/d_array.c
+++ b/src/d_array.c
@@ -76,6 +76,15 @@ static void arrayvec_testvec(t_arrayvec *v)
 static void arrayvec_set(t_arrayvec *v, int argc, t_atom *argv)
 {
     int i;
+    if (!argc)  /* unset */
+    {
+        for (i = 0; i < v->v_n; i++)
+        {
+            gpointer_unset(&v->v_vec[i].d_gp);
+            v->v_vec[i].d_symbol = &s_;
+        }
+        return;
+    }
     for (i = 0; i < v->v_n && i < argc; i++)
     {
         gpointer_unset(&v->v_vec[i].d_gp); /* reset the pointer */

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -225,7 +225,7 @@ static void sigreceive_setup(void)
         A_DEFSYM, A_DEFFLOAT, 0);
     class_setdspflags(sigreceive_class, CLASS_MULTICHANNEL);
     class_addmethod(sigreceive_class, (t_method)sigreceive_set, gensym("set"),
-        A_SYMBOL, 0);
+        A_DEFSYM, 0);
     class_addmethod(sigreceive_class, (t_method)sigreceive_dsp,
         gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(sigreceive_class, gensym("send-receive-tilde"));
@@ -392,7 +392,7 @@ static void sigthrow_setup(void)
     sigthrow_class = class_new(gensym("throw~"), (t_newmethod)sigthrow_new, 0,
         sizeof(t_sigthrow), CLASS_MULTICHANNEL, A_DEFSYM, 0);
     class_addmethod(sigthrow_class, (t_method)sigthrow_set, gensym("set"),
-        A_SYMBOL, 0);
+        A_DEFSYM, 0);
     CLASS_MAINSIGNALIN(sigthrow_class, t_sigthrow, x_f);
     class_addmethod(sigthrow_class, (t_method)sigthrow_dsp,
         gensym("dsp"), A_CANT, 0);


### PR DESCRIPTION
An empty "set" message, previously forbidden, can now be used to unset `[receive~]`, `[throw~]` and all the table DSP objects.