### PR TITLE
add new API function `pd_findbyclassname`

### DIFF
--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -6,6 +6,8 @@
 #include "m_imp.h"
 #include "g_canvas.h"   /* just for LB_LOAD */
 
+#include <string.h>
+
     /* FIXME no out-of-memory testing yet! */
 
 t_pd *pd_new(t_class *c)
@@ -211,6 +213,42 @@ t_pd *pd_findbyclass(t_symbol *s, const t_class *c)
             }
             x = e->e_who;
         }
+    }
+    return x;
+}
+
+t_pd *pd_findbyclassname(t_symbol *s, const t_symbol *classname)
+{
+    t_pd *x = 0;
+
+    if (!s->s_thing) return (0);
+#ifdef PDINSTANCE
+        /* NB: the class name symbol is shared between instances
+        so we can't rely on pointer identity! */
+    if (!strcmp((*s->s_thing)->c_name->s_name, classname->s_name))
+        return (s->s_thing);
+#else
+    if ((*s->s_thing)->c_name == classname) return (s->s_thing);
+#endif
+    if (*s->s_thing == bindlist_class)
+    {
+        t_bindlist *b = (t_bindlist *)s->s_thing;
+        t_bindelem *e, *e2;
+        int warned = 0;
+        for (e = b->b_list; e; e = e->e_next)
+        #ifdef PDINSTANCE /* see above */
+            if (!strcmp((*e->e_who)->c_name->s_name, classname->s_name))
+        #else
+            if ((*e->e_who)->c_name == classname)
+        #endif
+            {
+                if (x && !warned)
+                {
+                    post("warning: %s: multiply defined", s->s_name);
+                    warned = 1;
+                }
+                x = e->e_who;
+            }
     }
     return x;
 }

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -437,6 +437,7 @@ EXTERN void pd_free(t_pd *x);
 EXTERN void pd_bind(t_pd *x, t_symbol *s);
 EXTERN void pd_unbind(t_pd *x, t_symbol *s);
 EXTERN t_pd *pd_findbyclass(t_symbol *s, const t_class *c);
+EXTERN t_pd *pd_findbyclassname(t_symbol *s, const t_symbol *classname);
 EXTERN void pd_pushsym(t_pd *x);
 EXTERN void pd_popsym(t_pd *x);
 EXTERN void pd_bang(t_pd *x);


### PR DESCRIPTION
The standard method for data sharing in Pd is to bind objects to symbols. Internally, objects call `pd_findbyclass` to get another object from a symbol. Since every symbol can be bound to multiple objects with the same name (but with different classes) the user needs to pass a pointer to the expected class (`t_class*`). This is all fine as long as all objects are defined in the same module (e.g. in the Pd core or in a single-binary-library). However, as soon as the objects live in different binaries, you run into problems because you need to share the class pointer across DLL boundaries, which turns out to be very tricky.

To solve this problem, I've introduced a new function called `pd_findbyclassname`. This is the same as `pd_findbyclass()`, except that you pass the class name instead of the class pointer. This way you can share Pd objects without being forced to compile everything as a single binary. It even allows to share Pd objects between different external libraries, which hasn't been possible so far AFAICT!