### PR TITLE
allow reading array indexes with signals in [expr~]

### DIFF
--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1623,8 +1623,11 @@ eval_var(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
 
         }
 
+/* (nivlekp) commenting this for now;
+* Why are we assuming the type of optr?
+* This does not work well with table
         optr->ex_type = ET_INT;
-        optr->ex_int = 0;
+        optr->ex_int = 0; */
         if (!novar)
                 (void)max_ex_var(expr, (t_symbol *)var, optr, idx);
         return (++eptr);


### PR DESCRIPTION
This is a remake of https://github.com/pure-data/pure-data/pull/853 but on top of the new code changes in [expr] (see https://github.com/pure-data/pure-data/commit/cad91dc791c7b17972d4d508f6bf6a93f1ff0613 )

The thing is that we can previously access array values with float inlet inputs for indexes in [expr], as in [expr arrayname[$f1]]. It's also possible to use signal inputs in [fexpr~], as in [fexpr~ arrayname[$x1]], but we couldn't do it with [expr~].

This PR allows something like [expr~ arrayname[$v1]].

One problem that I see now is that currently - as of https://github.com/pure-data/pure-data/commit/cad91dc791c7b17972d4d508f6bf6a93f1ff0613 - a signal input for index makes it interpolate! This is funny because using signals as inputs is still not possible, but changes were made so that using signals would interpolate, see https://github.com/pure-data/pure-data/blob/master/src/x_vexp_if.c#L1087

But then, [fexrp~] doesn't interpolate. So before merging this and allowing signal inlets for indexes, we must get things straight and think carefully about what to do...

I think [expr~] should not interpolate and be consistent with how [expr] and [fexpr~] already work. Another option is that all ([expr], [expr~] and [fexpr~]) do interpolate and we have a compatibility flag to not interpolate with [expr] and [fexpr~]. Another option is to have a new table reading function that we can choose if we want interpolation or not... we could even choose and set what kind of interpolation with a flag. For instance '0' is no interpolation, '1' is linear interpolation and maybe something like '2' could be cubic (lagrange) interpolation.