### PR TITLE
Update translatables

### DIFF
--- a/po/az.po
+++ b/po/az.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2004-03-12 22:22+0200\n"
 "Last-Translator: Metin Amiroff <metin@karegen.com>\n"
 "Language-Team: Azerbaijani <translation-team-az@lists.sourceforge.net>\n"
@@ -1286,6 +1286,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1400,11 +1403,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/bg.po
+++ b/po/bg.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2022-10-30 07:04+0000\n"
 "Last-Translator: Max Neupert <abonnements@revolwear.com>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1273,6 +1273,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1387,11 +1390,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/de.po
+++ b/po/de.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.52\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-03-14 20:00+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/pure-data/"
-"pure-data/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/pure-data/pure-"
+"data/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1268,6 +1268,9 @@ msgstr "leere Domäne kann nicht gelöscht werden"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Konnte Einstellungen '%1$s' nicht in %2$s erstellen"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1382,12 +1385,12 @@ msgstr "Vietnamesisch"
 msgid "Chinese (Traditional)"
 msgstr "Chinesisch (traditionell)"
 
+msgid "(no translation)"
+msgstr "(keine Übersetzung)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(Standardsprache: %s)"
-
-msgid "(no translation)"
-msgstr "(keine Übersetzung)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/el.po
+++ b/po/el.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2009-09-13 01:51+0200\n"
 "Last-Translator: Γεώργιος Κερατζάκης <geokeratz@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1274,6 +1274,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1388,11 +1391,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/en.po
+++ b/po/en.po
@@ -6,11 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.51.4\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-03-14 20:00+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
-"Language-Team: English <https://hosted.weblate.org/projects/pure-data/"
-"pure-data/en/>\n"
+"Language-Team: English <https://hosted.weblate.org/projects/pure-data/pure-"
+"data/en/>\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1244,6 +1244,9 @@ msgstr "refusing to delete empty domain"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Couldn't create preferences \"%1$s\" in %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1358,12 +1361,12 @@ msgstr "Vietnamese"
 msgid "Chinese (Traditional)"
 msgstr "Chinese (Traditional)"
 
+msgid "(no translation)"
+msgstr "(no translation)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(default language: %s)"
-
-msgid "(no translation)"
-msgstr "(no translation)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/en_ca.po
+++ b/po/en_ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-06-27 06:05+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
 "Language-Team: English (Canada) <https://hosted.weblate.org/projects/pure-"
@@ -1246,6 +1246,9 @@ msgstr "refusing to delete empty domain"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Couldn't create preferences \"%1$s\" in %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1360,12 +1363,12 @@ msgstr "Vietnamese"
 msgid "Chinese (Traditional)"
 msgstr "Chinese (Traditional)"
 
+msgid "(no translation)"
+msgstr "(no translation)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(default language: %s)"
-
-msgid "(no translation)"
-msgstr "(no translation)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/es.po
+++ b/po/es.po
@@ -12,11 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-04-23 21:07+0000\n"
 "Last-Translator: porres <porres@gmail.com>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/pure-data/"
-"pure-data/es/>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/pure-data/pure-"
+"data/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1262,6 +1262,9 @@ msgstr "negándose a borrar un dominio vacío"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "No se pudo crear el archivo de preferencias '%1$s' en %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1376,12 +1379,12 @@ msgstr "Vietnamita"
 msgid "Chinese (Traditional)"
 msgstr "Chino (tradicional)"
 
+msgid "(no translation)"
+msgstr "(sin traducciones)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(Idioma predeterminado: %s)"
-
-msgid "(no translation)"
-msgstr "(sin traducciones)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/eu.po
+++ b/po/eu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2022-10-30 07:04+0000\n"
 "Last-Translator: Max Neupert <abonnements@revolwear.com>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1294,6 +1294,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1408,11 +1411,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,11 +10,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53-0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-03-14 20:00+0000\n"
 "Last-Translator: baptiste <baptiste.chatel@gmail.com>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/pure-data/"
-"pure-data/fr/>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/pure-data/pure-"
+"data/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1275,6 +1275,9 @@ msgstr "refus de supprimer un domaine vide"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Impossible de créer des préférences \"%1$s\" dans %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1389,12 +1392,12 @@ msgstr "Vietnamien"
 msgid "Chinese (Traditional)"
 msgstr "Chinois (traditionnel)"
 
+msgid "(no translation)"
+msgstr "(pas de traduction)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(langue par défaut : %s)"
-
-msgid "(no translation)"
-msgstr "(pas de traduction)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/gu.po
+++ b/po/gu.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data-0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2005-09-14 12:49+0530\n"
 "Last-Translator: Ankit Patel <ankit644@yahoo.com>\n"
 "Language-Team: Gujarati <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1289,6 +1289,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1403,11 +1406,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/he.po
