### PR TITLE
allow concurrent calls for pdgui_vmess()

### DIFF
--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -160,6 +160,7 @@ struct _instanceinter
 #endif
 #if PDTHREADS
     pthread_mutex_t i_mutex;
+    pthread_mutex_t i_guimutex;
     pthread_mutex_t i_messqueue_mutex;
     t_messqueue *i_messqueue_head;
     t_messqueue *i_messqueue_tail;
@@ -854,7 +855,7 @@ void sys_vgui(const char *fmt, ...)
     if(msglen < 0)
     {
         fprintf(stderr,
-            "sys_vgui: pd_snprintf() failed with error code %d\n", errno);
+            "Pd: buffer space wasn't sufficient for long GUI string\n");
         return;
     }
     if (msglen >= INTER->i_guisize - INTER->i_guihead)
@@ -932,9 +933,11 @@ static const char**namelist2strings(t_namelist *nl, unsigned int *N) {
     }
     return result;
 }
-
+void pdgui_lock(void);
+void pdgui_unlock(void);
 static int sys_flushtogui(void)
 {
+    pdgui_lock();
     int writesize = INTER->i_guihead - INTER->i_guitail,
         nwrote = 0;
     if (writesize > 0)
@@ -942,7 +945,6 @@ static int sys_flushtogui(void)
             INTER->i_guisock,
             INTER->i_guibuf + INTER->i_guitail,
             writesize, 0);
-
 #if 0
     if (writesize)
         fprintf(stderr, "wrote %d of %d\n", nwrote, writesize);
@@ -953,8 +955,10 @@ static int sys_flushtogui(void)
         perror("pd-to-gui socket");
         sys_bail(1);
     }
-    else if (!nwrote)
+    else if (!nwrote) {
+        pdgui_unlock();
         return (0);
+    }
     else if (nwrote >= INTER->i_guihead - INTER->i_guitail)
         INTER->i_guihead = INTER->i_guitail = 0;
     else if (nwrote)
@@ -969,6 +973,7 @@ static int sys_flushtogui(void)
             INTER->i_guitail = 0;
         }
     }
+    pdgui_unlock();
     return (1);
 }
 
@@ -1925,6 +1930,7 @@ void s_inter_newpdinstance(void)
     pthread_mutex_init(&INTER->i_mutex, NULL);
     pthread_mutex_init(&INTER->i_messqueue_mutex, NULL);
     pd_this->pd_islocked = 0;
+    pthread_mutex_init(&INTER->i_guimutex, NULL);
 #endif
 #ifdef _WIN32
     INTER->i_freq = 0;
@@ -1946,6 +1952,7 @@ void s_inter_free(t_instanceinter *inter)
     }
 #if PDTHREADS
     pthread_mutex_destroy(&inter->i_mutex);
+    pthread_mutex_destroy(&inter->i_guimutex);
         /* flush message queue */
     while (inter->i_messqueue_head)
     {
@@ -2095,6 +2102,14 @@ void messqueue_dispatch(void)
     }
 }
 
+void pdgui_lock(void)
+{
+    pthread_mutex_lock(&INTER->i_guimutex);
+}
+void pdgui_unlock(void)
+{
+    pthread_mutex_unlock(&INTER->i_guimutex);
+}
 #else /* PDTHREADS */
 
 #ifdef TEST_LOCKING /* run standalone Pd with this to find deadlocks */
