### PR TITLE
Set t_signal->s_overlap in signals

### DIFF
--- a/libpd/Makefile
+++ b/libpd/Makefile
@@ -11,7 +11,7 @@ PLATFORM_ARCH ?= $(shell $(CC) -dumpmachine | sed -e 's,-.*,,')
 
 ifeq ($(UNAME), Darwin)  # Mac
   SOLIB_EXT = dylib
-  PLATFORM_CFLAGS = -DHAVE_LIBDL
+  PLATFORM_CFLAGS = -DHAVE_LIBDL -DHAVE_MACHINE_ENDIAN_H
   PLATFORM_LDFLAGS = -dynamiclib -ldl -Wl,-no_compact_unwind
   ifeq ($(FAT_LIB), true)
     # macOS universal "fat" lib compilation
@@ -35,14 +35,15 @@ else
     SOLIB_PREFIX =
     LIBPD_IMPLIB = libpd.lib
     LIBPD_DEF = libpd.def
-    PLATFORM_CFLAGS = -DWINVER=0x502 -DWIN32 -D_WIN32 -DPD_INTERNAL
+    PLATFORM_CFLAGS = -DWINVER=0x502 -DWIN32 -D_WIN32
     MINGW_LDFLAGS = -shared -Wl,--export-all-symbols -lws2_32 -lkernel32 \
                     -static-libgcc
     PLATFORM_LDFLAGS = $(MINGW_LDFLAGS) -Wl,--output-def=$(LIBPD_DEF) \
                        -Wl,--out-implib=$(LIBPD_IMPLIB)
   else  # Linux or *BSD
     SOLIB_EXT = so
-    PLATFORM_CFLAGS = -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fPIC
+    PLATFORM_CFLAGS = -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -fPIC \
+                      -DHAVE_ENDIAN_H
     PLATFORM_LDFLAGS = -shared -Wl,-Bsymbolic
     ifeq ($(UNAME), Linux)
       PLATFORM_CFLAGS += -DHAVE_LIBDL
@@ -59,8 +60,8 @@ VPATH = ../src:\
 # to allow easy overriding of CODECFLAGS and to allow adding MORECFLAGS:
 
 # C preprocessor flags, and flags controlling errors and warnings
-CPPFLAGS = -I../src -DPD -DHAVE_UNISTD_H -DUSEAPI_DUMMY -DLIBPD_EXTRA \
-    -DPDINSTANCE -DPD_INTERNAL
+CPPFLAGS = -I../src -DPD -DUSEAPI_DUMMY -DPD_INTERNAL -DHAVE_UNISTD_H \
+           -DHAVE_ALLOCA_H -DLIBPD_EXTRA -DPDINSTANCE
 
 # code generation flags (e.g., optimization).
 CODECFLAGS = -fPIC -ffast-math -funroll-loops -fomit-frame-pointer -O3

--- a/src/d_arithmetic.c
+++ b/src/d_arithmetic.c
@@ -933,7 +933,7 @@ typedef struct _scalarlog_tilde
 
 static void *log_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("-~: extra arguments ignored");
