### PR TITLE
bytestruct: parse lists of bytes into messages according to a struct definition (and vice versa)

### DIFF
--- a/doc/5.reference/bytestruct-help.pd
+++ b/doc/5.reference/bytestruct-help.pd
@@ -1,0 +1,646 @@
+#N canvas 196 105 753 818 12;
+#X text 459 69 details:;
+#X text 457 52 click for;
+#X text 38 703 see also:;
+#X text 405 712 updated for Pd version 0.52;
+#X obj 28 96 bytestruct pack;
+#X obj 28 126 bytestruct unpack;
+#X obj 28 166 bytestruct size;
+#X obj 123 702 oscformat;
+#X obj 123 732 oscparse;
+#X obj 215 702 fudiformat;
+#X obj 215 732 fudiparse;
+#X obj 304 716 file;
+#N canvas 458 97 1119 822 pack 0;
+#X text 146 24 pack - convert Pd atoms in bytelists;
+#X floatatom 62 239 3 0 0 0 - - -;
+#X floatatom 85 239 3 0 0 0 - - -;
+#X floatatom 108 239 3 0 0 0 - - -;
+#X floatatom 131 239 3 0 0 0 - - -;
+#X floatatom 172 239 3 0 0 0 - - -;
+#X floatatom 195 239 3 0 0 0 - - -;
+#X floatatom 218 239 3 0 0 0 - - -;
+#X floatatom 241 239 3 0 0 0 - - -;
+#X floatatom 282 239 3 0 0 0 - - -;
+#X floatatom 305 239 3 0 0 0 - - -;
+#X floatatom 328 239 3 0 0 0 - - -;
+#X floatatom 351 239 3 0 0 0 - - -;
+#X obj 62 155 bytestruct pack f2i3s;
+#X obj 62 180 unpack 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0;
+#X floatatom 395 239 3 0 0 0 - - -;
+#X floatatom 418 239 3 0 0 0 - - -;
+#X floatatom 441 239 3 0 0 0 - - -;
+#X text 66 264 float;
+#X text 190 264 int;
+#X text 289 264 int;
+#X text 401 264 string;
+#X text 489 236 byte representation;
+#X text 236 145 packs the incoming numbers according to the "format
+specification": float \, float \, integer \, char[3], f 67;
+#X msg 62 126 list 1.5 2 0 pi;
+#X obj 67 431 list prepend set;
+#X obj 67 456 list trim;
+#X obj 307 431 list prepend set;
+#X obj 307 456 list trim;
+#X text 754 371 hhl: 2*short int + 1*long int;
+#X obj 517 431 list prepend set;
+#X obj 517 456 list trim;
+#X obj 517 406 bytestruct pack <hhl;
+#X obj 757 431 list prepend set;
+#X obj 757 456 list trim;
+#X obj 757 406 bytestruct pack >hhl;
+#X obj 67 373 t l l l l;
+#X obj 67 406 bytestruct pack @hhl;
+#X obj 307 406 bytestruct pack =hhl;
+#X text 73 574 native size & byte-order;
+#X text 316 504 standard-size;
+#X text 318 521 + native byte order;
+#X text 518 521 + little endian;
+#X text 761 521 + big endian;
+#X text 516 504 standard-size;
+#X text 756 504 standard-size;
+#X msg 67 310 list 1 2 -1;
+#X msg 103 346 list 3.14 100000 0;
+#X text 263 335 fractional numbers and out-of-range numbers are converted
+to the specified numbers;
+#X msg 67 551;
+#X msg 307 481;
+#X msg 517 482;
+#X msg 757 481;
+#X obj 1016 411 loadbang;
+#X msg 68 671 list oopsie;
+#X obj 68 696 bytestruct pack @d;
+#X obj 191 721 bng 20 250 50 0 empty empty empty 17 7 0 10 -257985
+-258113 -1;
+#X obj 68 721 print nada;
+#X obj 471 721 bng 20 250 50 0 empty empty empty 17 7 0 10 -257985
+-258113 -1;
+#X obj 348 721 print nada;
+#X obj 348 696 bytestruct pack @Z;
+#X msg 348 672 list 3;
+#X text 66 646 invalid input;
+#X text 346 646 invalid format specification;
+#X connect 13 0 14 0;
+#X connect 14 0 1 0;
+#X connect 14 1 2 0;
+#X connect 14 2 3 0;
+#X connect 14 3 4 0;
+#X connect 14 4 5 0;
+#X connect 14 5 6 0;
+#X connect 14 6 7 0;
+#X connect 14 7 8 0;
+#X connect 14 8 9 0;
+#X connect 14 9 10 0;
+#X connect 14 10 11 0;
+#X connect 14 11 12 0;
+#X connect 14 12 15 0;
+#X connect 14 13 16 0;
+#X connect 14 14 17 0;
+#X connect 24 0 13 0;
+#X connect 25 0 26 0;
+#X connect 26 0 49 0;
+#X connect 27 0 28 0;
+#X connect 28 0 50 0;
+#X connect 30 0 31 0;
+#X connect 31 0 51 0;
+#X connect 32 0 30 0;
+#X connect 33 0 34 0;
+#X connect 34 0 52 0;
+#X connect 35 0 33 0;
+#X connect 36 0 37 0;
+#X connect 36 1 38 0;
+#X connect 36 2 32 0;
+#X connect 36 3 35 0;
+#X connect 37 0 25 0;
+#X connect 38 0 27 0;
+#X connect 46 0 36 0;
+#X connect 47 0 36 0;
+#X connect 53 0 33 0;
+#X connect 53 0 30 0;
+#X connect 53 0 27 0;
+#X connect 53 0 25 0;
+#X connect 54 0 55 0;
+#X connect 55 0 57 0;
+#X connect 55 1 56 0;
+#X connect 60 0 59 0;
+#X connect 60 1 58 0;
+#X connect 61 0 60 0;
+#X restore 460 96 pd pack;
+#N canvas 751 166 707 608 unpack 0;
+#X text 146 24 unpack - convert byteslists to Pd atoms;
+#X text 53 79 a "byteslist" is just an list of numbers in the range
+0..255;
+#X obj 46 186 unpack s f f f;
+#X symbolatom 46 304 0 0 0 0 - - -;
+#X floatatom 77 276 5 0 0 0 - - -;
+#X floatatom 109 246 5 0 0 0 - - -;
+#X floatatom 141 216 5 0 0 0 - - -;
+#X msg 46 136 112 117 114 101 32 100 97 116 97 0 51 0 3 0 0 0;
+#X obj 46 160 bytestruct unpack <9sBHI;
+#X msg 32 414 0 0 0 1;
+#X floatatom 32 465 5 0 0 0 - - -;
+#X msg 169 412 symbol >i;
+#X obj 32 440 bytestruct unpack >h;
+#X obj 169 464 bng 20 250 50 0 empty empty empty 17 7 0 10 -257985
+-258113 -1;
+#X text 27 380 wrong number of bytes;
+#X text 33 526 to check the number of bytes required \, you can use
+, f 38;
+#X obj 33 569 bytestruct size;
+#X text 252 412 this format is better;
+#X connect 2 0 3 0;
+#X connect 2 1 4 0;
+#X connect 2 2 5 0;
+#X connect 2 3 6 0;
+#X connect 7 0 8 0;
+#X connect 8 0 2 0;
+#X connect 9 0 12 0;
+#X connect 11 0 12 1;
+#X connect 12 0 10 0;
+#X connect 12 1 13 0;
+#X restore 460 126 pd unpack;
+#N canvas 730 134 747 498 size 0;
+#X text 65 44 Size - calculate the bytesize required to hold the struct
+specified by the format;
+#X obj 102 427 bytestruct size;
+#X symbolatom 102 397 10 0 0 0 - - -;
+#X floatatom 102 452 5 0 0 1 size - -;
+#X obj 204 452 bng 20 250 50 0 empty empty error 25 10 0 10 -257985
+-258113 -1;
+#X msg 102 117 symbol f;
+#X text 200 119 single float (4 bytes);
+#X text 200 156 three doubles (each 8 bytes) + one short int (2 bytes)
++ 2 ints (each 4 bytes). "native" alignment requires 2 padding bytes
+between the short int and the 2 ints which are automatically added.
+;
+#X msg 102 177 symbol 3dh2i;
+#X msg 102 257 symbol =3dh2i;
+#X text 204 236 same as above but with standard sizes and no alignment.
+because there's no alignment \, there are no automatic padding bytes
+and the result is 2 bytes shorter;
+#X msg 113 320 symbol !2BH2H2BH2I;
+#X text 253 313 simplified header of an IP packet (the last two integers
+are source and destination IP address);
+#X msg 145 361 symbol Z;
+#X text 225 366 an illegal struct format...;
+#X connect 1 0 3 0;
+#X connect 1 1 4 0;
+#X connect 2 0 1 0;
+#X connect 5 0 2 0;
+#X connect 8 0 2 0;
+#X connect 9 0 2 0;
+#X connect 11 0 2 0;
+#X connect 13 0 2 0;
+#X restore 460 166 pd size;
+#X text 28 67 The bytestruct object's first argument sets its function:
+;
+#X text 165 125 - unpack bytelists into Pd atoms;
+#X text 165 95 - pack Pd atoms into bytelists;
+#X text 166 167 - calculate the number of bytes required;
+#X text 59 223 struct format specification;
+#X text 28 422 the format specification string closely follows the
+specifications of the Python standard library "struct";
+#X text 31 464 you may also want to consult https://docs.python.org/3/library/struct.html
+, f 74;
+#N canvas 6 187 450 300 (subpatch) 0;
+#X obj 100 100 bng 30 250 50 0 \$0-pythonstruct \$0-pythonstruct empty
+17 7 0 10 -262144 -1 -1;
+#X obj 60 210 pdcontrol;
+#X msg 60 185 browse https://docs.python.org/3/library/struct.html
+;
+#X obj 60 155 r \$0-pythonstruct;
+#X connect 2 0 1 0;
+#X connect 3 0 2 0;
+#X coords 0 -1 1 1 30 30 1 100 100;
+#X restore 566 457 pd;
+#X text 26 311 each format character CAN be preceded by a 'repeat count'.
+, f 60;
+#X text 27 335 by default \, the byte representation uses the machine's
+native format and byte order and is properly aligned ny skipping pads
+if necessary. this can be adjusted by a optional first character that
+indicates byte-order \, size and alignment;
+#N canvas 6 70 838 840 format 0;
+#X text 49 11 format characters;
+#X text 71 50 Character;
+#X text 246 50 C Type;
+#X text 162 41 std.size;
+#X text 382 50 Pd-type;
+#X msg 110 100 x;
+#X msg 110 130 c;
+#X text 200 130 1;
+#X msg 250 130 char;
+#X msg 110 160 b;
+#X text 200 160 1;
+#X msg 110 190 B;
+#X text 200 190 1;
+#X msg 110 220 ?;
+#X text 200 220 1;
+#X msg 110 260 h;
+#X text 200 260 2;
+#X msg 250 260 short;
+#X msg 110 290 H;
+#X text 200 290 2;
+#X msg 110 320 i;
+#X text 200 320 4;
+#X msg 250 320 int;
+#X msg 110 350 I;
+#X text 200 350 4;
+#X msg 110 380 l;
+#X text 200 380 4;
+#X msg 250 380 long;
+#X msg 110 410 L;
+#X text 200 410 4;
+#X msg 110 440 q;
+#X text 200 440 8;
+#X msg 110 470 Q;
+#X text 200 470 8;
+#X msg 110 500 n;
+#X msg 250 500 ssize_t;
+#X msg 110 530 N;
+#X msg 250 530 size_t;
+#X msg 110 560 e;
+#X text 200 560 2;
+#X msg 110 590 f;
+#X text 200 590 4;
+#X msg 250 590 float;
+#X msg 110 620 d;
+#X text 200 620 8;
+#X msg 250 620 double;
+#X msg 110 650 s;
+#X text 200 650 ...;
+#X msg 250 650 char[];
+#X msg 110 680 S;
+#X text 200 680 ...;
+#X msg 250 680 wchar[];
+#X msg 110 710 p;
+#X text 200 710 ...;
+#X msg 110 740 P;
+#X msg 250 740 void*;
+#X msg 250 160 signed char;
+#X msg 250 190 unsigned char;
+#X msg 250 290 unsigned short;
+#X msg 250 350 unsigned int;
+#X msg 250 410 unsigned long;
+#X msg 250 440 long long;
+#X msg 250 470 unsigned long long;
+#X text 250 560 (float16);
+#X text 250 220 (Bool);
+#X text 400 100 (none);
+#X text 161 59 (in bytes);
+#X text 400 260 'number';
+#X text 400 290 positive 'number';
+#X text 400 320 'number';
+#X text 400 350 positive 'number';
+#X text 400 380 'number';
+#X text 400 410 positive 'number';
+#X text 400 440 'number';
+#X text 400 470 positive 'number';
+#X text 400 160 'number' (in the range of -128..127);
+#X text 400 190 positive 'number' (in the range of 0..255);
+#X text 400 560 'number';
+#X text 400 590 'number';
+#X text 400 620 'number';
+#X text 400 650 'symbol';
+#X text 400 680 'symbol';
+#X text 400 710 'symbol';
+#X text 400 740 ??? (only available for "native" alignment);
+#X text 400 530 positive 'number' (only available for "native" size)
+;
+#X text 400 500 'number' (only available in "native" size);
+#X text 200 500 ?;
+#X text 200 530 ?;
+#X text 200 740 ?;
+#X text 60 76 -----------------------------------------------------
+;
+#X text 49 21 =================;
+#X text 250 710 pascal string;
+#X text 97 779 some of the larger number formats - like double \, (unsigned)
+int \, (unsigned) long \, (unsigned) long long - may not be representable
+accurately within Pd for some values.;
+#X text 400 123 single byte \, either a 'number' in the range 0..255
+\, or (when packing) the first character of a 'symbol'.;
+#X text 401 212 boolean value (when packing \, 0 and empty symbol are
+false \, the rest is true \; for unpacking this is either 0 or 1);
+#X text 243 100 (pad byte);
+#X restore 473 281 pd format characters;
+#N canvas 81 128 506 513 byte-order 0;
+#X text 101 110 Character;
+#X text 44 344 Native size and alignment are determined using the C
+compiler's "sizeof" expression. This is always combined with native
+byte order.;
+#X text 190 150 native;
+#X text 290 150 native;
+#X text 370 150 native;
+#X msg 130 180 @;
+#X text 190 180 native;
+#X text 290 180 native;
+#X text 370 180 native;
+#X msg 130 210 =;
+#X text 190 210 native;
+#X text 290 210 standard;
+#X text 370 210 none;
+#X msg 130 240 <;
+#X text 190 240 little-endian;
+#X text 290 240 standard;
+#X text 370 240 none;
+#X msg 130 270 >;
+#X text 290 270 standard;
+#X text 370 270 none;
+#X msg 130 300 !;
+#X text 190 300 network;
+#X text 290 300 standard;
+#X text 370 300 none;
+#X text 190 110 Byte Order;
+#X text 290 110 Size;
+#X text 370 110 Alignment;
+#X text 190 270 big-endian;
+#X text 190 315 (big-endian);
+#X text 120 150 (none);
+#X text 45 451 "none"-Alignment means \, that struct members are packed
+without any automatic padding;
+#X text 90 126 -------------------------------------------------;
+#X text 39 21 byte-order & alignment;
+#X text 39 31 ======================;
+#X text 43 63 the first character (only) can select the byte-order
+\, size and alignment of the struct;
+#X text 41 399 Some struct types (like 'size_t' and 'ssize_t') can
+only be used with native size.;
+#X restore 473 361 pd byte-order & alignment;
+#N canvas 260 163 504 506 size 0;
+#X text 38 24 size specifications;
+#X text 38 34 ===================;
+#X text 62 75 Prefixing a format character with an integer number \,
+which simply repeats that character.;
+#X text 62 115 E.g. the format string '4h' means exactly the same as
+'hhhh' (that is: four signed int16 numbers);
+#X text 62 335 The pascal string format 'p' is similar to the string
+format \, but includes a leading byte indicating the length of the
+string.;
+#X text 62 255 E.g. "10s" means a single string (symbol) consisting
+of 10 bytes \, whereas "10c" are 10 separate characters (bytes) \,
+unpacked as numbers.;
+#X text 62 395 E.g. "3p" means a pascal string of 3 bytes \, the first
+byte holding the length of the remaining string (<=2) \, followed by
+two (2) bytes (characters) that constitute the actual string.;
+#X text 62 185 For the string formats 's' and 'S' \, the size specifier
+means the length of the string. for packing \, the incoming symbol
+may be truncated or zero-padded as appropriate to make it fit the specifications.
+;
+#X restore 473 321 pd size specification;
+#X text 38 538 here are some examples showing how to use these objects
+;
+#N canvas 410 128 848 741 read 0;
+#X obj 142 136 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
+#X obj 142 161 openpanel;
+#X obj 142 320 file;
+#X obj 142 348 bytestruct unpack <4s4x4s4s4xHHIIHH;
+#X symbolatom 312 405 10 0 0 0 - - -;
+#X symbolatom 312 465 10 0 0 0 - - -;
+#X obj 142 373 unpack s s s f f f f f f;
+#X symbolatom 312 495 10 0 0 0 - - -;
+#X floatatom 314 555 5 0 0 0 - - -;
+#X floatatom 314 585 5 0 0 0 - - -;
+#X floatatom 314 615 5 0 0 0 - - -;
+#X floatatom 314 645 0 0 0 0 - - -;
+#X floatatom 314 676 5 0 0 0 - - -;
+#X floatatom 314 706 5 0 0 0 - - -;
+#X text 279 313 the format-spec that reads the RIFF-header + the fmt-chunk
+takes exactly 36 bytes;
+#X text 191 76 this only works for WAV-files (no AIFF \, CAF \, ...)
+\, and assumes that the 'fmt' chunk is the very first chunk (which
+is true for most WAV-files \, but there might be the odd outlier);
+#X text 416 407 4s: magic header 'RIFF';
+#X text 416 467 4s: RIFF-type 'WAVE';
+#X text 423 557 H: compression code (1=PCM);
+#X text 423 587 H: number of channels;
+#X text 423 617 I: sample rate;
+#X text 416 437 4x: (ignored): filesize;
+#X text 416 527 4x: (ignored): chunksize;
+#X text 423 677 H: block align;
+#X text 423 707 H: bits-per-sample;
+#X text 423 647 I: average bytes per second;
+#X text 419 376 <: WAV-Files are always littlen-endian;
+#X msg 218 211 open \$1;
+#X obj 165 234 bytestruct size <4s4x4s4s4xHHIIHH;
+#X floatatom 165 259 5 0 0 0 - - -;
+#X msg 142 285 close;
+#X obj 142 188 t b b s;
+#X text 416 497 4s: chunk name ("fmt ");
+#X text 95 49 example 2: read the header of a WAV-file and display
+some meta-information, f 74;
+#X connect 0 0 1 0;
+#X connect 1 0 31 0;
+#X connect 2 0 3 0;
+#X connect 3 0 6 0;
+#X connect 6 0 4 0;
+#X connect 6 1 5 0;
+#X connect 6 2 7 0;
+#X connect 6 3 8 0;
+#X connect 6 4 9 0;
+#X connect 6 5 10 0;
+#X connect 6 6 11 0;
+#X connect 6 7 12 0;
+#X connect 6 8 13 0;
+#X connect 27 0 2 0;
+#X connect 28 0 29 0;
+#X connect 29 0 2 0;
+#X connect 30 0 2 0;
+#X connect 31 0 30 0;
+#X connect 31 1 28 0;
+#X connect 31 2 27 0;
+#X restore 133 602 pd read WAV header;
+#N canvas 251 172 1204 760 read 0;
+#X text 99 61 WAV-files can store loops in the 'smpl' chunk.;
+#X text 99 80 the loops-points are stored as byte-offsets - so we need
+to convert them to sample-offsets first (the information for that is
+within the 'fmt ' chunk) \,;
+#X text 592 103 https://sites.google.com/site/musicgapi/technical-documents/wav-file-format
+, f 75;
+#X text 590 78 a description of the WAV chunks:;
+#X msg 142 265 open \$1 \, 12 \, close;
+#X obj 142 351 list trim;
+#X obj 142 374 route RIFF;
+#X obj 142 397 route WAVE;
+#X obj 142 328 bytestruct unpack <4s4x4s;
+#X obj 142 467 until;
+#X obj 748 567 until;
+#X msg 748 486 seek 28 current \, 8;
+#X text 887 594 each loop takes 24 bytes;
+#X obj 142 564 bytestruct unpack <4sI;
+#X obj 748 541 bytestruct unpack <I4x;
+#X obj 748 637 bytestruct unpack <6I;
+#X obj 142 422 t b;
+#X msg 748 592 seek 0 current \, 24;
+#X obj 142 589 pack s f f;
+#X obj 272 539 route bang seek;
+#X obj 748 615 file handle \$0.file;
+#X obj 142 663 file handle \$0.file;
+#X obj 142 515 file handle \$0.file;
+#X obj 142 290 file handle \$0.file;
+#X obj 748 514 file handle \$0.file;
+#X msg 142 492 seek 0 relative \, 8;
+#X msg 142 638 seek \$3 start \, seek \$2 relative \, seek 8 relative
+;
+#X text 852 663 loop# loop-type start end fraction repeatcount;
+#X text 339 328 read and verify the RIFF-header;
+#X text 424 530 iterate over chunks;
+#X obj 142 612 t l l;
+#X obj 174 702 list trim;
+#X obj 174 725 route smpl;
+#X text 272 703 <chunkID> <chunkLen> <chunkPos>;
+#X text 718 397 here we parse the 'smpl' chunk for the loop-information
+;
+#X obj 142 206 bng 15 250 50 0 empty empty empty 17 7 0 10 -262144
+-1 -1;
+#X obj 142 231 openpanel;
+#X obj 748 662 print LOOP;
+#X obj 736 254 file define \$0.file;
+#X text 99 146 again \, this only works for WAV-files.;
+#X text 914 491 skip the header \, and read the number of loops, f
+36;
+#X text 732 216 all [file handle] objects work on the same file:,
+f 25;
+#X text 71 27 example 3: this extract loop-points from WAV-files;
+#X connect 4 0 23 0;
+#X connect 5 0 6 0;
+#X connect 6 0 7 0;
+#X connect 7 0 16 0;
+#X connect 8 0 5 0;
+#X connect 9 0 25 0;
+#X connect 10 0 17 0;
+#X connect 11 0 24 0;
+#X connect 13 0 18 0;
+#X connect 14 0 10 0;
+#X connect 15 0 37 0;
+#X connect 16 0 9 0;
+#X connect 17 0 20 0;
+#X connect 18 0 30 0;
+#X connect 19 0 9 1;
+#X connect 19 1 18 2;
+#X connect 20 0 15 0;
+#X connect 22 0 13 0;
+#X connect 22 1 19 0;
+#X connect 23 0 8 0;
+#X connect 24 0 14 0;
+#X connect 25 0 22 0;
+#X connect 26 0 21 0;
+#X connect 30 0 26 0;
+#X connect 30 1 31 0;
+#X connect 31 0 32 0;
+#X connect 32 0 11 0;
+#X connect 35 0 36 0;
+#X connect 36 0 4 0;
+#X restore 133 629 pd read WAV loop-points;
+#N canvas 358 106 1378 681 OSC-bundles 0;
+#X obj 603 277 bytestruct unpack !8sQ;
+#X obj 603 252 list split 16;
+#X obj 626 483 list, f 19;
+#X obj 230 396 oscformat;
+#X obj 190 314 list;
+#X obj 190 363 list split 1;
+#X obj 190 338 t l s;
+#X obj 262 461 list length;
+#X obj 230 429 t l l;
+#X obj 110 597 list store;
+#X obj 110 208 route ] [, f 12;
+#X obj 110 233 t b;
+#X obj 262 486 bytestruct pack !I;
+#X obj 230 511 list prepend append;
+#X obj 230 536 list trim;
+#X obj 177 267 bytestruct pack !8sQ;
+#X msg 177 242 list #bundle 1;
+#X obj 110 622 t a a;
+#X obj 142 652 print rawOSC;
+#X obj 603 302 list trim;
+#X obj 603 327 route #bundle;
+#X floatatom 844 372 0 0 0 0 timestamp - -;
+#X msg 603 379 0;
+#X obj 564 411 spigot;
+#X obj 564 220 t l l b;
+#X msg 781 262 1;
+#X obj 603 352 t b b f;
+#X obj 626 508 t l l;
+#X obj 791 508 list split 4;
+#X obj 791 533 bytestruct unpack !I;
+#X obj 626 562 list split, f 24;
+#X obj 564 591 t l;
+#X obj 564 616 oscparse;
+#X obj 626 531 list split 4;
+#X obj 626 457 until;
+#X obj 791 630 t b;
+#X obj 564 641 print OSC;
+#X msg 110 183 [ \, test 5 6 7 \, dog eat dog \, ];
+#X msg 284 364 set \$1;
+#X text 338 253 bundle header;
+#X text 403 467 each OSC-message is prepended by its length, f 18
+;
+#X text 566 162 split an OSC-bundle into separate messages;
+#X text 98 155 build a bundle with multiple OSC-messages;
+#X text 807 298 here we detect if the OSC-message actually is an OSC-bundle
+(it starts with '#bundle'), f 36;
+#X text 948 534 read the message size;
+#X text 841 565 and extract the message.;
+#X text 845 583 the rest is left for the next iteration;
+#X text 831 633 stop if all the messages are done;
+#X text 67 27 example 1: build and parse OSC-bundles;
+#X text 102 59 Pd's built-in [oscformat] and [oscparse] objects only
+deal with simple OSC messages \, but not with OSC-bundles.;
+#X text 105 98 bytestruct to the rescue!;
+#X connect 0 0 19 0;
+#X connect 1 0 0 0;
+#X connect 1 1 2 1;
+#X connect 2 0 27 0;
+#X connect 3 0 8 0;
+#X connect 4 0 6 0;
+#X connect 5 1 3 0;
+#X connect 6 0 5 0;
+#X connect 6 1 38 0;
+#X connect 7 0 12 0;
+#X connect 8 0 13 0;
+#X connect 8 1 7 0;
+#X connect 9 0 17 0;
+#X connect 10 0 11 0;
+#X connect 10 1 16 0;
+#X connect 10 2 4 0;
+#X connect 11 0 9 0;
+#X connect 12 0 13 0;
+#X connect 13 0 14 0;
+#X connect 14 0 9 0;
+#X connect 15 0 9 1;
+#X connect 16 0 15 0;
+#X connect 17 0 24 0;
+#X connect 17 1 18 0;
+#X connect 19 0 20 0;
+#X connect 20 0 26 0;
+#X connect 22 0 23 1;
+#X connect 23 0 31 0;
+#X connect 24 0 23 0;
+#X connect 24 1 1 0;
+#X connect 24 2 25 0;
+#X connect 25 0 23 1;
+#X connect 26 0 22 0;
+#X connect 26 1 34 0;
+#X connect 26 2 21 0;
+#X connect 27 0 33 0;
+#X connect 27 1 28 0;
+#X connect 28 0 29 0;
+#X connect 28 2 35 0;
+#X connect 29 0 30 1;
+#X connect 30 0 31 0;
+#X connect 30 1 2 1;
+#X connect 30 2 35 0;
+#X connect 31 0 32 0;
+#X connect 32 0 36 0;
+#X connect 33 1 30 0;
+#X connect 34 0 2 0;
+#X connect 35 0 34 1;
+#X connect 37 0 10 0;
+#X connect 38 0 3 0;
+#X restore 133 573 pd OSC-bundles;
+#X text 59 233 ---------------------------;
+#X text 29 20 bytestruct - parse lists of bytes into messages according
+to a struct definition, f 81;
+#X text 25 257 the "format specification string" describes a fixed-sized
+data-layout. it consists of a number of "format characters" that define
+the type of data to be packed/unpacked.;

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -347,6 +347,7 @@ nobase_dist_libpd_DATA = \
      ./5.reference/block~-help.pd \
      ./5.reference/bng-help.pd \
      ./5.reference/bp~-help.pd \
