### PR TITLE
fexpr~: check if shorthand exceeds outlet count

### DIFF
--- a/src/x_vexp.c
+++ b/src/x_vexp.c
@@ -1241,6 +1241,16 @@ ex_eval(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
                  * we need to look at the previous results buffer
                  */
                 optr->ex_type = ET_FLT;
+                if (eptr->ex_int >= expr->exp_nexpr) {
+                        if (!(expr->exp_error & EE_YO_RANGE)) {
+                                expr->exp_error |= EE_YO_RANGE;
+                                post("fexpr~: $y%d illegal: not that many expr's",
+                                                                    eptr->ex_int + 1);
+                                post("fexpr~: no error report till next reset");
+                        }
+                        optr->ex_flt = 0;
+                        return(++eptr);
+                }
                 if (idx == 0)
                         optr->ex_flt =
                         expr->exp_p_res[eptr->ex_int][expr->exp_vsize - 1];
@@ -1712,8 +1722,12 @@ eval_sigidx(struct expr *expr, struct ex_ex *eptr, struct ex_ex *optr, int idx)
                         i = -1;
                 }
                 if (eptr->ex_int >= expr->exp_nexpr) {
-                        post("fexpr~: $y%d illegal: not that many expr's",
-                                                                eptr->ex_int);
+                        if (!(expr->exp_error & EE_YO_RANGE)) {
+                                expr->exp_error |= EE_YO_RANGE;
+                                post("fexpr~: $y%d illegal: not that many expr's",
+                                                                    eptr->ex_int + 1);
+                                post("fexpr~: no error report till next reset");
+                        }
                         optr->ex_flt = 0;
                         return (reteptr);
                 }

--- a/src/x_vexp.h
+++ b/src/x_vexp.h
@@ -210,6 +210,7 @@ struct ex_ex {
 #define EE_NOTABLE      0x08    /* NO TABLE */
 #define EE_NOVAR        0x10    /* NO VARIABLE */
 #define EE_BADSYM       0x20    /* Symbol passed for Vector */
+#define EE_YO_RANGE     0x40    /* $y index exceeds number of expressions */
 
 typedef struct expr {
 #ifdef PD


### PR DESCRIPTION
catches crash by adding check for shorthand form of output in `fexpr~`.

example: `fexpr~ $y2` crashed Pd.

the check for `$y2[-n]` was already present. this is duplicated here for the shorthand version.
Also fixes a minor off-by-one error in the log output and adds
* new error type to prevent console flooding
* additional message similar to comparable error types ("no error report till next reset")

- closes #2526