### PR TITLE
Fall back to system check for endian include

### DIFF
--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -82,9 +82,9 @@
 #   include <machine/endian.h>
 #  elif defined(__GNUC__)
 #    include <endian.h>
-#  elif defined(__MINGW32__)
-#    include <sys/param.h>
-#  endif
+#endif
+#if __MINGW32__
+#  include <sys/param.h>
 #endif
 
 /* BSD has deprecated BYTE_ORDER in favour of _BYTE_ORDER

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -72,20 +72,21 @@
 
 // known headers?
 #if defined(HAVE_MACHINE_ENDIAN_H) || defined(HAVE_ENDIAN_H)
-#  if defined(HAVE_MACHINE_ENDIAN_H)
-#    include <machine/endian.h>
-#  elif defined(HAVE_ENDIAN_H)
-#    include <endian.h>
-#  endif
+# if defined(HAVE_MACHINE_ENDIAN_H)
+#  include <machine/endian.h>
+# elif defined(HAVE_ENDIAN_H)
+#  include <endian.h>
+# endif
 #else // try to detect from system
-#  if defined(__APPLE__)
-#   include <machine/endian.h>
-#  elif defined(__GNUC__)
-#    include <endian.h>
-#  endif
+# if defined(__APPLE__)
+#  include <machine/endian.h>
+# elif defined(__GNUC__)
+#  include <endian.h>
+# endif
 #endif
+
 #ifdef __MINGW32__
-#  include <sys/param.h>
+# include <sys/param.h>
 #endif
 
 /* BSD has deprecated BYTE_ORDER in favour of _BYTE_ORDER

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -69,14 +69,22 @@
 
 
 /* --------------------------- endianness helpers --------------------- */
-#ifdef HAVE_MACHINE_ENDIAN_H
-# include <machine/endian.h>
-#elif defined HAVE_ENDIAN_H
-# include <endian.h>
-#endif
 
-#ifdef __MINGW32__
-# include <sys/param.h>
+// known headers?
+#if defined(HAVE_MACHINE_ENDIAN_H) || defined(HAVE_ENDIAN_H)
+#  if defined(HAVE_MACHINE_ENDIAN_H)
+#    include <machine/endian.h>
+#  elif defined(HAVE_ENDIAN_H)
+#    include <endian.h>
+#  endif
+#else // try to detect from system
+#  if defined(__APPLE__)
+#   include <machine/endian.h>
+#  elif defined(__GNUC__)
+#    include <endian.h>
+#  elif defined(__MINGW32__)
+#    include <sys/param.h>
+#  endif
 #endif
 
 /* BSD has deprecated BYTE_ORDER in favour of _BYTE_ORDER
@@ -108,7 +116,7 @@
 #endif
 
 
-/* -------------------------MSVC compat defines --------------------- */
+/* ------------------------- MSVC compat defines --------------------- */
 #ifdef _MSC_VER
 # define snprintf _snprintf
 #endif

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -82,8 +82,9 @@
 #   include <machine/endian.h>
 #  elif defined(__GNUC__)
 #    include <endian.h>
+#  endif
 #endif
-#if __MINGW32__
+#ifdef __MINGW32__
 #  include <sys/param.h>
 #endif
 


### PR DESCRIPTION
I'm updating libpd for 0.54 and notice an issue with the move to m_private_utils.h.

The existing libpd Makefile builds are broken as either `HAVE_ENDIAN_H` or `HAVE_MACHINE_ENDIAN_H` on non-Windows is *required*, otherwise the build halts on the endian check `#error`. On Windows if MINGW is detected, `sys/param.h` is included which pulls in the endian stuff for you.

Overall, I think this private header is a *good idea* however I don't like that it's focused on auto tools this way. A better approach, IMO is to fall back to a system-based include mechanism which I have put together in this PR.

Why do this when you can simply set a define based on the platform? Well, for instance, the libpd python wrapper is built using setup.py which doesn't seem to have *any* option to apply defines based on platform... they are set for *all*. I can't pre-define them in a source file as I don't have easy control of when m_private_utils.h is included in the build process and/or I'd have to put it before every include to m_pd.h. Not ideal either.