### PR TITLE
support ctrl+click in pd window on macos

### DIFF
--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -119,12 +119,10 @@ proc ::pdwindow::insert_log_line {object_id level message} {
             "::pdwindow::select_by_id $object_id; break"
         $win tag bind $tag <Enter> "::pdwindow::set_findinstance_cursor %W Control_L 1"
         $win tag bind $tag <Leave> "::pdwindow::set_findinstance_cursor %W Control_L 0"
-        if {$::windowingsystem eq "aqua"} {
-            set key <2>
-        } else {
-            set key <3>
+        set rightclicks [expr {$::windowingsystem eq "aqua" ? {<2> <Control-Button-1>} : {<3>}}]
+        foreach event $rightclicks {
+            $win tag bind $tag $event [list ::pdwindow::message_contextmenu %W %x %y $object_id]
         }
-        $win tag bind $tag $key [list ::pdwindow::message_contextmenu %W %x %y $object_id]
     }
 }
 


### PR DESCRIPTION
this adds "right click" via ctrl+click via `<Control-Button-1>` in the Pd window for macOS similar to the canvas window behaviour:

https://github.com/pure-data/pure-data/blob/eaaf7991748a71412686a6d4a52972d67c4d4933/tcl/pd_bindings.tcl#L299-L300