### PR TITLE
API to allow external objects (libraries, abstractions) to load an accompanying gui plugins

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -112,6 +112,11 @@ void max_default(t_pd *x, t_symbol *s, int argc, t_atom *argv)
     endpost();
 }
 
+/* loading/interacting with GUI plugins */
+void glob_pluginload(t_pd *dummy, t_symbol *plugin, t_symbol *path)
+{
+    pdgui_vmess("load_plugin", "ss", plugin->s_name, path->s_name);
+}
 void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
 {
     pdgui_vmess("pdtk_plugin_dispatch", "a", argc, argv);
@@ -195,6 +200,8 @@ void glob_init(void)
         gensym("compatibility"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_plugindispatch,
         gensym("plugin-dispatch"), A_GIMME, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_pluginload,
+        gensym("plugin-load"), A_SYMBOL, A_DEFSYM, 0);
     class_addmethod(glob_pdobject, (t_method)glob_helpintro,
         gensym("help-intro"), A_GIMME, 0);
     class_addmethod(glob_pdobject, (t_method)glob_fastforward,

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -739,14 +739,38 @@ proc check_for_running_instances { } {
 # ------------------------------------------------------------------------------
 # load plugins on startup
 
-proc load_plugin_script {filename} {
+proc load_plugin_script {filename {duplicate basename} {warn 1}} {
+    # read $filename and evaluate it (for loading plugins)
+    # $duplicate: specifies how to check for duplicates; possible values are
+    # - ignore: do not do any duplicate checking (might load scripts multiple times)
+    # - basename: only check the base filename (without path) [ DEFAULT ]
+    # - filename: check the full $filename
+    # $warn: whether an attempt to load a script multiple times leads to a warning or not
+    # - 1 : warn if duplicate [ DEFAULT ]
+    # - 0 : silently ignore duplicates
     global errorInfo
 
-    set basename [file tail $filename]
-    if {[lsearch $::loaded_plugins $basename] > -1} {
-        ::pdwindow::post [ format [_ "'%1\$s' already loaded, ignoring: '%2\$s'"] $basename $filename]
+    if {[ file exists $filename ]} {} else {
+        ::pdwindow::post [_ "Ignoring non-existant plugin '%s'" $filename]
         ::pdwindow::post "\n"
         return
+    }
+
+    set basename [ file tail $filename ]
+    if { $duplicate eq "filename" } {
+        set dupe $filename
+    } else {
+        set dupe $basename
+    }
+
+    if { $duplicate ne "ignore" } {
+        if {[lsearch $::loaded_plugins $dupe] > -1} {
+            if { $warn } {
+                ::pdwindow::post [ format [_ "'%1\$s' already loaded, ignoring: '%2\$s'"] $basename $filename]
+                ::pdwindow::post "\n"
+            }
+            return
+        }
     }
 
     ::pdwindow::debug [ format [_ "Loading plugin: %s"] $filename ]
@@ -762,6 +786,9 @@ proc load_plugin_script {filename} {
         ::pdwindow::error "\n-----------\n"
     } else {
         lappend ::loaded_plugins $basename
+        if { $basename ne $filename } {
+               lappend ::loaded_plugins $filename
+        }
     }
 }
 

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -792,6 +792,12 @@ proc load_plugin_script {filename {duplicate basename} {warn 1}} {
     }
 }
 
+proc load_plugin {name {path {}}} {
+    # load a GUI plugin $name (without extension) found in $path
+    # so the actual filename is "${path}/${name}.tcl"
+    set filename [ file join ${path} ${name} ]
+    load_plugin_script "${filename}.tcl" filename 0
+}
 proc load_startup_plugins {} {
     # load built-in plugins
     load_plugin_script [file join $::sys_guidir pd_deken.tcl]


### PR DESCRIPTION
This adds a global message "plugin-load" to the `pd` receiver, that is forwarded to the GUI to load a plugin script.

E.g. this
```
[pd plugin-load helloworld-plugin /path/to/helloworld(
```
will load the */path/to/helloworld/helloworld-plugin.tcl*.

- the message is modelled after the `open` message (and saves the user from joining a path with a filename)
- the API omits the filename extension (to support multiple GUI backends, when we get there in 2300)
- the duplicate check is somewhat relaxed to only match exact filenames (so if both `[foo/guiabs]` ans `[bar/guiabs]` come with their `guiabs-plugin.tcl`, both can be loaded)

imo, this obsoletes https://github.com/pure-data/pure-data/pull/1766 