### PR TITLE
Add signal comparison/logical operators

### DIFF
--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -101,30 +101,26 @@ static void any_binop_scalar_dsp(t_signal **sp, t_sample *g,
         4, sp[0]->s_vec, g, sp[1]->s_vec, bign);
 }
 
-
-/* ----------------------------- plus ----------------------------- */
-static t_class *plus_class, *scalarplus_class;
-
-typedef struct _plus
+typedef struct _binop
 {
     t_object x_obj;
     t_float x_f;
-} t_plus;
+} t_binop;
 
-typedef struct _scalarplus
+typedef struct _scalarbinop
 {
     t_object x_obj;
     t_float x_f;
-    t_float x_g;            /* inlet value */
-} t_scalarplus;
+    t_float x_g;
+} t_scalarbinop;
 
-static void *plus_new(t_symbol *s, int argc, t_atom *argv)
+static void *any_binop_new(t_symbol *s, int argc, t_atom *argv,
+    t_class *binop_class, t_class *scalarbinop_class)
 {
-    if (argc > 1)
-        post("+~: extra arguments ignored");
-    if (argc)   /* argument implies we'll do a scalar add as in "+~ 1" */
+    if (argc > 1) post("%s: extra arguments ignored", s->s_name);
+    if (argc)
     {
-        t_scalarplus *x = (t_scalarplus *)pd_new(scalarplus_class);
+        t_scalarbinop *x = (t_scalarbinop *)pd_new(scalarbinop_class);
         floatinlet_new(&x->x_obj, &x->x_g);
         x->x_g = atom_getfloatarg(0, argc, argv);
         outlet_new(&x->x_obj, &s_signal);
@@ -133,12 +129,47 @@ static void *plus_new(t_symbol *s, int argc, t_atom *argv)
     }
     else
     {
-        t_plus *x = (t_plus *)pd_new(plus_class);
+        t_binop *x = (t_binop *)pd_new(binop_class);
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
         outlet_new(&x->x_obj, &s_signal);
         x->x_f = 0;
         return (x);
     }
+}
+
+typedef void *(*t_binop_newmethod)(t_symbol *, int, t_atom *);
+typedef void (*t_binop_dspmethod)(t_binop *, t_signal **);
+typedef void (*t_scalarbinop_dspmethod)(t_scalarbinop *, t_signal **);
+
+static t_class *any_binop_class(t_symbol *name, t_binop_newmethod newmethod,
+    t_binop_dspmethod dspmethod)
+{
+    t_class *class = class_new(name, (t_newmethod)newmethod, 0, sizeof(t_binop),
+        CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
+            A_GIMME, 0);
+    CLASS_MAINSIGNALIN(class, t_binop, x_f);
+    class_addmethod(class, (t_method)dspmethod, gensym("dsp"), A_CANT, 0);
+    class_sethelpsymbol(class, gensym("binops-tilde"));
+    return class;
+}
+
+static t_class *any_scalarbinop_class(t_symbol *name,
+    t_scalarbinop_dspmethod dspmethod)
+{
+    t_class *class = class_new(name, 0, 0, sizeof(t_scalarbinop),
+        CLASS_MULTICHANNEL, 0);
+    CLASS_MAINSIGNALIN(class, t_scalarbinop, x_f);
+    class_addmethod(class, (t_method)dspmethod, gensym("dsp"), A_CANT, 0);
+    class_sethelpsymbol(class, gensym("binops-tilde"));
+    return class;
+}
+
+/* ----------------------------- plus ----------------------------- */
+static t_class *plus_class, *scalarplus_class;
+
+static void *plus_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, plus_class, scalarplus_class);
 }
 
 t_int *scalarplus_perform(t_int *w)
@@ -168,71 +199,30 @@ t_int *scalarplus_perf8(t_int *w)
     return (w+5);
 }
 
-static void plus_dsp(t_plus *x, t_signal **sp)
+static void plus_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, plus_perform, plus_perf8,
         scalarplus_perform, scalarplus_perf8,
         scalarplus_perform, scalarplus_perf8);
 }
 
