### PR TITLE
stable development branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,9 @@ AS_CASE([$host],
         EXTERNAL_CFLAGS="-fPIC"
         EXTERNAL_EXTENSION=d_fat
 
+        # helps for machine/endian.h to be found
+        PD_CFLAGS="-D_DARWIN_C_SOURCE"
+
         # a set of search paths are used on macOS in s_inter.c
         wish="default search paths"
 

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,9 @@ AS_CASE([$host],
         # helps for machine/endian.h to be found
         PD_CFLAGS="-D_DARWIN_C_SOURCE"
 
+        # increase max allowed file descriptors
+        PD_CFLAGS="$PD_CFLAGS -D_DARWIN_UNLIMITED_SELECT -DFD_SETSIZE=10240"
+
         # a set of search paths are used on macOS in s_inter.c
         wish="default search paths"
 

--- a/libpd/Makefile
+++ b/libpd/Makefile
@@ -11,9 +11,12 @@ PLATFORM_ARCH ?= $(shell $(CC) -dumpmachine | sed -e 's,-.*,,')
 
 ifeq ($(UNAME), Darwin)  # Mac
   SOLIB_EXT = dylib
-  PLATFORM_CFLAGS = -DHAVE_ALLOCA_H -DHAVE_LIBDL -DHAVE_MACHINE_ENDIAN_H \
-                    -D_DARWIN_C_SOURCE -D_DARWIN_UNLIMITED_SELECT
+  PLATFORM_CFLAGS = -DHAVE_ALLOCA_H -DHAVE_LIBDL -DHAVE_MACHINE_ENDIAN_H
   PLATFORM_LDFLAGS = -dynamiclib -ldl -Wl,-no_compact_unwind
+  # helps for machine/endian.h to be found
+  PLATFORM_CFLAGS += -D_DARWIN_C_SOURCE
+  # increase max allowed file descriptors
+  PLATFORM_CFLAGS += -D_DARWIN_UNLIMITED_SELECT -DFD_SETSIZE=10240
   ifeq ($(FAT_LIB), true)
     # macOS universal "fat" lib compilation
     MAC_VER = $(shell sw_vers -productVersion | cut -f1 -f2 -d.)

--- a/src/d_global.c
+++ b/src/d_global.c
@@ -224,7 +224,7 @@ static void sigreceive_setup(void)
         (t_newmethod)sigreceive_new, 0,
         sizeof(t_sigreceive), CLASS_MULTICHANNEL, A_DEFSYM, 0);
     class_addcreator((t_newmethod)sigreceive_new, gensym("r~"),
-        A_DEFSYM, A_DEFFLOAT, 0);
+        A_DEFSYM, 0);
     class_addmethod(sigreceive_class, (t_method)sigreceive_set, gensym("set"),
         A_SYMBOL, 0);
     class_addmethod(sigreceive_class, (t_method)sigreceive_dsp,

--- a/src/m_obj.c
+++ b/src/m_obj.c
@@ -86,6 +86,12 @@ static void inlet_wrong(t_inlet *x, t_symbol *s)
     pd_error(x->i_owner, "inlet: expected '%s' but got '%s'",
         x->i_symfrom->s_name, s->s_name);
 }
+static void _inlet_wrong(t_inlet *x, t_symbol *s, int argc, t_atom*argv)
+{
+    (void)argc;
+    (void)argv;
+    inlet_wrong(x, s);
+}
 
 static void inlet_list(t_inlet *x, t_symbol *s, int argc, t_atom *argv);
 extern t_class *vinlet_class;

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -36,7 +36,7 @@ CPPFLAGS = -DINSTALL_PREFIX=\"$(prefix)\" \
     -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 \
     -DHAVE_ALLOCA_H=1 \
     -DHAVE_QSORT_R_COMPAR_LAST=1 \
-    -DHAVE_MACHINE_ENDIAN_H=1 \
+    -DHAVE_MACHINE_ENDIAN_H=1 -D_DARWIN_C_SOURCE \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \
     -I$(PMDIR)/pm_mac -I$(PMDIR)/porttime \

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -37,6 +37,7 @@ CPPFLAGS = -DINSTALL_PREFIX=\"$(prefix)\" \
     -DHAVE_ALLOCA_H=1 \
     -DHAVE_QSORT_R_COMPAR_LAST=1 \
     -DHAVE_MACHINE_ENDIAN_H=1 -D_DARWIN_C_SOURCE \
+    -D_DARWIN_UNLIMITED_SELECT -DFD_SETSIZE=10240 \
     -I$(PADIR)/include -I$(PADIR)/src/common  \
     -I$(PADIR)/src/os/mac_osx/ -I$(PMDIR)/pm_common \
     -I$(PMDIR)/pm_mac -I$(PMDIR)/porttime \

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1614,11 +1614,15 @@ static int sys_do_startgui(const char *libdir)
 
     sys_init_deken();
 
-    do {
+    {
         t_audiosettings as;
         sys_get_audio_settings(&as);
         sys_vgui("set pd_whichapi %d\n", as.a_api);
-    } while(0);
+
+        pdgui_vmess("pdtk_pd_dsp", "s",
+            THISGUI->i_dspstate ? "ON" : "OFF");
+    }
+
     return (0);
 }
 
@@ -1796,11 +1800,11 @@ void sys_doneglobinit( void)
 }
 
     /* start the GUI up.  Before we actually draw our "visible" windows
-    we have to wait for the GUI to give us our font metrics.  LATER
-    it would be cool to figure out what metrics we really need and tell
-    the GUI - that way we can support arbitrary zoom with appropriate font
-    sizes.   And/or: if we ever move definitively to a vector-based GUI
-    lib we might be able to skip this step altogether. */
+    we have to wait for the GUI to give us our font metrics, see
+    glob_initfromgui().  LATER it would be cool to figure out what metrics
+    we really need and tell the GUI - that way we can support arbitrary
+    zoom with appropriate font sizes.   And/or: if we ever move definitively
+    to a vector-based GUI lib we might be able to skip this step altogether. */
 int sys_startgui(const char *libdir)
 {
     t_canvas *x;


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to Pd-files in this PR, as it is just too easy to end up with unresolvable file conflicts)

it supersedes https://github.com/pure-data/pure-data/pull/2251

---

### Core

- a few more fixes for emscripten (notably `[r~]` and "inlet: expted 'foo' but got 'bar'" (admittedly you should only run well-behaving patches - that make sure that the correct messages land in any given inlet - within emscripten; but if you do make an error, PdWASM shouldn't freeze...)
  - Closes: #2258 (again)
- raise maximum allowed filehandles on Darwin, see https://github.com/pure-data/pure-data/pull/2252#issuecomment-2056524791

### GUI

- `sys_do_startgui`: also set "DSP" display; this makes sure that the DSP state is correctly displayed when opening a patch on startup that turns on DSP with a loadbang.

### Buildsystem

- set `_DARWIN_C_SOURCES` to allow inclusion of `machine/endian.h` on modern  macOS