### PR TITLE
safe (pseudo)stack allocation

### DIFF
--- a/extra/bonk~/bonk~.c
+++ b/extra/bonk~/bonk~.c
@@ -491,11 +491,7 @@ static void bonk_tick(t_bonk *x)
     t_template *tp;
     int nfit, ninsig = x->x_ninsig, ntemplate = x->x_ntemplate, nfilters = x->x_nfilters;
     t_insig *gp;
-#ifdef _MSC_VER
-    t_float powerout[MAXNFILTERS*MAXCHANNELS];
-#else
     t_float *powerout = alloca(x->x_nfilters * x->x_ninsig * sizeof(*powerout));
-#endif
     
     for (i = ninsig, pp = powerout, gp = x->x_insig; i--; gp++)
     {

--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -50,6 +50,13 @@ for example, defines this in the file d_fft_mayer.c or d_fft_fftsg.c. */
 #define HAVE_ALLOCA 1
 #endif
 
+#ifdef PD
+
+#define BUF_ALLOCA(n) (pd_stack_alloc(n))
+#define BUF_FREEA(x, n) (pd_stack_free((x), (n)))
+
+#else /* PD */
+
 /* limit stack allocation to ~400kB (enough for 16384 points).
  * usually the stack size is at least 1 MB */
 #define ALLOCA_MAXBYTES 400000
@@ -63,6 +70,8 @@ for example, defines this in the file d_fft_mayer.c or d_fft_fftsg.c. */
 #define BUF_ALLOCA(n) (getbytes(n))
 #define BUF_FREEA(x, n) (freebytes((x), (n)))
 #endif
+
+#endif /* PD */
 
 typedef struct peak
 {

--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -6,7 +6,7 @@
 /* ---------- clone - maintain copies of a patch ----------------- */
 
 #include "m_private_utils.h"
-#define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
+#define LIST_NGETBYTE 100 /* bigger than this we allocate on the heap */
 
 t_class *clone_class;
 static t_class *clone_in_class, *clone_out_class;

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -51,6 +51,8 @@ void g_canvas_freepdinstance( void);
 void d_ugen_newpdinstance( void);
 void d_ugen_freepdinstance( void);
 void new_anything(void *dummy, t_symbol *s, int argc, t_atom *argv);
+void pd_stack_init(void);
+void pd_stack_cleanup(void);
 
 void s_stuff_newpdinstance(void)
 {
@@ -61,10 +63,12 @@ void s_stuff_newpdinstance(void)
     STUFF->st_dacsr = DEFDACSAMPLERATE;
     STUFF->st_printhook = sys_printhook;
     STUFF->st_impdata = NULL;
+    pd_stack_init();
 }
 
 void s_stuff_freepdinstance(void)
 {
+    pd_stack_cleanup();
     freebytes(STUFF, sizeof(*STUFF));
 }
 

--- a/src/m_memory.c
+++ b/src/m_memory.c
@@ -5,9 +5,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include "m_pd.h"
+#include "s_stuff.h"
 #if (defined LOUD) || (defined DEBUGMEM)
 # include <stdio.h>
 #endif
+
+/*-------------------------- heap allocation --------------------------------*/
 
 /* #define DEBUGMEM */
 #ifdef DEBUGMEM
@@ -82,3 +85,171 @@ void glob_foo(void *dummy, t_symbol *s, int argc, t_atom *argv)
     fprintf(stderr, "total mem %d\n", totalmem);
 }
 #endif
+
+/*-------------------------- pseudo-stack allocation --------------------------------*/
+
+#define PAGESIZE 4096
+#define STACK_ALIGNMENT 16
+#define STACK_ALIGN(x) (((x) + (STACK_ALIGNMENT - 1)) & ~(STACK_ALIGNMENT - 1))
+#define STACK_MAGIC 0xDEADBEEF
+
+/* define this for debugging purposes */
+/* #define DEBUG_STACK */
+
+/* define this for additional safety; slightly slower and with some memory overhead */
+/* #define SAFE_STACK */
+
+#ifdef SAFE_STACK
+typedef struct _memheader
+{
+    size_t size;
+    char heap;
+} t_memheader;
+
+#define MEMHEADERSIZE STACK_ALIGNMENT
+#endif
+
+void pd_stack_init(void)
+{
+        /* align stack memory to page size.
+         * LATER allow to set stack size with a command line option? */
+    char *mem;
+    size_t extrabytes = PAGESIZE - 1;
+    size_t allocsize = PD_DEFSTACKSIZE + extrabytes;
+    STUFF->st_stackmem = mem = getbytes(allocsize);
+    STUFF->st_stackstart = (char *)(((size_t)mem + extrabytes) & ~extrabytes);
+    STUFF->st_stackend = mem + allocsize;
+    STUFF->st_stackptr = STUFF->st_stackstart;
+#ifndef NDEBUG
+        /* initialize memory with magic value */
+    while (mem < STUFF->st_stackend)
+    {
+        uint32_t val = STACK_MAGIC;
+        memcpy(mem, &val, sizeof(val));
+        mem += sizeof(val);
+    }
+#endif
+}
+
+void pd_stack_cleanup(void)
+{
+    freebytes(STUFF->st_stackmem, (STUFF->st_stackend - STUFF->st_stackmem));
+}
+
+void *pd_stack_alloc(size_t nbytes)
+{
+    size_t allocsize = STACK_ALIGN(nbytes);
+    char *ptr = STUFF->st_stackptr;
+#ifdef SAFE_STACK
+    t_memheader m = { nbytes, 0 };
+    allocsize += MEMHEADERSIZE;
+#endif
+    if (allocsize > (STUFF->st_stackend - ptr))
+    {
+        /* out of memory: fallback to heap allocation */
+#ifdef DEBUG_STACK
+        fprintf(stderr, "pd_stack_alloc: heap allocate %d (%d) bytes\n",
+                (int)nbytes, (int)allocsize);
+#endif
+#ifdef SAFE_STACK
+        m.heap = 1;
+#endif
+        ptr = getbytes(allocsize);
+    }
+    else
+    {
+        STUFF->st_stackptr += allocsize;
+#ifdef DEBUG_STACK
+        fprintf(stderr, "pd_stack_alloc: allocate %d (%d) bytes\n"
+            "  total usage: %d / %d bytes\n",
+                (int)nbytes, (int)allocsize,
+                (int)(STUFF->st_stackptr - STUFF->st_stackstart),
+                (int)(STUFF->st_stackend - STUFF->st_stackstart));
+#endif
+    }
+#ifdef SAFE_STACK
+    memcpy(ptr, &m, sizeof(m));
+    ptr += MEMHEADERSIZE;
+#endif
+    return ptr;
+}
+
+void pd_stack_free(void *x, size_t nbytes)
+{
+    size_t allocsize = STACK_ALIGN(nbytes);
+#ifdef SAFE_STACK
+    t_memheader *m = (t_memheader *)((char *)x - MEMHEADERSIZE);
+    allocsize += MEMHEADERSIZE;
+    if (m->size != nbytes)
+    {
+        bug("pd_stack_free: wrong size (%d, expected %d)", (int)nbytes, (int)m->size);
+            /* bash to "real" alloc size */
+        allocsize = STACK_ALIGN(m->size) + MEMHEADERSIZE;
+    }
+    if (!m->heap)
+#else
+        /* check if the pointer belongs to our pseudo-stack memory region.
+         * NB: according to the C standard, relational pointer comparison
+         * is undefined if the pointers do not point into the same object/array.
+         * The integer cast gets rid of the undefined behavior, but it is still
+         * implementation defined. In practice, the code below should work fine
+         * on all major platforms; otherwise we'd just need to define SAFE_STACK. */
+    if ((uintptr_t)x >= (uintptr_t)STUFF->st_stackstart &&
+        (uintptr_t)x < (uintptr_t)STUFF->st_stackend)
+#endif
+    {
+        if ((STUFF->st_stackptr -= allocsize) < STUFF->st_stackstart)
+        {
+            bug("pd_stack_free");
+            STUFF->st_stackptr = STUFF->st_stackstart;
+        }
+#ifndef NDEBUG
+        else /* fill reclaimed memory with magic number */
+        {
+            char *ptr = STUFF->st_stackptr;
+            char *end = ptr + allocsize;
+            while (ptr < end)
+            {
+                uint32_t val = STACK_MAGIC;
+                memcpy(ptr, &val, sizeof(val));
+                ptr += sizeof(val);
+            }
+        }
+#endif
+#ifdef SAFE_STACK
+        if ((char *)m != STUFF->st_stackptr)
+            bug("pd_stack_free: not the most recent allocation");
+#endif
+#ifdef DEBUG_STACK
+        fprintf(stderr, "pd_stack_free: free %d (%d) bytes\n"
+            "  total usage: %d / %d bytes\n",
+                (int)nbytes, (int)allocsize,
+                (int)(STUFF->st_stackptr - STUFF->st_stackstart),
+                (int)(STUFF->st_stackend - STUFF->st_stackstart));
+#endif
+    }
+    else /* has been allocated from the heap */
+    {
+#ifdef DEBUG_STACK
+        fprintf(stderr, "pd_stack_free: heap free %d (%d) bytes\n",
+            (int)nbytes, (int)allocsize);
+#endif
+#ifdef SAFE_STACK
+        freebytes(m, allocsize);
+#else
+        freebytes(x, allocsize);
+#endif
+    }
+}
+
+int pd_stack_check(void)
+{
+    if (STUFF->st_stackptr == STUFF->st_stackstart)
+        return 1;
+    else
+    {
+        pd_error(0, "leaked %d bytes of stack memory!",
+            (int)(STUFF->st_stackptr - STUFF->st_stackstart));
+        return 0;
+    }
+}

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -20,6 +20,8 @@ behavior for "gobjs" appears at the end of this file.  */
 #define INLINE inline
 #endif
 
+#define FWD_NGETBYTE 100 /* bigger than this we allocate on the heap */
+
 union inletunion
 {
     t_symbol *iu_symto;
@@ -152,12 +154,14 @@ static void inlet_symbol(t_inlet *x, t_symbol *s)
     /* forward a message to an inlet~ object */
 static void inlet_fwd(t_inlet *x, t_symbol *s, int argc, t_atom *argv)
 {
-    t_atom *argvec = (t_atom *)alloca((argc+1) * sizeof(t_atom));
+    t_atom *argvec;
     int i;
+    ALLOCA(t_atom, argvec, argc+1, FWD_NGETBYTE);
     SETSYMBOL(argvec, s);
     for (i = 0; i < argc; i++)
         argvec[i+1] = argv[i];
     typedmess(x->i_dest, gensym("fwd"), argc+1, argvec);
+    FREEA(t_atom, argvec, argc+1, FWD_NGETBYTE);
 }
 
 static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv)

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -315,6 +315,14 @@ EXTERN void *copybytes(const void *src, size_t nbytes);
 EXTERN void freebytes(void *x, size_t nbytes);
 EXTERN void *resizebytes(void *x, size_t oldsize, size_t newsize);
 
+/* safe and fast (recursive) stack allocation routines to be used
+ * within Pd object methods. Replaces the unsafe use of alloca().
+ * IMPORTANT: memory must be freed in the exact reverse order as
+ * it has been allocated! Do not use in perform routines!
+ */
+EXTERN void *pd_stack_alloc(size_t nbytes);
+EXTERN void pd_stack_free(void *x, size_t nbytes);
+
 /* -------------------- atoms ----------------------------- */
 
 #define SETSEMI(atom) ((atom)->a_type = A_SEMI, (atom)->a_w.w_index = 0)

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -208,6 +208,7 @@ void glob_fastforward(void *dummy, t_floatarg f)
 }
 
 void dsp_tick(void);
