### PR TITLE
fix incorrect mutex being destroyed for s_inter_free()

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1859,7 +1859,7 @@ void s_inter_free(t_instanceinter *inter)
         inter->i_nfdpoll = 0;
     }
 #if PDTHREADS
-    pthread_mutex_destroy(&INTER->i_mutex);
+    pthread_mutex_destroy(&inter->i_mutex);
 #endif
     freebytes(inter, sizeof(*inter));
 }


### PR DESCRIPTION
Changes destroyed mutex to correct instance.

Current implementation can lead to a crash when running multiple instances of pure data as INTER points to the main instance, not the instance being freed.