### PR TITLE
Fix build when dprintf is defined as a macro

### DIFF
--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -170,6 +170,9 @@ static void print_val(t_val v) {
 }
 #else
 static void print_val(t_val v) { ; }
+#ifdef dprintf
+#undef dprintf
+#endif
 int dprintf(int fd, const char* format, ...) { return -1; }
 #endif
 


### PR DESCRIPTION
This avois errors when building with clang on NixOS.

Excerpt of the compile errors this avoids: 

```
/nix/store/svf4zn4qg9lsxfn4znyxk7nl80hlmgpm-clang-wrapper-17.0.6/bin/clang -DHAVE_ALLOCA_H=1 -DHAVE_ENDIAN_H=1 -DHAVE_LIBDL=1 -DHAVE_UNISTD_H=1 -DLIBPD_EXTRA=1 -DPD=1 -DPDINSTANCE=1 -DPDTHREADS=1 -DPD_INTERNAL=1 -DQT_DISABLE_DEPRECATED_BEFORE=0x0605ff -DQT_NO_KEYWORDS -DUSEAPI_DUMMY=1 -I/build/score-master/build/libpd -I/build/score-master/3rdparty/libpd -I/build/score-master/build -I/build/score-master/3rdparty/libpd/libpd_wrapper -I/build/score-master/3rdparty/libpd/pure-data/src -isystem /build/score-master/3rdparty/libossia/3rdparty/nano-signal-slot -isystem /build/score-master/3rdparty/libossia/3rdparty/readerwriterqueue -isystem /build/score-master/3rdparty/magicitems/include -isystem /build/score-master/3rdparty/avendish/include -w -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -w -O3 -DNDEBUG -ffast-math -funroll-loops -fomit-frame-pointer -O3 -std=gnu11 -fPIC -fvisibility=hidden -Wno-gnu-anonymous-struct -Wno-nested-anon-types -Wno-dtor-name -fopenmp-simd -MD -MT libpd/CMakeFiles/libpd_static.dir/pure-data/src/s_inter_gui.c.o -MF libpd/CMakeFiles/libpd_static.dir/pure-data/src/s_inter_gui.c.o.d -o libpd/CMakeFiles/libpd_static.dir/pure-data/src/s_inter_gui.c.o -c /build/score-master/3rdparty/libpd/pure-data/src/s_inter_gui.c
/build/score-master/3rdparty/libpd/pure-data/src/s_inter_gui.c:173:5: error: expected parameter declarator
  173 | int dprintf(int fd, const char* format, ...) { return -1; }
      |     ^
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/bits/stdio2.h:122:22: note: expanded from macro 'dprintf'
  122 |   __dprintf_chk (fd, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
      |                      ^
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/features.h:428:31: note: expanded from macro '__USE_FORTIFY_LEVEL'
  428 | #  define __USE_FORTIFY_LEVEL 2
      |                               ^
/build/score-master/3rdparty/libpd/pure-data/src/s_inter_gui.c:173:5: error: expected ')'
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/bits/stdio2.h:122:22: note: expanded from macro 'dprintf'
  122 |   __dprintf_chk (fd, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
      |                      ^
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/features.h:428:31: note: expanded from macro '__USE_FORTIFY_LEVEL'
  428 | #  define __USE_FORTIFY_LEVEL 2
      |                               ^
/build/score-master/3rdparty/libpd/pure-data/src/s_inter_gui.c:173:5: note: to match this '('
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/bits/stdio2.h:122:17: note: expanded from macro 'dprintf'
  122 |   __dprintf_chk (fd, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
      |                 ^
/build/score-master/3rdparty/libpd/pure-data/src/s_inter_gui.c:173:5: error: conflicting types for '__dprintf_chk'
  173 | int dprintf(int fd, const char* format, ...) { return -1; }
      |     ^
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/bits/stdio2.h:122:3: note: expanded from macro 'dprintf'
  122 |   __dprintf_chk (fd, __USE_FORTIFY_LEVEL - 1, __VA_ARGS__)
      |   ^
/nix/store/4vgk1rlzdqjnpjicb5qcxjcd4spi7wyw-glibc-2.39-52-dev/include/bits/stdio2-decl.h:60:12: note: previous declaration is here
   60 | extern int __dprintf_chk (int __fd, int __flag, const char *__restrict __fmt,
      |            ^
3 errors generated.
```