+int pd_stack_check(void);
 
 static int sched_useaudio = SCHED_AUDIO_NONE;
 static double sched_referencerealtime, sched_referencelogicaltime;
@@ -260,6 +261,7 @@ void sched_tick(void)
     pd_this->pd_systime = next_sys_time;
     dsp_tick();
     sched_counter++;
+    pd_stack_check();
 }
 
 int sched_get_sleepgrain( void)

--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -38,6 +38,8 @@
 # undef FREEA
 #endif
 
+    /* NB: don't use the ALLOCA and FREEA macros from "m_private_utils.h"
+    because they are not thread-safe! */
 #if HAVE_ALLOCA
 # define ALLOCA(t, x, n, max) ((x) = (t *)((n) < (max) ?            \
             alloca((n) * sizeof(t)) : getbytes((n) * sizeof(t))))

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -393,6 +393,11 @@ EXTERN void inmidi_polyaftertouch(int portno,
 /* } jsarlo */
 EXTERN int sys_zoom_open;
 
+/* default Pd stack size */
+#ifndef PD_DEFSTACKSIZE
+#define PD_DEFSTACKSIZE 262144 /* 256 KB */
+#endif
+
 struct _instancestuff
 {
     t_namelist *st_externlist;
@@ -410,6 +415,10 @@ struct _instancestuff
     double st_time_per_dsp_tick;    /* obsolete - included for GEM?? */
     t_printhook st_printhook;   /* set this to override per-instance printing */
     void *st_impdata; /* optional implementation-specific data for libpd, etc */
+    char *st_stackmem; /* pseudo stack for safe (recursive) stack allocations */
+    char *st_stackstart; /* (aligned) stack start */
+    char *st_stackend; /* stack end */
+    char *st_stackptr; /* current stack pointer */
 };
 
 #define STUFF (pd_this->pd_stuff)

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -151,11 +151,13 @@ static char*do_expandpath(const char *from, char *to, int bufsize)
     }
 #ifdef _WIN32
     {
-        char *buf = alloca(bufsize);
+        char *buf;
+        ALLOCA(char, buf, bufsize, MAXPDSTRING);
         ExpandEnvironmentStrings(to, buf, bufsize-1);
         buf[bufsize-1] = 0;
         strncpy(to, buf, bufsize);
         to[bufsize-1] = 0;
+        FREEA(char, buf, bufsize, MAXPDSTRING);
     }
 #endif
     return to;
