### PR TITLE
new API functions for thread-safe messaging

### DIFF
--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -236,6 +236,9 @@ typedef struct _atom
     union word a_w;
 } t_atom;
 
+EXTERN_STRUCT _pdinstance;
+#define t_pdinstance struct _pdinstance
+
 EXTERN_STRUCT _class;
 #define t_class struct _class
 
@@ -648,11 +651,23 @@ EXTERN int sys_close(int fd);
 EXTERN FILE *sys_fopen(const char *filename, const char *mode);
 EXTERN int sys_fclose(FILE *stream);
 
-/* ------------  threading ------------------- */
+/* ------------- threading ------------------- */
+
+/* NB: do not use this in externals because it may deadlock!
+ * For a safe alternative see pd_queue_mess() */
 EXTERN void sys_lock(void);
 EXTERN void sys_unlock(void);
 EXTERN int sys_trylock(void);
 
+typedef void (*t_messfn)(t_pd *obj, void *data);
+/* send a message to a Pd object from another (helper) thread.
+ * 'fn' will be called on the scheduler thread with 'obj' and 'data'.
+ * If the message has been canceled, the 'obj' argument is NULL, see
+ * pd_queue_cancel() below. NB: do not forget to free the 'data' object! */
+EXTERN void pd_queue_mess(struct _pdinstance *instance, t_pd *obj, void *data, t_messfn fn);
+/* cancel all pending messages for the given object;
+ * typically called in the object destructor AFTER joining the helper thread. */
+EXTERN void pd_queue_cancel(t_pd *obj);
 
 /* --------------- signals ----------------------------------- */
 
@@ -1009,7 +1024,6 @@ struct _pdinstance
     int pd_islocked;
 #endif
 };
-#define t_pdinstance struct _pdinstance
 EXTERN t_pdinstance pd_maininstance;
 
 /* m_pd.c */

--- a/src/m_sched.c
+++ b/src/m_sched.c
@@ -285,6 +285,8 @@ int sched_get_using_audio(void)
     return sched_useaudio;
 }
 
+void messqueue_dispatch();
+
     /* take the scheduler forward one DSP tick, also handling clock timeouts */
 void sched_tick(void)
 {
@@ -308,6 +310,7 @@ void sched_tick(void)
             return;
     }
     pd_this->pd_systime = next_sys_time;
+    messqueue_dispatch();
     dsp_tick();
     sched_counter++;
 }

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -125,6 +125,16 @@ typedef struct _guiqueue
     struct _guiqueue *gq_next;
 } t_guiqueue;
 
+#if PDTHREADS
+typedef struct _messqueue
+{
+    t_pd *m_obj;
+    void *m_data;
+    t_messfn m_fn;
+    struct _messqueue *m_next;
+} t_messqueue;
+#endif
+
 struct _instanceinter
 {
     int i_havegui;
@@ -149,6 +159,9 @@ struct _instanceinter
 #endif
 #if PDTHREADS
     pthread_mutex_t i_mutex;
+    pthread_mutex_t i_messqueue_mutex;
+    t_messqueue *i_messqueue_head;
+    t_messqueue *i_messqueue_tail;
 #endif
 
     unsigned char i_recvbuf[NET_MAXPACKETSIZE];
@@ -1856,6 +1869,7 @@ void s_inter_newpdinstance(void)
     INTER = getbytes(sizeof(*INTER));
 #if PDTHREADS
     pthread_mutex_init(&INTER->i_mutex, NULL);
+    pthread_mutex_init(&INTER->i_messqueue_mutex, NULL);
     pd_this->pd_islocked = 0;
 #endif
 #ifdef _WIN32
@@ -1876,6 +1890,16 @@ void s_inter_free(t_instanceinter *inter)
     }
 #if PDTHREADS
     pthread_mutex_destroy(&inter->i_mutex);
+        /* flush message queue */
+    while (inter->i_messqueue_head)
+    {
+        t_messqueue *m = inter->i_messqueue_head, *next = m->m_next;
+            /* m_fn is responsible for freeing m_data */
+        m->m_fn(NULL, m->m_data);
+        freebytes(m, sizeof(*m));
+        inter->i_messqueue_head = next;
+    }
+    pthread_mutex_destroy(&inter->i_messqueue_mutex);
 #endif
     freebytes(inter, sizeof(*inter));
 }