-static void scalarplus_dsp(t_scalarplus *x, t_signal **sp)
+static void scalarplus_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalarplus_perform, scalarplus_perf8);
 }
 
 static void plus_setup(void)
 {
-    plus_class = class_new(gensym("+~"), (t_newmethod)plus_new, 0,
-        sizeof(t_plus),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    class_addmethod(plus_class, (t_method)plus_dsp, gensym("dsp"), A_CANT, 0);
-    CLASS_MAINSIGNALIN(plus_class, t_plus, x_f);
-    class_sethelpsymbol(plus_class, gensym("binops-tilde"));
-    scalarplus_class = class_new(gensym("+~"), 0, 0,
-        sizeof(t_scalarplus), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarplus_class, t_scalarplus, x_f);
-    class_addmethod(scalarplus_class, (t_method)scalarplus_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarplus_class, gensym("binops-tilde"));
+    plus_class = any_binop_class(gensym("+~"), plus_new, plus_dsp);
+    scalarplus_class = any_scalarbinop_class(gensym("+~"), scalarplus_dsp);
 }
 
 /* ----------------------------- minus ----------------------------- */
 static t_class *minus_class, *scalarminus_class;
 
-typedef struct _minus
-{
-    t_object x_obj;
-    t_float x_f;
-} t_minus;
-
-typedef struct _scalarminus
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalarminus;
-
 static void *minus_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("-~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarminus *x = (t_scalarminus *)pd_new(scalarminus_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_minus *x = (t_minus *)pd_new(minus_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv, minus_class, scalarminus_class);
 }
 
 t_int *minus_perform(t_int *w)
@@ -319,72 +309,31 @@ t_int *reversescalarminus_perf8(t_int *w)
     return (w+5);
 }
 
-static void minus_dsp(t_minus *x, t_signal **sp)
+static void minus_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, minus_perform, minus_perf8,
         scalarminus_perform, scalarminus_perf8,
         reversescalarminus_perform, reversescalarminus_perf8);
 }
 
-static void scalarminus_dsp(t_scalarminus *x, t_signal **sp)
+static void scalarminus_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalarminus_perform, scalarminus_perf8);
 }
 
 static void minus_setup(void)
 {
-    minus_class = class_new(gensym("-~"), (t_newmethod)minus_new, 0,
-        sizeof(t_minus),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(minus_class, t_minus, x_f);
-    class_addmethod(minus_class, (t_method)minus_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(minus_class, gensym("binops-tilde"));
-    scalarminus_class = class_new(gensym("-~"), 0, 0,
-        sizeof(t_scalarminus), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarminus_class, t_scalarminus, x_f);
-    class_addmethod(scalarminus_class, (t_method)scalarminus_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarminus_class, gensym("binops-tilde"));
+    minus_class = any_binop_class(gensym("-~"), minus_new, minus_dsp);
+    scalarminus_class = any_scalarbinop_class(gensym("-~"), scalarminus_dsp);
 }
 
 /* ----------------------------- times ----------------------------- */
 
 static t_class *times_class, *scalartimes_class;
 
-typedef struct _times
-{
-    t_object x_obj;
-    t_float x_f;
-} t_times;
-
-typedef struct _scalartimes
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalartimes;
-
 static void *times_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("*~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalartimes *x = (t_scalartimes *)pd_new(scalartimes_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_times *x = (t_times *)pd_new(times_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv, times_class, scalartimes_class);
 }
 
 t_int *times_perform(t_int *w)
@@ -444,71 +393,30 @@ t_int *scalartimes_perf8(t_int *w)
     return (w+5);
 }
 
-static void times_dsp(t_times *x, t_signal **sp)
+static void times_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, times_perform, times_perf8,
         scalartimes_perform, scalartimes_perf8,
         scalartimes_perform, scalartimes_perf8);
 }
 
-static void scalartimes_dsp(t_scalartimes *x, t_signal **sp)
+static void scalartimes_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalartimes_perform, scalartimes_perf8);
 }
 
 static void times_setup(void)
 {
-    times_class = class_new(gensym("*~"), (t_newmethod)times_new, 0,
-        sizeof(t_times),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(times_class, t_times, x_f);
-    class_addmethod(times_class, (t_method)times_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(times_class, gensym("binops-tilde"));
-    scalartimes_class = class_new(gensym("*~"), 0, 0,
-        sizeof(t_scalartimes), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalartimes_class, t_scalartimes, x_f);
-    class_addmethod(scalartimes_class, (t_method)scalartimes_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalartimes_class, gensym("binops-tilde"));
+    times_class = any_binop_class(gensym("*~"), times_new, times_dsp);
+    scalartimes_class = any_scalarbinop_class(gensym("*~"), scalartimes_dsp);
 }
 
 /* ----------------------------- over ----------------------------- */
 static t_class *over_class, *scalarover_class;
 
-typedef struct _over
-{
-    t_object x_obj;
-    t_float x_f;
-} t_over;
-
-typedef struct _scalarover
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalarover;
-
 static void *over_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("/~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarover *x = (t_scalarover *)pd_new(scalarover_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_over *x = (t_over *)pd_new(over_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv, over_class, scalarover_class);
 }
 
 t_int *over_perform(t_int *w)
@@ -614,71 +522,30 @@ t_int *reversescalarover_perf8(t_int *w)
 }
 
 
-static void over_dsp(t_over *x, t_signal **sp)
+static void over_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, over_perform, over_perf8,
         scalarover_perform, scalarover_perf8,
         reversescalarover_perform, reversescalarover_perf8);
 }
 
