### PR TITLE
m_pd.h: fix thread-local support for clang on windows

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -969,7 +969,7 @@ EXTERN void pdinstance_free(t_pdinstance *x);
 #endif /* PDINSTANCE */
 
 #if defined(PDTHREADS) && defined(PDINSTANCE)
-#ifdef _MSC_VER
+#if defined(_WIN32) && (defined(_MSC_VER) || defined(__clang__))
 #define PERTHREAD __declspec(thread)
 #else
 #define PERTHREAD __thread


### PR DESCRIPTION
This fixes the following error when linking against libpd-multi.dll: 

    ld.lld: error: unable to automatically import from pd_this with relocation type IMAGE_REL_AMD64_SECREL in CMakeFiles/pdtest_gui.dir/samples/c/pdtest_gui/pdtest_gui.c.obj