### PR TITLE
stable development branch

### DIFF
--- a/tcl/pd_guiprefs.tcl
+++ b/tcl/pd_guiprefs.tcl
@@ -68,12 +68,13 @@ proc ::pd_guiprefs::init {} {
     switch -- $::platform {
         "Darwin" {
             set backend "plist"
-            # on macOS the domain should be the same as the bundle ID
-            catch {
-                set ::pd_guiprefs::domain [exec defaults read
-                                           [file join $::sys_guidir .. .. Info]
-                                           CFBundleIdentifier]
-            }
+            ## on macOS the domain should be the same as the bundle ID
+            ## (disabled for now, as it slows down startup by several seconds)
+            #catch {
+            #    set ::pd_guiprefs::domain [exec defaults read
+            #                               [file join $::sys_guidir .. .. Info]
+            #                               CFBundleIdentifier]
+            #}
         }
         "W32" {
             set backend "registry"


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts. use the `documentation` branch for updating the documentation).

it supersedes https://github.com/pure-data/pure-data/pull/2306

---

### core

- disable dynamic guiprefs domains on macOS (Fixes the extraordinarily long startup time on macOS 14)