### PR TITLE
parseable releasenotes

### DIFF
--- a/doc/1.manual/resources/chapter5.htm
+++ b/doc/1.manual/resources/chapter5.htm
@@ -22,39 +22,40 @@
 
 <P>This chapter tracks changes in Pd's current implementation.</P>
 
-
-<H3> <A href="#s5.1" id="s5.1"> 5.1. Release notes </A> </H3>
-
-<P> ------------------ 0.55-2 ------------------------------
-
-<P> Bug fixes in jack - 16+ channels crashed in linux; auto-connect improved to
-only connect to usable audio devices.
-
-<P> Fixed compatibility problems with the newest tcl/tk (version 9).
-
-<P> Documenttaion updates.
-
-<P> Fixed -nharmonics creation argument to [sigmund~].
-
-<P> Supplied missing "clear" message to [vcf~].
+<H3> <A href="#s5.1" id="s5.1"> 5.1. Release notes </A> </H3><section><div>
 
 
-<P> ------------------ 0.55-1 ------------------------------
+</div></section><section class="releasenote"><h4 id="0.55-2">0.55-2</h4><div>
 
-<P> Shahrokh updated the "expr" family of objects and added string handling (yay!)
+<P>Bug fixes in jack - 16+ channels crashed in linux; auto-connect improved to
+only connect to usable audio devices.</P>
+
+<P>Fixed compatibility problems with the newest tcl/tk (version 9).</P>
+
+<P>Documenttaion updates.</P>
+
+<P>Fixed -nharmonics creation argument to [sigmund~].</P>
+
+<P>Supplied missing "clear" message to [vcf~].</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.55-1">0.55-1</h4><div>
+
+<P>Shahrokh updated the "expr" family of objects and added string handling (yay!)
 There are several new functions to manipulate strings and a new var() function that
-takes symbols and treats them as variables from a [value] object.
+takes symbols and treats them as variables from a [value] object.</P>
 
-<P> bug fixes, notably a crasher bug when sending "open" to [readsf~] in verbose
+<P>bug fixes, notably a crasher bug when sending "open" to [readsf~] in verbose
 mode, but other improvements in thread safety mostly relevant to RISC architectures.
 The [readsf~]'s "open" method now also searches in the canvas environment. This means
-you can use paths added via [declare] (which wasn't possible before).
+you can use paths added via [declare] (which wasn't possible before).</P>
 
-<P> Numerous documentation improvements
+<P>Numerous documentation improvements</P>
 
-<P> ------------------ 0.55-0 ------------------------------
 
-<P> The [osc~], [cos~] and [vcf~] objects now rely on a 2048 points
+</div></section><section class="releasenote"><h4 id="0.55-0">0.55-0</h4><div>
+
+<P>The [osc~], [cos~] and [vcf~] objects now rely on a 2048 points
 cosine table. The table size used to be 512-point for fast, approximate
 calculations, which was adequate for most "computer music" applications
 in the 90s when this was decided (and at that time there could be a
@@ -62,1283 +63,1341 @@ serious performance penalty for using larger tables). To get the original
 512-point tables you can run Pd with compatiblity level 0.54. Also, in
 systems with very tight memory constraints (such as Espressif ESP32),
 Pd can be recompiled with the C preprocessor variable COSTABLESIZE set
-to 512 to get the old memory footprint.
+to 512 to get the old memory footprint.</P>
 
-<P> Many bug fixes and code-level updates and improvements, notably to libpd and
+<P>Many bug fixes and code-level updates and improvements, notably to libpd and
 for emscripten support thanks to Claude Heiland-Allen and IOhannes, Dan, and
 Christof. The emscripten support, in particular, should someday allow Pd to run
-in a web browser.
+in a web browser.</P>
 
-<P> Also thanks to Christof, you can now use just 'set' to unset [receive~] and
+<P>Also thanks to Christof, you can now use just 'set' to unset [receive~] and
 [throw~] objects, plus a much improved audio interfacing and related scheduler
-updates.
+updates.</P>
 
-<P> Many documentation updates, thanks to Alexandre Porres, Ben Wesch, and
+<P>Many documentation updates, thanks to Alexandre Porres, Ben Wesch, and
 others. Most notably several updates and edits were made to Pd's HTML manual,
 specially a new section on 'advanced editing techniques' (aka 'intelligent
-patching').
+patching').</P>
 
-<P> The [oscparse] object was updated by Porres to allow numeric addresses
+<P>The [oscparse] object was updated by Porres to allow numeric addresses
 via a new '-n' flag and a right outlet was added to output split point
-between address and message.
+between address and message.</P>
 
-<P> Minor improvements to the [file] object by IOhannes, such as properly
+<P>Minor improvements to the [file] object by IOhannes, such as properly
 expanding '~' to home directory and allowing [file which] to also search
-paths relative to the parent patch.
+paths relative to the parent patch.</P>
 
-<P> 64-bit soundfile reading and writing support by Dan Wilcox for [readsf~],
-[writesf~] and [soundfiler].
+<P>64-bit soundfile reading and writing support by Dan Wilcox for [readsf~],
+[writesf~] and [soundfiler].</P>
 
-<P> Updates to language support.
+<P>Updates to language support.</P>
 
-<P> ------------------ 0.54-1 ------------------------------
+
+</div></section><section class="releasenote"><h4 id="0.54-1">0.54-1</h4><div>
 
 <p> Fixes a compatibility problem with MacOS 14.
 
-<p> Numerous bug fixes and documentation updates.
+<p> Numerous bug fixes and documentation updates.</P>
 
-<P> ------------------ 0.54-0 ------------------------------
 
-<P> Multichannel audio signals are supported for many objects.  They may be created
+</div></section><section class="releasenote"><h4 id="0.54-0">0.54-0</h4><div>
+
+<P>Multichannel audio signals are supported for many objects.  They may be created
 or split into component channels using the new [snake~] object.  Supported objects
 include stateless tilde objects such as [abs~], [sqrt~], [rsqrt~], [wrap~], [exp~],
 [cos~], [ftom~], [mtof~], [dbtorms~], [rmstodb~], [dbtopow~], [powtodb~], [clip~],
 [+], [-], [*], [/], [max~], [min~], [log~], [pow~], [fft~], ifft~], [rfft~], [rifft~] and
 [lrshift~]. The [send~]/[receive~], [throw~]/[catch~] also manage multichannel signals and
 [tabwrite~], [tabread~], [tabread4~] and [tabplay~] now deal with more than one array and
-multichannel signals.
+multichannel signals.</P>
 
-<P> The [inlet~]/[outlet~] objects are not always stateless but it was judged necessary to
+<P>The [inlet~]/[outlet~] objects are not always stateless but it was judged necessary to
 support them. The [clone] object received special attention since it might be desirable to
 distribute multichannel signals among the cloned patches or to pass them directly into all
 copies as multichannel inputs and outputs. The [adc~] object can also generate multichannel
 signals from the input card, while [dac~] can directly manage a multichannel signal and
-distribute to different channels.
+distribute to different channels.</P>
 
-<P> The [clone] object takes a message to change the number of copies.  So now Pd
+<P>The [clone] object takes a message to change the number of copies.  So now Pd
 is useful as a non-real-time software synthesizer.  Changing the number of
 copies will cause massive reinitialization and memory allocation and should not
-be used during performance, only during setup.
+be used during performance, only during setup.</P>
 
-<P> The [sigmund~] object got some new optimizations and has more parameters that can be
+<P>The [sigmund~] object got some new optimizations and has more parameters that can be
 tuned for a particular instrument.  A longstanding octave-jumping problem has been
 partially addressed, and anyway, a new output type offers even/odd balance so
 that a synth can play in unison with an instrument with very few octave jumps
-by coherently mixing both possible octaves.
+by coherently mixing both possible octaves.</P>
 
-<P> The [lop~] object can now also take a signal to set rolloff frequency, but the same
-slightly faster algorithm is used if you have a scalar input instead.
+<P>The [lop~] object can now also take a signal to set rolloff frequency, but the same
+slightly faster algorithm is used if you have a scalar input instead.</P>
 
-<P> There are new methods for the [file] object by IOhannes, namely "cwd", "patchpath",
-"normalize" and "isabsolute".
+<P>There are new methods for the [file] object by IOhannes, namely "cwd", "patchpath",
+"normalize" and "isabsolute".</P>
 
-<P> The 64-bit windows build uses the lower-latency WASAPI audio system in place
+<P>The 64-bit windows build uses the lower-latency WASAPI audio system in place
 of the older MMIO.  This therefore only runs on Windows 7 and newer.  The 32-bit version
-can still run all the way back to Windows XP.
+can still run all the way back to Windows XP.</P>
 
-<P> There's a new design for the stereo [output~] abstraction in the 'extra' library
+<P>There's a new design for the stereo [output~] abstraction in the 'extra' library
 by Alexandre Porres. This is widely used in the documentation and now has a slider
 to set the volume and you can also use a number box. It can also distribute a mono
-input to both channels.
+input to both channels.</P>
 
-<P> The Windows installer can be run on non-admin users.
+<P>The Windows installer can be run on non-admin users.</P>
 
-<P> Improved settings dialog window.
+<P>Improved settings dialog window.</P>
 
-<P> As usual, countless bug fixes and miscellaneous improvements.
+<P>As usual, countless bug fixes and miscellaneous improvements.</P>
 
-<P> ------------------ 0.53-2 ------------------------------
 
-<P> Update portaudio to version v19.7.0 to fix macintosh hanging problem.
+</div></section><section class="releasenote"><h4 id="0.53-2">0.53-2</h4><div>
 
-<P> ------------------ 0.53-1 ------------------------------
+<P>Update portaudio to version v19.7.0 to fix macintosh hanging problem.</P>
 
-<P> Bug fixes, mostly from IOhannes concerning iemguis regression bugs because of
-the cleanup/rewrite for 0.53. Also more documentation updates by Alexandre Porres.
 
-<P> ------------------ 0.53-0 ------------------------------
+</div></section><section class="releasenote"><h4 id="0.53-1">0.53-1</h4><div>
 
-<P> This is being released quickly to fix a bug in version 0.52, in which
+<P>Bug fixes, mostly from IOhannes concerning iemguis regression bugs because of
+the cleanup/rewrite for 0.53. Also more documentation updates by Alexandre Porres.</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.53-0">0.53-0</h4><div>
+
+<P>This is being released quickly to fix a bug in version 0.52, in which
 soundfile reading was disrupted. There are some internal updates serious enough
 to warrant a version number change, such as the unification of horizontal and
 vertical sliders/radio buttons and the fact you can now change their orientation
-via a new 'orientation' message, but no new features other than that.
+via a new 'orientation' message, but no new features other than that.</P>
 
-<P> The IEMGUI default sizes increased, as part of an ongoing cleanup/rewrite.
+<P>The IEMGUI default sizes increased, as part of an ongoing cleanup/rewrite.</P>
 
-<P> As usual, there are many minor bug fixes (thanks to several developers)
-and updates to documentation by Alexandre Porres.
+<P>As usual, there are many minor bug fixes (thanks to several developers)
+and updates to documentation by Alexandre Porres.</P>
 
-<P> The 'deken' plugin (external extension search tool) has been updated to a
-new version.
+<P>The 'deken' plugin (external extension search tool) has been updated to a
+new version.</P>
 
-<P> Many updated string translations.
+<P>Many updated string translations.</P>
 
-<P> ------------------ 0.52-2 ------------------------------
 
-<p> Many small bug fixes, and a few larger ones: under jack, Pd's delay adjusted
-upward to the jack blocksize if needed (to prevent a hang).
+</div></section><section class="releasenote"><h4 id="0.52-2">0.52-2</h4><div>
 
-<p> Many documentation fixes and improvements by Alexandre Porres
+<P> Many small bug fixes, and a few larger ones: under jack, Pd's delay adjusted
+upward to the jack blocksize if needed (to prevent a hang).</P>
 
-<p> Reverted behavior when selecting and dragging a single text box, so that
+<P> Many documentation fixes and improvements by Alexandre Porres</P>
+
+<P> Reverted behavior when selecting and dragging a single text box, so that
 it now activates the text as traditional until 0.51.  Sometimes one behavior is
 wanted, sometimes the other, so there should be an easy-to-understand way for
 users to control this.  At the moment you can rectangle-select an object to
 displace it without selecting the text, which is perhaps adequate, perhaps not.
+</P>
 
-<p> added an indirect way to open Pd's gui on one machine and the real-time
+<P> added an indirect way to open Pd's gui on one machine and the real-time
 program on another without using X windows (so that it can be easily done on
 MacOS and Windows).  Requires ssh expertise - see commit c0e320f2142.  (This
-was already included in pd-0.51-1 but not documented).
+was already included in pd-0.51-1 but not documented).</P>
 
-<P> ------------------ 0.52-0 and 0.52-1 ------------------------------
 
-<P> The Macintosh compiled version is now compiled at IEM (as part of the
+</div></section><section class="releasenote" id="0.52-1"><h4 id="0.52-0">0.52-0 and 0.52-1</h4><div>
+
+<P>The Macintosh compiled version is now compiled at IEM (as part of the
 continuous-integration setup available at git.iem.at/pd/pure-data/pipelines).
 This should make Pd appear to be "safely" signed.  Added compilation for
-arm64 target (but not sure if the released binary will include that or not).
+arm64 target (but not sure if the released binary will include that or not).</P>
 
-<P> New "list" box, like number and symbol but allows lists in addition to
+<P>New "list" box, like number and symbol but allows lists in addition to
 single atoms.  You can scroll up and down on any of the numbers in a list as
 if it were a number box. All boxes (number, symbol, list) can now set different
 sizes and you can also double-click on them to activate a "real" editor you can
-copy/paste from/to.
+copy/paste from/to.</P>
 
-<P> A new "trace" object allows you to get backward and forward traces of
-message passing.
+<P>A new "trace" object allows you to get backward and forward traces of
+message passing.</P>
 
-<P> New "file" object by IOhannes with contributions from Jean-Michael
-Celerier - general file operations.
+<P>New "file" object by IOhannes with contributions from Jean-Michael
+Celerier - general file operations.</P>
 
-<P> Support for uncompressed CAF and AIFC soundfiles (by Dan Wilcox) - the soundfile
-code reorganized to make it more modular.
+<P>Support for uncompressed CAF and AIFC soundfiles (by Dan Wilcox) - the soundfile
+code reorganized to make it more modular.</P>
 
-<P> Improvements to the audio implementation - the most noticeable improvement
-is better control of latency under jack.
+<P>Improvements to the audio implementation - the most noticeable improvement
+is better control of latency under jack.</P>
 
-<P> Pd's GUI checks that Pd actually exits when asked to and if not, kills it
-to prevent rogue invisible pd instances from collecting behind the scenes.
+<P>Pd's GUI checks that Pd actually exits when asked to and if not, kills it
+to prevent rogue invisible pd instances from collecting behind the scenes.</P>
 
-<P> Bugfix in bob~ to output "correct" signal (old behavior still available
-by setting pd compatibility &lt; 52).
+<P>Bugfix in bob~ to output "correct" signal (old behavior still available
+by setting pd compatibility &lt; 52).</P>
 
-<P> libpd included as part of the Pd distribution.  A test libpd project is included
-in ../pd/libpd.
+<P>libpd included as part of the Pd distribution.  A test libpd project is included
+in ../pd/libpd.</P>
 
-<P> Raised the limit on the size of incoming UDP packets in netreceive.
+<P>Raised the limit on the size of incoming UDP packets in netreceive.</P>
 
-<P> Some improvements to label handling in IEMguis.
+<P>Some improvements to label handling in IEMguis.</P>
 
-<P> Improved window positioning.
+<P>Improved window positioning.</P>
 
-<p> New method for garrays to set colors, line width, visibility, display style
+<P> New method for garrays to set colors, line width, visibility, display style
 and disable mouse editing (documented in 2.control.examples/16.more.arrays.pd).
 Also added more flags to the "plot" object that plots arrays in data structures
-(by Christof Ressi).
+(by Christof Ressi).</P>
 
-<p> "set", "send", "delete" and "insert" methods added to "list store" object,
-and new features added to "get" method (by Christof Ressi).
+<P> "set", "send", "delete" and "insert" methods added to "list store" object,
+and new features added to "get" method (by Christof Ressi).</P>
 
-<p> The output~ abstraction, widely used in Pd's documentation is now part of
+<P> The output~ abstraction, widely used in Pd's documentation is now part of
 'extra' - plus several documentation updates/improvements to the help files and
 chapter 4 of the manual (by Alexandre Porres). Also, other updates to the manual
-by Lucas Cordiviola.
+by Lucas Cordiviola.</P>
 
-<P> As usual, numerous bug fixes.
+<P>As usual, numerous bug fixes.</P>
 
-<P> ------------------ 0.51-4 ------------------------------
 
-<P> Bug fixes: infinite loop on Windows if  writesf~ encountered a write error;
-another hack at TCL/TK window size confusion; and better libpd and build support
+</div></section><section class="releasenote"><h4 id="0.51-4">0.51-4</h4><div>
 
-<P> ------------------ 0.51-3 ------------------------------
+<P>Bug fixes: infinite loop on Windows if  writesf~ encountered a write error;
+another hack at TCL/TK window size confusion; and better libpd and build support</P>
 
-<P> New functions for expr: mtof, ftom, rmstodb, dbtorms, powtodb, dbtopow, and two
-bug fixes.
 
-<P> The "use callbacks" switch in the audio dialog only appears if it's already on
+</div></section><section class="releasenote"><h4 id="0.51-3">0.51-3</h4><div>
+
+<P>New functions for expr: mtof, ftom, rmstodb, dbtorms, powtodb, dbtopow, and two
+bug fixes.</P>
+
+<P>The "use callbacks" switch in the audio dialog only appears if it's already on
 (via the command line or app default settings).  It was crashing and hanging Pd in
 several situations.  It might still be useful for reducing audio latency by a block
-or so, but won't buy you much in any case.  I'll try to fix it later.
+or so, but won't buy you much in any case.  I'll try to fix it later.</P>
 
-<P> More white-space fixes (primarily affecting pd~ on Windows).
+<P>More white-space fixes (primarily affecting pd~ on Windows).</P>
 
-<P> Much work dealing with upgrade issues in MACOS 10.15 (thanks Dan Wilcox)
+<P>Much work dealing with upgrade issues in MACOS 10.15 (thanks Dan Wilcox)</P>
 
-<P> ------------------ 0.51-2 ------------------------------
 
-<P> Better support for white space in file path to pd, especially for pd~ object.
+</div></section><section class="releasenote"><h4 id="0.51-2">0.51-2</h4><div>
+
+<P>Better support for white space in file path to pd, especially for pd~ object.
 Also fixed an annoyamce in which pd~ started up a command prompt window on PCs.
-The pd~ source is also now updated to work (again) in Max/MSP, on Mac or PC.
+The pd~ source is also now updated to work (again) in Max/MSP, on Mac or PC.</P>
 
-<P> ------------------ 0.51-1 ------------------------------
 
-<P> Bug fixes, mostly from the git updates branch
+</div></section><section class="releasenote"><h4 id="0.51-1">0.51-1</h4><div>
 
-<P> (long overdue) Buttons in the audio dialog to set some standard sample
+<P>Bug fixes, mostly from the git updates branch</P>
+
+<P>(long overdue) Buttons in the audio dialog to set some standard sample
 rates.  You can still run Pd at 3.14159 Hz if you want to but you'll have to
-type that one in.
+type that one in.</P>
 
-<P> On Macintosh tcl/tk is upgraded to 8.6.10 (should work on MacOS from
-10.6 to 11.0 aka "Bug Sur").
+<P>On Macintosh tcl/tk is upgraded to 8.6.10 (should work on MacOS from
+10.6 to 11.0 aka "Bug Sur").</P>
 
-<P> You can send "pd fast-forward &lt;msecs&gt;" to make Pd run its scheduler at full
+<P>You can send "pd fast-forward &lt;msecs&gt;" to make Pd run its scheduler at full
 speed, without waiting for A/D/A or the real-time clock.  Useful for running
 batch-style jobs interactively.  You can advance a variable amount of time by
 specifying a large value and then later sending "pd fast-forward 0" - but note
-that outside input is ignored while in fast forward.
+that outside input is ignored while in fast forward.</P>
 
-<P> ------------------ 0.51-0 ------------------------------
 
-<P> Many bug fixes and some enhancements to network objects.  Many thanks
+</div></section><section class="releasenote"><h4 id="0.51-0">0.51-0</h4><div>
+
+<P>Many bug fixes and some enhancements to network objects.  Many thanks
 to Dan Wilcox, Christof Ressi, and IOhannes Zmoelnig who did almost all the
-work.
+work.</P>
 
-<P> (Also Dan) some fix I don't understand about code signing for MacOS 10.15,
-without which externals refused to load.
+<P>(Also Dan) some fix I don't understand about code signing for MacOS 10.15,
+without which externals refused to load.</P>
 
-<P> The "inlet~" object can now also optionally forward messages via an extra
-outlet.
+<P>The "inlet~" object can now also optionally forward messages via an extra
+outlet.</P>
 
-<P> New "mode" argument to openpanel object to allow selecting directories or multiple files
+<P>New "mode" argument to openpanel object to allow selecting directories or multiple files</P>
 
-<P> New "equal" message to pointer object to test if two pointers are equal.
+<P>New "equal" message to pointer object to test if two pointers are equal.</P>
 
-<P> Pd should now function OK if recompiled with float size set to 64 bits.
+<P>Pd should now function OK if recompiled with float size set to 64 bits.</P>
 
-<P> ------------------ 0.50-2 ------------------------------
 
-<P> fix backspace problem on MacOS
+</div></section><section class="releasenote"><h4 id="0.50-2">0.50-2</h4><div>
 
-<P> ------------------ 0.50-1 ------------------------------
+<P>fix backspace problem on MacOS</P>
 
-<P> improved handling of tilde chartacters for Portuguese and Spanish keyboard
-maps
 
-<P> handling spaces in path to HTML file open message to pdcontrol object
+</div></section><section class="releasenote"><h4 id="0.50-1">0.50-1</h4><div>
 
-<P> ------------------ 0.50-0 ------------------------------
+<P>improved handling of tilde chartacters for Portuguese and Spanish keyboard
+maps</P>
 
-<P> new pdcontrol object allows getting patch's owning directory and calling
+<P>handling spaces in path to HTML file open message to pdcontrol object</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.50-0">0.50-0</h4><div>
+
+<P>new pdcontrol object allows getting patch's owning directory and calling
 arguments, and opening files in web browser under patch control (useful in help
-files).
+files).</P>
 
-<P> new nonlinear low-pass filter, slop~, for use in designing envelope
-followers and dynamics processors.
+<P>new nonlinear low-pass filter, slop~, for use in designing envelope
+followers and dynamics processors.</P>
 
-<P> attempted to fix limitations on incoming MIDI and network packets.
-Things seem to be improved but the improvements aren't exhaustively tested yet.
+<P>attempted to fix limitations on incoming MIDI and network packets.
+Things seem to be improved but the improvements aren't exhaustively tested yet.</P>
 
-<P> improved HTML style in documentation and more info on managing externs.
+<P>improved HTML style in documentation and more info on managing externs.</P>
 
-<P> updates to IOhannes's smart patching features
+<P>updates to IOhannes's smart patching features</P>
 
-<P> sort method for text object.  Also text searching can deal with restricted
+<P>sort method for text object.  Also text searching can deal with restricted
 range of lines (so that, for instance, you can iteratively get all the matches,
-not just the first one).
+not just the first one).</P>
 
