### PR TITLE
Fix read at index -1 in [sigmund~]

### DIFF
--- a/extra/sigmund~/sigmund~.c
+++ b/extra/sigmund~/sigmund~.c
@@ -488,9 +488,9 @@ static void sigmund_getpitch(int npeak, t_peak *peakv, t_float *freqp,
 
         /* first guess by parabolic peak fitting */
     fbestbin = bestbin + (ppt[bestbin+1].p_weight
-        - ppt[bestbin-1].p_weight) /
+        - ppt[bestbin == 0 ? 0 : bestbin-1].p_weight) /
             (ppt[bestbin+1].p_weight +  ppt[bestbin].p_weight +
-                ppt[bestbin-1].p_weight);
+                ppt[bestbin == 0 ? 0 : bestbin-1].p_weight);
 
     freq = 2*fperbin * exp((LOG2/STEPSPEROCTAVE)*fbestbin);
     for (sumamp = sumweight = sumfreq = 0, i = 0; i < nsalient; i++)


### PR DESCRIPTION
If bestbin comes back at index 0, it will try to read the adjacent bin at index bestbin-1, which is out of bounds.

Instead, if bestbin is 0, we can just sample bin 0 twice. This solves the memory error, and should lead to well defined behaviour if bestbin equals 0.