-static void scalarover_dsp(t_scalarover *x, t_signal **sp)
+static void scalarover_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalarover_perform, scalarover_perf8);
 }
 
 static void over_setup(void)
 {
-    over_class = class_new(gensym("/~"), (t_newmethod)over_new, 0,
-        sizeof(t_over),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(over_class, t_over, x_f);
-    class_addmethod(over_class, (t_method)over_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(over_class, gensym("binops-tilde"));
-    scalarover_class = class_new(gensym("/~"), 0, 0,
-        sizeof(t_scalarover), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarover_class, t_scalarover, x_f);
-    class_addmethod(scalarover_class, (t_method)scalarover_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarover_class, gensym("binops-tilde"));
+    over_class = any_binop_class(gensym("/~"), over_new, over_dsp);
+    scalarover_class = any_scalarbinop_class(gensym("/~"), scalarover_dsp);
 }
 
 /* ----------------------------- max ----------------------------- */
 static t_class *max_class, *scalarmax_class;
 
-typedef struct _max
-{
-    t_object x_obj;
-    t_float x_f;
-} t_max;
-
-typedef struct _scalarmax
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalarmax;
-
 static void *max_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("max~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarmax *x = (t_scalarmax *)pd_new(scalarmax_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_max *x = (t_max *)pd_new(max_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv, max_class, scalarmax_class);
 }
 
 t_int *max_perform(t_int *w)
@@ -750,71 +617,30 @@ t_int *scalarmax_perf8(t_int *w)
     return (w+5);
 }
 
-static void max_dsp(t_max *x, t_signal **sp)
+static void max_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, max_perform, max_perf8,
         scalarmax_perform, scalarmax_perf8,
         scalarmax_perform, scalarmax_perf8);
 }
 
-static void scalarmax_dsp(t_scalarmax *x, t_signal **sp)
+static void scalarmax_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalarmax_perform, scalarmax_perf8);
 }
 
 static void max_setup(void)
 {
-    max_class = class_new(gensym("max~"), (t_newmethod)max_new, 0,
-        sizeof(t_max),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(max_class, t_max, x_f);
-    class_addmethod(max_class, (t_method)max_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(max_class, gensym("binops-tilde"));
-    scalarmax_class = class_new(gensym("max~"), 0, 0,
-        sizeof(t_scalarmax), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarmax_class, t_scalarmax, x_f);
-    class_addmethod(scalarmax_class, (t_method)scalarmax_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarmax_class, gensym("binops-tilde"));
+    max_class = any_binop_class(gensym("max~"), max_new, max_dsp);
+    scalarmax_class = any_scalarbinop_class(gensym("max~"), scalarmax_dsp);
 }
 
 /* ----------------------------- min ----------------------------- */
 static t_class *min_class, *scalarmin_class;
 
-typedef struct _min
-{
-    t_object x_obj;
-    t_float x_f;
-} t_min;
-
-typedef struct _scalarmin
-{
-    t_object x_obj;
-    t_float x_g;
-    t_float x_f;
-} t_scalarmin;
-
 static void *min_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("min~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarmin *x = (t_scalarmin *)pd_new(scalarmin_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_min *x = (t_min *)pd_new(min_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv, min_class, scalarmin_class);
 }
 
 t_int *min_perform(t_int *w)
@@ -886,72 +712,31 @@ t_int *scalarmin_perf8(t_int *w)
     return (w+5);
 }
 
-static void min_dsp(t_min *x, t_signal **sp)
+static void min_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, min_perform, min_perf8,
         scalarmin_perform, scalarmin_perf8,
         scalarmin_perform, scalarmin_perf8);
 }
 
