### PR TITLE
Fixes for arm64 on Windows and for buliding TclTk-9.0

### DIFF
--- a/mac/tcltk-wish.sh
+++ b/mac/tcltk-wish.sh
@@ -48,7 +48,7 @@ Options:
   -h,--help           display this help message
 
   --arch ARCH         choose a specific arch ie. ppc, i386, x86_64, arm64
-  
+
   --universal         "universal" multi-arch build based on detected macOS SDK
                       10.6:          ppc i386 x86_64
                       10.7  - 10.13: i386 x86_64
@@ -92,7 +92,7 @@ Examples:
     tcltk-wish.sh --universal 8.6.6
 
     # build Wish-master-git.app with the latest master branch from git
-    tcltk-wish.sh --git master-git 
+    tcltk-wish.sh --git master-git
 
     # build Wish-8.6.6-git.app with embedded Tcl/Tl 8.6.6
     # from git using the core_8_6_6 tag in the master branch
@@ -106,6 +106,29 @@ Examples:
     tcltk-wish.sh --build --keep 8.5.19
 
 EOF
+}
+
+buildinfo() {
+    cat <<EOF
+# Tcl/Tk
+${TCLTK}
+
+# macOS
+EOF
+sw_vers
+
+cat <<EOF
+
+# XCode
+EOF
+pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
+
+
+cat <<EOF
+
+# buildflags
+EOF
+echo "CFLAGS: ${CFLAGS}"
 }
 
 # Parse command line arguments
@@ -323,7 +346,7 @@ fi
 export CFLAGS
 
 # build Tcl and Tk
-# outputs into local "build" & "embedded" directories 
+# outputs into local "build" & "embedded" directories
 make -C "${tcldir}/macosx" embedded
 make -C "${tkdir}/macosx" embedded
 make -C "${tcldir}/macosx" install-embedded INSTALL_ROOT="$(pwd)/embedded"
@@ -331,6 +354,7 @@ make -C "${tkdir}/macosx"  install-embedded INSTALL_ROOT="$(pwd)/embedded"
 
 # move Wish.app located in "embedded"
 mv embedded/Applications/Utilities/Wish.app "${WISH}"
+buildinfo > "${WISH}/Contents/Resources/tcltck_buildinfo.txt"
 
 # finish up
 if [ $LEAVE = false ] ; then

--- a/mac/tcltk-wish.sh
+++ b/mac/tcltk-wish.sh
@@ -38,7 +38,7 @@ override_macos_version_min="no"
 #----------------------------------------------------------
 help() {
 cat <<EOF
-Usage: tcltk-wish.sh [OPTIONS] VERSION
+Usage: $0 [OPTIONS] VERSION
 
   Downloads and builds a Wish-VERSION.app for macOS
   with the chosen Tcl/Tk framework version,
@@ -82,28 +82,28 @@ Arguments:
 Examples:
 
     # build Wish-8.5.19.app with embedded Tcl/Tk 8.5.19
-    tcltk-wish.sh 8.5.19
+    $0 8.5.19
 
     # build 32bit Wish-8.6.6.app with embedded Tcl/Tk 8.6.6
-    tcltk-wish.sh --arch i386 8.6.6
+    $0 --arch i386 8.6.6
 
     # build Wish-8.6.6.app with embedded Tcl/Tk 8.6.6
     # and universal archs (detected from Xcode macOS SDK)
-    tcltk-wish.sh --universal 8.6.6
+    $0 --universal 8.6.6
 
     # build Wish-master-git.app with the latest master branch from git
-    tcltk-wish.sh --git master-git
+    $0 --git master-git
 
     # build Wish-8.6.6-git.app with embedded Tcl/Tl 8.6.6
     # from git using the core_8_6_6 tag in the master branch
-    tcltk-wish.sh --git 8.6.6-git -b master core_8_6_6
+    $0 --git 8.6.6-git -b master core_8_6_6
 
     # download the tcl8.5.19 and tk8.5.19 source paths, do not build
-    tcltk-wish.sh --download 8.5.19
+    $0 --download 8.5.19
 
     # build from existing tcl8.5.19 and tk8.5.19 source paths, do not download
     # note: --keep ensures the source trees are not deleted after building
-    tcltk-wish.sh --build --keep 8.5.19
+    $0 --build --keep 8.5.19
 
 EOF
 }