+++ b/po/he.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.1\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-07-01 07:53+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1244,6 +1244,9 @@ msgstr "עלה סירוב למחיקת שם תחום ריק"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "לא ניתן ליצור העדפות „%1$s” תחת %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "אפריקאנס"
 
@@ -1358,12 +1361,12 @@ msgstr "וייטנאמית"
 msgid "Chinese (Traditional)"
 msgstr "סינית מסורתית"
 
+msgid "(no translation)"
+msgstr "(אין תרגום)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(שפת ברירת המחדל: %s)"
-
-msgid "(no translation)"
-msgstr "(אין תרגום)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/hi.po
+++ b/po/hi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2005-05-04 12:50+0530\n"
 "Last-Translator: Rajesh Ranjan <rranjan@redhat.com>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1286,6 +1286,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1400,11 +1403,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/hu.po
+++ b/po/hu.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2010-01-29 21:09+0100\n"
 "Last-Translator: Andras Muranyi <muranyia@gmail.com>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1275,6 +1275,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1389,11 +1392,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/id.po
+++ b/po/id.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-03-04 23:01+0000\n"
 "Last-Translator: Reza Almanda <rezaalmanda27@gmail.com>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/pure-data/"
@@ -1233,6 +1233,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1347,11 +1350,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/it.po
+++ b/po/it.po
@@ -9,11 +9,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-03-20 21:01+0000\n"
 "Last-Translator: Alberto Zin <alberto.zin@gmail.com>\n"
-"Language-Team: Italian <https://hosted.weblate.org/projects/pure-data/"
-"pure-data/it/>\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/pure-data/pure-"
+"data/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1263,6 +1263,9 @@ msgstr "non cancello il dominio vuoto"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Impossibile creare le preferenze \"%1$s\" in %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Afrikaans"
 
@@ -1377,12 +1380,12 @@ msgstr "Vietnamita"
 msgid "Chinese (Traditional)"
 msgstr "Cinese (Tradizionale)"
 
+msgid "(no translation)"
+msgstr "(nessuna traduzione)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "Lingua di default: %s"
-
-msgid "(no translation)"
-msgstr "(nessuna traduzione)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-02-13 12:36+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1275,6 +1275,9 @@ msgstr "空のドメインの削除を拒否されました"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "環境設定 \"%1$s\" を %2$s に作成できませんでした"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1389,13 +1392,13 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, fuzzy, tcl-format
-msgid "(default language: %s)"
-msgstr "デフォルトのプラットフォーム: %s"
-
 #, fuzzy
 msgid "(no translation)"
 msgstr "翻訳"
+
+#, fuzzy, tcl-format
+msgid "(default language: %s)"
+msgstr "デフォルトのプラットフォーム: %s"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-04-26 08:48+0000\n"
 "Last-Translator: simmon <simmon@nplob.com>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1269,6 +1269,9 @@ msgstr "비어있는 도메인 삭제가 거부되었습니다"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "환경설정 \"%1$s\"에서 %2$s을(를) 만들지 못했습니다"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1383,13 +1386,13 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, fuzzy, tcl-format
-msgid "(default language: %s)"
-msgstr "기본 플랫폼: %s"
-
 #, fuzzy
 msgid "(no translation)"
 msgstr "번역"
+
+#, fuzzy, tcl-format
+msgid "(default language: %s)"
+msgstr "기본 플랫폼: %s"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-06-06 09:30+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1262,6 +1262,9 @@ msgstr "weigeren leeg domein te verwijderen"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Kon voorkeuren \"%1$s\" niet aanmaken in %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1376,12 +1379,12 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
+msgid "(no translation)"
+msgstr "(geen vertaling)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(standaardtaal: %s)"
-
-msgid "(no translation)"
-msgstr "(geen vertaling)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/pa.po
+++ b/po/pa.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2005-11-04 08:04+0530\n"
 "Last-Translator: Amanpreet Singh Alam <amanpreetalam@yahoo.com>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1288,6 +1288,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1402,11 +1405,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2022-10-20 12:48+0000\n"
 "Last-Translator: | || | | <aalderson@caramail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1234,6 +1234,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1348,11 +1351,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/pt_br.po
+++ b/po/pt_br.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2024-04-26 17:07+0000\n"
 "Last-Translator: porres <porres@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
-"pure-data/pure-data/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/pure-"
+"data/pure-data/pt_BR/>\n"
 "Language: pt_br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1253,6 +1253,9 @@ msgstr "recusando deletar domínio vazio"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Não foi possível criar preferências \"%1$s\" em %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Africâner"
 
