### PR TITLE
print: add '-l' flag to specify the log level

### DIFF
--- a/src/x_interface.c
+++ b/src/x_interface.c
@@ -19,30 +19,55 @@ extern void startlogpost(const void *object, const int level, const char *fmt, .
 
   /* avoid prefixing with "verbose(PRINT_LOGLEVEL): "
   when printing to stderr or via printhook. */
-#define print_startlogpost(object, fmt, ...) do{ \
+#define print_startpost(object, fmt, ...) do { \
     if (STUFF->st_printhook || sys_printtostderr) \
         startpost(fmt, __VA_ARGS__); \
-    else startlogpost(object, PRINT_LOGLEVEL, fmt, __VA_ARGS__); \
+    else startlogpost(object, x->x_level, fmt, __VA_ARGS__); \
 } while(0)
 
 typedef struct _print
 {
     t_object x_obj;
     t_symbol *x_sym;
+    int x_level;
 } t_print;
 
 static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 {
     t_print *x = (t_print *)pd_new(print_class);
-    if (argc == 0)
+    int level = PRINT_LOGLEVEL;
+    int suppress = 0;
+    while (argc > 0 && argv->a_type == A_SYMBOL)
+    {
+        const char *c = atom_getsymbol(argv)->s_name;
+        if (!strcmp(c, "-n"))
+        {
+            suppress = 1;
+            argc--; argv++;
+        }
+        else if (!strcmp(c, "-l"))
+        {
+            if (argc >= 1 && argv[1].a_type == A_FLOAT)
+            {
+                level = atom_getfloat(argv + 1);
+                argc -= 2; argv += 2;
+            }
+            else
+            {
+                pd_error(x, "missing argument for '-l' flag");
+                argc--; argv++;
+                break;
+            }
+        }
+        else break;
+    }
+    x->x_level = level;
+    if (suppress)
+        x->x_sym = &s_;
+    else if (argc == 0)
         x->x_sym = gensym("print");
     else if (argc == 1 && argv->a_type == A_SYMBOL)
-    {
-        t_symbol *s = atom_getsymbolarg(0, argc, argv);
-        if (!strcmp(s->s_name, "-n"))
-            x->x_sym = &s_;
-        else x->x_sym = s;
-    }
+        x->x_sym = atom_getsymbol(argv);
     else
     {
         int bufsize;
@@ -61,32 +86,35 @@ static void *print_new(t_symbol *sel, int argc, t_atom *argv)
 
 static void print_bang(t_print *x)
 {
-    print_startlogpost(x, "%s%sbang", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startpost(x, "%s%sbang",
+        x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
     endpost();
 }
 
 static void print_pointer(t_print *x, t_gpointer *gp)
 {
-    print_startlogpost(x, "%s%s(pointer)", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
+    print_startpost(x, "%s%s(pointer)",
+        x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""));
     endpost();
 }
 
 static void print_float(t_print *x, t_float f)
 {
-    print_startlogpost(x, "%s%s%g", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
+    print_startpost(x, "%s%s%g",
+        x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), f);
     endpost();
 }
 
 static void print_anything(t_print *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
-    print_startlogpost(x, "%s%s%s", x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""),
-        s->s_name);
+    print_startpost(x, "%s%s%s",
+        x->x_sym->s_name, (*x->x_sym->s_name ? ": " : ""), s->s_name);
     for (i = 0; i < argc; i++)
     {
         char buf[MAXPDSTRING];
         atom_string(argv+i, buf, MAXPDSTRING);
-        print_startlogpost(x, " %s", buf);
+        print_startpost(x, " %s", buf);
     }
     endpost();
 }
@@ -116,17 +144,15 @@ static void print_list(t_print *x, t_symbol *s, int argc, t_atom *argv)
     else if (argv->a_type == A_FLOAT)
     {
         int i;
-        /* print first (numeric) atom, to avoid a leading space */
-        if (*x->x_sym->s_name)
-            print_startlogpost(x, "%s: %g", x->x_sym->s_name, atom_getfloat(argv));
-        else
-            print_startlogpost(x, "%g", atom_getfloat(argv));
+            /* print first (numeric) atom, to avoid a leading space */
+        print_startpost(x, "%s%s%g", x->x_sym->s_name,
+            (*x->x_sym->s_name ? ": " : ""), atom_getfloat(argv));
         argc--; argv++;
         for (i = 0; i < argc; i++)
         {
             char buf[MAXPDSTRING];
             atom_string(argv+i, buf, MAXPDSTRING);
-            print_startlogpost(x, " %s", buf);
+            print_startpost(x, " %s", buf);
         }
         endpost();
     }


### PR DESCRIPTION
This would finally allow to print error or debug messages on the patch level. Long overdue IMO.

`[print -l 0]` -> critical
`[print -l 1]` -> error
`[print -l 2]` -> normal (default)
`[print -l 3]` -> debug
`[print -l 4]` -> verbose