--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -176,6 +176,8 @@ if [  "${PDARCH}" = "" ]; then
         PDARCH=32
     elif file -b "${pd_exe}" | grep -E "^PE32\+ .* x86-64[, ]" >/dev/null; then
         PDARCH=64
+    elif file -b "${pd_exe}" | grep -E "^PE32\+ .* (ARM|Aarch)64[, ]" >/dev/null; then
+        PDARCH=64
     fi
 fi
 if [  "${PDARCH}" = "" ]; then

--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -172,9 +172,9 @@ fi
 
 # autodetect architecture if not given on the cmdline
 if [  "${PDARCH}" = "" ]; then
-    if file -b "${pd_exe}" | grep -E "^PE32 .* 80386 " >/dev/null; then
+    if file -b "${pd_exe}" | grep -E "^PE32 .* 80386[, ]" >/dev/null; then
         PDARCH=32
-    elif file -b "${pd_exe}" | grep -E "^PE32\+ .* x86-64 " >/dev/null; then
+    elif file -b "${pd_exe}" | grep -E "^PE32\+ .* x86-64[, ]" >/dev/null; then
         PDARCH=64
     fi
 fi

--- a/msw/build-nsi.sh
+++ b/msw/build-nsi.sh
@@ -256,7 +256,7 @@ if makensis -DPDVER="${PDVERSION}" -DWISHN="${WISHNAME}" -DARCHI="${PDARCH}" \
     -DPDEXE=$(basename "${pd_exe}") "${NSIFILE}" 1>&2
 then
   error "Build successful"
-  echo "${OUTDIR}/pd-${PDVERSION}.windows-installer.exe"
+  echo "${OUTDIR}/Pd-${PDVERSION}.windows-installer.exe"
 else
   error "Some error occurred during compilation of ${NSIFILE}"
   error "(files are not cleaned up so you can inspect them)"

--- a/msw/msw-app.sh
+++ b/msw/msw-app.sh
@@ -20,8 +20,8 @@ sources=false
 
 # strip binaries
 strip=true
-STRIP=${STRIP-strip}
-STRIPARGS=${STRIPARGS-"--strip-unneeded -R .note -R .comment"}
+STRIP="${STRIP-strip}"
+STRIPARGS="${STRIPARGS-"--strip-unneeded -R .note -R .comment"}"
 
 # build dir, relative to working directory
 custom_builddir=false
@@ -76,15 +76,15 @@ EOF
 
 # Parse command line arguments
 #----------------------------------------------------------
-while [ "$1" != "" ] ; do
-    case $1 in
+while [ -n "${1}" ] ; do
+    case "${1}" in
         -t|--tk)
             shift 1
             if [ $# = 0 ] ; then
                 echo "-t,--tk option requires a VER or DIR argument" 1>&2
                 exit 1
             fi
-            TK="$1"
+            TK="${1}"
             prototype_tk=false
             ;;
         -s|--sources)
@@ -99,7 +99,7 @@ while [ "$1" != "" ] ; do
                 exit 1
             fi
             shift 1
-            BUILD=${1%/} # remove trailing slash
+            BUILD="${1%/}" # remove trailing slash
             custom_builddir=true
             ;;
         -h|--help)
@@ -113,29 +113,29 @@ while [ "$1" != "" ] ; do
 done
 
 # check for version argument and set app path in the dir the script is run from
-if [ "x$1" != "x" ] ; then
-    APP=$(pwd)/pd-$1
+if [ -n "${1}" ] ; then
+    APP="$(pwd)/pd-${1}"
 else
     # version not specified
-    APP=$(pwd)/pd
+    APP="$(pwd)/pd"
 fi
 
 # Go
 #----------------------------------------------------------
 
 # make sure custom build directory is an absolute path