+    if (argc > 1) post("log~: extra arguments ignored");
     if (argc)
     {
         t_scalarlog_tilde *x =
@@ -1033,7 +1033,7 @@ static void log_tilde_setup(void)
     CLASS_MAINSIGNALIN(log_tilde_class, t_log_tilde, x_f);
     class_addmethod(log_tilde_class, (t_method)log_tilde_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(log_tilde_class, gensym("binops-tilde"));
-    scalarlog_tilde_class = class_new(gensym("-~"), 0, 0,
+    scalarlog_tilde_class = class_new(gensym("log~"), 0, 0,
         sizeof(t_scalarlog_tilde), CLASS_MULTICHANNEL, 0);
     CLASS_MAINSIGNALIN(scalarlog_tilde_class, t_scalarlog_tilde, x_f);
     class_addmethod(scalarlog_tilde_class, (t_method)scalarlog_tilde_dsp,
@@ -1059,7 +1059,7 @@ typedef struct _scalarpow_tilde
 
 static void *pow_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
-    if (argc > 1) post("-~: extra arguments ignored");
+    if (argc > 1) post("pow~: extra arguments ignored");
     if (argc)
     {
         t_scalarpow_tilde *x =
@@ -1150,7 +1150,7 @@ static void pow_tilde_setup(void)
     CLASS_MAINSIGNALIN(pow_tilde_class, t_pow_tilde, x_f);
     class_addmethod(pow_tilde_class, (t_method)pow_tilde_dsp, gensym("dsp"), A_CANT, 0);
     class_sethelpsymbol(pow_tilde_class, gensym("binops-tilde"));
-    scalarpow_tilde_class = class_new(gensym("-~"), 0, 0,
+    scalarpow_tilde_class = class_new(gensym("pow~"), 0, 0,
         sizeof(t_scalarpow_tilde), CLASS_MULTICHANNEL, 0);
     CLASS_MAINSIGNALIN(scalarpow_tilde_class, t_scalarpow_tilde, x_f);
     class_addmethod(scalarpow_tilde_class, (t_method)scalarpow_tilde_dsp,

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -110,7 +110,7 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
         SETFLOAT(&defarg[0], 1);
         SETFLOAT(&defarg[1], 2);
     }
-    if (argc >= 2 && argv[0].a_type == A_SYMBOL &&
+    if (argc > 0 && argv[0].a_type == A_SYMBOL &&
         !strcmp(argv[0].a_w.w_symbol->s_name, "-m"))
     {       /* multichannel version: -m [nchans] [start channel] */
         x->x_multi = 1;

--- a/src/d_dac.c
+++ b/src/d_dac.c
@@ -118,7 +118,7 @@ static void *adc_new(t_symbol *s, int argc, t_atom *argv)
             x->x_n = 2;
         if ((firstchan = atom_getfloatarg(2, argc, argv)) < 1)
             firstchan = 1;
-        x->x_vec = (int *)getbytes(argc * sizeof(*x->x_vec));
+        x->x_vec = (int *)getbytes(x->x_n * sizeof(*x->x_vec));
         for (i = 0; i < x->x_n; i++)
             x->x_vec[i] = firstchan+i;
         outlet_new(&x->x_obj, &s_signal);
@@ -202,4 +202,3 @@ void d_dac_setup(void)
     dac_setup();
     adc_setup();
 }
-

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -636,6 +636,7 @@ struct _dspcontext
 };
 #define DC_LENGTH(x) ((x)->dc_nullsignal.s_length)
 #define DC_SR(x) ((x)->dc_nullsignal.s_sr)
+#define DC_OVERLAP(x) ((x)->dc_nullsignal.s_overlap)
 
 #define t_dspcontext struct _dspcontext
 
@@ -1050,6 +1051,7 @@ void ugen_done_graph(t_dspcontext *dc)
     int chainafterall;      /* and after signal outlet epilog */
     int reblock = 0, switched;
     int downsample = 1, upsample = 1;
+    int realoverlap = 1;
 
         /* debugging printout */
     if (THIS->u_loud)
@@ -1093,7 +1095,6 @@ void ugen_done_graph(t_dspcontext *dc)
     }
     if (blk)
     {
-        int realoverlap;
         calcsize = blk->x_calcsize;
         if (calcsize == 0)
             calcsize = parent_vecsize;
@@ -1134,6 +1135,7 @@ void ugen_done_graph(t_dspcontext *dc)
     dc->dc_switched = switched;
     dc->dc_nullsignal.s_sr = srate;
     dc->dc_nullsignal.s_length = calcsize;
+    dc->dc_nullsignal.s_overlap = realoverlap;
     dc->dc_nullsignal.s_nchans = -1;    /* fake so we can sanity check */
 
         /* if we're reblocking or switched, we now have to create output

--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -1050,8 +1050,8 @@ void ugen_done_graph(t_dspcontext *dc)
     int chainafterall;      /* and after signal outlet epilog */
     int reblock = 0, switched;
     int downsample = 1, upsample = 1;
-    /* debugging printout */
 
+        /* debugging printout */
     if (THIS->u_loud)
     {
         post("ugen_done_graph...");

--- a/src/g_io.c
+++ b/src/g_io.c
@@ -528,12 +528,14 @@ void voutlet_dspprolog(struct _voutlet *x, t_signal **parentsigs,
         x->x_borrowed = 0;
     else    /* OK, borrow it */
     {
+        int overlap = (*(x->x_parentsignal))->s_overlap;
         x->x_borrowed = 1;
         if (!parentsigs)
             bug("voutlet_dspprolog");
                 /* create new borrowed signal to be set in dsp routine below */
         *(x->x_parentsignal) = signal_new(0, 1,
             (*(x->x_parentsignal))->s_sr, 0);
+        (*(x->x_parentsignal))->s_overlap = overlap;
     }
     if (reblock)
     {

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -400,21 +400,27 @@ static void sys_initsavepreferences(void)
 {
     if (sys_prefsavefp)
         bug("sys_initsavepreferences");
-    else    /* delete audio and MIDI device keys */
+    else    /* delete previous audio/MIDI device and search path entries */
     {
         int i, j;
-        char dev[MAXPDSTRING], devname[MAXPDSTRING];
+        char buf[MAXPDSTRING], devname[MAXPDSTRING];
         const char *key[4] = { "audioin", "audioout", "midiin", "midiout" };
         int maxnum[4] = { MAXAUDIOINDEV, MAXAUDIOOUTDEV, MAXMIDIINDEV, MAXMIDIOUTDEV };
         for (i = 0; i < 4; i++)
         {
             for (j = 0; j < maxnum[i]; j++)
             {
-                snprintf(dev, sizeof(dev), "%sdev%d", key[i], j + 1);
+                snprintf(buf, sizeof(buf), "%sdev%d", key[i], j + 1);
                 snprintf(devname, sizeof(devname), "%sdevname%d", key[i], j + 1);
-                if (!sys_deletepreference(dev) || !sys_deletepreference(devname))
+                if (!sys_deletepreference(buf) || !sys_deletepreference(devname))
                     break;
             }
+        }
+        for (i = 0; ; i++)
+        {
+            snprintf(buf, sizeof(buf), "path%d", i + 1);
+            if (!sys_deletepreference(buf))
+                break;
         }
     }
 }

--- a/src/s_libpdmidi.c
+++ b/src/s_libpdmidi.c
@@ -71,4 +71,6 @@ void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv) {}
 int sys_mididevnametonumber(int output, const char *name) { return 0; }
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize) {}
 void sys_set_midi_api(int api) {}
+void sys_gui_midipreferences(void) {}
+
 int sys_midiapi;

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -21,6 +21,9 @@
 #include <windows.h>
 #include <winbase.h>
 #endif
+#ifdef __APPLE__
+#include <mach-o/dyld.h> // for _NSGetExecutablePath
+#endif
 #include "m_private_utils.h"
 
 #define stringify(s) str(s)

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -395,7 +395,19 @@ int sys_main(int argc, const char **argv)
     if (getuid() != geteuid())
     {
         fprintf(stderr, "warning: canceling setuid privilege\n");
-        setuid(getuid());
+        if(setuid(getuid()) < 0) {
+                /* sometimes this fails (which, according to 'man 2 setuid' is a
+                 * grave security error), in which case we bail out and quit. */
+            fprintf(stderr, "\n\nFATAL: could not cancel setuid privilege");
+            fprintf(stderr, "\nTo fix this, please remove the setuid flag from the Pd binary");
+            if(argc>0) {
+                fprintf(stderr, "\ne.g. by running the following as root/superuser:");
+                fprintf(stderr, "\n chmod u-s '%s'", argv[0]);
+            }
+            fprintf(stderr, "\n\n");
+            perror("setuid");
+            return (1);
+        }
     }
 #endif  /* _WIN32 */
     if (socket_init())

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -155,9 +155,9 @@ proc ::pd_bindings::global_bindings {} {
 proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
     variable modifier
 
-    bind $mytoplevel <KeyPress-Escape>          "dialog_${dialogname}::cancel $mytoplevel"
-    bind $mytoplevel <KeyPress-Return>          "dialog_${dialogname}::ok $mytoplevel"
-    bind_capslock $mytoplevel $::modifier-Key w "dialog_${dialogname}::cancel $mytoplevel"
+    bind $mytoplevel <KeyPress-Escape>          "dialog_${dialogname}::cancel $mytoplevel; break"
+    bind $mytoplevel <KeyPress-Return>          "dialog_${dialogname}::ok $mytoplevel; break"
+    bind_capslock $mytoplevel $::modifier-Key w "dialog_${dialogname}::cancel $mytoplevel; break"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
     if {$mytoplevel ne ".find"} {

--- a/tcl/scrollbox.tcl
+++ b/tcl/scrollbox.tcl
@@ -13,6 +13,9 @@ array set ::scrollbox::entrytext {}
 
 proc ::scrollbox::get_curidx { mytoplevel } {
     set box $mytoplevel.listbox.box
+    if { ! [winfo exists $box] } {
+        return
+    }
     set idx [$box index active]
     if {$idx < 0 || \
             $idx == [$box index end]} {
@@ -105,11 +108,17 @@ proc ::scrollbox::add_item { mytoplevel add_method } {
     } else {
         set dir [$add_method]
     }
-    insert_item $mytoplevel [expr {[get_curidx $mytoplevel] + 1}] $dir
+    set idx [get_curidx $mytoplevel]
+    if { $idx ne {} } {
+        insert_item $mytoplevel [expr {[get_curidx $mytoplevel] + 1}] $dir
+    }
 }
 
 proc ::scrollbox::edit_item { mytoplevel edit_method } {
     set idx [get_curidx $mytoplevel]
+    if { $idx eq {} } {
+        return
+    }
     set box $mytoplevel.listbox.box
     set initialValue [$box get $idx]
     if {$initialValue != ""} {
@@ -117,6 +126,9 @@ proc ::scrollbox::edit_item { mytoplevel edit_method } {
             set dir [::scrollbox::my_edit $mytoplevel $initialValue ]
         } else {
             set dir [$edit_method $initialValue]
+        }
+        if { ! [winfo exists $box ] } {
+            return
         }
 
         if {$dir != ""} {

--- a/tcl/scrollbox.tcl
+++ b/tcl/scrollbox.tcl
@@ -12,10 +12,11 @@ namespace eval scrollbox {
 array set ::scrollbox::entrytext {}
 
 proc ::scrollbox::get_curidx { mytoplevel } {
-    set idx [$mytoplevel.listbox.box index active]
+    set box $mytoplevel.listbox.box
+    set idx [$box index active]
     if {$idx < 0 || \
-            $idx == [$mytoplevel.listbox.box index end]} {
-        return [expr {[$mytoplevel.listbox.box index end] + 1}]
+            $idx == [$box index end]} {
+        return [expr {[$box index end] + 1}]
     }
     return [expr $idx]
 }
@@ -108,8 +109,9 @@ proc ::scrollbox::add_item { mytoplevel add_method } {
 }
 
 proc ::scrollbox::edit_item { mytoplevel edit_method } {
-    set idx [expr {[get_curidx $mytoplevel]}]
-    set initialValue [$mytoplevel.listbox.box get $idx]
+    set idx [get_curidx $mytoplevel]
+    set box $mytoplevel.listbox.box
+    set initialValue [$box get $idx]
     if {$initialValue != ""} {
         if { $edit_method == "" } {
             set dir [::scrollbox::my_edit $mytoplevel $initialValue ]
@@ -118,13 +120,13 @@ proc ::scrollbox::edit_item { mytoplevel edit_method } {
         }
 
         if {$dir != ""} {
-            $mytoplevel.listbox.box delete $idx
+            $box delete $idx
             insert_item $mytoplevel $idx $dir
         }
-        $mytoplevel.listbox.box activate $idx
-        $mytoplevel.listbox.box selection clear 0 end
-        $mytoplevel.listbox.box selection set active
-        focus $mytoplevel.listbox.box
+        $box activate $idx
+        $box selection clear 0 end
+        $box selection set active
+        focus $box
     }
 }
 


### PR DESCRIPTION
As of Pd-0.54, the `t_signal` struct has an `s_overlap` member to get the overlap factor in the patch.
Unfortunately, so far it is nowhere set (and thus 0).

This PR attempts to fix this.

Like the `s_sr` member, the `s_overlap` accumulates overlap factors (thus nesting two subpatches with `[block~ 256 4]` will report the overlap factor as `16`.
(I don't think that there are any use cases for overlapping already overlapped signals; the current behaviour is merely to get consistent behaviour with the `s_sr` member)

the implementation in the PR is written to ***keep** binary compatibilty* with externals that use `signal_new()`:
- creating a new signal with `signal_new()` will set the initial overlap value to `0` ("unknown").
- the caller of `signal_new()` is responsible for setting the overlap factor on the returned value
- other functions (`signal_newlike()`, `signal_setborrowed()`, `signal_setmultiout()`, `signal_newfromcontext()`) do update the `s_overlap` value (since they have enough information to do so).

i would have  preferred to add an overlap argument to `signal_new()`, but that obviously introduces a binary incompatibility. a quick check on my harddisk has not revealed any externals that call this function, but you never know. an alternative would have been to introduce a `pdsignal_new()` function with the additional argument (and make `signal_new()` a wrapper around this).
because of these concerns i haven't committed directly to the `develop` branch and request a review.

Closes: #2071 