### PR TITLE
cross-platform atomics macros

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -92,10 +92,10 @@ static int jack_blocksize = 0; /* should this be PERTHREAD? */
 #ifdef THREADSIGNAL
 t_semaphore *jack_sem;
 #endif
-static PA_VOLATILE char *jack_outbuf;
-static PA_VOLATILE sys_ringbuf jack_outring;
-static PA_VOLATILE char *jack_inbuf;
-static PA_VOLATILE sys_ringbuf jack_inring;
+static char *jack_outbuf;
+static sys_ringbuf jack_outring;
+static char *jack_inbuf;
+static sys_ringbuf jack_inring;
 
     /* callback routine for non-callback client... throw samples into
         and read them out of a FIFO.  Since we don't know at compile time

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -53,10 +53,10 @@ static t_audiocallback pa_callback;
 static int pa_started;
 static volatile int pa_dio_error;
 
-static PA_VOLATILE char *pa_outbuf;
-static PA_VOLATILE sys_ringbuf pa_outring;
-static PA_VOLATILE char *pa_inbuf;
-static PA_VOLATILE sys_ringbuf pa_inring;
+static char *pa_outbuf;
+static sys_ringbuf pa_outring;
+static char *pa_inbuf;
+static sys_ringbuf pa_inring;
 #ifdef THREADSIGNAL
 t_semaphore *pa_sem;
 #endif

--- a/src/s_audio_paring.h
+++ b/src/s_audio_paring.h
@@ -40,34 +40,32 @@ extern "C"
  *
  */
 
-/* If it's ever desired to use shared memory so that one process reads and
-another one writes to the same ring buffer, define this as 'volatile' : */
-#define PA_VOLATILE
+#include "m_private_utils.h"
 
 typedef struct
 {
-    long   bufferSize;              /* Number of bytes in FIFO.
-                                        Set by sys_ringbuf_init */
-    PA_VOLATILE long   writeIndex; /* Index of next writable byte.
-                                        Set by sys_ringbuf_AdvanceWriteIndex */
-    PA_VOLATILE long   readIndex;  /* Index of next readable byte.
-                                        Set by sys_ringbuf_AdvanceReadIndex */
+    long bufferSize;        /* Number of bytes in FIFO.
+                            Set by sys_ringbuf_init */
+    atomic_int writeIndex;  /* Index of next writable byte.
+                            Set by sys_ringbuf_AdvanceWriteIndex */
+    atomic_int readIndex;   /* Index of next readable byte.
+                            Set by sys_ringbuf_AdvanceReadIndex */
 } sys_ringbuf;
 
 /* Initialize Ring Buffer. */
-long sys_ringbuf_init(PA_VOLATILE sys_ringbuf *rbuf, long numBytes,
-    PA_VOLATILE char *dataPtr, long nfill);
+long sys_ringbuf_init(sys_ringbuf *rbuf, long numBytes,
+    char *dataPtr, long nfill);
 
 /* Return number of bytes available for writing. */
-long sys_ringbuf_getwriteavailable(PA_VOLATILE sys_ringbuf *rbuf);
+long sys_ringbuf_getwriteavailable(sys_ringbuf *rbuf);
 /* Return number of bytes available for read. */
-long sys_ringbuf_getreadavailable(PA_VOLATILE sys_ringbuf *rbuf);
+long sys_ringbuf_getreadavailable(sys_ringbuf *rbuf);
 /* Return bytes written. */
-long sys_ringbuf_write(PA_VOLATILE sys_ringbuf *rbuf, const void *data,
-    long numBytes, PA_VOLATILE char *buffer);
+long sys_ringbuf_write(sys_ringbuf *rbuf, const void *data,
+    long numBytes, char *buffer);
 /* Return bytes read. */
-long sys_ringbuf_read(PA_VOLATILE sys_ringbuf *rbuf, void *data, long numBytes,
-    PA_VOLATILE char *buffer);
+long sys_ringbuf_read(sys_ringbuf *rbuf, void *data, long numBytes,
+    char *buffer);
 
 /* semaphore for signaling the consumer thread */
 struct _semaphore;

