### PR TITLE
restore old behavior of "quit" message and add new "exit" message

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -3321,7 +3321,7 @@ void glob_verifyquit(void *dummy, t_floatarg f)
             ".pdwindow",
             1, &msg,
             "pd quit", "yes");
-    else glob_quit(0);
+    else glob_exit(0, 0);
 }
 
     /* close a window (or possibly quit Pd), checking for dirty flags.

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -15,6 +15,7 @@ int pd_compatibilitylevel = 100000;  /* e.g., 43 for pd 0.43 compatibility */
 over.  Some others are prototyped in m_imp.h as well. */
 
 void glob_menunew(void *dummy, t_symbol *name, t_symbol *dir);
+void glob_quit(void *dummy, t_floatarg status);
 void glob_verifyquit(void *dummy, t_floatarg f);
 void glob_dsp(void *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_key(void *dummy, t_symbol *s, int ac, t_atom *av);
@@ -131,7 +132,8 @@ void glob_init(void)
         A_SYMBOL, A_SYMBOL, 0);
     class_addmethod(glob_pdobject, (t_method)glob_open, gensym("open"),
         A_SYMBOL, A_SYMBOL, A_DEFFLOAT, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_exit, gensym("quit"), A_DEFFLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_quit, gensym("quit"), A_DEFFLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_exit, gensym("exit"), A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_verifyquit,
         gensym("verifyquit"), A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_foo, gensym("foo"), A_GIMME, 0);

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -107,7 +107,6 @@ void pd_globalunlock(void);
 
 EXTERN t_pd *glob_evalfile(t_pd *ignore, t_symbol *name, t_symbol *dir);
 EXTERN void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv);
-EXTERN void glob_quit(void *dummy); /* glob_exit(0); */
 EXTERN void glob_exit(void *dummy, t_float status);
 EXTERN void glob_watchdog(void *dummy); /* glob_exit(0); */
 EXTERN void open_via_helppath(const char *name, const char *dir);

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1758,7 +1758,7 @@ void sys_setrealtime(const char *libdir)
 void sys_do_close_audio(void);
 
 /* This is called when something bad has happened, like a segfault.
-Call glob_quit() below to exit cleanly.
+Call glob_exit() below to exit cleanly.
 LATER try to save dirty documents even in the bad case. */
 void sys_bail(int n)
 {
@@ -1782,13 +1782,16 @@ void sys_bail(int n)
 
 void sys_exit(int status);
 
-void glob_exit(void *dummy, t_float status)
+    /* exit scheduler and shut down gracefully */
+void glob_exit(void *dummy, t_floatarg status)
 {
     sys_exit(status);
 }
-void glob_quit(void *dummy)
+
+    /* force-quit */
+void glob_quit(void *dummy, t_floatarg status)
 {
-    glob_exit(dummy, 0);
+    exit(status);
 }
 
     /* recursively descend to all canvases and send them "vis" messages


### PR DESCRIPTION
* the "quit" message force-quits Pd, like it did before Pd 0.55

* the (new) "exit" message exits from the scheduler and quits gracefully (but only after the current clock tick has finished)

Closes https://github.com/pure-data/pure-data/issues/2339 