### PR TITLE
improve language detection

### DIFF
--- a/tcl/dialog_find.tcl
+++ b/tcl/dialog_find.tcl
@@ -70,12 +70,12 @@ proc ::dialog_find::ok {mytoplevel} {
             .pdwindow.text see [lindex $matches 0]
             lappend find_history $findstring
             .find.searchin configure -text \
-                [format [_ "Found '%1\$s' in %2\$s"] \
+                [_ "Found '%1\$s' in %2\$s" \
                 [get_search_string] [lookup_windowname $find_in_window] ]
         } else {
             if {$::windowingsystem eq "aqua"} {bell}
             .find.searchin configure -text \
-                [format [_ "Couldn't find '%1\$s' in %2\$s"] \
+                [_ "Couldn't find '%1\$s' in %2\$s" \
                 [get_search_string] [lookup_windowname $find_in_window] ]
         }
         # done searching
@@ -147,7 +147,7 @@ proc ::dialog_find::set_window_to_search {mytoplevel} {
             set find_in_window [winfo toplevel [lindex [wm stackorder .] end-1]]
         }
         .find.searchin configure -text \
-            [format [_ "Search in %s for:"] [lookup_windowname $find_in_window] ]
+            [_ "Search in %s for:" [lookup_windowname $find_in_window] ]
     }
     update_bindings
 }
