### PR TITLE
improve garrays: add message to hide name, save properties

### DIFF
--- a/src/d_array.c
+++ b/src/d_array.c
@@ -57,6 +57,7 @@ static int dsparray_get_array(t_dsparray *d, int *npoints, t_word **vec,
         else
         {
             gpointer_setarray(&d->d_gp, garray_getarray(a), *vec);
+            garray_usedindsp(a);
             return 1;
         }
     }

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -9,6 +9,7 @@
 #include "g_canvas.h"
 
     /* common struct for reading or writing to an array at DSP time. */
+#define MAX_PHASE 0x7fffffff
 typedef struct _dsparray
 {
     t_symbol *d_symbol;
@@ -94,7 +95,7 @@ static void arrayvec_set(t_arrayvec *v, int argc, t_atom *argv)
                 v->v_vec[i].d_symbol = &s_;
         else
         {
-            v->v_vec[i].d_phase = 0x7fffffff;
+            v->v_vec[i].d_phase = MAX_PHASE;
             v->v_vec[i].d_symbol = argv[i].a_w.w_symbol;
         }
     }
@@ -119,7 +120,7 @@ static void arrayvec_init(t_arrayvec *v, void *x, int rawargc, t_atom *rawargv)
     for (i = 0; i < v->v_n; i++)
     {
         v->v_vec[i].d_owner = x;
-        v->v_vec[i].d_phase = 0x7fffffff;
+        v->v_vec[i].d_phase = MAX_PHASE;
         gpointer_init(&v->v_vec[i].d_gp);
     }
     arrayvec_set(v, argc, argv);
@@ -187,11 +188,11 @@ static t_int *tabwrite_tilde_perform(t_int *w)
         if (phase >= endphase)
         {
             tabwrite_tilde_redraw(d->d_symbol);
-            phase = 0x7fffffff;
+            phase = MAX_PHASE;
         }
         d->d_phase = phase;
     }
-    else d->d_phase = 0x7fffffff;
+    else d->d_phase = MAX_PHASE;
 noop:
     return (w+4);
 }
@@ -228,10 +229,10 @@ static void tabwrite_tilde_stop(t_tabwrite_tilde *x)
 {
     int i;
     for (i = 0; i < x->x_v.v_n; i++)
-        if (x->x_v.v_vec[i].d_phase != 0x7fffffff)
+        if (x->x_v.v_vec[i].d_phase != MAX_PHASE)
     {
         tabwrite_tilde_redraw(x->x_v.v_vec[i].d_symbol);
-        x->x_v.v_vec[i].d_phase = 0x7fffffff;
+        x->x_v.v_vec[i].d_phase = MAX_PHASE;
     }
 }
 