@@ -621,8 +623,9 @@ static void file_handle_do_read(t_file_handle*x, t_float f) {
     } else {
         pd_error(x, "couldn't allocate buffer for %d bytes", (int)outc);
     }
-    FREEA(unsigned char, buf, outc, 100);
+        /* free in reverse order! */
     FREEA(t_atom, outv, outc, 100);
+    FREEA(unsigned char, buf, outc, 100);
 }
 static void file_handle_do_write(t_file_handle*x, int argc, t_atom*argv) {
     unsigned char*buf;

--- a/src/x_list.c
+++ b/src/x_list.c
@@ -7,7 +7,7 @@
 
 #include "m_private_utils.h"
 
-#define LIST_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
+#define LIST_NGETBYTE 100 /* bigger than this we allocate on the heap */
 
 /* the "list" object family.
 

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -21,7 +21,7 @@ static t_class *text_define_class;
 
 #include "m_private_utils.h"
 
-#define TEXT_NGETBYTE 100 /* bigger that this we use alloc, not alloca */
+#define TEXT_NGETBYTE 100 /* bigger than this we allocate on the heap */
 
 /* --- unified qsort_r --- */
 


### PR DESCRIPTION
Pd heavily depends on large stack allocations. Without precautions, this could easily lead to stack overflows, particularly when functions are called recursively.

The current strategy is to let every object method define some arbitrary size limit above which it would allocate on the heap instead. This is typically done with the `ALLOCA` and `FREEA` macros.

There are some problems with this approach:
1. the size limit is just an arbitrary guess
2. it can still cause stack overflows if the stack limit is too high or the OS stack size too small
3. without recursion, the limit could be much larger, but a function doesn't know if it will be called recursively.
4. the default OS stack size can be very different between platforms

---

This draft PR proposes to maintain a pseudo-stack and add two new API functions:
1. `void *pd_stack_alloc(size_t size)` - allocate memory from the pseudo-stack
2. `void pd_stack_free(void *ptr, size_t size)` - return memory to the pseudo-stack

The pseudo-stack is just a large continuous memory region with start/end pointers and the current position (= stack pointer).
If the pseudo-stack notices that it cannot serve the allocation request, it will automatically allocate on the heap instead. This means that the caller does not have to care about the stack size at all! Heap allocation is only triggered when the stack is really exhausted - which should only happen at deep recursion levels or with very large requests.

The size of the pseudo-stack can be configured at compile time (and maybe later also at runtime with command line option?), so you are in control and get consistent behavior across platforms.

If you define `-DSAFE_STACK`, every allocation will have a small metadata header, containing the allocation size. This is a bit slower and uses more memory, but it would help to catch memory management errors at runtime. (Stack allocation errors are particularly nasty to debug.)

After each tick, the scheduler calls `pd_stack_check()` which checks if the stack pointer is back to the beginning; otherwise we'd have a memory leak and get an error message.

As a proof-of-concept, I have changed the `ALLOCA` and `FREEA` macros in `m_private_utils.h` to use `pd_stack_alloc` and `pd_stack_free`.

---

NB: memory must be freed in the exact reverse order as it has been allocated! This happens naturally when `pd_stack_alloc` and `pd_stack_free` are called in nested functions, but extra care has to be taken when a single function makes multiple calls to `pd_stack_alloc`:

```
t_atom *vec1 = (t_atom *)pd_stack_alloc(n1 * sizeof(t_atom));
int *vec2 = (int *)pd_stack_alloc(n2 * sizeof(int));
...
// free in reverse order!
pd_stack_free(vec2, n2 * sizeof(int));
pd_stack_free(vec1, n1 * sizeof(t_atom));
```

In the above case, messing up the order wouldn't cause any real harm, but you'd get a consistency check error if `SAFE_STACK` is defined.