@@ -1966,6 +1990,55 @@ int sys_trylock(void)
 #endif
 }
 
+void pd_queue_mess(struct _pdinstance *instance, t_pd *obj, void *data, t_messfn fn)
+{
+    t_instanceinter *inter = instance->pd_inter;
+    t_messqueue *m = (t_messqueue *)getbytes(sizeof(*m));
+    m->m_obj = obj;
+    m->m_data = data;
+    m->m_fn = fn;
+    m->m_next = 0;
+    pthread_mutex_lock(&inter->i_messqueue_mutex);
+    if (inter->i_messqueue_tail) /* add to tail */
+        inter->i_messqueue_tail = (inter->i_messqueue_tail->m_next = m);
+    else /* empty queue */
+        inter->i_messqueue_head = inter->i_messqueue_tail = m;
+    pthread_mutex_unlock(&inter->i_messqueue_mutex);
+}
+
+void pd_queue_cancel(t_pd *obj)
+{
+    t_messqueue *m;
+    pthread_mutex_lock(&INTER->i_messqueue_mutex);
+    for (m = INTER->i_messqueue_head; m; m = m->m_next)
+    {
+        if (m->m_obj == obj)
+            m->m_obj = NULL; /* mark as canceled */
+    }
+    pthread_mutex_unlock(&INTER->i_messqueue_mutex);
+}
+
+void messqueue_dispatch(void)
+{
+    t_messqueue *m, *next;
+        /* first unlink all messages */
+    pthread_mutex_lock(&INTER->i_messqueue_mutex);
+    m = INTER->i_messqueue_head;
+    INTER->i_messqueue_head = INTER->i_messqueue_tail = NULL;
+    pthread_mutex_unlock(&INTER->i_messqueue_mutex);
+        /* then dispatch (without lock!) */
+    while (m)
+    {
+            /* NB: if the message has been canceled, m_obj is NULL;
+            we still need to call m_fn because it is responsible
+            for freeing the data! */
+        next = m->m_next;
+        m->m_fn(m->m_obj, m->m_data);
+        freebytes(m, sizeof(*m));
+        m = next;
+    }
+}
+
 #else /* PDTHREADS */
 
 #ifdef TEST_LOCKING /* run standalone Pd with this to find deadlocks */
@@ -1987,5 +2060,15 @@ void sys_unlock(void) {}
 #endif
 void pd_globallock(void) {}
 void pd_globalunlock(void) {}
+
+    /* doesn't really make sense without threads... */
+void pd_queue_mess(struct _pdinstance instance, t_pd *obj, void *data, t_messfn fn)
+{
+    fn(obj, data);
+}
+
+void pd_queue_cancel(t_pd *obj) {}
+
+void messqueue_dispatch(void) {}
 
 #endif /* PDTHREADS */


### PR DESCRIPTION
Currently, there is no obvious and safe way for posting a message from a helper thread to a Pd object.

People sometimes try to execute code between a pair of  `sys_lock` + `sys_unlock`, but this can actually deadlock when you join the thread. The correct solution would be to implement your own thread-safe queue and poll it regularly with a clock; this is neither obvious nor trivial.

Therefore I propose the following API:

* `EXTERN void pd_queue_mess(struct _pdinstance *instance, t_pd *obj, void *data, t_messfn fn)`

  This sends a message to a Pd object from another (helper) thread. `fn`will be called on the scheduler thread with `obj` and `data`.  If the message has been canceled, the `obj` argument is `NULL`; the function will still be called because it is reponsible for freeing the message data.

* `EXTERN void pd_queue_cancel(t_pd *obj)`

  Cancel all pending messages for the given object. This would be typically called in the object destructor AFTER joining the helper thread.

As you can see, the implementation is very simple.

---

This PR is somewhat related to https://github.com/pure-data/pure-data/pull/1357. Ideally we would have both. #1357 should really be preferred for any kind of asynchronous command; this API would be more useful in situations where an object receives a continuous stream of data from another thread (e.g. a websocket server).