-static void scalarmin_dsp(t_scalarmin *x, t_signal **sp)
+static void scalarmin_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, scalarmin_perform, scalarmin_perf8);
 }
 
 static void min_setup(void)
 {
-    min_class = class_new(gensym("min~"), (t_newmethod)min_new, 0,
-        sizeof(t_min),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(min_class, t_min, x_f);
-    class_addmethod(min_class, (t_method)min_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(min_class, gensym("binops-tilde"));
-    scalarmin_class = class_new(gensym("min~"), 0, 0,
-        sizeof(t_scalarmin), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarmin_class, t_scalarmin, x_f);
-    class_addmethod(scalarmin_class, (t_method)scalarmin_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarmin_class, gensym("binops-tilde"));
+    min_class = any_binop_class(gensym("min~"), min_new, min_dsp);
+    scalarmin_class = any_scalarbinop_class(gensym("min~"), scalarmin_dsp);
 }
 
 /* ----------------------------- log ----------------------------- */
 static t_class *log_tilde_class, *scalarlog_tilde_class;
 
-typedef struct _log_tilde
-{
-    t_object x_obj;
-    t_float x_f;
-} t_log_tilde;
-
-typedef struct _scalarlog_tilde
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalarlog_tilde;
-
 static void *log_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("log~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarlog_tilde *x =
-            (t_scalarlog_tilde *)pd_new(scalarlog_tilde_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_log_tilde *x = (t_log_tilde *)pd_new(log_tilde_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv,
+        log_tilde_class, scalarlog_tilde_class);
 }
 
 t_int *log_tilde_perform(t_int *w)
@@ -1011,14 +796,14 @@ t_int *log_tilde_perform_reversescalar(t_int *w)
     return (w+5);
 }
 
-static void log_tilde_dsp(t_log_tilde *x, t_signal **sp)
+static void log_tilde_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, log_tilde_perform, log_tilde_perform,
         log_tilde_perform_scalar, log_tilde_perform_scalar,
         log_tilde_perform_reversescalar, log_tilde_perform_reversescalar);
 }
 
-static void scalarlog_tilde_dsp(t_scalarlog_tilde *x, t_signal **sp)
+static void scalarlog_tilde_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, log_tilde_perform_scalar,
         log_tilde_perform_scalar);
