### PR TITLE
stable development branch

### DIFF
--- a/doc/5.reference/writesf~-help.pd
+++ b/doc/5.reference/writesf~-help.pd
@@ -57,8 +57,8 @@
 #X text 42 478 The soundfile is uncompressed 2- or 3-byte integer ("pcm") or 4- or 8-byte floating point. The soundfile format is determined by the file extension (ie. "foo.wav" \, "foo.aiff" \, "foo.caf" \, "foo.snd")., f 80;
 #N canvas 809 273 480 224 8-byte 0;
 #X text 19 62 The precision of the 8-byte samples is based on the precision of the Pure Data build. If Pd is single precision (using 32-bit float internally) \, the written samples will be cast from 4-byte float to 8-byte double when writing to a file with -bytes 8 argument. In this case it's better to write with 4-byte float samples for a smaller file with the same precision., f 63;
-#X text 19 159 if Pd is double-precision \, writing 8-byte float samples will be full precision as Pd uses 64-bit float internally., f 63;
-#X text 19 19 Writing 8-byte (ie. 64-bit) floating point samples are supported for the .wave \, .aiff/.aifc and .caf file types.;
+#X text 19 159 If Pd is double-precision \, writing 8-byte float samples will be full precision as Pd uses 64-bit float internally., f 63;
+#X text 19 19 Writing 8-byte (ie. 64-bit) floating point samples are supported for the wave \, aiff/aifc \, and caf file types.;
 #X restore 470 175 pd 8-byte float;
 #X text 101 175 -bytes <2 \, 3 \, 4 \, or 8> (number of bytes resolution);
 #X text 241 193 (affects the soundfile header but the file is NOT resampled), f 30;

--- a/portaudio/README.txt
+++ b/portaudio/README.txt
@@ -1,3 +1,5 @@
+# PortAudio
+
 The cross-platform PortAudio library is included with the PureData distribution
 so that Pd can be built without any main external dependencies.
 
@@ -5,6 +7,10 @@ It is built as a libtool convenience library when using autotools to build Pd:
 
     ./configure
     make
+
+For more info on PortAudio, see http://portaudio.com
+
+## Updating
 
 If you want to update to a newer version of PortAudio, simply use the
 "update.sh" script:
@@ -21,9 +27,9 @@ You *may* need to add or remove source file or header lines in the Makefile.am,
 if the source or include files have changed in PortAudio. To check the current
 git revision, see "portaudio/src/common/pa_gitrevision.h"
 
+## System-installed PortAudio
+
 As a second option, you can build Pd using a system-installed PortAudio via:
 
     ./configure --without-local-portaudio
     make
-
-For more info on PortAudio, see http://portaudio.com

--- a/portaudio/update.sh
+++ b/portaudio/update.sh
@@ -36,43 +36,49 @@ copysrc() {
 }
 
 usage() {
-    cat <<EOF 1>&2
-Usage: $0 [OPTIONS] [<VERSION>]
+cat <<EOF 1>&2
+Usage: $0 [OPTIONS] [VERSION]
 
-OPTIONS
-   -f       : force (do not abort if '${DEST}/' exists)
-              this updates existing files but keeps removed files.
-              only use this if you know what you are doing!
+Options:
+   -h      display this help message
 
-   <VERSION>  : tag/commitish of portaudio to import
+   -f      force (do not abort if '${DEST}/' exists)
+           this updates existing files but keeps removed files,
+           only use this if you know what you are doing!
+
+Arguments:
+
+VERSION    tag/commit/branch of portaudio to import
+
 EOF
 }
 
-
-##### GO
+##### ARGUMENTS
 
 force=no
 OPTIND=1
 while getopts ":hf" opt; do
-  case "$opt" in
-    h)
-      usage
-      exit 0
-      ;;
-    f)
-      force=yes
-      ;;
-    '?')
-      usage
-      exit 1
-      ;;
+    case "$opt" in
+        h)
+            usage
+            exit 0
+            ;;
+        f)
+            force=yes
+            ;;
+        '?')
+            usage
+            exit 1
+            ;;
     esac
 done
-shift "$((OPTIND-1))" # Shift off the options and optional --.
+shift "$((OPTIND-1))" # Shift off the options and optional --
 
 if [ $# -gt 0 ] ; then
     VERSION="$1"
 fi
+
+##### GO
 
 # move to this scripts dir
 scriptdir=$(dirname "$0")
@@ -80,14 +86,14 @@ cd "${scriptdir}"
 
 # check if target exists
 if [ -d "${DEST}" ]; then
-	echo "Destination '${DEST}' exists" 1>&2
-	if [ "${force}" = "yes" ]; then
-		echo "	forced to update existing files" 1>&2
-	else
-		echo "  Please remove '$(pwd)/${DEST}' before running $0" 1>&2
-		echo "  Or check the '-h' flag" 1>&2
-		exit 1
-	fi
+    echo "Destination '${DEST}' exists" 1>&2
+    if [ "${force}" = "yes" ]; then
+        echo "  forced to update existing files" 1>&2
+    else
+        echo "  Please remove '$(pwd)/${DEST}' before running $0" 1>&2
+        echo "  or check the '-h' flag" 1>&2
+        exit 1
+    fi
 fi
 
 # clone source
@@ -104,8 +110,8 @@ fi
 
 # set git revision
 if [ -f "${SRC}"/update_gitrevision.sh ] ; then
-	echo "==== Set git revision"
-	cd "${SRC}" && ./update_gitrevision.sh && cd -
+    echo "==== Set git revision"
+    cd "${SRC}" && ./update_gitrevision.sh && cd -
 fi
 
 echo "==== Copying"

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -207,7 +207,7 @@ unsigned int sys_getversion(int *major, int *minor, int *bugfix)
     if (bugfix)
         *bugfix = PD_BUGFIX_VERSION;
 
-    return PD_CODE_VERSION;
+    return PD_VERSION_CODE;
 }
 
 unsigned int sys_getfloatsize()

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -14,13 +14,13 @@ extern "C" {
 #define PD_TEST_VERSION "test2"
 
 /* compile-time version check:
-   #if PD_CODE_VERSION < PD_VERSION(0, 56, 0)
+   #if PD_VERSION_CODE < PD_VERSION(0, 56, 0)
       // put legacy code for Pd<<0.56 in here
    #endif
  */
 #define PD_VERSION(major, minor, bugfix) \
     (((major) << 16) + ((minor) << 8) + ((bugfix) > 255 ? 255 : (bugfix)))
-#define PD_CODE_VERSION PD_VERSION(PD_MAJOR_VERSION, PD_MINOR_VERSION, PD_BUGFIX_VERSION)
+#define PD_VERSION_CODE PD_VERSION(PD_MAJOR_VERSION, PD_MINOR_VERSION, PD_BUGFIX_VERSION)
 
 extern int pd_compatibilitylevel;   /* e.g., 43 for pd 0.43 compatibility */
 


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts. use the `documentation` branch for updating the documentation).

it supersedes https://github.com/pure-data/pure-data/pull/2299

---

### core

- rename `PD_CODE_VERSION` back to `PD_VERSION_CODE` (the version-extraction code has been fixed!)

### vendored libraries

- update portaudio updater script (indentation,...)

### docs

- small clarification in `writesf~-help.pd`