### PR TITLE
Safe cross-platform `snprintf` and `vsnprintf` alternative

### DIFF
--- a/extra/pd~/pd~.c
+++ b/extra/pd~/pd~.c
@@ -34,7 +34,6 @@ typedef int socklen_t;
 
 #ifdef _MSC_VER
 #pragma warning (disable: 4305 4244)
-#define snprintf _snprintf
 #define stat _stat
 #endif
 
@@ -87,6 +86,13 @@ void critical_exit(int z);
 #include "s_stuff.h"
 static t_class *pd_tilde_class;
 #define PDERROR pd_error(x,
+#else
+#ifdef _MSC_VER
+/* Sorry, MSP! */
+#define pd_snprintf _snprintf
+#else
+#define pd_snprintf snprintf
+#endif
 #endif
 
 #if defined(__x86_64__) || defined(_M_X64)
@@ -559,15 +565,15 @@ static void pd_tilde_dostart(t_pd_tilde *x, const char *pddir,
     sprintf(ninsigstr, "%d", ninsig);
     sprintf(noutsigstr, "%d", noutsig);
     sprintf(sampleratestr, "%f", (float)samplerate);
-    snprintf(tmpbuf, MAXPDSTRING, "%s/bin/pd" EXTENT, pddir);
+    pd_snprintf(tmpbuf, MAXPDSTRING, "%s/bin/pd" EXTENT, pddir);
     sys_bashfilename(tmpbuf, pdexecbuf);
     if (stat(pdexecbuf, &statbuf) < 0)
     {
-        snprintf(tmpbuf, MAXPDSTRING, "%s/../../../bin/pd" EXTENT, pddir);
+        pd_snprintf(tmpbuf, MAXPDSTRING, "%s/../../../bin/pd" EXTENT, pddir);
         sys_bashfilename(tmpbuf, pdexecbuf);
         if (stat(pdexecbuf, &statbuf) < 0)
         {
-            snprintf(tmpbuf, MAXPDSTRING, "%s/pd" EXTENT, pddir);
+            pd_snprintf(tmpbuf, MAXPDSTRING, "%s/pd" EXTENT, pddir);
             sys_bashfilename(tmpbuf, pdexecbuf);
             if (stat(pdexecbuf, &statbuf) < 0)
             {
@@ -579,7 +585,7 @@ static void pd_tilde_dostart(t_pd_tilde *x, const char *pddir,
         /* check that the scheduler dynamic linkable exists w either suffix */
     for(dllextent=get_dllextent(); *dllextent; dllextent++)
     {
-      snprintf(tmpbuf, MAXPDSTRING, "%s/pdsched%s", schedlibdir, *dllextent);
+      pd_snprintf(tmpbuf, MAXPDSTRING, "%s/pdsched%s", schedlibdir, *dllextent);
       sys_bashfilename(tmpbuf, schedbuf);
       if (stat(schedbuf, &statbuf) >= 0)
         goto gotone;
@@ -589,33 +595,33 @@ static void pd_tilde_dostart(t_pd_tilde *x, const char *pddir,
 
 gotone:
         /* but the sub-process wants the scheduler name without the suffix */
-    snprintf(tmpbuf, MAXPDSTRING, "%s/pdsched", schedlibdir);
+    pd_snprintf(tmpbuf, MAXPDSTRING, "%s/pdsched", schedlibdir);
     sys_bashfilename(tmpbuf, schedbuf);
-    /* was: snprintf(cmdbuf, MAXPDSTRING,
+    /* was: pd_snprintf(cmdbuf, MAXPDSTRING,
 "'%s' -schedlib '%s'/pdsched -path '%s' -inchannels %d -outchannels %d -r \
 %g %s\n",
         pdexecbuf, schedlibdir, patchdir, ninsig, noutsig, samplerate, pdargs);
         */
-    snprintf(cmdbuf, MAXPDSTRING, "%s", pdexecbuf);
+    pd_snprintf(cmdbuf, MAXPDSTRING, "%s", pdexecbuf);
 #ifdef _WIN32
     /* _spawnv wants the command without quotes as in cmdbuf above;
         but in the argument vector paths must be quoted if they contain
         whitespace */
     if (strchr(pdexecbuf, ' ') && *pdexecbuf != '"' && *pdexecbuf != '\'')
     {
-        if (snprintf(tmpbuf, MAXPDSTRING, "\"%s\"", pdexecbuf) >= 0)
-            snprintf(pdexecbuf, MAXPDSTRING, "%s", tmpbuf);
+        if (pd_snprintf(tmpbuf, MAXPDSTRING, "\"%s\"", pdexecbuf) >= 0)
+            pd_snprintf(pdexecbuf, MAXPDSTRING, "%s", tmpbuf);
     }
     if (strchr(schedbuf, ' ') && *schedbuf != '"' && *schedbuf != '\'')
     {
-        if (snprintf(tmpbuf, MAXPDSTRING, "\"%s\"", schedbuf) >= 0)
-            snprintf(schedbuf, MAXPDSTRING, "%s", tmpbuf);
+        if (pd_snprintf(tmpbuf, MAXPDSTRING, "\"%s\"", schedbuf) >= 0)
+            pd_snprintf(schedbuf, MAXPDSTRING, "%s", tmpbuf);
     }
     if (strchr(patchdir_c, ' ') && *patchdir_c != '"' && *patchdir_c != '\'')
-        snprintf(patchdir, MAXPDSTRING, "\"%s\"", patchdir_c);
+        pd_snprintf(patchdir, MAXPDSTRING, "\"%s\"", patchdir_c);
     else
 #endif /* _WIN32 */
-        snprintf(patchdir, MAXPDSTRING, "%s", patchdir_c);
+        pd_snprintf(patchdir, MAXPDSTRING, "%s", patchdir_c);
 
     execargv[0] = pdexecbuf;
     execargv[1] = "-schedlib";
@@ -636,7 +642,7 @@ gotone:
     {
 #ifdef PD
         if (argv[i].a_type == A_SYMBOL)
-            snprintf(tmpbuf, MAXPDSTRING, "%s", argv[i].a_w.w_symbol->s_name);
+            pd_snprintf(tmpbuf, MAXPDSTRING, "%s", argv[i].a_w.w_symbol->s_name);
         else if (argv[i].a_type == A_FLOAT)
             sprintf(tmpbuf,  "%f", (float)argv[i].a_w.w_float);
 #endif
@@ -657,8 +663,8 @@ gotone:
         if (strchr(tmpbuf, ' ') && *tmpbuf != '"' && *tmpbuf != '\'')
         {
             char nutherbuf[MAXPDSTRING];
-            snprintf(nutherbuf, MAXPDSTRING, "\"%s\"", tmpbuf);
-            snprintf(tmpbuf, MAXPDSTRING, "%s", nutherbuf);
+            pd_snprintf(nutherbuf, MAXPDSTRING, "\"%s\"", tmpbuf);
+            pd_snprintf(tmpbuf, MAXPDSTRING, "%s", nutherbuf);
         }
 #endif /* _WIN32 */
         execargv[FIXEDARG+i] = malloc(strlen(tmpbuf) + 1);

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -311,9 +311,9 @@ static t_symbol* color2symbol(int col) {
     {
             /* compatibility with Pd<=0.47: saves colors as numbers with limited resolution */
         int col2 = -1 - (((0xfc0000 & col) >> 6)|((0xfc00 & col) >> 4)|((0xfc & col) >> 2));
-        snprintf(colname, MAXPDSTRING-1, "%d", col2);
+        pd_snprintf(colname, MAXPDSTRING-1, "%d", col2);
     } else {
-        snprintf(colname, MAXPDSTRING-1, "#%06x", col);
+        pd_snprintf(colname, MAXPDSTRING-1, "#%06x", col);
     }
     return gensym(colname);
 }
@@ -822,7 +822,7 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
 
 void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
 {
-#define SETCOLOR(a, col) do {char color[MAXPDSTRING]; snprintf(color, MAXPDSTRING-1, "#%06x", 0xffffff & col); color[MAXPDSTRING-1] = 0; SETSYMBOL(a, gensym(color));} while(0)
+#define SETCOLOR(a, col) do {char color[MAXPDSTRING]; pd_snprintf(color, MAXPDSTRING-1, "#%06x", 0xffffff & col); color[MAXPDSTRING-1] = 0; SETSYMBOL(a, gensym(color));} while(0)
     t_float zoom = iemgui->x_glist->gl_zoom;
     t_symbol *srl[3];
     int for_undo = 1;

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -687,7 +687,7 @@ static void canvas_dosetbounds(t_canvas *x, int x1, int y1, int x2, int y2)
 t_symbol *canvas_makebindsym(t_symbol *s)
 {
     char buf[MAXPDSTRING];
-    snprintf(buf, MAXPDSTRING-1, "pd-%s", s->s_name);
+    pd_snprintf(buf, MAXPDSTRING-1, "pd-%s", s->s_name);
     buf[MAXPDSTRING-1] = 0;
     return (gensym(buf));
 }
@@ -1669,7 +1669,7 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
         /* check whether the given subdir is in one of the user search-paths */
     for (nl=STUFF->st_searchpath; nl; nl=nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
+        pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
         strbuf[MAXPDSTRING-1]=0;
         if (check_exists(strbuf))
         {
@@ -1681,7 +1681,7 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
         /* check whether the given subdir is in one of the standard-paths */
     for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
+        pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, path);
         strbuf[MAXPDSTRING-1]=0;
         if (check_exists(strbuf))
         {
@@ -1715,7 +1715,7 @@ static void canvas_lib(t_canvas *x, t_canvasenvironment *e, const char *lib)
     /* check whether the given lib is located in one of the user search-paths */
     for (nl=STUFF->st_searchpath; nl; nl=nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, lib);
+        pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, lib);
         strbuf[MAXPDSTRING-1]=0;
         if (sys_load_lib(x, strbuf))
             return;
@@ -1747,7 +1747,7 @@ static void canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
     /* check whether the given subdir is in one of the standard-paths */
     for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, stdpath);
+        pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s/", nl->nl_string, stdpath);
         strbuf[MAXPDSTRING-1]=0;
         if (check_exists(strbuf))
         {
@@ -1778,7 +1778,7 @@ static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
     /* check whether the given lib is located in one of the standard-paths */
     for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
     {
-        snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, stdlib);
+        pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, stdlib);
         strbuf[MAXPDSTRING-1]=0;
         if (sys_load_lib(0, strbuf))
             return;

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -796,9 +796,9 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
     char namebuf[MAXPDSTRING];
 
     if (*dirname)
-        snprintf(namebuf, MAXPDSTRING-1, "%s/%s", dirname, filename);
+        pd_snprintf(namebuf, MAXPDSTRING-1, "%s/%s", dirname, filename);
     else
-        snprintf(namebuf, MAXPDSTRING-1, "%s", filename);
+        pd_snprintf(namebuf, MAXPDSTRING-1, "%s", filename);
     namebuf[MAXPDSTRING-1] = 0;
 
     if ((fd = sys_open(namebuf, 0)) < 0)
@@ -893,9 +893,9 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
     int indx;
 
     if (*dir)
-        snprintf(fbuf, MAXPDSTRING-1, "%s/%s", dir, filename);
+        pd_snprintf(fbuf, MAXPDSTRING-1, "%s/%s", dir, filename);
     else
-        snprintf(fbuf, MAXPDSTRING-1, "%s", filename);
+        pd_snprintf(fbuf, MAXPDSTRING-1, "%s", filename);
     fbuf[MAXPDSTRING-1] = 0;
 
     if (!strcmp(filename + strlen(filename) - 4, ".pat") ||

--- a/src/m_class.c
+++ b/src/m_class.c
@@ -123,7 +123,7 @@ static void class_addmethodtolist(t_class *c, t_methodentry **methodlist,
         if (sel && (*methodlist)[i].me_name == sel)
     {
         char nbuf[80];
-        snprintf(nbuf, 80, "%s_aliased", sel->s_name);
+        pd_snprintf(nbuf, 80, "%s_aliased", sel->s_name);
         nbuf[79] = 0;
         (*methodlist)[i].me_name = dogensym(nbuf, 0, pdinstance);
         if (c == pd_objectmaker)

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -8,6 +8,7 @@ behavior for "gobjs" appears at the end of this file.  */
 
 #include "m_pd.h"
 #include "m_imp.h"
+#include "s_stuff.h"
 #include <string.h>
 
 #include "m_private_utils.h"
@@ -400,14 +401,14 @@ static void backtracer_printmsg(t_pd *who, t_symbol *s,
 {
     char msgbuf[104];
     int nprint = (argc > NARGS ? NARGS : argc), nchar, i;
-    snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
+    pd_snprintf(msgbuf, 100, "%s: %s ", class_getname(*who), s->s_name);
     nchar = strlen(msgbuf);
     for (i = 0; i < nprint && nchar < 100; i++)
         if (nchar < 100)
     {
         char buf[100];
         atom_string(&argv[i], buf, 100);
-        snprintf(msgbuf + nchar, 100-nchar, " %s", buf);
+        pd_snprintf(msgbuf + nchar, 100-nchar, " %s", buf);
         nchar = strlen(msgbuf);
     }
     if (argc > nprint && nchar < 100)

--- a/src/m_private_utils.h
+++ b/src/m_private_utils.h
@@ -107,11 +107,4 @@
 # endif
 #endif
 
-
-/* -------------------------MSVC compat defines --------------------- */
-#ifdef _MSC_VER
-# define snprintf _snprintf
-#endif
-
-
 #endif /* M_PRIVATE_UTILS_H */

--- a/src/s_audio_mmio.c
+++ b/src/s_audio_mmio.c
@@ -784,7 +784,7 @@ void mmio_getdevs(char *indevlist, int *nindevs,
         wRtn = waveInGetDevCaps(i, (LPWAVEINCAPS) &wicap, sizeof(wicap));
         if (!wRtn)
             u8_nativetoutf8(utf8device, MAXPDSTRING, wicap.szPname, -1);
-        _snprintf(indevlist + i * devdescsize, devdescsize, "%s",
+        pd_snprintf(indevlist + i * devdescsize, devdescsize, "%s",
             (wRtn ? "???" : utf8device));
         indevlist[(i+1) * devdescsize - 1] = 0;
     }
@@ -799,7 +799,7 @@ void mmio_getdevs(char *indevlist, int *nindevs,
         wRtn = waveOutGetDevCaps(i, (LPWAVEOUTCAPS) &wocap, sizeof(wocap));
         if (!wRtn)
             u8_nativetoutf8(utf8device, MAXPDSTRING, wocap.szPname, -1);
-        _snprintf(outdevlist + i * devdescsize,  devdescsize, "%s",
+        pd_snprintf(outdevlist + i * devdescsize,  devdescsize, "%s",
             (wRtn ? "???" : utf8device));
         outdevlist[(i+1) * devdescsize - 1] = 0;
     }

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -709,10 +709,10 @@ static char*pdi2devname(const PaDeviceInfo*pdi, char*buf, size_t bufsize) {
 
     api = Pa_GetHostApiInfo(pdi->hostApi);
     if(api)
-        snprintf(utf8device, MAXPDSTRING, "%s: %s",
+        pd_snprintf(utf8device, MAXPDSTRING, "%s: %s",
             api->name, pdi->name);
     else
-        snprintf(utf8device, MAXPDSTRING, "%s",
+        pd_snprintf(utf8device, MAXPDSTRING, "%s",
             pdi->name);
 
     u8_nativetoutf8(buf, bufsize, utf8device, MAXPDSTRING);
@@ -738,13 +738,13 @@ void pa_getdevs(char *indevlist, int *nindevs,
         if (pdi->maxInputChannels > 0 && nin < maxndev)
         {
                 /* LATER figure out how to get API name correctly */
-            snprintf(indevlist + nin * devdescsize, devdescsize,
+            pd_snprintf(indevlist + nin * devdescsize, devdescsize,
                 "%s", devname);
             nin++;
         }
         if (pdi->maxOutputChannels > 0 && nout < maxndev)
         {
-            snprintf(outdevlist + nout * devdescsize, devdescsize,
+            pd_snprintf(outdevlist + nout * devdescsize, devdescsize,
                 "%s", devname);
             nout++;
         }

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -141,9 +141,9 @@ static int preferences_getloadpath(char *dst, size_t size)
     char user_prefs[MAXPDSTRING];
     char *homedir = getenv("HOME");
     struct stat statbuf;
-    snprintf(embedded_prefs, MAXPDSTRING, "%s/../org.puredata.pd",
+    pd_snprintf(embedded_prefs, MAXPDSTRING, "%s/../org.puredata.pd",
         sys_libdir->s_name);
-    snprintf(user_prefs, MAXPDSTRING,
+    pd_snprintf(user_prefs, MAXPDSTRING,
         "%s/Library/Preferences/org.puredata.pd.plist", homedir);
     if (stat(user_prefs, &statbuf) == 0)
     {
@@ -161,7 +161,7 @@ static int preferences_getloadpath(char *dst, size_t size)
 static void preferences_getsavepath(char *dst, size_t size)
 {
     char user_prefs[MAXPDSTRING];
-    snprintf(user_prefs, MAXPDSTRING,
+    pd_snprintf(user_prefs, MAXPDSTRING,
         "%s/Library/Preferences/org.puredata.pd.plist", getenv("HOME"));
     strncpy(dst, user_prefs, size);
 }
@@ -326,10 +326,10 @@ static int sys_getpreference(const char *key, char *value, int size)
         char path[MAXPDSTRING];
         int embedded = preferences_getloadpath(path, MAXPDSTRING);
         if (embedded)
-            snprintf(cmdbuf, 256, "defaults read %s %s 2> /dev/null\n",
+            pd_snprintf(cmdbuf, 256, "defaults read %s %s 2> /dev/null\n",
                 path, key);
         else
-            snprintf(cmdbuf, 256, "defaults read org.puredata.pd %s 2> /dev/null\n",
+            pd_snprintf(cmdbuf, 256, "defaults read org.puredata.pd %s 2> /dev/null\n",
                 key);
         FILE *fp = popen(cmdbuf, "r");
         while (nread < size)
@@ -373,7 +373,7 @@ static void sys_putpreference(const char *key, const char *value)
     else {
         /* fallback to defaults command */
         char cmdbuf[MAXPDSTRING];
-        snprintf(cmdbuf, MAXPDSTRING,
+        pd_snprintf(cmdbuf, MAXPDSTRING,
             "defaults write org.puredata.pd %s \"%s\" 2> /dev/null\n", key, value);
         system(cmdbuf);
     }
@@ -410,15 +410,15 @@ static void sys_initsavepreferences(void)
         {
             for (j = 0; j < maxnum[i]; j++)
             {
-                snprintf(buf, sizeof(buf), "%sdev%d", key[i], j + 1);
-                snprintf(devname, sizeof(devname), "%sdevname%d", key[i], j + 1);
+                pd_snprintf(buf, sizeof(buf), "%sdev%d", key[i], j + 1);
+                pd_snprintf(devname, sizeof(devname), "%sdevname%d", key[i], j + 1);
                 if (!sys_deletepreference(buf) || !sys_deletepreference(devname))
                     break;
             }
         }
         for (i = 0; ; i++)
         {
-            snprintf(buf, sizeof(buf), "path%d", i + 1);
+            pd_snprintf(buf, sizeof(buf), "path%d", i + 1);
             if (!sys_deletepreference(buf))
                 break;
         }
@@ -515,9 +515,9 @@ static void sys_initloadpreferences(void)
     char default_prefs_file[MAXPDSTRING];
     struct stat statbuf;
 
-    snprintf(default_prefs_file, MAXPDSTRING, "%s/default.pdsettings",
+    pd_snprintf(default_prefs_file, MAXPDSTRING, "%s/default.pdsettings",
         sys_libdir->s_name);
-    snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
+    pd_snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
         (homedir ? homedir : "."));
     if (stat(user_prefs_file, &statbuf) == 0)
         strncpy(filenamebuf, user_prefs_file, MAXPDSTRING);
@@ -546,7 +546,7 @@ static void sys_initsavepreferences(void)
 
     if (!homedir)
         return;
-    snprintf(filenamebuf, MAXPDSTRING, "%s/.pdsettings", homedir);
+    pd_snprintf(filenamebuf, MAXPDSTRING, "%s/.pdsettings", homedir);
     filenamebuf[MAXPDSTRING-1] = 0;
     sys_initsavepreferences_file(filenamebuf);
 }
@@ -891,7 +891,7 @@ void glob_forgetpreferences(t_pd *dummy)
     char user_prefs_file[MAXPDSTRING]; /* user prefs file */
     const char *homedir = getenv("HOME");
     struct stat statbuf;
-    snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
+    pd_snprintf(user_prefs_file, MAXPDSTRING, "%s/.pdsettings",
         (homedir ? homedir : "."));
     user_prefs_file[MAXPDSTRING-1] = 0;
     if (stat(user_prefs_file, &statbuf) != 0) {
@@ -908,7 +908,7 @@ void glob_forgetpreferences(t_pd *dummy)
     if (!sys_getpreference("audioapi", cmdbuf, MAXPDSTRING))
         post("no Pd settings to clear"), warn = 0;
             /* do it anyhow, why not... */
-    snprintf(cmdbuf, MAXPDSTRING,
+    pd_snprintf(cmdbuf, MAXPDSTRING,
         "defaults delete org.puredata.pd 2> /dev/null\n");
     if (system(cmdbuf) && warn)
         post("failed to erase Pd settings");

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -129,7 +129,7 @@ static char*add_deken_extension(const char*systemext, int float_agnostic, int cp
         return 0;
     ext[MAXPDSTRING-1] = 0;
 
-    if(snprintf(ext, MAXPDSTRING-1, ".%s%s", extbuf, systemext) > 0)
+    if(pd_snprintf(ext, MAXPDSTRING-1, ".%s%s", extbuf, systemext) > 0)
         add_dllextension(ext);
     else
     {
@@ -535,7 +535,7 @@ int sys_run_scheduler(const char *externalschedlibname,
     for(dllextent=sys_get_dllextensions(); *dllextent; dllextent++)
     {
         struct stat statbuf;
-        snprintf(filename, sizeof(filename), "%s%s", externalschedlibname,
+        pd_snprintf(filename, sizeof(filename), "%s%s", externalschedlibname,
             *dllextent);
         sys_bashfilename(filename, filename);
         if(!stat(filename, &statbuf))
@@ -604,7 +604,7 @@ static t_pd *do_create_abstraction(t_symbol*s, int argc, t_atom *argv)
         int fd = -1;
 
         t_pd *was = s__X.s_thing;
-        snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
+        pd_snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
         if ((fd = canvas_open(canvas, objectname, ".pd",
                   dirbuf, &nameptr, MAXPDSTRING, 0)) >= 0 ||
             (fd = canvas_open(canvas, objectname, ".pat",
@@ -640,7 +640,7 @@ static int sys_do_load_abs(t_canvas *canvas, const char *objectname,
            but we have already tried all paths */
     if (!path) return (0);
 
-    snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
+    pd_snprintf(classslashclass, MAXPDSTRING, "%s/%s", objectname, objectname);
     if ((fd = sys_trytoopenone(path, objectname, ".pd",
               dirbuf, &nameptr, MAXPDSTRING, 1)) >= 0 ||
         (fd = sys_trytoopenone(path, objectname, ".pat",

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -14,6 +14,58 @@
 t_printhook sys_printhook = NULL;
 int sys_printtostderr;
 
+#ifdef _WIN32
+
+    /* NB: Unlike vsnprintf(), _vsnprintf() does *not* null-terminate
+    the output if the resulting string is too large to fit into the buffer.
+    Also, it just returns -1 instead of the required number of bytes.
+    Strictly speaking, the UCRT in Windows 10 actually contains a standard-
+    conforming vsnprintf() function that is not just an alias for _vsnprintf().
+    However, MinGW traditionally links against the old msvcrt.dll runtime library.
+    Recent versions of MinGW seem to have their own (standard-conformating)
+    implementation of vsnprintf(), but to ensure portability we rather use our
+    own implementation for all Windows builds. */
+int pd_vsnprintf(char *buf, size_t size, const char *fmt, va_list argptr)
+{
+    int ret = _vsnprintf(buf, size, fmt, argptr);
+    if (ret < 0)
+    {
+            /* null-terminate the buffer and get the required number of bytes. */
+        ret = _vscprintf(fmt, argptr);
+        buf[size - 1] = '\0';
+    }
+    return ret;
+}
+
+int pd_snprintf(char *buf, size_t size, const char *fmt, ...)
+{
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = pd_vsnprintf(buf, size, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+#else
+
+int pd_vsnprintf(char *buf, size_t size, const char *fmt, va_list argptr)
+{
+    return vsnprintf(buf, size, fmt, argptr);
+}
+
+int pd_snprintf(char *buf, size_t size, const char *fmt, ...)
+{
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = vsnprintf(buf, size, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+#endif
+
 /* escape characters for tcl/tk */
 char* pdgui_strnescape(char *dst, size_t dstlen, const char *src, size_t srclen)
 {
@@ -76,7 +128,7 @@ static void doerror(const void *object, const char *s)
     // what about sys_printhook_error ?
     if (STUFF->st_printhook)
     {
-        snprintf(upbuf, MAXPDSTRING-1, "error: %s", s);
+        pd_snprintf(upbuf, MAXPDSTRING-1, "error: %s", s);
         (*STUFF->st_printhook)(upbuf);
     }
     else if (sys_printtostderr)
@@ -108,7 +160,7 @@ static void dologpost(const void *object, const int level, const char *s)
     // what about sys_printhook_verbose ?
     if (STUFF->st_printhook)
     {
-        snprintf(upbuf, MAXPDSTRING-1, "verbose(%d): %s", level, s);
+        pd_snprintf(upbuf, MAXPDSTRING-1, "verbose(%d): %s", level, s);
         (*STUFF->st_printhook)(upbuf);
     }
     else if (sys_printtostderr)
@@ -135,7 +187,7 @@ void logpost(const void *object, int level, const char *fmt, ...)
     va_list ap;
     if (level > PD_DEBUG && !sys_verbose) return;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -148,7 +200,7 @@ void startlogpost(const void *object, const int level, const char *fmt, ...)
     va_list ap;
     if (level > PD_DEBUG && !sys_verbose) return;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
 
     dologpost(object, level, buf);
@@ -162,7 +214,7 @@ void post(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -176,7 +228,7 @@ void startpost(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
 
     dopost(buf);
@@ -229,7 +281,7 @@ EXTERN void error(const char *fmt, ...)
     int i;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -246,7 +298,7 @@ void verbose(int level, const char *fmt, ...)
     if (level > sys_verbose) return;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -272,7 +324,7 @@ void pd_error(const void *object, const char *fmt, ...)
     static int saidit = 0;
 
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
     strcat(buf, "\n");
 
@@ -329,7 +381,7 @@ void bug(const char *fmt, ...)
     t_int arg[8];
     int i;
     va_start(ap, fmt);
-    vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
+    pd_vsnprintf(buf, MAXPDSTRING-1, fmt, ap);
     va_end(ap);
 
     pd_error(0, "consistency check failed: %s", buf);

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -423,3 +423,7 @@ struct _instancestuff
  * 'srclen' can be 0, in which case the 'src' string must be 0-terminated.
  */
 EXTERN char*pdgui_strnescape(char* dst, size_t dstlen, const char*src, size_t srclen);
+
+/* safe cross-platform alternatives to snprintf and vsnprintf. */
+EXTERN int pd_snprintf(char *buf, size_t size, const char *fmt, ...);
+EXTERN int pd_vsnprintf(char *buf, size_t size, const char *fmt, va_list argptr);

--- a/src/x_file.c
+++ b/src/x_file.c
@@ -7,6 +7,7 @@
 
 #include "m_pd.h"
 #include "g_canvas.h"
+#include "s_stuff.h"
 #include "s_utf8.h"
 
 #include "m_private_utils.h"
@@ -312,7 +313,7 @@ static const char*do_errmsg(char*buffer, size_t bufsize) {
     s=buffer + strlen(buffer)-1;
     while(('\r' == *s || '\n' == *s) && s>buffer)
         *s--=0;
-    snprintf(errcode, sizeof(errcode), " [%ld]", err);
+    pd_snprintf(errcode, sizeof(errcode), " [%ld]", err);
     errcode[sizeof(errcode)-1] = 0;
     strcat(buffer, errcode);
     return buffer;
@@ -1220,7 +1221,7 @@ static void file_patchpath_list(t_file_handle*x, t_symbol*s, int argc, t_atom*ar
             s = gensym(pathname);
         } else {
             char buf[MAXPDSTRING];
-            snprintf(buf, MAXPDSTRING, "%s/%s",
+            pd_snprintf(buf, MAXPDSTRING, "%s/%s",
                      canvas_getdir(c)->s_name, pathname);
             buf[MAXPDSTRING-1] = 0;
             s = gensym(buf);
@@ -1381,7 +1382,7 @@ static int file_do_copy(const char*source, const char*destination, int mode) {
                 filename=source;
             else
                 filename++;
-            snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
+            pd_snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
             dst = sys_open(destfile, O_WRONLY | O_CREAT | O_TRUNC, mode);
         }
     }
@@ -1424,7 +1425,7 @@ static int file_do_move(const char*source, const char*destination, int mode) {
                 filename=source;
             else
                 filename++;
-            snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
+            pd_snprintf(destfile, MAXPDSTRING, "%s/%s", destination, filename);
             result = sys_rename(source, destfile);
             olderrno = errno;
         }

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -7,6 +7,7 @@ away before the panel does... */
 
 #include "m_pd.h"
 #include "g_canvas.h"
+#include "s_stuff.h"
 #include <stdio.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -489,7 +490,7 @@ static void pdcontrol_dir(t_pdcontrol *x, t_symbol *s, t_floatarg f)
     if (*s->s_name)
     {
         char buf[MAXPDSTRING];
-        snprintf(buf, MAXPDSTRING, "%s/%s",
+        pd_snprintf(buf, MAXPDSTRING, "%s/%s",
             canvas_getdir(c)->s_name, s->s_name);
         buf[MAXPDSTRING-1] = 0;
         outlet_symbol(x->x_outlet, gensym(buf));


### PR DESCRIPTION
Currently, we define `snprintf` as `_snprintf` when building with MSVC. However, `_snprintf` is *not* a drop-in replacement for `snprintf`! Most importantly, it does not null-terminate the output buffer on truncation! Also, it outputs -1 instead of the number of required bytes.

Note that the UCRT (universal C runtime), provided for Windows 10 and above, actually contains a C99-conforming `snprintf` function. When targetting older systems, MSVC would just define `snprintf` as `_snprintf`. See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170.

On MinGW the situation is also a bit complicated, as it traditionally uses the old `msvcrt.dll`, which only has the non-conforming `_snprintf`. Some versions define `snprintf` as an alias for `_snprintf`, but other (more recent?) versions seem to ship their own C99-conforming `snprintf` implementation.

Instead of dealing with all of this incompatibilities, I would suggest to introduce a safe cross-platform alternative: `pd_snprintf` and `pd_vsnprintf`. On non-Windows systems this would just be a macro for `snprintf` resp. `vsnprintf`. On Windows, `pd_vsnprintf` calls `_vsnprintf`; if the function fails (i.e. returns -1), we obtain the required number of bytes with `_vscprintf` and null-terminate the output buffer.

In this PR, I replaced all occurances of `snprintf`/`vsnprintf` with `pd_snprintf`/`pd_vsnprintf`.

---

Currently, this is only meant for internal use, but it may be moved to `m_pd.h` if desired.