### PR TITLE
support tcl9 for pd window right click on macos

### DIFF
--- a/tcl/pdwindow.tcl
+++ b/tcl/pdwindow.tcl
@@ -119,7 +119,12 @@ proc ::pdwindow::insert_log_line {object_id level message} {
             "::pdwindow::select_by_id $object_id; break"
         $win tag bind $tag <Enter> "::pdwindow::set_findinstance_cursor %W Control_L 1"
         $win tag bind $tag <Leave> "::pdwindow::set_findinstance_cursor %W Control_L 0"
-        set rightclicks [expr {$::windowingsystem eq "aqua" ? {<2> <Control-Button-1>} : {<3>}}]
+        if {$::windowingsystem eq "aqua"} {
+            set rightbtn [expr {$::tcl_version < 9.0 ? 2 : 3}]
+            set rightclicks [list <$rightbtn> <Control-Button-1>]
+        } else {
+            set rightclicks {<3>}
+        }
         foreach event $rightclicks {
             $win tag bind $tag $event [list ::pdwindow::message_contextmenu %W %x %y $object_id]
         }


### PR DESCRIPTION
support right click on error messages in Pd Window on macOS with Wish9.x
