### PR TITLE
[WIP] Copy-paste patch objects using system clipboard text buffer

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4152,31 +4152,20 @@ void canvas_got_clipboard_contents(t_canvas *x, t_floatarg flagf, t_symbol *s) {
             clipboard_patch_bb = binbuf_new();
             break;
 
+        case CLIPBOARD_PATCH_TEXT_LINE_PARTIAL:
         case CLIPBOARD_PATCH_TEXT_LINE_END:
             if (clipboard_patch_bb) {
-                char* received_data = strdup(s->s_name);
                 t_binbuf *temp_bb = binbuf_new();
-                binbuf_text(temp_bb, received_data, strlen(received_data));
-                binbuf_addsemi(temp_bb);
+                binbuf_text(temp_bb, s->s_name, strlen(s->s_name));
+                if (flag == CLIPBOARD_PATCH_TEXT_LINE_END) {
+                    binbuf_addsemi(temp_bb);
+                }
                 binbuf_add(clipboard_patch_bb, binbuf_getnatom(temp_bb), binbuf_getvec(temp_bb));
                 binbuf_clear(temp_bb);
                 binbuf_free(temp_bb);
-                free(received_data);
             }
             break;
-
-        case CLIPBOARD_PATCH_TEXT_LINE_PARTIAL:
-            if (clipboard_patch_bb) {
-                char* received_data = strdup(s->s_name);
-                t_binbuf *temp_bb = binbuf_new();
-                binbuf_text(temp_bb, received_data, strlen(received_data));
-                binbuf_add(clipboard_patch_bb, binbuf_getnatom(temp_bb), binbuf_getvec(temp_bb));
-                binbuf_clear(temp_bb);
-                binbuf_free(temp_bb);
-                free(received_data);
-            }
-            break;
-
+            
         case CLIPBOARD_PATCH_TEXT_END:
             if (clipboard_patch_bb) {
                 canvas_dopaste(x, clipboard_patch_bb);
@@ -4985,8 +4974,7 @@ void g_editor_setup(void)
         A_GIMME, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_motion, gensym("motion"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_got_clipboard_contents,
-        gensym("got-clipboard-contents"), A_FLOAT, A_SYMBOL, A_NULL);
+
 /* ------------------------ menu actions ---------------------------- */
     class_addmethod(canvas_class, (t_method)canvas_menuclose,
         gensym("menuclose"), A_DEFFLOAT, 0);
@@ -4995,7 +4983,9 @@ void g_editor_setup(void)
     class_addmethod(canvas_class, (t_method)canvas_copy,
         gensym("copy"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_copy_to_clipboard_as_text,
-        gensym("copy-to-clipboard-as-text"), A_NULL);        
+        gensym("copy-to-clipboard-as-text"), A_NULL);
+    class_addmethod(canvas_class, (t_method)canvas_got_clipboard_contents,
+        gensym("got-clipboard-contents"), A_FLOAT, A_DEFSYMBOL, A_NULL);            
     class_addmethod(canvas_class, (t_method)canvas_paste,
         gensym("paste"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_paste_replace,

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4139,11 +4139,6 @@ static void canvas_paste(t_canvas *x)
     }
 }
 
-static void canvas_paste_from_clipboard_text(t_canvas *x)
-{
-    pdgui_vmess("pdtk_get_clipboard_text", "^", x);
-}
-
 static t_binbuf *clipboard_patch_bb = NULL;
 
 void canvas_got_clipboard_contents(t_canvas *x, t_floatarg flagf, t_symbol *s) {
@@ -5003,8 +4998,6 @@ void g_editor_setup(void)
         gensym("copy-to-clipboard-as-text"), A_NULL);        
     class_addmethod(canvas_class, (t_method)canvas_paste,
         gensym("paste"), A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_paste_from_clipboard_text,
-        gensym("paste-from-clipboard-text"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_paste_replace,
         gensym("paste-replace"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_duplicate,

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -200,6 +200,8 @@ set recentfiles_list {}
 set total_recentfiles 5
 # modifier for key commands (Ctrl/Control on most platforms, Cmd/Mod1 on MacOSX)
 set modifier ""
+# on Mac OS X/Aqua, the Alt/Option key is called Option in Tcl
+set alt ""
 # current state of the Edit Mode menu item
 set editmode_button 0
 
@@ -294,6 +296,7 @@ proc init_for_platform {} {
     switch -- $::windowingsystem {
         "x11" {
             set ::modifier "Control"
+            set ::alt "Alt"
             option add *PatchWindow*Canvas.background "white" startupFile
             # add control to show/hide hidden files in the open panel (load
             # the tk_getOpenFile dialog once, otherwise it will not work)
@@ -334,6 +337,7 @@ proc init_for_platform {} {
             # from the commandline incorporates the special mac event handling
             package require apple_events
             set ::modifier "Mod1"
+            set ::alt "Option"
             if {$::tcl_version < 8.5} {
                 # old default font for Tk 8.4 on macOS
                 # since font detection requires 8.5+
@@ -371,6 +375,7 @@ proc init_for_platform {} {
         }
         "win32" {
             set ::modifier "Control"
+            set ::alt "Alt"
             option add *PatchWindow*Canvas.background "white" startupFile
             # fix menu font size on Windows with tk scaling = 1
             font create menufont -family Tahoma -size -11

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -141,7 +141,7 @@ proc ::pd_bindings::global_bindings {} {
         bind_capslock all $::modifier-Key m       {menu_minimize %W}
 
         bind_capslock all $::modifier-$::alt-Key c {menu_send %W copy-to-clipboard-as-text}
-        bind_capslock all $::modifier-$::alt-Key v {menu_send %W paste-from-clipboard-text}
+        bind_capslock all $::modifier-$::alt-Key v {::pdtk_canvas::pdtk_get_clipboard_text $::focused_window}
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -57,7 +57,6 @@ proc ::pd_bindings::global_bindings {} {
     bind_capslock all $::modifier-Key a {menu_send %W selectall}
     bind_capslock all $::modifier-Key b {menu_helpbrowser}
     bind_capslock all $::modifier-Key c {menu_send %W copy}
-    bind_capslock all $::modifier-$::alt-Key c {menu_send %W copy-to-clipboard-as-text}
     bind_capslock all $::modifier-Key d {menu_send %W duplicate}
     bind_capslock all $::modifier-Key e {menu_toggle_editmode}
     bind_capslock all $::modifier-Key f {menu_find_dialog}
@@ -70,7 +69,6 @@ proc ::pd_bindings::global_bindings {} {
     bind_capslock all $::modifier-Key s {menu_send %W menusave}
     bind_capslock all $::modifier-Key t {menu_send %W triggerize}
     bind_capslock all $::modifier-Key v {menu_send %W paste}
-    bind_capslock all $::modifier-$::alt-Key v {menu_send %W paste-from-clipboard-text}    
     bind_capslock all $::modifier-Key w {::pd_bindings::window_close %W}
     bind_capslock all $::modifier-Key x {menu_send %W cut}
     bind_capslock all $::modifier-Key z {menu_undo}
@@ -122,6 +120,12 @@ proc ::pd_bindings::global_bindings {} {
             bind_capslock all $::modifier-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
             bind all <$::modifier-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
         }
+
+        # On mac, the copy/paste menu command bindings also execute the commands, results in paste executed twice
+        # however, if we don't set this binding, the regular copy and paste gets called even with alt pressed
+        bind_capslock all $::modifier-$::alt-Key c {}
+        bind_capslock all $::modifier-$::alt-Key v {}
+
         # BackSpace/Delete report the wrong isos (unicode representations) on OSX,
         # so we set them to the empty string and let ::pd_bindings::sendkey guess the correct values
         bind all <KeyPress-BackSpace>      {::pd_bindings::sendkey %W 1 %K "" 1 %k}
@@ -135,6 +139,9 @@ proc ::pd_bindings::global_bindings {} {
     } else {
         bind_capslock all $::modifier-Key q       {::pd_connect::menu_quit}
         bind_capslock all $::modifier-Key m       {menu_minimize %W}
+
+        bind_capslock all $::modifier-$::alt-Key c {menu_send %W copy-to-clipboard-as-text}
+        bind_capslock all $::modifier-$::alt-Key v {menu_send %W paste-from-clipboard-text}
 
         bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
         bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -57,6 +57,7 @@ proc ::pd_bindings::global_bindings {} {
     bind_capslock all $::modifier-Key a {menu_send %W selectall}
     bind_capslock all $::modifier-Key b {menu_helpbrowser}
     bind_capslock all $::modifier-Key c {menu_send %W copy}
+    bind_capslock all $::modifier-$::alt-Key c {menu_send %W copy-to-clipboard-as-text}
     bind_capslock all $::modifier-Key d {menu_send %W duplicate}
     bind_capslock all $::modifier-Key e {menu_toggle_editmode}
     bind_capslock all $::modifier-Key f {menu_find_dialog}
@@ -69,6 +70,7 @@ proc ::pd_bindings::global_bindings {} {
     bind_capslock all $::modifier-Key s {menu_send %W menusave}
     bind_capslock all $::modifier-Key t {menu_send %W triggerize}
     bind_capslock all $::modifier-Key v {menu_send %W paste}
+    bind_capslock all $::modifier-$::alt-Key v {menu_send %W paste-from-clipboard-text}    
     bind_capslock all $::modifier-Key w {::pd_bindings::window_close %W}
     bind_capslock all $::modifier-Key x {menu_send %W cut}
     bind_capslock all $::modifier-Key z {menu_undo}

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -64,6 +64,8 @@ proc ::pd_menus::configure_for_pdwindow {} {
     $menubar.file entryconfigure [_ "Print..."] -state disabled
 
     # Edit menu
+    $menubar.edit entryconfigure [_ "Copy to clipboard (text)"] -state disabled
+    $menubar.edit entryconfigure [_ "Paste from clipboard (text)"] -state disabled
     $menubar.edit entryconfigure [_ "Paste Replace"] -state disabled
     $menubar.edit entryconfigure [_ "Duplicate"] -state disabled
     $menubar.edit entryconfigure [_ "Font"] -state normal
@@ -96,6 +98,8 @@ proc ::pd_menus::configure_for_canvas {mytoplevel} {
     $menubar.file entryconfigure [_ "Save As..."] -state normal
     $menubar.file entryconfigure [_ "Print..."] -state normal
     # Edit menu
+    $menubar.edit entryconfigure [_ "Copy to clipboard (text)"] -state normal
+    $menubar.edit entryconfigure [_ "Paste from clipboard (text)"] -state normal    
     $menubar.edit entryconfigure [_ "Paste Replace"] -state normal
     $menubar.edit entryconfigure [_ "Duplicate"] -state normal
     $menubar.edit entryconfigure [_ "Font"] -state normal
@@ -142,6 +146,8 @@ proc ::pd_menus::configure_for_dialog {mytoplevel} {
 
     # Edit menu
     $menubar.edit entryconfigure [_ "Font"] -state disabled
+    $menubar.edit entryconfigure [_ "Copy to clipboard (text)"] -state disabled
+    $menubar.edit entryconfigure [_ "Paste from clipboard (text)"] -state disabled    
     $menubar.edit entryconfigure [_ "Paste Replace"] -state disabled
     $menubar.edit entryconfigure [_ "Duplicate"] -state disabled
     $menubar.edit entryconfigure [_ "Zoom In"] -state disabled
@@ -196,8 +202,12 @@ proc ::pd_menus::build_edit_menu {mymenu} {
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window cut}
     $mymenu add command -label [_ "Copy"]       -accelerator "$accelerator+C" \
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window copy}
+    $mymenu add command -label [_ "Copy to clipboard (text)"] -accelerator "$accelerator+$::alt+C" \
+        -command {::pd_menucommands::scheduleAction menu_send $::focused_window copy-to-clipboard-as-text}        
     $mymenu add command -label [_ "Paste"]      -accelerator "$accelerator+V" \
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste}
+    $mymenu add command -label [_ "Paste from clipboard (text)"] -accelerator "$accelerator+$::alt+V" \
+        -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste-from-clipboard-text}           
     $mymenu add command -label [_ "Duplicate"]  -accelerator "$accelerator+D" \
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window duplicate}
     $mymenu add command -label [_ "Paste Replace" ]  \

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -207,7 +207,7 @@ proc ::pd_menus::build_edit_menu {mymenu} {
     $mymenu add command -label [_ "Paste"]      -accelerator "$accelerator+V" \
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste}
     $mymenu add command -label [_ "Paste from clipboard (text)"] -accelerator "$accelerator+$::alt+V" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste-from-clipboard-text}           
+        -command {::pdtk_canvas::pdtk_get_clipboard_text $::focused_window}     
     $mymenu add command -label [_ "Duplicate"]  -accelerator "$accelerator+D" \
         -command {::pd_menucommands::scheduleAction menu_send $::focused_window duplicate}
     $mymenu add command -label [_ "Paste Replace" ]  \

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -250,6 +250,32 @@ proc pdtk_canvas_clickpaste {tkcanvas x y b} {
     }
 }
 
+proc pdtk_get_clipboard_text {tkcanvas} {
+    set clipboard_data [clipboard get]
+    # TODO: better validation of PD patch clipboard data
+    if {[string index $clipboard_data 0] != "#"} {
+        ::pdwindow::post "Warning: Clipboard content does not seem to be valid PD patch: \n"
+        ::pdwindow::post $clipboard_data
+        return
+    }
+    set escaped_data [string map {" " "\\ " ";" "\\;" "\n" "\\n"} $clipboard_data]
+    pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $escaped_data"
+}
+
+proc pdtk_copy_to_clipboard_as_text {tkcanvas args} {
+    clipboard clear
+    set atom_line ""
+    foreach atom $args {
+        if {$atom == ";"} {
+            set trimmed_line [string trim $atom_line]
+            clipboard append "${trimmed_line};\n"
+            set atom_line ""
+        } else {
+            append atom_line $atom " "
+        }
+    }
+}
+
 #------------------------------------------------------------------------------#
 # canvas popup menu
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -251,9 +251,6 @@ proc pdtk_canvas_clickpaste {tkcanvas x y b} {
 }
 
 proc ::pdtk_canvas::pdtk_get_clipboard_text {tkcanvas} {
-    set CLIPBOARD_PATCH_TEXT_START 0
-    set CLIPBOARD_PATCH_TEXT_END 1
-    set CLIPBOARD_PATCH_TEXT_APPENDUTF8 2
     set MAX_CHUNK_SIZE 960
     set toplevel [winfo toplevel $tkcanvas]
     set clipboard_data [clipboard get]
@@ -264,13 +261,13 @@ proc ::pdtk_canvas::pdtk_get_clipboard_text {tkcanvas} {
         ::pdwindow::post $clipboard_data
         return
     }
-    pdsend "$toplevel got-clipboard-contents $CLIPBOARD_PATCH_TEXT_START"
+    pdsend "$toplevel got-clipboard-contents begin"
     set output {}
     foreach char [split $clipboard_data ""] {
         lappend output [scan $char %c]
     }
-    pdsend "$toplevel got-clipboard-contents $CLIPBOARD_PATCH_TEXT_APPENDUTF8 $output"
-    pdsend "$toplevel got-clipboard-contents $CLIPBOARD_PATCH_TEXT_END"
+    pdsend "$toplevel got-clipboard-contents addbytes $output"
+    pdsend "$toplevel got-clipboard-contents end"
 }
 
 proc pdtk_copy_to_clipboard_as_text {tkcanvas args} {

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -250,7 +250,7 @@ proc pdtk_canvas_clickpaste {tkcanvas x y b} {
     }
 }
 
-proc pdtk_get_clipboard_text {tkcanvas} {
+proc ::pdtk_canvas::pdtk_get_clipboard_text {tkcanvas} {
     set CLIPBOARD_PATCH_TEXT_START 0;
     set CLIPBOARD_PATCH_TEXT_LINE_END 1;
     set CLIPBOARD_PATCH_TEXT_END 2;
@@ -298,10 +298,7 @@ proc pdtk_copy_to_clipboard_as_text {tkcanvas args} {
         set atom [lindex $args $i]
         set next_atom [lindex $args [expr $i + 1]]
         set next_next_atom [lindex $args [expr $i + 2]]
-        # ::pdwindow::post "|$atom"
-        
         # Check for beginning of new line (#) but discard hex colors
-        #
         if {[string first "#" $atom] == 0 && ![regexp {^#[0-9a-fA-F]{6}$} $atom]} {
             append clipboard_content [string trim $atom_line]
             append clipboard_content "\n"
@@ -331,9 +328,6 @@ proc pdtk_copy_to_clipboard_as_text {tkcanvas args} {
     append clipboard_content "$atom_line\n"
     set processed_content $clipboard_content
     clipboard append [string trimleft $processed_content]
-
-    pdsend "[winfo toplevel $tkcanvas] my-new-function 0 HelloWorld\\ hello!"
-    pdsend "[winfo toplevel $tkcanvas] my-new-function 1 HelloWorld\\ yes\\ sir!"
 }
 
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -264,7 +264,7 @@ proc ::pdtk_canvas::pdtk_get_clipboard_text {tkcanvas} {
         ::pdwindow::post $clipboard_data
         return
     }
-    pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $CLIPBOARD_PATCH_TEXT_START NONE"
+    pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $CLIPBOARD_PATCH_TEXT_START"
     
     foreach line [split $clipboard_data \n] {
         if {[string length $line] > 0} {
@@ -284,7 +284,7 @@ proc ::pdtk_canvas::pdtk_get_clipboard_text {tkcanvas} {
             pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $CLIPBOARD_PATCH_TEXT_LINE_END $escaped_line"
         }
     }
-    pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $CLIPBOARD_PATCH_TEXT_END NONE"
+    pdsend "[winfo toplevel $tkcanvas] got-clipboard-contents $CLIPBOARD_PATCH_TEXT_END"
 }
 
 

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -305,11 +305,10 @@ proc pdtk_copy_to_clipboard_as_text {tkcanvas args} {
         } else {
             if {$atom == ";" && ([string first "#" $next_atom] == 0 || $next_atom == "")} {
                 set atom_line [string trimright $atom_line]
+                set atom_line [regsub -all -- {\$} $atom_line {\\$}]
                 append atom_line ";"
             } elseif {$atom == ";"} {
                 append atom_line "\\; "
-            } elseif {[string first "\$" $atom] == 0} {
-                append atom_line "\\$" [string range $atom 1 end] " "
             } elseif {$atom == ","} {
                 # text items can have unescaped comma delimiting the width attribute
                 if {$obj_type == "text"} {


### PR DESCRIPTION
Opening wip PR for discussion
Related issue https://github.com/pure-data/pure-data/issues/635


Todo
- [ ] do not use static variables (use gl_privatedata for clipboard length and text)
- [ ] edit commit history so copy/paste functionality are in separate commits, remove unnecessary
- [ ] refactor, DRY, etc..
- [ ] copy: test serialization (escaping special chars in particular) by diffing saved patches and patches serialized to clipboard 
- [ ] memory allocation checks (+error handling)
- [ ] Validate patch data before attempting paste (regex?)
- [x] handle atom width attribute, i.e. `,f 16` in the end of each patch line (atom width in chars)

**Maybe**
- [ ] figure out whether to include #N for new canvas. i.e. on copying, should the copied patch include the canvas in order to be saved as a proper patch, and on pasting, the first #N should be then ignored.
- [ ] Should paste be single action instead of two? Currently there's 2 functional copy buffers (internal and text)

**Testing**
- [x] Test on windows (latest build tested on win10 64bit)
- [x] Test on osx (latest build tested on arm64 m1, osx 13.2.1)
- [x] Test on linux (latest build tested on arm64 debian 11)

**Other**
- [x] escape clipboard string when sending back from tcl to c when pasting
- [x] Text to binbuf chunks - maximum string length is now limited by MAXPDSTRING, which limits the amount of objects you can copy/paste
- [x] split lines to handle longer messages (long arrays for example) through pdsend
- [x] bug: handle double paste on mac, resulting from menu command keybind declaration running the command twice
- [x] handle paste undo