-<P> internal changes to improve scheduler behavior and memory management.
+<P>internal changes to improve scheduler behavior and memory management.</P>
 
-<P> "zoom" feature updates to handle data structs better.
+<P>"zoom" feature updates to handle data structs better.</P>
 
-<P> ------------------ 0.49-0 ------------------------------
 
-<P>  "Undo" and "Redo" menu items now may be repeated to undo/redo
+</div></section><section class="releasenote"><h4 id="0.49-0">0.49-0</h4><div>
+
+<P> "Undo" and "Redo" menu items now may be repeated to undo/redo
 more than one successive edit.  This feature was introduced by Ivica Ico
-Bukvic and ported to Pd vanilla by Johannes Zmoelnig.
+Bukvic and ported to Pd vanilla by Johannes Zmoelnig.</P>
 
-<P> Various editing shortcuts, also from Johannes.
+<P>Various editing shortcuts, also from Johannes.</P>
 
-<P> "Declare" -path & -lib flags now search user search paths.
+<P>"Declare" -path & -lib flags now search user search paths.</P>
 
-<P> Search path handling made easier and more consistent between user
+<P>Search path handling made easier and more consistent between user
 preferences, "declare" objects and command line flags.  See help file for
-the "declare" object.
+the "declare" object.</P>
 
-<P> A "savestate" object allows abstractions to be designed so that they can
-save state information as part of the calling patch.
+<P>A "savestate" object allows abstractions to be designed so that they can
+save state information as part of the calling patch.</P>
 
-<P> "Pointer" object has a "delete" method.
+<P>"Pointer" object has a "delete" method.</P>
 
-<P> "Text", "array", and "scalar" objects have the same methods (bang and "send")
-for outputting pointers to themselves
+<P>"Text", "array", and "scalar" objects have the same methods (bang and "send")
+for outputting pointers to themselves</P>
 
-<P> An optional argument was added to the "pd open" message, to allow opening
+<P>An optional argument was added to the "pd open" message, to allow opening
 a file only if it is not currently open; to get this behavior send "pd open
 &lt;file&gt; &lt;directory&gt; 1".  It is still under discussion whether this would be the
 appropriate response when the user clicks on a patch to open it in the file
-browser.
+browser.</P>
 
-<P> 4 million point default limit on resizing soundfile read to array changed to
+<P>4 million point default limit on resizing soundfile read to array changed to
 2^31-1 (about 2 billion) samples.  If invoked without an array name,  soundfiler
 still outputs the file's sample rate, etc., although it still reads the samples
 only to throw them away; so if you really just want the soundfile info, consider
-reading into an unused one-sample table instead.
+reading into an unused one-sample table instead.</P>
 
-<P> The "log" object has an optional argument to specify the laogarythm's base,
+<P>The "log" object has an optional argument to specify the laogarythm's base,
 and a new inlet, to match "log~", and "pow" and "pow~" can now raise negative
-numbers to integer powers, like the C math library "pow()" function.
+numbers to integer powers, like the C math library "pow()" function.</P>
 
-<P> Changes to audio I/O handling to time out if device freezes (as when you
-unplug a USB device in MACOSX).
+<P>Changes to audio I/O handling to time out if device freezes (as when you
+unplug a USB device in MACOSX).</P>
 
-<P> Backslashes may now be typed into object/message boxes.  They escape
-following "$", "," and ";" characters.
+<P>Backslashes may now be typed into object/message boxes.  They escape
+following "$", "," and ";" characters.</P>
 
-<P> ------------------ 0.48-2 ------------------------------
 
-<P> More bug fixes.  Audio on linux improved; various improvements to the
+</div></section><section class="releasenote"><h4 id="0.48-2">0.48-2</h4><div>
+
+<P>More bug fixes.  Audio on linux improved; various improvements to the
 pd~ object, -no-gui windows patches able to use netsend/netreceive; loadbang
 order fix for clone object; soundfiler no longer limiting size of soundfiles
 to 4million points by default; updates to deken (external extension search
-tool); seed message added to noise~; many code-level enhancements.
+tool); seed message added to noise~; many code-level enhancements.</P>
 
-<P> ------------------ 0.48-1 ------------------------------
 
-<P> Many bug fixes and a re-working of font handling that might make font
+</div></section><section class="releasenote"><h4 id="0.48-1">0.48-1</h4><div>
+
+<P>Many bug fixes and a re-working of font handling that might make font
 sizes resemble 0.47 more closely.  most of the work was done by Dan Wilcox and
-IOhannes Zmoelnig.
+IOhannes Zmoelnig.</P>
 
-<P> ------------------ 0.48-0 ------------------------------
 
