### PR TITLE
Doc: adsr.pd abstraction: localize send/receive paths

### DIFF
--- a/doc/3.audio.examples/adsr.pd
+++ b/doc/3.audio.examples/adsr.pd
@@ -51,10 +51,10 @@ then attack (instead of attacking from the current location).;
 #X text 343 20 Arguments: level \, attack time \, decay time \, sustain
 level \, release time. A \, D \, and R are in msec and S is in percent.
 This patch is used as an abstraction in various examples.;
-#X obj 596 356 s line;
-#X obj 485 419 s line;
-#X obj 190 328 s line;
-#X obj 595 419 r line;
+#X obj 596 356 s $0-line;
+#X obj 485 419 s $0-line;
+#X obj 190 328 s $0-line;
+#X obj 595 419 r $0-line;
 #X text 309 374 multiply by peak level and pack with decay time, f
 24;
 #X text 292 281 on attack \, set a delay for sustain, f 17;


### PR DESCRIPTION
Reported on the forum: https://forum.pdpatchrepo.info/topic/14684/abstraction-issue-with-d02-adsr-pd-d05-envelope-pitch-pd

Example D05 does not make sound because there are two instances of adsr.pd, but this abstraction does not `$0` localize sends/receives.

Apparently this has been broken a long time: "I found an unresolved post from 13 years ago that references the same issue..." so it's a bit overdue for a fix.