### PR TITLE
add support for 8-bit wav audios in [soundfiler]

### DIFF
--- a/src/d_soundfile_wave.c
+++ b/src/d_soundfile_wave.c
@@ -286,7 +286,7 @@ static int wave_readheader(t_soundfile *sf)
             bytespersample = swap2(format->fc_bitspersample, swap) / 8;
             switch (bytespersample)
             {
-                case 2: case 3: break;
+                case 1: case 2: case 3: break;
                 case 4: case 8:
                     if (formattag == WAVE_FORMAT_FLOAT) /* 32 bit int? */
                         break;


### PR DESCRIPTION
closes #2393

- add support for 8-bit pcm audio for `[soundfiler]`

note: `[write]` still defaults to 2 bytes when banging `[write ~/test.wav sample]` so to test writing, use `[write -bytes 1 ~/test.wav sample]`