+     ./5.reference/bytestruct-help.pd \
      ./5.reference/canvas-help.pd \
      ./5.reference/change-help.pd \
      ./5.reference/clip-help.pd \

--- a/libpd/Makefile
+++ b/libpd/Makefile
@@ -96,6 +96,7 @@ PDSRC = d_arithmetic.c d_array.c d_ctl.c d_dac.c d_delay.c d_fft.c \
         s_net.c s_path.c  s_print.c s_utf8.c \
         x_acoustics.c x_arithmetic.c x_array.c x_connective.c x_file.c x_gui.c \
         x_interface.c x_list.c x_midi.c x_misc.c x_net.c x_scalar.c x_text.c \
+        x_bytestruct.c \
         x_time.c x_vexp.c x_vexp_if.c x_vexp_fun.c
 
 EXTRASRC = bob~.c bonk~.c choice.c fiddle~.c loop~.c lrshift~.c pique.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -175,6 +175,7 @@ pd_SOURCES_core = \
     x_acoustics.c \
     x_arithmetic.c \
     x_array.c \
+    x_bytestruct.c \
     x_connective.c \
     x_file.c \
     x_gui.c \

--- a/src/m_conf.c
+++ b/src/m_conf.c
@@ -27,6 +27,7 @@ void m_pd_setup(void);
 void x_acoustics_setup(void);
 void x_interface_setup(void);
 void x_connective_setup(void);