@@ -163,16 +163,16 @@ proc ::dialog_find::pdtk_showfindresult {mytoplevel success which total} {
         if {$total eq 0} {
             if {$::windowingsystem eq "aqua"} {bell}
             set infostring \
-                [format [_ "Couldn't find '%1\$s' in %2\$s"] \
+                [_ "Couldn't find '%1\$s' in %2\$s" \
                 [get_search_string] [lookup_windowname $mytoplevel] ]
         } else {
             set infostring \
-                [format [_ "Showed last '%1\$s' in %2\$s"] \
+                [_ "Showed last '%1\$s' in %2\$s" \
                 [get_search_string] [lookup_windowname $mytoplevel] ]
         }
     } else {
         set infostring \
-        [format [_ "Showing '%1\$d' out of %2\$d items in %3\$s"] \
+        [_ "Showing '%1\$d' out of %2\$d items in %3\$s" \
             $which $total [get_search_string] [lookup_windowname $mytoplevel] ]
     }
     ::pdwindow::debug "$infostring\n"
@@ -204,7 +204,7 @@ proc ::dialog_find::create_dialog {mytoplevel} {
     ::pd_bindings::dialog_bindings .find "find"
 
     label .find.searchin -text \
-            [format [_ "Search in %s for:"] [_ "Pd window"] ]
+            [_ "Search in %s for:" [_ "Pd window"] ]
     pack .find.searchin -side top -fill x -pady 1
 
     entry .find.entry -width 54 -font 18 -relief sunken \

--- a/tcl/dialog_font.tcl
+++ b/tcl/dialog_font.tcl
@@ -120,7 +120,7 @@ proc ::dialog_font::cancel {gfxstub} {
 proc ::dialog_font::update_font_dialog {mytoplevel} {
     variable canvaswindow $mytoplevel
     if {[winfo exists .font]} {
-        wm title .font [format [_ "%s Font"] [lookup_windowname $mytoplevel]]
+        wm title .font [_ "%s Font" [lookup_windowname $mytoplevel]]
     }
 }
 

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -399,7 +399,7 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
     }
 
     toplevel $mytoplevel -class DialogWindow
-    wm title $mytoplevel [format [_ "%s Properties"] $iemgui_type]
+    wm title $mytoplevel [_ "%s Properties" $iemgui_type]
     wm group $mytoplevel .
     wm resizable $mytoplevel 0 0
     wm transient $mytoplevel $::focused_window

--- a/tcl/dialog_path.tcl
+++ b/tcl/dialog_path.tcl
@@ -235,7 +235,7 @@ proc ::dialog_path::add {} {
 }
 
 proc ::dialog_path::edit {currentpath} {
-    return [::dialog_path::choosePath $currentpath [format [_ "Edit existing path \[%s\]" ] $currentpath] ]
+    return [::dialog_path::choosePath $currentpath [_ "Edit existing path \[%s\]" $currentpath] ]
 }
 
 proc ::dialog_path::commit {new_path} {

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -574,12 +574,13 @@ proc pdtk_yesnodialog {mytoplevel message default} {
 ## pdtk_check .pdwindow "Hello world!" "pd dsp 1" no
 proc pdtk_check {mytoplevel message reply_to_pd default} {
     # example: 'pdtk_check . [list "Switch compatibility to %s?" $compat] [list pd compatibility $compat ] no'
+
     if {[lindex $message 0] == [lindex [lindex $message 0] 0]} {
         set message [ list $message ]
     }
 
     if {[ catch {
-              set msg [format [_ [ lindex $message 0 ] ] {*}[lrange $message 1 end] ]
+              set msg [_ {*}$message]
           } ]} {
            set msg [_ $message]
        }

--- a/tcl/pd_docsdir.tcl
+++ b/tcl/pd_docsdir.tcl
@@ -187,7 +187,7 @@ proc ::pd_docsdir::create_path {path} {
     if {[file mkdir [file normalize "$path"]] eq ""} {
         return 1
     }
-    set msg [format [_ "couldn't create Pd documents directory: %s"] $path]
+    set msg [_ "couldn't create Pd documents directory: %s" $path]
     ::pdwindow::error "${msg}\n"
     return 0
 }
@@ -222,7 +222,7 @@ proc ::pd_docsdir::create_externals_path {{path ""}} {
     if {[file mkdir "$newpath" ] eq ""} {
         return 1
     }
-    set msg [format [_ "couldn't create \"externals\" directory in: %s"] $path]
+    set msg [_ "couldn't create \"externals\" directory in: %s" $path]
     ::pdwindow::error "${msg}\n"
     return 0
 }

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -402,7 +402,7 @@ proc ::pd_guiprefs::prepare_domain {{domain {}}} {
         set absconfdir ${::pd_guiprefs::configdir}
         catch { set absconfdir [file normalize ${::pd_guiprefs::configdir} ] }
 
-        ::pdwindow::error [format [_ "Couldn't create preferences \"%1\$s\" in %2\$s" ] $domain $absconfdir]
+        ::pdwindow::error [_ "Couldn't create preferences \"%1\$s\" in %2\$s" $domain $absconfdir]
         ::pdwindow::error "\n"
     }
     return $domain

--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -12,16 +12,16 @@ namespace eval ::pd_guiprefs:: {
     namespace export write_recentfiles
     namespace export update_recentfiles
     namespace export write_loglevel
+
+    # preference keys
+    variable recentfiles_key ""
+    variable loglevel_key "loglevel"
+
+    # platform specific
+    variable domain org.puredata.pd.pd-gui
+    variable configdir ""
+    variable recentfiles_is_array false
 }
-
-# preference keys
-set ::pd_guiprefs::recentfiles_key ""
-set ::pd_guiprefs::loglevel_key "loglevel"
-
-# platform specific
-set ::pd_guiprefs::domain ""
-set ::pd_guiprefs::configdir ""
-set ::pd_guiprefs::recentfiles_is_array false
 
 #################################################################
 # preferences storage locations
@@ -65,11 +65,15 @@ set ::pd_guiprefs::recentfiles_is_array false
 # init preferences
 #
 proc ::pd_guiprefs::init {} {
-    set ::pd_guiprefs::domain org.puredata.pd.pd-gui
-
     switch -- $::platform {
         "Darwin" {
             set backend "plist"
+            # on macOS the domain should be the same as the bundle ID
+            catch {
+                set ::pd_guiprefs::domain [exec defaults read
+                                           [file join $::sys_guidir .. .. Info]
+                                           CFBundleIdentifier]
+            }
         }
         "W32" {
             set backend "registry"

--- a/tcl/pd_i18n.tcl
+++ b/tcl/pd_i18n.tcl
@@ -9,16 +9,13 @@ package require msgcat
 package require pdtcl_compat
 
 namespace eval ::pd_i18n:: {
-    variable podir
-    variable language
+    variable podir [file join [file dirname [info script]] .. po]
+    variable language ""
+    variable systemlanguage [::msgcat::mcpreferences]
     catch {namespace import ::pdtcl_compat::dict}
 
     namespace export _
 }
-set ::pd_i18n::language ""
-
-set ::pd_i18n::podir  [file join [file dirname [info script]] .. po]
-
 
 #### official GNU gettext msgcat shortcut
 ## initialization code:
@@ -37,54 +34,32 @@ if {$::tcl_version < 8.5} {
     proc ::pd_i18n::_ {args} {return [::msgcat::mc {*}$args]}
 }
 
-proc ::pd_i18n::get_system_language {} {
-    # on any UNIX-like environment, Tcl should automatically use LANG, LC_ALL,
-    # etc. otherwise we need to dig it up.  Mac OS X only uses LANG, etc. from
-    # the Terminal, and Windows doesn't have LANG, etc unless you manually set
-    # it up yourself.  Windows apps don't use the locale env vars usually.
-    if {$::tcl_platform(os) eq "Darwin" && ! [info exists ::env(LANG)]} {
-        # http://thread.gmane.org/gmane.comp.lang.tcl.mac/5215
-        # http://thread.gmane.org/gmane.comp.lang.tcl.mac/6433
-        if {![catch "exec defaults read com.apple.dock loc" lang]} {
-            # ...
-        } elseif {![catch "exec defaults read NSGlobalDomain AppleLocale" lang]} {
-            # ...
-        }
-    } elseif {$::tcl_platform(platform) eq "windows"} {
-        # using LANG on Windows is useful for easy debugging
-        if {[info exists ::env(LANG)] && $::env(LANG) ne "C" && $::env(LANG) ne ""} {
-            set lang $::env(LANG)
-        } elseif {![catch {package require registry}]} {
-            set lang [string tolower \
-                          [string range \
-                               [registry get {HKEY_CURRENT_USER\Control Panel\International} sLanguage] 0 1] ]
-        }
-    } elseif {[info exists ::env(LANG)]} {
-        set lang $::env(LANG)
-    } else {
-        set lang ""
-    }
-    set lang [file rootname [string tolower $lang]]
-    if { $lang == "c" } {
-        set lang "C"
-    }
-    return $lang
-}
-
 proc ::pd_i18n::load_locale {{lang ""}} {
+    # loads the current locale, can only be called once!
+    # <lang>=""  : use the preferred language from the system
+    # <lang>="default": use the preferred language from the system (legacy)
+    # <lang>="." : no translation
+    # <lang>="fr": french
+
+    ::msgcat::mcload $::pd_i18n::podir
+
     if { $lang == "default" } {
         set lang ""
     }
-    if { $lang == "" } {
-        set lang [lindex [split [ ::pd_i18n::get_system_language ] ":" ] 0]
+    if { $lang != "" } {
+        ::msgcat::mclocale $lang
     }
+    set ::pd_i18n::language $lang
 
-    if { $::pd_i18n::language == "" || $lang == $::pd_i18n::language } {
-        if { $lang != "" } {
-            ::msgcat::mclocale $lang
-        }
+    # we can only change the language once
+    # (otherwise the menus will play havoc)
+    # so replace *this* proc with a dummy
+    proc [info level 0] {{lang ""}} {
         ::msgcat::mcload $::pd_i18n::podir
-        set ::pd_i18n::language $lang
+        if { $lang != "" && $lang != $::pd_i18n::language} {
+            set msg [_ "The language can only be set during startup."]
+            ::pdwindow::error "${msg}\n"
+        }
     }
 }
 
@@ -156,9 +131,25 @@ proc ::pd_i18n::get_available_languages {{podir ""}} {
     }
     set havelanguages [lsort -index 0 $havelanguages]
 
-    set lang [lindex [split [ ::pd_i18n::get_system_language ] ":" ] 0]
-    if [ dict exists $polanguages $lang ] {
-        set lang [ dict get $polanguages $lang ]
+    # TODO: get default language
+    #set lang [lindex [split [ ::pd_i18n::get_system_language ] ":" ] 0]
+    #if [ dict exists $polanguages $lang ] {
+    #    set lang [ dict get $polanguages $lang ]
+    #}
+    foreach lang $::pd_i18n::systemlanguage {
+        if [ dict exists $polanguages $lang ] {
+            set lang [ dict get $polanguages $lang ]
+            break
+        }
+    }
+    if { $lang == "" } {
+        # the system language was not in our list.
+        # either it's a not-yet-supported language (in which case we print its short name)
+        # or it is the default
+        set lang [lindex $::pd_i18n::systemlanguage 0]
+        if { $lang == "" || [string tolower $lang] == "c" } {
+            set lang [_ "(no translation)" ]
+        }
     }
     lappend havelanguages [list [_ "(default language: %s)" $lang] "default" ]
     lappend havelanguages [list [_ "(no translation)" ] "." ]

--- a/tcl/pd_i18n.tcl
+++ b/tcl/pd_i18n.tcl
@@ -160,7 +160,7 @@ proc ::pd_i18n::get_available_languages {{podir ""}} {
     if [ dict exists $polanguages $lang ] {
         set lang [ dict get $polanguages $lang ]
     }
-    lappend havelanguages [list [format [_ "(default language: %s)" ] $lang] "default" ]
+    lappend havelanguages [list [_ "(default language: %s)" $lang] "default" ]
     lappend havelanguages [list [_ "(no translation)" ] "." ]
     return $havelanguages
 }

--- a/tcl/pd_i18n.tcl
+++ b/tcl/pd_i18n.tcl
@@ -27,7 +27,15 @@ set ::pd_i18n::podir  [file join [file dirname [info script]] .. po]
 # > ::pd_i18n::init
 ## usage
 # > puts [_ "Quit" ]
-proc ::pd_i18n::_ {s} {return [::msgcat::mc $s]}
+
+## make `::pd_i18n::_` (and thus `_`) an alias for `::msgcat::mc` (with varargs)
+if {$::tcl_version < 8.5} {
+    # uplevel works an all versions of Tcl-8.x
+    proc ::pd_i18n::_ args {return [uplevel 0 [concat ::msgcat::mc $args]]}
+} else {
+    # the `{*}` operator was introduced with Tcl-8.5
+    proc ::pd_i18n::_ {args} {return [::msgcat::mc {*}$args]}
+}
 
 proc ::pd_i18n::get_system_language {} {
     # on any UNIX-like environment, Tcl should automatically use LANG, LC_ALL,

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -237,7 +237,7 @@ proc ::pd_menucommands::menu_aboutpd {} {
     set versionstring "Pd $::PD_MAJOR_VERSION.$::PD_MINOR_VERSION.$::PD_BUGFIX_VERSION$::PD_TEST_VERSION"
     set filename "$::sys_libdir/doc/1.manual/1.introduction.txt"
     if {![file exists $filename]} {
-        ::pdwindow::error [format [_ "ignoring '%s': doesn't exist"] $filename]
+        ::pdwindow::error [_ "ignoring '%s': doesn't exist" $filename]
         ::pdwindow::error "\n"
         #return
     }
@@ -267,7 +267,7 @@ proc ::pd_menucommands::menu_aboutpd {} {
             }
             close $textfile
         } stderr ] } {
-            ::pdwindow::error [format [_ "couldn't read \"%s\" document" ] [_ "About Pd" ] ]
+            ::pdwindow::error [_ "couldn't read \"%s\" document" [_ "About Pd" ] ]
             ::pdwindow::error "\n\t$stderr\n"
             destroy .aboutpd
         }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -204,7 +204,7 @@ proc pdtk_canvas_saveas {mytoplevel initialfile initialdir destroyflag} {
 proc ::pdtk_canvas::pdtk_canvas_menuclose {mytoplevel reply_to_pd} {
     raise $mytoplevel
     set filename [lindex [array get ::pdtk_canvas::::window_fullname $mytoplevel] 1]
-    set message [format [_ "Do you want to save the changes you made in '%s'?"] $filename]
+    set message [_ "Do you want to save the changes you made in '%s'?" $filename]
     set answer [tk_messageBox -message $message -type yesnocancel -default "yes" \
                     -parent $mytoplevel -icon question]
     switch -- $answer {

--- a/tcl/pdtk_textwindow.tcl
+++ b/tcl/pdtk_textwindow.tcl
@@ -121,7 +121,7 @@ proc pdtk_textwindow_close {name ask} {
             if {[string equal -length 1 $title "*"]} {
                 set title [string range $title 1 end]
             }
-            set msg [format [_ "Accept changes to '%s'?"] $title]
+            set msg [_ "Accept changes to '%s'?" $title]
             set answer [tk_messageBox -type yesnocancel \
              -icon question \
              -message $msg \

--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -95,7 +95,7 @@ proc ::pdwindow::buffer_message {object_id level message} {
             incr keepitems
         }
         set logbuffer [lrange $logbuffer end-$keepitems end]
-        set msg [format [_ "dropped %d lines from the Pd window" ] [expr $_curlogbuffer - $count]]
+        set msg [_ "dropped %d lines from the Pd window" [expr $_curlogbuffer - $count]]
         set _curlogbuffer 0
         ::pdwindow::verbose 10 "$msg\n"
         ::pdwindow::filter_logbuffer
@@ -138,7 +138,7 @@ proc ::pdwindow::filter_logbuffer {} {
 # this has 'args' to satisfy trace, but its not used
 proc ::pdwindow::filter_buffer_to_text {args} {
     set i [::pdwindow::filter_logbuffer]
-    set msg [format [_ "the Pd window filtered %d lines" ] $i ]
+    set msg [_ "the Pd window filtered %d lines" $i ]
     ::pdwindow::verbose 10 "$msg\n"
 }
 
@@ -311,7 +311,7 @@ proc ::pdwindow::update_title {w} {
         switch -- ${::deken::platform(floatsize)} {
             32 { set floatsize "" }
             64 { set floatsize [_ "EXPERIMENTAL double (64bit) precision"] }
-            default  { set floatsize [format [_ "%dbit-floats EXPERIMENTAL" ]  ${::deken::platform(floatsize)}]}
+            default  { set floatsize [_ "%dbit-floats EXPERIMENTAL" ${::deken::platform(floatsize)}]}
         }
         if { ${floatsize} ne "" } {
             set fulltitle "${fulltitle} - ${floatsize}"

--- a/tcl/wheredoesthisgo.tcl
+++ b/tcl/wheredoesthisgo.tcl
@@ -15,7 +15,7 @@ proc open_file {filename} {
     set directory [file normalize [file dirname $filename]]
     set basename [file tail $filename]
     if { ! [file exists $filename]} {
-        ::pdwindow::post [format [_ "ignoring '%s': doesn't exist"] $filename]
+        ::pdwindow::post [_ "ignoring '%s': doesn't exist" $filename]
         ::pdwindow::post "\n"
         # remove from recent files
         ::pd_guiprefs::update_recentfiles $filename true
@@ -28,7 +28,7 @@ proc open_file {filename} {
         # now this is done in pd_guiprefs
         ::pd_guiprefs::update_recentfiles $filename
     } else {
-        ::pdwindow::post [format [_ "ignoring '%s': doesn't look like a Pd file"] $filename]
+        ::pdwindow::post [_ "ignoring '%s': doesn't look like a Pd file" $filename]
         ::pdwindow::post "\n"
     }
 }


### PR DESCRIPTION
this PR attempts to fix some issues with the i18n framework within Pd.

#### better detection of the default language (as requested by the system)

the original code has convoluted (and incorrect) platform-specific attempts to get the correct property stating the system's chosen language (Windows registry, macOS defaults, `$env(LANG)`...).
however, the `msgcat` extension (which handles translations), can also provide this information (and more correctly). so the new code just *uses* these defaults (if no override is specified)

- Closes: https://github.com/pure-data/pure-data/issues/2270

#### macOS: allow setting the application-specific language via the system preferences

macOS's System Settings allow selecting a language for a specific app.
For this to work, the app has to declare which languages it supports.
this was disabled by 6b42a26d52708a4cc8df18f4901bfa48fc9fbb66 with the following comment:
> commented out for 0.48-1 because it seems to misbehave - open/save dialogs
> are opening in a random language (and meanwhile Pd doesn't yet respect
> current language setting - I don't know what's going on here.  -msp

now that Pd does respect the current language settings (see above), I think it behaves as it should.
at least i haven't been able to observe that the "open/save dialogs are opening in random languages".
instead, they open in the language specified.

also, i think that the original code was a bit broken, as it was trying to add the Pd-version as the primary language. maybe this was the reason for the weird behavior.


#### macOS: sync the language chosen via the Pd-prefs with the System Preferences.

When Pd switches the translation (in `::pd_i18n::init`) to the chosen language, macOS has already translated some of the immutable menu entries (e.g. the entire :apple:-menu).
this can result in a weird mix of languages in the menus (see https://github.com/pure-data/pure-data/issues/2269#issuecomment-2081609542), iff the language which Pd thinks it should use differs from the language macOS thinks Pd should use.

therefore, changing the language via the Pd-preferences will also inform macOS with which language Pd should be started (so the two are in sync).

- Related: https://github.com/pure-data/pure-data/issues/2269


#### simplify code
the old code was full of explicit calls to `format` on translated strings, which is unnecessary as the actual translating proc already has `format` built-in.
this reduces lines like
```tcl
set msg [format [_ "the Pd window filtered %d lines" ] $i ]
```
to
```tcl
set msg [_ "the Pd window filtered %d lines" $i ]
```
which i believe is more readable.

- Closes: https://github.com/pure-data/pure-data/issues/2271


## remaining bugs

on macOS, there are still some places, where the Pd translations are ignored (e.g. the <kbd>Yes</kbd>, <kbd>No</kbd>, <kbd>Cancel</kbd> buttons in dialogs, but also some standard menu entries, like `Quit`), and the system falls back to English (or possibly the installation language of macOS).
afaict this is a bug in TclTk, and cannot be fixed on the Pd side.