-if [ "x$custom_builddir" = "xtrue" ] ; then
-    if [ "x${BUILD#/}" = "x${BUILD}" ] ; then
+if [ "${custom_builddir}" = "true" ] ; then
+    if [ "${BUILD#/}" = "${BUILD}" ] ; then
         # BUILD isn't absolute as it doesn't start with '/'
-        BUILD="$(pwd)/$BUILD"
+        BUILD="$(pwd)/${BUILD}"
     fi
 fi
 
 # is $TK a version or a directory?
-if [ -d "$TK" ] ; then
+if [ -d "${TK}" ] ; then
     # directory, make sure it's absolute
-    if [ "x${TK#/}" = "x${TK}" ] ; then
-        TK="$(pwd)/$TK"
+    if [ "${TK#/}" = "${TK}" ] ; then
+        TK="$(pwd)/${TK}"
     fi
 else
     # version, so it will be downloaded & built
@@ -143,116 +143,118 @@ else
 fi
 
 # change to the dir of this script
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-echo "==== Creating $(basename $APP)"
+echo "==== Creating $(basename "${APP}")"
 
 # remove old app dir if found
-if [ -d $APP ] ; then
+if [ -d "${APP}" ] ; then
     echo "removing existing directory"
-    rm -rf $APP
+    rm -rf "${APP}"
 fi
 
 # install to app directory
-make -C $BUILD install DESTDIR=$APP prefix=/
+make -C "${BUILD}" install DESTDIR="${APP}" prefix=/
 
 # don't need man pages
-rm -rf $APP/share
+rm -rf "${APP}/share"
 
 # place headers together in src directory
