### PR TITLE
fix libpd ios build by wrapping dlopen call with HAVE_LIBDL

### DIFF
--- a/doc/5.reference/list-help.pd
+++ b/doc/5.reference/list-help.pd
@@ -661,7 +661,7 @@
 #X obj 182 527 float;
 #X obj 143 527 text;
 #X obj 230 527 symbol;
-#N canvas 485 65 613 631 from/to 1;
+#N canvas 485 65 613 631 from/to 0;
 #X symbolatom 47 221 10 0 0 0 - - - 0;
 #X obj 47 251 list fromsymbol;
 #X msg 239 163 115 101 118 101 110 116 101 101 110;

--- a/src/d_soundfile.h
+++ b/src/d_soundfile.h
@@ -28,6 +28,7 @@
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
 #define off_t ssize_t
+#endif /* _MSC_VER */
 /* choose appropriate size if SSIZE_MAX is not defined */
 #ifndef SSIZE_MAX
 #ifdef _WIN64
@@ -36,7 +37,6 @@ typedef SSIZE_T ssize_t;
 #define SSIZE_MAX INT_MAX
 #endif
 #endif /* SSIZE_MAX */
-#endif /* _MSC_VER */
 
     /** should be large enough for all file type min sizes */
 #define SFHDRBUFSIZE 128

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -689,7 +689,9 @@ t_method sys_getfunbyname(const char *name)
             GetLastError());
         return NULL;
     }
-#else
+#elif HAVE_LIBDL
     return (t_method)dlsym(dlopen(NULL, RTLD_NOW), name);
+#else
+    return NULL;
 #endif
 }

--- a/src/s_print.c
+++ b/src/s_print.c
@@ -173,7 +173,7 @@ static void dologpost(const void *object, const int level, const char *s)
         fwprintf(stderr, L"verbose(%d): " PD_FWPRINTF_NARROW_FORMATTER, level, s);
         fflush(stderr);
 #else
-        fprintf(stderr, "verbose(%d): %s", level, s);
+        fprintf(stderr, "%s", s);
 #endif
     }
     else


### PR DESCRIPTION
This fixes an oversight when a new function was added to s_loader.c: iOS doesn't support dlopen, so we need to wrap it with `HAVE_LIBDL`.