### PR TITLE
shebang support

### DIFF
--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -826,6 +826,23 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int flag
         buf+= 3;
     }
 
+        /* optionally skip the shebang */
+    if (flag & BINBUF_SHEBANG
+        && length >=3
+        && buf[0] == '#' && buf[1] == '!')
+    {
+        long offset = 0;
+        for(offset = 0; offset<length; offset++)
+        {
+            if (buf[offset] == '\n')
+            {
+                length -= offset;
+                buf += offset;
+                break;
+            }
+        }
+    }
+
         /* optionally map carriage return to semicolon */
     if (flag & BINBUF_CR)
     {
@@ -1452,7 +1469,7 @@ void binbuf_evalfile(t_symbol *name, t_symbol *dir)
     int dspstate = canvas_suspend_dsp();
         /* set filename so that new canvases can pick them up */
     glob_setfilename(0, name, dir);
-    if (binbuf_read(b, name->s_name, dir->s_name, 0))
+    if (binbuf_read(b, name->s_name, dir->s_name, BINBUF_SHEBANG))
         pd_error(0, "%s: read failed; %s", name->s_name, strerror(errno));
     else
     {

--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -779,7 +779,7 @@ broken:
          FREEA(t_atom, mstack, maxnargs, HUGEMSG);
 }
 
-int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crflag)
+int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int flag)
 {
     long length, length0;
     int fd;
@@ -827,7 +827,7 @@ int binbuf_read(t_binbuf *b, const char *filename, const char *dirname, int crfl
     }
 
         /* optionally map carriage return to semicolon */
-    if (crflag)
+    if (flag & BINBUF_CR)
     {
         int i;
         for (i = 0; i < length; i++)
@@ -927,7 +927,7 @@ int binbuf_write(const t_binbuf *x, const char *filename, const char *dir, int c
         }
         if ((ap->a_type == A_SEMI || ap->a_type == A_COMMA) &&
             bp > sbuf && bp[-1] == ' ') bp--;
-        if (!crflag || ap->a_type != A_SEMI)
+        if (!(crflag & BINBUF_CR) || ap->a_type != A_SEMI)
         {
             atom_string(ap, bp, (unsigned int)((ep-bp)-2));
             length = (int)strlen(bp);

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -404,14 +404,16 @@ EXTERN int binbuf_getnatom(const t_binbuf *x);
 EXTERN t_atom *binbuf_getvec(const t_binbuf *x);
 EXTERN int binbuf_resize(t_binbuf *x, int newsize);
 EXTERN void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv);
+/* binbuf read/write flags */
+#define BINBUF_CR      (1<<0)
 EXTERN int binbuf_read(t_binbuf *b, const char *filename, const char *dirname,
-    int crflag);
+    int flag);
 EXTERN int binbuf_read_via_canvas(t_binbuf *b, const char *filename, const t_canvas *canvas,
-    int crflag);
+    int flag);
 EXTERN int binbuf_read_via_path(t_binbuf *b, const char *filename, const char *dirname,
-    int crflag);
+    int flag);
 EXTERN int binbuf_write(const t_binbuf *x, const char *filename, const char *dir,
-    int crflag);
+    int flag);
 EXTERN void binbuf_evalfile(t_symbol *name, t_symbol *dir);
 EXTERN t_symbol *binbuf_realizedollsym(t_symbol *s, int ac, const t_atom *av,
     int tonew);

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -406,6 +406,7 @@ EXTERN int binbuf_resize(t_binbuf *x, int newsize);
 EXTERN void binbuf_eval(const t_binbuf *x, t_pd *target, int argc, const t_atom *argv);
 /* binbuf read/write flags */
 #define BINBUF_CR      (1<<0)
+#define BINBUF_SHEBANG (1<<1)
 EXTERN int binbuf_read(t_binbuf *b, const char *filename, const char *dirname,
     int flag);
 EXTERN int binbuf_read_via_canvas(t_binbuf *b, const char *filename, const t_canvas *canvas,


### PR DESCRIPTION
this PR adds basic support for Pd-files that contain a shebang.

Closes: https://github.com/pure-data/pure-data/issues/672

### what's a shebang

a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) is a special character sequence at the beginning of an executable file, that tells the program loader which interpreter to use to execute the file.

a `.pd` file with a shebang could be used as a standalone script.

e.g. consider a Pd file `hello.pd`:

```pd
#!/usr/bin/env -S pd -nogui -open
#N canvas 2655 476 280 264 12;
#X msg 142 143 world;
#X obj 142 168 print hello;
#X obj 72 91 loadbang;
#X obj 72 123 t b b;
#X msg 72 148 \; pd quit;
#X connect 0 0 1 0;
#X connect 2 0 3 0;
#X connect 3 0 4 0;
#X connect 3 1 0 0;
```

when made executable (`chmod +x hello.pd`) you could simply run:

```sh
$ ./hello.pd
hello: world
$
```


## about the PR

to support shebangs, Pd simply has to ignore the first line of a patch file if it starts with `#!`.

unfortunately:
- Pd uses a unified method for reading text-files into binbufs, and then evaluates the binbuf
- a shebang line must not be semicolon-terminated (it is simply terminated with `\n`)

this is a bit problematic as:
- we do not want to ignore the shebang when opening general file with `binbuf_read()` (e.g. with the `[text]` object)
- since Pd-patches use semicolon as line terminator, the CR terminating the shebang-line is simply swalled by `binbuf_read()`

the solution is to turn the `binbuf_read()`'s `crflag` into a general flag, so we can tell `binbuf_read()` to explicitly ignore the shebang if so desired (e.g. in the context of `binbuf_evalfile()`)

I have checked all the pd-externals packaged in Debian, and none use `crflags` with any value other than `0` or `1`.
Since the new flag for ignoring the shebang is `| 2`, I do not expect any problems.


### persistence

as of now, saving a patch-file within Pd will clear any shebang it might have had.