@@ -1026,58 +811,19 @@ static void scalarlog_tilde_dsp(t_scalarlog_tilde *x, t_signal **sp)
 
 static void log_tilde_setup(void)
 {
-    log_tilde_class = class_new(gensym("log~"), (t_newmethod)log_tilde_new, 0,
-        sizeof(t_log_tilde),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(log_tilde_class, t_log_tilde, x_f);
-    class_addmethod(log_tilde_class, (t_method)log_tilde_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(log_tilde_class, gensym("binops-tilde"));
-    scalarlog_tilde_class = class_new(gensym("log~"), 0, 0,
-        sizeof(t_scalarlog_tilde), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarlog_tilde_class, t_scalarlog_tilde, x_f);
-    class_addmethod(scalarlog_tilde_class, (t_method)scalarlog_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarlog_tilde_class, gensym("binops-tilde"));
+    log_tilde_class = any_binop_class(gensym("log~"),
+        log_tilde_new, log_tilde_dsp);
+    scalarlog_tilde_class = any_scalarbinop_class(gensym("log~"),
+        scalarlog_tilde_dsp);
 }
 
 /* ----------------------------- pow ----------------------------- */
 static t_class *pow_tilde_class, *scalarpow_tilde_class;
 
-typedef struct _pow_tilde
-{
-    t_object x_obj;
-    t_float x_f;
-} t_pow_tilde;
-
-typedef struct _scalarpow_tilde
-{
-    t_object x_obj;
-    t_float x_f;
-    t_float x_g;
-} t_scalarpow_tilde;
-
 static void *pow_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("pow~: extra arguments ignored");
-    if (argc)
-    {
-        t_scalarpow_tilde *x =
-            (t_scalarpow_tilde *)pd_new(scalarpow_tilde_class);
-        floatinlet_new(&x->x_obj, &x->x_g);
-        x->x_g = atom_getfloatarg(0, argc, argv);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
-    else
-    {
-        t_pow_tilde *x = (t_pow_tilde *)pd_new(pow_tilde_class);
-        inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
-        outlet_new(&x->x_obj, &s_signal);
-        x->x_f = 0;
-        return (x);
-    }
+    return any_binop_new(s, argc, argv,
+        pow_tilde_class, scalarpow_tilde_class);
 }
 
 t_int *pow_tilde_perform(t_int *w)
@@ -1128,14 +874,14 @@ t_int *pow_tilde_perform_reversescalar(t_int *w)
     return (w+5);
 }
 
-static void pow_tilde_dsp(t_pow_tilde *x, t_signal **sp)
+static void pow_tilde_dsp(t_binop *x, t_signal **sp)
 {
     any_binop_dsp(sp, pow_tilde_perform, pow_tilde_perform,
         pow_tilde_perform_scalar, pow_tilde_perform_scalar,
         pow_tilde_perform_reversescalar, pow_tilde_perform_reversescalar);
 }
 
-static void scalarpow_tilde_dsp(t_scalarpow_tilde *x, t_signal **sp)
+static void scalarpow_tilde_dsp(t_scalarbinop *x, t_signal **sp)
 {
     any_binop_scalar_dsp(sp, &x->x_g, pow_tilde_perform_scalar,
         pow_tilde_perform_scalar);
@@ -1143,19 +889,10 @@ static void scalarpow_tilde_dsp(t_scalarpow_tilde *x, t_signal **sp)
 
 static void pow_tilde_setup(void)
 {
-    pow_tilde_class = class_new(gensym("pow~"), (t_newmethod)pow_tilde_new, 0,
-        sizeof(t_pow_tilde),
-            CLASS_MULTICHANNEL | CLASS_NOPROMOTESIG | CLASS_NOPROMOTELEFT,
-                A_GIMME, 0);
-    CLASS_MAINSIGNALIN(pow_tilde_class, t_pow_tilde, x_f);
-    class_addmethod(pow_tilde_class, (t_method)pow_tilde_dsp, gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(pow_tilde_class, gensym("binops-tilde"));
-    scalarpow_tilde_class = class_new(gensym("pow~"), 0, 0,
-        sizeof(t_scalarpow_tilde), CLASS_MULTICHANNEL, 0);
-    CLASS_MAINSIGNALIN(scalarpow_tilde_class, t_scalarpow_tilde, x_f);
-    class_addmethod(scalarpow_tilde_class, (t_method)scalarpow_tilde_dsp,
-        gensym("dsp"), A_CANT, 0);
-    class_sethelpsymbol(scalarpow_tilde_class, gensym("binops-tilde"));
+    pow_tilde_class = any_binop_class(gensym("pow~"),
+        pow_tilde_new, pow_tilde_dsp);
+    scalarpow_tilde_class = any_scalarbinop_class(gensym("pow~"),
+        scalarpow_tilde_dsp);
 }
 
 /* ----------------------- global setup routine ---------------- */

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -1338,6 +1338,172 @@ static void le_tilde_setup(void)
     scalar_le_tilde_class = any_scalarbinop_class(gensym("<=~"), scalar_le_tilde_dsp);
 }
 
+/* ----------------------------- &&~ ----------------------------- */
+static t_class *and_tilde_class, *scalarand_tilde_class;
+
+static void *and_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, and_tilde_class, scalarand_tilde_class);
+}
+
+t_int *and_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ && *in2++;
+    return (w+5);
+}
+
+t_int *and_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 && g0; out[1] = f1 && g1; out[2] = f2 && g2; out[3] = f3 && g3;
+        out[4] = f4 && g4; out[5] = f5 && g5; out[6] = f6 && g6; out[7] = f7 && g7;
+    }
+    return (w+5);
+}
+
+t_int *scalarand_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ && f;
+    return (w+5);
+}
+
+t_int *scalarand_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 && g; out[1] = f1 && g; out[2] = f2 && g; out[3] = f3 && g;
+        out[4] = f4 && g; out[5] = f5 && g; out[6] = f6 && g; out[7] = f7 && g;
+    }
+    return (w+5);
+}
+
+static void and_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, and_tilde_perform, and_tilde_perf8,
+        scalarand_tilde_perform, scalarand_tilde_perf8,
+        scalarand_tilde_perform, scalarand_tilde_perf8);
+}
+
+static void scalarand_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g, scalarand_tilde_perform, scalarand_tilde_perf8);
+}
+
+static void and_tilde_setup(void)
+{
+    and_tilde_class = any_binop_class(gensym("&&~"), and_tilde_new, and_tilde_dsp);
+    scalarand_tilde_class = any_scalarbinop_class(gensym("&&~"), scalarand_tilde_dsp);
+}
+
+/* ----------------------------- ||~ ----------------------------- */
+static t_class *or_tilde_class, *scalaror_tilde_class;
+
+static void *or_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, or_tilde_class, scalaror_tilde_class);
+}
+
+t_int *or_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ || *in2++;
+    return (w+5);
+}
+
+t_int *or_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 || g0; out[1] = f1 || g1; out[2] = f2 || g2; out[3] = f3 || g3;
+        out[4] = f4 || g4; out[5] = f5 || g5; out[6] = f6 || g6; out[7] = f7 || g7;
+    }
+    return (w+5);
+}
+
+t_int *scalaror_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ || f;
+    return (w+5);
+}
+
+t_int *scalaror_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 || g; out[1] = f1 || g; out[2] = f2 || g; out[3] = f3 || g;
+        out[4] = f4 || g; out[5] = f5 || g; out[6] = f6 || g; out[7] = f7 || g;
+    }
+    return (w+5);
+}
+
+static void or_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, or_tilde_perform, or_tilde_perf8,
+        scalaror_tilde_perform, scalaror_tilde_perf8,
+        scalaror_tilde_perform, scalaror_tilde_perf8);
+}
+
+static void scalaror_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g, scalaror_tilde_perform, scalaror_tilde_perf8);
+}
+
+static void or_tilde_setup(void)
+{
+    or_tilde_class = any_binop_class(gensym("||~"), or_tilde_new, or_tilde_dsp);
+    scalaror_tilde_class = any_scalarbinop_class(gensym("||~"), scalaror_tilde_dsp);
+}
+
 /* ----------------------- global setup routine ---------------- */
 void d_arithmetic_setup(void)
 {
@@ -1355,4 +1521,6 @@ void d_arithmetic_setup(void)
     lt_tilde_setup();
     ge_tilde_setup();
     le_tilde_setup();
+    and_tilde_setup();
+    or_tilde_setup();
 }

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -895,6 +895,449 @@ static void pow_tilde_setup(void)
         scalarpow_tilde_dsp);
 }
 