-mv $APP/include $APP/src
-mv $APP/src/pd/* $APP/src
-rm -rf $APP/src/pd
+mv "${APP}/include" "${APP}/src"
+mv "${APP}/src/pd"/* "${APP}/src"
+rm -rf "${APP}/src/pd"
 
 # move folders from lib/pd into top level directory
-rm -rf $APP/lib/pd/bin
-for d in $APP/lib/pd/*; do
-    mv $d $APP/
+rm -rf "${APP}/lib/pd/bin"
+for d in "${APP}/lib/pd"/*; do
+    mv "${d}" "${APP}/"
 done
-rm -rf $APP/lib/
+rm -rf "${APP:?}/lib/"
 
 # install sources
-if [ "x$sources" = xtrue ] ; then
-    mkdir -p $APP/src
-    cp -v ../src/*.c $APP/src/
-    cp -v ../src/*.h $APP/src/
-    for d in $APP/extra/*/; do
-        s=${d%/}
-        s=../extra/${s##*/}
+if [ "${sources}" = true ] ; then
+    mkdir -p "${APP}/src"
+    cp -v ../src/*.c "${APP}/src/"
+    cp -v ../src/*.h "${APP}/src/"
+    for d in "${APP}/extra"/*/; do
+        s="${d%/}"
+        s="../extra/${s##*/}"
         cp -v "${s}"/*.c "${d}"
     done
 fi
 
 # untar pdprototype.tgz
-tar -xf pdprototype.tgz -C $APP/ --strip-components=1
-if [ "x$prototype_tk" = xfalse ] ; then
+tar -xf pdprototype.tgz -C "${APP}/" --strip-components=1
+if [ "$prototype_tk" = false ] ; then
 
     # remove bundled tcl & tk as we'll install our own,
     # keep dlls needed by pd & externals
-    rm -rf $APP/bin/tcl* $APP/bin/tk* \
-           $APP/bin/wish*.exe $APP/bin/tclsh*.exe \
-           $APP/lib
+    rm -rf "${APP:?}/bin"/tcl* "${APP:?}/bin"/tk* \
+           "${APP:?}/bin"/wish*.exe "${APP:?}/bin"/tclsh*.exe \
+           "${APP:?}/lib"
 
     # remove headers which should be provided by MinGW
-    rm -f $APP/src/pthread.h
+    rm -f "${APP}/src/pthread.h"
 
     # build, if needed
-    if [ "x$build_tk" = xtrue ] ; then
+    if [ "${build_tk}" = true ] ; then
          echo "Building tcltk-$TK"
-        ./tcltk-dir.sh $TK
-        TK=tcltk-${TK}
+        ./tcltk-dir.sh "${TK}"
+        TK="tcltk-${TK}"
     else
         echo "Using $TK"
     fi
 
     # install tcl & tk
-    cp -R $TK/bin $APP/
-    cp -R $TK/lib $APP/
+    cp -R "${TK}/bin" "${APP}"/
+    cp -R "${TK}/lib" "${APP}/"
 
     # remove bundled Tcl packages Pd doesn't need
-    rm -rf $APP/lib/itcl* $APP/lib/sqlite* $APP/lib/tdbc*
+    rm -rf "${APP}/lib"/itcl* "${APP}/lib"/sqlite* "${APP}/lib"/tdbc*
 fi
 
 # install pthread from MinGW from:
 # * Windows:             $MINGW_PREFIX/bin
 # * Linux cross-compile: $MINGW_PREFIX/lib
-if [ "x${MINGW_PREFIX}" != "x" ] ; then
-    if [ -e $MINGW_PREFIX/bin/$PTHREAD_DLL ] ; then
-        pthread_dll="${MINGW_PREFIX}/bin/${PTHREAD_DLL}"
-    elif [ -e $MINGW_PREFIX/lib/$PTHREAD_DLL ] ; then
-        pthread_dll="${MINGW_PREFIX}/lib/${PTHREAD_DLL}"
-    fi
+if [ -n "${MINGW_PREFIX}" ] ; then
+    for p in bin lib; do
+        p="${MINGW_PREFIX}/${p}/${PTHREAD_DLL}"
+        if [ -e "${p}" ] ; then
+            pthread_dll="${p}"
+            break
+        fi
+    done
 fi
 
-if [  -e "${pthread_dll}" ]; then
-    find "${APP}" -type f '(' -name "pd.dll" -o -name "pd64.dll" -o -name "pd32.dll" ')' -exec dirname {} ";" | sort -u | while read dir ; do
+if [ -e "${pthread_dll}" ]; then
+    find "${APP}" -type f '(' -name "pd.dll" -o -name "pd64.dll" -o -name "pd32.dll" ')' -exec dirname {} ";" | sort -u | while read -r dir ; do
     cp -v "${pthread_dll}" "${dir}/"
     done
 fi
 
 # copy info and resources not handled via "make install"
-cp -v ../README.txt  $APP/
-cp -v ../LICENSE.txt $APP/
-cp -vR ../font $APP/
+cp -v ../README.txt  "${APP}/"
+cp -v ../LICENSE.txt "${APP}/"
+cp -vR ../font "${APP}/"
 
 # strip executables,
 # use temp files as stripping in place doesn't seem to work reliably on Windows
-if [ "x$strip" = xtrue ] ; then
+if [ "${strip}" = true ] ; then
     find "${APP}" -type f '(' -iname "*.exe" -o -iname "*.com" -o -iname "*.dll" ')' \
-    | while read file ; do \
-        "${STRIP}" ${STRIPARGS} -o "$file.stripped" "$file" && \
-        mv "$file.stripped" "$file" && \
-        echo "stripped $file" || \
-        echo "NOT stripped $file" ; \
+    | while read -r file ; do \
+        "${STRIP}" ${STRIPARGS} -o "${file}.stripped" "${file}" && \
+        mv "${file}.stripped" "${file}" && \
+        echo "stripped ${file}" || \
+        echo "NOT stripped ${file}" ; \
     done
 fi
 
 # set permissions and clean up
-find $APP -type f -exec chmod -x {} +
-find $APP -type f '(' -iname "*.exe" -o -iname "*.com" ')' -exec chmod +x {} +
-find $APP -type f '(' -iname "*.la" -o -iname "*.dll.a" -o -iname "*.am" ')' -delete
-find $APP/bin -type f -not -name "*.*" -delete
+find "${APP}" -type f -exec chmod -x {} +
+find "${APP}" -type f '(' -iname "*.exe" -o -iname "*.com" ')' -exec chmod +x {} +
+find "${APP}" -type f '(' -iname "*.la" -o -iname "*.dll.a" -o -iname "*.am" ')' -delete
+find "${APP}/bin" -type f -not -name "*.*" -delete
 
 # finished
-touch $APP
-echo  "==== Finished $(basename $APP)"
+touch "${APP}"
+echo  "==== Finished $(basename ${APP})"

--- a/msw/msw-app.sh
+++ b/msw/msw-app.sh
@@ -242,7 +242,8 @@ if [ "x$strip" = xtrue ] ; then
     | while read file ; do \
         "${STRIP}" ${STRIPARGS} -o "$file.stripped" "$file" && \
         mv "$file.stripped" "$file" && \
-        echo "stripped $file" ; \
+        echo "stripped $file" || \
+        echo "NOT stripped $file" ; \
     done
 fi
 

--- a/msw/tcltk-dir.sh
+++ b/msw/tcltk-dir.sh
@@ -26,7 +26,7 @@ GIT=false
 FORCE64BIT=false
 
 # configure options
-if [ "x${OPTIONS}" = "x" ] ; then
+if [ -z "${OPTIONS}" ] ; then
     OPTIONS="--enable-threads"
 fi
 
@@ -76,7 +76,7 @@ EOF
 # Parse command line arguments
 #----------------------------------------------------------
 while [ "$1" != "" ] ; do
-    case $1 in
+    case "$1" in
         -h|--help)
             help
             exit 0
@@ -98,72 +98,79 @@ if [ "$1" = "" ] ; then
     echo "Usage: $0 [OPTIONS] VERSION" 1>&2
     exit 1
 fi
-TCLTK=$1
+TCLTK="$1"
 shift 1
 
 # Go
 #----------------------------------------------------------
 
-DEST=$(pwd)/tcltk-${TCLTK}
+DEST="$(pwd)/tcltk-${TCLTK}"
 
 # change to the dir of this script
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 # remove old dir if found
-if [ -d "$DEST" ] ; then
-    rm -rf $DEST
+if [ -d "${DEST}" ] ; then
+    rm -rf "${DEST}"
 fi
-mkdir -p $DEST
+mkdir -p "${DEST}"
 
-echo "==== Creating tcltk-$TCLTK"
 
-if [ "x$GIT" = xtrue ] ; then
+echo "==== Creating tcltk-${TCLTK}"
+
+# fetch Tcl and Tk
+if [ "${GIT}" = true ] ; then
+    echo "---- Cloning TclTk"
 
     # shallow clone sources, pass remaining args to git
-    git clone --depth 1 https://github.com/tcltk/tcl.git $@
-    git clone --depth 1 https://github.com/tcltk/tk.git $@
+    git clone --depth 1 https://github.com/tcltk/tcl.git "$@"
+    git clone --depth 1 https://github.com/tcltk/tk.git "$@"
 
     tcldir=tcl
     tkdir=tk
 else
+    echo "---- Downloading TclTk-${TCLTK}"
 
     # download source packages
-    curl -LO http://prdownloads.sourceforge.net/tcl/tcl${TCLTK}-src.tar.gz
-    curl -LO http://prdownloads.sourceforge.net/tcl/tk${TCLTK}-src.tar.gz
+    curl -LO "http://prdownloads.sourceforge.net/tcl/tcl${TCLTK}-src.tar.gz"
+    curl -LO "http://prdownloads.sourceforge.net/tcl/tk${TCLTK}-src.tar.gz"
 
     # unpack
-    tar -xzf tcl${TCLTK}-src.tar.gz
-    tar -xzf tk${TCLTK}-src.tar.gz
+    tar -xzf "tcl${TCLTK}-src.tar.gz"
+    tar -xzf "tk${TCLTK}-src.tar.gz"
 
-    tcldir=tcl${TCLTK}
-    tkdir=tk${TCLTK}
+    tcldir="tcl${TCLTK}"
+    tkdir="tk${TCLTK}"
 fi
 
 # 64 bit support
-if [ "x${FORCE64BIT}" = xtrue ] ; then
+if [ "${FORCE64BIT}" = true ] ; then
     echo "==== Forcing 64 bit"
-    OPTIONS="$OPTIONS --enable-64bit"
+    OPTIONS="${OPTIONS} --enable-64bit"
 else
     # try to detect 64 bit MinGW using MSYSTEM env var
     if [ "x${MSYSTEM}" = "xMINGW64" ] ; then
         echo "==== Detected 64 bit"
-        OPTIONS="$OPTIONS --enable-64bit"
+        OPTIONS="${OPTIONS} --enable-64bit"
     fi
 fi
 
 # build Tcl and Tk
-cd ${tcldir}/win
-./configure $OPTIONS --prefix=$DEST
+echo "---- Building Tcl-${TCLTK}"
+cd "${tcldir}/win"
+./configure ${OPTIONS} --prefix="${DEST}"
 make
 make install
 cd -
-cd ${tkdir}/win
-./configure $OPTIONS --prefix=$DEST
+echo "---- Building Tk-${TCLTK}"
+cd "${tkdir}/win"
+./configure ${OPTIONS} --prefix="${DEST}"
 make
 make install
 cd -
 
 # finish up
-rm -rf ${tcldir} ${tkdir} ${tcldir}-src.tar.gz ${tkdir}-src.tar.gz
+echo "---- Cleaning up TclTk-${TCLTK}"
+rm -rf "${tcldir}" "${tkdir}" "${tcldir}-src.tar.gz" "${tkdir}-src.tar.gz"
 
-echo  "==== Finished tcltk-$TCLTK"
+echo  "==== Finished tcltk-${TCLTK}"

--- a/msw/tcltk-dir.sh
+++ b/msw/tcltk-dir.sh
@@ -116,6 +116,25 @@ fi
 mkdir -p "${DEST}"
 
 
+# 64 bit support
+if [ "${FORCE64BIT}" = true ] ; then
+    echo "==== Forcing 64 bit"
+    OPTIONS="${OPTIONS} --enable-64bit"
+else
+    # try to detect 64 bit MinGW using MSYSTEM env var
+    case "${MSYSTEM}" in
+        MINGW64 | UCRT64 | CLANG64)
+            echo "==== Detected 64 bit"
+            OPTIONS="${OPTIONS} --enable-64bit"
+            ;;
+        CLANGARM64)
+            echo "==== Detected 64 bit (arm)"
+            OPTIONS="${OPTIONS} --enable-64bit=arm64"
+            ;;
+    esac
+fi
+
+
 echo "==== Creating tcltk-${TCLTK}"
 
 # fetch Tcl and Tk
@@ -141,18 +160,6 @@ else
 
     tcldir="tcl${TCLTK}"
     tkdir="tk${TCLTK}"
-fi
-
-# 64 bit support
-if [ "${FORCE64BIT}" = true ] ; then
-    echo "==== Forcing 64 bit"
-    OPTIONS="${OPTIONS} --enable-64bit"
-else
-    # try to detect 64 bit MinGW using MSYSTEM env var
-    if [ "x${MSYSTEM}" = "xMINGW64" ] ; then
-        echo "==== Detected 64 bit"
-        OPTIONS="${OPTIONS} --enable-64bit"
-    fi
 fi
 
 # build Tcl and Tk


### PR DESCRIPTION
This PR includes a number of fixes for building Pd for Windows-on-arm, as well as for building TclTk-9.0

So far, no changes to the source code have been required :-)
However, there are a few amendments to the build-scripts in the `msw/` subdirectory:
- `tcltk-dir.sh`
   - allow building on MSYS2/clang-aarch64 (and other MSYS2 variants)
- `msw-app.sh`
   - fix stripping of binaries, e.g.
      -  do not fail if there are some wrong-arch binaries that cannot be stripped
      - do not strip TclTk binaries (from the pdprototypes), as TclTk-9.0 now embeds the stdlib in the DLL as a zip-package, which would get stripped away, leading to an unusable TclTk engine.
- `build-nsi`
   - recognize arm64 as a 64bit architecture
   - improve architecture detection in general

and a few more in the `mac/` subdirectory:
- `tcltk-wish.sh`
   - adjust `macosx-version-min` when building Tcl/Tk-9.0
     Closes: https://github.com/pure-data/pure-data/issues/2519
   - also allow the use to specify a custom `macosx-version-min`