-<P> It's possible to save and recall "settings" to files, and/or to erase system
+</div></section><section class="releasenote"><h4 id="0.48-0">0.48-0</h4><div>
+
+<P>It's possible to save and recall "settings" to files, and/or to erase system
 settings.  On Pcs, the settings are now stored in the "user" resource area
 (before, it was per-machine, and users who weren't administrators apparently
-couldn't save their settings.)
+couldn't save their settings.)</P>
 
-<P> On the first startup, Pd queries the user as to whether to create a
+<P>On the first startup, Pd queries the user as to whether to create a
 directory such as ~/Documents/Pd and set path to point there.  Many updates
 were also made to the "path" dialog and deken to better integrate downloading
-stuff and path maintenance.
+stuff and path maintenance.</P>
 
-<P> The expr family (expr, expr~, fexpr~) got an update from Shahrokh Yadegari,
+<P>The expr family (expr, expr~, fexpr~) got an update from Shahrokh Yadegari,
 and the help file was reorganized and updated by Alexandre Porres.  Many more
 math functions are supported, and the parser was updated so that expressions
-using "if" skip evaluating the argument that isn't used.
+using "if" skip evaluating the argument that isn't used.</P>
 
-<P> New "fudiparse", "fudiformat" objects.
+<P>New "fudiparse", "fudiformat" objects.</P>
 
-<P> New "list store" object for faster and easier concatenation and splitting
-apart of lists.
+<P>New "list store" object for faster and easier concatenation and splitting
+apart of lists.</P>
 
-<P> New notification outlet in "text define" so the patch can know when the text
-is changed.
+<P>New notification outlet in "text define" so the patch can know when the text
+is changed.</P>
 
-<P> New "text insert" object.
+<P>New "text insert" object.</P>
 
-<P> "delwrite~" now has a "clear" message.
+<P>"delwrite~" now has a "clear" message.</P>
 
-<P> "soundfiler" now has a right outlet which outputs a list with the
-sample rate, header size, number of channels, byte depth, and endianness.
+<P>"soundfiler" now has a right outlet which outputs a list with the
+sample rate, header size, number of channels, byte depth, and endianness.</P>
 
-<P> "declare -path" inside abstractions was changed so that, if the declaration
+<P>"declare -path" inside abstractions was changed so that, if the declaration
 isn't an absolute filename, it's relative to the abstraction's directory, not to
 the owning patch's directory.  This might be considered an incompatible change; but
 since the situation with paths declared inside abstractions has always been so
 confused, I think nobody will have got away without editing patches that relied
-on it as things changed in the past.
+on it as things changed in the past.</P>
 
-<P> "float" now understands symbol messages that look like floats.  The help
-files for "float", "value" and "send" were updated to reflect this.
+<P>"float" now understands symbol messages that look like floats.  The help
+files for "float", "value" and "send" were updated to reflect this.</P>
 
-
-<P> But the biggest changes are under the hood.  Pd now can manage more
+<P>But the biggest changes are under the hood.  Pd now can manage more
 than one running instance, so that it is possible to make plug-ins of various
 sorts out of Pd and they can coexist with each other.  This will allow people to
 write much better VST plug-ins in Pd.  I'm grateful to Carlos Eduardo Batista
-for much help on this.
+for much help on this.</P>
 
-<P> The Pd API allows starting and/or shutting down the GUI dynamically while
-Pd is running.
+<P>The Pd API allows starting and/or shutting down the GUI dynamically while
+Pd is running.</P>
 
-<P> Another internal change: the pd~ object now communicates with sub-processes
+<P>Another internal change: the pd~ object now communicates with sub-processes
 in binary by default.  This increases the numerical accuracy of signal passing
 (it should be exact now) and makes the passing back and forth of audio signals
-much more efficient.
+much more efficient.</P>
 
-<P> Thanks to much effort by Dan Wilcox and IOhannes zm&ouml;lnig, the
+<P>Thanks to much effort by Dan Wilcox and IOhannes zm&ouml;lnig, the
 compile-and-build system is much improved, especially for Macintosh computers.
 One visible effect is that language support is finally working in the
-compiled versions on msp.ucsd.edu.
+compiled versions on msp.ucsd.edu.</P>
 
-<P> ------------------ 0.47-1 ------------------------------
 
-<P> Improvements to deken plug-in ("find externals" menu item).  Now unzipping
-works automatically in windows.
+</div></section><section class="releasenote"><h4 id="0.47-1">0.47-1</h4><div>
 
-<P> improved "clone" argument parsing and added option to suppress numbering
-of clones as first argument
+<P>Improvements to deken plug-in ("find externals" menu item).  Now unzipping
+works automatically in windows.</P>
 
-<P> fixed a bug in initbang (didn't work in subpatches)
+<P>improved "clone" argument parsing and added option to suppress numbering
+of clones as first argument</P>
 
-<P> "improved" zoom-in menu binding again (now '+' or '=' zooms in).
+<P>fixed a bug in initbang (didn't work in subpatches)</P>
 
-<P> restored a function needed by GUI externs such as 'knob'
+<P>"improved" zoom-in menu binding again (now '+' or '=' zooms in).</P>
 
-<P> ------------------ 0.47-0 ------------------------------
+<P>restored a function needed by GUI externs such as 'knob'</P>
 
-<P> The "deken" plug-in is integrated into the Pd help menu - you can download
-and install Pd libraries using the "Find Externals" menu command.
 
-<P> New clone object that opens multiple copies of an abstraction and
+</div></section><section class="releasenote"><h4 id="0.47-0">0.47-0</h4><div>
+
+<P>The "deken" plug-in is integrated into the Pd help menu - you can download
+and install Pd libraries using the "Find Externals" menu command.</P>
+
+<P>New clone object that opens multiple copies of an abstraction and
 routes messages and signals to/from them, for making banks of voices or
-whatnot
+whatnot</P>
 
-<P> "Zoom" feature for dealing with high-resolution displays.  IEM GUIs are
-only somewhat dodgily handled (font sizes of labels aren't managed well).
+<P>"Zoom" feature for dealing with high-resolution displays.  IEM GUIs are
+only somewhat dodgily handled (font sizes of labels aren't managed well).</P>
 
-<P> Controllable font sizes for menus and dialogs: setting the "pd window"
-font size also sets font sizes for menus/dialogs.
+<P>Controllable font sizes for menus and dialogs: setting the "pd window"
+font size also sets font sizes for menus/dialogs.</P>
 
-<P> The expr, expr~, and fexpr~ objects are included in Pd proper, not loaded
+<P>The expr, expr~, and fexpr~ objects are included in Pd proper, not loaded
 as externs as before.  This reflects their new license (lgpl) and should allow
 them to be used in IOS apps via libpd.  Shahrokh Yadegari has updated the
 source and made manifold improvements in the objects.  Notably, they now allow
-access to variables in Pd defined via the "value" object.
+access to variables in Pd defined via the "value" object.</P>
 
-<P> Backward messaging to netsend now works in UDP as well as TCP.
+<P>Backward messaging to netsend now works in UDP as well as TCP.</P>
 
-<P> Dialogs now work more Apple-ishly (changes taking place without the need
-to hit an "apply" button in many cases).  Thanks to Dan Wilcox.
+<P>Dialogs now work more Apple-ishly (changes taking place without the need
+to hit an "apply" button in many cases).  Thanks to Dan Wilcox.</P>
 
-<P> API support for "initbang" and "closebang" objects (from IEM library
+<P>API support for "initbang" and "closebang" objects (from IEM library
 I think, but anyhow you can now get them in Pd Vanilla via deken (help
-menu "Find externals").
+menu "Find externals").</P>
 
-<P> "Declare" object path settings now take effect immediately when you edit
-the declare object.
+<P>"Declare" object path settings now take effect immediately when you edit
+the declare object.</P>
 
-<P> (IOhannes) Abstractions, externs, and stuff written in other languages
+<P>(IOhannes) Abstractions, externs, and stuff written in other languages
 (python, Lua, etc) are now loaded logically, that is, if you have one patch
 that loads an external named X, you can still load abstractions named X in
-other patches.  Miller now officially Does Not Know How This Works (DNKHTW).
+other patches.  Miller now officially Does Not Know How This Works (DNKHTW).</P>
 
-<P> Many bug fixes.
+<P>Many bug fixes.</P>
 
-<P> ------------------ 0.46-7 ------------------------------
 
-<P> Fixed non-working declare -stdpath on windows
+</div></section><section class="releasenote"><h4 id="0.46-7">0.46-7</h4><div>
 
-<P> Fixed bug in which [array min/max] ignored onset argument
+<P>Fixed non-working declare -stdpath on windows</P>
 
-<P> Fixed jack audio back-ed not to auto-start the daemon
+<P>Fixed bug in which [array min/max] ignored onset argument</P>
 
-<P> Various compilation and architecture fixes
+<P>Fixed jack audio back-ed not to auto-start the daemon</P>
 
-<P> ------------------ 0.46-6 ------------------------------
+<P>Various compilation and architecture fixes</P>
 
-<P> fixed bug selecting and saving/restoring MIDI output devices.
 
-<P> new bob~ object (Moog filter emulation) in extra. (This was intended for
-0.47 but it was easiest to leave it in place for this bug-fix release).
+</div></section><section class="releasenote"><h4 id="0.46-6">0.46-6</h4><div>
 
-<P> ------------------ 0.46-5 ------------------------------
+<P>fixed bug selecting and saving/restoring MIDI output devices.</P>
 
-<P> fixed crasher bug (cutting all text in an object then cutting again to
-delete the object sometimes crashed Pd)
+<P>new bob~ object (Moog filter emulation) in extra. (This was intended for
+0.47 but it was easiest to leave it in place for this bug-fix release).</P>
 
-<P> added two checks to re-sort DSP when arrays are created or renamed
 
-<P> patched Makefile.am for correct list of objects (fixes broken make install)
+</div></section><section class="releasenote"><h4 id="0.46-5">0.46-5</h4><div>
 
-<P> fixed configure.ac to use fftw3
+<P>fixed crasher bug (cutting all text in an object then cutting again to
+delete the object sometimes crashed Pd)</P>
 
-<P> ------------------ 0.46-4 ------------------------------
+<P>added two checks to re-sort DSP when arrays are created or renamed</P>
 
-<P> fixed crasher bug in 0.364-3
+<P>patched Makefile.am for correct list of objects (fixes broken make install)</P>
 
-<P> ------------------ 0.46-3 ------------------------------
+<P>fixed configure.ac to use fftw3</P>
 
-<P> changed priority settings to agree with new restrictions on linux --
+
+</div></section><section class="releasenote"><h4 id="0.46-4">0.46-4</h4><div>
+
+<P>fixed crasher bug in 0.364-3</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.46-3">0.46-3</h4><div>
+
+<P>changed priority settings to agree with new restrictions on linux --
 apparently non-root processes can't set to any of the top 5 or so priority
-levels.
+levels.</P>
 
-<P> three minor fixes for array graphics
+<P>three minor fixes for array graphics</P>
 
-<P> new "set" messages and wildcard '-' template names for "set", "get",
-"elem", "setsize", "getsize", and "append" objects
+<P>new "set" messages and wildcard '-' template names for "set", "get",
+"elem", "setsize", "getsize", and "append" objects</P>
 
-<P> updated Makefile.am to reflect new and corrected help file names
+<P>updated Makefile.am to reflect new and corrected help file names</P>
 
-<P> took out bogus object in rev3~
+<P>took out bogus object in rev3~</P>
 
-<P> ------------------ 0.46-2 ------------------------------
 
-<P> fixed bug calculating widths of pre-version-0.39 GOPs
+</div></section><section class="releasenote"><h4 id="0.46-2">0.46-2</h4><div>
 
-<P> added a pd_getdspstate() function to replace dspstate external variable
+<P>fixed bug calculating widths of pre-version-0.39 GOPs</P>
+
+<P>added a pd_getdspstate() function to replace dspstate external variable
 which was moved to the pd instance structure.  Strictly speaking this doesn't
 restore binary compatibility but I believe only one extern writer was using
-dspstate (and he's actively maintaining the externs) so I think this is OK.
+dspstate (and he's actively maintaining the externs) so I think this is OK.</P>
 
-<P> The old standard-error "realtime priority" debug message under linux
+<P>The old standard-error "realtime priority" debug message under linux
 only appears if Pd is started 'verbose'.  OTOH, if realtime priority-setting
-fails, the user is notified in the Pd window.
+fails, the user is notified in the Pd window.</P>
 
-<P> fixed debian compile bug.
+<P>fixed debian compile bug.</P>
 
-<P> fixed "array" object to allow a size of 1.
+<P>fixed "array" object to allow a size of 1.</P>
 
-<P> ------------------ 0.46-1 ------------------------------
 
-<P> Bug fix in oscparse (truncated some messages)
+</div></section><section class="releasenote"><h4 id="0.46-1">0.46-1</h4><div>
 
-<P> Fixed ALSA (on linux) to open devices with fewer channels than requested
+<P>Bug fix in oscparse (truncated some messages)</P>
 
-<P> Other small bug fixes.
+<P>Fixed ALSA (on linux) to open devices with fewer channels than requested</P>
 
-<P> ------------------ 0.46-0 ------------------------------
+<P>Other small bug fixes.</P>
 
-<P> The biggest change in 0.46 was to make possible loading multiple Pd
+
+</div></section><section class="releasenote"><h4 id="0.46-0">0.46-0</h4><div>
+
+<P>The biggest change in 0.46 was to make possible loading multiple Pd
 instances into a single address space.  The instances share symbols (there
 are no namespaces) but have different schedulers, DSP networks, and MIDI
 I/O structures.  In principle it should be possible to design Pd plug-ins
-that don't interact with each other using libpd.
+that don't interact with each other using libpd.</P>
 
-<P> New oscparse and oscformat objects to facilitate OSC I/O.  No support for
-streaming; UDP only so far.
+<P>New oscparse and oscformat objects to facilitate OSC I/O.  No support for
+streaming; UDP only so far.</P>
 
-<P> At long last, Pd vanilla compiled for Macintosh computers is distributed
-with Jack support.
+<P>At long last, Pd vanilla compiled for Macintosh computers is distributed
+with Jack support.</P>
 
-<P> Bug fixes to IEM GUIs: sliders and radio buttons pass floating-point numbers
+<P>Bug fixes to IEM GUIs: sliders and radio buttons pass floating-point numbers
 through without limiting them to the GUI's range or resolution.  Also, the
 toggle no longer resets its "value" (the nonzero number it outputs) when
 receiving numbers in messages.  Set compatibility to 0.45 or earlier to get the
-old behavior (using "pd compatibility" message or a startup flag).
+old behavior (using "pd compatibility" message or a startup flag).</P>
 
-<P> Audio and MIDI settings are now saved by device name, not number, so
+<P>Audio and MIDI settings are now saved by device name, not number, so
 that, hopefully, adding or reordering devices doesn't change the devices
 Pd opens as saved in preferences.  You can also specify them by name on
-Pd's command line with new flags such as "-audioadddev".
+Pd's command line with new flags such as "-audioadddev".</P>
 
-<P> New [text tosymbol] and [text fromsymbol] to allow string manipulation.
+<P>New [text tosymbol] and [text fromsymbol] to allow string manipulation.</P>
 
-<P> Netsend/netreceive can send messages bidirectionally if using TCP protocol.
+<P>Netsend/netreceive can send messages bidirectionally if using TCP protocol.</P>
 
-<P> Added some startup flags (mostly from IOhannes) - -nostderr, etc.  Also
-added a flag (-noautopatch) to suppress autoconnect.
+<P>Added some startup flags (mostly from IOhannes) - -nostderr, etc.  Also
+added a flag (-noautopatch) to suppress autoconnect.</P>
 
-<P> improved the sound of rev2~ and rev3~ reverberators
+<P>improved the sound of rev2~ and rev3~ reverberators</P>
 
-<P> Made stdlib and stdpath flags and declarations follow standard search
-paths (IOhannes again).
+<P>Made stdlib and stdpath flags and declarations follow standard search
+paths (IOhannes again).</P>
 
-<P> Dozens of small bug fixes.
+<P>Dozens of small bug fixes.</P>
 
-<P> ------------------ 0.45-3 ---------------------------
 
-<P> fixed a bug pasting text into Pd and an audio problem in Mac OSX (non-default
-sample rates with built-in hardware needed huge buffering)
+</div></section><section class="releasenote"><h4 id="0.45-3">0.45-3</h4><div>
 
-<P> ------------------ 0.45-1,2 ---------------------------
+<P>fixed a bug pasting text into Pd and an audio problem in Mac OSX (non-default
+sample rates with built-in hardware needed huge buffering)</P>
 
-<P> fixed bug in which backspace to dialog windows got sent to the last
-edited patch
 
-<P> ------------------ 0.45 ---------------------------
+</div></section><section class="releasenote"><h4 id="0.45-1,2">0.45-1,2</h4><div>
 
-<P> multi-purpose "array" and "text" objects.  "Array" is a more general
+<P>fixed bug in which backspace to dialog windows got sent to the last
+edited patch</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.45">0.45</h4><div>
+
+<P>multi-purpose "array" and "text" objects.  "Array" is a more general
 replacement for the "table", "tabread" and "tabwrite" objects.  "text" is
 sort of like Max's "coll" but simpler and hopefully more powerful.
-"text"s are also available as fields in data structures.
+"text"s are also available as fields in data structures.</P>
 
-<P> "tempo" messages for delay, metro, timer, and "test sequence".  In
+<P>"tempo" messages for delay, metro, timer, and "test sequence".  In
 particular you can specify or measure time in samples, but you can also use this
-for changing the speed of an ensemble of delay loops while keeping them in sync.
+for changing the speed of an ensemble of delay loops while keeping them in sync.</P>
 
-<P> binary netsend/netreceive (so you should no longer need an extern for OSC).
+<P>binary netsend/netreceive (so you should no longer need an extern for OSC).</P>
 
-<P> pd~ (multiprocessing) works on windows and is less likely to deadlock
-although not yet perfect.
+<P>pd~ (multiprocessing) works on windows and is less likely to deadlock
+although not yet perfect.</P>
 
-<P> Objects/messages/comments have settable box widths.  By default they're
+<P>Objects/messages/comments have settable box widths.  By default they're
 auto, but you can change that by dragging on the right-hand-side border.  You can
 set it back to the default just by dragging or to whatever width the default
 would have been.  If a box's width isn't "auto" and you open the patch back in
 Pd version 0.44 you'll see a warning; if you open it in earlier versions you'll
 get pages of error messages but no real harm.  You can open and save a patch in
-0.44 if you'd like to reset all box widths to auto.
+0.44 if you'd like to reset all box widths to auto.</P>
 
-<P> The Pd window now tells you whether PD has an audio device open or not,
+<P>The Pd window now tells you whether PD has an audio device open or not,
 and various error and status messages that used to go to standard error now
-appear on the Pd window (this improvement was way overdue!)
+appear on the Pd window (this improvement was way overdue!)</P>
 
-<P> Fixed hangups exiting when using jack.
+<P>Fixed hangups exiting when using jack.</P>
 
-<P> Got ASIO working again on PC (it was apparently broken; I don't know for how
-long.)
+<P>Got ASIO working again on PC (it was apparently broken; I don't know for how
+long.)</P>
 
-<P> Various other small improvements in audio and midi handling:  Notably,
+<P>Various other small improvements in audio and midi handling:  Notably,
 except when using Jack, Pd doesn't open audio on startup; sometimes you want to
 get to the dialog panel before audio ever starts (for instance, on Mac,
 to prevent Pd from hanging when someone walks in the building with an apple TV --
-gee, thanks, Apple!)
+gee, thanks, Apple!)</P>
 
-<P> Took a patch from IOhannes zm&ouml;lnig to make Pd source conform to strict
+<P>Took a patch from IOhannes zm&ouml;lnig to make Pd source conform to strict
 aliasing rules.  The vanilla release is still compiled with -fno-strict-aliasing
-but this will be dropped after more testing.
+but this will be dropped after more testing.</P>
 
-<P> The vanilla release now includes a 64 bit binary for MacOS.  This is a
+<P>The vanilla release now includes a 64 bit binary for MacOS.  This is a
 separate app and it won't load externs that haven't been compiled with
 -arch x86_64.  (Externs can be future-proofed by including both i386 and i86_64
-binaries by compiling with  -arch i386 -arch x86_64).
+binaries by compiling with  -arch i386 -arch x86_64).</P>
 
-<P> The soundfiler now writes correct sample rate to AIFF files (was previously
+<P>The soundfiler now writes correct sample rate to AIFF files (was previously
 hard-coded to 44100).  Still no way to detect the sample rate of a file when
-reading it.
+reading it.</P>
 
 
+</div></section><section class="releasenote"><h4 id="0.44-3">0.44-3</h4><div>
+
+<P>Fix hip~ AC gain once more (still didn't have it right).</P>
+
+<P>Small improvements in MIDI handling (midiin and sysexin device numbering;
+two linux-specific fixes).</P>
+
+<P>"open recent" fixed for linux</P>
 
 
-<P> ------------------ 0.44-3 ---------------------------
+</div></section><section class="releasenote"><h4 id="0.44-2">0.44-2</h4><div>
 
-<P> Fix hip~ AC gain once more (still didn't have it right).
+<P>Fix underflow problem for Raspberry Pi (no effect on other platforms)</P>
 
-<P> Small improvements in MIDI handling (midiin and sysexin device numbering;
-two linux-specific fixes).
 
-<P> "open recent" fixed for linux
+</div></section><section class="releasenote"><h4 id="0.44-1">0.44-1</h4><div>
 
-<P> ------------------ 0.44-2 ---------------------------
-
-<P> Fix underflow problem for Raspberry Pi (no effect on other platforms)
-
-<P> ------------------ 0.44-1 ---------------------------
-
-<P> Fixed default API settings to prefer MMIO over ASIO for MS Windows and
+<P>Fixed default API settings to prefer MMIO over ASIO for MS Windows and
 anything over jack (so that first-time users are most likely to get audio
-out).
+out).</P>
 
-<P> ------------------ 0.44 ---------------------------
 
-<P> many, many changes (hopefully improvements) in audio and MIDI I/O
-and in scheduling.
+</div></section><section class="releasenote"><h4 id="0.44">0.44</h4><div>
 
-<P> got rid of the "old" (cd src; ./configure etc) build system.  src now
+<P>many, many changes (hopefully improvements) in audio and MIDI I/O
+and in scheduling.</P>
+
+<P>got rid of the "old" (cd src; ./configure etc) build system.  src now
 contains fallback makefiles for gnu/linux and mac as well as windows.  But
-the "official" way to build Pd is now to invoke automake.
+the "official" way to build Pd is now to invoke automake.</P>
 
-<P> better handling of reading and writing files with non-ASCII filenames in
-Microsoft Windows.
+<P>better handling of reading and writing files with non-ASCII filenames in
+Microsoft Windows.</P>
 
-<P> fixed a bug in hip~ (incorrect gain; noticeably different when the cutoff
+<P>fixed a bug in hip~ (incorrect gain; noticeably different when the cutoff
 frequency is set about 5K or higher.)  To get the old behavior you can set
-Pd to be 0.43 compatible; see the hip~ help window for details.
+Pd to be 0.43 compatible; see the hip~ help window for details.</P>
 
-<P> inlet~ and outlet~, if configured to do upsampling, now use sample/hold
+<P>inlet~ and outlet~, if configured to do upsampling, now use sample/hold
 instead of zero padding by default; arguably this is a bug fix as the DC gain
-isn't one for zero padding.  Also undoable by setting compatibility to 0.43.
+isn't one for zero padding.  Also undoable by setting compatibility to 0.43.</P>
 
-<P> ------------------ 0.43.2-3 ---------------------------
 
-<P> bug fixes, notably allowing an increase in incoming MIDI bandwidth.
+</div></section><section class="releasenote"><h4 id="0.43.2-3">0.43.2-3</h4><div>
 
-<P> added an "f" message to canvases which might in the future be used
-to specify formatting info (width; font size) box by box.
+<P>bug fixes, notably allowing an increase in incoming MIDI bandwidth.</P>
 
-<P> ------------------ 0.43.1 ---------------------------
+<P>added an "f" message to canvases which might in the future be used
+to specify formatting info (width; font size) box by box.</P>
 
-<P> bug fix: in "perf mode" (having sent pd the "perf" message to prevent
+
+</div></section><section class="releasenote"><h4 id="0.43.1">0.43.1</h4><div>
+
+<P>bug fix: in "perf mode" (having sent pd the "perf" message to prevent
 undesired patch closure) Pd crashed (oops!) when one asked for the patch to
-close after all.
+close after all.</P>
 
-<P> Improvements to Mac version of bonk~ -- "learn" parameter handled correctly and
-compilation fixes.
+<P>Improvements to Mac version of bonk~ -- "learn" parameter handled correctly and
+compilation fixes.</P>
 
-<P> Default font size is the same on all platforms.
+<P>Default font size is the same on all platforms.</P>
 
-<P> Bug fixes reading and writing AIFF files, particularly 24 bit ones
+<P>Bug fixes reading and writing AIFF files, particularly 24 bit ones</P>
 
-<P> "edit mode" menu checkbox should work now.
+<P>"edit mode" menu checkbox should work now.</P>
 
-<P> X Pasting text into boxes now works in linux.
+<P>X Pasting text into boxes now works in linux.</P>
 
-<P> fixed bug that hung Pd when closing more than one pd~ subpatch out of order.
+<P>fixed bug that hung Pd when closing more than one pd~ subpatch out of order.</P>
 
-<P> fixed segfault if DSP loop found and main patch had signal inlets/outlets
+<P>fixed segfault if DSP loop found and main patch had signal inlets/outlets</P>
 
-<P> miscellaneous cleanups.
+<P>miscellaneous cleanups.</P>
 
-<P> STILL BUGGY: when you change the contents of a graph-on-parent subpatch the
-old stuff often doesn't get erased correctly.
-<P> ------------------ 0.43 ---------------------------
+<P>STILL BUGGY: when you change the contents of a graph-on-parent subpatch the
+old stuff often doesn't get erased correctly.</P>
 
-<P> Completely new TCL front end, thanks to Hans-Christophe Steiner,
-IOhannes zm&ouml;lnig, and others.
 
-<P> ------------------ 0.42-5 ---------------------------
+</div></section><section class="releasenote"><h4 id="0.43">0.43</h4><div>
 
-<P> broken abs~ and log~ fixed
+<P>Completely new TCL front end, thanks to Hans-Christophe Steiner,
+IOhannes zm&ouml;lnig, and others.</P>
 
-<P> pd~ -ninsig 0 hang fixed
 
-<P> testtone updated and 16ch version added
+</div></section><section class="releasenote"><h4 id="0.42-5">0.42-5</h4><div>
 
-<P> lrshift~ bug fix
+<P>broken abs~ and log~ fixed</P>
 
-<P> 32 channel limit removed for portaudio (ASIO/Windows and Mac)
+<P>pd~ -ninsig 0 hang fixed</P>
 
-<P> ------------------ 0.42-4 ---------------------------
+<P>testtone updated and 16ch version added</P>
 
-<P> added -noautopatch startup argument to defeat auto-connecting to
-new objects (some folks like it and others hate it)
+<P>lrshift~ bug fix</P>
 
-<P> gfxstub bug fix
+<P>32 channel limit removed for portaudio (ASIO/Windows and Mac)</P>
 
-<P> fixed crash on deleting "s" objects with no args
 
-<P> re-fixed seteuid(0 problem
+</div></section><section class="releasenote"><h4 id="0.42-4">0.42-4</h4><div>
 
-<P> fixed crash on "find $1" (still not useful though)
+<P>added -noautopatch startup argument to defeat auto-connecting to
+new objects (some folks like it and others hate it)</P>
 
-<P> ------------------ 0.42.1-3 ---------------------------
+<P>gfxstub bug fix</P>
 
-<P> Bug fix on Windows(cancelling window close deactivated window).
+<P>fixed crash on deleting "s" objects with no args</P>
 
-<P> Bug fix running Pd from command line in MacOS.
+<P>re-fixed seteuid(0 problem</P>
 
-<P> "Select all" fixed to select none if everything already selected.
+<P>fixed crash on "find $1" (still not useful though)</P>
 
-<P> ------------------ 0.42 ---------------------------
 
-<P> The 'struct' object can now be used to catch a small but growing variety of
-events (mouse clicks on data, selection/deselection).
+</div></section><section class="releasenote"><h4 id="0.42.1-3">0.42.1-3</h4><div>
 
-<P> The 'tabread4~' object was fixed to allow message-time onset into the table.
+<P>Bug fix on Windows(cancelling window close deactivated window).</P>
+
+<P>Bug fix running Pd from command line in MacOS.</P>
+
+<P>"Select all" fixed to select none if everything already selected.</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.42">0.42</h4><div>
+
+<P>The 'struct' object can now be used to catch a small but growing variety of
+events (mouse clicks on data, selection/deselection).</P>
+
+<P>The 'tabread4~' object was fixed to allow message-time onset into the table.
 This makes it possible (at last) to use tabread4~ effectively with large (> 1
 second) samples.  New help files 3.audio.examples/B15 and B16 show how to
-use it.  It's not pretty but it's at least possible.
+use it.  It's not pretty but it's at least possible.</P>
 
-<P> Took patches from IOhannes zm&ouml;lnig to make Pd work when compiled to use
+<P>Took patches from IOhannes zm&ouml;lnig to make Pd work when compiled to use
 64-bit floating-point audio.  I didn't test this; doubtless there will still be
 some problems.  (This isn't the same thing as running in '64 bit mode' which
-already works fine and is the default when compiled on a 64-bit linux machine.)
+already works fine and is the default when compiled on a 64-bit linux machine.)</P>
 
-<P> New objects in extra, 'pd~', and 'stdout', allow running a separate Pd
+<P>New objects in extra, 'pd~', and 'stdout', allow running a separate Pd
 instance in a sub-process.  Theoretically this should make it possible to use
 multiprocessors efficiently in {d.  It's still somewhat experimental; it might
-not work well to pass large numbers of messages and/or signals back and forth.
+not work well to pass large numbers of messages and/or signals back and forth.</P>
 
-<P> A -batch flag allows Pd to be run efficiently from scripts.  You should
+<P>A -batch flag allows Pd to be run efficiently from scripts.  You should
 probably also specify -nosound.  With these flags Pd runs as quickly as it
 can without waiting for real time.  It's up to the patch to arrange to exit
-at the appropriate time via a 'pd quit' message.
+at the appropriate time via a 'pd quit' message.</P>
 
-<P> Large and sweeping improvements have been made to bonk~ and sigmund~.  The
+<P>Large and sweeping improvements have been made to bonk~ and sigmund~.  The
 new bonk~ features are documented in its help window; sigmund~ works better but
-has the same old features.
+has the same old features.</P>
 
-<P> Closing and quitting Pd now act more politely, querying the user only if
+<P>Closing and quitting Pd now act more politely, querying the user only if
 there are edited windows.  There's also a query if the user types into a box
 holding an edited abstraction to prevent the changes from getting lost
 accidentally.  A new 'pd perf' message re-enables the old "really close this
 window" behavior, which is appropriate for performances where you don't want the
-wrong keyclick to stop Pd brusquely.
+wrong keyclick to stop Pd brusquely.</P>
 
-<P> The process of reloading multiple copies of a modified abstraction was
-sped up.
+<P>The process of reloading multiple copies of a modified abstraction was
+sped up.</P>
 
-<P> The 'find' dialog permits searching for substrings.  This is useful for
+<P>The 'find' dialog permits searching for substrings.  This is useful for
 strings containing "$" arguments, where it's unclear what 'find' does or should
-do.
+do.</P>
 
-<P> New pow~, log~, exp~, abs~, and 'wrap' objects.
+<P>New pow~, log~, exp~, abs~, and 'wrap' objects.</P>
 
-<P> The 'print' object takes "-n" flag to suppress "print:" in output
+<P>The 'print' object takes "-n" flag to suppress "print:" in output</P>
 
-<P> "clear" button in Pd output window
+<P>"clear" button in Pd output window</P>
 
-<P> ".pdrc" loading suppressed if pd is started with "-noprefs".
+<P>".pdrc" loading suppressed if pd is started with "-noprefs".</P>
 
-<P> Bug fix in pipe object: if sending a list to pipe, it didn't update the
-delay time when asked to.
+<P>Bug fix in pipe object: if sending a list to pipe, it didn't update the
+delay time when asked to.</P>
 
-<P> Binbufs fixed to handle arbitrary length messages.  (This fixed a problem
-reloading data structures with huge arrays).
+<P>Binbufs fixed to handle arbitrary length messages.  (This fixed a problem
+reloading data structures with huge arrays).</P>
 
-<P> various fixes to
-<P> ------------------ 0.41-3,4 ---------------------------
+<P>various fixes to</P>
 
-<P> 2 fixes for PC: no bonk~, and the audio device selection
-dialogs didn't show all the devices.
 
-<P> ------------------ 0.41-2 ----------------------------
+</div></section><section class="releasenote"><h4 id="0.41-3,4">0.41-3,4</h4><div>
 
-<P> More bug fixes: large netsends dropping messages, and crash bug when turning
-DSP on and off repeatedly in MS windows
+<P>2 fixes for PC: no bonk~, and the audio device selection
+dialogs didn't show all the devices.</P>
 
-<P> ------------------ 0.41-1 ----------------------------
 
-<P> Fixed a startup problem for Mac OSX 10.5.1 (other platforms should not be affected)
+</div></section><section class="releasenote"><h4 id="0.41-2">0.41-2</h4><div>
 
-<P> ------------------ 0.41 ----------------------------
+<P>More bug fixes: large netsends dropping messages, and crash bug when turning
+DSP on and off repeatedly in MS windows</P>
 
-<P> Pd may be compiled in 64 bit address spaces; this is well tested on
+
+</div></section><section class="releasenote"><h4 id="0.41-1">0.41-1</h4><div>
+
+<P>Fixed a startup problem for Mac OSX 10.5.1 (other platforms should not be affected)</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.41">0.41</h4><div>
+
+<P>Pd may be compiled in 64 bit address spaces; this is well tested on
 linux and at least seems to work on Microsoft and MacOS.  On linux, in fact,
 if you compile Pd in a 64-bit version of the OS it's automatically in the
-64 bit address space.
+64 bit address space.</P>
 
-<P> In linux, a "-nosleep" flag causes Pd to poll instead of sleeping as it
+<P>In linux, a "-nosleep" flag causes Pd to poll instead of sleeping as it
 waits for dac and adc; this is useful on multiprocessors when you don't mind
 having Pd occupy 100% of one processor and want to get latency as low as
 possible.  (If you don't use this, latency on multiprocessors - Intel Core 2 at
 least - is much worse for some reason than it is on uniprocessors.)  It's
-"experimental" but I use it every day.
+"experimental" but I use it every day.</P>
 
-<P> added an experimental callback scheduler.  This might reduce latency in
-MacOS and/or Microsoft, although I haven't seen that actually happen yet.
+<P>added an experimental callback scheduler.  This might reduce latency in
+MacOS and/or Microsoft, although I haven't seen that actually happen yet.</P>
 
-<P> removed limitation on huge messages from text files; this prevented long
-"data" arrays from reloading from disk correctly.
+<P>removed limitation on huge messages from text files; this prevented long
+"data" arrays from reloading from disk correctly.</P>
 
-<P> fixed crash bug closing patches with open GOPs.
+<P>fixed crash bug closing patches with open GOPs.</P>
 
-<P> changed selection strategy so that, right after duplicating a collection
-of objects, clicking tends to select an already-selected object.
+<P>changed selection strategy so that, right after duplicating a collection
+of objects, clicking tends to select an already-selected object.</P>
 
-<P> the cursor changes slightly more appropriately when switching between edit
-to run modes.
+<P>the cursor changes slightly more appropriately when switching between edit
+to run modes.</P>
 
-<P> got really confused about the proper role of "declare 'path" in abstractions;
+<P>got really confused about the proper role of "declare 'path" in abstractions;
 for the moment they are ignored.  I the future, it may be worthwhile to allow
 them but to have them act only locally to the abstraction; but this might mean
-a lot more computation overhead when opening files.
+a lot more computation overhead when opening files.</P>
 
-<P> limited window sizes to that of the screen (otherwise, on Mac OS, it's
-impossible to resize them.)
+<P>limited window sizes to that of the screen (otherwise, on Mac OS, it's
+impossible to resize them.)</P>
 
-<P> fixed "startup" dialogs to allow unlimited "path" and "lib"  entries
+<P>fixed "startup" dialogs to allow unlimited "path" and "lib"  entries</P>
 
-<P> started, but didn't finish, the process of getting Pd to compile with
-t_float as 64 bits.  This would slow Pd down but improve tabread4~'s accuracy.
+<P>started, but didn't finish, the process of getting Pd to compile with
+t_float as 64 bits.  This would slow Pd down but improve tabread4~'s accuracy.</P>
 
-<P> made IEM Guis respect "-font" flag and friends.  New startup flags:
+<P>made IEM Guis respect "-font" flag and friends.  New startup flags:
 "-font-face" (badly named); "-font-size" synonym of "-font".  (Large patch from
-HC).
+HC).</P>
 
-<P> String overflow protection here and there.
+<P>String overflow protection here and there.</P>
 
-<P> migrated to ".net" compiler ("VC 2005", a free download).
+<P>migrated to ".net" compiler ("VC 2005", a free download).</P>
 
 
-<P> ------------------ 0.40-1 --------------------------
+</div></section><section class="releasenote"><h4 id="0.40-1">0.40-1</h4><div>
 
-<P> Fixed "declare" which wasn't working properly yet in 0.40-0, and
+<P>Fixed "declare" which wasn't working properly yet in 0.40-0, and
 made more objects (notably "soundfiler") respect "declared" paths.  Path
 entries are relative to the parent patch.  Declares inside abstractions are
-ignored.
+ignored.</P>
 
-<P> "drawnumbers" are draggable now, even if they're in arrays.
+<P>"drawnumbers" are draggable now, even if they're in arrays.</P>
 
-<P> Bug fix opening "html" help from windows.
+<P>Bug fix opening "html" help from windows.</P>
 
-<P> Changed MACOSX to __APPLE__ in 4 places.
+<P>Changed MACOSX to __APPLE__ in 4 places.</P>
 
-<P> ------------------ 0.40 -----------------------------
 
-<P> A new object, "declare", allows patches to control where Pd looks
-for resources such as abstractions and libraries.
+</div></section><section class="releasenote"><h4 id="0.40">0.40</h4><div>
 
-<P> Symbols can now be built using multiple dollar sign variables, as in
+<P>A new object, "declare", allows patches to control where Pd looks
+for resources such as abstractions and libraries.</P>
+
+<P>Symbols can now be built using multiple dollar sign variables, as in
 "$1-$2.$3".  Meanwhile, naming subpatches as in "pd $1-foo" now seems to
-work correctly.
+work correctly.</P>
 
-<P> The switch~ object takes a "bang" message to compute one block of DSP on
+<P>The switch~ object takes a "bang" message to compute one block of DSP on
 demand.  Also, block sizes are no longer required to be powers of two
-(although reblocking only works between powers of two.)
+(although reblocking only works between powers of two.)</P>
 
-<P> Externs may have characters in their names that aren't part of valid
-C variable names (i.e., outsize the range a-z,A-Z,0-9, _).
+<P>Externs may have characters in their names that aren't part of valid
+C variable names (i.e., outsize the range a-z,A-Z,0-9, _).</P>
 
-<P> Openpanel and savepanel take an argument to set the initial directory to
-search.
+<P>Openpanel and savepanel take an argument to set the initial directory to
+search.</P>
 
-<P> Support for large (>2G) soundfiles, in operating systems that offer it.
+<P>Support for large (>2G) soundfiles, in operating systems that offer it.</P>
 
-<P> Text copy/paste fixed (I hope) for Macintosh
+<P>Text copy/paste fixed (I hope) for Macintosh</P>
 
-<P> Intel Mac binaries.  New naming scheme for externs to allow disambiguation
-(although Pd falls back to the old names for compatibility.)
+<P>Intel Mac binaries.  New naming scheme for externs to allow disambiguation
+(although Pd falls back to the old names for compatibility.)</P>
 
-<P> Templates can get notified when data are selected/deselected.  I want
-to provide this for mouse actions on locked canvases too, but haven't yet.
+<P>Templates can get notified when data are selected/deselected.  I want
+to provide this for mouse actions on locked canvases too, but haven't yet.</P>
 
-<P> Characters like "\", "[", etc., typed into dialogs for labelling
+<P>Characters like "\", "[", etc., typed into dialogs for labelling
 number boxes or other GUI objects, get filtered out so that they at
-least don't hang Pd up.
+least don't hang Pd up.</P>
 
-<P> Drawcurve (and the others, filledcurve, drawpolygon, filledpolygon)
+<P>Drawcurve (and the others, filledcurve, drawpolygon, filledpolygon)
 have a new "-x" flag that inhibits a scalar getting
 selected when the curve is clicked on.  This is useful for drawing stuff in
-the background (grids, clefs, etc).
+the background (grids, clefs, etc).</P>
 
-<P> 6 or so patches adopted from sourceforge.
+<P>6 or so patches adopted from sourceforge.</P>
 
-<P> A "list length" object
+<P>A "list length" object</P>
 
-<P> IEM Gui labels (except for the VU meter) default to 10 point fonts
-(typically 8 before).
+<P>IEM Gui labels (except for the VU meter) default to 10 point fonts
+(typically 8 before).</P>
 
-<P> "send" without an argument gets an inlet to set the destination
+<P>"send" without an argument gets an inlet to set the destination</P>
 
-<P> A -noprefs flag defeats loading startup preferences.  This gives you a
-way to rescue things if Pd's settings somehow crash Pd on startup.
+<P>A -noprefs flag defeats loading startup preferences.  This gives you a
+way to rescue things if Pd's settings somehow crash Pd on startup.</P>
 
-<P> tabwrite~ takes a "start" message to allow writing into the middle
-of the table.
+<P>tabwrite~ takes a "start" message to allow writing into the middle
+of the table.</P>
 
-<P> ------------------ 0.39.2 --------------------------
 
-<P> Bug fixes: memory leak in OSX version; problem printing numbers as symbols.
+</div></section><section class="releasenote"><h4 id="0.39.2">0.39.2</h4><div>
 
-<P> ------------------ 0.39.1 --------------------------
+<P>Bug fixes: memory leak in OSX version; problem printing numbers as symbols.</P>
 
-<P> Bug fixes: compatibility problems with older version of TK
 
-<P> ------------------ 0.39.0 --------------------------
+</div></section><section class="releasenote"><h4 id="0.39.1">0.39.1</h4><div>
 
-<P> At the source level, "regular" arrays and arrays within data structures are
+<P>Bug fixes: compatibility problems with older version of TK</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.39.0">0.39.0</h4><div>
+
+<P>At the source level, "regular" arrays and arrays within data structures are
 now the same thing.  This will mean that, in the future, features introduced to
 one array type will become available on the other one too.  Array elements are
 "scalars" (i.e., data structures) and if they have drawing instructions, each
 point of the array is drawn according to them; they can be clicked on, etc.,
 just like any other scalars. "Regular" arrays have points which are of a
-special, built-in template, "float".
+special, built-in template, "float".</P>
 
-<P> Drawing instructions now can use variable ranges for screen coordinates;
+<P>Drawing instructions now can use variable ranges for screen coordinates;
 for instance, specifying an offset of "a(0:10)(100:200)(0.2)" specifies that
 the member "a", which should range from 0 to 10, should be graphed at locations
 ranging from 100 to 200 (relative to the scalar's base location) and should
-have a "grain" of 0.2, i.e., steps of 2 pixels each.
+have a "grain" of 0.2, i.e., steps of 2 pixels each.</P>
 
-<P> Drawing instructions can be turned on and off, either globally
-(for all data of the given structure) or by a data field.
+<P>Drawing instructions can be turned on and off, either globally
+(for all data of the given structure) or by a data field.</P>
 
-<P> The "struct" object has an outlet to notify you when a datum is selected or
-deselected.
+<P>The "struct" object has an outlet to notify you when a datum is selected or
+deselected.</P>
 
-<P> Graph-on-parent subpatches and abstractions no longer scale the GUI objects
+<P>Graph-on-parent subpatches and abstractions no longer scale the GUI objects
 to fit the parent rectangle; instead you get a sub-rectangle in the subpatch,
 of the same size as the parent object, to place GUI objects in.  GUI objects
 that don't fit inside aren't shown on the parent, and the parent objects no
 longer stretches itself to show things that wouldn't otherwise fit.  Older
 patches work as before until you try to edit them - at which point you have
-no choice but to use the new functionality.
+no choice but to use the new functionality.</P>
 
-<P> The font size of a Graph-on-parent abstraction is that of the abstraction
-itself, not the calling patch.
+<P>The font size of a Graph-on-parent abstraction is that of the abstraction
+itself, not the calling patch.</P>
 
-<P> Message boxes now take "addcomma" and similar messages.
+<P>Message boxes now take "addcomma" and similar messages.</P>
 
-<P> A "list" object is provided for joining and splitting lists, and converting
-between lists and non-list messages.
+<P>A "list" object is provided for joining and splitting lists, and converting
+between lists and non-list messages.</P>
 
-<P> Pd extension is now added automatically to files on Macintish when you
+<P>Pd extension is now added automatically to files on Macintish when you
 do a "save as".  The tcl/tk version is updated to 8.4.5.  This should run on
 OSX version 10.2 and later.  Also on Mac, drag-and-drop startups read
-"libraries" (specified in "startup" dialog) before opening the file.
+"libraries" (specified in "startup" dialog) before opening the file.</P>
 
-<P> The "pointer" object has a method to rewind to the beginning of a list.
+<P>The "pointer" object has a method to rewind to the beginning of a list.
 A "sendwindow" message forwards any message to the window continuing the
-scalar currently pointed to.
+scalar currently pointed to.</P>
 
-<P> Abstractions don't produce visible windows, even if subwindows of the
-abstraction were visible when the abstraction was saved.
+<P>Abstractions don't produce visible windows, even if subwindows of the
+abstraction were visible when the abstraction was saved.</P>
 
-<P> MIDI sysex messages should now work on all platforms.
+<P>MIDI sysex messages should now work on all platforms.</P>
 
-<P> Bug fixes:
+<P>Bug fixes:</P>
 
-<P> sending lists to arrays now correctly interprets the first number of the
+<P>sending lists to arrays now correctly interprets the first number of the
 list as the starting index (following values are then stored sequentially in the
-array.)
+array.)</P>
 
-<P> The rfft~ object's imaginary part had the wrong sign.  Also, the Nyquist
-bin is now supplied correctly.
+<P>The rfft~ object's imaginary part had the wrong sign.  Also, the Nyquist
+bin is now supplied correctly.</P>
 
-<P> Fixed problems writing aiff files using the writesf~ and soundfiler objects.
+<P>Fixed problems writing aiff files using the writesf~ and soundfiler objects.
 Writesf, if sent an "open" while a file was previously being written, closes the
-previous file first.
+previous file first.</P>
 
-<P> Bug fix in number2 which sometimes crashed Pd.
+<P>Bug fix in number2 which sometimes crashed Pd.</P>
 
-<P> Stale-pointer protection made more robust.
+<P>Stale-pointer protection made more robust.</P>
 
-<P> Some of Pd's tcl/tk error messages have been tracked down, but probably
-not all of them yet.
+<P>Some of Pd's tcl/tk error messages have been tracked down, but probably
+not all of them yet.</P>
 
-<P> "Find" crashed Pd when the found object was in a GOP.
+<P>"Find" crashed Pd when the found object was in a GOP.</P>
 
-<P> Mouse motion over arrays no longer is quite so CPU-consuming (but is
-still somewhat so.)
+<P>Mouse motion over arrays no longer is quite so CPU-consuming (but is
+still somewhat so.)</P>
 
-<P> samplerate~ now reflects up/downsampling.
+<P>samplerate~ now reflects up/downsampling.</P>
 
-<P> Tilde objects in blocked, overlapped subpatches no longer adjust their
-internal sample rate to reflect the overlap.
+<P>Tilde objects in blocked, overlapped subpatches no longer adjust their
+internal sample rate to reflect the overlap.</P>
 
-<P> Fixed a thread-safety problem in sys_microsleep().
+<P>Fixed a thread-safety problem in sys_microsleep().</P>
 
 
-<P> ------------------ 0.38.1 --------------------------
+</div></section><section class="releasenote"><h4 id="0.38.1">0.38.1</h4><div>
 
-Fixed two bugs that crashed Pd when deleting number boxes in certain
-situations.
+<P>Fixed two bugs that crashed Pd when deleting number boxes in certain
+situations.</P>
 
-<P> ------------------ 0.38.0 --------------------------
 
-<P> The big change is queued graphics updates, which apply (so far)
+</div></section><section class="releasenote"><h4 id="0.38.0">0.38.0</h4><div>
+
+<P>The big change is queued graphics updates, which apply (so far)
 to tables and number/symbol boxes.  The IEM GUIS aren't enqueued yet.
 This along with a better graphics update buffering scheme makes Pd's
-graphics run much better.
+graphics run much better.</P>
 
-<P> Support for cutting/copying/pasting text between boxes and between Pd and
-other applications.
+<P>Support for cutting/copying/pasting text between boxes and between Pd and
+other applications.</P>
 
-<P> Dialogs for setting and saving path, libs-to-load-on-startup, and some
+<P>Dialogs for setting and saving path, libs-to-load-on-startup, and some
 other things.  This and the audio settings can be saved automatically to
 the appropriate repository (.pdsettings on linux; registry on MS windows;
-"Preferences" on Mac.)
+"Preferences" on Mac.)</P>
 
-<P> "Print" printout goes to the Pd window by default.  You can revert to
-the old (standard error) behavior with the "-stderr" startup flag.
+<P>"Print" printout goes to the Pd window by default.  You can revert to
+the old (standard error) behavior with the "-stderr" startup flag.</P>
 
-<P> The "gui" TK script can now start Pd up (previously Pd had to be
-started first.)  This is needed for Pd to work as an "App" on Mac.
+<P>The "gui" TK script can now start Pd up (previously Pd had to be
+started first.)  This is needed for Pd to work as an "App" on Mac.</P>
 
-<P> new filter objects: cpole~, fpole~, etc... these will get used in the
-upcoming Techniques chapter 8.
+<P>new filter objects: cpole~, fpole~, etc... these will get used in the
+upcoming Techniques chapter 8.</P>
 
-<P> Objects whose creation failed get a distinctive outline; if they are
+<P>Objects whose creation failed get a distinctive outline; if they are
 already inside a patch they sprout inlets and outlets as necessary to
-preserve connections.
+preserve connections.</P>
 
-<P> Filenames in the "search path", etc., now may contain spaces, commas,
-and semicolons.
+<P>Filenames in the "search path", etc., now may contain spaces, commas,
+and semicolons.</P>
 
-<P> bug fix: click on miniaturized subpatch failed to "vis" it
+<P>bug fix: click on miniaturized subpatch failed to "vis" it</P>
 
-<P> bug fix: font size change crash reported by CK
+<P>bug fix: font size change crash reported by CK</P>
 
-<P> Key bindings like control-Q now work even from within most dialogs.
+<P>Key bindings like control-Q now work even from within most dialogs.</P>
 
-<P> The audio settings dialog now permits turning audio input and/or output
-off without forgetting how many channels it should be when on.
+<P>The audio settings dialog now permits turning audio input and/or output
+off without forgetting how many channels it should be when on.</P>
 
-<P> RME Hammerfall ALSA support from Winfried -- but specify the number of
-channels correctly or else Pd crashes.
+<P>RME Hammerfall ALSA support from Winfried -- but specify the number of
+channels correctly or else Pd crashes.</P>
 
-<P> portaudio (e.g., Mac) audio support fixed for inchans != outchans,
-so the emi emagic can now be used 2-in. 6-out, for example.
+<P>portaudio (e.g., Mac) audio support fixed for inchans != outchans,
+so the emi emagic can now be used 2-in. 6-out, for example.</P>
 
-<P> (linux) The configure script can set the setuid flag on "make install".
-The "-enable" flags to ./configure should now work correctly too.
+<P>(linux) The configure script can set the setuid flag on "make install".
+The "-enable" flags to ./configure should now work correctly too.</P>
 
-<P> atan2 had its inlets switched to conform to standard usage
+<P>atan2 had its inlets switched to conform to standard usage</P>
 
-<P> ------------------ 0.37.3 --------------------------
 
-<P> Oops- added __i386__ macro to windows makefile so it would test for
+</div></section><section class="releasenote"><h4 id="0.37.3">0.37.3</h4><div>
+
+<P>Oops- added __i386__ macro to windows makefile so it would test for
 underflows correctly.  This affects only Microsoft Windows; the other
-two platforms are fine as 0.37.2.  Thanks to Thomas Musil...
+two platforms are fine as 0.37.2.  Thanks to Thomas Musil...</P>
 
-<P> ------------------ 0.37.2 --------------------------
 
-<P> fixed a bug in soundfile reading (soundfiles now default to wav better.)
+</div></section><section class="releasenote"><h4 id="0.37.2">0.37.2</h4><div>
 
-<P> fixed gfx update problem in hradio and vradio
+<P>fixed a bug in soundfile reading (soundfiles now default to wav better.)</P>
 
-<P> minor changes to built-in Max import feature (but you should
-still use cyclone's instead.)
+<P>fixed gfx update problem in hradio and vradio</P>
 
-<P> colors for scalars fixed (probably never worked before!)
+<P>minor changes to built-in Max import feature (but you should
+still use cyclone's instead.)</P>
 
-<P> added a "set" message to the line object
+<P>colors for scalars fixed (probably never worked before!)</P>
 
-<P> aliased spaces to underscores in GUI labels so that at least they won't
-destroy the object.
+<P>added a "set" message to the line object</P>
 
-<P> ------------------ 0.37.1 --------------------------
+<P>aliased spaces to underscores in GUI labels so that at least they won't
+destroy the object.</P>
 
-<P> fixed the apple key on OSX so it does key accelerators
 
-<P> fixed bug in -inchannels/-outchannels arg parsing
+</div></section><section class="releasenote"><h4 id="0.37.1">0.37.1</h4><div>
 
-<P> major editions to the IEM GUIs to fix bugs in how "$" variables are handled.
-The code still isn't pretty but hopefully at least works now.
+<P>fixed the apple key on OSX so it does key accelerators</P>
 
-<P> bug fix in vd~ for very small delays
+<P>fixed bug in -inchannels/-outchannels arg parsing</P>
 
-<P> fixed MSW version not to make windows grow by 2 pixels on save/restore
+<P>major editions to the IEM GUIs to fix bugs in how "$" variables are handled.
+The code still isn't pretty but hopefully at least works now.</P>
 
-<P> added an "nrt" flag for OSX to defeat real-time prioritization
-(useful when running Gem.)
+<P>bug fix in vd~ for very small delays</P>
 
-<P> on some platforms, audio open failures are handled more gracefully.
+<P>fixed MSW version not to make windows grow by 2 pixels on save/restore</P>
 
-<P> added a "changelog" file in the source directory to document source-level
-changes.
+<P>added an "nrt" flag for OSX to defeat real-time prioritization
+(useful when running Gem.)</P>
 
-<P> ------------------ 0.37 --------------------------
+<P>on some platforms, audio open failures are handled more gracefully.</P>
 
-<P> Pd is finally fixed so that it can open and close audio and MIDI devices
+<P>added a "changelog" file in the source directory to document source-level
+changes.</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.37">0.37</h4><div>
+
+<P>Pd is finally fixed so that it can open and close audio and MIDI devices
 on-the-fly (previously it opened them once at startup and hogged them until
 Pd quit).  Starting DSP causes audio devices to be opened, and
 stopping it closes them.
 There are dialog panels in the "Media" menu (which used to be called
 "Audio") for choosing audio and MIDI settings.  The "path" also can be changed
-on the fly via a dialog in the "File" menu.
+on the fly via a dialog in the "File" menu.</P>
 
-<P> A "vline" object acts like "line" but to sub-sample accuracy.  See
+<P>A "vline" object acts like "line" but to sub-sample accuracy.  See
 the audio example, C04.control.to.signal.pd (and/or chapter 3 of
 <A HREF="http://msp.ucsd.edu/techniques.htm">
-<I> Theory and Techniques of Electronic Music </I></a>).
+<I> Theory and Techniques of Electronic Music </I></a>).</P>
 
-<P> The block~/switch~ object now takes a "set" message to dynamically change
-block size, etc.
+<P>The block~/switch~ object now takes a "set" message to dynamically change
+block size, etc.</P>
 
-<P> The makefilename object takes a "set" message to set the "pattern".  You
-can use this to kludge multiple substitutions (as shown in the help file).
+<P>The makefilename object takes a "set" message to set the "pattern".  You
+can use this to kludge multiple substitutions (as shown in the help file).</P>
 
-<P> The writesf~ object got an update and a better help window.  It now should
+<P>The writesf~ object got an update and a better help window.  It now should
 be able to write 32bit floating-point WAV soundfiles.  The file's sample rate
-is now set "correctly".
+is now set "correctly".</P>
 
-<P>  Various improvements were made in audio I/O to improve stability and
-reduce latency.
+<P> Various improvements were made in audio I/O to improve stability and
+reduce latency.</P>
 
-<P>  Jack support should work for Mac OSX (it appears as a separate API).
+<P> Jack support should work for Mac OSX (it appears as a separate API).
 Linux is offering experimental portaudio V19 support (but Mac and Window/ASIO
-are still based on PA V18.)
+are still based on PA V18.)</P>
 
-<P>  The fiddle~ object (in extra) has an "npoints" method to set the analysis
-window size dynamically.
+<P> The fiddle~ object (in extra) has an "npoints" method to set the analysis
+window size dynamically.</P>
 
-<P> (windows) Pd is now distributed as a self-extracting archive.
+<P>(windows) Pd is now distributed as a self-extracting archive.</P>
 
-<P> (windows) url files in the help directories are opened correctly.
+<P>(windows) url files in the help directories are opened correctly.</P>
 
-<P> (Mac) the arrow keys should now be fixed.
+<P>(Mac) the arrow keys should now be fixed.</P>
 
-<P> (linux) The "configure" script should be better at finding TK in various
-distributions (debian users previously had to use a special configure script.)
+<P>(linux) The "configure" script should be better at finding TK in various
+distributions (debian users previously had to use a special configure script.)</P>
 
-<P> (developers) Pd now exits cleanly from its main loop instead of bailing
+<P>(developers) Pd now exits cleanly from its main loop instead of bailing
 out.  A mutex protects Pd's data so it can be accessed from other threads.
-(Thomas Grill's improvements.)
+(Thomas Grill's improvements.)</P>
 
-<P> (developers) The "savefunction" and "dialog" widget behaviors
+<P>(developers) The "savefunction" and "dialog" widget behaviors
 were replaced by a better mechanism (class_setsavefn() and
 class_setpropertiesfn()).  They're declared in m_pd.h so you don't have to
-include the (unstable) g_canvas.h to get them.
+include the (unstable) g_canvas.h to get them.</P>
 
-<P> (developers) Better flag handling in the IEM GUIs (g_toggle.c, etc) should
-compile with fewer warnings and be more portable.
+<P>(developers) Better flag handling in the IEM GUIs (g_toggle.c, etc) should
+compile with fewer warnings and be more portable.</P>
 
 
-<P> ------------------ 0.37-test 1 --------------------------
+</div></section><section class="releasenote"><h4 id="0.37-test 1">0.37-test 1</h4><div>
 
-<P> The MacOSX version now prioritizes itself effectively (thanks to
+<P>The MacOSX version now prioritizes itself effectively (thanks to
 gert@test.at (v93r)) via Adam Lindsay).  Adam also made a proper MacOSX
-"package" for Pd.
+"package" for Pd.</P>
 
-<P> A bug was fixed in readsf~/writesf~ (things were coming out in the wrong
-number of channels.)
+<P>A bug was fixed in readsf~/writesf~ (things were coming out in the wrong
+number of channels.)</P>
 
-<P> A problem compiling Pd with TK8.4 (the latest version) was fixed.
+<P>A problem compiling Pd with TK8.4 (the latest version) was fixed.</P>
 
-<P> Large numbers of GUI improvements by Adam Lindsay, especially relevant
-to Mac OSX.
+<P>Large numbers of GUI improvements by Adam Lindsay, especially relevant
+to Mac OSX.</P>
 
-<P> For externs, the binary may now be included in a subdirectory of the
+<P>For externs, the binary may now be included in a subdirectory of the
 same name (e.g., "choice/choice.pd_linux" and "choice\choice.dll").  So
 now you can pack multiple binaries for the same extern, along with the
 source, in one convenient place.  (Note that
 "expr~" is an exception, since it goes by three different names, so this
-trick fails for that example.)
+trick fails for that example.)</P>
 
-<P>  "Help" files renamed "help-xxx.pd", so that help files are now possible
+<P> "Help" files renamed "help-xxx.pd", so that help files are now possible
 for abstractions.  The "help path" feature from CVS (I forgot who contributed
 that) is also included but should now not be needed: Pd remembers where it got
 externs and abstractions and looks back in the same directory for a help file.
-See the way "extras" is organized.
+See the way "extras" is organized.</P>
 
-<P>  Pd refuses to connect signal outlets to non-signal inlets.
+<P> Pd refuses to connect signal outlets to non-signal inlets.</P>
 
-<P>  When you save any patch, Pd looks for all invocations of that patch
+<P> When you save any patch, Pd looks for all invocations of that patch
 as an abstraction and reloads them.  This unfortunately has the side effect of
-making all the containing windows visible, but it's better than nothing.
+making all the containing windows visible, but it's better than nothing.</P>
 
-<P> ------------------ 0.36-1 -------------------------------
 
-<P> "print" now queries you for a file to save the postscript to.
+</div></section><section class="releasenote"><h4 id="0.36-1">0.36-1</h4><div>
 
-<P> "expr" brought up to date (0.4) -- a bug was fixed involving expressions
-like "max($f1, 100)" which had erroneously output an integer.
+<P>"print" now queries you for a file to save the postscript to.</P>
 
-<P> a bug fix in the 4-point interpolation formula, which affects tabosc4~,
+<P>"expr" brought up to date (0.4) -- a bug was fixed involving expressions
+like "max($f1, 100)" which had erroneously output an integer.</P>
+
+<P>a bug fix in the 4-point interpolation formula, which affects tabosc4~,
 tabread4~, tabread4, and vd~.  These should have significantly lower
-distortion than before.
+distortion than before.</P>
 
-<P> bug fix: vradio, hradio "send symbol" feature didn't work
+<P>bug fix: vradio, hradio "send symbol" feature didn't work</P>
 
-<P> ------------------ 0.36 -------------------------------
 
-<P> There's now an "undo" for most editing operations.  Undoing is only
+</div></section><section class="releasenote"><h4 id="0.36">0.36</h4><div>
+
+<P>There's now an "undo" for most editing operations.  Undoing is only
 available in the window that was most recently edited.  (One gotcha remains,
 that "stretching" (in the font menu) affects all windows and you can't undo any
 but the last one it touched.)  Also, there's no "undo" for run-time operations,
-only editing ones.  That might be worth thinking about.
+only editing ones.  That might be worth thinking about.</P>
 
-<P> Some bugs were fixed that affected "flipped" canvases (ones whose
+<P>Some bugs were fixed that affected "flipped" canvases (ones whose
 "properties show a positive "y" increment per pixel.)  Also, the coordinates
 are now saved and restored correctly.  "text" objects (comments) now stick to
-the bottom of the window for flipped canvases.
+the bottom of the window for flipped canvases.</P>
 
-<P> Signal lines now show up fatter than control lines.  (Now I have to go
-through the figures in the HTML doc again... drat)
+<P>Signal lines now show up fatter than control lines.  (Now I have to go
+through the figures in the HTML doc again... drat)</P>
 
-<P> "Classic" number boxes now can have labels and send/receive signals, which
+<P>"Classic" number boxes now can have labels and send/receive signals, which
 work in the same way as the IEMGUI controls do.  I think "$1" style
 label/send/receive names work too.  I fixed a related bug
-in the IEM code (typing at boxes sometimes crashed Pd).
+in the IEM code (typing at boxes sometimes crashed Pd).</P>
 
-<P> "vdial" and "hdial" were renamed "vradio" and "hradio", and fixed to
+<P>"vdial" and "hdial" were renamed "vradio" and "hradio", and fixed to
 output numbers, not lists, like the other GUIs.  The old ones are still around
-for compatibility with old patches.
+for compatibility with old patches.</P>
 
-<P> "Make install" should now actually make Pd before trying to install it.
+<P>"Make install" should now actually make Pd before trying to install it.</P>
 
-<P> "expr" is updated to Shahrokh's 0.4test3 version (which I modified somewhat
-to get it to compile.)
+<P>"expr" is updated to Shahrokh's 0.4test3 version (which I modified somewhat
+to get it to compile.)</P>
 
-<P> The problem of CPU usage skyrocketing on underflows in P4s should
-be fixed.
+<P>The problem of CPU usage skyrocketing on underflows in P4s should
+be fixed.</P>
 
-<P> Compiled "pdsend" and "pdreceive" for Windows.
+<P>Compiled "pdsend" and "pdreceive" for Windows.</P>
 
-<P> "PD_VERSION" macro added to m_pd.h
+<P>"PD_VERSION" macro added to m_pd.h</P>
 
-<P> ------------------ 0.35 -------------------------------
 
-<P> An experimental new feature called graph-on-parent allows subpatches and abstractions to show
+</div></section><section class="releasenote"><h4 id="0.35">0.35</h4><div>
+
+<P>An experimental new feature called graph-on-parent allows subpatches and abstractions to show
 GUI features; so, for instance, you can make an oscillator with a number box to
 control the frequency.  This is described in section 2.7.2 of the HTML
-documentation and an example is shown in 7.stuff/synth1/.
+documentation and an example is shown in 7.stuff/synth1/.</P>
 
-<P> Spaces are allowed in pathnames to Pd and to patches; however, the "path"
+<P>Spaces are allowed in pathnames to Pd and to patches; however, the "path"
 variable still can't have spaces.  (You can address path directories using
 relative pathnames as in "../sound" (or ..\sound on Windows), even if there
-are spaces further "up" the path to the patch.  See 3.7, "dealing with files."
+are spaces further "up" the path to the patch.  See 3.7, "dealing with files."</P>
 
-<P> The soundfile reading routine (used in readsf~ and soundfiler) is much
+<P>The soundfile reading routine (used in readsf~ and soundfiler) is much
 better at opening wav files with different header sizes and odd chunks.
 You can now read floating-point "wav" files -- although you can't write them
-yet.
+yet.</P>
 
-<P> Templates and data structures are extensively reworked.  A "struct"
+<P>Templates and data structures are extensively reworked.  A "struct"
 object replaces "template", so that you specify the name of the structure as
 the first argument to "struct" (previously it was derived from the
 window name.)  You can now have multiple "structs" of the same name; the
@@ -1348,880 +1407,931 @@ a "struct" and all the associated data will be modified to fit the new
 structure definition.  Data are persistent, i.e., saved with the containing
 patch.  You can copy and paste data between patches.  If you save data to a file
 explicitly, you can read it into another patch and the data are conformed
-automatically to the new data structures.
+automatically to the new data structures.</P>
 
-<P> A new version of Thomas Musil's GUI objects was merged in.
+<P>A new version of Thomas Musil's GUI objects was merged in.</P>
 
-<P> The testtone patch works for up to 6 channels of audio input and output.
+<P>The testtone patch works for up to 6 channels of audio input and output.</P>
 
-<P> Lots of improvements got made to audio I/O in general.  In NT you may
+<P>Lots of improvements got made to audio I/O in general.  In NT you may
 specify "-asio" to use ASIO drivers; see HTML documentation section 3.2.
 You may specify lists of audio input and output devices.  In Linux, Pd
 will now attempt to open each /dev/dsp* only once, even if it's requested
-for reading and writing.
+for reading and writing.</P>
 
-<P> The "extra" directory is now searched after the directories in the
-search path, not before (so now you can override objects like "fiddle~").
+<P>The "extra" directory is now searched after the directories in the
+search path, not before (so now you can override objects like "fiddle~").</P>
 
-<P> A bug in paf~ is fixed.
+<P>A bug in paf~ is fixed.</P>
 
-<P> In Linux, the ".pdrc" is now read before the command line arguments, so
-that command line arguments override the .pdrc (it was backwards before.)
+<P>In Linux, the ".pdrc" is now read before the command line arguments, so
+that command line arguments override the .pdrc (it was backwards before.)</P>
 
-<P> In Linux, "help" now can invoke either mozilla or netscape to start
-up the HTML documentation.  This doesn't work in Windows or Mac land yet.
+<P>In Linux, "help" now can invoke either mozilla or netscape to start
+up the HTML documentation.  This doesn't work in Windows or Mac land yet.</P>
 
-<P> In Linux, the "-32bit" flag was added, which you must now use if
+<P>In Linux, the "-32bit" flag was added, which you must now use if
 running Guenter's OSS RME Hammerfall driver.  (This was necessary because
 OSS went and used the same "bit" for a different purpose, so that Pd tried
-to open some other cards in 32bit mode inappropriately.)
+to open some other cards in 32bit mode inappropriately.)</P>
 
-<P> In Linux, MIDI is now opened "-NODELAY" ... this makes the OSS Creative
-driver take MIDI input correctly which it didn't before.
+<P>In Linux, MIDI is now opened "-NODELAY" ... this makes the OSS Creative
+driver take MIDI input correctly which it didn't before.</P>
 
-<P> In MS windows, you can now use "readsf~/writesf~" for spooling sounds to
-and from disk.
+<P>In MS windows, you can now use "readsf~/writesf~" for spooling sounds to
+and from disk.</P>
 
-<P> MS Windows bug fixes: -nosound was ignored, and now works.  Also, clicking
+<P>MS Windows bug fixes: -nosound was ignored, and now works.  Also, clicking
 to open abstractions, when they were already open anyway, used to lose the
 keyboard; this should be fixed now.  Finally, "netreceive" didn't work when
 running "-nogui". This is fixed, and moreover, you should definitely include
 a netreceive object in any -nogui patch in MSW, otherwise it eats up all
-available CPU time gratuitously.
+available CPU time gratuitously.</P>
 
-<P> The outlet is removed from the "table" object.
+<P>The outlet is removed from the "table" object.</P>
 
-<P> In MS Windows, Pd now has "-resync" and "-noresync" flags so that you
+<P>In MS Windows, Pd now has "-resync" and "-noresync" flags so that you
 can specify how to deal with audio input and output blocksize nonsense in
 MMIO.  If "resync" is on, whenever the audio input and output seem out
 of whack the audio driver resynchronizes all input and output devices;
 otherwise the situation is simply ignored.  "Noresync" is probably best for
 consumer stereo cards (and is the default if you're running only 2 channels in
 and out).  If you're running more than 2 channels in either direction, the
-default is "resync".
+default is "resync".</P>
 
-<P> In soundfiler's read method, if you specify "-maxsize", that implies
-"-resize" (as it ought to.)
+<P>In soundfiler's read method, if you specify "-maxsize", that implies
+"-resize" (as it ought to.)</P>
 
-<P> You can use $1-style names for arrays and tables.
+<P>You can use $1-style names for arrays and tables.</P>
 
-<P> Pd will now refuse to make duplicate connections between objects.
+<P>Pd will now refuse to make duplicate connections between objects.</P>
 
-<P> Pd is (somewhat shakily) running on Macintosh OS/X.  See section 3.4 of
+<P>Pd is (somewhat shakily) running on Macintosh OS/X.  See section 3.4 of
 the HTML doc.  For Macs with one-button mice, you can double-click in edit
 mode to simulate a right click.  Unfortunately, the "alt" key doesn't work
-yet.
+yet.</P>
 
-<P> In Linux, ALSA audio is now fixed to clip, not wrap around, on output
-overflows.
+<P>In Linux, ALSA audio is now fixed to clip, not wrap around, on output
+overflows.</P>
 
-<P> Various problems were fixed with objects changing size.  Number boxes never
+<P>Various problems were fixed with objects changing size.  Number boxes never
 wrap to two lines (as they used to), and lines are reconnected appropriately
-when objects are resized.
+when objects are resized.</P>
 
-<P> A function call is added to retrieve a unique event-dependent number,
-so that objects like "buddy" can be written.
+<P>A function call is added to retrieve a unique event-dependent number,
+so that objects like "buddy" can be written.</P>
 
-<P> All the "sound" command-line flags now have "audio" equivalents.
+<P>All the "sound" command-line flags now have "audio" equivalents.</P>
 
-<P> The "-listdev" flag now works on Mac and MSW/ASIO.
+<P>The "-listdev" flag now works on Mac and MSW/ASIO.</P>
 
-<P> Help file updates for env~, route, and pointer
-
-<P> ------------------ 0.34.3 -------------------------------
-
-<P> fixed a bug in "udp" netreceive that crashed pd
-
-<P> fixed a bug in tabosc4~ that caused gritty sound
-
-<P> changed "specfile" for RPM releases (thanks Fernando)
-
-<P> adopted Krzysztof's glob_setfilename bug fix
-
-<P> bug fixes from "the joy of global variables" thread in Pd list
-
-<P> made a help window for "table".
-
-<P> ------------------ 0.34.2 -------------------------------
-
-<P> fixed ".pdrc" bug
-
-<P> added an experimental "pd restart-audio" feature for (new) Alsa
-
-<P> ------------------ 0.34.1 -------------------------------
-
-<P> Bug fixes:
-
-<P> 1.  Closing a window with objects selected crashed Pd.
-
-<P> 2.  "find" when it opened a window to show the found object crashed Pd.
-
-<P> 3.  (Linux only) Oversized .pdrc files crashed pd...
-
-<P> Also, I updated Thomas Musil's IEM GUI objects and their help files.
+<P>Help file updates for env~, route, and pointer</P>
 
 
-<P> ------------------ 0.34 -------------------------------
+</div></section><section class="releasenote"><h4 id="0.34.3">0.34.3</h4><div>
 
-<P> NEW FEATURES:
+<P>fixed a bug in "udp" netreceive that crashed pd</P>
 
-<P> I incorporated Thomas Musil's GUI objects (slider, button, etc.) into
+<P>fixed a bug in tabosc4~ that caused gritty sound</P>
+
+<P>changed "specfile" for RPM releases (thanks Fernando)</P>
+
+<P>adopted Krzysztof's glob_setfilename bug fix</P>
+
+<P>bug fixes from "the joy of global variables" thread in Pd list</P>
+
+<P>made a help window for "table".</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.34.2">0.34.2</h4><div>
+
+<P>fixed ".pdrc" bug</P>
+
+<P>added an experimental "pd restart-audio" feature for (new) Alsa</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.34.1">0.34.1</h4><div>
+
+<P>Bug fixes:</P>
+
+<P>1.  Closing a window with objects selected crashed Pd.</P>
+
+<P>2.  "find" when it opened a window to show the found object crashed Pd.</P>
+
+<P>3.  (Linux only) Oversized .pdrc files crashed pd...</P>
+
+<P>Also, I updated Thomas Musil's IEM GUI objects and their help files.</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.34">0.34</h4><div>
+
+<P>NEW FEATURES:</P>
+
+<P>I incorporated Thomas Musil's GUI objects (slider, button, etc.) into
 the Pd release so Thomas won't have to publish patches to Pd anymore.  I
 didn't take the graphical inlets and outlets for reasons explained elsewhere,
-but Thomas might decide to continue supplying them on a patch basis.
+but Thomas might decide to continue supplying them on a patch basis.</P>
 
-<P> Many new examples were added to the "2.control" and especially
+<P>Many new examples were added to the "2.control" and especially
 "3.audio" example patches.  A list of differences between Max/MSP and Pd
-now appears at the end of this section.
+now appears at the end of this section.</P>
 
-<P> Finally, I fixed Pd to notice window iconification and suspend graphical
-updates for iconified windows.
+<P>Finally, I fixed Pd to notice window iconification and suspend graphical
+updates for iconified windows.</P>
 
-<P> Numbering of versions of Pd will now be as in "0.34.2" instead of
-"0.34PATCH2" which was confusing.
+<P>Numbering of versions of Pd will now be as in "0.34.2" instead of
+"0.34PATCH2" which was confusing.</P>
 
-<P> BUGS FIXED:
+<P>BUGS FIXED:</P>
 
-<P> I incorporated Krzysztof Czaja's menuclose bug fix in g_canvas.c.
+<P>I incorporated Krzysztof Czaja's menuclose bug fix in g_canvas.c.</P>
 
-<P> (Linux) the configure script is more rational.
+<P>(Linux) the configure script is more rational.</P>
 
-<P> the qlist and pack objects were fixed to handle reentrancy correctly.
+<P>the qlist and pack objects were fixed to handle reentrancy correctly.</P>
 
-<P> Pd now complains about running out of memory (before it dies.)  I intend
+<P>Pd now complains about running out of memory (before it dies.)  I intend
 to provide advance warning and automatically back out of loading patches that
-would run out of memory, but that's not in place yet.
+would run out of memory, but that's not in place yet.</P>
 
-<P> Typing into a message box sometimes left you with lines from the output
-pointing to the wrong location.  Fixed.
+<P>Typing into a message box sometimes left you with lines from the output
+pointing to the wrong location.  Fixed.</P>
 
-<P> Reading of "wav" and nextstep soundfiles now handles the headers better.
+<P>Reading of "wav" and nextstep soundfiles now handles the headers better.</P>
 
-<P> ------------------ 0.33 -------------------------------
 
-<P> AUDIO AND MIDI:
+</div></section><section class="releasenote"><h4 id="0.33">0.33</h4><div>
 
-<P> MIDI time jitter is reduced.  Theoretically, it could now be
+<P>AUDIO AND MIDI:</P>
+
+<P>MIDI time jitter is reduced.  Theoretically, it could now be
 as low as the audio blocksize (and so if you care about MIDI timing, keep your
 audio blocksize low.)  If you run Pd with audio in stream mode or without
 audio at all, and perhaps in some cases in block more too (?),
 the controlling parameter for MIDI jitter is "-sleepgrain", which specifies
-the interval of time Pd sleeps when it believes it's idle.
+the interval of time Pd sleeps when it believes it's idle.</P>
 
-<P> You can now specify multiple MIDI input and output devices.  For example,
+<P>You can now specify multiple MIDI input and output devices.  For example,
 "pd -midiindev 3 -midioutdev 4,2" asks for the third MIDI input device and the
 fourth and second MIDI output device.  The "channel message" midi objects in Pd
 such as notein or pgmout will take channels 1-16 to mean the first open MIDI
 port, 17-32 the second one, and so on.  The midiin, sysexin, midiout objects
 give you a separate inlet to specify which of the open MIDI port numbers
-you want.
+you want.</P>
 
-<P> (Linux only) By default, Pd now reads and write audio in "block mode."
+<P>(Linux only) By default, Pd now reads and write audio in "block mode."
 Previously you have to specify "-frags" and/or "-fragsize" to get this.
 As of this version you have to specify "-streammode" to get the opposite,
 streaming mode.  This mode seems only to work with a small number of sound
-cards, notably Ensoniq ens1370 and ens1371.
+cards, notably Ensoniq ens1370 and ens1371.</P>
 
-<P> (Linux only) Also, "-fragsize" is replaced with a more convenient
+<P>(Linux only) Also, "-fragsize" is replaced with a more convenient
 "-blocksize" which you specify in sample frames.  It defaults to 64 which is
 Pd's audio computation block size but may be larger or smaller.  Typically you
 would specify "-audiobuf" and "-blocksize" and Pd will  compute "-frags" for
-you; but you can also specify "-frags" explicitly.
+you; but you can also specify "-frags" explicitly.</P>
 
-<P> (Linux only) OSS and ALSA audio support are improved.  You can now talk to
+<P>(Linux only) OSS and ALSA audio support are improved.  You can now talk to
 RME9652 using Guenter's OSS driver; this is different from the "-RME" support
 which uses Winfried's older driver.  Other multichannel OSS drivers might now
 work as well.  Pd also seems to work with ALSA 0.9 Beta 4; I've tested this
 with Midiman Delta 66 and Soundblaster live.  I plan to update the linux audio
-setup documentation accordingly.
+setup documentation accordingly.</P>
 
-<P> NEW FEATURES:
+<P>NEW FEATURES:</P>
 
-<P> I've put in Shahrokh's new expr, expr~, and fexpr~ objects.  The latter
+<P>I've put in Shahrokh's new expr, expr~, and fexpr~ objects.  The latter
 allows you to make expressions referring to prior input and output samples in
 case you're interested in writing your own recursive filters, oscillators,
-or chaotic sound generators...
+or chaotic sound generators...</P>
 
-<P>  In support of expr, you can now use commas in "object" boxes; they just
-become symbols.
+<P> In support of expr, you can now use commas in "object" boxes; they just
+become symbols.</P>
 
-<P>  sqrt~ is fixed so that it apparently has 24-bit accurate mantissas.
+<P> sqrt~ is fixed so that it apparently has 24-bit accurate mantissas.
 It turned out to be easier to just make it accurate than to confront the
-question of how a reduced-accuracy version should be named.
+question of how a reduced-accuracy version should be named.</P>
 
-<P> The bizarre framp~ object which does phase vocoder analysis got a help
+<P>The bizarre framp~ object which does phase vocoder analysis got a help
 window.  The phase vocoder example doesn't use framp~ and I had forgotten
-what it did until Guenter dug it back up.
+what it did until Guenter dug it back up.</P>
 
-<P> (Linux only) I finally got around to incorporating Guenter's autoconf
+<P>(Linux only) I finally got around to incorporating Guenter's autoconf
 stuff, and learned about RPM.  Major new Linux releases will probably be
 in .tar.gz and .rpm formats; "test" releases will probably just be in .tar.gz.
 I also fixed it so that the installation prefix is overridden if you invoke
 pd by its full pathname, so that you can still use compilations with
-installation prefixes before you actually install them.
+installation prefixes before you actually install them.</P>
 
-<P> (NT only) I added support for directX using the portaudio package
+<P>(NT only) I added support for directX using the portaudio package
 by Ross Bencina and Phil Burk.  I couldn't discover any way this would ever
 outperform the old "multimedia" API Pd uses.  So the release contains the sources,
 but you have to recompile Pd to use directX.  Use "makefile.nt.portaudio".  Only
 1 or 2 channels of audio are supported.  The interesting thing is that the same
 code will run on Macintosh.  There are a couple of other obstacles to a
-MacOS port of Pd though; it's hard to predict when this will be feasible.
+MacOS port of Pd though; it's hard to predict when this will be feasible.</P>
 
-<P> BUG FIXES:
+<P>BUG FIXES:</P>
 
-<P> "drawnumber" was broken in 0.32 -- fixed.
+<P>"drawnumber" was broken in 0.32 -- fixed.</P>
 
-<P> new arrays in 0.32p6 got ill-fitting graphs -- fixed.
+<P>new arrays in 0.32p6 got ill-fitting graphs -- fixed.</P>
 
-<P> ------------------ 0.32 PATCH 6 -------------------
 
-<P> Got array and graph dialogs to behave better when there are more
-than one.
+</div></section><section class="releasenote"><h4 id="0.32 PATCH 6">0.32 PATCH 6</h4><div>
 
-<P> put in mtof~, etc.
+<P>Got array and graph dialogs to behave better when there are more
+than one.</P>
 
-<P> made Pd search the "extra" directory without having to specify it in "path."
+<P>put in mtof~, etc.</P>
 
-<P> bug fix in exporting patches to Max
+<P>made Pd search the "extra" directory without having to specify it in "path."</P>
 
-<P> ------------------ 0.32 PATCH 5 -------------------
+<P>bug fix in exporting patches to Max</P>
 
-<P> Reversed the order of these release notes so that the newest appear first.
 
-<P> Arrays can save their content with containing patch; the properties
+</div></section><section class="releasenote"><h4 id="0.32 PATCH 5">0.32 PATCH 5</h4><div>
+
+<P>Reversed the order of these release notes so that the newest appear first.</P>
+
+<P>Arrays can save their content with containing patch; the properties
 dialog selects this.  The dialog shows up when you create a new array from
 the menu, and allows you to set the name and size.  Only floating point arrays
-can be created and edited this way.
+can be created and edited this way.</P>
 
-<P> Bug fix: the figures in the NT web doc were garbage.
+<P>Bug fix: the figures in the NT web doc were garbage.</P>
 
-<P> Bug fix: large tables (> 800 pixels and points) no longer crash the GUI.
+<P>Bug fix: large tables (> 800 pixels and points) no longer crash the GUI.
 A related problem remains; large arrays are truncated to either 1000 points
-or 1000 pixels.
+or 1000 pixels.</P>
 
-<P> Bug fix: doing "save as" on an instantiated abstraction no longer sets
-the window title.
+<P>Bug fix: doing "save as" on an instantiated abstraction no longer sets
+the window title.</P>
 
-<P> in linux, a couple of status messages on opening /dev/dsp only appear now
-if Pd is run "-verbose".
+<P>in linux, a couple of status messages on opening /dev/dsp only appear now
+if Pd is run "-verbose".</P>
 
 
-<BR> <BR>
-<P> ------------------ 0.32 PATCH 2, 3, 4 -------------------
+</div></section><section class="releasenote"><h4 id="0.32 PATCH 2, 3, 4">0.32 PATCH 2, 3, 4</h4><div>
 
-<P> Hassled more with font size differences between NT and Linux, and updated
-many help files.  Minor bug fixes here and there.
+<P>Hassled more with font size differences between NT and Linux, and updated
+many help files.  Minor bug fixes here and there.</P>
 
-<P> the table object now takes a second argument to set size in points.
+<P>the table object now takes a second argument to set size in points.</P>
 
-<P> Improved underflow protection in some DSP objects.
+<P>Improved underflow protection in some DSP objects.</P>
 
-<P> pointer now has a "vnext" traversal method which goes forward to the
-next SELECTED object.
+<P>pointer now has a "vnext" traversal method which goes forward to the
+next SELECTED object.</P>
 
-<P> improvements to throw~ (it now sums) and receive~ fixed to be settable.
+<P>improvements to throw~ (it now sums) and receive~ fixed to be settable.</P>
 
-<P> bug fix in which RME driver always thought sample rate was 44100.
+<P>bug fix in which RME driver always thought sample rate was 44100.</P>
 
-<BR> <BR>
-<P> ------------------ 0.32 PATCH 1 -------------------
 
-<P> bug fixes (bugs flagged by mik): vcf~ help window crashed; writesf~
+</div></section><section class="releasenote"><h4 id="0.32 PATCH 1">0.32 PATCH 1</h4><div>
+
+<P>bug fixes (bugs flagged by mik): vcf~ help window crashed; writesf~
 only wrote 1 channel soundfiles; "table" object didn't open when clicked
-on;
+on;</P>
 
-<P> new object: tabosc4~ -- finally, a real wavetable oscillator for Pd.
+<P>new object: tabosc4~ -- finally, a real wavetable oscillator for Pd.</P>
 
-<P> much work on "data" editing; go to 7.stuff/data-structures, open patches
+<P>much work on "data" editing; go to 7.stuff/data-structures, open patches
 5 and 7, and try clicking on things.  Alt clicks delete or add points; regular
 clicks drag values around.  The cursor changes to show you what will happen
-if you click.
+if you click.</P>
 
-<BR> <BR>
-------------------- 0.32 -----------------
 
-<P> <strong> New objects: </strong>
+</div></section><section class="releasenote"><h4 id="0.32">0.32</h4><div>
 
-<P> midiin, sysexin, midiout.  (I don't think MIDI sysex is working
-in Windows yet though.)
+<P><strong> New objects: </strong></P>
 
-<P> threshold~ as in Jmax, triggers from audio level.
+<P>midiin, sysexin, midiout.  (I don't think MIDI sysex is working
+in Windows yet though.)</P>
 
-<P> value as in Max and Jmax.
+<P>threshold~ as in Jmax, triggers from audio level.</P>
 
-<P> writesf as in Jmax.
+<P>value as in Max and Jmax.</P>
 
-<P> <strong> New startup flags: </strong>
+<P>writesf as in Jmax.</P>
 
-<P> -sleepgrain: if you aren't using audio I/O, this can reduce time jitter in
-MIDI I/O.  Otherwise, MIDI I/O jitter is limited by the audio buffer size.
+<P><strong> New startup flags: </strong></P>
 
-<P> -noloadbang: cancels loadbangs.
+<P>-sleepgrain: if you aren't using audio I/O, this can reduce time jitter in
+MIDI I/O.  Otherwise, MIDI I/O jitter is limited by the audio buffer size.</P>
 
-<P> -nogui: suppress starting the GUI.  You can then still talk to Pd using,
+<P>-noloadbang: cancels loadbangs.</P>
+
+<P>-nogui: suppress starting the GUI.  You can then still talk to Pd using,
 perhaps among other possibilities, the new network connection programs now
-included in the release.
+included in the release.</P>
 
-<P> -guicmd: lets you specify the command string Pd calls to start the GUI,
-in case you've written your own GUI to replace the TK one Pd comes with.
+<P>-guicmd: lets you specify the command string Pd calls to start the GUI,
+in case you've written your own GUI to replace the TK one Pd comes with.</P>
 
-<P> -send: after loading all the patches specified in the command line,
+<P>-send: after loading all the patches specified in the command line,
 you can specify "startup" messages to send.  For example, if you want to use
 Pd just to play 50-channel soundfiles from a shell, this is how you can specify
-the soundfile name on the command line.
+the soundfile name on the command line.</P>
 
-<P> <strong> bug fixes. </strong>
+<P><strong> bug fixes. </strong></P>
 
-<P> A readsf~ problem got fixed.
+<P>A readsf~ problem got fixed.</P>
 
-<P> hitting the tab key used to cause Pd windows to relinquish the keyboard.
+<P>hitting the tab key used to cause Pd windows to relinquish the keyboard.</P>
 
-<P> The $0 feature appears now to work.
+<P>The $0 feature appears now to work.</P>
 
-<P> Inlets and outlets of subpatches sometimes got out of left-to-right order.
+<P>Inlets and outlets of subpatches sometimes got out of left-to-right order.</P>
 
-<P> Scrollbars are less out of whack than they were before.
+<P>Scrollbars are less out of whack than they were before.</P>
 
-<P> Pd now knows to de-iconify windows if you "vis" them from the parent.
+<P>Pd now knows to de-iconify windows if you "vis" them from the parent.</P>
 
-<P>  <strong> in general: </strong>
+<P> <strong> in general: </strong></P>
 
-<P> In Linux the treatment of MIDI input is now much more efficient.  Also,
-bugs were fixed in notein and (for SGI) bendin.
+<P>In Linux the treatment of MIDI input is now much more efficient.  Also,
+bugs were fixed in notein and (for SGI) bendin.</P>
 
-<P> You can "select all" from the Edit menu.
+<P>You can "select all" from the Edit menu.</P>
 
-<P> standalone programs "pd-send" and "pd-receive" are provided that can send
+<P>standalone programs "pd-send" and "pd-receive" are provided that can send
 messages to Pd or receive messages from Pd via the netsend~ and netreceive~
 objects.  This should allow you to interface a wide variety of other programs
 with Pd either on the same machine or over the network.  Also you should be
 able to hack the code into your own programs to make them interoperate with
-Pd and/or each other.  The underlying protocol is called FUDI.
+Pd and/or each other.  The underlying protocol is called FUDI.</P>
 
-<P> "Properties" for scalars, graphs, and number boxes: left click on them.
+<P>"Properties" for scalars, graphs, and number boxes: left click on them.
 In particular, number boxes can have fixed widths and finite ranges; if you
 make them one character wide they act as toggles.  Later you'll be able to
-configure them as sliders.
+configure them as sliders.</P>
 
-<P> As to scalars, the properties dialog lets you edit the data in the raw.
-Don't try to edit the template though; you can't.
+<P>As to scalars, the properties dialog lets you edit the data in the raw.
+Don't try to edit the template though; you can't.</P>
 
-<P> You can now type into a "pd" object to change its name without losing the
-contents.
+<P>You can now type into a "pd" object to change its name without losing the
+contents.</P>
 
-<P> An experimental "scalar" _text_ object now allows abstractions to draw
+<P>An experimental "scalar" _text_ object now allows abstractions to draw
 primitive control panels on their parents when you invoke them, as if they were
-Moog or Buchla modules.  See the "7.stuff/data" examples.
+Moog or Buchla modules.  See the "7.stuff/data" examples.</P>
 
-<P> New help windows for the "data" classes (pointer, append, template, etc.)
-and for send/receive which somehow I had neglected.
+<P>New help windows for the "data" classes (pointer, append, template, etc.)
+and for send/receive which somehow I had neglected.</P>
 
-<P> When you hit "copy" with nothing selected, the copy buffer used to be
-cleared.  This is fixed to do nothing.
+<P>When you hit "copy" with nothing selected, the copy buffer used to be
+cleared.  This is fixed to do nothing.</P>
 
-<BR> <BR>
-------------------- 0.31 -----------------
 
-<P> ALSA support in Linux has been completely overhauled.  It now works with
+</div></section><section class="releasenote"><h4 id="0.31">0.31</h4><div>
+
+<P>ALSA support in Linux has been completely overhauled.  It now works with
 Midiman (up to 10 in/12 out!) and es1370.  There are problems with SBLive under
 ALSA but it works in OSS emulation with a "-frags" setting. See the "getting
-started" documentation.
+started" documentation.</P>
 
-<P> In NT, the default is now "noresync" if you're running stereo.  You can
+<P>In NT, the default is now "noresync" if you're running stereo.  You can
 override this with the "-resync" flag.  If you're running more than 2 channels
-it's the opposite (as it was before.)
+it's the opposite (as it was before.)</P>
 
-<P> "symbol" boxes now display symbols and let you type them in.
+<P>"symbol" boxes now display symbols and let you type them in.</P>
 
-<P> There was a bug when you renamed a patch from outside Pd; the old filename
-still showed in the title bar (and there were other bad side effects.)   Fixed.
+<P>There was a bug when you renamed a patch from outside Pd; the old filename
+still showed in the title bar (and there were other bad side effects.)   Fixed.</P>
 
-<P> Protection was added against patches opening themselves as abstractions.
+<P>Protection was added against patches opening themselves as abstractions.</P>
 
-<P> The "route" object's handling of leading symbols was improved.  I'm not
-sure whether it's Max compatible or not.
+<P>The "route" object's handling of leading symbols was improved.  I'm not
+sure whether it's Max compatible or not.</P>
 
-<P> You can draw into arrays with the mouse, at least in the case where there's
+<P>You can draw into arrays with the mouse, at least in the case where there's
 at least one pixel per point.  (I'm not sure if the other case even makes
-sense.)
+sense.)</P>
 
-<P> Abstractions display their "$1", etc., arguments in the window title bar.
+<P>Abstractions display their "$1", etc., arguments in the window title bar.</P>
 
-<P> A "sort" method was added for lists to make them easier to use as
-sequencers.
+<P>A "sort" method was added for lists to make them easier to use as
+sequencers.</P>
 
-<P> The "save as" dialog makes a more reasonable choice of start-up directory.
+<P>The "save as" dialog makes a more reasonable choice of start-up directory.</P>
 
-<P> "Trigger i" is now disallowed (it used to crash Pd.)
+<P>"Trigger i" is now disallowed (it used to crash Pd.)</P>
 
-<P> Getbytes and resizebytes now zero out new memory.
+<P>Getbytes and resizebytes now zero out new memory.</P>
 
-<P> A memory leak reported by Hannes has been partly, hopefully mostly, fixed.
+<P>A memory leak reported by Hannes has been partly, hopefully mostly, fixed.</P>
 
-<P> The "signal_free 2" bug reported by Fogar is fixed.
+<P>The "signal_free 2" bug reported by Fogar is fixed.</P>
 
-<P> New graphs now reliably avoid using already-taken "graph%d" names.
+<P>New graphs now reliably avoid using already-taken "graph%d" names.</P>
 
-<P> The old bug which showed up as ".xxxxxxxxx: no such object" is fixed.
+<P>The old bug which showed up as ".xxxxxxxxx: no such object" is fixed.</P>
 
-<P> The FFT examples have been reworked and the "pique" and "shift" objects
-are moved to "extra".
+<P>The FFT examples have been reworked and the "pique" and "shift" objects
+are moved to "extra".</P>
 
-<BR> <BR>
-------------------- 0.30 -----------------
-<P> in Linux, you can get Pd to promote itself to "real time" priority.
+
+</div></section><section class="releasenote"><h4 id="0.30">0.30</h4><div>
+
+<P>in Linux, you can get Pd to promote itself to "real time" priority.
 A "watchdog" process protects you from having Pd lock your machine up.  You
 must request real time by running "pd -rt" or "pd -realtime".  You must  either
 be superuser or make Pd a root-owned SETUID program (chown root .../pd/bin/pd;
 chmod 4755 .../pd/bin/pd).  For security reasons, Pd relinquishes root
 privilege immediately after setting its priority, before loading
-any patches or externs.
+any patches or externs.</P>
 
-<P> Protection was added against message loops.
+<P>Protection was added against message loops.</P>
 
-<P> loadbang was fixed so that loadbangs in abstractions go off before loadbangs
-in the owner patch.  Within each patch, loadbangs go off first in subpatches.
+<P>loadbang was fixed so that loadbangs in abstractions go off before loadbangs
+in the owner patch.  Within each patch, loadbangs go off first in subpatches.</P>
 
-<P> new object: tabplay~, a non-interpolating sample reader.
+<P>new object: tabplay~, a non-interpolating sample reader.</P>
 
-<P> new objects (in "extra" library): loop~; rev1~.
+<P>new objects (in "extra" library): loop~; rev1~.</P>
 
-<P> The "toys" library was renamed "extra" and incorporated in the Pd release.
+<P>The "toys" library was renamed "extra" and incorporated in the Pd release.</P>
 
-<P> In Linux, timeouts were added to the driver opening and closing code
-(which used to hang under some conditions.)
+<P>In Linux, timeouts were added to the driver opening and closing code
+(which used to hang under some conditions.)</P>
 
-<P> the "field" object was replaced by "template"; see "data.structures"
-examples in 7.stuff.  Data lists can be read from and written to files now.
+<P>the "field" object was replaced by "template"; see "data.structures"
+examples in 7.stuff.  Data lists can be read from and written to files now.</P>
 
-<P> You can invoke an external object by pathname, as in "../../extra/loop~".
+<P>You can invoke an external object by pathname, as in "../../extra/loop~".</P>
 
-<P> hip~, etc. should no longer get stuck when they get a NAN on input.
+<P>hip~, etc. should no longer get stuck when they get a NAN on input.</P>
 
-<P> a bug was fixed in expanding symbols such as "$1-foo".
+<P>a bug was fixed in expanding symbols such as "$1-foo".</P>
 
-<BR> <BR>
-------------------- 0.29 -----------------
 
-<P> readsf~ - a MAX/FTS style soundfile player, which reads multichannel
+</div></section><section class="releasenote"><h4 id="0.29">0.29</h4><div>
+
+<P>readsf~ - a MAX/FTS style soundfile player, which reads multichannel
 soundfiles in wave, aiff, or next formats.  The files must be 16 or 24 bit
 fixed point or 32 bit floating point (only nextstep headers understand the
 latter.) You can also override the header.  A "skip" flag lets you read
 starting anywhere in the file.  (Sorry: linux only for now; I can't find
-Posix threads packages for the other platforms.)
+Posix threads packages for the other platforms.)</P>
 
-<P> soundfiler - support for reading and writing soundfiles (wave, aiff,
+<P>soundfiler - support for reading and writing soundfiles (wave, aiff,
 nextstep) to and from arrays.  Multichannel soundfiles can be read into or
 written from several arrays at once.  When reading you can ask that the tables
 be automatically resized; in any event the object obligingly outputs the number
 of samples actually read.  When writing you can specify a sub-segment of the
 arrays, and/or request that the soundfile's maximum amplitude be normalized to
-one.
+one.</P>
 
-<P> tabplay~ - a non-interpolating sample player
+<P>tabplay~ - a non-interpolating sample player</P>
 
-<P> Garry Kling reports having compiled Pd for "yellowdog" linux on Macintosh
+<P>Garry Kling reports having compiled Pd for "yellowdog" linux on Macintosh
 computers.  One "fix" has been made to s_linux.c to facilitate this.  I don't
 have access to a Mac running linux at the moment so I can't verify whether
-any particular release of mine actually works there.
+any particular release of mine actually works there.</P>
 
-<P> Signal objects now automatically convert scalars to vectors, so that you
+<P>Signal objects now automatically convert scalars to vectors, so that you
 can just run a number box into a signal input.  One caveat is that the binops
 "+~", "-~", "*~", "/~", "max~", "min~" run slightly faster if you give them
 an argument to tell them that their right inlet will be scalar; so the
 construction "+~ 0" is still meaningful.  This will get fixed at some later
-date...
+date...</P>
 
-<P> Font sizes work in what I hope will be a more machine-portable way.  On
+<P>Font sizes work in what I hope will be a more machine-portable way.  On
 any machine, the point sizes 8, 10, 12, 14, 16, 24 are DEFINED to be the
 largest fonts Pd can find that don't exceed their size on my linux machine.
 This way I can write patches that everyone else can read, and others will
 at least have fewer portability problems than before.  The downside is that
 your old patches may appear with a different type size than you want; use the
-"font" menu item to fix them.
+"font" menu item to fix them.</P>
 
-<P> The OSS support no longer asks the audio driver whether full duplex
+<P>The OSS support no longer asks the audio driver whether full duplex
 is needed; it just tries to open it.  Apparently some drivers (such as
 ALSA's OSS emulation) might do full duplex but not implement the call Pd
-used to query for it.
+used to query for it.</P>
 
-<P> You can give "-nomidi" as a flag (previously you had to type "-nomidiin
--nomidiout".)
+<P>You can give "-nomidi" as a flag (previously you had to type "-nomidiin
+-nomidiout".)</P>
 
-<P> A GUI bug reported by Iain Mott was fixed.
+<P>A GUI bug reported by Iain Mott was fixed.</P>
 
-<P> You can now type symbols such as "$3-poodle" and the "$3" portion gets
+<P>You can now type symbols such as "$3-poodle" and the "$3" portion gets
 expanded properly.  Someone was also asking about the FTS-style #0 feature,
 but I couldn't figure out how to reconcile it with Pd's usage of "$" for "#"
 in abstractions.  So I'm still searching for a good way to provide local
-symbols.
+symbols.</P>
 
-<P> the GUI now protects itself from "\", "{" and "}" characters by dropping
+<P>the GUI now protects itself from "\", "{" and "}" characters by dropping
 them.  I wonder how many NT users have crashed Pd trying to type in filenames
-with backslashes...
+with backslashes...</P>
 
-<P> samphold_set and tabwrite_stop methods added.  There turned out to be
-no help window for samphold~ so one was supplied.
+<P>samphold_set and tabwrite_stop methods added.  There turned out to be
+no help window for samphold~ so one was supplied.</P>
 
-<BR> <BR>
-------------------- 0.28 -----------------
 
-<P> Version 0.28 has a primitive in-box text editor... about time!
+</div></section><section class="releasenote"><h4 id="0.28">0.28</h4><div>
 
-<P> the "front panel" now gives you information on audio levels and
-sync errors.
+<P>Version 0.28 has a primitive in-box text editor... about time!</P>
 
-<P> Message boxes flash, sort of, when you click them.
+<P>the "front panel" now gives you information on audio levels and
+sync errors.</P>
+
+<P>Message boxes flash, sort of, when you click them.</P>
 
 <P>
 Support has been added for RME 9652 soundcards; see the Linux soundcard section of
 the documentation.  Support files for RME and PCI128 (Ensoniq es1370) cards
-are released separately from Pd.
+are released separately from Pd.</P>
 
-<P> The delete and backspace keys clear the current selection.  There is
+<P>The delete and backspace keys clear the current selection.  There is
 unfortunately no "undo" though; I'm not sure this is a good thing to have
-put in.
+put in.</P>
 
-<P> The "until" object has a "float" method which limits the number of bangs
-it will output.
+<P>The "until" object has a "float" method which limits the number of bangs
+it will output.</P>
 
-<P> The audio setup is better documented for NT and Linux.
+<P>The audio setup is better documented for NT and Linux.</P>
 
-<P> The externs in 4.fft and 6.externs got recompiled and tested.
+<P>The externs in 4.fft and 6.externs got recompiled and tested.</P>
 
-<P> BUG FIX: the "read16" message to tables was broken on NT and is now fixed.
+<P>BUG FIX: the "read16" message to tables was broken on NT and is now fixed.</P>
 
-<P> BUG FIX: In Linux, starting Pd up sometimes changed the audio mixer
-setting.
+<P>BUG FIX: In Linux, starting Pd up sometimes changed the audio mixer
+setting.</P>
 
-<P> BUG FIX: sending "floats" to inlets expecting lists now works correctly.
+<P>BUG FIX: sending "floats" to inlets expecting lists now works correctly.</P>
 
-<P> BUG FIX: "route" on symbols now deals better with symbols, floats and lists.
+<P>BUG FIX: "route" on symbols now deals better with symbols, floats and lists.</P>
 
-<BR> <BR>
-------------------- 0.27 -----------------
+
+</div></section><section class="releasenote"><h4 id="0.27">0.27</h4><div>
+
 <P>
 The main new feature is the "find" menu stuff.  You can search for boxes
 containing specified atoms, including semicolons or commas.  Most errors are
-now trackable, allowing you to "find last error".  Look in the "Find" menu.
+now trackable, allowing you to "find last error".  Look in the "Find" menu.</P>
 
 <P>
-New objects written: change, max, max~, min, min~, and swap.
+New objects written: change, max, max~, min, min~, and swap.</P>
 
 <P>
 I looked in 0.INTRO.txt in 5.reference, and found that the objects
-bag, cputime, realtime, pipe, symbol, poly, and bang were missing.
+bag, cputime, realtime, pipe, symbol, poly, and bang were missing.</P>
 
 <P>
-Five or six bug fixes.
+Five or six bug fixes.</P>
 
 <P>
 Some audio problems in 0.25 were addresses.  In Linux, audio drivers that
 don't support the GETISPACE/GETOSPACE ioctl calls can be called using the
 (inferior) "-frags/-fragsize" mechanism.  If you specify either a "-frags"
-or a "-fragsize" option, the GETIOSPACE calls are cancelled.
+or a "-fragsize" option, the GETIOSPACE calls are cancelled.</P>
 
 <P>
 Under NT, for some audio drivers the 0.26 release gave a constant stream of
 "resync" events.  I don't know what causes this but I added a "-noresync"
-option which simply never resyncs at all.
+option which simply never resyncs at all.</P>
 
-<BR> <BR>
-------------------- 0.26 -----------------
+
+</div></section><section class="releasenote"><h4 id="0.26">0.26</h4><div>
+
 <P>
 phasor~ and osc~ can be configured to take floating point messages to set
 their frequencies,  as an alternative to having an input signal to do the
 same.  Also, +~, etc, can take floating point arguments (and messages) to
 add or multiply scalars.  The +~, etc, loops were unrolled to make them
-run faster.
+run faster.</P>
 
 <P>
 A switch~ object is provided to let you switch sub-patches on and off.  The
 inlet~ and outlet~ objects were re-written to avoid adding any overhead when
-moving signals in or out of sub patches.
+moving signals in or out of sub patches.</P>
 
 <P>
 In Linux at least, the audio latency is much reduced.  It's possible to poll
-for audio I/O lateness errors by sending "pd audiostatus".
+for audio I/O lateness errors by sending "pd audiostatus".</P>
 
 <P>
 When reading a sample using tabread4~, you can switch between sample tables
-using the "set" message.
+using the "set" message.</P>
 
 <P>
-A new "textfile" object is like qlist but more flexible.
+A new "textfile" object is like qlist but more flexible.</P>
 
 <P>
-Many help windows got updated (but at least a dozen more need work urgently).
+Many help windows got updated (but at least a dozen more need work urgently).</P>
 
 <P>
 A dsp_addv function was added to allow variable-length DSP calls (for writers
-of tilde externs.)
+of tilde externs.)</P>
 
 <P>
 It's possible for a tilde extern to have a name ending in "tilde" now.  Name
-the setup routine "foo_tilde" for "foo~", etc.
+the setup routine "foo_tilde" for "foo~", etc.</P>
 
 <P>
 The dac~ object was fixed to clip its output when out of    range (before it
-wrapped around.)
+wrapped around.)</P>
 
 <P>
 A first line of protection was added against getting numerical underflow
 in delay feedback loops.  Before, when a reverberator tailed out there was
 a sudden jump in CPU usage because the numerical underflows would trap to the
 kernel.  Now, if any delwrite~ is given a value less than 1e-20 or so, it
-records a true zero to avoid this.
+records a true zero to avoid this.</P>
 
 <P>
-Signal division checks for divide by zero.
+Signal division checks for divide by zero.</P>
 
 <P>
 A "Font bomb" feature is provided for resizing fonts and stretching and
-contracting patches to fit.
+contracting patches to fit.</P>
 
 <P>
-Pds now bind themselves to the symbol pd-&lt;window-name).
+Pds now bind themselves to the symbol pd-&lt;window-name).</P>
 
 <P>
 IN Linux, if Pd is called as root it tries to promote its run-time
 priority.  You can make pd a setuid root owned program if you want this
 behavior for non-root users who start pd.
 (Don't make pd-gui setuid though.  That would make a security
-hole in your system.)
+hole in your system.)</P>
 
 <P>
-The Pd command line can take multiple "open" arguments.
+The Pd command line can take multiple "open" arguments.</P>
 
 <P>
-The file search path feature was fixed and generalized.
+The file search path feature was fixed and generalized.</P>
 
 <P>
 Alt-clicking a table gives you a dialog to set its x and y range and pixel
-size.
+size.</P>
 
-<BR> <BR>
-------------------- 0.25 -----------------
+
+</div></section><section class="releasenote"><h4 id="0.25">0.25</h4><div>
+
 <P>
-Lots of minor, under-the-hood improvements and bug fixes...
+Lots of minor, under-the-hood improvements and bug fixes...</P>
+
 <P>
 The Netsend/netreceive objects were improved; you can now choose between UDP
-and TCP and there's an outlet to tell you whether they're connected.
+and TCP and there's an outlet to tell you whether they're connected.</P>
+
 <P>
 You can now alt click on an object to get its help window (and the help
-windows got a fair amount of work.)
+windows got a fair amount of work.)</P>
+
 <P>
 multichannel audio I/O -- you can get up to 8 audio channels in and out.
 On SGI this is done correctly; on NT it's done using sequential "stereo"
-devices.  I'm not sure of the status of multichannel in linux...
-<P>
-The "text" window got new accelerators and a bigger font size
-<P>
-there are 3 "tool" patches in 7.stuff: filtering, pvoc, ring mod.
-<P>
-In NT, command-line backslashes are converted to forward slashes.
-<P>
-There's a load measurement tool in the "help" menu.
-<P>
-The SGI version contains an n32 binary (look at the "bin" directory).
+devices.  I'm not sure of the status of multichannel in linux...</P>
 
-<BR> <BR>
-------------------- 0.24 ---------------
+<P>
+The "text" window got new accelerators and a bigger font size</P>
+
+<P>
+there are 3 "tool" patches in 7.stuff: filtering, pvoc, ring mod.</P>
+
+<P>
+In NT, command-line backslashes are converted to forward slashes.</P>
+
+<P>
+There's a load measurement tool in the "help" menu.</P>
+
+<P>
+The SGI version contains an n32 binary (look at the "bin" directory).</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.24">0.24</h4><div>
+
 <P>
 new objects:
-<BR> - bang - convert any message to a "bang"
-<BR> - qlist -      message sequencer
-<BR> - textfile -   file to message converter
-<BR> - makefilename - format a name with a variable field
-<BR> - openpanel - "Open" dialog
-<BR> - savepanel - "Save as" dialog
+<UL>
+<LI>bang - convert any message to a "bang"</LI>
+<LI>qlist -      message sequencer</LI>
+<LI>textfile -   file to message converter</LI>
+<LI>makefilename - format a name with a variable field</LI>
+<LI>openpanel - "Open" dialog</LI>
+<LI>savepanel - "Save as" dialog</LI>
+</UL></P>
+
 <P>
 Bug fixes:
-<BR> - Fixed a bug in "const" message to arrays
-<BR> - "exp" was broken on NT, now fixed
-<BR> - phase vocoder example improved
-<BR> - "read" message to arrays now zero out unread samples
-<BR> - bug fix in "key" object
-<BR> - bug fix in ifft~ (thanks to Peter Lunden)
-<BR> - "print" object fixed to distinguish between lists starting with symbols and
-    other messages
-<BR> - polygon, curve, fpolygon, fcurve renamed to fix name clash with Gem
-<BR> - improved "new object" placement on screen
-<BR> - fixed help dialog to remember previous directory (thanks to Harry Castle)
-<BR> - heterogeneous lists
+<UL>
+<LI>Fixed a bug in "const" message to arrays</LI>
+<LI>"exp" was broken on NT, now fixed</LI>
+<LI>phase vocoder example improved</LI>
+<LI>"read" message to arrays now zero out unread samples</LI>
+<LI>bug fix in "key" object</LI>
+<LI>bug fix in ifft~ (thanks to Peter Lunden)</LI>
+<LI>"print" object fixed to distinguish between lists starting with symbols and
+    other messages</LI>
+<LI>polygon, curve, fpolygon, fcurve renamed to fix name clash with Gem</LI>
+<LI>improved "new object" placement on screen</LI>
+<LI>fixed help dialog to remember previous directory (thanks to Harry Castle)</LI>
+<LI>heterogeneous lists</LI>
+</UL></P>
+
 <P>
 
 Arrays can be written to and read from text files or from 16-bit
-binary files.  See ../2.starter/2G for an overview.
+binary files.  See ../2.starter/2G for an overview.</P>
+
 <P>
 
 Guenter Geiger has contributed a Max-style "table" object which
-creates an "array" object in a subwindow.
+creates an "array" object in a subwindow.</P>
+
 <P>
 
 Guenter has also put in a "search path" feature for externs, abstractions,
-etc.
+etc.</P>
+
 <P>
 
-The Help menu got reworked.
+The Help menu got reworked.</P>
+
 <P>
 
-Select and Route were extended to work Zack-style with symbols.
+Select and Route were extended to work Zack-style with symbols.</P>
+
 <P>
 
-"random" takes seeds now (see the "help" window)
+"random" takes seeds now (see the "help" window)</P>
+
 <P>
 
 Some more work on graphical lists; you can see the current state in
-../7.stuff/data-structures.  It's still nascent.
+../7.stuff/data-structures.  It's still nascent.</P>
 
-------------------- 0.23 -------------------
+
+</div></section><section class="releasenote"><h4 id="0.23">0.23</h4><div>
+
 <P>
 A first cut at the "pure data" feature is now included.  See section 6
 of the documentation for a quick introduction to it; see also patches 12 and
-14 in the FFT examples.
+14 in the FFT examples.</P>
+
 <P>
 The documentation has been reorganized.  The most interesting new features are:
-<BR> - some new "tutorial" patches
-<BR> - 15 "fft" examples
-<BR> - improved help navigation
+<UL>
+<LI>some new "tutorial" patches</LI>
+<LI>15 "fft" examples</LI>
+<LI>improved help navigation</LI>
+</UL></P>
+
 <P>
-more bug fixes:
-<BR> - titles on abstractions no longer saved inside file
-<BR> - left-to-right sorting of inlets/outlets now seems to work
-<BR> - nt audio setup got confused when driver couldn't do full duplex
-<BR> - opening window with audio on is now fixed
-<BR> - deleting inlets/outlets deletes connections first (used to crash)
-<BR> - 1e20 parsed correctly now
-<BR> - osc1~ fixed and optimized
-<BR> - resizing arrays with DSP on used to crash; now fixed
-<BR> - pasting now adds to the end of the list (used to add to beginning)
-<BR> - clicking now selects the most recent object when two or more overlap
-<BR> - Pd's "open" and "help" dialogs now maintain separate paths
+  more bug fixes:
+<UL>
+<LI>titles on abstractions no longer saved inside file</LI>
+<LI>left-to-right sorting of inlets/outlets now seems to work</LI>
+<LI>nt audio setup got confused when driver couldn't do full duplex</LI>
+<LI>opening window with audio on is now fixed</LI>
+<LI>deleting inlets/outlets deletes connections first (used to crash)</LI>
+<LI>1e20 parsed correctly now</LI>
+<LI>osc1~ fixed and optimized</LI>
+<LI>resizing arrays with DSP on used to crash; now fixed</LI>
+<LI>pasting now adds to the end of the list (used to add to beginning)</LI>
+<LI>clicking now selects the most recent object when two or more overlap</LI>
+<LI>Pd's "open" and "help" dialogs now maintain separate paths</LI>
+</UL></P>
+
 <P>
 The phasor~ object's "float" method has been REMOVED -- use the right-hand
 inlet to set the internal phase.  This is so that I can later fix all tilde
-objects to convert messages to signals automatically at all signal inputs.
+objects to convert messages to signals automatically at all signal inputs.</P>
 
-<BR> <BR>
-------------------- 0.22 -------------------
-<BR>
+
+</div></section><section class="releasenote"><h4 id="0.22">0.22</h4><div>
+<P>
 bug fixes
-<BR> - parsing 1e+006 gave symbol (now float)
-<BR> - "." parsed as number, should be symbol
-<BR> - change GUI polling loop to TK event dispatch (unix only)
-<BR> - improved "tidy up" feature
-<BR> - size check added to text boxes (used to crash; still not correct.)
-<BR> - occasional bug sending text with CRs to tk
-<BR> - binop startup bug
-<BR> - key accelerators for creators wrong
-<BR> - ftom range to 1500
-<BR> - bug in pack, unpack
-<BR> - windows restore bigger than saved
-<BR>
-<BR>
+<UL>
+<LI>parsing 1e+006 gave symbol (now float)</LI>
+<LI>"." parsed as number, should be symbol</LI>
+<LI>change GUI polling loop to TK event dispatch (unix only)</LI>
+<LI>improved "tidy up" feature</LI>
+<LI>size check added to text boxes (used to crash; still not correct.)</LI>
+<LI>occasional bug sending text with CRs to tk</LI>
+<LI>binop startup bug</LI>
+<LI>key accelerators for creators wrong</LI>
+<LI>ftom range to 1500</LI>
+<LI>bug in pack, unpack</LI>
+<LI>windows restore bigger than saved</LI>
+</UL>
+</P>
 
+<P>
 Nt-specific bug fixes:
-<BR> - getsockopt for netreceive fails.  Just omitted it for NT.
-<BR> - put tcl dlls in tcl bin, not pd bin
-<BR> --- archive tcl subsystem for easier version updates
-<BR> --- fix README accordingly
-<BR> - deal with bell sound
-<BR> - turn on optimization
-<BR> - looked for audio timeout bug but couldn't find it.
-<BR> <BR>
+<UL>
+<LI>getsockopt for netreceive fails.  Just omitted it for NT.</LI>
+<LI>put tcl dlls in tcl bin, not pd bin</LI>
+  <UL>
+    <LI>archive tcl subsystem for easier version updates</LI>
+    <LI>fix README accordingly</LI>
+  </UL>
+<LI>deal with bell sound</LI>
+<LI>turn on optimization</LI>
+<LI>looked for audio timeout bug but couldn't find it.</LI>
+</UL>
+</P>
 
-------------------- 0.21 -------------------
+
+</div></section><section class="releasenote"><h4 id="0.21">0.21</h4><div>
 
 <P>
 bug fixes:
 
-<P>
-table size change with DSP on:  It used to crash Pd to resize an array
-when DSP was turned on.  This is now fixed.
+<P>table size change with DSP on:  It used to crash Pd to resize an array
+when DSP was turned on.  This is now fixed.</P>
 
-<P>
-deselect all when locking.  When you lock a patch the selection is cleared.
+<P>deselect all when locking.  When you lock a patch the selection is cleared.</P>
 
-<P>
-unlock when pasting.  .. and if you paste into a pastch, it's unlocked.
+<P>unlock when pasting.  .. and if you paste into a pastch, it's unlocked.</P>
 
-<P>
+<P>lost keyboard events.  Version 0.20 lost keyboard events and
+forgot window size changes.  This should now be fixed.</P>
 
-lost keyboard events.  Version 0.20 lost keyboard events and
-forgot window size changes.  This should now be fixed.
-
-<BR> subpatches came up in wrong font size
-<BR> dirty flag on window title bar fixed
-<BR> improvement to netreceive suggested by Mark Danks
-<BR> style notes fleshed out as suggested by Larry Troxler
-<BR> fixed Bill Kleinsasser's bug (short and long array in same graph)
+<P> subpatches came up in wrong font size</P>
+<P> dirty flag on window title bar fixed</P>
+<P> improvement to netreceive suggested by Mark Danks</P>
+<P> style notes fleshed out as suggested by Larry Troxler</P>
+<P> fixed Bill Kleinsasser's bug (short and long array in same graph)</P>
+</P>
 
 <P>
 new features:
 
-<BR> phase setting for phasor~
-<BR> fft objects.  Also, block~, for specifying block sizes and overlaps for FFTs.
-<BR> canvas_makefilename() (used, e.g.,  by array_read and write)
-<BR> "stuff" directory with examples of real Pd applications.
+<P> phase setting for phasor~</P>
+<P> fft objects.  Also, block~, for specifying block sizes and overlaps for FFTs.</P>
+<P> canvas_makefilename() (used, e.g.,  by array_read and write)</P>
+<P> "stuff" directory with examples of real Pd applications.</P>
+</P>
 
-<BR> <BR>
-------------------- 0.20 -------------------
+
+</div></section><section class="releasenote"><h4 id="0.20">0.20</h4><div>
 
 <P>
 In NT, the 0.19 release turned out not to contain all the files needed to make
-TCL run.  This problem should now be fixed.
+TCL run.  This problem should now be fixed.</P>
 
 <P>
-Also, the array_write routine was fixed.
+Also, the array_write routine was fixed.</P>
 
-<BR> <BR>
-------------------- 0.19 -------------------
 
-<BR>
+</div></section><section class="releasenote"><h4 id="0.19">0.19</h4><div>
+
+<P>
 notable new objects:
 
-<BR>
-- vcf~, a band-pass filter with a signal input for center frequency.
-<BR>
-- delread, delwrite, vd, as in ISPW Max.
-<BR>
-- various math and midi stuff
-<BR>
-- catch~, throw~, send~, receive~ for nonlocal signal connections
+<UL>
+<LI> vcf~, a band-pass filter with a signal input for center frequency.</LI>
+<LI> delread, delwrite, vd, as in ISPW Max.</LI>
+<LI> various math and midi stuff</LI>
+<LI> catch~, throw~, send~, receive~ for nonlocal signal connections</LI>
+</UL>
+</P>
+
 <P>
-- an experimental facility for array of floats is included. You can make a new
+an experimental facility for array of floats is included. You can make a new
 array (from the "put" menu) which will be given a name such as "array1".  You
 can then send it "read &lt;file&gt;", "write &lt;file&gt;", "resize &lt;N&gt;", and "print"
 messages.  File reading and writing is in ascii.  "resize" changes the size of
 the array, and "print" prints its vital signs.  You can then use "tabread4~"
 to do a 4-point interpolating table lookup, and tabwrite~ to write audio
-samples into the table.
+samples into the table.</P>
+
 <P>
 Numbers now default to floating point, although certain objects like "spigot"
 and "metro" still convert their boolean inputs to integers so that 0.5 is
 "false." This behavior will probably change later.  The "div" and "mod"
-objects are introduced for explicit integer division and remainder.
+objects are introduced for explicit integer division and remainder.</P>
+
 <P>
 Number boxes drag in integer increments, or in hundredths if you hold the
-"shift" key down when you click.
+"shift" key down when you click.</P>
+
 <P>
 Pd documents now save their font sizes.  The font size is global to an entire
 document.  New documents come up in the font size Pd was started in (using
 the "-font" flag.)  If you want to change the font size of an existing
 document, use a text editor; the font size is the last argument on the first
-line. 8, 10, 12, 14, 16, 18, and 24 are supported.
+line. 8, 10, 12, 14, 16, 18, and 24 are supported.</P>
+
 <P>
-The abbreviations "t," "f," and "i" stand for "trigger,", "float", and "int."
+The abbreviations "t", "f", and "i" stand for "trigger", "float", and "int".</P>
+
 <P>
 Inlets and outlets of subpatches are now sorted correctly; although there is
-still a problem deleting inlets/outlets which have connections.
+still a problem deleting inlets/outlets which have connections.</P>
+
 <P>
-The size and screen location of Pd documents is saved correctly.
+The size and screen location of Pd documents is saved correctly.</P>
+
 <P>
 Tilde objects now work in "subpages" although there is no way to send
-signals through their inlets and outlets; use throw~/catch~ or send~/receive~.
+signals through their inlets and outlets; use throw~/catch~ or send~/receive~.</P>
+
 <P>
 On NT, the default is to open both audio output and input (this used not
 to work.)  The situation is still shaky; audio seems to hang up sporadically
@@ -2230,186 +2340,177 @@ I had to set a huge output FIFO (1/3 sec or so!) to get it to work at all.
 You can type "pd -dac", "pd -adc", or "pd -nosound" to get output only,
 input only, or no audio at all.
 NT's MIDI input and output are supported, but on my machine MIDI output is
-flaky.  I'm curious how all this will work on other machines...
+flaky.  I'm curious how all this will work on other machines...</P>
+
 <P>
-The list of classes is now:
+The list of classes is now:</P>
+
 <P>
 
 GENERAL:
 field inlet outlet print int float send receive select route pack unpack
 trigger spigot moses delay metro line timer makenote stripnote random loadbang
-serial get netsend netreceive
+serial get netsend netreceive</P>
+
 <P>
 
 MATH:
 + - * / == != &gt; &lt; &gt;= &lt;= & && | || %
 mod div sin cos tan atan atan2 sqrt log exp abs
-mtof ftom powtodb rmstodb dbtopow dbtorms
+mtof ftom powtodb rmstodb dbtopow dbtorms</P>
+
 <P>
 
 MIDI:
 notein ctlin pgmin bendin touchin polytouchin noteout ctlout pgmout bendout
-touchout polytouchout
+touchout polytouchout</P>
+
 <P>
 
 SIGNAL:
 dac~ adc~ sig~ line~ snapshot~ +~ -~ *~ /~ phasor~ cos~ vcf~ noise~ env~ hip~
 lop~ bp~ biquad~ samphold~ clip~ rsqrt~ sqrt~ wrap~ print~ scope~ tabwrite~
-tabread4~ send~ receive~ catch~ throw~ delwrite~ delread~ vd~
+tabread4~ send~ receive~ catch~ throw~ delwrite~ delread~ vd~</P>
 
-<BR> <BR>
-------------------- 0.18 -------------------
 
-<BR>
+</div></section><section class="releasenote"><h4 id="0.18">0.18</h4><div>
+
+<P>
 Release notes now describe the three platforms Pd runs on: IRIX and
-NT (maintained at UCSD) and LINUX, maintained by Guenter Geiger.
+NT (maintained at UCSD) and LINUX, maintained by Guenter Geiger.</P>
 
 <P>
 menu "close" on a dirty document now checks if you really want to close
-without saving (although "quit" will still exit Pd without verification.)
+without saving (although "quit" will still exit Pd without verification.)</P>
 
 <P>
-Got rid of "dll" error printout when loading abstractions
+Got rid of "dll" error printout when loading abstractions</P>
 
-<BR> <BR>
-------------------- 0.12 - 0.17 -------------------
 
-<BR>
+</div></section><section class="releasenote"><h4 id="0.12 - 0.17">0.12 - 0.17</h4><div>
+
+<P>
 got Pd running under NT, although driver problems remain.  Gem is also
-distributed for both platforms.
+distributed for both platforms.</P>
 
-<BR> <BR>
-------------------- 0.11  -------------------
 
-<BR>
+</div></section><section class="releasenote"><h4 id="0.11 ">0.11 </h4><div>
+
 Here's a list of all the objects in this release:
 
+<P> general: print int float send receive select pack unpack trigger spigot</P>
+<P> time handling: delay metro line timer</P>
+<P> arithmetic: + - * / == != &gt; &lt; &gt;= &lt;= & && | || %</P>
+<P> midi: notein noteout makenote stripnote</P>
+<P> other: random get</P>
+<P> signals: dac~ adc~ sig~ line~ snapshot~ +~ *~</P>
+<P> signal oscillators: phasor~ cos~</P>
+<P> signal filters: env~ hip~</P>
+<P> signal debugging : print~ scope~</P>
 <BR>
-general: print int float send receive select pack unpack trigger spigot
-<BR>
-time handling: delay metro line timer
-<BR>
-arithmetic: + - * / == != &gt; &lt; &gt;= &lt;= & && | || %
-<BR>
-midi: notein noteout makenote stripnote
-<BR>
-other: random get
-<BR>
-signals: dac~ adc~ sig~ line~ snapshot~ +~ *~
-<BR>
-signal oscillators: phasor~ cos~
-<BR>
-signal filters: env~ hip~
-<BR>
-signal debugging : print~ scope~
-<BR>
-<BR>
+<P>"spigot" replaces "gate" but has the inputs reversed.</P>
 
-"spigot" replaces "gate" but has the inputs reversed.
 
-<BR> <BR>
-------------------- 0.10  -------------------
-<BR>
-
-Many bug fixes.  This was the first pre-release to be put on the FTP site.
-
-<BR> <BR>
-------------------- 0.09  -------------------
-
-<BR> set up the "Help" menu
-<BR> Bug in DSP sorting fixed
-<BR> "Notein" and "noteout" objects
-<BR> Comments from the Put menu say "comment" (they were invisible before)
-<BR> The scheduler deals better when sound I/O malfunctions
-
-<BR> <BR>
-------------------- 0.08  -------------------
-
-<BR> metro bug
-<BR> scrollbars
-<BR> scheduler bug
-<BR> text box wraparound at 80 chars.
-<BR> fixed boxes to reconnect on retype
-
-<BR> <BR>
-------------------- 0.07  -------------------
-
-<BR>
-- made an adc~ object
-
-<BR> <BR>
-------------------- 0.06 -------------------
-
-<BR>
-- fixed two bugs in DSP sorting
-<BR>
-- added DSP on/off gui
-<BR>
-- added lock/unlock and changed the cursor behavior
-<BR>
-- fixed -font flag to set font pointsize
-
-<BR> <BR>
-------------------- 0.05 -------------------
+</div></section><section class="releasenote"><h4 id="0.10 ">0.10 </h4><div>
 <P>
-- added scope~, which is just a stopgap until real sound editing comes up.
-<BR>
-- improved the open panel slightly.
-<BR>
-- added atoms (int only).
-<BR>
-- reworked text editing to reside in Pd, not Pd-gui.
-<BR>
-- included a dbx-debuggable Pd in the distribution.  I haven't yet figured
-    out how to get dbx to work with externs though.
+Many bug fixes.  This was the first pre-release to be put on the FTP site.</P>
 
-<BR> <BR>
-------------------- 0.04 -------------------
+
+</div></section><section class="releasenote"><h4 id="0.09 ">0.09 </h4><div>
+<P> set up the "Help" menu</P>
+<P> Bug in DSP sorting fixed</P>
+<P> "Notein" and "noteout" objects</P>
+<P> Comments from the Put menu say "comment" (they were invisible before)</P>
+<P> The scheduler deals better when sound I/O malfunctions</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.08 ">0.08 </h4><div>
+
+<P>metro bug</P>
+<P>scrollbars</P>
+<P>scheduler bug</P>
+<P>text box wraparound at 80 chars.</P>
+<P>fixed boxes to reconnect on retype</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.07 ">0.07 </h4><div>
+
+<P>made an adc~ object</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.06">0.06</h4><div>
+
+<P> fixed two bugs in DSP sorting</P>
+<P> added DSP on/off gui</P>
+<P> added lock/unlock and changed the cursor behavior</P>
+<P> fixed -font flag to set font pointsize</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.05">0.05</h4><div>
+
+<P>added scope~, which is just a stopgap until real sound editing comes up.</P>
+<P> improved the open panel slightly.</P>
+<P> added atoms (int only).</P>
+<P> reworked text editing to reside in Pd, not Pd-gui.</P>
+<P> included a dbx-debuggable Pd in the distribution.
+  I haven't yet figured out how to get dbx to work with externs though.</P>
+
+
+</div></section><section class="releasenote"><h4 id="0.04">0.04</h4><div>
+
 <P>
 fixed "cut" which crashed 0.03 if DSP was running.
-added clip~, print~, line~, snapshot~.
+added clip~, print~, line~, snapshot~.</P>
 
 
-<BR> <BR>
-------------------- 0.03 -------------------
+</div></section><section class="releasenote"><h4 id="0.03">0.03</h4><div>
+
 <P>
 "pd dsp 1", "pd dsp 0" messages added.  If you edit a patch with DSP on,
 PD resorts the DSP network as needed.  Unconnected and multiple signal inlets
-are allowed.
+are allowed.</P>
 
-<BR> <BR>
-------------------- 0.02 -------------------
+
+</div></section><section class="releasenote"><h4 id="0.02">0.02</h4><div>
+
 <P>
 A DSP network mechanism has been added.  DSP objects are:
-sig~, +~, *~, phasor~, cos~.
+sig~, +~, *~, phasor~, cos~.</P>
+
 <P>
 Loading of externs is provided (although there is no search path mechanism
 so the extern has to be in the patch's current directory.)  Look in
-pd/externs for an example.
+pd/externs for an example.</P>
 
-<BR> <BR>
 
-------------------- 0.01. -------------------
+</div></section><section class="releasenote"><h4 id="0.01">0.01</h4><div>
+
 <P>
 This first release serves mostly to test the "release" mechanism.  A Pd
 "canvas" object is provided which does both graphing and patch editing.
 The editing features apply only to the Max-like part; the graphs have
-to be edited into a Pd file via text editor.
+to be edited into a Pd file via text editor.</P>
+
 <P>
 Four menu items (in the "put" menu) create the four kinds of "patchable"
 objects; they can be dragged and connected as in Max; to break a connection,
 just click on it (the cursor becomes a turkey to indicate this.)  Cut,
-paste, and duplicate seem to work, and a "Pd" class offers subwindows.
+paste, and duplicate seem to work, and a "Pd" class offers subwindows.</P>
+
 <P>
 The following max-like objects are included:
-
-    print;
-    +, *, -, /, ==, !=, &gt;, &lt;, &gt;=, &lt;=, &, |, &&, ||, %;
-    int, float, pack, unpack, trigger;
-    delay, metro, timer;
-    send, receive.
+<UL>
+<LI>print</LI>
+<LI>+, *, -, /, ==, !=, &gt;, &lt;, &gt;=, &lt;=, &amp;, |, &amp;&amp;, ||, %</LI>
+<LI>int, float, pack, unpack, trigger</LI>
+<LI>delay, metro, timer</LI>
+<LI>send, receive</LI>
+</UL>
+</P>
+</div></section>
 
 </div>
+
 <div class="nav nav-bottom">
     <div class="nav-back"><A href="chapter4.htm">&lt; Chapter 4: Externals</A></div>
     <div class="nav-home"><A href="../index.htm#s5">Table of contents</A></div>

--- a/doc/1.manual/resources/chapter5.htm
+++ b/doc/1.manual/resources/chapter5.htm
@@ -32,7 +32,7 @@ only connect to usable audio devices.</P>
 
 <P>Fixed compatibility problems with the newest tcl/tk (version 9).</P>
 
-<P>Documenttaion updates.</P>
+<P>Documentation updates.</P>
 
 <P>Fixed -nharmonics creation argument to [sigmund~].</P>
 
@@ -60,7 +60,7 @@ cosine table. The table size used to be 512-point for fast, approximate
 calculations, which was adequate for most "computer music" applications
 in the 90s when this was decided (and at that time there could be a
 serious performance penalty for using larger tables). To get the original
-512-point tables you can run Pd with compatiblity level 0.54. Also, in
+512-point tables you can run Pd with compatibility level 0.54. Also, in
 systems with very tight memory constraints (such as Espressif ESP32),
 Pd can be recompiled with the C preprocessor variable COSTABLESIZE set
 to 512 to get the old memory footprint.</P>

--- a/doc/1.manual/resources/pdmanual.css
+++ b/doc/1.manual/resources/pdmanual.css
@@ -243,6 +243,35 @@ blockquote p {
     margin-right: auto;
 }
 
+/* release notes */
+.releasenote h4:before, .releasenote h4:after {
+    display: inline-block;
+    content: "";
+
+    border-top:1px solid;
+
+    height:5px;
+    width: 5rem;
+}
+.releasenote h4:before {
+    right:100%;
+    margin-right:15px;
+}
+.releasenote h4:after {
+    left:100%;
+    margin-left:15px;
+    width: 6rem;
+}
+.releasenote h4 {
+    font-weight: normal;
+    font-size: inherit;
+    margin-left: 0;
+}
+.releasenote li {
+    padding: 0;
+}
+
+
 /* responsive css for small "devices" and browser windows */
 
 @media screen and (max-device-width: 700px), screen and (max-width: 700px) {


### PR DESCRIPTION
this PR uses HTML tags and classes in the release-notes (`doc/1.manual/resources/chapter5.htm`), so they become parseable.

the motivation behind this is to be able to transform the release-notes to other formats, most importantly the [appstream metadata](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html).

the main difference is, that now instead of something like
```html
<P> ------------------ 0.53-2 ------------------------------
```

you have to write
```html
</section><section class="releasenote"><h4 id="0.53-2">0.53-2</h4>
```

while being there, i have cleaned up closing tags (that is: for every `<P>` tag, there is now a matching `</P>` tag).

i've also adjusted the CSS to render (almost the same), automatically adding the `---------` lines (actually, now it renders a real line, rather than dashes).

as a side-effect (of adding `id`s to the `<h4>` tag), it is now possible to reference specific releases in URLs, e.g. https://msp.ucsd.edu/Pd_documentation/resources/chapter5.htm#0.55-2


I've also fixed one or two typos.