@@ -2126,5 +2141,8 @@ void pd_queue_mess(struct _pdinstance instance, t_pd *obj, void *data, t_messfn 
 void pd_queue_cancel(t_pd *obj) {}
 
 void messqueue_dispatch(void) {}
+
+void pdgui_lock(void) {}
+void pdgui_unlock(void) {}
 
 #endif /* PDTHREADS */

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -990,7 +990,7 @@ static int sys_flushqueue(void)
     {
         if (INTER->i_bytessincelastping >= GUI_BYTESPERPING)
         {
-            pdgui_vmess("pdtk_ping", "");
+            pdgui_vmess("pdtk_ping", 0);
             INTER->i_bytessincelastping = 0;
             INTER->i_waitingforping = 1;
             return (1);
@@ -1123,10 +1123,14 @@ void sys_gui_preferences(void)
                 , nlibs, startuplibs
                 );
 
-    sys_vgui("set_escaped ::sys_verbose %d\n", sys_verbose);
-    sys_vgui("set_escaped ::sys_use_stdpath %d\n", sys_usestdpath);
-    sys_vgui("set_escaped ::sys_defeatrt %d\n", sys_defeatrt);
-    sys_vgui("set_escaped ::sys_zoom_open %d\n", (sys_zoom_open == 2));
+        /* FIXME: 'set_escaped' is really low-level Tcl code,
+           we want something more highlevel
+        */
+    pdgui_vmess("set_escaped", "ri", "::sys_verbose", sys_verbose);
+    pdgui_vmess("set_escaped", "ri", "::sys_use_stdpath", sys_usestdpath);
+    pdgui_vmess("set_escaped", "ri", "::sys_defeatrt", sys_defeatrt);
+    pdgui_vmess("set_escaped", "ri", "::sys_zoom_open", (sys_zoom_open == 2));
+
     pdgui_vmess("::dialog_startup::set_flags", "s",
                 (sys_flags? sys_flags->s_name : ""));
 
@@ -1647,7 +1651,7 @@ static int sys_do_startgui(const char *libdir)
             /* here is where we start the pinging. */
 #if PD_WATCHDOG
     if (sys_hipriority)
-        pdgui_vmess("pdtk_watchdog", "");
+        pdgui_vmess("pdtk_watchdog", 0);
 #endif
     sys_get_audio_apis(apibuf);
     sys_get_midi_apis(apibuf2);
@@ -1655,19 +1659,21 @@ static int sys_do_startgui(const char *libdir)
     sys_gui_preferences();     /* tell GUI about path and startup flags */
 
         /* ... and about font, media APIS, etc */
-    sys_vgui("pdtk_pd_startup %d %d %d {%s} %s %s {%s} %s\n",
-             PD_MAJOR_VERSION, PD_MINOR_VERSION,
-             PD_BUGFIX_VERSION, PD_TEST_VERSION,
-             apibuf, apibuf2,
-             pdgui_strnescape(quotebuf, MAXPDSTRING, sys_font, 0),
-             sys_fontweight);
+    pdgui_vmess("pdtk_pd_startup", "iiis rr ss"
+                , PD_MAJOR_VERSION, PD_MINOR_VERSION
+                , PD_BUGFIX_VERSION, PD_TEST_VERSION
 
+                , apibuf, apibuf2
+                , sys_font, sys_fontweight
+        );
     sys_init_deken();
 
     {
         t_audiosettings as;
         sys_get_audio_settings(&as);
-        sys_vgui("set pd_whichapi %d\n", as.a_api);
+        pdgui_vmess("set", "ri"
+                    , "pd_whichapi", as.a_api
+            );
 
         pdgui_vmess("pdtk_pd_dsp", "s",
             THISGUI->i_dspstate ? "ON" : "OFF");

--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -411,8 +411,10 @@ void pdgui_vamess(const char* message, const char* format, va_list args_)
     }
     va_end(args);
 }
-void pdgui_lock(void) {}
-void pdgui_unlock(void) {}
+
+void pdgui_lock(void);
+void pdgui_unlock(void);
+
 void pdgui_startmess(void)
 {
     pdgui_lock();
@@ -427,7 +429,6 @@ void pdgui_endmess(void)
     pdgui_unlock();
 }
 
-
 /* constructs a string that can be passed on to sys_gui() */
 /* TODO: shouldn't this have a pointer to t_pdinstance? */
 void pdgui_vmess(const char* message, const char* format, ...)
@@ -437,8 +438,11 @@ void pdgui_vmess(const char* message, const char* format, ...)
         return;
     if(!format)
     {
-        if (message)
-            sys_vgui("%s;\n", message);
+        if (message) {
+            pdgui_startmess();
+            sys_vgui("%s", message);
+            pdgui_endmess();
+        }
         return;
     }
     pdgui_startmess();

--- a/src/s_inter_gui.c
+++ b/src/s_inter_gui.c
@@ -411,6 +411,12 @@ void pdgui_vamess(const char* message, const char* format, va_list args_)
     }
     va_end(args);
 }
+void pdgui_lock(void) {}
+void pdgui_unlock(void) {}
+void pdgui_startmess(void)
+{
+    pdgui_lock();
+}
 void pdgui_endmess(void)
 {
     t_val v;
@@ -418,6 +424,7 @@ void pdgui_endmess(void)
     v.size = 1;
     v.value.p = ";\n";
     addmess(&v);
+    pdgui_unlock();
 }
 
 
@@ -434,6 +441,7 @@ void pdgui_vmess(const char* message, const char* format, ...)
             sys_vgui("%s;\n", message);
         return;
     }
+    pdgui_startmess();
     va_start(args, format);
     pdgui_vamess(message, format, args);
     va_end(args);

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -77,7 +77,7 @@ void gfxstub_new(t_pd *owner, void *key, const char *cmd)
             gfxstub_deleteforkey(key);
     if (strlen(cmd) + 50 > 4*MAXPDSTRING)
     {
-        bug("audio dialog too long");
+        bug("dialog too long");
         bug("%s", cmd);
         return;
     }

--- a/src/x_gui.c
+++ b/src/x_gui.c
@@ -203,6 +203,7 @@ static void gfxstub_setup(void)
 
 #include <stdarg.h>
 /* pdgui_*mess() are from s_inter_gui.c */
+void pdgui_startmess(void);
 void pdgui_vamess(const char* message, const char* format, va_list args);
 void pdgui_endmess(void);
 
@@ -232,6 +233,7 @@ void pdgui_stub_vnew(t_pd *owner, const char* destination, void *key, const char
     x->x_next = gfxstub_list;
     gfxstub_list = x;
 
+    pdgui_startmess();
     _pdguistub_vamess(destination, "s", s->s_name);
     va_start(args, fmt);
     pdgui_vamess(0, fmt, args);


### PR DESCRIPTION
This introduces a new (per-instance) lock, to ensure that messages sent to the GUI from different threads do not produce garbage.


this only protects the new-style `pdgui_vmess()` calls (so users of `sys_vgui()` and friends should switch ;-))

- Closes: https://github.com/pure-data/pure-data/issues/2404 

see also https://github.com/Spacechild1/pure-data/commit/3be5d4ac3a4b763a056c0f498889c25781757c32#commitcomment-145643167 for a bit of discussion