### PR TITLE
handle focus switch for <Modifier-Click> (fixes macOS behavior)

### DIFF
--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -221,17 +221,17 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
     bind $tkcanvas <Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 1"
     bind $tkcanvas <$::modifier-ButtonPress-1> \
-        "pdtk_canvas_mouse %W %x %y %b 2"
+        "::pd_bindings::handle_modifier_click %W %x %y %b 2"
     bind $tkcanvas <$::modifier-Shift-ButtonPress-1> \
-        "pdtk_canvas_mouse %W %x %y %b 3"
+        "::pd_bindings::handle_modifier_click %W %x %y %b 3"
     bind $tkcanvas <$alt-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 4"
     bind $tkcanvas <$alt-Shift-ButtonPress-1> \
         "pdtk_canvas_mouse %W %x %y %b 5"
     bind $tkcanvas <$::modifier-$alt-ButtonPress-1> \
-        "pdtk_canvas_mouse %W %x %y %b 6"
+        "::pd_bindings::handle_modifier_click %W %x %y %b 6"
     bind $tkcanvas <$::modifier-$alt-Shift-ButtonPress-1> \
-        "pdtk_canvas_mouse %W %x %y %b 7"
+        "::pd_bindings::handle_modifier_click %W %x %y %b 7"
 
     bind $tkcanvas <ButtonRelease-1> \
         "pdtk_canvas_mouseup %W %x %y %b 0"
@@ -321,6 +321,19 @@ proc ::pd_bindings::patch_bindings {mytoplevel} {
 
 #------------------------------------------------------------------------------#
 # event handlers
+
+# handle modifier clicks with focus management
+proc ::pd_bindings::handle_modifier_click {window x y button modifier} {
+    # force focus on macOS if we're clicking in a different window
+    if {$::windowingsystem eq "aqua"} {
+        set mytoplevel [winfo toplevel $window]
+        if {$mytoplevel ne $::focused_window} {
+            focus -force $window
+            ::pd_bindings::window_focusin $mytoplevel
+        }
+    }
+    pdtk_canvas_mouse $window $x $y $button $modifier
+}
 
 # do tasks when changing focus (Window menu, scrollbars, etc.)
 proc ::pd_bindings::window_focusin {mytoplevel} {


### PR DESCRIPTION
closes #2347

this fixes the macOS issue mentioned above where a `cmd`+`click` in another patch window changes the "interaction focus", but the previously focused window still looks like the one in focus and an actual focus change back to the front window requires a clicks outside and then inside the front window.

not sure if this is the proper way to fix this - but it does solve this rather annoying behavior by forcing the window focus for modifier+click.

currently only tested on macOS. ~~maybe this should be macOS-only code, since it doesn't seem to cause issues on other systems?~~ EDIT: forced focus only happens on macOS now.