### PR TITLE
More clone improvements

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1962,6 +1962,7 @@ static void canvas_f(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
     }
     if (!x->gl_list)
         return;
+        /* apply the format to the most recently created object */
     for (g = x->gl_list; (g2 = g->g_next); g = g2)
         ;
     if ((ob = pd_checkobject(&g->g_pd)))

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -290,6 +290,17 @@ int clone_reload(t_pd *z, t_canvas *except)
     return 1;
 }
 
+void glist_doreload(t_glist *gl, t_symbol *name, t_symbol *dir, t_canvas *except);
+
+    /* Continue abstraction reloading inside a clone object. See glist_doreload(). */
+void clone_doreload(t_pd *z, t_symbol *name, t_symbol *dir, t_canvas *except)
+{
+    int i;
+    t_clone *x = (t_clone *)z;
+    for (i = 0; i < x->x_n; i++)
+        glist_doreload(x->x_vec[i].c_gl, name, dir, except);
+}
+
 static void clone_setn(t_clone *x, t_floatarg f)
 {
     int nwas = x->x_n, wantn = f, i, j;

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -808,11 +808,11 @@ static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
     {
             /* if not an abstraction, reset title bar and directory */
         if (!x->gl_owner)
-{
+        {
             canvas_rename(x, filename, dir);
             /* update window list in case Save As changed the window name */
             canvas_updatewindowlist();
-}
+        }
         post("saved to: %s/%s", dir->s_name, filename->s_name);
         canvas_dirty(x, 0);
         canvas_reload(filename, dir, x);


### PR DESCRIPTION
1. If a cloned abstraction is saved, Pd currently just remakes the corresponding clone object and restores the window of the previously save instance. This is not a real solution, as the current abstraction is fully reinitialized - which can be *very* annoying.

    Instead we first try to update the clone object(s). This is done by reinitializing the canvases, without touching the currently saved abstraction! However, if the inlets/outlets appear to have changed, we refuse to update and rather remake the whole object.

    Closes https://github.com/pure-data/pure-data/issues/495

2. If an abstraction is saved, Pd searches all canvases for other instances and remakes them. Now we extend this search to instances *inside cloned abstractions*. Otherwise, cloned abstractions would still contain outdated versions of that abstraction.

3. Support `[savestate]` inside cloned abstractions.

    In clone's save method, we ask each canvas instances to save its state. We prepend each series of `#A saved ...` messages with a corresponding `#A set <n>` message, where `<n>` is the abstraction index. When the clone object is reloaded, the "set" message would set the current abstraction index and the "saved" message would forward its arguments to the currently set abstraction.

    We also make sure that cloned abstractions preserve their state when they are reloaded after the abstraction has been saved, as it is already case with non-cloned abstractions.