@@ -1367,12 +1370,12 @@ msgstr "Vietnamita"
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
+msgid "(no translation)"
+msgstr "(sem tradução)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(idioma padrão: %s)"
-
-msgid "(no translation)"
-msgstr "(sem tradução)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/pt_pt.po
+++ b/po/pt_pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-12-19 16:08+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
@@ -1253,6 +1253,9 @@ msgstr "recusando deletar domínio vazio"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Não foi possível criar preferências \"%1$s\" em %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr "Africâner"
 
@@ -1367,12 +1370,12 @@ msgstr "Vietnamita"
 msgid "Chinese (Traditional)"
 msgstr "Chinês (Tradicional)"
 
+msgid "(no translation)"
+msgstr "(sem tradução)"
+
 #, tcl-format
 msgid "(default language: %s)"
 msgstr "(idioma padrão: %s)"
-
-msgid "(no translation)"
-msgstr "(sem tradução)"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-02-19 20:36+0000\n"
 "Last-Translator: Alex Nadzharov <anadjarov@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1280,6 +1280,9 @@ msgstr "невозможно удалить пустой объект"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Невозможно создать свойства \"%1$s\" в %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1394,13 +1397,13 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, fuzzy, tcl-format
-msgid "(default language: %s)"
-msgstr "Платформа по умолчанию: %s"
-
 #, fuzzy
 msgid "(no translation)"
 msgstr "переводы"
+
+#, fuzzy, tcl-format
+msgid "(default language: %s)"
+msgstr "Платформа по умолчанию: %s"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/sq.po
+++ b/po/sq.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2005-03-07 11:12+0200\n"
 "Last-Translator: Besnik Bleta <besnik@spymac.com>\n"
 "Language-Team: Albanian <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1287,6 +1287,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1401,11 +1404,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2009-08-22 11:20+0100\n"
 "Last-Translator: Johannes Burström <johannes@ljud.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1278,6 +1278,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1392,11 +1395,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/template.pot
+++ b/po/template.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.54.1\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1221,6 +1221,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1335,11 +1338,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2023-02-13 12:36+0000\n"
 "Last-Translator: umläute <dev@umlaeute.mur.at>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/pure-data/pure-"
@@ -1293,6 +1293,9 @@ msgstr "неможливо видалити порожній об'єкт"
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr "Неможливо створити властивості %1$s у %2$s"
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1407,13 +1410,13 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, fuzzy, tcl-format
-msgid "(default language: %s)"
-msgstr "Платформа за замовчуванням: %s"
-
 #, fuzzy
 msgid "(no translation)"
 msgstr "переклади"
+
+#, fuzzy, tcl-format
+msgid "(default language: %s)"
+msgstr "Платформа за замовчуванням: %s"
 
 #, tcl-format
 msgid "ignoring '%s': doesn't exist"

--- a/po/vi.po
+++ b/po/vi.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.43\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2005-07-28 17:29+0930\n"
 "Last-Translator: Clytie Siddall <clytie@riverland.net.au>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/pure-data/"
@@ -1287,6 +1287,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1401,11 +1404,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format

--- a/po/zh_tw.po
+++ b/po/zh_tw.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pure Data 0.53.0\n"
 "Report-Msgid-Bugs-To: pd-dev@iem.at\n"
-"POT-Creation-Date: 2024-03-14 18:04+0100\n"
+"POT-Creation-Date: 2024-05-06 10:09+0200\n"
 "PO-Revision-Date: 2022-10-30 07:04+0000\n"
 "Last-Translator: Max Neupert <abonnements@revolwear.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -1234,6 +1234,9 @@ msgstr ""
 msgid "Couldn't create preferences \"%1$s\" in %2$s"
 msgstr ""
 
+msgid "The language can only be set during startup."
+msgstr ""
+
 msgid "Afrikaans"
 msgstr ""
 
@@ -1348,11 +1351,11 @@ msgstr ""
 msgid "Chinese (Traditional)"
 msgstr ""
 
-#, tcl-format
-msgid "(default language: %s)"
+msgid "(no translation)"
 msgstr ""
 
-msgid "(no translation)"
+#, tcl-format
+msgid "(default language: %s)"
 msgstr ""
 
 #, tcl-format


### PR DESCRIPTION
**note** #2279 (recently merged) contained a new translatable string. as side-effect, building Pd `master` now changes the translation files in `po/` (adding the new translatable). this PR permanently adds the new translatable (so running `make` no longer updates the files).
if we wait a bit longer, hopefully some actual translations for the new translatable will show up as well :-)

### updated translations
- ...

### current status
![Weblate translation status](https://hosted.weblate.org/widget/pure-data/pure-data/horizontal-auto.svg)