### PR TITLE
Remove first FREEA

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -157,7 +157,7 @@ static int jack_polling_callback(jack_nframes_t nframes, void *unused)
             }
         }
     }
-    FREEA(t_sample, muxbuffer, muxbufsize, MAX_ALLOCA_SAMPLES);
+
 #ifdef THREADSIGNAL
     sys_semaphore_post(jack_sem);
 #endif


### PR DESCRIPTION
In s_audio_jack.c removed the first FREEA(t_sample, muxbuffer, muxbufsize, MAX_ALLOCA_SAMPLES); at line 155. This should fix Pd to crash while invoked with Jack in polling mode.