### PR TITLE
Fix scheduler when audio device numbers are out of range

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -389,7 +389,7 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     jack_didshutdown = 0;
     jack_dio_error = 0;
 
-    if ((inchans == 0) && (outchans == 0)) return 0;
+    if ((inchans == 0) && (outchans == 0)) return 1;
 
     if (outchans > MAX_JACK_PORTS) {
         pd_error(0, "JACK: %d output ports not supported, setting to %d",

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -356,6 +356,12 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
                 devno++;
             }
         }
+        if (pa_indev == -1)
+        {
+            inchans = 0;
+            pd_error(0, "audio input device number (%d) out of range",
+                indeviceno);
+        }
     }
 
     if (outchans > 0)
@@ -376,12 +382,13 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
                 devno++;
             }
         }
+        if (pa_outdev == -1)
+        {
+            outchans = 0;
+            pd_error(0, "audio output device number (%d) out of range",
+                outdeviceno);
+        }
     }
-
-    if (inchans > 0 && pa_indev == -1)
-        inchans = 0;
-    if (outchans > 0 && pa_outdev == -1)
-        outchans = 0;
 
     logpost(NULL, PD_VERBOSE, "input device %d, channels %d", pa_indev, inchans);
     logpost(NULL, PD_VERBOSE, "output device %d, channels %d", pa_outdev, outchans);

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -395,6 +395,9 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     logpost(NULL, PD_VERBOSE, "framesperbuf %d, nbufs %d", framesperbuf, nbuffers);
     logpost(NULL, PD_VERBOSE, "rate %d", rate);
 
+    if (!inchans && !outchans)
+        return (1);
+
     pa_inchans = STUFF->st_inchannels = inchans;
     pa_outchans = STUFF->st_outchannels = outchans;
     pa_soundin = soundin;
@@ -408,9 +411,6 @@ int pa_open_audio(int inchans, int outchans, int rate, t_sample *soundin,
     pa_sem = sys_semaphore_create();
 #endif
     pa_lastdactime = 0;
-
-    if (!inchans && !outchans)
-        return (0);
 
     if (callbackfn)
     {


### PR DESCRIPTION
portaudio: warn if audio device numbers are out of range

portaudio/jack: return failure if there is no input and output device, so that the scheduler is set to `SCHED_AUDIO_NONE`.