### PR TITLE
feat: Add support to `oscparse` for handling `d` type tag (double)

### DIFF
--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -294,17 +294,21 @@ typedef struct _oscparse
                     ((((int)(((x)+2)->a_w.w_float)) & 0xff) << 8) | \
                     ((((int)(((x)+3)->a_w.w_float)) & 0xff) << 0)
 
-#define READDOUBLE(x) ({ \
-    uint32_t hi = READINT(x); \
-    uint32_t lo = READINT((x)+4); \
-    union { \
-        double d; \
-        struct { uint32_t lo; uint32_t hi; } i; \
-    } u; \
-    u.i.lo = lo; \
-    u.i.hi = hi; \
-    u.d; \
-})
+static double readdouble(t_atom *x)
+{
+    uint32_t hi = READINT(x);
+    uint32_t lo = READINT((x)+4);
+    union {
+        double d;
+        struct {
+            uint32_t lo;
+            uint32_t hi;
+        } i;
+    } u;
+    u.i.lo = lo;
+    u.i.hi = hi;
+    return u.d;
+}
 
 static t_symbol *grabstring(int argc, t_atom *argv, int *ip, int slash)
 {
@@ -478,7 +482,7 @@ static void oscparse_list(t_oscparse *x, t_symbol *s, int argc, t_atom *argv)
             if (k > argc - 8)
                 goto tooshort;
             {
-                double d = READDOUBLE(argv+k);
+                double d = readdouble(argv+k);
                 /* lossy conversion from double to float */
                 t_float f = (t_float)d;
                 if (PD_BADFLOAT(f))

--- a/src/x_misc.c
+++ b/src/x_misc.c
@@ -294,7 +294,7 @@ typedef struct _oscparse
                     ((((int)(((x)+2)->a_w.w_float)) & 0xff) << 8) | \
                     ((((int)(((x)+3)->a_w.w_float)) & 0xff) << 0)
 
-static double readdouble(t_atom *x)
+PD_INLINE double readdouble(t_atom *x)
 {
     uint32_t hi = READINT(x);
     uint32_t lo = READINT((x)+4);


### PR DESCRIPTION
The [Open Sound Control 1.0 spec](https://opensoundcontrol.stanford.edu/spec-1_0.html) mentions a (non-standard) `d` type tag for handling 64-bit floating point values. This adds support to the `oscparse` object for parsing osc args of this type.

Note that this implementation results in a potentially lossy conversion from `double` to `t_float` in the case that `t_float` is `float`.

This was motivated by some personal software that emits doubles for certain control values. Previously I was receiving these in supercollider without issue, but after experimenting with receiving the same data in puredata I noticed the `d` tag was unsupported, so thought I'd have a go at contributing it! If the non-standard flags are intentionally unsupported, feel free to disregard.