### PR TITLE
Check for multiple dollar signs in binbuf_restore

### DIFF
--- a/src/m_binbuf.c
+++ b/src/m_binbuf.c
@@ -20,6 +20,15 @@
 
 #include "m_private_utils.h"
 
+    /* returns the start of a valid dollar or dollsym */
+static const char *str_dollar(const char *s)
+{
+    for (; (s = strchr(s, '$')); ++s)
+        if (('0' <= s[1] && s[1] <= '9'))
+            break;
+    return s;
+}
+
 struct _binbuf
 {
     int b_n;
@@ -393,8 +402,7 @@ void binbuf_restore(t_binbuf *x, int argc, const t_atom *argv)
                     usestr = buf;
                 }
                 else usestr = str;
-                if (dollar || (usestr== str && (str2 = strchr(usestr, '$')) &&
-                    str2[1] >= '0' && str2[1] <= '9'))
+                if (dollar || (usestr == str && (str2 = str_dollar(usestr))))
                 {
                     int dollsym = 0;
                     if (*usestr != '$')


### PR DESCRIPTION
In the event that the first dollar sign we come across isn't related to a dollarsym atom, we need to keep looking. Otherwise, there will be inconsistencies between a patch's state upon saving, and its state after closing and re-opening.

Example: in the message "$$1", the 1st $ is actually a dollarsym's prefix, so we need to check the 2nd $ as well.

Here is a video showing a before and after of this PR:

https://github.com/user-attachments/assets/41db09b5-5ce1-4f67-a648-7bdc5dc0cc4c
