### PR TITLE
fix `pd_this` on Windows

### DIFF
--- a/src/m_class.c
+++ b/src/m_class.c
@@ -147,6 +147,11 @@ EXTERN void pd_setinstance(t_pdinstance *x)
     pd_this = x;
 }
 
+t_pdinstance *pd_getinstance(void)
+{
+    return pd_this;
+}
+
 static void pdinstance_renumber(void)
 {
     int i;

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -965,6 +965,7 @@ EXTERN t_pdinstance pd_maininstance;
 #ifdef PDINSTANCE
 EXTERN t_pdinstance *pdinstance_new(void);
 EXTERN void pd_setinstance(t_pdinstance *x);
+EXTERN t_pdinstance *pd_getinstance(void);
 EXTERN void pdinstance_free(t_pdinstance *x);
 #endif /* PDINSTANCE */
 
@@ -979,7 +980,18 @@ EXTERN void pdinstance_free(t_pdinstance *x);
 #endif
 
 #ifdef PDINSTANCE
-extern PERTHREAD t_pdinstance *pd_this;
+#ifdef _WIN32
+/* Windows does not allow exporting thread-local variables from DLLs,
+so externals need to get 'pd_this' with an (implicit) function call.
+Internally, we may directly access 'pd_this', but we must not export it! */
+#ifdef PD_INTERNAL
+extern PERTHREAD t_pdinstance *pd_this; /* not EXTERN! */
+#else
+#define pd_this pd_getinstance()
+#endif /* PD_INTERNAL */
+#else
+EXTERN PERTHREAD t_pdinstance *pd_this;
+#endif /* _WIN32 */
 EXTERN t_pdinstance **pd_instances;
 EXTERN int pd_ninstances;
 #else


### PR DESCRIPTION
On Windows it is not possible to 'properly' export a thread local variable from a DLL. MinGW can do it, but the resulting symbol (`__emutls_v.pd_this`) is not portable and certainly not understood by MSVC. As a consequence, Windows externals built with  `-DPDINSTANCE` cannot really use `pd_this` - unless both the external and the host is built with MinGW.

The solution is to access `pd_this` via a function call, for this I've added a new API function `pd_getinstance()`. For externals, `pd_this` is now a macro for `pd_getinstance()`. Internally, we directly access 'pd_this', but we don't try to export it.

On other platforms, `pd_this` is now properly marked `EXTERN`.