@@ -307,10 +308,10 @@ static t_int *tabplay_tilde_perform(t_int *w)
     if (phase >= endphase)
     {
         int i, playing = 0;
-        d->d_phase = 0x7fffffff;
+        d->d_phase = MAX_PHASE;
             /* set the clock when all channels have run out */
         for (i = 0; i < x->x_v.v_n; i++)
-            if (x->x_v.v_vec[i].d_phase < 0x7fffffff)
+            if (x->x_v.v_vec[i].d_phase < MAX_PHASE)
                 playing = 1;
         if (!playing)
             clock_delay(x->x_clock, 0);
@@ -349,7 +350,7 @@ static void tabplay_tilde_list(t_tabplay_tilde *x, t_symbol *s,
     int i;
     if (start < 0) start = 0;
     if (length <= 0)
-        x->x_limit = 0x7fffffff;
+        x->x_limit = MAX_PHASE;
     else
         x->x_limit = (int)(start + length);
     for (i = 0; i < x->x_v.v_n; i++)
@@ -360,7 +361,7 @@ static void tabplay_tilde_stop(t_tabplay_tilde *x)
 {
     int i;
     for (i = 0; i < x->x_v.v_n; i++)
-        x->x_v.v_vec[i].d_phase = 0x7fffffff;
+        x->x_v.v_vec[i].d_phase = MAX_PHASE;
 }
 
 static void tabplay_tilde_tick(t_tabplay_tilde *x)

--- a/src/d_array.c
+++ b/src/d_array.c
@@ -64,6 +64,33 @@ static int dsparray_get_array(t_dsparray *d, int *npoints, t_word **vec,
     return 0;
 }
 
+static int dsparray_reset_array(t_dsparray *d) {
+    int size0 = 0, size1 = 0;
+    int phase = d->d_phase;
+    t_word *vec0 = 0, *vec1 = 0;
+    t_garray *a = 0;
+    if (d->d_symbol == &s_)
+        return 0;
+    a = (t_garray *)pd_findbyclass(d->d_symbol, garray_class);
+    if(!a)
+        return 0;
+    if (garray_getfloatwords(a, &size1, &vec1) && dsparray_get_array(d, &size0, &vec0, 0)) {
+        if(vec0 == vec1)
+                /* no change */
+            return 0;
+    }
+
+    gpointer_unset(&d->d_gp);
+#if 0
+        /*
+          JMZ: arrayvec_reset() calls dsparray_get_array() via arrayvec_testvec(),
+          so we skip it here
+        */
+    dsparray_get_array(d, &size1, &vec1, 1);
+#endif
+    return 1;
+}
+
 static void arrayvec_testvec(t_arrayvec *v)
 {
     int i, vecsize;
@@ -73,6 +100,17 @@ static void arrayvec_testvec(t_arrayvec *v)
         if (*v->v_vec[i].d_symbol->s_name)
             dsparray_get_array(&v->v_vec[i], &vecsize, &vec, 1);
     }
+}
+static void arrayvec_reset(t_arrayvec *v)
+{
+    int i, vecsize;
+    t_word *vec;
+    for (i = 0; i < v->v_n; i++)
+    {
+        if (*v->v_vec[i].d_symbol->s_name)
+            dsparray_reset_array(&v->v_vec[i]);
+    }
+    arrayvec_testvec(v);
 }
 
 static void arrayvec_set(t_arrayvec *v, int argc, t_atom *argv)
@@ -208,7 +246,7 @@ static void tabwrite_tilde_dsp(t_tabwrite_tilde *x, t_signal **sp)
 {
     int i, nchans = (sp[0]->s_nchans < x->x_v.v_n ?
         sp[0]->s_nchans : x->x_v.v_n);
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < nchans; i++)
         dsp_add(tabwrite_tilde_perform, 3, x->x_v.v_vec+i,
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
@@ -337,7 +375,7 @@ static void tabplay_tilde_dsp(t_tabplay_tilde *x, t_signal **sp)
 {
     int i;
     signal_setmultiout(&sp[0], x->x_v.v_n);
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < x->x_v.v_n; i++)
         dsp_add(tabplay_tilde_perform, 4, x, &x->x_v.v_vec[i],
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
@@ -448,7 +486,7 @@ static void tabread_tilde_dsp(t_tabread_tilde *x, t_signal **sp)
 {
     int i;
     signal_setmultiout(&sp[1], x->x_v.v_n);
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < x->x_v.v_n; i++)
         dsp_add(tabread_tilde_perform, 4, &x->x_v.v_vec[i],
             sp[0]->s_vec + (i%(sp[0]->s_nchans)) * sp[0]->s_length,
@@ -553,7 +591,7 @@ static void tabread4_tilde_dsp(t_tabread4_tilde *x, t_signal **sp)
 {
     int i, length = sp[0]->s_length;
     signal_setmultiout(&sp[2], x->x_v.v_n);
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < x->x_v.v_n; i++)
         dsp_add(tabread4_tilde_perform, 5, &x->x_v.v_vec[i],
             sp[0]->s_vec + (i % sp[0]->s_nchans) * length,
@@ -648,7 +686,7 @@ static void tabsend_dsp(t_tabsend *x, t_signal **sp)
     if (tickspersec < 1)
         tickspersec = 1;
     x->x_graphperiod = tickspersec;
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < nchans; i++)
         dsp_add(tabsend_perform, 4, x, x->x_v.v_vec+i,
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);
@@ -724,7 +762,7 @@ static void tabreceive_dsp(t_tabreceive *x, t_signal **sp)
 {
     int i;
     signal_setmultiout(&sp[0], x->x_v.v_n);
-    arrayvec_testvec(&x->x_v);
+    arrayvec_reset(&x->x_v);
     for (i = 0; i < x->x_v.v_n; i++)
         dsp_add(tabreceive_perform, 3, &x->x_v.v_vec[i],
             sp[0]->s_vec + i * sp[0]->s_length, (t_int)sp[0]->s_length);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -747,28 +747,6 @@ static void garray_save(t_gobj *z, t_binbuf *b)
         fval = template_getfloat(
             scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, 1);
         binbuf_addv(b, "ssf;", gensym("#A"), gensym("width"), fval);
-
-        binbuf_addv(b, "ssffi;", gensym("#A"), gensym("xticks"),
-                    x->x_glist->gl_xtick.k_point, x->x_glist->gl_xtick.k_inc, x->x_glist->gl_xtick.k_lperb);
-        binbuf_addv(b, "ssffi;", gensym("#A"), gensym("yticks"),
-                    x->x_glist->gl_ytick.k_point, x->x_glist->gl_ytick.k_inc, x->x_glist->gl_ytick.k_lperb);
-
-        if(x->x_glist->gl_nxlabels>0) {
-            int i;
-            binbuf_addv(b, "ssf", gensym("#A"), gensym("xlabel"), x->x_glist->gl_xlabely);
-            for(i=0; i<x->x_glist->gl_nxlabels; i++) {
-                binbuf_addv(b, "s", x->x_glist->gl_xlabel[i]);
-            }
-            binbuf_addv(b, ";");
-        }
-        if(x->x_glist->gl_nylabels>0) {
-            int i;
-            binbuf_addv(b, "ssf", gensym("#A"), gensym("ylabel"), x->x_glist->gl_ylabelx);
-            for(i=0; i<x->x_glist->gl_nylabels; i++) {
-                binbuf_addv(b, "s", x->x_glist->gl_ylabel[i]);
-            }
-            binbuf_addv(b, ";");
-        }
     }
 }
 

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1220,7 +1220,7 @@ static void garray_rename(t_garray *x, t_symbol *s)
     /* } jsarlo */
     pd_unbind(&x->x_gobj.g_pd, x->x_realname);
     pd_bind(&x->x_gobj.g_pd, x->x_realname = x->x_name = s);
-    garray_redraw(x);
+    glist_redraw(x->x_glist);
 }
 
 static void garray_read(t_garray *x, t_symbol *filename)

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -445,10 +445,17 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
             gensym("style"), x->x_scalar->sc_vec, 1);
     if (deleteit != 0)
     {
+        const char *undo_name = "add array";
+        t_atom undo[4];
+        t_glist *gl = x->x_glist;
         garray_deleteit(x);
-    }
-    else
-    {
+        SETSYMBOL(undo+0, name);
+        SETFLOAT (undo+1, fsize);
+        SETSYMBOL(undo+2, gensym("float"));
+        SETFLOAT (undo+3, fflags);
+        pd_undo_set_objectstate(glist_getcanvas(gl), (t_pd*)gl, gensym("array"), 4, undo, 1, undo);
+        glist_redraw(gl);
+    } else {
         long size;
         t_array *a = garray_getarray(x);
         t_template *scalartemplate;

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1296,7 +1296,14 @@ static void garray_edit(t_garray *x, t_floatarg f)
 {
     x->x_edit = (int)f;
 }
-
+static void garray_visname(t_garray *x, t_floatarg f)
+{
+    int hidewas = x->x_hidename;
+    x->x_hidename = !((int)f);
+    if (hidewas != x->x_hidename) {
+        glist_redraw(x->x_glist);
+    }
+}
 static void garray_print(t_garray *x)
 {
     t_array *array = garray_getarray(x);
@@ -1329,6 +1336,8 @@ void g_array_setup(void)
     class_addmethod(garray_class, (t_method)garray_color, gensym("color"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_vis_msg, gensym("vis"),
+        A_FLOAT, 0);
+    class_addmethod(garray_class, (t_method)garray_visname, gensym("visname"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_rename, gensym("rename"),
         A_SYMBOL, 0);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -391,6 +391,7 @@ void glist_arraydialog(t_glist *parent, t_symbol *name, t_floatarg size,
         gl = glist_addglist(parent, &s_, 0, 1,
             size, -1, 0, 0, 0, 0);
     a = graph_array(gl, name, &s_float, size, flags);
+    glist_redraw(gl);
     canvas_dirty(parent, 1);
 }
 

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -867,6 +867,10 @@ void garray_setsaveit(t_garray *x, int saveit)
             x->x_name->s_name);
     x->x_saveit = saveit;
 }
+static void garray_saveit(t_garray *x, t_floatarg f)
+{
+    garray_setsaveit(x, (int)f);
+}
 
 /*------------------- Pd messages ------------------------ */
 static void garray_const(t_garray *x, t_floatarg g)
@@ -1327,6 +1331,8 @@ void g_array_setup(void)
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_rename, gensym("rename"),
         A_SYMBOL, 0);
+    class_addmethod(garray_class, (t_method)garray_saveit, gensym("keep"),
+        A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_read, gensym("read"),
         A_SYMBOL, A_NULL);
     class_addmethod(garray_class, (t_method)garray_write, gensym("write"),

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1100,6 +1100,7 @@ static void garray_style(t_garray *x, t_floatarg fstyle)
         scalartemplate, gensym("style"), x->x_scalar->sc_vec, 1);
     if (style != stylewas)
     {
+        t_float width;
         t_array *a = garray_getarray(x);
         if (!a)
         {
@@ -1110,10 +1111,16 @@ static void garray_style(t_garray *x, t_floatarg fstyle)
             garray_fittograph(x, a->a_n, style);
         template_setfloat(scalartemplate, gensym("style"),
             x->x_scalar->sc_vec, (t_float)style, 0);
-    #if 1
+
+        width = template_getfloat(
+            scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, 1);
+        if (style == PLOTSTYLE_POINTS && width < 2)
+            width = 2;
+        if (width < 1)
+            width = 1;
         template_setfloat(scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec,
-            ((style == PLOTSTYLE_POINTS) ? 2 : 1), 1);
-    #endif
+            width, 1);
+
         garray_redraw(x);
     }
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1212,6 +1212,7 @@ static void garray_vis_msg(t_garray *x, t_floatarg fvis)
     /* change the name of a garray. */
 static void garray_rename(t_garray *x, t_symbol *s)
 {
+    int wasused = x->x_usedindsp;
     /* jsarlo { */
     if (x->x_listviewing)
     {
@@ -1221,6 +1222,8 @@ static void garray_rename(t_garray *x, t_symbol *s)
     pd_unbind(&x->x_gobj.g_pd, x->x_realname);
     pd_bind(&x->x_gobj.g_pd, x->x_realname = x->x_name = s);
     glist_redraw(x->x_glist);
+    if (wasused)
+        canvas_update_dsp();
 }
 
 static void garray_read(t_garray *x, t_symbol *filename)

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -863,7 +863,7 @@ int garray_getfloatarray(t_garray *x, int *size, t_float **vec)
 void garray_setsaveit(t_garray *x, int saveit)
 {
     if (x->x_saveit && !saveit)
-        post("warning: array %s: clearing save-in-patch flag",
+        logpost(x->x_glist, PD_NORMAL, "warning: array %s: clearing save-in-patch flag",
             x->x_name->s_name);
     x->x_saveit = saveit;
 }

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -17,6 +17,22 @@
 #define ARRAYPAGESIZE 1000  /* this should match the page size in u_main.tk */
 /* } jsarlo */
 
+
+/* helpers */
+
+/* the GUI sends empty names as '-',
+ * and names starting with '-' are prefixed with dash as well
+ * so here we undo this
+ */
+static t_symbol *garray_unescapit(t_symbol *s)
+{
+    if (*s->s_name == '-')
+        return (gensym(s->s_name+1));
+    return s;
+}
+
+
+
 /* --------- "pure" arrays with scalars for elements. --------------- */
 
 /* Pure arrays have no a priori graphical capabilities.
@@ -396,6 +412,12 @@ void glist_arraydialog(t_glist *parent, t_symbol *name, t_floatarg size,
     int flags = fflags;
     t_atom undo[4];
 
+    name = garray_unescapit(name);
+    if(!*name->s_name) {
+        pd_error(0, "glist: cannot create array without a name");
+        return;
+    }
+
     if (size < 1)
         size = 1;
 
@@ -443,6 +465,13 @@ void garray_arraydialog(t_garray *x, t_symbol *name, t_floatarg fsize,
     t_float stylewas = template_getfloat(
         template_findbyname(x->x_scalar->sc_template),
             gensym("style"), x->x_scalar->sc_vec, 1);
+
+    name = garray_unescapit(name);
+    if(!*name->s_name) {
+        pd_error(0, "array: cannot create array without a name");
+        return;
+    }
+
     if (deleteit != 0)
     {
         const char *undo_name = "add array";

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -737,6 +737,39 @@ static void garray_save(t_gobj *z, t_binbuf *b)
         x->x_name, array->a_n, &s_float,
             x->x_saveit + 2 * filestyle + 8*x->x_hidename);
     garray_savecontentsto(x, b);
+
+    if (pd_compatibilitylevel >= 52) {
+        t_float fval;
+        style = template_getfloat(
+            scalartemplate, gensym("color"), x->x_scalar->sc_vec, 1);
+        binbuf_addv(b, "ssi;", gensym("#A"), gensym("color"), style);
+
+        fval = template_getfloat(
+            scalartemplate, gensym("linewidth"), x->x_scalar->sc_vec, 1);
+        binbuf_addv(b, "ssf;", gensym("#A"), gensym("width"), fval);
+
+        binbuf_addv(b, "ssffi;", gensym("#A"), gensym("xticks"),
+                    x->x_glist->gl_xtick.k_point, x->x_glist->gl_xtick.k_inc, x->x_glist->gl_xtick.k_lperb);
+        binbuf_addv(b, "ssffi;", gensym("#A"), gensym("yticks"),
+                    x->x_glist->gl_ytick.k_point, x->x_glist->gl_ytick.k_inc, x->x_glist->gl_ytick.k_lperb);
+
+        if(x->x_glist->gl_nxlabels>0) {
+            int i;
+            binbuf_addv(b, "ssf", gensym("#A"), gensym("xlabel"), x->x_glist->gl_xlabely);
+            for(i=0; i<x->x_glist->gl_nxlabels; i++) {
+                binbuf_addv(b, "s", x->x_glist->gl_xlabel[i]);
+            }
+            binbuf_addv(b, ";");
+        }
+        if(x->x_glist->gl_nylabels>0) {
+            int i;
+            binbuf_addv(b, "ssf", gensym("#A"), gensym("ylabel"), x->x_glist->gl_ylabelx);
+            for(i=0; i<x->x_glist->gl_nylabels; i++) {
+                binbuf_addv(b, "s", x->x_glist->gl_ylabel[i]);
+            }
+            binbuf_addv(b, ";");
+        }
+    }
 }
 
 const t_widgetbehavior garray_widgetbehavior =

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -1108,6 +1108,7 @@ t_glist *glist_findgraph(t_glist *x)
 
 extern void canvas_menuarray(t_glist *canvas);
 
+void glist_removearray(t_glist *x, t_symbol *name);
         /* in emscripten, the function signatures must match exactly
            (including the return type), so we need a (void)-returning wrapper
            around graph_array() to be used as canvas-method
@@ -1115,9 +1116,13 @@ extern void canvas_menuarray(t_glist *canvas);
 static void _graph_array(t_glist *gl, t_symbol *s, t_symbol *templateargsym,
     t_floatarg fsize, t_floatarg fflags)
 {
-    graph_array(gl, s, templateargsym, fsize, fflags);
+    if(templateargsym == gensym("")) {
+        glist_removearray(gl, s);
+        glist_redraw(gl);
+    } else {
+        graph_array(gl, s, templateargsym, fsize, fflags);
+    }
 }
-
 void g_graph_setup_class(t_class *c)
 {
     class_setwidget(c, &graph_widgetbehavior);
@@ -1132,7 +1137,7 @@ void g_graph_setup_class(t_class *c)
     class_addmethod(c, (t_method)graph_ylabel, gensym("ylabel"),
         A_GIMME, 0);
     class_addmethod(c, (t_method)_graph_array, gensym("array"),
-        A_SYMBOL, A_FLOAT, A_SYMBOL, A_DEFFLOAT, A_NULL);
+        A_SYMBOL, A_DEFFLOAT, A_DEFSYMBOL, A_DEFFLOAT, A_NULL);
     class_addmethod(c, (t_method)canvas_menuarray,
         gensym("menuarray"), A_NULL);
     class_addmethod(c, (t_method)glist_sort,

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -800,33 +800,23 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             t_float upix, lpix;
             if (y2 < y1)
                 upix = y1, lpix = y2;
-            else upix = y2, lpix = y1;
-            for (i = 0, f = x->gl_xtick.k_point;
-                f < 0.99 * x->gl_x2 + 0.01*x->gl_x1; i++,
-                    f += x->gl_xtick.k_inc)
+            else
+                upix = y2, lpix = y1;
+
+            for (i = (int)((x->gl_x1 - x->gl_xtick.k_point) / x->gl_xtick.k_inc) + (x->gl_xtick.k_point<x->gl_x1);
+                 i <= (int)((x->gl_x2 - x->gl_xtick.k_point) / x->gl_xtick.k_inc) - (x->gl_xtick.k_point>x->gl_x2);
+                 i++)
             {
+                t_float fx = x->gl_xtick.k_point + (i * x->gl_xtick.k_inc);
                 int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
+                int ix = (int)glist_xtopixels(x, x->gl_xtick.k_point + (i * x->gl_xtick.k_inc));
                 _graph_create_line4(x,
-                    (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix,
+                    ix, (int)upix,
+                    ix, (int)upix - tickpix,
                     tags2);
                 _graph_create_line4(x,
-                    (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix,
-                    tags2);
-            }
-            for (i = 1, f = x->gl_xtick.k_point - x->gl_xtick.k_inc;
-                f > 0.99 * x->gl_x1 + 0.01*x->gl_x2;
-                    i++, f -= x->gl_xtick.k_inc)
-            {
-                int tickpix = (i % x->gl_xtick.k_lperb ? 2 : 4);
-                _graph_create_line4(x,
-                    (int)glist_xtopixels(x, f), (int)upix,
-                    (int)glist_xtopixels(x, f), (int)upix - tickpix,
-                    tags2);
-                _graph_create_line4(x,
-                    (int)glist_xtopixels(x, f), (int)lpix,
-                    (int)glist_xtopixels(x, f), (int)lpix + tickpix,
+                    ix, (int)lpix,
+                    ix, (int)lpix + tickpix,
                     tags2);
             }
         }
@@ -837,33 +827,23 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             t_float ubound, lbound;
             if (x->gl_y2 < x->gl_y1)
                 ubound = x->gl_y1, lbound = x->gl_y2;
-            else ubound = x->gl_y2, lbound = x->gl_y1;
-            for (i = 0, f = x->gl_ytick.k_point;
-                f < 0.99 * ubound + 0.01 * lbound;
-                    i++, f += x->gl_ytick.k_inc)
+            else
+                ubound = x->gl_y2, lbound = x->gl_y1;
+            for (i =  (int)((lbound - x->gl_ytick.k_point) / x->gl_ytick.k_inc) + (x->gl_ytick.k_point<lbound);
+                 i <= (int)((ubound - x->gl_ytick.k_point) / x->gl_ytick.k_inc) - (x->gl_ytick.k_point>ubound);
+                 i++)
             {
+                t_float fy = x->gl_ytick.k_point + (i * x->gl_ytick.k_inc);
                 int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
+                int iy = (int)glist_ytopixels(x, fy);
+
                 _graph_create_line4(x,
-                    x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f),
+                    x1, iy,
+                    x1 + tickpix, iy,
                     tags2);
                 _graph_create_line4(x,
-                    x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f),
-                    tags2);
-            }
-            for (i = 1, f = x->gl_ytick.k_point - x->gl_ytick.k_inc;
-                f > 0.99 * lbound + 0.01 * ubound;
-                    i++, f -= x->gl_ytick.k_inc)
-            {
-                int tickpix = (i % x->gl_ytick.k_lperb ? 2 : 4);
-                _graph_create_line4(x,
-                    x1, (int)glist_ytopixels(x, f),
-                    x1 + tickpix, (int)glist_ytopixels(x, f),
-                    tags2);
-                _graph_create_line4(x,
-                    x2, (int)glist_ytopixels(x, f),
-                    x2 - tickpix, (int)glist_ytopixels(x, f),
+                    x2, iy,
+                    x2 - tickpix, iy,
                     tags2);
             }
         }

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -743,17 +743,17 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
     if (x->gl_isgraph)
     {
         if (x->gl_xtick.k_lperb) {
-            binbuf_addv(b, "ssffi;", gensym("#A"), gensym("xticks"),
+            binbuf_addv(b, "ssffi;", gensym("#X"), gensym("xticks"),
                 x->gl_xtick.k_point, x->gl_xtick.k_inc, x->gl_xtick.k_lperb);
         }
         if (x->gl_ytick.k_lperb) {
-            binbuf_addv(b, "ssffi;", gensym("#A"), gensym("yticks"),
+            binbuf_addv(b, "ssffi;", gensym("#X"), gensym("yticks"),
                 x->gl_ytick.k_point, x->gl_ytick.k_inc, x->gl_ytick.k_lperb);
         }
 
         if(x->gl_nxlabels>0) {
             int i;
-            binbuf_addv(b, "ssf", gensym("#A"), gensym("xlabel"), x->gl_xlabely);
+            binbuf_addv(b, "ssf", gensym("#X"), gensym("xlabel"), x->gl_xlabely);
             for(i=0; i<x->gl_nxlabels; i++) {
                 binbuf_addv(b, "s", x->gl_xlabel[i]);
             }
@@ -761,7 +761,7 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
         }
         if(x->gl_nylabels>0) {
             int i;
-            binbuf_addv(b, "ssf", gensym("#A"), gensym("ylabel"), x->gl_ylabelx);
+            binbuf_addv(b, "ssf", gensym("#X"), gensym("ylabel"), x->gl_ylabelx);
             for(i=0; i<x->gl_nylabels; i++) {
                 binbuf_addv(b, "s", x->gl_ylabel[i]);
             }

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -715,6 +715,7 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
         binbuf_addv(b, "ssiiii;", gensym("#X"), gensym("connect"),
             srcno, t.tr_outno, sinkno, t.tr_inno);
     }
+
         /* unless everything is the default (as in ordinary subpatches)
         print out a "coords" message to set up the coordinate systems */
     if (x->gl_isgraph || x->gl_x1 || x->gl_y1 ||
@@ -736,6 +737,36 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
                 x->gl_x2, x->gl_y2,
                 (t_float)x->gl_pixwidth, (t_float)x->gl_pixheight,
                 (t_float)x->gl_isgraph);
+    }
+
+        /* graph ticks and labels */
+    if (x->gl_isgraph)
+    {
+        if (x->gl_xtick.k_lperb) {
+            binbuf_addv(b, "ssffi;", gensym("#A"), gensym("xticks"),
+                x->gl_xtick.k_point, x->gl_xtick.k_inc, x->gl_xtick.k_lperb);
+        }
+        if (x->gl_ytick.k_lperb) {
+            binbuf_addv(b, "ssffi;", gensym("#A"), gensym("yticks"),
+                x->gl_ytick.k_point, x->gl_ytick.k_inc, x->gl_ytick.k_lperb);
+        }
+
+        if(x->gl_nxlabels>0) {
+            int i;
+            binbuf_addv(b, "ssf", gensym("#A"), gensym("xlabel"), x->gl_xlabely);
+            for(i=0; i<x->gl_nxlabels; i++) {
+                binbuf_addv(b, "s", x->gl_xlabel[i]);
+            }
+            binbuf_addv(b, ";");
+        }
+        if(x->gl_nylabels>0) {
+            int i;
+            binbuf_addv(b, "ssf", gensym("#A"), gensym("ylabel"), x->gl_ylabelx);
+            for(i=0; i<x->gl_nylabels; i++) {
+                binbuf_addv(b, "s", x->gl_ylabel[i]);
+            }
+            binbuf_addv(b, ";");
+        }
     }
 }
 


### PR DESCRIPTION
- add a `visname` message to *garray* to hide the name
   Closes: https://github.com/pure-data/pure-data/issues/2422
  (this is automatically persisted, as the `hidename` flag has been there forever... Just without an option to set it)
- add a `keep` message to *garray* to set the "saveit" flag
  Closes: https://github.com/pure-data/pure-data/issues/2428
- store the following properties when saving an array:
   - `color`
   - `width` (linewidth)
  (they are only stored if compatibility is >0.52 where these messages were introduced)
  Closes: https://github.com/pure-data/pure-data/issues/1838 (well partly, there's no corresponding properties dialog entry)
  
  i think these properties are meant to be persistent (you typically either need them for an array or you don't, but not both)
  the `vis` and `edit` properties are kept as runtime configuration and are not saved (as i think they are typically changed at runtime, and also can cause much confusion when being saved in the "wrong" state)
  th e`visname` property is stored in the patch (as was always the case)
- changing the `style` now no longer resets the line width (it just makes sure, that the minimum width (which is different for the points case) is not exceeded)
- store the following properties when saving a graph (and they are non-empty):
   - `xticks`, `yticks`
   - `xlabels`, `ylabels`
- confine `[xy]ticks` to the graph size
  Closes: https://github.com/pure-data/pure-data/issues/2421
- force a redraw when adding more garrays to a graph
   Closes: https://github.com/pure-data/pure-data/issues/1486
- force a redraw when deleting garrays from graph
   Closes: https://github.com/pure-data/pure-data/issues/2464
- force a redraw when renaming garrays
   Closes: https://github.com/pure-data/pure-data/issues/2465
- switch to edit-mode when creating graphs (and as a consequence garrays), and follow the mouse-pointer for positioning
  Closes: https://github.com/pure-data/pure-data/issues/1088
- Fix undo for adding garrays
  Closes: https://github.com/pure-data/pure-data/issues/1546
- Fix updating of arrays on rename (and have [tab...~] mark arrays as used in DSP)
  Closes: https://github.com/pure-data/pure-data/issues/2533
- Closes: https://github.com/pure-data/pure-data/issues/2036