### PR TITLE
Fix a typo in example patch 05 in data structures

### DIFF
--- a/doc/4.data.structures/05.symbol.text.pd
+++ b/doc/4.data.structures/05.symbol.text.pd
@@ -1,6 +1,6 @@
 #N struct template5a float x float y symbol sym;
 #N struct template5b float x float y text bla;
-#N canvas 343 24 628 655 12;
+#N canvas 343 25 628 627 12;
 #X text 406 607 Updated for Pd version 0.52;
 #N canvas 972 30 304 326 data5 1;
 #X scalar template5a 50 50 banana \;;
@@ -92,9 +92,9 @@
 #X text 371 448 <-- open to see how it works.;
 #X obj 197 271 bng 19 250 50 0 empty empty empty 17 7 0 10 #dfdfdf #000000 #000000;
 #X text 20 11 Besides floats \, scalars can have other data types \, namely: symbols \, text and arrays. This example shows how to deal with symbols and text. A text can have many lines with lists of one or more elements (symbols and/or floats)., f 82;
-#X text 20 60 Unlike floa fields \, that you can set when adding an item with [append] \, you can only use the [set] object to set symbol values and the [text set] object to set texts. When setting a symbol with [set] \, you need the "-symbol" flag and you can't set floats and symbols with the same [set] object. For [text] \, you need to use the "-s" flag to deal with Data Structures. Check also the help file of [text] to see how to use [text get] to get values from text fields., f 82;
 #X text 20 154 We now have two separate templates mixed in the same collection on [pd data5]. See that [pointer] can have an argument to specify a particular template \, we use it to traverse the two scalars containing symbols. Another feature of [pointer] here is to use the "send" message to send the pointer to a [get] object., f 82;
 #X text 472 493 get pointer;
+#X text 20 60 Unlike float fields \, that you can set when adding an item with [append] \, you can only use the [set] object to set symbol values and the [text set] object to set texts. When setting a symbol with [set] \, you need the "-symbol" flag and you can't set floats and symbols with the same [set] object. For [text] \, you need to use the "-s" flag to deal with Data Structures. Check also the help file of [text] to see how to use [text get] to get values from text fields., f 82;
 #X connect 2 0 5 0;
 #X connect 3 0 2 0;
 #X connect 8 0 29 0;


### PR DESCRIPTION
The word float was missing a 't'. This applies to a comment in the second paragraph.