### PR TITLE
PD_BADFLOAT: let zero count as a valid float

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -847,7 +847,7 @@ static inline int PD_BADFLOAT(t_float f)  /* malformed float */
     t_bigorsmall32 pun;
     pun.f = f;
     pun.ui &= 0x7f800000;
-    return((pun.ui == 0) | (pun.ui == 0x7f800000));
+    return (f != 0) & ((pun.ui == 0) | (pun.ui == 0x7f800000));
 }
 
 static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-64,64) */
@@ -870,7 +870,7 @@ static inline int PD_BADFLOAT(t_float f)  /* malformed double */
     t_bigorsmall64 pun;
     pun.f = f;
     pun.ui[1] &= 0x7ff00000;
-    return((pun.ui[1] == 0) | (pun.ui[1] == 0x7ff00000));
+    return (f != 0) & ((pun.ui[1] == 0) | (pun.ui[1] == 0x7ff00000));
 }
 
 static inline int PD_BIGORSMALL(t_float f)  /* exponent outside (-512,512) */


### PR DESCRIPTION
I recently came across some strange behavior with sliders. They don't allow being set to zero from their inlet:

https://github.com/pure-data/pure-data/assets/3401272/9fe3eda6-cd2f-41a5-95ec-f8dc29468ac4

It turns out that `PD_BADFLOAT` currently makes no distinction between zero and denormalized numbers.