+void x_bytestruct_setup(void);
 void x_time_setup(void);
 void x_arithmetic_setup(void);
 void x_array_setup(void);
@@ -75,6 +76,7 @@ void conf_init(void)
     clone_setup();
     m_pd_setup();
     x_acoustics_setup();
+    x_bytestruct_setup();
     x_interface_setup();
     x_connective_setup();
     x_time_setup();

--- a/src/makefile.gnu
+++ b/src/makefile.gnu
@@ -128,7 +128,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_bytestruct.c x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 OBJ = $(SRC:.c=.o)

--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -103,7 +103,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_bytestruct.c x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 OBJ = $(SRC:.c=.o)

--- a/src/makefile.mingw
+++ b/src/makefile.mingw
@@ -135,7 +135,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_file.c x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c
+    x_bytestruct.c x_file.c x_scalar.c x_vexp.c x_vexp_if.c x_vexp_fun.c
 
 SRSRC = u_pdsend.c u_pdreceive.c s_net.c
 

--- a/src/makefile.msvc
+++ b/src/makefile.msvc
@@ -95,7 +95,7 @@ SRC = g_canvas.c g_graph.c g_text.c g_rtext.c g_array.c g_template.c g_io.c \
     d_soundfile_next.c d_soundfile_wave.c \
     x_arithmetic.c x_connective.c x_interface.c x_midi.c x_misc.c \
     x_time.c x_acoustics.c x_net.c x_text.c x_gui.c x_list.c x_array.c \
