### PR TITLE
simplify compile-time and runtime version-checks

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -198,7 +198,7 @@ void glob_init(void)
 
     /* function to return version number at run time.  Any of the
     calling pointers may be zero in case you don't need all of them. */
-void sys_getversion(int *major, int *minor, int *bugfix)
+unsigned int sys_getversion(int *major, int *minor, int *bugfix)
 {
     if (major)
         *major = PD_MAJOR_VERSION;
@@ -206,6 +206,8 @@ void sys_getversion(int *major, int *minor, int *bugfix)
         *minor = PD_MINOR_VERSION;
     if (bugfix)
         *bugfix = PD_BUGFIX_VERSION;
+
+    return PD_VERSION_CODE;
 }
 
 unsigned int sys_getfloatsize()

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -911,8 +911,8 @@ static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-512,512) */
 #endif
 #endif /* _MSC_VER */
 
-    /* get version number at run time */
-EXTERN void sys_getversion(int *major, int *minor, int *bugfix);
+    /* get major/minor/bugifx version numbers and version code at run time */
+EXTERN unsigned int sys_getversion(int *major, int *minor, int *bugfix);
 
     /* get floatsize at run time */
 EXTERN unsigned int sys_getfloatsize(void);


### PR DESCRIPTION
this PR implements a `PD_VERSION` macro that calculates a single number from the major/minor/bugfix version, as well as a `PD_VERSION_CODE` which does this for the current values of PD_MAJOR_VERSION and friends.

This makes it simple to do compile-time checks for the required Pd-version:

```C
#if PD_VERSION_CODE < PD_VERSION(0,56,0)
# error this code requires at least Pd-0.56.0
#endif
```

additionally, this PR extends the `sys_getversion()` function to return the runtime Pd version code at.
this makes it simple to do runtime checks for the required Pd-version

```C
if (sys_getversion(0,0,0) > PD_VERSION(0, 99, 0) {
    post("Pd is still around...");
}
```

the macro follows best practice from the linux kernel (where it is called `KERNEL_VERSION` resp `KERNEL_VERSION_CODE`; see your favorite `/usr/include/linux/version.h`).


this is somewhat related to @Spacechild1's #2211 , as both PRs allow external writers to better provide backward and forward compatibility.

of course, these macros can only be used with newer Pd headers, so they should have been introduced about 2 decades ago.