### PR TITLE
nbx: add support for disabling changes via click/motion events

### DIFF
--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -268,6 +268,7 @@ typedef struct _my_numbox
     char     x_buf[IEMGUI_MAX_NUM_LEN];
     int      x_numwidth;
     int      x_log_height;
+    int      x_cantchange;
 } t_my_numbox;
 
 extern int iemgui_color_hex[];

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -425,7 +425,7 @@ static void my_numbox_motion(t_my_numbox *x, t_floatarg dx, t_floatarg dy,
     t_floatarg up)
 {
     double k2 = 1.0;
-    if (up != 0)
+    if (up != 0 || x->x_cantchange != 0)
         return;
 
     if(x->x_gui.x_fsf.x_finemoved)
@@ -442,8 +442,11 @@ static void my_numbox_motion(t_my_numbox *x, t_floatarg dx, t_floatarg dy,
 static void my_numbox_click(t_my_numbox *x, t_floatarg xpos, t_floatarg ypos,
                             t_floatarg shift, t_floatarg ctrl, t_floatarg alt)
 {
-    glist_grab(x->x_gui.x_glist, &x->x_gui.x_obj.te_g,
-        (t_glistmotionfn)my_numbox_motion, my_numbox_key, xpos, ypos);
+    t_glistmotionfn motionfn = 0;
+    if (x->x_cantchange == 0)
+        motionfn = (t_glistmotionfn)my_numbox_motion;
+    glist_grab(x->x_gui.x_glist, &x->x_gui.x_obj.te_g, motionfn, my_numbox_key,
+        xpos, ypos);
 }
 
 static int my_numbox_newclick(t_gobj *z, struct _glist *glist,
@@ -661,6 +664,11 @@ static void my_numbox_list(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
     }
 }
 
+static void my_numbox_cantchange(t_my_numbox *x, t_floatarg v)
+{
+     x->x_cantchange = v != 0.;
+}
+
 static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
 {
     t_my_numbox *x = (t_my_numbox *)iemgui_new(my_numbox_class);
@@ -793,6 +801,8 @@ void g_numbox_setup(void)
         gensym("log_height"), A_FLOAT, 0);
     class_addmethod(my_numbox_class, (t_method)iemgui_zoom,
         gensym("zoom"), A_CANT, 0);
+    class_addmethod(my_numbox_class, (t_method)my_numbox_cantchange,
+        gensym("cantchange"), A_FLOAT, 0);
     my_numbox_widgetbehavior.w_getrectfn =    my_numbox_getrect;
     my_numbox_widgetbehavior.w_displacefn =   iemgui_displace;
     my_numbox_widgetbehavior.w_selectfn =     iemgui_select;


### PR DESCRIPTION
This tries to follow the semantics of Max's number box, using the same message name cantchange, and identical (from my testing) semantics.

This is not fully Max-compatible yet, as it applies only to nbx/my_numbox, not floatatoms, and does not add support for the parameter in the properties TCL properties page, or initialization arguments/attributes.

---

I'm sure this sort of thing can be controversial -- I like having the ability to lock a value from being edited using the cursor, to prevent accidental, confusing, or meaningless edits.

If this kind of change is upstreamable, I'd be happy to add improvements to the UX (like hinting at the readonly-ness of the field graphically, adding support to the property page or a means of initialiizing the object this way, or making the float atom primitive behave similarly).

I'm also open to using different names, but being somewhat compatible with Max seemed like a nice touch.