-    x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
+    x_bytestruct.c x_file.c x_scalar.c  x_vexp.c x_vexp_if.c x_vexp_fun.c \
     $(SYSSRC)
 
 PADIR = ../portaudio/portaudio

--- a/src/x_bytestruct.c
+++ b/src/x_bytestruct.c
@@ -1,0 +1,1078 @@
+/* Copyright (c) 2021 IOhannes m zmölnig and others.
+ * For information on usage and redistribution, and for a DISCLAIMER OF ALL
+ * WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* The "bytestruct" object. */
+
+#include "m_pd.h"
+#include "s_utf8.h"
+#include <string.h>
+
+#if defined(__FreeBSD__) || defined(__APPLE__) || defined(__FreeBSD_kernel__) \
+    || defined(__OpenBSD__)
+# include <machine/endian.h>
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) ||    \
+    defined(ANDROID)
+# include <endian.h>
+#endif
+
+
+#ifdef __MINGW32__
+# include <sys/param.h>
+#endif
+
+#ifdef _MSC_VER
+/* _MSVC lacks BYTE_ORDER and LITTLE_ENDIAN */
+# define LITTLE_ENDIAN 0x0001
+# define BYTE_ORDER LITTLE_ENDIAN
+/* and ssize_t */
+# include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
+#if !defined(BYTE_ORDER) || !defined(LITTLE_ENDIAN)
+# error No byte order defined
+#endif
+
+#define MARK() post("%s@%d:%s", __FILE__, __LINE__, __FUNCTION__)
+
+/* float16 helpers
+   taken from https://github.com/OGRECave/ogre/blob/master/OgreMain/include/OgreBitwise.h
+   (be8c2a225ecae636c8e669a12129b603db6b0e3c)
+
+   Copyright (c) 2000-2014 Torus Knot Software Ltd
+   License: MIT
+
+   these are not perfect, as they use trunc() rather than round(),
+   unlike the python version...
+
+   a simplified version of the float32->float16 can be found on
+   https://stackoverflow.com/questions/3026441/float32-to-float16
+
+   ```
+   t_bytes_number32 f32;
+   t_bytes_number16 f16;
+   uint16_t tmp;
+   f32.f=f;
+   f16.u = (f32.u >> 31) << 5;
+   tmp = (f32.u >> 23) & 0xff;
+   tmp = (tmp - 0x70) & ((unsigned int)((int)(0x70 - tmp) >> 4) >> 27);
+   f16.u = (f16.u | tmp) << 10;
+   f16.u |= (f32.u >> 13) & 0x3ff;
+   ```
+*/
+
+    /** Converts float in uint32 format to a half in uint16 format */
+static uint16_t floatToHalfI(uint32_t i)
+{
+    int s =  (i >> 16) & 0x00008000;
+    int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+    int m =   i        & 0x007fffff;
+
+    if (e <= 0)
+    {
+        if (e < -10)
+        {
+            return 0;
+        }
+        m = (m | 0x00800000) >> (1 - e);
+
+        return (uint16_t)(s | (m >> 13));
+    }
+    else if (e == 0xff - (127 - 15))
+    {
+        if (m == 0) /* Inf */
+        {
+            return (uint16_t)(s | 0x7c00);
+        }
+        else    /* NAN */
+        {
+            m >>= 13;
+            return (uint16_t)(s | 0x7c00 | m | (m == 0));
+        }
+    }
+    else
+    {
+        if (e > 30) /* Overflow */
+        {
+            return (uint16_t)(s | 0x7c00);
+        }
+
+        return (uint16_t)(s | (e << 10) | (m >> 13));
+    }
+}
+
+    /* Converts a half in uint16 format to a float in uint32 format */
+static uint32_t halfToFloatI(uint16_t y)
+{
+    int s = (y >> 15) & 0x00000001;
+    int e = (y >> 10) & 0x0000001f;
+    int m =  y        & 0x000003ff;
+
+    if (e == 0)
+    {
+        if (m == 0) /* Plus or minus zero */
+        {
+            return s << 31;
+        }
+        else /* Denormalized number -- renormalize it */
+        {
+            while (!(m & 0x00000400))
+            {
+                m <<= 1;
+                e -=  1;
+            }
+
+            e += 1;
+            m &= ~0x00000400;
+        }
+    }
+    else if (e == 31)
+    {
+        if (m == 0) /* Inf */
+        {
+            return (s << 31) | 0x7f800000;
+        }
+        else /* NaN */
+        {
+            return (s << 31) | 0x7f800000 | (m << 13);
+        }
+    }
+
+    e = e + (127 - 15);
+    m = m << 13;
+
+    return (s << 31) | (e << 23) | m;
+}
+
+
+/* bitstruct helpers */
+
+typedef enum {
+    PAD=0,
+    CHAR,
+    SIGNED_CHAR,
+    UNSIGNED_CHAR,
+    BOOL,
+    SIGNED_SHORT,
+    UNSIGNED_SHORT,
+    SIGNED_INT,
+    UNSIGNED_INT,
+    SIGNED_LONG,
+    UNSIGNED_LONG,
+    SIGNED_LONGLONG,
+    UNSIGNED_LONGLONG,
+    SIGNED_SIZE,
+    UNSIGNED_SIZE,
+    HALFFLOAT,
+    FLOAT,
+    DOUBLE,
+    STRING,
+    WSTRING,
+    PASCALSTRING,
+    POINTER,
+    ILLEGAL
+} t_structtype;
+
+static char structtype2char(t_structtype t) {
+    switch(t) {
+    case PAD: return 'x';
+    case CHAR: return 'c';
+    case BOOL: return '?';
+    case SIGNED_CHAR: return 'b';
+    case UNSIGNED_CHAR: return 'B';
+    case SIGNED_SHORT: return 'h';
+    case UNSIGNED_SHORT: return 'H';
+    case SIGNED_INT: return 'i';
+    case UNSIGNED_INT: return 'I';
+    case SIGNED_LONG: return 'l';
+    case UNSIGNED_LONG: return 'L';
+    case SIGNED_LONGLONG: return 'q';
+    case UNSIGNED_LONGLONG: return 'Q';
+    case SIGNED_SIZE: return 'n';
+    case UNSIGNED_SIZE: return 'N';
+    case HALFFLOAT: return 'e';
+    case FLOAT: return 'f';
+    case DOUBLE: return 'd';
+    case STRING: return 's';
+    case WSTRING: return 'S';
+    case PASCALSTRING: return 'p';
+    case POINTER: return 'P';
+    default: break;
+    }
+    return 0;
+}
+static t_structtype char2structtype(char c) {
+    switch(c) {
+    case 'x': return PAD;
+    case 'c': return CHAR;
+    case '?': return BOOL;
+    case 'b': return SIGNED_CHAR;
+    case 'B': return UNSIGNED_CHAR;
+    case 'h': return SIGNED_SHORT;
+    case 'H': return UNSIGNED_SHORT;
+    case 'i': return SIGNED_INT;
+    case 'I': return UNSIGNED_INT;
+    case 'l': return SIGNED_LONG;
+    case 'L': return UNSIGNED_LONG;
+    case 'q': return SIGNED_LONGLONG;
+    case 'Q': return UNSIGNED_LONGLONG;
+    case 'n': return SIGNED_SIZE;
+    case 'N': return UNSIGNED_SIZE;
+    case 'e': return HALFFLOAT;
+    case 'f': return FLOAT;
+    case 'd': return DOUBLE;
+    case 's': return STRING;
+    case 'S': return WSTRING;
+    case 'p': return PASCALSTRING;
+    case 'P': return POINTER;
+    default: break;
+    }
+    return ILLEGAL;
+}
+
+/* size=0: evaluate at runtime */
+/* size=-1: illegal (no UNSIGNED_SIZE, SIGNED_SIZE and POINTER in 'standard' mode) */
+static const int structtype_size[][2] = {
+        /* {standard, native} */
+    {0, 0}, /* PAD */
+    {1, sizeof(char)}, /* CHAR */
+    {1, sizeof(signed char)}, /* SIGNED_CHAR */
+    {1, sizeof(unsigned char)}, /* UNSIGNED_CHAR */
+    {1, sizeof(char)}, /* BOOL */
+    {2, sizeof(short)}, /* SHORT */
+    {2, sizeof(unsigned short)}, /* UNSIGNED_SHORT */
+    {4, sizeof(int)}, /* INT */
+    {4, sizeof(unsigned int)}, /* UNSIGNED_INT */
+    {4, sizeof(long)}, /* LONG */
+    {4, sizeof(unsigned long)}, /* UNSIGNED_LONG */
+    {8, sizeof(long long)}, /* LONGLONG */
+    {8, sizeof(unsigned long long)}, /* UNSIGNED_LONGLONG */
+    {-1, sizeof(ssize_t)}, /* SIGNED_SIZE */
+    {-1, sizeof(size_t)}, /* UNSIGNED_SIZE */
+    {2, 2}, /* HALFFLOAT */
+    {4, sizeof(float)}, /* FLOAT */
+    {8, sizeof(double)}, /* DOUBLE */
+    {0, 0}, /* STRING */
+    {0, 0}, /* WSTRING */
+    {0, 0}, /* PASCALSTRING */
+    {-1, sizeof(void*)}, /* POINTER */
+    {-1, -1} /* ILLEGAL */
+};
+
+/* converter functions
+   valid byte-memory is buf[0:size-1]
+   returns 1 on success, 0 on error
+*/
+typedef int (*t_packfun)(const t_atom*inatom, unsigned char*outbuf, size_t outsize, int byteswap);
+typedef int (*t_unpackfun)(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap);
+
+typedef struct _bs_list {
+    t_structtype type;
+    t_packfun packfun; /* converter function: atom to bytes */
+    t_unpackfun unpackfun; /* converter function: bytes to atom */
+    size_t atomcount; /* number of atoms to consume */
+    size_t bytecount; /* number of bytes to consume */
+
+    struct _bs_list*next;
+} t_bs_list;
+
+typedef union {
+    signed char s;
+    unsigned char u;
+    unsigned char b[1];
+} t_bytes_number8;
+typedef union {
+    int16_t s;
+    uint16_t u;
+    unsigned char b[2];
+} t_bytes_number16;
+typedef union {
+    float f;
+    int32_t s;
+    uint32_t u;
+    unsigned char b[4];
+} t_bytes_number32;
+typedef union {
+    double f;
+    int64_t s;
+    uint64_t u;
+    unsigned char b[8];
+} t_bytes_number64;
+typedef union {
+    const void*ptr;
+    unsigned char bytes[8];
+} t_bytes_pointer;
+
+static int copy_bs(const unsigned char*src, unsigned char*dest, size_t len, int byteswap) {
+    if(byteswap) {
+        src += len-1;
+        while(len--) {
+            *dest++ = *src--;
+        }
+    } else {
+        memcpy(dest, src, len);
+    }
+    return (int)len;
+}
+#define copy_value2outbuf()                             \
+    copy_bs(value.b, outbuf, sizeof(value.b), byteswap)
+
+/* pack converters: atom -> bytes */
+static int bs_atom_pad(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    (void)a;
+    (void)byteswap;
+    memset(outbuf, 0, outsize);
+    return 1;
+}
+static int bs_atom_char(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    (void)outsize;
+    (void)byteswap;
+    switch(a->a_type) {
+    case A_FLOAT:
+        *outbuf=(char)atom_getfloat(a);
+        break;
+    case A_SYMBOL:
+        *outbuf=(char)atom_getsymbol(a)->s_name[0];
+        break;
+    default:
+        return 01;
+    }
+    return 1;
+}
+static int bs_atom_bool(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    (void)outsize;
+    (void)byteswap;
+    switch(a->a_type) {
+    case A_FLOAT:
+        *outbuf=(char)((atom_getfloat(a))!=0);
+        break;
+    case A_SYMBOL:
+        *outbuf=(atom_getsymbol(a)!=gensym(""));
+        break;
+    default:
+        return 0;
+    }
+    return 1;
+}
+static int bs_atom_float16(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    t_bytes_number32 f32;
+    t_bytes_number16 value;
+    (void)outsize;
+
+    switch(a->a_type) {
+    case A_FLOAT:
+        f32.f=atom_getfloat(a);
+        break;
+    default:
+        return 0;
+    }
+    value.u = floatToHalfI(f32.u);
+    copy_value2outbuf();
+    return 1;
+}
+
+#define bs_atom_number(typename, unionname, member, type)               \
+    static int bs_atom_##typename(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) { \
+        t_bytes_##unionname value;                                      \
+        (void)outsize;                                                  \
+        switch(a->a_type) {                                             \
+        case A_FLOAT:                                                   \
+            value.member = (type)atom_getfloat(a);                      \
+            break;                                                      \
+        default:                                                        \
+            return 0;                                                   \
+        }                                                               \
+        copy_value2outbuf();                                            \
+        return 1;                                                       \
+    }
+
+
+bs_atom_number(int8, number8, s, signed char);
+bs_atom_number(uint8, number8, u, unsigned char);
+bs_atom_number(int16, number16, s, int16_t);
+bs_atom_number(uint16, number16, u, uint16_t);
+bs_atom_number(int32, number32, s, int32_t);
+bs_atom_number(uint32, number32, u, uint32_t);
+bs_atom_number(int64, number64, s, int64_t);
+bs_atom_number(uint64, number64, u, uint64_t);
+bs_atom_number(float32, number32, f, float);
+bs_atom_number(float64, number64, f, double);
+
+static int bs_atom_string(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    const char*s=0;
+    (void)byteswap;
+    switch(a->a_type) {
+    case A_SYMBOL:
+        s=atom_getsymbol(a)->s_name;
+        break;
+    default:
+        return 0;
+    }
+    memset(outbuf, 0, outsize);
+    strncpy((char*)outbuf, s, outsize);
+    return 1;
+}
+static int bs_atom_wstring(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    uint16_t ucs2[MAXPDSTRING];
+    size_t i;
+    switch(a->a_type) {
+    case A_SYMBOL:
+        u8_utf8toucs2(ucs2, MAXPDSTRING, atom_getsymbol(a)->s_name, -1);
+        break;
+    default:
+        return 0;
+    }
+    memset(outbuf, 0, outsize);
+    if(outsize>=MAXPDSTRING)
+        outsize=MAXPDSTRING-1;
+    for(i=0; i<outsize; i++) {
+        copy_bs((const unsigned char*)(ucs2+i), outbuf+2*i, 2, byteswap);
+    }
+    return 1;
+}
+static int bs_atom_pascalstring(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    size_t len=0;
+    const char*s=0;
+    char*obuf=(char*)outbuf;
+    (void)byteswap;
+    switch(a->a_type) {
+    case A_SYMBOL:
+        s=atom_getsymbol(a)->s_name;
+        break;
+    default:
+        return 0;
+    }
+    if(!outsize)
+        return 1;
+    memset(obuf, 0, outsize);
+    len=strlen(s);
+    if(len>=outsize)
+        len=outsize-1;
+    if(len>0xFF)
+        len=0xFF;
+
+    obuf[0] = (unsigned char)(len);
+    strncpy(obuf+1, s, outsize-1);
+    return 1;
+}
+static int bs_atom_pointer(const t_atom*a, unsigned char*outbuf, size_t outsize, int byteswap) {
+    t_bytes_pointer value;
+    (void)byteswap;
+    switch(a->a_type) {
+    case A_POINTER:
+        value.ptr=a->a_w.w_gpointer;
+        break;
+    case A_SYMBOL:
+        value.ptr=atom_getsymbol(a)->s_name;
+        break;
+    default:
+        return 0;
+    }
+    memcpy(outbuf, value.bytes, outsize);
+    return 1;
+}
+
+/* pack converters: bytes -> atom */
+static int bs_pad_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    (void)inbuf;
+    (void)insize;
+    (void)outatom;
+    (void)byteswap;
+    return 1;
+}
+static int bs_char_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    char value = *inbuf;
+    (void)insize;
+    (void)byteswap;
+    SETFLOAT(outatom, value);
+    return 1;
+}
+static int bs_bool_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    char value = *inbuf;
+    (void)insize;
+    (void)byteswap;
+    SETFLOAT(outatom, value!=0);
+    return 1;
+}
+#define bs_number_atom(typename, unionname, member, type)               \
+    static int bs_##typename##_atom(const unsigned char*inbuf, size_t insize, t_atom *a, int byteswap) { \
+        t_bytes_##unionname value;                                      \
+        (void)insize;                                                   \
+        copy_bs(inbuf, value.b, sizeof(value.b), byteswap);             \
+        SETFLOAT(a, value.member);                                      \
+        return 1;                                                       \
+    }
+bs_number_atom(int8, number8, s, signed char);
+bs_number_atom(uint8, number8, u, unsigned char);
+bs_number_atom(int16, number16, s, int16_t);
+bs_number_atom(uint16, number16, u, uint16_t);
+bs_number_atom(int32, number32, s, int32_t);
+bs_number_atom(uint32, number32, u, uint32_t);
+bs_number_atom(int64, number64, s, int64_t);
+bs_number_atom(uint64, number64, u, uint64_t);
+bs_number_atom(float32, number32, f, float);
+bs_number_atom(float64, number64, f, double);
+
+
+static int bs_float16_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    t_bytes_number32 f32;
+    t_bytes_number16 value;
+    (void)insize;
+    copy_bs(inbuf, value.b, sizeof(value.b), byteswap);
+    f32.u = halfToFloatI(value.u);
+    SETFLOAT(outatom, f32.f);
+    return 1;
+}
+static int bs_string_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    char s[MAXPDSTRING];
+    (void)byteswap;
+    if(insize>=MAXPDSTRING)
+        insize=MAXPDSTRING-1;
+    strncpy(s, (char*)inbuf, insize);
+    s[insize]=0;
+
+    SETSYMBOL(outatom, gensym(s));
+    return 1;
+}
+static int bs_wstring_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    char s[MAXPDSTRING];
+    uint16_t ucs2[MAXPDSTRING];
+    size_t i;
+    if(insize>=MAXPDSTRING)
+        insize=MAXPDSTRING-1;
+    for(i=0; i<insize; i++) {
+        copy_bs(inbuf+2*i, (unsigned char*)(ucs2+i), 2, byteswap);
+    }
+    u8_ucs2toutf8(s, MAXPDSTRING, ucs2, insize);
+    s[insize]=0;
+
+    SETSYMBOL(outatom, gensym(s));
+    return 1;
+}
+static int bs_pascalstring_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    size_t len = *inbuf++;
+    char s[MAXPDSTRING];
+    (void)byteswap;
+    if(0xFF == len || len>insize)
+        len = insize;
+    if(len>=MAXPDSTRING)
+        len=MAXPDSTRING-1;
+    strncpy(s, (char*)inbuf, len);
+    SETSYMBOL(outatom, gensym(s));
+    return 1;
+}
+static int bs_pointer_atom(const unsigned char*inbuf, size_t insize, t_atom*outatom, int byteswap) {
+    const t_int*data=(void*)inbuf;
+    void*ptr = (void*)data[0];
+    char s[MAXPDSTRING];
+    (void)insize;
+    (void)byteswap;
+    sprintf(s, "%p", ptr);
+    SETSYMBOL(outatom, gensym(s));
+    return 1;
+}
+
+static t_packfun inttype2packfun(size_t bytecount, int issigned) {
+    switch (bytecount) {
+    case 1: return issigned?bs_atom_int8:bs_atom_uint8;
+    case 2: return issigned?bs_atom_int16:bs_atom_uint16;
+    case 4: return issigned?bs_atom_int32:bs_atom_uint32;
+    case 8: return issigned?bs_atom_int64:bs_atom_uint64;
+    default: break;
+    }
+    return 0;
+}
+static t_packfun floattype2packfun(size_t bytecount) {
+    switch (bytecount) {
+    case 2: return bs_atom_float16;
+    case 4: return bs_atom_float32;
+    case 8: return bs_atom_float64;
+    default: break;
+    }
+    return 0;
+}
+
+static t_packfun type2packfun(t_structtype t, int native) {
+    switch(t) {
+    case PAD: return bs_atom_pad;
+    case CHAR: return bs_atom_char;
+    case BOOL: return bs_atom_bool;
+    case SIGNED_CHAR: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_CHAR: return inttype2packfun(structtype_size[t][native], 0);
+    case SIGNED_SHORT: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_SHORT: return inttype2packfun(structtype_size[t][native], 0);
+    case SIGNED_INT: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_INT: return inttype2packfun(structtype_size[t][native], 0);
+    case SIGNED_LONG: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_LONG: return inttype2packfun(structtype_size[t][native], 0);
+    case SIGNED_LONGLONG: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_LONGLONG: return inttype2packfun(structtype_size[t][native], 0);
+    case SIGNED_SIZE: return inttype2packfun(structtype_size[t][native], 1);
+    case UNSIGNED_SIZE: return inttype2packfun(structtype_size[t][native], 0);
+
+    case HALFFLOAT: return floattype2packfun(structtype_size[t][native]);
+    case FLOAT: return floattype2packfun(structtype_size[t][native]);
+    case DOUBLE: return floattype2packfun(structtype_size[t][native]);
+
+    case STRING: return bs_atom_string;
+    case WSTRING: return bs_atom_wstring;
+    case PASCALSTRING: return bs_atom_pascalstring;
+    case POINTER: return bs_atom_pointer;
+    default: break;
+    }
+    return 0;
+}
+
+static t_unpackfun inttype2unpackfun(size_t bitsize, int issigned) {
+    switch (bitsize) {
+    case 1: return issigned?bs_int8_atom:bs_uint8_atom;
+    case 2: return issigned?bs_int16_atom:bs_uint16_atom;
+    case 4: return issigned?bs_int32_atom:bs_uint32_atom;
+    case 8: return issigned?bs_int64_atom:bs_uint64_atom;
+    default: break;
+    }
+    return 0;
+}
+static t_unpackfun floattype2unpackfun(size_t bitsize) {
+    switch (bitsize) {
+    case 2: return bs_float16_atom;
+    case 4: return bs_float32_atom;
+    case 8: return bs_float64_atom;
+    default: break;
+    }
+    return 0;
+}
+
+static t_unpackfun type2unpackfun(t_structtype t, int native) {
+    switch(t) {
+    case PAD: return bs_pad_atom;
+    case CHAR: return bs_char_atom;
+    case BOOL: return bs_bool_atom;
+    case SIGNED_CHAR: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_CHAR: return inttype2unpackfun(structtype_size[t][native], 0);
+    case SIGNED_SHORT: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_SHORT: return inttype2unpackfun(structtype_size[t][native], 0);
+    case SIGNED_INT: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_INT: return inttype2unpackfun(structtype_size[t][native], 0);
+    case SIGNED_LONG: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_LONG: return inttype2unpackfun(structtype_size[t][native], 0);
+    case SIGNED_LONGLONG: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_LONGLONG: return inttype2unpackfun(structtype_size[t][native], 0);
+    case SIGNED_SIZE: return inttype2unpackfun(structtype_size[t][native], 1);
+    case UNSIGNED_SIZE: return inttype2unpackfun(structtype_size[t][native], 0);
+
+    case HALFFLOAT: return floattype2unpackfun(structtype_size[t][native]);
+    case FLOAT: return floattype2unpackfun(structtype_size[t][native]);
+    case DOUBLE: return floattype2unpackfun(structtype_size[t][native]);
+
+    case STRING: return bs_string_atom;
+    case WSTRING: return bs_wstring_atom;
+    case PASCALSTRING: return bs_pascalstring_atom;
+    case POINTER: return bs_pointer_atom;
+    default: break;
+    }
+    return 0;
+}
+static t_bs_list*bs_free(t_bs_list*bs) {
+    while(bs) {
+        t_bs_list*next=bs->next;
+        freebytes(bs, sizeof(*bs));
+        bs=next;
+    }
+    return bs;
+}
+static t_bs_list*bs_do_new(t_structtype t, int native) {
+    t_bs_list*bs;
+    t_unpackfun ufun = type2unpackfun(t, native);
+    t_packfun pfun = type2packfun(t, native);
+    int bytecount;
+    if(!ufun || !pfun)
+        return 0;
+    bytecount = structtype_size[t][native];
+    if(bytecount<0)
+        return 0;
+    bs = getbytes(sizeof(*bs));
+    bs->type = t;
+    bs->packfun = pfun;
+    bs->unpackfun = ufun;
+    bs->atomcount = (t!=PAD);
+    bs->bytecount = bytecount;
+    bs->next = 0;
+    return bs;
+}
+static t_bs_list*bs_new(t_structtype t, unsigned int count, int native) {
+    t_bs_list*bs, *bs2;
+    if(!count) {
+        switch(t) {
+        default:
+            return 0;
+        case PASCALSTRING: case STRING: case WSTRING:
+            break;
+        }
+    }
+    bs = bs_do_new(t, native);
+    if(!bs)
+        return bs;
+    if (!bs->bytecount) {
+        switch(t) {
+        default: break;
+        case WSTRING: count *= 2;
+        }
+        bs->bytecount = count;
+        return bs;
+    }
+    bs2=bs;
+    while(--count) {
+        t_bs_list*b = bs_do_new(t, native);
+        if(!b) {
+            return bs_free(bs);
+        }
+        bs2->next = b;
+        bs2 = b;
+    }
+    return bs;
+}
+
+static void bs_print(t_bs_list*bs) {
+    while(bs) {
+        post("%c[%d] bytes=%d atoms=%d"
+             , structtype2char(bs->type)
+             , bs->type
+             , bs->bytecount
+             , bs->atomcount
+#if 0
+             , bs->packfun
+             , bs->unpackfun
+#endif
+            );
+        bs = bs->next;
+    }
+}
+
+/* ================================================================ */
+typedef struct _bytestruct {
+    t_object x_obj;
+    t_outlet*x_dataout;
+    t_outlet*x_infoout;
+
+    t_bs_list*x_bs;
+    unsigned int x_wantatoms;
+    unsigned int x_natoms;
+    t_atom*x_atoms;
+    unsigned int x_nbytes;
+    unsigned char*x_bytes;
+    int x_byteswap;
+} t_bytestruct;
+
+static t_class*bytestruct_size_class;
+static t_class*bytestruct_pack_class;
+static t_class*bytestruct_unpack_class;
+static void bytestruct_free(t_bytestruct*x);
+
+static int bytestruct_do_set(t_bytestruct*x, t_symbol*formatsym) {
+    const char*format=formatsym?formatsym->s_name:0;
+    int native = 1;
+    int bigendian =
+#if BYTE_ORDER == LITTLE_ENDIAN
+        0
+#else
+        1
+#endif
+        ;
+    const int endianness = bigendian;
+    size_t atomcount = 0, bytecount = 0;
+    t_bs_list*bs = 0;
+
+    bytestruct_free(x);
+    if(!format || !*format)
+        goto fail;
+
+        /* LATER: ignore whitespace... */
+
+        /* post("parsing bytestruct '%s'", format); */
+    switch(*format) {
+    case '@':
+        format++;
+        break;
+    case '=':
+        native = 0;
+        format++;
+        break;
+    case '<':
+        native = 0;
+        bigendian = 0;
+        format++;
+        break;
+    case '>': case '!':
+        native = 0;
+        bigendian = 1;
+        format++;
+        break;
+    default:
+        break;
+    }
+    while(*format) {
+        t_structtype structtype = ILLEGAL;
+        unsigned int count = 0;
+        t_bs_list*nextbs = 0, *tmpbs;
+        int didit=0;
+        while (*format && *format >= '0' && *format <= '9') {
+            count=10*count + (*format++-'0');
+            didit=1;
+        }
+            /* default count = 1 */
+        if (!count && !didit) count=1;
+        structtype = char2structtype(*format++);
+        if(native && structtype && structtype<ILLEGAL && bytecount) {
+                /* we might need padding */
+            int alignment = structtype_size[structtype][native];
+            if(alignment>0 && bytecount % alignment) {
+                int padding = alignment-(bytecount%alignment);
+                nextbs=bs_new(PAD, padding, native);
+                if(!nextbs) goto fail;
+                bytecount+=padding;
+                bs->next = nextbs;
+                for(; bs->next; bs=bs->next);
+            }
+        }
+        nextbs = bs_new(structtype, count, native);
+        if(!nextbs){
+            if(count)
+                goto fail;
+            continue;
+        }
+
+        for(tmpbs=nextbs; tmpbs; tmpbs=tmpbs->next) {
+            atomcount += tmpbs->atomcount;
+            bytecount += tmpbs->bytecount;
+        }
+        if(!bs) {
+            bs=nextbs;
+        } else {
+            bs->next = nextbs;
+        }
+        if(!x->x_bs)
+            x->x_bs = bs;
+        for(; bs->next; bs=bs->next);
+    }
+    x->x_wantatoms = atomcount;
+        /* we allocate enough atoms so we can use it for both the
+         * output of 'unpack' (atom list) and the
+         * output of 'pack' (byte list)
+         */
+    if(bytecount>atomcount)
+        atomcount=bytecount;
+    x->x_atoms = getbytes(atomcount*sizeof(*x->x_atoms));
+    if(x->x_atoms) x->x_natoms=atomcount;
+
+    x->x_bytes = getbytes(bytecount*sizeof(*x->x_bytes));
+    if(x->x_bytes) x->x_nbytes=bytecount;
+    x->x_byteswap = (endianness != bigendian);
+    return 1;
+fail:
+    bytestruct_free(x);
+    x->x_wantatoms=(unsigned int)-1;
+    return 0;
+
+}
+static void bytestruct_set(t_bytestruct*x, t_symbol*formatsym) {
+    bytestruct_do_set(x, formatsym);
+}
+static void bytestruct_dump(t_bytestruct*x) {
+    post("bytes=%d", x->x_nbytes);
+    post("atoms=%d [%d]", x->x_wantatoms, x->x_natoms);
+    post("byteswap=%d", x->x_byteswap);
+    bs_print(x->x_bs);
+}
+
+static void bytestruct_free(t_bytestruct*x) {
+    x->x_bs = bs_free(x->x_bs);
+
+    if(x->x_natoms) {
+        freebytes(x->x_atoms, x->x_natoms * sizeof(*x->x_atoms));
+    }
+    x->x_natoms = 0;
+    x->x_atoms = 0;
+    x->x_wantatoms = 0;
+
+    if(x->x_nbytes) {
+        freebytes(x->x_bytes, x->x_nbytes * sizeof(*x->x_bytes));
+    }
+    x->x_nbytes = 0;
+    x->x_bytes = 0;
+}
+
+static void bytestruct_pack_list(t_bytestruct*x, t_symbol*s, int argc, t_atom*argv) {
+    t_bs_list*bs;
+    unsigned char*buffer=x->x_bytes;
+    (void)s;
+    if(!x->x_bs && x->x_wantatoms) {
+        pd_error(x, "illegal struct specification");
+        outlet_bang(x->x_infoout);
+        return;
+    }
+    if(x->x_wantatoms != (unsigned int)argc) {
+        pd_error(x, "expected %d atoms, but got %d", x->x_wantatoms, argc);
+        outlet_bang(x->x_infoout);
+        return;
+    }
+    for(bs = x->x_bs; bs; bs=bs->next) {
+        if(!bs->packfun(argv, buffer, bs->bytecount, x->x_byteswap)) {
+            pd_error(x, "failed to convert atom");
+            outlet_bang(x->x_infoout);
+            return;
+        }
+        argv+=bs->atomcount;
+        buffer+=bs->bytecount;
+    }
+    for(size_t i=0;i<x->x_nbytes;i++) {
+        SETFLOAT(x->x_atoms+i, x->x_bytes[i]);
+    }
+    outlet_list(x->x_dataout, gensym("list"), x->x_nbytes, x->x_atoms);
+}
+
+static void bytestruct_unpack_list(t_bytestruct*x, t_symbol*s, int argc, t_atom*argv) {
+    t_bs_list*bs;
+    unsigned char*buffer=x->x_bytes;
+    int i;
+    (void)s;
+    if(!x->x_bs && x->x_wantatoms) {
+        pd_error(x, "illegal struct specification");
+        outlet_bang(x->x_infoout);
+        return;
+    }
+
+    if(x->x_nbytes != (unsigned int)argc) {
+        pd_error(x, "expected %d atoms, but got %d", x->x_nbytes, argc);
+        outlet_bang(x->x_infoout);
+        return;
+    }
+    for(i=0;i<argc;i++) {
+        t_float f=atom_getfloat(argv+i);
+        if(argv[i].a_type != A_FLOAT ||
+           (f<0 || f>255)) {
+            pd_error(x, "invalid atom#%d: must be a number 0..255!", i);
+            return;
+        }
+        buffer[i] = (char)f;
+    }
+
+    buffer = x->x_bytes;
+    argv = x->x_atoms;
+    for(bs = x->x_bs; bs; bs=bs->next) {
+        if(!bs->unpackfun(buffer, bs->bytecount, argv, x->x_byteswap)) {
+            pd_error(x, "failed to convert atom");
+            outlet_bang(x->x_infoout);
+            return;
+        }
+        argv+=bs->atomcount;
+        buffer+=bs->bytecount;
+    }
+    outlet_list(x->x_dataout, gensym("list"), x->x_wantatoms, x->x_atoms);
+}
+
+static void bytestruct_size_bang(t_bytestruct*x) {
+    if(!x->x_bs && x->x_wantatoms) {
+        pd_error(x, "illegal struct specification");
+        outlet_bang(x->x_infoout);
+    } else {
+        outlet_float(x->x_dataout, x->x_nbytes);
+    }
+}
+static void bytestruct_size_symbol(t_bytestruct*x, t_symbol*s) {
+    bytestruct_do_set(x, s);
+    bytestruct_size_bang(x);
+}
+static t_pd*bytestruct_do_new(t_class*c, t_symbol*s) {
+    t_bytestruct*x=(t_bytestruct*)pd_new(c);
+    x->x_dataout = outlet_new((t_object*)x, 0);
+    x->x_infoout = outlet_new((t_object*)x, 0);
+    bytestruct_set(x, s);
+    return (t_pd*)x;
+}
+static t_pd*bytestruct_size_new(t_symbol*s) {
+    return bytestruct_do_new(bytestruct_size_class, s);
+}
+static t_pd*bytestruct_pack_new(t_symbol*s) {
+    t_pd*x=bytestruct_do_new(bytestruct_pack_class, s);
+    inlet_new((t_object*)x, x, gensym("symbol"), gensym("set"));
+    return x;
+}
+static t_pd*bytestruct_unpack_new(t_symbol*s) {
+    t_pd*x=bytestruct_do_new(bytestruct_unpack_class, s);
+    inlet_new((t_object*)x, x, gensym("symbol"), gensym("set"));
+    return x;
+}
+
+static t_pd*bytestruct_new(t_symbol*s, int argc, t_atom*argv) {
+    t_symbol*verb = atom_getsymbolarg(0, argc, argv);
+    if(argc<1 || argc>2 || A_SYMBOL != argv[0].a_type) {
+        goto fail;
+    }
+    s = atom_getsymbol(argv+0);
+    if (0) ;
+    else if (!strcmp("pack", verb->s_name))
+        return bytestruct_pack_new(atom_getsymbolarg(1, argc, argv));
+    else if (!strcmp("unpack", verb->s_name))
+        return bytestruct_unpack_new(atom_getsymbolarg(1, argc, argv));
+    else if (!strcmp("size", verb->s_name))
+        return bytestruct_size_new(atom_getsymbolarg(1, argc, argv));
+fail:
+    pd_error(0, "%s: valid verbs are 'pack', 'unpack' 'size'", s->s_name);
+    return 0;
+}
+
+void x_bytestruct_setup(void)
+{
+    class_addcreator((t_newmethod)bytestruct_new, gensym("bytestruct"), A_GIMME, 0);
+
+        /* [bytestruct size] */
+    bytestruct_size_class = class_new(
+        gensym("bytestruct size"),
+        (t_newmethod)bytestruct_size_new,
+        (t_method)bytestruct_free,
+        sizeof(t_bytestruct),
+        0,
+        A_DEFSYM, 0);
+    class_addbang(bytestruct_size_class, (t_method)bytestruct_size_bang);
+    class_addsymbol(bytestruct_size_class, (t_method)bytestruct_size_symbol);
+
+        /* [bytestruct pack] */
+    bytestruct_pack_class = class_new(
+        gensym("bytestruct pack"),
+        (t_newmethod)bytestruct_pack_new,
+        (t_method)bytestruct_free,
+        sizeof(t_bytestruct),
+        0,
+        A_DEFSYM, 0);
+    class_addlist(bytestruct_pack_class, (t_method)bytestruct_pack_list);
+    class_addmethod(bytestruct_pack_class, (t_method)bytestruct_set,
+                    gensym("set"), A_SYMBOL, 0);
+
+        /* [bytestruct unpack] */
+    bytestruct_unpack_class = class_new(
+        gensym("bytestruct unpack"),
+        (t_newmethod)bytestruct_unpack_new,
+        (t_method)bytestruct_free,
+        sizeof(t_bytestruct),
+        0,
+        A_DEFSYM, 0);
+    class_addlist(bytestruct_unpack_class, (t_method)bytestruct_unpack_list);
+    class_addmethod(bytestruct_unpack_class, (t_method)bytestruct_set,
+                    gensym("set"), A_SYMBOL, 0);
+
+
+    class_addmethod(bytestruct_pack_class, (t_method)bytestruct_dump,
+                    gensym("dump"), 0);
+    class_addmethod(bytestruct_unpack_class, (t_method)bytestruct_dump,
+                    gensym("dump"), 0);
+    class_addmethod(bytestruct_size_class, (t_method)bytestruct_dump,
+                    gensym("dump"), 0);
+
+    class_sethelpsymbol(bytestruct_size_class, gensym("bytestruct"));
+    class_sethelpsymbol(bytestruct_pack_class, gensym("bytestruct"));
+    class_sethelpsymbol(bytestruct_unpack_class, gensym("bytestruct"));
+}