--- a/src/z_ringbuffer.c
+++ b/src/z_ringbuffer.c
@@ -14,29 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if __STDC_VERSION__ >= 201112L // use stdatomic if C11 is available
-  #include <stdatomic.h>
-  #define SYNC_FETCH(ptr) atomic_fetch_or((_Atomic int *)ptr, 0)
-  #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-          atomic_compare_exchange_strong((_Atomic int *)ptr, &oldval, newval)
-#else // use platform specfics
-  #ifdef __APPLE__ // apple atomics
-    #include <libkern/OSAtomic.h>
-    #define SYNC_FETCH(ptr) OSAtomicOr32Barrier(0, (volatile uint32_t *)ptr)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            OSAtomicCompareAndSwap32Barrier(oldval, newval, ptr)
-  #elif defined(_WIN32) || defined(_WIN64) // win api atomics
-    #include <windows.h>
-    #define SYNC_FETCH(ptr) InterlockedOr(ptr, 0)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            InterlockedCompareExchange(ptr, newval, oldval)
-  #else // gcc atomics
-    #define SYNC_FETCH(ptr) __sync_fetch_and_or(ptr, 0)
-    #define SYNC_COMPARE_AND_SWAP(ptr, oldval, newval) \
-            __sync_val_compare_and_swap(ptr, oldval, newval)
-  #endif
-#endif
-
 ring_buffer *rb_create(int size) {
   if (size & 0xff) return NULL;  // size must be a multiple of 256
   ring_buffer *buffer = malloc(sizeof(ring_buffer));
@@ -62,8 +39,8 @@ int rb_available_to_write(ring_buffer *buffer) {
     // note: the largest possible result is buffer->size - 1 because
     // we adopt the convention that read_idx == write_idx means that the
     // buffer is empty
-    int read_idx = SYNC_FETCH(&(buffer->read_idx));
-    int write_idx = SYNC_FETCH(&(buffer->write_idx));
+    int read_idx = atomic_int_load(&buffer->read_idx);
+    int write_idx = atomic_int_load(&buffer->write_idx);
     return (buffer->size + read_idx - write_idx - 1) % buffer->size;
   } else {
     return 0;
@@ -72,8 +49,8 @@ int rb_available_to_write(ring_buffer *buffer) {
 
 int rb_available_to_read(ring_buffer *buffer) {
   if (buffer) {
-    int read_idx = SYNC_FETCH(&(buffer->read_idx));
-    int write_idx = SYNC_FETCH(&(buffer->write_idx));
+    int read_idx = atomic_int_load(&buffer->read_idx);
+    int write_idx = atomic_int_load(&buffer->write_idx);
     return (buffer->size + write_idx - read_idx) % buffer->size;
   } else {
     return 0;
@@ -102,8 +79,7 @@ int rb_write_to_buffer(ring_buffer *buffer, int n, ...) {
     write_idx = (write_idx + len) % buffer->size;
   }
   va_end(args);
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
-      write_idx);  // includes memory barrier
+  atomic_int_store(&buffer->write_idx, write_idx); // includes memory barrier
   return 0;
 }
 
@@ -121,8 +97,7 @@ int rb_write_value_to_buffer(ring_buffer *buffer, int value, int n) {
     memset(buffer->buf_ptr, value, n - d);
   }
   write_idx = (write_idx + n) % buffer->size;
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx,
-    write_idx);  // includes memory barrier
+  atomic_int_store(&buffer->write_idx, write_idx); // includes memory barrier
   return 0;
 }
 
@@ -140,15 +115,14 @@ int rb_read_from_buffer(ring_buffer *buffer, char *dest, int len) {
     memcpy(dest, buffer->buf_ptr + read_idx, d);
     memcpy(dest + d, buffer->buf_ptr, len - d);
   }
-  SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx,
-       (read_idx + len) % buffer->size);  // includes memory barrier
+  atomic_int_store(&buffer->read_idx, read_idx); // includes memory barrier
   return 0;
 }
 
 // simply reset the indices
 void rb_clear_buffer(ring_buffer *buffer) {
   if (buffer) {
-  SYNC_COMPARE_AND_SWAP(&(buffer->read_idx), buffer->read_idx, 0);
-  SYNC_COMPARE_AND_SWAP(&(buffer->write_idx), buffer->write_idx, 0);
+    atomic_int_store(&buffer->read_idx, 0);
+    atomic_int_store(&buffer->write_idx, 0);
   }
 }

--- a/src/z_ringbuffer.h
+++ b/src/z_ringbuffer.h
@@ -11,13 +11,15 @@
 #ifndef __Z_RING_BUFFER_H__
 #define __Z_RING_BUFFER_H__
 
+#include "m_private_utils.h"
+
 /// simple lock-free ring buffer implementation for one writer thread
 /// and one consumer thread
 typedef struct ring_buffer {
     int size;
     char *buf_ptr;
-    int write_idx;
-    int read_idx;
+    atomic_int write_idx;
+    atomic_int read_idx;
 } ring_buffer;
 
 /// create a ring buffer, size must be a multiple of 256


### PR DESCRIPTION
This PR adds cross-platform macros for atomic integer operations.

We try to use C11 atomics if available; otherwise we emulate them with Win32 resp. GCC/Clang intrinsics.

These new macros are now used in `z_ringbuffer` and `s_audio_paring`.

I have added these to `m_private_utils.h` because they might be useful for other things. (In fact, I am currently working on PRs that would make use of them.)

---

I'm targeting the `develop` branch. If you think this would require Miller's attention and I should target `master`, just tell me.