+/* ----------------------------- ==~ ----------------------------- */
+static t_class *ee_tilde_class, *scalar_ee_tilde_class;
+
+static void *ee_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, ee_tilde_class, scalar_ee_tilde_class);
+}
+
+t_int *ee_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ == *in2++;
+    return (w+5);
+}
+
+t_int *ee_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 == g0; out[1] = f1 == g1; out[2] = f2 == g2; out[3] = f3 == g3;
+        out[4] = f4 == g4; out[5] = f5 == g5; out[6] = f6 == g6; out[7] = f7 == g7;
+    }
+    return (w+5);
+}
+
+t_int *scalar_ee_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ == f;
+    return (w+5);
+}
+
+t_int *scalar_ee_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 == g; out[1] = f1 == g; out[2] = f2 == g; out[3] = f3 == g;
+        out[4] = f4 == g; out[5] = f5 == g; out[6] = f6 == g; out[7] = f7 == g;
+    }
+    return (w+5);
+}
+
+static void ee_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, ee_tilde_perform, ee_tilde_perf8,
+        scalar_ee_tilde_perform, scalar_ee_tilde_perf8,
+        scalar_ee_tilde_perform, scalar_ee_tilde_perf8);
+}
+
+static void scalar_ee_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g, scalar_ee_tilde_perform, scalar_ee_tilde_perf8);
+}
+
+static void ee_tilde_setup(void)
+{
+    ee_tilde_class = any_binop_class(gensym("==~"), ee_tilde_new, ee_tilde_dsp);
+    scalar_ee_tilde_class = any_scalarbinop_class(gensym("==~"), scalar_ee_tilde_dsp);
+}
+
+/* ----------------------------- !=~ ----------------------------- */
+static t_class *ne_tilde_class, *scalar_ne_tilde_class;
+
+static void *ne_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, ne_tilde_class, scalar_ne_tilde_class);
+}
+
+t_int *ne_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ != *in2++;
+    return (w+5);
+}
+
+t_int *ne_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 != g0; out[1] = f1 != g1; out[2] = f2 != g2; out[3] = f3 != g3;
+        out[4] = f4 != g4; out[5] = f5 != g5; out[6] = f6 != g6; out[7] = f7 != g7;
+    }
+    return (w+5);
+}
+
+t_int *scalar_ne_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ != f;
+    return (w+5);
+}
+
+t_int *scalar_ne_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 != g; out[1] = f1 != g; out[2] = f2 != g; out[3] = f3 != g;
+        out[4] = f4 != g; out[5] = f5 != g; out[6] = f6 != g; out[7] = f7 != g;
+    }
+    return (w+5);
+}
+
+static void ne_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, ne_tilde_perform, ne_tilde_perf8,
+        scalar_ne_tilde_perform, scalar_ne_tilde_perf8,
+        scalar_ne_tilde_perform, scalar_ne_tilde_perf8);
+}
+
+static void scalar_ne_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g, scalar_ne_tilde_perform, scalar_ne_tilde_perf8);
+}
+
+static void ne_tilde_setup(void)
+{
+    ne_tilde_class = any_binop_class(gensym("!=~"), ne_tilde_new, ne_tilde_dsp);
+    scalar_ne_tilde_class = any_scalarbinop_class(gensym("!=~"), scalar_ne_tilde_dsp);
+}
+
+/* ------------------------ >~ >=~ <~ <=~ ------------------------ */
+static t_class *gt_tilde_class, *scalar_gt_tilde_class;
+static t_class *ge_tilde_class, *scalar_ge_tilde_class;
+static t_class *lt_tilde_class, *scalar_lt_tilde_class;
+static t_class *le_tilde_class, *scalar_le_tilde_class;
+
+static void *gt_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, gt_tilde_class, scalar_gt_tilde_class);
+}
+
+static void *ge_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, ge_tilde_class, scalar_ge_tilde_class);
+}
+
+static void *lt_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, lt_tilde_class, scalar_lt_tilde_class);
+}
+
+static void *le_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    return any_binop_new(s, argc, argv, le_tilde_class, scalar_le_tilde_class);
+}
+
+static t_int *gt_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ > *in2++;
+    return (w+5);
+}
+
+static t_int *gt_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 > g0; out[1] = f1 > g1; out[2] = f2 > g2; out[3] = f3 > g3;
+        out[4] = f4 > g4; out[5] = f5 > g5; out[6] = f6 > g6; out[7] = f7 > g7;
+    }
+    return (w+5);
+}
+
+static t_int *ge_tilde_perform(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in1++ >= *in2++;
+    return (w+5);
+}
+
+static t_int *ge_tilde_perf8(t_int *w)
+{
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *in2 = (t_sample *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in1 += 8, in2 += 8, out += 8)
+    {
+        t_sample f0 = in1[0], f1 = in1[1], f2 = in1[2], f3 = in1[3];
+        t_sample f4 = in1[4], f5 = in1[5], f6 = in1[6], f7 = in1[7];
+
+        t_sample g0 = in2[0], g1 = in2[1], g2 = in2[2], g3 = in2[3];
+        t_sample g4 = in2[4], g5 = in2[5], g6 = in2[6], g7 = in2[7];
+
+        out[0] = f0 >= g0; out[1] = f1 >= g1; out[2] = f2 >= g2; out[3] = f3 >= g3;
+        out[4] = f4 >= g4; out[5] = f5 >= g5; out[6] = f6 >= g6; out[7] = f7 >= g7;
+    }
+    return (w+5);
+}
+
+static t_int *scalar_gt_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ > f;
+    return (w+5);
+}
+
+static t_int *scalar_gt_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 > g; out[1] = f1 > g; out[2] = f2 > g; out[3] = f3 > g;
+        out[4] = f4 > g; out[5] = f5 > g; out[6] = f6 > g; out[7] = f7 > g;
+    }
+    return (w+5);
+}
+
+static t_int *scalar_ge_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ >= f;
+    return (w+5);
+}
+
+static t_int *scalar_ge_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 >= g; out[1] = f1 >= g; out[2] = f2 >= g; out[3] = f3 >= g;
+        out[4] = f4 >= g; out[5] = f5 >= g; out[6] = f6 >= g; out[7] = f7 >= g;
+    }
+    return (w+5);
+}
+
+static t_int *scalar_lt_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ < f;
+    return (w+5);
+}
+
+static t_int *scalar_lt_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 < g; out[1] = f1 < g; out[2] = f2 < g; out[3] = f3 < g;
+        out[4] = f4 < g; out[5] = f5 < g; out[6] = f6 < g; out[7] = f7 < g;
+    }
+    return (w+5);
+}
+
+static t_int *scalar_le_tilde_perform(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float f = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    while (n--) *out++ = *in++ <= f;
+    return (w+5);
+}
+
+static t_int *scalar_le_tilde_perf8(t_int *w)
+{
+    t_sample *in = (t_sample *)(w[1]);
+    t_float g = *(t_float *)(w[2]);
+    t_sample *out = (t_sample *)(w[3]);
+    int n = (int)(w[4]);
+    for (; n; n -= 8, in += 8, out += 8)
+    {
+        t_sample f0 = in[0], f1 = in[1], f2 = in[2], f3 = in[3];
+        t_sample f4 = in[4], f5 = in[5], f6 = in[6], f7 = in[7];
+
+        out[0] = f0 <= g; out[1] = f1 <= g; out[2] = f2 <= g; out[3] = f3 <= g;
+        out[4] = f4 <= g; out[5] = f5 <= g; out[6] = f6 <= g; out[7] = f7 <= g;
+    }
+    return (w+5);
+}
+
+static void gt_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, gt_tilde_perform, gt_tilde_perf8,
+        scalar_gt_tilde_perform, scalar_gt_tilde_perf8,
+                /* a > b is the same as b < a */
+            scalar_lt_tilde_perform, scalar_lt_tilde_perf8);
+}
+
+static void scalar_gt_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g, scalar_gt_tilde_perform, scalar_gt_tilde_perf8);
+}
+
+static void ge_tilde_dsp(t_binop *x, t_signal **sp)
+{
+    any_binop_dsp(sp, ge_tilde_perform, ge_tilde_perf8,
+        scalar_ge_tilde_perform, scalar_ge_tilde_perf8,
+                /* a >= b is the same as b <= a */
+            scalar_le_tilde_perform, scalar_le_tilde_perf8);
+}
+
+static void scalar_ge_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g,
+        scalar_ge_tilde_perform, scalar_ge_tilde_perf8);
+}
+
+static void lt_tilde_dsp(t_binop *x, t_signal **sp)
+{
+        /* a < b is the same as b > a, so we just swap the inputs */
+    t_signal *tmp[3] = { sp[1], sp[0], sp[2] };
+    any_binop_dsp(tmp, gt_tilde_perform, gt_tilde_perf8,
+        scalar_gt_tilde_perform, scalar_gt_tilde_perf8,
+            scalar_lt_tilde_perform, scalar_lt_tilde_perf8);
+    sp[2] = tmp[2]; /* assign result of signal_setmultiout()! */
+}
+
+static void scalar_lt_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g,
+        scalar_lt_tilde_perform, scalar_lt_tilde_perf8);
+}
+
+static void le_tilde_dsp(t_binop *x, t_signal **sp)
+{
+        /* a <= b is the same as b >= a, so we just swap the inputs */
+    t_signal *tmp[3] = { sp[1], sp[0], sp[2] };
+    any_binop_dsp(tmp, ge_tilde_perform, ge_tilde_perf8,
+        scalar_ge_tilde_perform, scalar_ge_tilde_perf8,
+            scalar_le_tilde_perform, scalar_le_tilde_perf8);
+    sp[2] = tmp[2]; /* assign result of signal_setmultiout()! */
+}
+
+static void scalar_le_tilde_dsp(t_scalarbinop *x, t_signal **sp)
+{
+    any_binop_scalar_dsp(sp, &x->x_g,
+        scalar_le_tilde_perform, scalar_le_tilde_perf8);
+}
+
+static void gt_tilde_setup(void)
+{
+    gt_tilde_class = any_binop_class(gensym(">~"), gt_tilde_new, gt_tilde_dsp);
+    scalar_gt_tilde_class = any_scalarbinop_class(gensym(">~"), scalar_gt_tilde_dsp);
+}
+
+static void ge_tilde_setup(void)
+{
+    ge_tilde_class = any_binop_class(gensym(">=~"), ge_tilde_new, ge_tilde_dsp);
+    scalar_ge_tilde_class = any_scalarbinop_class(gensym(">=~"), scalar_ge_tilde_dsp);
+}
+
+static void lt_tilde_setup(void)
+{
+    lt_tilde_class = any_binop_class(gensym("<~"), lt_tilde_new, lt_tilde_dsp);
+    scalar_lt_tilde_class = any_scalarbinop_class(gensym("<~"), scalar_lt_tilde_dsp);
+}
+
+static void le_tilde_setup(void)
+{
+    le_tilde_class = any_binop_class(gensym("<=~"), le_tilde_new, le_tilde_dsp);
+    scalar_le_tilde_class = any_scalarbinop_class(gensym("<=~"), scalar_le_tilde_dsp);
+}
+
 /* ----------------------- global setup routine ---------------- */
 void d_arithmetic_setup(void)
 {
@@ -906,4 +1349,10 @@ void d_arithmetic_setup(void)
     min_setup();
     log_tilde_setup();
     pow_tilde_setup();
+    ee_tilde_setup();
+    ne_tilde_setup();
+    gt_tilde_setup();
+    lt_tilde_setup();
+    ge_tilde_setup();
+    le_tilde_setup();
 }


### PR DESCRIPTION
Maybe the new multichannel feature is a good excuse to finally(!) add the missing signal comparison/logical operators:

`[==~]`, [`!=~]`, `[>~]`, `[<~]`, `[>=~]`, `[<=~]`, `[&&~]`, `[||~]`

IMO, it is a bit silly that we currently need externals (`zexy`, `cyclone`) or `[expr~]` for these basic math operations, even more so as the former are (still) single channel.

---

As a first step, I have added more convenience functions to `d_arithmetic.c` which remove a lot of the code duplication. In total, this PR only adds 350 lines (700 added, 350 removed).

Side note: it would be possible to further reduce the code size - drastically! - by implementing the perform routines as macros, taking the binary operator as an argument, but this might be a bit controversial, so I haven't done it.