### PR DESCRIPTION
(reboot of #1360, rebased on current `master` (3810461b9faf5c0d2559bcd0bb6e059543e5aa71), moved the source of the PR from the main Pd repository to my personal fork)

---

Pd has a couple of objects to convert between binary data and Pd messages (`list {to,form}symbol`, `osc{parse,format}`, `fudi{parse,format}`,...)

this PR adds another - more generic - one: `bytestruct`.
it allows one to specify a memory layout of a [POD structure](https://en.wikipedia.org/wiki/Passive_data_structure) via a format-string, and it will turn lists of bytes into an atom-list according to this definition.

It is closely modelled after the [Python `struct` standard library](https://docs.python.org/3/library/struct.html)

as with `text`, `array`, `list` & `file`, the `bytestruct` uses verbs to distinguish between different modes of operation:

- `[bytestruct pack]` turns a general atom-list into a bytelist
- `[bytestruct unpack]` turns a bytelist back into a general atom-list
- `[bytestruct size]` returns the number of bytes required to represent the structure

the format specification is rather flexible and can express, integers (8bit, 16bit, 32bit, 64bit; all signed and unsigned), floats (16bit(!), 32bit, 64bit), strings (wchar[], char[], pascal strings), bools, bytes and padding bytes (that are present in the binary representation but are ignored otherwise).

### limitations
the struct format string, describes a fixed-sized struct. while this is quite flexible, it does not lend itself to variable size-data (zero-terminated strings, run-length encoded data).

### examples
the help-patch comes with some examples:
- creating/parsing OSC-bundles
- reading a WAV file info (using the `fmt` chunk)
- reading loops from a WAV-file (using the `smpl` chunk)