### PR TITLE
html: document using 'control' key to temporarily get out of edit mode

### DIFF
--- a/doc/1.manual/x2.htm
+++ b/doc/1.manual/x2.htm
@@ -234,7 +234,10 @@ clicks affect the patch.  In edit mode, clicking and dragging selects and
 moves boxes or makes and cuts connections; in run mode clicking on boxes sends
 them messages which they react to in different ways.  In run mode, number and
 message boxes can be used as controls.  Normally, when you are in a performance
-you will stay in run mode; to change the patch you go to edit mode.
+you will stay in run mode; to change the patch you go to edit mode. If you are
+in edit mode and you need to briefly switch to run mode you can hold the
+control key (command in mac computers) and you'll be able to use the mouse
+as in run mode until you release the control key.
 
 <H3> <A id=s2.2> 2.2.2. creating boxes </A> </H3>
 


### PR DESCRIPTION
@porres this PR is targeted to `documentation` branch.