### PR TITLE
configurable keyboard shortcuts

### DIFF
--- a/tcl/Makefile.am
+++ b/tcl/Makefile.am
@@ -23,6 +23,7 @@ dist_libpdtcl_DATA = \
     apple_events.tcl \
     dialog_array.tcl \
     dialog_audio.tcl \
+    dialog_bindings.tcl \
     dialog_canvas.tcl \
     dialog_data.tcl \
     dialog_find.tcl \

--- a/tcl/dialog_bindings.tcl
+++ b/tcl/dialog_bindings.tcl
@@ -1,0 +1,409 @@
+package provide dialog_bindings 0.1
+
+package require pd_menucommands
+package require pd_guiprefs
+package require pd_bindings
+
+namespace eval ::dialog_bindings:: {
+    # the current shortcut as displayed (e.g. 'Control+Shift+M')
+    variable currentshortcut
+    # the treeview cell ({<treeid> <item> <column>}, e.g. {.editor.f.tree File|New #1}
+    # or empty
+    variable currentID
+
+    # whether we allow single-char shortcuts, like 'a' or 'Shift-A'
+    variable allow1char 0
+
+    array set usedshortcuts {}
+}
+
+proc ::dialog_bindings::getleaveitems {treeid {root {}}} {
+    set items {}
+    foreach item [$treeid children $root] {
+        if { [$treeid children $item] == {} } {
+            set values {}
+            foreach v [$treeid item $item -values] {
+                if { $v != {} } {
+                    dict set values $v 1
+                }
+            }
+            lappend items $item
+            lappend items [dict keys $values]
+        } else {
+            set items [concat $items [getleaveitems $treeid $item]]
+        }
+    }
+    return $items
+}
+
+# https://wiki.tcl-lang.org/page/Combinatorial%20mathematics%20functions
+proc ::dialog_bindings::combinations {myList size {prefix {}}} {
+    ;# End recursion when size is 0 or equals our list size
+    if {$size == 0} {return [list $prefix]}
+    if {$size == [llength $myList]} {return [list [concat $prefix $myList]]}
+
+    set first [lindex $myList 0]
+    set rest [lrange $myList 1 end]
+
+    ;# Combine solutions w/ first element and solutions w/o first element
+    set ans1 [combinations $rest [expr {$size-1}] [concat $prefix $first]]
+    set ans2 [combinations $rest $size $prefix]
+    return [concat $ans1 $ans2]
+}
+
+proc ::dialog_bindings::getshortcuts {treeid} {
+    # get a list of <event> <shortcuts> tuples, as stored in the current treeview
+    # as a side-effect, this updates the 'usedshortcuts' array
+    set result {}
+    array unset ::dialog_bindings::usedshortcuts
+    foreach {ev keys} [getleaveitems $treeid] {
+        set shortcuts {}
+        foreach k $keys {
+            lappend shortcuts [split $k +]
+            set ::dialog_bindings::usedshortcuts($k) $ev
+        }
+        lappend result $ev $shortcuts
+    }
+    return $result
+}
+
+
+proc ::dialog_bindings::make_treecolumns {treeid numcolumns} {
+    set columns {}
+    for {set i 0} {$i < $numcolumns} {incr i} {
+        lappend columns [_ "Shortcut#%d" $i]
+    }
+    $treeid configure -columns $columns
+    foreach c $columns {
+        $treeid heading $c -text $c
+    }
+}
+
+proc ::dialog_bindings::filltree {treeid bindlist {labelroot {}}} {
+    array set labels {}
+    if { $labelroot != {} } {
+        array set labels [::pd_menus::get_events $labelroot label]
+    }
+    set numshortcuts 0
+    foreach {event shortcuts} $bindlist {
+        set evs {}
+        foreach e [split $event "|"] {
+            set evs2 [concat $evs $e]
+            set ev [join $evs2 "|"]
+            if { ![$treeid exists $ev] } {
+                set name $e
+                if { [info exists labels(<<${ev}>>)] } {
+                    foreach name $labels(<<${ev}>>) {break}
+                }
+                ${treeid} insert [join $evs "|"] end -id ${ev} -text ${name} -open 1
+            }
+            set evs $evs2
+        }
+        if { [llength $shortcuts] > $numshortcuts } {
+            set numshortcuts [llength $shortcuts]
+        }
+        set values {}
+        foreach shortcut $shortcuts {
+            lappend values [join $shortcut +]
+        }
+        $treeid item ${event} -values ${values}
+    }
+    make_treecolumns $treeid $numshortcuts
+    getshortcuts $treeid
+}
+
+#.menubar add cascade -label Tools -underline 0 -menu [set m [menu .menubar.tools]]
+#::pd_menus::add_menu $m command [_ "Install externals..." ] "<<Tools|Deken>>"
+proc ::dialog_bindings::get_extra_bindings {bindlist} {
+    # tries to find additional bindings from the menu, and returns [concat $bindlist $newbindings]
+    # with duplicates removed
+    array set seen {}
+
+    foreach {ev binding} $bindlist {
+        set seen($ev) 1
+    }
+    foreach event [::pd_menus::get_events] {
+        set ev [string trim $event <>]
+        if { [info exists seen($ev)] } {
+            continue
+        }
+        set shortcuts {}
+        foreach b [event info ${event}] {
+            lappend shortcuts [split [string map {-Key- -} [string trim $b <>]]  -]
+        }
+        lappend bindlist $ev
+        lappend bindlist $shortcuts
+        set seen($ev) 1
+    }
+    return $bindlist
+}
+
+
+proc ::dialog_bindings::create {winid} {
+    label ${winid}.help -justify left \
+        -text [_ "To edit a keyboard shortcut, double-click on the corresponding event (or shortcut) and type a new accelerator.\nUse right-click for a context-menu to remove shortcuts." ]
+
+    checkbutton ${winid}.allow1char \
+        -variable ::dialog_bindings::allow1char \
+        -justify left \
+        -text [_ "Allow single-character shortcuts.\nDANGER: this can seriously impact the patching workflow." ]
+
+    set treeid ${winid}.tree
+    ::ttk::treeview ${treeid} -selectmode browse
+    $treeid column #0 -stretch
+    $treeid heading #0 -text [_ "Event" ]
+
+    pack ${winid}.help -anchor w -padx 5 -pady 5
+    pack ${winid}.allow1char -anchor w -padx 5 -pady 5
+    pack ${treeid} -expand 1 -fill both
+
+    set ::pd_bindings::bindlist [get_extra_bindings $::pd_bindings::bindlist]
+
+    filltree $treeid $::pd_bindings::bindlist .
+
+    set f [frame $winid.but]
+    pack $f -side left -pady 5 -padx 5 -ipadx 5
+    button $f.previous -text [_ "Reset to previous state" ] -command [list ::dialog_bindings::filltree $treeid $::pd_bindings::bindlist]
+    button $f.defaults -text [_ "Reset to defaults" ] -command [list ::dialog_bindings::filltree $treeid $::pd_bindings::default_bindlist]
+    pack $f.previous -side left
+    pack $f.defaults -side left
+
+
+    bind $treeid <Double-ButtonRelease-1> "::dialog_bindings::doubleclick %W %x %y"
+    if {$::windowingsystem eq "aqua"} {
+        set rightbutton <2>
+    } else {
+        set rightbutton <3>
+    }
+    bind $treeid $rightbutton "::dialog_bindings::rightclick %W %x %y"
+
+    # order of modifier keys:
+    # - TheGIMP  : Shift-Control-Alt
+    # - Apple    : Control-Option-Shift-Command
+    # - Microsoft: Control-Alt-Shift
+    # - JMZ      : i would type either Ctrl-Alt-Shift or Ctrl-Shift-Alt
+
+    # guidelines:
+    # - https://developer.apple.com/design/human-interface-guidelines/macos/user-interaction/keyboard/
+    # - http://msdn.microsoft.com/en-us/library/ms971323.aspx#atg_keyboardshortcuts_windows_shortcut_keys
+
+    # we *really* want the default shortcutsto yield the same results as a recorded shortcut.
+    # (e.g. '${control} Shift S'), so duplicate detection is easier
+    set metakeys {Control Alt Shift}
+    if {$::windowingsystem eq "aqua"} {
+        # macOS displays accelerators in this order: Control-Option-Shift-Command
+        # with 'Alt' a synonym for 'Option', and 'Control' being distinct from 'Command'
+        # we would like the recorded shortcuts match closely with the shown accelerator.
+        # however, 'Command' needs to go before 'Shift' (for dupe detection)
+
+        set metakeys {Control Command Option Shift}
+    }
+
+    set tag ::dialog_bindings::popup
+    for {set i 1} {$i <= [llength $metakeys]} {incr i} {
+        foreach modifiers [combinations $metakeys $i] {
+            if {$modifiers  == "Shift" } {continue}
+            set binding [join [concat $modifiers Key] -]
+            bind ${tag} <${binding}> [list ::dialog_bindings::shortcut %W %K ${modifiers} 1]
+            set binding [join [concat $modifiers KeyRelease] -]
+            bind ${tag} <${binding}> [list ::dialog_bindings::shortcut %W %K ${modifiers} 0]
+        }
+    }
+    # the KeyRelease events are intentionally bound to shortcut,
+    # to properly detect KeyRelease on macOS if the modifiers are released before the actual key
+    bind ${tag} <Shift-Key> [list ::dialog_bindings::shortcut1 %W %K Shift 1]
+    bind ${tag} <Shift-KeyRelease> [list ::dialog_bindings::shortcut %W %K Shift 0]
+    bind ${tag} <KeyPress> [list ::dialog_bindings::shortcut1 %W %K {} 1]
+    bind ${tag} <KeyRelease> [list ::dialog_bindings::shortcut %W %K {} 0]
+
+    # update the list of used shortcuts:
+    getshortcuts $treeid
+}
+proc ::dialog_bindings::doubleclick {treeid x y} {
+    set popup ${treeid}.popup
+    destroy $popup
+    set item [$treeid identify item $x $y]
+    set col [$treeid identify column $x $y]
+    set type [$treeid identify region $x $y]
+    if { [$treeid children $item] != {} } {
+        # we are only interested in leaves
+        return
+    }
+    if { $type == "cell" } {
+        foreach {x y w h} [$treeid bbox $item $col] {break;}
+        set ::dialog_bindings::currentshortcut [$treeid set $item $col]
+    } elseif { $type == "tree" } {
+        foreach {x0 y w h} [$treeid bbox $item] {break;}
+        foreach x [$treeid bbox $item #1] {break;}
+        set w [expr $w + $x0 - $x]
+        set ::dialog_bindings::currentshortcut {}
+    } else {
+        # we are only interested in the shortcut cells
+        return
+    }
+    entry ${popup} -textvariable ::dialog_bindings::currentshortcut -state readonly
+    place $popup -x $x -y $y -w $w -h $h
+    set ::dialog_bindings::currentID [list $treeid $item $col]
+
+    bind $popup <FocusOut> [list ::dialog_bindings::popup_destroy %W]
+
+    # make need to bind to '::dialog_bindings::popup' as this is where the shortcut-keys go
+    # we also must make sure to *not* bind to 'all', so the normal keybindings do not work for us
+    bindtags $popup [list $popup [winfo class $popup] ::dialog_bindings::popup]
+
+    focus $popup
+}
+proc ::dialog_bindings::rightclick {treeid X Y} {
+    set m ${treeid}.contextmenu
+    destroy $m
+    set item [$treeid identify item $X $Y]
+    set col [$treeid identify column $X $Y]
+    set type [$treeid identify region $X $Y]
+    if { [$treeid children $item] != {} } {
+        # we are only interested in leaves
+        return
+    }
+
+    menu $m
+    if { $type == "cell" } {
+        foreach {x y w h} [$treeid bbox $item $col] {break;}
+        $m add command -label [_ "Edit shortcut" ] \
+            -command [list ::dialog_bindings::doubleclick $treeid $X $Y]
+        $m add command -label [_ "Delete shortcut" ] \
+            -command [list ::dialog_bindings::shortcut_clear %W]
+    } elseif { $type == "tree" } {
+        foreach {x y w h} [$treeid bbox $item] {break;}
+        #foreach x [$treeid bbox $item #1] {break;}
+        $m add command -label [_ "Add shortcut" ] \
+            -command [list ::dialog_bindings::doubleclick $treeid $X $Y]
+        $m add command -label [_ "Delete shortcuts" ] \
+            -command [list ::dialog_bindings::shortcut_clear %W]
+    } else {
+        # we are only interested in the shortcut cells
+        destroy $m
+        return
+    }
+
+    set ::dialog_bindings::currentID [list $treeid $item $col]
+    bindtags $m [list $m [winfo class $m] ::dialog_bindings::m]
+    tk_popup $m [expr [winfo rootx $treeid] + $x] [expr [winfo rooty $treeid] + $y]
+}
+
+proc ::dialog_bindings::popup_destroy {popid} {
+    # cleanup the popup
+    destroy $popid
+    set ::dialog_bindings::currentID {}
+    set ::dialog_bindings::currentshortcut {}
+}
+proc ::dialog_bindings::shortcut_set {shortcut} {
+    foreach {treeid item col} $::dialog_bindings::currentID {break}
+    if { ${col} == {} } {return}
+
+    # try to normalize the keyboard shortcut (titlecasing the actual key)
+    set keys [split $shortcut "+"]
+    set Keys [lreplace $keys end end [string totitle [lindex $keys end]]]
+
+    set testevent <<::pd_binding::editor::shortcut::test>>
+    catch {
+        event add ${testevent} <[join $Keys -]>
+        set keys $Keys
+    }
+    event delete ${testevent}
+
+    # check if shortcut is already taken
+    set sc [join $keys "+"]
+    set oldev [shortcut_check $sc]
+    if { $oldev != "" && $oldev != $item } {
+        tk_messageBox \
+            -title [_ "Shortcut in use!"] \
+            -message [_ "The shortcut '%1\$s' is already used for the '%2\$s' event." $sc $oldev] \
+            -detail [_ "Please remove the old shortcut before assigning it to a new event." ] \
+            -icon error -type ok
+        return
+    }
+
+    if { $sc !=  {} } {
+        set ::dialog_bindings::usedshortcuts($sc) $item
+    }
+
+    set shortcuts {}
+
+    if { $col != "#0" } {
+        set oldsc [$treeid set $item $col]
+        set ::dialog_bindings::usedshortcuts($oldsc) ""
+        $treeid set $item $col $sc
+    } else {
+        if { $sc != {} } {
+            # *add* a new shortcut (rather than replace an existing one
+            dict set shortcuts $sc 1
+        } else {
+            # remove all shortcuts
+            foreach col [$treeid cget -columns] {
+                set oldsc [$treeid set $item $col]
+                set ::dialog_bindings::usedshortcuts($oldsc) ""
+                $treeid set $item $col $sc
+            }
+
+        }
+    }
+
+    # remove duplicate and empty entries for the same event
+    foreach {it sc} [$treeid set $item] {
+        if { $sc != {} } {
+            dict set shortcuts $sc 1
+        }
+    }
+    set shortcuts [dict keys $shortcuts]
+    set numshortcuts [llength $shortcuts]
+    if { $numshortcuts > [llength [$treeid cget -columns]] } {
+        make_treecolumns $treeid $numshortcuts
+    }
+    $treeid item $item -values $shortcuts
+}
+
+proc ::dialog_bindings::shortcut_clear {popid} {
+    shortcut_set ""
+    after idle ::dialog_bindings::popup_destroy $popid
+}
+proc ::dialog_bindings::shortcut_check {shortcut} {
+    if { [info exists ::dialog_bindings::usedshortcuts($shortcut) ] } {
+        return $::dialog_bindings::usedshortcuts($shortcut)
+    }
+    return ""
+}
+
+proc ::dialog_bindings::shortcut {popid key modifier state} {
+    # the user pressed a new shortcut
+    # - ideally, prevent combination that only consist of modifier keys (e.g. "Control+Shift")
+    # - if they are releasing (the top-level combination), assign
+    if { ! [winfo exists $popid ] } {
+        return
+    }
+    set treeid [winfo parent $popid]
+    if { ! $state } {
+        # releasing and the user selected a shortcut
+        shortcut_set ${::dialog_bindings::currentshortcut}
+        popup_destroy $popid
+        return
+    }
+    set ::dialog_bindings::currentshortcut [join [concat $modifier $key] +]
+}
+proc ::dialog_bindings::shortcut1 {popid key modifier state} {
+    set allowed  $::dialog_bindings::allow1char
+    if { $allowed } {
+        return [::dialog_bindings::shortcut $popid $key $modifier $state]
+    }
+}
+
+
+proc ::dialog_bindings::reset {winid} {
+    set treeid ${winid}.tree
+    ::pdwindow::error "TODO: ::dialog_bindings::reset\n"
+}
+proc ::dialog_bindings::apply {winid} {
+    set data [getshortcuts ${winid}.tree]
+    set ::pd_bindings::bindlist $data
+    ::pd_guiprefs::write KeyBindings $data
+    ::pd_bindings::make_events ${data}
+    ::pd_menus::update_accelerators
+}

--- a/tcl/dialog_preferences.tcl
+++ b/tcl/dialog_preferences.tcl
@@ -127,6 +127,10 @@ proc ::dialog_preferences::create_dialog {{mytoplevel .gui_preferences}} {
         ::preferencewindow::add_apply ${mytoplevel} "::deken::preferences::apply ${prefs}"
     }
 
+    # shortcut options
+    set prefs [::preferencewindow::add_frame $mytoplevel [_ "keyboard shortcuts"]]
+    ::dialog_bindings::create $prefs
+    ::preferencewindow::add_apply ${mytoplevel} "::dialog_bindings::apply ${prefs}"
 
     # misc options
     set prefs [::preferencewindow::add_frame $mytoplevel [_ "misc preferences"]]

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -47,6 +47,7 @@ package require dialog_midi
 package require dialog_path
 package require dialog_startup
 package require dialog_preferences
+package require dialog_bindings
 package require helpbrowser
 package require pd_menucommands
 package require opt_parser

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -335,7 +335,7 @@ proc init_for_platform {} {
             # load tk::mac event callbacks here, this way launching pd
             # from the commandline incorporates the special mac event handling
             package require apple_events
-            set ::modifier "Mod1"
+            set ::modifier "Command"
             if {$::tcl_version < 8.5} {
                 # old default font for Tk 8.4 on macOS
                 # since font detection requires 8.5+

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -534,8 +534,7 @@ proc pdtk_pd_startup {major minor bugfix test
     set_base_font $sys_font $sys_fontweight
     set ::font_measured [fit_font_into_metrics $::font_family $::font_weight $::font_metrics]
     set ::font_zoom2_measured [fit_font_into_metrics $::font_family $::font_weight $::font_zoom2_metrics]
-    ::pd_bindings::class_bindings
-    ::pd_bindings::global_bindings
+    ::pd_bindings::setup
     ::pd_menus::create_menubar
     ::pdwindow::create_window
     ::pdwindow::configure_menubar

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -138,13 +138,8 @@ namespace eval ::pd_bindings:: {
     setshortcuts "Preferences|Forget"
 }
 
-proc ::pd_bindings::setup {} {
-    set data [::pd_guiprefs::read KeyBindings true]
-    if { ${data} != {} } {
-        set ::pd_bindings::bindlist ${data}
-    }
-
-    foreach {ev shortcuts} $::pd_bindings::bindlist {
+proc ::pd_bindings::make_events {bindlist} {
+    foreach {ev shortcuts} $bindlist {
         set event <<${ev}>>
         event delete ${event}
         foreach keys ${shortcuts} {
@@ -165,6 +160,15 @@ proc ::pd_bindings::setup {} {
     }
     ::pd_bindings::class_bindings
     ::pd_bindings::global_bindings
+}
+
+proc ::pd_bindings::setup {} {
+    set data [::pd_guiprefs::read KeyBindings]
+    if { ${data} != {} } {
+        set ::pd_bindings::bindlist ${data}
+    }
+    set stderr {}
+    catch {::pd_bindings::make_events $::pd_bindings::bindlist} stderr
 }
 
 # wrapper around bind(3tk)to deal with CapsLock

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -3,6 +3,7 @@ package provide pd_bindings 0.1
 package require pd_menucommands
 package require dialog_find
 package require pd_connect
+package require pd_guiprefs
 
 namespace eval ::pd_bindings:: {
     namespace export global_bindings
@@ -138,6 +139,11 @@ namespace eval ::pd_bindings:: {
 }
 
 proc ::pd_bindings::setup {} {
+    set data [::pd_guiprefs::read KeyBindings true]
+    if { ${data} != {} } {
+        set ::pd_bindings::bindlist ${data}
+    }
+
     foreach {ev shortcuts} $::pd_bindings::bindlist {
         set event <<${ev}>>
         event delete ${event}

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -15,7 +15,7 @@ namespace eval ::pd_bindings:: {
 
     # on Mac OS X/Aqua, the Alt/Option key is called Option in Tcl
     if {[tk windowingsystem] eq "aqua"} {
-        set control "Mod1"
+        set control "Command"
         set alt "Option"
     }
 }

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -72,7 +72,7 @@ proc ::pd_bindings::global_bindings {} {
     bind_capslock all ${control}-Key k {menu_send %W connect_selection}
     bind_capslock all ${control}-Key n {menu_new}
     bind_capslock all ${control}-Key o {menu_open}
-    bind_capslock all ${control}-Key p {menu_print $::focused_window}
+    bind_capslock all ${control}-Key p {menu_print %W}
     bind_capslock all ${control}-Key r {menu_raise_pdwindow}
     bind_capslock all ${control}-Key s {menu_send %W menusave}
     bind_capslock all ${control}-Key t {menu_send %W triggerize}

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -58,79 +58,80 @@ proc ::pd_bindings::class_bindings {} {
 }
 
 proc ::pd_bindings::global_bindings {} {
+    variable control
     # we use 'bind all' everywhere to get as much of Tk's automatic binding
     # behaviors as possible, things like not sending an event for 'O' when
     # 'Control-O' is pressed
-    bind_capslock all ${::modifier}-Key a {menu_send %W selectall}
-    bind_capslock all ${::modifier}-Key b {menu_helpbrowser}
-    bind_capslock all ${::modifier}-Key c {menu_send %W copy}
-    bind_capslock all ${::modifier}-Key d {menu_send %W duplicate}
-    bind_capslock all ${::modifier}-Key e {menu_toggle_editmode}
-    bind_capslock all ${::modifier}-Key f {menu_find_dialog}
-    bind_capslock all ${::modifier}-Key g {menu_send %W findagain}
-    bind_capslock all ${::modifier}-Key k {menu_send %W connect_selection}
-    bind_capslock all ${::modifier}-Key n {menu_new}
-    bind_capslock all ${::modifier}-Key o {menu_open}
-    bind_capslock all ${::modifier}-Key p {menu_print $::focused_window}
-    bind_capslock all ${::modifier}-Key r {menu_raise_pdwindow}
-    bind_capslock all ${::modifier}-Key s {menu_send %W menusave}
-    bind_capslock all ${::modifier}-Key t {menu_send %W triggerize}
-    bind_capslock all ${::modifier}-Key v {menu_send %W paste}
-    bind_capslock all ${::modifier}-Key w {::pd_bindings::window_close %W}
-    bind_capslock all ${::modifier}-Key x {menu_send %W cut}
-    bind_capslock all ${::modifier}-Key z {menu_undo}
-    bind all <${::modifier}-Key-1>        {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <${::modifier}-Key-2>        {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <${::modifier}-Key-3>        {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <${::modifier}-Key-4>        {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <${::modifier}-Key-5>        {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <${::modifier}-Key-KP_1>     {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <${::modifier}-Key-KP_2>     {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <${::modifier}-Key-KP_3>     {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <${::modifier}-Key-KP_4>     {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <${::modifier}-Key-KP_5>     {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <${::modifier}-Key-slash>    {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
-    bind all <${::modifier}-Key-period>   {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
+    bind_capslock all ${control}-Key a {menu_send %W selectall}
+    bind_capslock all ${control}-Key b {menu_helpbrowser}
+    bind_capslock all ${control}-Key c {menu_send %W copy}
+    bind_capslock all ${control}-Key d {menu_send %W duplicate}
+    bind_capslock all ${control}-Key e {menu_toggle_editmode}
+    bind_capslock all ${control}-Key f {menu_find_dialog}
+    bind_capslock all ${control}-Key g {menu_send %W findagain}
+    bind_capslock all ${control}-Key k {menu_send %W connect_selection}
+    bind_capslock all ${control}-Key n {menu_new}
+    bind_capslock all ${control}-Key o {menu_open}
+    bind_capslock all ${control}-Key p {menu_print $::focused_window}
+    bind_capslock all ${control}-Key r {menu_raise_pdwindow}
+    bind_capslock all ${control}-Key s {menu_send %W menusave}
+    bind_capslock all ${control}-Key t {menu_send %W triggerize}
+    bind_capslock all ${control}-Key v {menu_send %W paste}
+    bind_capslock all ${control}-Key w {::pd_bindings::window_close %W}
+    bind_capslock all ${control}-Key x {menu_send %W cut}
+    bind_capslock all ${control}-Key z {menu_undo}
+    bind all <${control}-Key-1>        {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
+    bind all <${control}-Key-2>        {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
+    bind all <${control}-Key-3>        {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
+    bind all <${control}-Key-4>        {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
+    bind all <${control}-Key-5>        {::pd_menucommands::scheduleAction menu_send_float %W text 0}
+    bind all <${control}-Key-KP_1>     {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
+    bind all <${control}-Key-KP_2>     {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
+    bind all <${control}-Key-KP_3>     {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
+    bind all <${control}-Key-KP_4>     {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
+    bind all <${control}-Key-KP_5>     {::pd_menucommands::scheduleAction menu_send_float %W text 0}
+    bind all <${control}-Key-slash>    {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
+    bind all <${control}-Key-period>   {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
 
     # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
     # "+" key... this only makes sense on US keyboards but some users
     # expected it... go figure.
-    bind all <${::modifier}-Key-equal>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${::modifier}-Key-plus>        {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${::modifier}-Key-minus>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
-    bind all <${::modifier}-Key-KP_Add>      {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${::modifier}-Key-KP_Subtract> {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind all <${control}-Key-equal>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${control}-Key-plus>        {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${control}-Key-minus>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind all <${control}-Key-KP_Add>      {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${control}-Key-KP_Subtract> {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
 
     # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
 
     # annoying, but Tk's bind needs uppercase letter to get the Shift
-    bind_capslock all ${::modifier}-Shift-Key A {menu_send %W menuarray}
-    bind_capslock all ${::modifier}-Shift-Key B {menu_send %W bng}
-    bind_capslock all ${::modifier}-Shift-Key C {menu_send %W mycnv}
-    bind_capslock all ${::modifier}-Shift-Key D {menu_send %W vradio}
-    bind_capslock all ${::modifier}-Shift-Key G {menu_send %W graph}
-    bind_capslock all ${::modifier}-Shift-Key J {menu_send %W hslider}
-    bind_capslock all ${::modifier}-Shift-Key I {menu_send %W hradio}
-    bind_capslock all ${::modifier}-Shift-Key L {menu_clear_console}
-    bind_capslock all ${::modifier}-Shift-Key M {menu_message_dialog}
-    bind_capslock all ${::modifier}-Shift-Key N {menu_send %W numbox}
-    bind_capslock all ${::modifier}-Shift-Key Q {pdsend "pd quit"}
-    bind_capslock all ${::modifier}-Shift-Key R {menu_send %W tidy}
-    bind_capslock all ${::modifier}-Shift-Key S {menu_send %W menusaveas}
-    bind_capslock all ${::modifier}-Shift-Key T {menu_send %W toggle}
-    bind_capslock all ${::modifier}-Shift-Key U {menu_send %W vumeter}
-    bind_capslock all ${::modifier}-Shift-Key V {menu_send %W vslider}
-    bind_capslock all ${::modifier}-Shift-Key W {::pd_bindings::window_close %W 1}
-    bind_capslock all ${::modifier}-Shift-Key Z {menu_redo}
+    bind_capslock all ${control}-Shift-Key A {menu_send %W menuarray}
+    bind_capslock all ${control}-Shift-Key B {menu_send %W bng}
+    bind_capslock all ${control}-Shift-Key C {menu_send %W mycnv}
+    bind_capslock all ${control}-Shift-Key D {menu_send %W vradio}
+    bind_capslock all ${control}-Shift-Key G {menu_send %W graph}
+    bind_capslock all ${control}-Shift-Key J {menu_send %W hslider}
+    bind_capslock all ${control}-Shift-Key I {menu_send %W hradio}
+    bind_capslock all ${control}-Shift-Key L {menu_clear_console}
+    bind_capslock all ${control}-Shift-Key M {menu_message_dialog}
+    bind_capslock all ${control}-Shift-Key N {menu_send %W numbox}
+    bind_capslock all ${control}-Shift-Key Q {pdsend "pd quit"}
+    bind_capslock all ${control}-Shift-Key R {menu_send %W tidy}
+    bind_capslock all ${control}-Shift-Key S {menu_send %W menusaveas}
+    bind_capslock all ${control}-Shift-Key T {menu_send %W toggle}
+    bind_capslock all ${control}-Shift-Key U {menu_send %W vumeter}
+    bind_capslock all ${control}-Shift-Key V {menu_send %W vslider}
+    bind_capslock all ${control}-Shift-Key W {::pd_bindings::window_close %W 1}
+    bind_capslock all ${control}-Shift-Key Z {menu_redo}
     bind all <KeyPress-Escape>         {menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1 %k}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
          # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
         if {$::tcl_version < 8.5} {
-            bind_capslock all ${::modifier}-Key q       {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
-            bind_capslock all ${::modifier}-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
-            bind all <${::modifier}-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
+            bind_capslock all ${control}-Key q       {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
+            bind_capslock all ${control}-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
+            bind all <${control}-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
         }
         # BackSpace/Delete report the wrong isos (unicode representations) on OSX,
         # so we set them to the empty string and let ::pd_bindings::sendkey guess the correct values
@@ -143,14 +144,14 @@ proc ::pd_bindings::global_bindings {} {
         bind all <KeyPress-Clear>          {::pd_bindings::sendkey %W 1 %K "" 1 %k}
         bind all <KeyRelease-Clear>        {::pd_bindings::sendkey %W 0 %K "" 1 %k}
     } else {
-        bind_capslock all ${::modifier}-Key q       {::pd_connect::menu_quit}
-        bind_capslock all ${::modifier}-Key m       {menu_minimize %W}
+        bind_capslock all ${control}-Key q       {::pd_connect::menu_quit}
+        bind_capslock all ${control}-Key m       {menu_minimize %W}
 
-        bind all <${::modifier}-Next>        {menu_raisenextwindow}    ;# PgUp
-        bind all <${::modifier}-Prior>       {menu_raisepreviouswindow};# PageDown
+        bind all <${control}-Next>        {menu_raisenextwindow}    ;# PgUp
+        bind all <${control}-Prior>       {menu_raisepreviouswindow};# PageDown
         # these can conflict with CMD+comma & CMD+period bindings in Tk Cococa
-        bind all <${::modifier}-greater>     {menu_raisenextwindow}
-        bind all <${::modifier}-less>        {menu_raisepreviouswindow}
+        bind all <${control}-greater>     {menu_raisenextwindow}
+        bind all <${control}-less>        {menu_raisepreviouswindow}
     }
 
     bind all <KeyPress>         {::pd_bindings::sendkey %W 1 %K %A 0 %k}
@@ -177,22 +178,22 @@ proc ::pd_bindings::global_bindings {} {
 # properties, iemgui properties, canvas properties, data structures
 # properties, Audio setup, and MIDI setup
 proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
-    variable modifier
+    variable control
 
     bind $mytoplevel <KeyPress-Escape>          "dialog_${dialogname}::cancel $mytoplevel; break"
+    bind_capslock $mytoplevel ${control}-Key w "dialog_${dialogname}::cancel $mytoplevel; break"
     bind $mytoplevel <KeyPress-Return>          "dialog_${dialogname}::ok $mytoplevel; break"
-    bind_capslock $mytoplevel ${::modifier}-Key w "dialog_${dialogname}::cancel $mytoplevel; break"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
     if {$mytoplevel ne ".find"} {
-        bind_capslock $mytoplevel ${::modifier}-Key s       {bell; break}
-        bind_capslock $mytoplevel ${::modifier}-Shift-Key s {bell; break}
-        bind_capslock $mytoplevel ${::modifier}-Key p       {bell; break}
+        bind_capslock $mytoplevel ${control}-Key s       {bell; break}
+        bind_capslock $mytoplevel ${control}-Shift-Key s {bell; break}
+        bind_capslock $mytoplevel ${control}-Key p       {bell; break}
     } else {
         # find may may allow passthrough to it's target search patch
         ::dialog_find::update_bindings
     }
-    bind_capslock $mytoplevel ${::modifier}-Key t           {bell; break}
+    bind_capslock $mytoplevel ${control}-Key t           {bell; break}
 
     wm protocol $mytoplevel WM_DELETE_WINDOW "dialog_${dialogname}::cancel $mytoplevel"
 }
@@ -216,7 +217,7 @@ proc ::pd_bindings::clear_compose_keys {window} {
     ::pd_bindings::sendkey ${window} 0 BackSpace "" 0
 }
 proc ::pd_bindings::patch_bindings {mytoplevel} {
-    variable modifier
+    variable control
     variable alt
     set tkcanvas [tkcanvas_name $mytoplevel]
 
@@ -227,45 +228,45 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     # events over the window frame and $tkcanvas for events over the canvas
     bind $tkcanvas <Motion>                    "pdtk_canvas_motion %W %x %y 0"
     bind $tkcanvas <Shift-Motion>              "pdtk_canvas_motion %W %x %y 1"
-    bind $tkcanvas <${::modifier}-Motion>        "pdtk_canvas_motion %W %x %y 2"
-    bind $tkcanvas <${::modifier}-Shift-Motion>  "pdtk_canvas_motion %W %x %y 3"
+    bind $tkcanvas <${control}-Motion>        "pdtk_canvas_motion %W %x %y 2"
+    bind $tkcanvas <${control}-Shift-Motion>  "pdtk_canvas_motion %W %x %y 3"
     bind $tkcanvas <${alt}-Motion>               "pdtk_canvas_motion %W %x %y 4"
     bind $tkcanvas <${alt}-Shift-Motion>         "pdtk_canvas_motion %W %x %y 5"
-    bind $tkcanvas <${::modifier}-${alt}-Motion>   "pdtk_canvas_motion %W %x %y 6"
-    bind $tkcanvas <${::modifier}-${alt}-Shift-Motion> "pdtk_canvas_motion %W %x %y 7"
+    bind $tkcanvas <${control}-${alt}-Motion>   "pdtk_canvas_motion %W %x %y 6"
+    bind $tkcanvas <${control}-${alt}-Shift-Motion> "pdtk_canvas_motion %W %x %y 7"
 
     bind $tkcanvas <ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 0"
     bind $tkcanvas <Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 1"
-    bind $tkcanvas <${::modifier}-ButtonPress-1> \
+    bind $tkcanvas <${control}-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 2"
-    bind $tkcanvas <${::modifier}-Shift-ButtonPress-1> \
+    bind $tkcanvas <${control}-Shift-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 3"
     bind $tkcanvas <${alt}-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 4"
     bind $tkcanvas <${alt}-Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 5"
-    bind $tkcanvas <${::modifier}-${alt}-ButtonPress-1> \
+    bind $tkcanvas <${control}-${alt}-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 6"
-    bind $tkcanvas <${::modifier}-${alt}-Shift-ButtonPress-1> \
+    bind $tkcanvas <${control}-${alt}-Shift-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 7"
 
     bind $tkcanvas <ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 0"
     bind $tkcanvas <Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 1"
-    bind $tkcanvas <${::modifier}-ButtonRelease-1> \
+    bind $tkcanvas <${control}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 2"
-    bind $tkcanvas <${::modifier}-Shift-ButtonRelease-1> \
+    bind $tkcanvas <${control}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 3"
     bind $tkcanvas <${alt}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 4"
     bind $tkcanvas <${alt}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 5"
-    bind $tkcanvas <${::modifier}-${alt}-ButtonRelease-1> \
+    bind $tkcanvas <${control}-${alt}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 6"
-    bind $tkcanvas <${::modifier}-${alt}-Shift-ButtonRelease-1> \
+    bind $tkcanvas <${control}-${alt}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 7"
 
     bind $tkcanvas <MouseWheel>       {::pdtk_canvas::scroll %W y %D}

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -126,7 +126,7 @@ namespace eval ::pd_bindings:: {
     setshortcuts "Help|CheckUpdates"
     setshortcuts "Help|ReportBug"
 
-    setshortcuts "Pd|Message"             "${control} Shift M"
+    setshortcuts "Tools|Message"          "${control} Shift M"
     setshortcuts "Pd|ClearConsole"        "${control} Shift L"
 
     setshortcuts "Preferences|Audio"
@@ -217,7 +217,6 @@ proc ::pd_bindings::global_bindings {} {
     bind  all  <<File|Open>>              {::pd_menucommands::scheduleAction menu_open}
     bind  all  <<File|Save>>              {::pd_menucommands::scheduleAction menu_send %W menusave}
     bind  all  <<File|SaveAs>>            {::pd_menucommands::scheduleAction menu_send %W menusaveas}
-    bind  all  <<Pd|Message>>             {::pd_menucommands::scheduleAction menu_message_dialog}
     bind  all  <<File|Print>>             {::pd_menucommands::scheduleAction menu_print %W}
     bind  all  <<File|ClearRecentFiles>>  {::pd_menucommands::scheduleAction ::pd_menus::clear_recentfiles_menu}
     bind  all  <<File|Close>>             {::pd_menucommands::scheduleAction ::pd_bindings::window_close %W}
@@ -278,6 +277,8 @@ proc ::pd_bindings::global_bindings {} {
     bind  all  <<Media|LoadMeter>>        {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools load-meter.pd}
     bind  all  <<Preferences|Audio>>      {::pd_menucommands::scheduleAction pdsend "pd audio-properties"}
     bind  all  <<Preferences|MIDI>>       {::pd_menucommands::scheduleAction pdsend "pd midi-properties"}
+
+    bind  all  <<Tools|Message>>          {::pd_menucommands::scheduleAction menu_message_dialog}
 
     bind  all  <<Window|Minimize>>        {::pd_menucommands::scheduleAction menu_minimize %W}
     bind  all  <<Window|Maximize>>        {::pd_menucommands::scheduleAction menu_maximize %W}

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -8,10 +8,17 @@ namespace eval ::pd_bindings:: {
     namespace export global_bindings
     namespace export dialog_bindings
     namespace export patch_bindings
-    variable key2iso
-}
-set ::pd_bindings::key2iso ""
+    variable key2iso ""
 
+    variable control "Control"
+    variable alt "Alt"
+
+    # on Mac OS X/Aqua, the Alt/Option key is called Option in Tcl
+    if {[tk windowingsystem] eq "aqua"} {
+        set control "Mod1"
+        set alt "Option"
+    }
+}
 
 # wrapper around bind(3tk)to deal with CapsLock
 # the actual bind-sequence is is build as '<${seq_prefix}-${seq_nocase}',
@@ -210,14 +217,8 @@ proc ::pd_bindings::clear_compose_keys {window} {
 }
 proc ::pd_bindings::patch_bindings {mytoplevel} {
     variable modifier
+    variable alt
     set tkcanvas [tkcanvas_name $mytoplevel]
-
-    # on Mac OS X/Aqua, the Alt/Option key is called Option in Tcl
-    if {$::windowingsystem eq "aqua"} {
-        set alt "Option"
-    } else {
-        set alt "Alt"
-    }
 
     # TODO move mouse bindings to global and bind to 'all'
 

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -18,6 +18,147 @@ namespace eval ::pd_bindings:: {
         set control "Command"
         set alt "Option"
     }
+
+    variable bindlist {}
+    variable default_bindlist {}
+    proc setshortcuts {event args} {
+        variable bindlist
+        variable default_bindlist
+        lappend bindlist $event $args
+        lappend default_bindlist $event $args
+    }
+
+    # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
+    setshortcuts "File|New"               "${control} N"
+    setshortcuts "File|Open"              "${control} O"
+    setshortcuts "File|Save"              "${control} S"
+    setshortcuts "File|SaveAs"            "${control} Shift S"
+    setshortcuts "File|Print"             "${control} P"
+    setshortcuts "File|ClearRecentFiles"
+    setshortcuts "File|Close"             "${control} W"
+    setshortcuts "File|CloseNow"          "${control} Shift W"
+    if {[tk windowingsystem] eq "aqua"} {
+        # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
+        if {$::tcl_version < 8.5} {
+            setshortcuts "File|Quit"      "${control} Q"
+        }
+    } else {
+        setshortcuts "File|Quit"          "${control} Q"
+    }
+    setshortcuts "File|QuitNow"           "${control} Shift Q"
+
+    # (at least on X11) the built-in events Undo/Redo/Cut/Copy/Paste are already bound to the usual shortcuts
+    # this is somewhat problematic, as we cannot unbind these events from the keys
+    setshortcuts "Edit|Undo"              "${control} Z"
+    setshortcuts "Edit|Redo"              "${control} Shift Z"
+    setshortcuts "Edit|Cut"               "${control} X"
+    setshortcuts "Edit|Copy"              "${control} C"
+    # TclTk says:
+    # setshortcuts "Paste"   Replace the currently selected widget contents with the contents of the clipboard.
+    # setshortcuts "PasteSelection" Insert the contents of the selection at the mouse location.
+    setshortcuts "Edit|Paste"             "${control} V"
+    setshortcuts "Edit|PasteReplace"
+    setshortcuts "Edit|Duplicate"         "${control} D"
+    setshortcuts "Edit|SelectAll"         "${control} A"
+    setshortcuts "Edit|SelectNone"        "Escape"
+    setshortcuts "Edit|Font"
+    # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
+    # "+" key... this only makes sense on US keyboards but some users
+    # expected it... go figure.
+    setshortcuts "Edit|ZoomIn"            "${control} plus" "${control} KP_Add" "${control} equal"
+    setshortcuts "Edit|ZoomOut"           "${control} minus" "${control} KP_Subtract"
+    setshortcuts "Edit|TidyUp"            "${control} Shift R"
+    setshortcuts "Edit|ConnectSelection"  "${control} K"
+    setshortcuts "Edit|Triggerize"        "${control} T"
+    setshortcuts "Edit|EditMode"          "${control} E"
+
+    setshortcuts "Put|Object"             "${control} 1" "${control} KP_1"
+    setshortcuts "Put|Message"            "${control} 2" "${control} KP_2"
+    setshortcuts "Put|Number"             "${control} 3" "${control} KP_3"
+    setshortcuts "Put|List"               "${control} 4" "${control} KP_4"
+    setshortcuts "Put|Symbol"
+    setshortcuts "Put|Comment"            "${control} 5" "${control} KP_5"
+    setshortcuts "Put|Bang"               "${control} Shift B"
+    setshortcuts "Put|Toggle"             "${control} Shift T"
+    setshortcuts "Put|Number2"            "${control} Shift N"
+    setshortcuts "Put|VerticalSlider"     "${control} Shift V"
+    setshortcuts "Put|HorizontalSlider"   "${control} Shift J"
+    setshortcuts "Put|VerticalRadio"      "${control} Shift D"
+    setshortcuts "Put|HorizontalRadio"    "${control} Shift I"
+    setshortcuts "Put|VUMeter"            "${control} Shift U"
+    setshortcuts "Put|Canvas"             "${control} Shift C"
+    setshortcuts "Put|Graph"              "${control} Shift G"
+    setshortcuts "Put|Array"              "${control} Shift A"
+
+    setshortcuts "Find|Find"              "${control} F"
+    setshortcuts "Find|FindAgain"         "${control} G"
+    setshortcuts "Find|FindLastError"
+
+    setshortcuts "Media|DSPOn"            "${control} slash"
+    setshortcuts "Media|DSPOff"           "${control} period"
+    setshortcuts "Media|TestAudioMIDI"
+    setshortcuts "Media|LoadMeter"
+
+    setshortcuts "Window|Maximize"
+    setshortcuts "Window|AllToFront"
+    setshortcuts "Window|CloseSubwindows"
+    setshortcuts "Window|PdWindow"        "${control} R"
+    setshortcuts "Window|Parent"
+
+    if {[tk windowingsystem] eq "aqua"} {
+        # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
+        if {$::tcl_version < 8.5} {
+            setshortcuts "Window|Minimize" "${control} M"
+            setshortcuts "Window|Next"     "${control} quoteleft"
+        }
+    } else {
+        setshortcuts "Window|Minimize"    "${control} M"
+        setshortcuts "Window|Next"        "${control} Next" "${control} greater"
+        setshortcuts "Window|Previous"    "${control} Prior" "${control} less"
+    }
+
+    setshortcuts "Help|About"
+    setshortcuts "Help|Manual"
+    setshortcuts "Help|Browser"           "${control} B"
+    setshortcuts "Help|ListObjects"
+    setshortcuts "Help|puredata.info"
+    setshortcuts "Help|CheckUpdates"
+    setshortcuts "Help|ReportBug"
+
+    setshortcuts "Pd|Message"             "${control} Shift M"
+    setshortcuts "Pd|ClearConsole"        "${control} Shift L"
+
+    setshortcuts "Preferences|Audio"
+    setshortcuts "Preferences|MIDI"
+    setshortcuts "Preferences|Edit"
+    setshortcuts "Preferences|Save"
+    setshortcuts "Preferences|SaveTo"
+    setshortcuts "Preferences|Load"
+    setshortcuts "Preferences|Forget"
+}
+
+proc ::pd_bindings::setup {} {
+    foreach {ev shortcuts} $::pd_bindings::bindlist {
+        set event <<${ev}>>
+        event delete ${event}
+        foreach keys ${shortcuts} {
+            if { "$keys" == "" } {continue}
+            set wantkeys $keys
+            set key [lindex $keys end]
+            lset keys end Key
+            foreach k [list $key [string tolower $key] [string totitle $key]] {
+                catch {
+                    event add $event <[join [concat $keys $k] -]>
+                    set wantkeys {}
+                }
+            }
+            if { $wantkeys != {}} {
+                ::pdwindow::error "Failed to bind $event to ${wantkeys}\n"
+            }
+        }
+    }
+    ::pd_bindings::class_bindings
+    ::pd_bindings::global_bindings
 }
 
 # wrapper around bind(3tk)to deal with CapsLock
@@ -39,100 +180,117 @@ proc ::pd_bindings::bind_capslock {tag seq_prefix seq_nocase script} {
 # binding by class is not recursive, so its useful for window events
 proc ::pd_bindings::class_bindings {} {
     # and the Pd window is in a class to itself
-    bind PdWindow <FocusIn>           "::pd_bindings::window_focusin %W"
-    bind PdWindow <Destroy>           "::pd_bindings::window_destroy %W"
+    bind PdWindow     <FocusIn>       "::pd_bindings::window_focusin %W"
+    bind PdWindow     <Destroy>       "::pd_bindings::window_destroy %W"
     # bind to all the windows dedicated to patch canvases
-    bind PatchWindow <FocusIn>        "::pd_bindings::window_focusin %W"
-    bind PatchWindow <Map>            "::pd_bindings::patch_map %W"
-    bind PatchWindow <Unmap>          "::pd_bindings::patch_unmap %W"
-    bind PatchWindow <Configure>      "::pd_bindings::patch_configure %W %w %h %x %y"
-    bind PatchWindow <Destroy>        "::pd_bindings::window_destroy %W"
+    bind PatchWindow  <FocusIn>       "::pd_bindings::window_focusin %W"
+    bind PatchWindow  <Map>           "::pd_bindings::patch_map %W"
+    bind PatchWindow  <Unmap>         "::pd_bindings::patch_unmap %W"
+    bind PatchWindow  <Configure>     "::pd_bindings::patch_configure %W %w %h %x %y"
+    bind PatchWindow  <Destroy>       "::pd_bindings::window_destroy %W"
     # dialog panel windows bindings, which behave differently than PatchWindows
     bind DialogWindow <Configure>     "::pd_bindings::dialog_configure %W"
     bind DialogWindow <FocusIn>       "::pd_bindings::dialog_focusin %W"
     bind DialogWindow <Destroy>       "::pd_bindings::window_destroy %W"
     # help browser bindings
-    bind HelpBrowser <Configure>      "::pd_bindings::dialog_configure %W"
-    bind HelpBrowser <FocusIn>        "::pd_bindings::dialog_focusin %W"
-    bind HelpBrowser <Destroy>        "::pd_bindings::window_destroy %W"
+    bind HelpBrowser  <Configure>     "::pd_bindings::dialog_configure %W"
+    bind HelpBrowser  <FocusIn>       "::pd_bindings::dialog_focusin %W"
+    bind HelpBrowser  <Destroy>       "::pd_bindings::window_destroy %W"
 }
 
 proc ::pd_bindings::global_bindings {} {
-    variable control
     # we use 'bind all' everywhere to get as much of Tk's automatic binding
     # behaviors as possible, things like not sending an event for 'O' when
     # 'Control-O' is pressed
-    bind_capslock all ${control}-Key a {menu_send %W selectall}
-    bind_capslock all ${control}-Key b {menu_helpbrowser}
-    bind_capslock all ${control}-Key c {menu_send %W copy}
-    bind_capslock all ${control}-Key d {menu_send %W duplicate}
-    bind_capslock all ${control}-Key e {menu_toggle_editmode}
-    bind_capslock all ${control}-Key f {menu_find_dialog}
-    bind_capslock all ${control}-Key g {menu_send %W findagain}
-    bind_capslock all ${control}-Key k {menu_send %W connect_selection}
-    bind_capslock all ${control}-Key n {menu_new}
-    bind_capslock all ${control}-Key o {menu_open}
-    bind_capslock all ${control}-Key p {menu_print %W}
-    bind_capslock all ${control}-Key r {menu_raise_pdwindow}
-    bind_capslock all ${control}-Key s {menu_send %W menusave}
-    bind_capslock all ${control}-Key t {menu_send %W triggerize}
-    bind_capslock all ${control}-Key v {menu_send %W paste}
-    bind_capslock all ${control}-Key w {::pd_bindings::window_close %W}
-    bind_capslock all ${control}-Key x {menu_send %W cut}
-    bind_capslock all ${control}-Key z {menu_undo}
-    bind all <${control}-Key-1>        {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <${control}-Key-2>        {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <${control}-Key-3>        {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <${control}-Key-4>        {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <${control}-Key-5>        {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <${control}-Key-KP_1>     {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <${control}-Key-KP_2>     {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <${control}-Key-KP_3>     {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <${control}-Key-KP_4>     {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <${control}-Key-KP_5>     {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <${control}-Key-slash>    {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
-    bind all <${control}-Key-period>   {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
 
-    # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
-    # "+" key... this only makes sense on US keyboards but some users
-    # expected it... go figure.
-    bind all <${control}-Key-equal>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${control}-Key-plus>        {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${control}-Key-minus>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
-    bind all <${control}-Key-KP_Add>      {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <${control}-Key-KP_Subtract> {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind  all  <<File|New>>               {::pd_menucommands::scheduleAction menu_new}
+    bind  all  <<File|Open>>              {::pd_menucommands::scheduleAction menu_open}
+    bind  all  <<File|Save>>              {::pd_menucommands::scheduleAction menu_send %W menusave}
+    bind  all  <<File|SaveAs>>            {::pd_menucommands::scheduleAction menu_send %W menusaveas}
+    bind  all  <<Pd|Message>>             {::pd_menucommands::scheduleAction menu_message_dialog}
+    bind  all  <<File|Print>>             {::pd_menucommands::scheduleAction menu_print %W}
+    bind  all  <<File|ClearRecentFiles>>  {::pd_menucommands::scheduleAction ::pd_menus::clear_recentfiles_menu}
+    bind  all  <<File|Close>>             {::pd_menucommands::scheduleAction ::pd_bindings::window_close %W}
+    bind  all  <<File|CloseNow>>          {::pd_menucommands::scheduleAction ::pd_bindings::window_close %W 1}
+    bind  all  <<File|Quit>>              {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
+    bind  all  <<File|QuitNow>>           {::pd_menucommands::scheduleAction pdsend "pd quit"}
 
-    # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
+    bind  all  <<Preferences|Edit>>       {::pd_menucommands::scheduleAction menu_preference_dialog}
+    bind  all  <<Preferences|Save>>       {::pd_menucommands::scheduleAction pdsend "pd save-preferences"}
+    bind  all  <<Preferences|SaveTo>>     {::pd_menucommands::scheduleAction ::pd_menus::savepreferences}
+    bind  all  <<Preferences|Load>>       {::pd_menucommands::scheduleAction ::pd_menus::loadpreferences}
+    bind  all  <<Preferences|Forget>>     {::pd_menucommands::scheduleAction ::pd_menus::forgetpreferences}
 
-    # annoying, but Tk's bind needs uppercase letter to get the Shift
-    bind_capslock all ${control}-Shift-Key A {menu_send %W menuarray}
-    bind_capslock all ${control}-Shift-Key B {menu_send %W bng}
-    bind_capslock all ${control}-Shift-Key C {menu_send %W mycnv}
-    bind_capslock all ${control}-Shift-Key D {menu_send %W vradio}
-    bind_capslock all ${control}-Shift-Key G {menu_send %W graph}
-    bind_capslock all ${control}-Shift-Key J {menu_send %W hslider}
-    bind_capslock all ${control}-Shift-Key I {menu_send %W hradio}
-    bind_capslock all ${control}-Shift-Key L {menu_clear_console}
-    bind_capslock all ${control}-Shift-Key M {menu_message_dialog}
-    bind_capslock all ${control}-Shift-Key N {menu_send %W numbox}
-    bind_capslock all ${control}-Shift-Key Q {pdsend "pd quit"}
-    bind_capslock all ${control}-Shift-Key R {menu_send %W tidy}
-    bind_capslock all ${control}-Shift-Key S {menu_send %W menusaveas}
-    bind_capslock all ${control}-Shift-Key T {menu_send %W toggle}
-    bind_capslock all ${control}-Shift-Key U {menu_send %W vumeter}
-    bind_capslock all ${control}-Shift-Key V {menu_send %W vslider}
-    bind_capslock all ${control}-Shift-Key W {::pd_bindings::window_close %W 1}
-    bind_capslock all ${control}-Shift-Key Z {menu_redo}
-    bind all <KeyPress-Escape>         {menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1 %k}
+    bind  all  <<Edit|Undo>>              {::pd_menucommands::scheduleAction menu_undo}
+    bind  all  <<Edit|Redo>>              {::pd_menucommands::scheduleAction menu_redo}
+    bind  all  <<Edit|Cut>>               {::pd_menucommands::scheduleAction menu_send %W cut}
+    bind  all  <<Edit|Copy>>              {::pd_menucommands::scheduleAction menu_send %W copy}
+    bind  all  <<Edit|Paste>>             {::pd_menucommands::scheduleAction menu_send %W paste}
+    bind  all  <<Edit|Duplicate>>         {::pd_menucommands::scheduleAction menu_send %W duplicate}
+    bind  all  <<Edit|PasteReplace>>      {::pd_menucommands::scheduleAction menu_send %W paste-replace}
+    bind  all  <<Edit|SelectAll>>         {::pd_menucommands::scheduleAction menu_send %W selectall}
+
+    bind  all  <<Edit|Font>>              {::pd_menucommands::scheduleAction menu_font_dialog}
+    bind  all  <<Edit|ZoomIn>>            {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind  all  <<Edit|ZoomOut>>           {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind  all  <<Edit|TidyUp>>            {::pd_menucommands::scheduleAction menu_send %W tidy}
+    bind  all  <<Edit|ConnectSelection>>  {::pd_menucommands::scheduleAction menu_send %W connect_selection}
+    bind  all  <<Edit|Triggerize>>        {::pd_menucommands::scheduleAction menu_send %W triggerize}
+    bind  all  <<Pd|ClearConsole>>        {::pd_menucommands::scheduleAction menu_clear_console}
+    bind  all  <<Edit|EditMode>>          {::pd_menucommands::scheduleAction menu_toggle_editmode}
+    bind  all  <<Edit|SelectNone>>        {::pd_menucommands::scheduleAction menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1 %k}
+
+    bind  all  <<Put|Object>>             {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
+    bind  all  <<Put|Message>>            {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
+    bind  all  <<Put|Number>>             {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
+    bind  all  <<Put|Symbol>>             {::pd_menucommands::scheduleAction menu_send_float %W symbolatom 0}
+    bind  all  <<Put|List>>               {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
+    bind  all  <<Put|Comment>>            {::pd_menucommands::scheduleAction menu_send_float %W text 0}
+    bind  all  <<Put|Array>>              {::pd_menucommands::scheduleAction menu_send %W menuarray}
+    bind  all  <<Put|Bang>>               {::pd_menucommands::scheduleAction menu_send %W bng}
+    bind  all  <<Put|Canvas>>             {::pd_menucommands::scheduleAction menu_send %W mycnv}
+    bind  all  <<Put|VerticalRadio>>      {::pd_menucommands::scheduleAction menu_send %W vradio}
+    bind  all  <<Put|Graph>>              {::pd_menucommands::scheduleAction menu_send %W graph}
+    bind  all  <<Put|HorizontalSlider>>   {::pd_menucommands::scheduleAction menu_send %W hslider}
+    bind  all  <<Put|HorizontalRadio>>    {::pd_menucommands::scheduleAction menu_send %W hradio}
+    bind  all  <<Put|Number2>>            {::pd_menucommands::scheduleAction menu_send %W numbox}
+    bind  all  <<Put|Toggle>>             {::pd_menucommands::scheduleAction menu_send %W toggle}
+    bind  all  <<Put|VUMeter>>            {::pd_menucommands::scheduleAction menu_send %W vumeter}
+    bind  all  <<Put|VerticalSlider>>     {::pd_menucommands::scheduleAction menu_send %W vslider}
+
+    bind  all  <<Find|Find>>              {::pd_menucommands::scheduleAction menu_find_dialog}
+    bind  all  <<Find|FindAgain>>         {::pd_menucommands::scheduleAction menu_send %W findagain}
+    bind  all  <<Find|FindLastError>>     {::pd_menucommands::scheduleAction pdsend {pd finderror}}
+
+    bind  all  <<Media|DSPOn>>            {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
+    bind  all  <<Media|DSPOff>>           {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
+    bind  all  <<Media|TestAudioMIDI>>    {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools testtone.pd}
+    bind  all  <<Media|LoadMeter>>        {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools load-meter.pd}
+    bind  all  <<Preferences|Audio>>      {::pd_menucommands::scheduleAction pdsend "pd audio-properties"}
+    bind  all  <<Preferences|MIDI>>       {::pd_menucommands::scheduleAction pdsend "pd midi-properties"}
+
+    bind  all  <<Window|Minimize>>        {::pd_menucommands::scheduleAction menu_minimize %W}
+    bind  all  <<Window|Maximize>>        {::pd_menucommands::scheduleAction menu_maximize %W}
+    bind  all  <<Window|AllToFront>>      {::pd_menucommands::scheduleAction menu_bringalltofront}
+    bind  all  <<Window|Next>>            {::pd_menucommands::scheduleAction menu_raisenextwindow}
+    bind  all  <<Window|Previous>>        {::pd_menucommands::scheduleAction menu_raisepreviouswindow}
+    bind  all  <<Window|CloseSubwindows>> {::pd_menucommands::scheduleAction pdsend "pd close-subwindows"}
+    bind  all  <<Window|PdWindow>>        {::pd_menucommands::scheduleAction menu_raise_pdwindow}
+    bind  all  <<Window|Parent>>          {::pd_menucommands::scheduleAction menu_send %W findparent}
+
+    bind  all  <<Help|About>>             {::pd_menucommands::scheduleAction menu_aboutpd}
+    bind  all  <<Help|Manual>>            {::pd_menucommands::scheduleAction menu_manual}
+    bind  all  <<Help|Browser>>           {::pd_menucommands::scheduleAction menu_helpbrowser}
+    bind  all  <<Help|ListObjects>>       {::pd_menucommands::scheduleAction menu_objectlist}
+    bind  all  <<Help|puredata.info>>     {::pd_menucommands::scheduleAction menu_openfile {https://puredata.info}}
+    bind  all  <<Help|CheckUpdates>>      {::pd_menucommands::scheduleAction menu_openfile {https://pdlatest.puredata.info}}
+    bind  all  <<Help|ReportBug>>         {::pd_menucommands::scheduleAction menu_openfile {https://bugs.puredata.info}}
+
+
+    # JMZ: shouldn't the keybindings only apply to PatchWindows?
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
-         # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
-        if {$::tcl_version < 8.5} {
-            bind_capslock all ${control}-Key q       {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
-            bind_capslock all ${control}-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
-            bind all <${control}-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
-        }
         # BackSpace/Delete report the wrong isos (unicode representations) on OSX,
         # so we set them to the empty string and let ::pd_bindings::sendkey guess the correct values
         bind all <KeyPress-BackSpace>      {::pd_bindings::sendkey %W 1 %K "" 1 %k}
@@ -143,15 +301,6 @@ proc ::pd_bindings::global_bindings {} {
         bind all <KeyRelease-KP_Enter>     {::pd_bindings::sendkey %W 0 %K "" 1 %k}
         bind all <KeyPress-Clear>          {::pd_bindings::sendkey %W 1 %K "" 1 %k}
         bind all <KeyRelease-Clear>        {::pd_bindings::sendkey %W 0 %K "" 1 %k}
-    } else {
-        bind_capslock all ${control}-Key q       {::pd_connect::menu_quit}
-        bind_capslock all ${control}-Key m       {menu_minimize %W}
-
-        bind all <${control}-Next>        {menu_raisenextwindow}    ;# PgUp
-        bind all <${control}-Prior>       {menu_raisepreviouswindow};# PageDown
-        # these can conflict with CMD+comma & CMD+period bindings in Tk Cococa
-        bind all <${control}-greater>     {menu_raisenextwindow}
-        bind all <${control}-less>        {menu_raisepreviouswindow}
     }
 
     bind all <KeyPress>         {::pd_bindings::sendkey %W 1 %K %A 0 %k}
@@ -446,6 +595,7 @@ proc ::pd_bindings::canvas_cycle {mytoplevel cycledir key iso shift {keycode ""}
     menu_send_float $mytoplevel cycleselect $cycledir
     ::pd_bindings::sendkey $mytoplevel 1 $key $iso $shift $keycode
 }
+
 
 #------------------------------------------------------------------------------#
 # key usage

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -54,76 +54,76 @@ proc ::pd_bindings::global_bindings {} {
     # we use 'bind all' everywhere to get as much of Tk's automatic binding
     # behaviors as possible, things like not sending an event for 'O' when
     # 'Control-O' is pressed
-    bind_capslock all $::modifier-Key a {menu_send %W selectall}
-    bind_capslock all $::modifier-Key b {menu_helpbrowser}
-    bind_capslock all $::modifier-Key c {menu_send %W copy}
-    bind_capslock all $::modifier-Key d {menu_send %W duplicate}
-    bind_capslock all $::modifier-Key e {menu_toggle_editmode}
-    bind_capslock all $::modifier-Key f {menu_find_dialog}
-    bind_capslock all $::modifier-Key g {menu_send %W findagain}
-    bind_capslock all $::modifier-Key k {menu_send %W connect_selection}
-    bind_capslock all $::modifier-Key n {menu_new}
-    bind_capslock all $::modifier-Key o {menu_open}
-    bind_capslock all $::modifier-Key p {menu_print $::focused_window}
-    bind_capslock all $::modifier-Key r {menu_raise_pdwindow}
-    bind_capslock all $::modifier-Key s {menu_send %W menusave}
-    bind_capslock all $::modifier-Key t {menu_send %W triggerize}
-    bind_capslock all $::modifier-Key v {menu_send %W paste}
-    bind_capslock all $::modifier-Key w {::pd_bindings::window_close %W}
-    bind_capslock all $::modifier-Key x {menu_send %W cut}
-    bind_capslock all $::modifier-Key z {menu_undo}
-    bind all <$::modifier-Key-1>        {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <$::modifier-Key-2>        {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <$::modifier-Key-3>        {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <$::modifier-Key-4>        {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <$::modifier-Key-5>        {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <$::modifier-Key-KP_1>     {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
-    bind all <$::modifier-Key-KP_2>     {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
-    bind all <$::modifier-Key-KP_3>     {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
-    bind all <$::modifier-Key-KP_4>     {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
-    bind all <$::modifier-Key-KP_5>     {::pd_menucommands::scheduleAction menu_send_float %W text 0}
-    bind all <$::modifier-Key-slash>    {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
-    bind all <$::modifier-Key-period>   {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
+    bind_capslock all ${::modifier}-Key a {menu_send %W selectall}
+    bind_capslock all ${::modifier}-Key b {menu_helpbrowser}
+    bind_capslock all ${::modifier}-Key c {menu_send %W copy}
+    bind_capslock all ${::modifier}-Key d {menu_send %W duplicate}
+    bind_capslock all ${::modifier}-Key e {menu_toggle_editmode}
+    bind_capslock all ${::modifier}-Key f {menu_find_dialog}
+    bind_capslock all ${::modifier}-Key g {menu_send %W findagain}
+    bind_capslock all ${::modifier}-Key k {menu_send %W connect_selection}
+    bind_capslock all ${::modifier}-Key n {menu_new}
+    bind_capslock all ${::modifier}-Key o {menu_open}
+    bind_capslock all ${::modifier}-Key p {menu_print $::focused_window}
+    bind_capslock all ${::modifier}-Key r {menu_raise_pdwindow}
+    bind_capslock all ${::modifier}-Key s {menu_send %W menusave}
+    bind_capslock all ${::modifier}-Key t {menu_send %W triggerize}
+    bind_capslock all ${::modifier}-Key v {menu_send %W paste}
+    bind_capslock all ${::modifier}-Key w {::pd_bindings::window_close %W}
+    bind_capslock all ${::modifier}-Key x {menu_send %W cut}
+    bind_capslock all ${::modifier}-Key z {menu_undo}
+    bind all <${::modifier}-Key-1>        {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
+    bind all <${::modifier}-Key-2>        {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
+    bind all <${::modifier}-Key-3>        {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
+    bind all <${::modifier}-Key-4>        {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
+    bind all <${::modifier}-Key-5>        {::pd_menucommands::scheduleAction menu_send_float %W text 0}
+    bind all <${::modifier}-Key-KP_1>     {::pd_menucommands::scheduleAction menu_send_float %W obj 0}
+    bind all <${::modifier}-Key-KP_2>     {::pd_menucommands::scheduleAction menu_send_float %W msg 0}
+    bind all <${::modifier}-Key-KP_3>     {::pd_menucommands::scheduleAction menu_send_float %W floatatom 0}
+    bind all <${::modifier}-Key-KP_4>     {::pd_menucommands::scheduleAction menu_send_float %W listbox 0}
+    bind all <${::modifier}-Key-KP_5>     {::pd_menucommands::scheduleAction menu_send_float %W text 0}
+    bind all <${::modifier}-Key-slash>    {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
+    bind all <${::modifier}-Key-period>   {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
 
     # take the '=' key as a zoom-in accelerator, because '=' is the non-shifted
     # "+" key... this only makes sense on US keyboards but some users
     # expected it... go figure.
-    bind all <$::modifier-Key-equal>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <$::modifier-Key-plus>        {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <$::modifier-Key-minus>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
-    bind all <$::modifier-Key-KP_Add>      {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
-    bind all <$::modifier-Key-KP_Subtract> {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind all <${::modifier}-Key-equal>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${::modifier}-Key-plus>        {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${::modifier}-Key-minus>       {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
+    bind all <${::modifier}-Key-KP_Add>      {::pd_menucommands::scheduleAction menu_send_float %W zoom 2}
+    bind all <${::modifier}-Key-KP_Subtract> {::pd_menucommands::scheduleAction menu_send_float %W zoom 1}
 
     # note: we avoid CMD-H & CMD+Shift-H as it hides Pd on macOS
 
     # annoying, but Tk's bind needs uppercase letter to get the Shift
-    bind_capslock all $::modifier-Shift-Key A {menu_send %W menuarray}
-    bind_capslock all $::modifier-Shift-Key B {menu_send %W bng}
-    bind_capslock all $::modifier-Shift-Key C {menu_send %W mycnv}
-    bind_capslock all $::modifier-Shift-Key D {menu_send %W vradio}
-    bind_capslock all $::modifier-Shift-Key G {menu_send %W graph}
-    bind_capslock all $::modifier-Shift-Key J {menu_send %W hslider}
-    bind_capslock all $::modifier-Shift-Key I {menu_send %W hradio}
-    bind_capslock all $::modifier-Shift-Key L {menu_clear_console}
-    bind_capslock all $::modifier-Shift-Key M {menu_message_dialog}
-    bind_capslock all $::modifier-Shift-Key N {menu_send %W numbox}
-    bind_capslock all $::modifier-Shift-Key Q {pdsend "pd quit"}
-    bind_capslock all $::modifier-Shift-Key R {menu_send %W tidy}
-    bind_capslock all $::modifier-Shift-Key S {menu_send %W menusaveas}
-    bind_capslock all $::modifier-Shift-Key T {menu_send %W toggle}
-    bind_capslock all $::modifier-Shift-Key U {menu_send %W vumeter}
-    bind_capslock all $::modifier-Shift-Key V {menu_send %W vslider}
-    bind_capslock all $::modifier-Shift-Key W {::pd_bindings::window_close %W 1}
-    bind_capslock all $::modifier-Shift-Key Z {menu_redo}
+    bind_capslock all ${::modifier}-Shift-Key A {menu_send %W menuarray}
+    bind_capslock all ${::modifier}-Shift-Key B {menu_send %W bng}
+    bind_capslock all ${::modifier}-Shift-Key C {menu_send %W mycnv}
+    bind_capslock all ${::modifier}-Shift-Key D {menu_send %W vradio}
+    bind_capslock all ${::modifier}-Shift-Key G {menu_send %W graph}
+    bind_capslock all ${::modifier}-Shift-Key J {menu_send %W hslider}
+    bind_capslock all ${::modifier}-Shift-Key I {menu_send %W hradio}
+    bind_capslock all ${::modifier}-Shift-Key L {menu_clear_console}
+    bind_capslock all ${::modifier}-Shift-Key M {menu_message_dialog}
+    bind_capslock all ${::modifier}-Shift-Key N {menu_send %W numbox}
+    bind_capslock all ${::modifier}-Shift-Key Q {pdsend "pd quit"}
+    bind_capslock all ${::modifier}-Shift-Key R {menu_send %W tidy}
+    bind_capslock all ${::modifier}-Shift-Key S {menu_send %W menusaveas}
+    bind_capslock all ${::modifier}-Shift-Key T {menu_send %W toggle}
+    bind_capslock all ${::modifier}-Shift-Key U {menu_send %W vumeter}
+    bind_capslock all ${::modifier}-Shift-Key V {menu_send %W vslider}
+    bind_capslock all ${::modifier}-Shift-Key W {::pd_bindings::window_close %W 1}
+    bind_capslock all ${::modifier}-Shift-Key Z {menu_redo}
     bind all <KeyPress-Escape>         {menu_send %W deselectall; ::pd_bindings::sendkey %W 1 %K %A 1 %k}
 
     # OS-specific bindings
     if {$::windowingsystem eq "aqua"} {
          # TK 8.5+ Cocoa handles quit, minimize, & raise next window for us
         if {$::tcl_version < 8.5} {
-            bind_capslock all $::modifier-Key q       {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
-            bind_capslock all $::modifier-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
-            bind all <$::modifier-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
+            bind_capslock all ${::modifier}-Key q       {::pd_menucommands::scheduleAction ::pd_connect::menu_quit}
+            bind_capslock all ${::modifier}-Key m       {::pd_menucommands::scheduleAction menu_minimize %W}
+            bind all <${::modifier}-quoteleft>   {::pd_menucommands::scheduleAction menu_raisenextwindow}
         }
         # BackSpace/Delete report the wrong isos (unicode representations) on OSX,
         # so we set them to the empty string and let ::pd_bindings::sendkey guess the correct values
@@ -136,14 +136,14 @@ proc ::pd_bindings::global_bindings {} {
         bind all <KeyPress-Clear>          {::pd_bindings::sendkey %W 1 %K "" 1 %k}
         bind all <KeyRelease-Clear>        {::pd_bindings::sendkey %W 0 %K "" 1 %k}
     } else {
-        bind_capslock all $::modifier-Key q       {::pd_connect::menu_quit}
-        bind_capslock all $::modifier-Key m       {menu_minimize %W}
+        bind_capslock all ${::modifier}-Key q       {::pd_connect::menu_quit}
+        bind_capslock all ${::modifier}-Key m       {menu_minimize %W}
 
-        bind all <$::modifier-Next>        {menu_raisenextwindow}    ;# PgUp
-        bind all <$::modifier-Prior>       {menu_raisepreviouswindow};# PageDown
+        bind all <${::modifier}-Next>        {menu_raisenextwindow}    ;# PgUp
+        bind all <${::modifier}-Prior>       {menu_raisepreviouswindow};# PageDown
         # these can conflict with CMD+comma & CMD+period bindings in Tk Cococa
-        bind all <$::modifier-greater>     {menu_raisenextwindow}
-        bind all <$::modifier-less>        {menu_raisepreviouswindow}
+        bind all <${::modifier}-greater>     {menu_raisenextwindow}
+        bind all <${::modifier}-less>        {menu_raisepreviouswindow}
     }
 
     bind all <KeyPress>         {::pd_bindings::sendkey %W 1 %K %A 0 %k}
@@ -174,18 +174,18 @@ proc ::pd_bindings::dialog_bindings {mytoplevel dialogname} {
 
     bind $mytoplevel <KeyPress-Escape>          "dialog_${dialogname}::cancel $mytoplevel; break"
     bind $mytoplevel <KeyPress-Return>          "dialog_${dialogname}::ok $mytoplevel; break"
-    bind_capslock $mytoplevel $::modifier-Key w "dialog_${dialogname}::cancel $mytoplevel; break"
+    bind_capslock $mytoplevel ${::modifier}-Key w "dialog_${dialogname}::cancel $mytoplevel; break"
     # these aren't supported in the dialog, so alert the user, then break so
     # that no other key bindings are run
     if {$mytoplevel ne ".find"} {
-        bind_capslock $mytoplevel $::modifier-Key s       {bell; break}
-        bind_capslock $mytoplevel $::modifier-Shift-Key s {bell; break}
-        bind_capslock $mytoplevel $::modifier-Key p       {bell; break}
+        bind_capslock $mytoplevel ${::modifier}-Key s       {bell; break}
+        bind_capslock $mytoplevel ${::modifier}-Shift-Key s {bell; break}
+        bind_capslock $mytoplevel ${::modifier}-Key p       {bell; break}
     } else {
         # find may may allow passthrough to it's target search patch
         ::dialog_find::update_bindings
     }
-    bind_capslock $mytoplevel $::modifier-Key t           {bell; break}
+    bind_capslock $mytoplevel ${::modifier}-Key t           {bell; break}
 
     wm protocol $mytoplevel WM_DELETE_WINDOW "dialog_${dialogname}::cancel $mytoplevel"
 }
@@ -226,45 +226,45 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     # events over the window frame and $tkcanvas for events over the canvas
     bind $tkcanvas <Motion>                    "pdtk_canvas_motion %W %x %y 0"
     bind $tkcanvas <Shift-Motion>              "pdtk_canvas_motion %W %x %y 1"
-    bind $tkcanvas <$::modifier-Motion>        "pdtk_canvas_motion %W %x %y 2"
-    bind $tkcanvas <$::modifier-Shift-Motion>  "pdtk_canvas_motion %W %x %y 3"
-    bind $tkcanvas <$alt-Motion>               "pdtk_canvas_motion %W %x %y 4"
-    bind $tkcanvas <$alt-Shift-Motion>         "pdtk_canvas_motion %W %x %y 5"
-    bind $tkcanvas <$::modifier-$alt-Motion>   "pdtk_canvas_motion %W %x %y 6"
-    bind $tkcanvas <$::modifier-$alt-Shift-Motion> "pdtk_canvas_motion %W %x %y 7"
+    bind $tkcanvas <${::modifier}-Motion>        "pdtk_canvas_motion %W %x %y 2"
+    bind $tkcanvas <${::modifier}-Shift-Motion>  "pdtk_canvas_motion %W %x %y 3"
+    bind $tkcanvas <${alt}-Motion>               "pdtk_canvas_motion %W %x %y 4"
+    bind $tkcanvas <${alt}-Shift-Motion>         "pdtk_canvas_motion %W %x %y 5"
+    bind $tkcanvas <${::modifier}-${alt}-Motion>   "pdtk_canvas_motion %W %x %y 6"
+    bind $tkcanvas <${::modifier}-${alt}-Shift-Motion> "pdtk_canvas_motion %W %x %y 7"
 
     bind $tkcanvas <ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 0"
     bind $tkcanvas <Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 1"
-    bind $tkcanvas <$::modifier-ButtonPress-1> \
+    bind $tkcanvas <${::modifier}-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 2"
-    bind $tkcanvas <$::modifier-Shift-ButtonPress-1> \
+    bind $tkcanvas <${::modifier}-Shift-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 3"
-    bind $tkcanvas <$alt-ButtonPress-1> \
+    bind $tkcanvas <${alt}-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 4"
-    bind $tkcanvas <$alt-Shift-ButtonPress-1> \
+    bind $tkcanvas <${alt}-Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 5"
-    bind $tkcanvas <$::modifier-$alt-ButtonPress-1> \
+    bind $tkcanvas <${::modifier}-${alt}-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 6"
-    bind $tkcanvas <$::modifier-$alt-Shift-ButtonPress-1> \
+    bind $tkcanvas <${::modifier}-${alt}-Shift-ButtonPress-1> \
         "::pd_bindings::handle_modifier_click %W %x %y %b 7"
 
     bind $tkcanvas <ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 0"
     bind $tkcanvas <Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 1"
-    bind $tkcanvas <$::modifier-ButtonRelease-1> \
+    bind $tkcanvas <${::modifier}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 2"
-    bind $tkcanvas <$::modifier-Shift-ButtonRelease-1> \
+    bind $tkcanvas <${::modifier}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 3"
-    bind $tkcanvas <$alt-ButtonRelease-1> \
+    bind $tkcanvas <${alt}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 4"
-    bind $tkcanvas <$alt-Shift-ButtonRelease-1> \
+    bind $tkcanvas <${alt}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 5"
-    bind $tkcanvas <$::modifier-$alt-ButtonRelease-1> \
+    bind $tkcanvas <${::modifier}-${alt}-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 6"
-    bind $tkcanvas <$::modifier-$alt-Shift-ButtonRelease-1> \
+    bind $tkcanvas <${::modifier}-${alt}-Shift-ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 7"
 
     bind $tkcanvas <MouseWheel>       {::pdtk_canvas::scroll %W y %D}

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -35,6 +35,9 @@ proc ::pd_menucommands::menu_open {} {
 # TODO set the current font family & size via the -fontmap option:
 # http://wiki.tcl.tk/41871
 proc ::pd_menucommands::menu_print {mytoplevel} {
+    if { [winfo exists ${mytoplevel}] } {
+        set mytoplevel [winfo toplevel ${mytoplevel}]
+    }
     set initialfile "[file rootname [lookup_windowname $mytoplevel]].ps"
     set filename [tk_getSaveFile -initialfile $initialfile \
                       -title [_ "Print..." ] \

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -220,6 +220,87 @@ proc ::pd_menus::update_accelerators {{menu .}} {
         ::pd_menus::update_accelerators $m
     }
 }
+proc ::pd_menus::get_events {{menu .} args} {
+    # recursively search the given menu for any commands that generate a virtual event
+    # and return a list of these events:
+    # e.g. '::pd_menus::get_events .menu.edit' -> '{<<Copy>> <<Paste>>}'
+    # the optional <args> is a list of additional options to query:
+    # e.g. '::pd_menus::get_events .menu.edit label accelerator' -> '{<<Copy>> {{Copy} {Ctrl-C}} <<Paste>> {{Paste} {Ctrl-V}}}'
+    if { ! [winfo exists $menu] } {return}
+
+    # flat list of events (for order preservation)
+    set events {}
+    # array with args-options of each event
+    array set seen {}
+
+    if { [winfo class $menu] == "Menu" } {
+        # this is a real menu, so update it
+        set lastmenu [$menu index end]
+        if { "${lastmenu}" eq "none" } { set lastmenu 0 }
+        for {set i 0} {$i <= $lastmenu} {incr i} {
+            set cmd {}
+            catch {
+                # some menu types (e.g. Seperators) do not have a command, so beware
+                set cmd [$menu entrycget $i -command]
+            }
+            if { $cmd == "" } {continue}
+            if { [regexp -all {event generate .* (<<[^>]*|[^>]*>>)} $cmd _ ev] } {
+                set options {}
+                foreach a $args {
+                    set o {}
+                    catch {
+                        set o [$menu entrycget $i -$a]
+                    }
+                    lappend options $o
+                }
+                if { [info exists seen($ev) ] } {
+                    # already seen, check if there are some new options
+                    set newoptions {}
+                    foreach o0 $seen($ev) o1 $options {
+                        if { $o0 != "" } {
+                            lappend newoptions $o0
+                        } else {
+                            lappend newoptions $o1
+                        }
+                    }
+                    set seen($ev) $newoptions
+                } else {
+                    lappend events $ev
+                    set seen($ev) $options
+                }
+            }
+        }
+    }
+
+    foreach m [winfo children $menu] {
+        foreach {ev options} [::pd_menus::get_events $m $args] {
+            if { [info exists seen($ev) ] } {
+                # already seen, check if there are some new options
+                set newoptions {}
+                foreach o0 $seen($ev) o1 $options {
+                    if { $o0 != "" } {
+                        lappend newoptions $o0
+                    } else {
+                        lappend newoptions $o1
+                    }
+                }
+                set seen($ev) $newoptions
+            } else {
+                lappend events $ev
+                set seen($ev) $options
+            }
+        }
+    }
+
+    set result {}
+    foreach ev $events {
+        lappend result $ev
+        if { $args != {} } {
+            lappend result $seen($ev)
+        }
+    }
+    return $result
+}
 
 
 

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -437,7 +437,7 @@ proc ::pd_menus::update_openrecent_menu {mymenu {write}} {
         incr i
     }
     $mymenu add separator
-    $mymenu add command -label [_ "Clear Menu"] \
+    $mymenu add command -label [_ "Clear Recent Files"] \
         -command {event generate [focus] <<File|ClearRecentFiles>>}
     # write to config file
     if {$write == true} { ::pd_guiprefs::write_recentfiles }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -198,6 +198,30 @@ proc ::pd_menus::menubar_for_dialog {mytoplevel} {
     $mytoplevel configure -menu $menubar
 }
 
+proc ::pd_menus::update_accelerators {{menu .}} {
+    if { ! [winfo exists $menu] } {return}
+    if { [winfo class $menu] == "Menu" } {
+        # this is a real menu, so update it
+        set lastmenu [$menu index end]
+        if { "${lastmenu}" eq "none" } { set lastmenu 0 }
+        for {set i 0} {$i <= $lastmenu} {incr i} {
+            set cmd {}
+            catch {
+                set cmd [$menu entrycget $i -command]
+            }
+            if { $cmd == "" } {continue}
+            if { [regexp -all {event generate \[focus\] <<([^>]*|[^>]*)>>} $cmd _ ev] } {
+                set accel [ ::pd_menus::get_accelerator_for_event <<${ev}>>]
+                $menu entryconfigure $i -accelerator $accel
+            }
+        }
+    }
+    foreach m [winfo children $menu] {
+        ::pd_menus::update_accelerators $m
+    }
+}
+
+
 
 
 proc ::pd_menus::build_file_menu {mymenu {patchwindow true}} {

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -26,6 +26,52 @@ namespace eval ::pd_menus:: {
 
     # turn off tearoff menus globally
     option add *tearOff 0
+
+    array set keynames { \
+                             "Key" "" \
+                             "Mod1" "Cmd" \
+                             "Mod2" "Option" \
+                             "Command" "Cmd" \
+                             "Control" "Ctrl" \
+                             "ISO_Level3_Shift" "AltGr" \
+                             "Next" "Page Down" \
+                             "Prior" "Page Up" \
+                             "exclam" "!" \
+                             "quotedbl" "\"" \
+                             "numbersign" "#" \
+                             "dollar" "$" \
+                             "percent" "%" \
+                             "ampersand" "&" \
+                             "apostrophe" "'" \
+                             "parenleft" "(" \
+                             "parenright" ")" \
+                             "asterisk" "*" \
+                             "plus" "+" \
+                             "comma" "," \
+                             "minus" "-" \
+                             "period" "." \
+                             "slash" "/" \
+                             "colon" ":" \
+                             "semicolon" ";" \
+                             "less" "<" \
+                             "equal" "=" \
+                             "greater" ">" \
+                             "question" "?" \
+                             "at" "@" \
+                             "bracketleft" "[" \
+                             "backslash" "\\" \
+                             "bracketright" "]" \
+                             "asciicircum" "^" \
+                             "underscore" "_" \
+                             "grave" "`" \
+                             "braceleft" "{" \
+                             "bar" "|" \
+                             "braceright" "}" \
+                             "asciitilde" "~" \
+                             "section" "§" \
+                             "acute" "´" \
+                             "degree" "°" \
+    }
 }
 
 set ::pd_menus::putmenu_struct {{} {}}

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -159,6 +159,37 @@ proc ::pd_menus::configure_for_dialog {mytoplevel} {
     }
 }
 
+# ------------------------------------------------------------------------------
+# menu building functions
+proc ::pd_menus::get_accelerator_for_event {event} {
+    foreach shortcut [event info $event] {
+        set accel {}
+        foreach k [split [string trim $shortcut <>] -] {
+            foreach {longname k} [array get ::pd_menus::keynames $k] {break}
+            if { $k != "" } {
+                lappend accel $k
+            }
+        }
+
+        if { $accel != {} } {
+            return [join $accel +]
+        }
+    }
+    return ""
+}
+proc ::pd_menus::add_menu {menu type label event args} {
+    $menu add $type \
+        -label $label \
+        -command "event generate \[focus\] $event"
+    set accel [::pd_menus::get_accelerator_for_event $event]
+    if { $accel != {} } {
+        $menu entryconfigure end -accelerator $accel
+    }
+    foreach {k v} $args {
+        $menu entryconfigure end $k $v
+    }
+}
+
 proc ::pd_menus::menubar_for_dialog {mytoplevel} {
     set menubar $::dialog_menubar
     if {$::windowingsystem eq "aqua"} {
@@ -168,33 +199,32 @@ proc ::pd_menus::menubar_for_dialog {mytoplevel} {
 }
 
 
-# ------------------------------------------------------------------------------
-# menu building functions
-proc ::pd_menus::build_file_menu {mymenu {patchwindow true}} {
-    variable accelerator
-    $mymenu add command -label [_ "New"]         -accelerator "$accelerator+N" -command {::pd_menucommands::scheduleAction menu_new}
-    $mymenu add command -label [_ "Open"]        -accelerator "$accelerator+O" -command {::pd_menucommands::scheduleAction menu_open}
 
+proc ::pd_menus::build_file_menu {mymenu {patchwindow true}} {
+    # run the platform-specific build_file_menu_* procs first, and config them
+    add_menu $mymenu command [_ "New" ] "<<File|New>>"
+    add_menu $mymenu command [_ "Open" ] "<<File|Open>>"
     $mymenu add cascade -label [_ "Open Recent"] -menu .openrecent
     $mymenu add separator
-    $mymenu add command -label [_ "Close"]       -accelerator "$accelerator+W" -command {::pd_menucommands::scheduleAction ::pd_bindings::window_close $::focused_window}
+    add_menu $mymenu command [_ "Close" ] "<<File|Close>>"
     if { $patchwindow } {
-    $mymenu add command -label [_ "Save"]        -accelerator "$accelerator+S" -command {::pd_menucommands::scheduleAction menu_send $::focused_window menusave}
+        add_menu $mymenu command [_ "Save" ] "<<File|Save>>"
     }
-    $mymenu add command -label [_ "Save As..."]  -accelerator "Shift+$accelerator+S" -command {::pd_menucommands::scheduleAction menu_send $::focused_window menusaveas}
-    #$mymenu add command -label [_ "Save All"]
-    #$mymenu add command -label [_ "Revert to Saved"] -command {::pd_menucommands::scheduleAction menu_revert $::focused_window}
+    add_menu $mymenu command [_ "Save As..." ] "<<File|SaveAs>>"
+    #add_menu $mymenu command [_ "Save All" ] "<<File|SaveAll>>"
+    #add_menu $mymenu command [_ "Revert to Saved" ] "<<File|Revert>>"
+    #$mymenu entryconfigure [_ "Revert*"]    -command {event generate [focus] <<File|Revert>>}
+
     $mymenu add  separator
     if {$::windowingsystem ne "aqua"} {
         $mymenu add cascade -label [_ "Preferences"] -menu .preferences
     }
     if { $patchwindow } {
-    $mymenu add command -label [_ "Print..."]    -accelerator "$accelerator+P" -command {::pd_menucommands::scheduleAction menu_print $::focused_window}
+        add_menu $mymenu command [_ "Print..." ] "<<File|Print>>"
     }
-    $mymenu add  separator
     if {$::windowingsystem ne "aqua"} {
-        $mymenu add command -label [_ "Quit"]    -accelerator "$accelerator+Q" \
-            -command {::pd_connect::menu_quit}
+        $mymenu add  separator
+        add_menu $mymenu command [_ "Quit" ] "<<File|Quit>>"
     }
 
     # update recent files
@@ -204,65 +234,38 @@ proc ::pd_menus::build_file_menu {mymenu {patchwindow true}} {
 proc ::pd_menus::build_edit_menu {mymenu {patchwindow true}} {
     variable accelerator
     if { $patchwindow } {
-    $mymenu add command -label [_ "Undo"]       -accelerator "$accelerator+Z" \
-        -command {::pd_menucommands::scheduleAction menu_undo}
-    $mymenu add command -label [_ "Redo"]       -accelerator "Shift+$accelerator+Z" \
-        -command {::pd_menucommands::scheduleAction menu_redo}
+    add_menu $mymenu command [_ "Undo" ] "<<Edit|Undo>>"
+    add_menu $mymenu command [_ "Redo" ] "<<Edit|Redo>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Cut"]        -accelerator "$accelerator+X" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window cut}
-    $mymenu add command -label [_ "Copy"]       -accelerator "$accelerator+C" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window copy}
-    $mymenu add command -label [_ "Paste"]      -accelerator "$accelerator+V" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste}
-    $mymenu add command -label [_ "Paste Replace" ]  \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window paste-replace}
+    add_menu $mymenu command [_ "Cut" ] "<<Edit|Cut>>"
+    add_menu $mymenu command [_ "Copy" ] "<<Edit|Copy>>"
+    add_menu $mymenu command [_ "Paste" ] "<<Edit|Paste>>"
+    add_menu $mymenu command [_ "Paste Replace" ] "<<Edit|PasteReplace>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Select All"] -accelerator "$accelerator+A" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window selectall}
+    add_menu $mymenu command [_ "Select All" ] "<<Edit|SelectAll>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Duplicate"]  -accelerator "$accelerator+D" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window duplicate}
-    $mymenu add command -label [_ "Tidy Up"]    -accelerator "$accelerator+Shift+R" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window tidy}
-    $mymenu add command -label [_ "(Dis)Connect Selection"]    -accelerator "$accelerator+K" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window connect_selection}
-    $mymenu add command -label [_ "Triggerize"] -accelerator "$accelerator+T" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window triggerize}
+    add_menu $mymenu command [_ "Duplicate" ] "<<Edit|Duplicate>>"
+    add_menu $mymenu command [_ "Tidy Up" ] "<<Edit|TidyUp>>"
+    add_menu $mymenu command [_ "(Dis)Connect Selection" ] "<<Edit|ConnectSelection>>"
+    add_menu $mymenu command [_ "Triggerize" ] "<<Edit|Triggerize>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Font"] \
-        -command {::pd_menucommands::scheduleAction menu_font_dialog}
-    $mymenu add command -label [_ "Zoom In"]    -accelerator "$accelerator++" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window zoom 2}
-    $mymenu add command -label [_ "Zoom Out"]   -accelerator "$accelerator+-" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window zoom 1}
+    add_menu $mymenu command [_ "Font" ] "<<Edit|Font>>"
+    add_menu $mymenu command [_ "Zoom In" ] "<<Edit|ZoomIn>>"
+    add_menu $mymenu command [_ "Zoom Out" ] "<<Edit|ZoomOut>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Clear Console"] \
-        -accelerator "Shift+$accelerator+L" -command {::pd_menucommands::scheduleAction menu_clear_console}
+    add_menu $mymenu command [_ "Clear Console" ] "<<Pd|ClearConsole>>"
     $mymenu add  separator
-    #TODO madness! how to set the state of the check box without invoking the menu!
-    $mymenu add check -label [_ "Edit Mode"]    -accelerator "$accelerator+E" \
-        -variable ::editmode_button \
-        -command {::pd_menucommands::scheduleAction menu_editmode $::editmode_button}
-
+    add_menu $mymenu check [_ "Edit Mode"] <<Edit|EditMode>> -variable ::editmode_button
     } else {
-    $mymenu add command -label [_ "Cut"]        -accelerator "$accelerator+X" \
-        -state disabled \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window cut}
-    $mymenu add command -label [_ "Copy"]       -accelerator "$accelerator+C" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window copy}
-    $mymenu add command -label [_ "Paste"]      -accelerator "$accelerator+V" \
-        -state disabled \
-        -command {::pd_menucommands::scheduleAction menu_send_paste $::focused_window paste}
-    $mymenu add  separator
-    $mymenu add command -label [_ "Select All"] -accelerator "$accelerator+A" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window selectall}
-    $mymenu add  separator
-    $mymenu add command -label [_ "Font"] \
-        -command {::pd_menucommands::scheduleAction menu_font_dialog}
-    $mymenu add  separator
-    $mymenu add command -label [_ "Clear Console"] \
-        -accelerator "Shift+$accelerator+L" -command {::pd_menucommands::scheduleAction menu_clear_console}
+        add_menu $mymenu command [_ "Cut" ] "<<Edit|Cut>>" -state disabled
+        add_menu $mymenu command [_ "Copy" ] "<<Edit|Copy>>"
+        add_menu $mymenu command [_ "Paste" ] "<<Edit|Paste>>" -state disabled
+        $mymenu add  separator
+        add_menu $mymenu command [_ "Select All" ] "<<Edit|SelectAll>>"
+        $mymenu add  separator
+        add_menu $mymenu command [_ "Font" ] "<<Edit|Font>>"
+        $mymenu add  separator
+        add_menu $mymenu command [_ "Clear Console" ] "<<Pd|ClearConsole>>"
     }
 }
 
@@ -271,39 +274,23 @@ proc ::pd_menus::build_put_menu {mymenu} {
     # The trailing 0 in menu_send_float basically means leave the object box
     # sticking to the mouse cursor. The iemguis always do that when created
     # from the menu, as defined in canvas_iemguis()
-    $mymenu add command -label [_ "Object"]   -accelerator "$accelerator+1" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window obj 0}
-    $mymenu add command -label [_ "Message"]  -accelerator "$accelerator+2" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window msg 0}
-    $mymenu add command -label [_ "Number"]   -accelerator "$accelerator+3" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window floatatom 0}
-    $mymenu add command -label [_ "List"]   -accelerator "$accelerator+4" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window listbox 0}
-    $mymenu add command -label [_ "Symbol"]  \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window symbolatom 0}
-    $mymenu add command -label [_ "Comment"]  -accelerator "$accelerator+5" \
-        -command {::pd_menucommands::scheduleAction menu_send_float $::focused_window text 0}
-    $mymenu add command -label [_ "Array"]    -accelerator "Shift+$accelerator+A" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window menuarray}
+    add_menu $mymenu command [_ "Object" ] "<<Put|Object>>"
+    add_menu $mymenu command [_ "Message" ] "<<Put|Message>>"
+    add_menu $mymenu command [_ "Number" ] "<<Put|Number>>"
+    add_menu $mymenu command [_ "List" ] "<<Put|List>>"
+    add_menu $mymenu command [_ "Symbol" ] "<<Put|Symbol>>"
+    add_menu $mymenu command [_ "Comment" ] "<<Put|Comment>>"
+    add_menu $mymenu command [_ "Array" ] "<<Put|Array>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Bang"]     -accelerator "Shift+$accelerator+B" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window bng}
-    $mymenu add command -label [_ "Toggle"]   -accelerator "Shift+$accelerator+T" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window toggle}
-    $mymenu add command -label [_ "Number2"]  -accelerator "Shift+$accelerator+N" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window numbox}
-    $mymenu add command -label [_ "Vslider"]  -accelerator "Shift+$accelerator+V" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window vslider}
-    $mymenu add command -label [_ "Hslider"]  -accelerator "Shift+$accelerator+J" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window hslider}
-    $mymenu add command -label [_ "Vradio"]   -accelerator "Shift+$accelerator+D" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window vradio}
-    $mymenu add command -label [_ "Hradio"]   -accelerator "Shift+$accelerator+I" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window hradio}
-    $mymenu add command -label [_ "VU Meter"] -accelerator "Shift+$accelerator+U" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window vumeter}
-    $mymenu add command -label [_ "Canvas"]   -accelerator "Shift+$accelerator+C" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window mycnv}
+    add_menu $mymenu command [_ "Bang" ] "<<Put|Bang>>"
+    add_menu $mymenu command [_ "Toggle" ] "<<Put|Toggle>>"
+    add_menu $mymenu command [_ "Number2" ] "<<Put|Number2>>"
+    add_menu $mymenu command [_ "Vslider" ] "<<Put|VerticalSlider>>"
+    add_menu $mymenu command [_ "Hslider" ] "<<Put|HorizontalSlider>>"
+    add_menu $mymenu command [_ "Vradio" ] "<<Put|VerticalRadio>>"
+    add_menu $mymenu command [_ "Hradio" ] "<<Put|HorizontalRadio>>"
+    add_menu $mymenu command [_ "VU Meter" ] "<<Put|VUMeter>>"
+    add_menu $mymenu command [_ "Canvas" ] "<<Put|Canvas>>"
     $mymenu add  separator
     $mymenu add cascade -label [_ "Scalar"] -menu [pdtk_newstructs] -state disabled
     set ::pd_menus::putmenu_struct [list $mymenu [$mymenu index last]]
@@ -314,26 +301,18 @@ proc ::pd_menus::build_put_menu {mymenu} {
 
 proc ::pd_menus::build_find_menu {mymenu {patchwindow true}} {
     variable accelerator
-    $mymenu add command -label [_ "Find..."]    -accelerator "$accelerator+F" \
-        -command {::pd_menucommands::scheduleAction menu_find_dialog}
-    if { $patchwindow } {
-    $mymenu add command -label [_ "Find Again"] -accelerator "$accelerator+G" \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window findagain}
-    }
-    $mymenu add command -label [_ "Find Last Error"] \
-        -command {::pd_menucommands::scheduleAction pdsend {pd finderror}}
+    add_menu $mymenu command [_ "Find..."] "<<Find|Find>>"
+    add_menu $mymenu command [_ "Find Again"] "<<Find|FindAgain>>"
+    add_menu $mymenu command [_ "Find Last Error"] "<<Find|FindLastError>>"
 }
 
 proc ::pd_menus::build_media_menu {mymenu} {
     variable accelerator
-    $mymenu add radiobutton -label [_ "DSP On"]  -accelerator "$accelerator+/" \
-        -variable ::dsp -value 1 -command {::pd_menucommands::scheduleAction pdsend "pd dsp 1"}
-    $mymenu add radiobutton -label [_ "DSP Off"] -accelerator "$accelerator+." \
-        -variable ::dsp -value 0 -command {::pd_menucommands::scheduleAction pdsend "pd dsp 0"}
+    add_menu $mymenu radiobutton [_ "DSP On" ] "<<Media|DSPOn>>" -variable ::dsp -value 1
+    add_menu $mymenu radiobutton [_ "DSP Off" ] "<<Media|DSPOff>>" -variable ::dsp -value 0
 
     $mymenu add  separator
-    $mymenu add command -label [_ "Test Audio and MIDI..."] \
-        -command {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools testtone.pd}
+    add_menu $mymenu command [_ "Test Audio and MIDI..."] "<<Media|TestAudioMIDI>>"
 
     set audio_apilist_length [llength $::audio_apilist]
     if {$audio_apilist_length > 0} {$mymenu add separator}
@@ -354,10 +333,8 @@ proc ::pd_menus::build_media_menu {mymenu} {
     }
 
     $mymenu add  separator
-    $mymenu add command -label [_ "Audio Settings..."] \
-        -command {::pd_menucommands::scheduleAction pdsend "pd audio-properties"}
-    $mymenu add command -label [_ "MIDI Settings..."] \
-        -command {::pd_menucommands::scheduleAction pdsend "pd midi-properties"}
+    add_menu $mymenu command [_ "Audio Settings..."] "<<Preferences|Audio>>"
+    add_menu $mymenu command [_ "MIDI Settings..."] "<<Preferences|MIDI>>"
 }
 
 proc ::pd_menus::build_window_menu {mymenu} {
@@ -365,67 +342,48 @@ proc ::pd_menus::build_window_menu {mymenu} {
     if {$::windowingsystem eq "aqua"} {
         # Tk 8.5+ automatically adds default Mac window menu items
         if {$::tcl_version < 8.5} {
-            $mymenu add command -label [_ "Minimize"] -accelerator "$accelerator+M" \
-                -command {::pd_menucommands::scheduleAction menu_minimize $::focused_window}
-            $mymenu add command -label [_ "Zoom"] \
-                -command {::pd_menucommands::scheduleAction menu_maximize $::focused_window}
+            add_menu $mymenu command [_ "Minimize" ] "<<Window|Minimize>>"
+            add_menu $mymenu command [_ "Zoom" ] "<<Window|Maximize>>"
             $mymenu add  separator
-            $mymenu add command -label [_ "Bring All to Front"] \
-                -command {::pd_menucommands::scheduleAction menu_bringalltofront}
+            add_menu $mymenu command [_ "Bring All to Front" ] "<<Window|AllToFront>>"
         }
     } else {
-        $mymenu add command -label [_ "Minimize"] -accelerator "$accelerator+M" \
-                -command {::pd_menucommands::scheduleAction menu_minimize $::focused_window}
-        $mymenu add command -label [_ "Next Window"] \
-            -command {::pd_menucommands::scheduleAction menu_raisenextwindow} \
-            -accelerator [_ "$accelerator+Page Down"]
-        $mymenu add command -label [_ "Previous Window"] \
-            -command {::pd_menucommands::scheduleAction menu_raisepreviouswindow} \
-            -accelerator [_ "$accelerator+Page Up"]
+        add_menu $mymenu command [_ "Minimize" ] "<<Window|Minimize>>"
+        add_menu $mymenu command [_ "Next Window" ] "<<Window|Next>>"
+        add_menu $mymenu command [_ "Previous Window" ] "<<Window|Previous>>"
     }
     $mymenu add command -label [_ "Close subwindows"] \
         -command {pdsend "pd close-subwindows"}
     $mymenu add  separator
-    $mymenu add command -label [_ "Pd window"] -command {::pd_menucommands::scheduleAction menu_raise_pdwindow} \
-        -accelerator "$accelerator+R"
-    $mymenu add command -label [_ "Parent Window"] \
-        -command {::pd_menucommands::scheduleAction menu_send $::focused_window findparent}
+    add_menu $mymenu command [_ "Close subwindows" ] "<<Window|CloseSubwindows>>"
+    add_menu $mymenu command [_ "Pd window" ] "<<Window|PdWindow>>"
+    add_menu $mymenu command [_ "Parent Window" ] "<<Window|Parent>>"
     $mymenu add  separator
 }
 
 proc ::pd_menus::build_tools_menu {mymenu} {
     variable accelerator
-
-    $mymenu add command -label [_ "Load Meter"] \
-        -command {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools load-meter.pd}
+    add_menu $mymenu command [_ "Load Meter"] "<<Media|LoadMeter>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Message..."] \
-        -accelerator "$accelerator+Shift+M" \
-        -command {::pd_menucommands::scheduleAction menu_message_dialog}
+    add_menu $mymenu command [_ "Message..."] <<Pd|Message>>
 }
 
 proc ::pd_menus::build_help_menu {mymenu} {
     variable accelerator
     if {$::windowingsystem ne "aqua"} {
         # Tk creates this automatically on Mac
-        $mymenu add command -label [_ "About Pd"] -command {::pd_menucommands::scheduleAction menu_aboutpd}
+        add_menu $mymenu command [_ "About Pd" ] "<<Help|About>>"
     }
     if {$::windowingsystem ne "aqua" || $::tcl_version < 8.5} {
         # TK 8.5+ on Mac creates this automatically, other platforms do not
-        $mymenu add command -label [_ "HTML Manual..."] \
-                -command {::pd_menucommands::scheduleAction menu_manual}
+        add_menu $mymenu command [_ "HTML Manual..." ] "<<Help|Manual>>"
     }
-    $mymenu add command -label [_ "Browser..."] -accelerator "$accelerator+B" \
-        -command {::pd_menucommands::scheduleAction menu_helpbrowser}
-    $mymenu add command -label [_ "List of objects..."] \
-        -command {::pd_menucommands::scheduleAction menu_objectlist}
+    add_menu $mymenu command [_ "Browser..." ] "<<Help|Browser>>"
+    add_menu $mymenu command [_ "List of objects..." ] "<<Help|ListObjects>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "puredata.info"] \
-        -command {::pd_menucommands::scheduleAction menu_openfile {https://puredata.info}}
-    $mymenu add command -label [_ "Check for updates"] -command {::pd_menucommands::scheduleAction menu_openfile \
-        {https://pdlatest.puredata.info}}
-    $mymenu add command -label [_ "Report a bug"] -command {::pd_menucommands::scheduleAction menu_openfile \
-        {https://bugs.puredata.info}}
+    add_menu $mymenu command [_ "puredata.info" ] "<<Help|puredata.info>>"
+    add_menu $mymenu command [_ "Check for updates" ] "<<Help|CheckUpdates>>"
+    add_menu $mymenu command [_ "Report a bug" ] "<<Help|ReportBug>>"
 }
 
 #------------------------------------------------------------------------------#
@@ -480,12 +438,7 @@ proc ::pd_menus::update_openrecent_menu {mymenu {write}} {
     }
     $mymenu add separator
     $mymenu add command -label [_ "Clear Menu"] \
-        -command {::pd_menucommands::scheduleAction ::pd_menus::clear_recentfiles_menu}
-
-    if {[llength $::recentfiles_list] == 0} {
-        $mymenu entryconfigure end -state disabled
-    }
-
+        -command {event generate [focus] <<File|ClearRecentFiles>>}
     # write to config file
     if {$write == true} { ::pd_guiprefs::write_recentfiles }
 }
@@ -526,7 +479,8 @@ proc ::pd_menus::insert_into_menu {mymenu entry parent} {
         append label " "
     }
     append label $::windowname($entry)
-    $mymenu insert $insertat command -label $label -command "::pd_menucommands::scheduleAction raise $entry"
+    $mymenu insert $insertat command -label $label \
+        -command "::pd_menucommands::scheduleAction raise $entry"
 }
 
 # recurse through a list of parent windows and add to the menu
@@ -607,17 +561,12 @@ proc ::pd_menus::forgetpreferences {} {
 
 proc ::pd_menus::build_preferences_menu {mymenu} {
     menu $mymenu
-    $mymenu add command -label [_ "Edit Preferences..."] \
-        -command {menu_preference_dialog}
+    add_menu $mymenu command [_ "Edit Preferences..." ] "<<Preferences|Edit>>"
     $mymenu add  separator
-    $mymenu add command -label [_ "Save All Preferences"] \
-        -command {::pd_menucommands::scheduleAction pdsend "pd save-preferences"}
-    $mymenu add command -label [_ "Save to..."] \
-        -command {::pd_menucommands::scheduleAction ::pd_menus::savepreferences}
-    $mymenu add command -label [_ "Load from..."] \
-        -command {::pd_menucommands::scheduleAction ::pd_menus::loadpreferences}
-    $mymenu add command -label [_ "Forget All..."] \
-        -command {::pd_menucommands::scheduleAction ::pd_menus::forgetpreferences}
+    add_menu $mymenu command [_ "Save All Preferences" ] "<<Preferences|Save>>"
+    add_menu $mymenu command [_ "Save to..." ] "<<Preferences|SaveTo>>"
+    add_menu $mymenu command [_ "Load from..." ] "<<Preferences|Load>>"
+    add_menu $mymenu command [_ "Forget All..." ] "<<Preferences|Forget>>"
     $mymenu add  separator
     $mymenu add check -label [_ "Tabbed preferences"] \
         -variable ::dialog_preferences::use_ttknotebook \
@@ -631,7 +580,8 @@ proc ::pd_menus::build_preferences_menu {mymenu} {
 proc ::pd_menus::create_apple_menu {mymenu} {
     # TODO this should open a Pd patch called about.pd
     menu $mymenu.apple
-    $mymenu.apple add command -label [_ "About Pd"] -command {::pd_menucommands::scheduleAction menu_aboutpd}
+    $mymenu.apple add command -label [_ "About Pd"] \
+        -command {event generate [focus] <<Help|About>>}
     $mymenu.apple add separator
     $mymenu.apple add cascade -label [_ "Preferences"] \
         -menu .preferences

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -465,6 +465,7 @@ proc ::pd_menus::find_mapped_parent {parentlist} {
 # find the first parent patch that has a mapped window
 proc ::pd_menus::insert_into_menu {mymenu entry parent} {
     set insertat [$mymenu index end]
+    if { "${insertat}" eq "none" } { set insertat 0 }
     for {set i 0} {$i <= [$mymenu index end]} {incr i} {
         if {[$mymenu type $i] ne "command"} {continue}
         set currentcommand [$mymenu entrycget $i -command]
@@ -509,7 +510,9 @@ proc ::pd_menus::update_window_menu {} {
 
     set mymenu $::patch_menubar.window
     # find the last separator and delete everything after that
-    for {set i 0} {$i <= [$mymenu index end]} {incr i} {
+    set lastmenu [$mymenu index end]
+    if { "${lastmenu}" eq "none" } { set lastmenu 0 }
+    for {set i 0} {$i <= $lastmenu} {incr i} {
         if {[$mymenu type $i] eq "separator"} {
             set deleteat $i
         }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -470,7 +470,7 @@ proc ::pd_menus::build_tools_menu {mymenu} {
     variable accelerator
     add_menu $mymenu command [_ "Load Meter"] "<<Media|LoadMeter>>"
     $mymenu add  separator
-    add_menu $mymenu command [_ "Message..."] <<Pd|Message>>
+    add_menu $mymenu command [_ "Message..."] "<<Tools|Message>>"
 }
 
 proc ::pd_menus::build_help_menu {mymenu} {

--- a/tcl/pkgIndex.tcl
+++ b/tcl/pkgIndex.tcl
@@ -11,6 +11,7 @@
 package ifneeded apple_events 0.1 [list source [file join $dir apple_events.tcl]]
 package ifneeded dialog_array 0.1 [list source [file join $dir dialog_array.tcl]]
 package ifneeded dialog_audio 0.1 [list source [file join $dir dialog_audio.tcl]]
+package ifneeded dialog_bindings 0.1 [list source [file join $dir dialog_bindings.tcl]]
 package ifneeded dialog_canvas 0.1 [list source [file join $dir dialog_canvas.tcl]]
 package ifneeded dialog_data 0.1 [list source [file join $dir dialog_data.tcl]]
 package ifneeded dialog_find 0.1 [list source [file join $dir dialog_find.tcl]]


### PR DESCRIPTION
this PR makes keyboard shortcuts configurable by the user.
- Closes: https://github.com/pure-data/pure-data/issues/2353
- Closes: https://github.com/pure-data/pure-data/issues/1729
- Closes: https://github.com/pure-data/pure-data/issues/2349
- Closes: https://github.com/pure-data/pure-data/issues/1914

So if you prefer <kbd>Control</kbd>+<kbd>space</kbd> to save your documents or quit Pd, you can have that.
Or if you think that you would rather have a shortcut for the `Audio settings` than for `Find again`, be my friend.
While testing, I found <kbd>Control</kbd>+<kbd>,</kbd> to open up the preferences very useful :-)

### under the hood
in order to synchronize the keyboard accelerators keys displayed in the menu bar (which doesn't do anything) with the real shortcuts, this PR creates a new indirection:
- each menu action is now triggered by a virtual event. e.g. for saving a file, you can send the `<<File|Save>>` event to a patch window
- each virtual event can be associated with a keyboard shortcut (or multiple keyboard shortcuts)
- each menu entry only triggers the corresponding virtual event
- the accelerator key (shown in the menu) is calculated from the sequence associated with the virtual event

e.g. the `<<File|New>>` event triggers the execution of the `menu_new` command to create a new patch.
if you use a specific shortcut (e.g. <kbd>Control</kbd>+<kbd>n</kbd>) the associated virtual event (here `<<File|New>>`) is sent to the current window, this creating a new patch.
if otoh you navigate the menu to `File` -> `New`, you will trigger the same virtual event (`<<File|New>>`), with the same effect.
when the menu associated with the `<<File|New>>` event is created (or updated), it looks up the shortcut sequence for this event (which in tcl is `Control-Key-n`) and translates it to a visually pleasing acceleration string (e.g. `Ctrl-N`)


### editing sequences
the preference window gained a new tab "keyboard shortcuts", where you can interactively record a new shortcut for each event.
**TODO** as of now, the mapping goes from "virtual event" (as opposed to "menu entry") to the shortcut, which gives slightly raw strings (e.g. `Find|FindLastError|` is displayed as `Find`->`FindLastError`) which shouldn't really be translated. however, i think we can come up with something that uses the menu labels)

### issues
- [x] no keybindings for <kbd>Command</kbd> and <kbd>Option</kbd> (required for macOS)
- [x] (re)storing preferences on macOS does not work (see also #2381)
- [x] check for duplicates does not work reliably (e.g. <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> is not detected to be the same as <kbd>Shift</kbd>+<kbd>Command</kbd>+<kbd>S</kbd>)
- [x] printing a patch always suggest to print as `ERROR.ps`
- [x] on macOS, you have to release the terminal key first when recording a new shortcut (e.g. recording <kbd>Command</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>, you start with pressing <kbd>Command</kbd>+<kbd>Shift</kbd>, holding these and then press <kbd>R</kbd>; if you then release the <kbd>Shift</kbd>-key first,, followed by <kbd>R</kbd> the recording stays in limbo; if you instead release the <kbd>R</kbd>-key first, everything works as expected)
- [ ] virtual events should also be used in in dialogs
- [ ] shortcut editor could be more intuitive
- [ ] shortcut editor sometimes does not show the currently pressed keys

### test binaries
- [macOS universal](https://git.iem.at/zmoelnig/pure-data/-/jobs/artifacts/feature/keyboard-shortcuts/download?job=macOS)
- [Windows 64](https://git.iem.at/zmoelnig/pure-data/-/jobs/artifacts/feature/keyboard-shortcuts/download?job=w64)
- [Windows 32](https://git.iem.at/zmoelnig/pure-data/-/jobs/artifacts/feature/keyboard-shortcuts/download?job=w32)


if the links above do not work, you should be able to find artifacts at <https://git.iem.at/zmoelnig/pure-data/-/pipelines?ref=feature%2Fkeyboard-shortcuts> (somewhere at the right-hand side  there's a download pulldown)
