### PR TITLE
snake~: add more verbs and enhance 'in'

### DIFF
--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -252,6 +252,74 @@ static void *snake_sum_tilde_new(void)
     return (x);
 }
 
+/* ------------------------ snake_split~ ------------------------- */
+
+static t_class *snake_split_tilde_class;
+
+typedef struct _snake_split
+{
+    t_object x_obj;
+    t_sample x_f;
+    int x_index;        /* split index (0-based) */
+} t_snake_split;
+
+static void snake_split_tilde_dsp(t_snake_split *x, t_signal **sp)
+{
+    int i, nchans = sp[0]->s_nchans;
+    int left_chans, right_chans;
+
+        /* calculate output channel counts */
+    if (x->x_index <= 0) {
+        left_chans = 1;     /* single channel of zeros */
+        right_chans = nchans;
+    } else if (x->x_index >= nchans) {
+        left_chans = nchans;
+        right_chans = 1;    /* single channel of zeros */
+    } else {
+        left_chans = x->x_index;
+        right_chans = nchans - x->x_index;
+    }
+
+        /* set up output signals */
+    signal_setmultiout(&sp[1], left_chans);   /* left output */
+    signal_setmultiout(&sp[2], right_chans);  /* right output */
+
+        /* route channels to outputs */
+    if (x->x_index <= 0) {
+            /* left output: zeros, right output: all channels */
+        dsp_add_zero(sp[1]->s_vec, sp[1]->s_length);
+        dsp_add_copy(sp[0]->s_vec, sp[2]->s_vec, nchans * sp[0]->s_length);
+    } else if (x->x_index >= nchans) {
+            /* left output: all channels, right output: zeros */
+        dsp_add_copy(sp[0]->s_vec, sp[1]->s_vec, nchans * sp[0]->s_length);
+        dsp_add_zero(sp[2]->s_vec, sp[2]->s_length);
+    } else {
+            /* normal split */
+        for (i = 0; i < left_chans; i++)
+            dsp_add_copy(sp[0]->s_vec + i * sp[0]->s_length,
+                sp[1]->s_vec + i * sp[1]->s_length, sp[0]->s_length);
+        for (i = 0; i < right_chans; i++)
+            dsp_add_copy(sp[0]->s_vec + (x->x_index + i) * sp[0]->s_length,
+                sp[2]->s_vec + i * sp[2]->s_length, sp[0]->s_length);
+    }
+}
+
+static void snake_split_tilde_index(t_snake_split *x, t_floatarg f)
+{
+    x->x_index = (int)f;
+    canvas_update_dsp();
+}
+
+static void *snake_split_tilde_new(t_floatarg f)
+{
+    t_snake_split *x = (t_snake_split *)pd_new(snake_split_tilde_class);
+    x->x_index = (int)f;
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_float, gensym("index"));
+    outlet_new(&x->x_obj, &s_signal);
+    outlet_new(&x->x_obj, &s_signal);
+    return (x);
+}
+
 /* ------------------------ snake_pick~ -------------------------- */
 
 static t_class *snake_pick_tilde_class;
@@ -349,6 +417,9 @@ static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
         else if (!strcmp(str, "sum"))
             pd_this->pd_newest =
                 snake_sum_tilde_new();
+        else if (!strcmp(str, "split"))
+            pd_this->pd_newest =
+                snake_split_tilde_new(atom_getfloatarg(1, argc, argv));
         else if (!strcmp(str, "pick"))
             pd_this->pd_newest =
                 snake_pick_tilde_new(s, argc-1, argv+1);
@@ -386,6 +457,16 @@ static void snake_tilde_setup(void)
     class_addmethod(snake_sum_tilde_class, (t_method)snake_sum_tilde_dsp,
         gensym("dsp"), 0);
     class_sethelpsymbol(snake_sum_tilde_class, gensym("snake-tilde"));
+
+    snake_split_tilde_class = class_new(gensym("snake_split~"),
+        (t_newmethod)snake_split_tilde_new, 0, sizeof(t_snake_split),
+            CLASS_MULTICHANNEL, A_DEFFLOAT, 0);
+    CLASS_MAINSIGNALIN(snake_split_tilde_class, t_snake_split, x_f);
+    class_addmethod(snake_split_tilde_class, (t_method)snake_split_tilde_dsp,
+        gensym("dsp"), 0);
+    class_addmethod(snake_split_tilde_class, (t_method)snake_split_tilde_index,
+        gensym("index"), A_FLOAT, 0);
+    class_sethelpsymbol(snake_split_tilde_class, gensym("snake-tilde"));
 
     snake_pick_tilde_class = class_new(gensym("snake_pick~"),
         (t_newmethod)snake_pick_tilde_new, (t_method)snake_pick_tilde_free,

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -141,27 +141,43 @@ typedef struct _snake_in
 {
     t_object x_obj;
     t_sample x_f;
-    int x_nchans;
+    int x_nin;
+    t_sample *x_copybuf;
+    int x_copysize;
 } t_snake_in;
+
+static void snake_in_tilde_free(t_snake_in *x)
+{
+    if (x->x_copybuf)
+        freebytes(x->x_copybuf, x->x_copysize * sizeof(t_sample));
+}
 
 static void snake_in_tilde_dsp(t_snake_in *x, t_signal **sp)
 {
-    int i;
-        /* create an n-channel output signal. sp has n+1 elements. */
-    signal_setmultiout(&sp[x->x_nchans], x->x_nchans);
-        /* add n copy operations to the DSP chain, one from each input */
-    for (i = 0; i < x->x_nchans; i++)
-         dsp_add_copy(sp[i]->s_vec,
-            sp[x->x_nchans]->s_vec + i * sp[0]->s_length, sp[0]->s_length);
+    int i, nchans = 0, offset, copysize;
+    for (i = 0; i < x->x_nin; i++)
+        nchans += sp[i]->s_nchans;
+    copysize = nchans * sp[0]->s_length;
+    x->x_copybuf = (t_sample *)resizebytes(x->x_copybuf,
+        x->x_copysize * sizeof(t_sample), copysize * sizeof(t_sample));
+    x->x_copysize = copysize;
+        /* snapshot inputs before allocating output */
+    for (offset = 0, i = 0; i < x->x_nin; offset += sp[i]->s_nchans, i++)
+        dsp_add_copy(sp[i]->s_vec, x->x_copybuf + offset * sp[0]->s_length,
+            sp[i]->s_nchans * sp[0]->s_length);
+    signal_setmultiout(&sp[x->x_nin], nchans);
+    dsp_add_copy(x->x_copybuf, sp[x->x_nin]->s_vec, copysize);
 }
 
 static void *snake_in_tilde_new(t_floatarg fnchans)
 {
     t_snake_in *x = (t_snake_in *)pd_new(snake_in_tilde_class);
     int i;
-    if ((x->x_nchans = fnchans) <= 0)
-        x->x_nchans = 2;
-    for (i = 1; i < x->x_nchans; i++)
+    x->x_copybuf = 0;
+    x->x_copysize = 0;
+    if ((x->x_nin = fnchans) <= 0)
+        x->x_nin = 2;
+    for (i = 1; i < x->x_nin; i++)
         inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     outlet_new(&x->x_obj, &s_signal);
     return (x);
@@ -231,8 +247,8 @@ static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
 static void snake_tilde_setup(void)
 {
     snake_in_tilde_class = class_new(gensym("snake_in~"),
-        (t_newmethod)snake_in_tilde_new, 0, sizeof(t_snake_in),
-            CLASS_MULTICHANNEL, A_DEFFLOAT, 0);
+        (t_newmethod)snake_in_tilde_new, (t_method)snake_in_tilde_free,
+            sizeof(t_snake_in), CLASS_MULTICHANNEL, A_DEFFLOAT, 0);
     CLASS_MAINSIGNALIN(snake_in_tilde_class, t_snake_in, x_f);
     class_addmethod(snake_in_tilde_class, (t_method)snake_in_tilde_dsp,
         gensym("dsp"), 0);

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -252,6 +252,86 @@ static void *snake_sum_tilde_new(void)
     return (x);
 }
 
+/* ------------------------ snake_pick~ -------------------------- */
+
+static t_class *snake_pick_tilde_class;
+
+typedef struct _snake_pick
+{
+    t_object x_obj;
+    t_sample x_f;
+    int x_npick;        /* number of channels to pick */
+    int *x_indices;     /* array of channel indices */
+} t_snake_pick;
+
+static void snake_pick_tilde_dsp(t_snake_pick *x, t_signal **sp)
+{
+    int i, srcindex;
+    t_signal *inputcopy;
+
+        /* if no indices set, default to pass-through */
+    if (x->x_npick == 0)
+    {
+        signal_setmultiout(&sp[1], sp[0]->s_nchans);
+        dsp_add_copy(sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_nchans * sp[0]->s_length);
+        return;
+    }
+
+    signal_setmultiout(&sp[1], x->x_npick);
+        /* use temporary buffer to avoid overwriting input during reordering */
+    inputcopy = signal_new(sp[0]->s_length, sp[0]->s_nchans, sp[0]->s_sr, 0);
+    for (i = 0; i < sp[0]->s_nchans; i++)
+        dsp_add_copy(sp[0]->s_vec + i * sp[0]->s_length,
+            inputcopy->s_vec + i * sp[0]->s_length, sp[0]->s_length);
+    for (i = 0; i < x->x_npick; i++)
+    {
+        if ((srcindex = x->x_indices[i]) >= 0 && srcindex < sp[0]->s_nchans)
+            dsp_add_copy(inputcopy->s_vec + srcindex * sp[0]->s_length,
+                sp[1]->s_vec + i * sp[0]->s_length, sp[0]->s_length);
+        else
+                /* output zeros for invalid or missing input channels */
+            dsp_add_zero(sp[1]->s_vec + i * sp[0]->s_length, sp[0]->s_length);
+    }
+}
+
+static void snake_pick_tilde_channels(t_snake_pick *x, t_symbol *s, int argc, t_atom *argv)
+{
+    int i;
+
+        /* (re)allocate indices array if channel count changed */
+    if (argc != x->x_npick)
+    {
+        if (x->x_indices)
+            freebytes(x->x_indices, x->x_npick * sizeof(int));
+        x->x_indices = argc ? (int *)getbytes(argc * sizeof(int)) : NULL;
+        x->x_npick = argc;
+    }
+
+        /* update indices (convert from 1-based to 0-based) */
+    for (i = 0; i < argc; i++)
+        x->x_indices[i] = (int)atom_getfloatarg(i, argc, argv) - 1;
+    canvas_update_dsp();
+}
+
+static void snake_pick_tilde_free(t_snake_pick *x)
+{
+    if (x->x_indices)
+        freebytes(x->x_indices, x->x_npick * sizeof(int));
+}
+
+static void *snake_pick_tilde_new(t_symbol *s, int argc, t_atom *argv)
+{
+    t_snake_pick *x = (t_snake_pick *)pd_new(snake_pick_tilde_class);
+
+    x->x_npick = 0;
+    x->x_indices = NULL;
+    snake_pick_tilde_channels(x, s, argc, argv);
+
+    inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_list, gensym("channels"));
+    outlet_new(&x->x_obj, &s_signal);
+    return (x);
+}
+
 static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
     if (!argc || argv[0].a_type != A_SYMBOL)
@@ -269,6 +349,9 @@ static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
         else if (!strcmp(str, "sum"))
             pd_this->pd_newest =
                 snake_sum_tilde_new();
+        else if (!strcmp(str, "pick"))
+            pd_this->pd_newest =
+                snake_pick_tilde_new(s, argc-1, argv+1);
         else
         {
             pd_error(0, "snake~ %s: unknown function", str);
@@ -303,6 +386,16 @@ static void snake_tilde_setup(void)
     class_addmethod(snake_sum_tilde_class, (t_method)snake_sum_tilde_dsp,
         gensym("dsp"), 0);
     class_sethelpsymbol(snake_sum_tilde_class, gensym("snake-tilde"));
+
+    snake_pick_tilde_class = class_new(gensym("snake_pick~"),
+        (t_newmethod)snake_pick_tilde_new, (t_method)snake_pick_tilde_free,
+            sizeof(t_snake_pick), CLASS_MULTICHANNEL, A_GIMME, 0);
+    CLASS_MAINSIGNALIN(snake_pick_tilde_class, t_snake_pick, x_f);
+    class_addmethod(snake_pick_tilde_class, (t_method)snake_pick_tilde_dsp,
+        gensym("dsp"), 0);
+    class_addmethod(snake_pick_tilde_class, (t_method)snake_pick_tilde_channels,
+        gensym("channels"), A_GIMME, 0);
+    class_sethelpsymbol(snake_pick_tilde_class, gensym("snake-tilde"));
 
     class_addcreator((t_newmethod)snake_tilde_new, gensym("snake~"),
         A_GIMME, 0);

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -221,6 +221,37 @@ static void *snake_out_tilde_new(t_floatarg fnchans)
     return (x);
 }
 
+/* ------------------------ snake_sum~ -------------------------- */
+
+static t_class *snake_sum_tilde_class;
+
+typedef struct _snake_sum
+{
+    t_object x_obj;
+    t_sample x_f;
+} t_snake_sum;
+
+static void snake_sum_tilde_dsp(t_snake_sum *x, t_signal **sp)
+{
+    int i;
+        /* create single channel output signal */
+    signal_setmultiout(&sp[1], 1);
+        /* copy first channel to output */
+    dsp_add_copy(sp[0]->s_vec, sp[1]->s_vec, sp[0]->s_length);
+        /* add remaining channels */
+    for (i = 1; i < sp[0]->s_nchans; i++)
+        dsp_add_plus(sp[1]->s_vec,
+            sp[0]->s_vec + i * sp[0]->s_length,
+            sp[1]->s_vec, sp[0]->s_length);
+}
+
+static void *snake_sum_tilde_new(void)
+{
+    t_snake_sum *x = (t_snake_sum *)pd_new(snake_sum_tilde_class);
+    outlet_new(&x->x_obj, &s_signal);
+    return (x);
+}
+
 static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
 {
     if (!argc || argv[0].a_type != A_SYMBOL)
@@ -235,6 +266,9 @@ static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
         else if (!strcmp(str, "out"))
             pd_this->pd_newest =
                 snake_out_tilde_new(atom_getfloatarg(1, argc, argv));
+        else if (!strcmp(str, "sum"))
+            pd_this->pd_newest =
+                snake_sum_tilde_new();
         else
         {
             pd_error(0, "list %s: unknown function", str);
@@ -261,6 +295,14 @@ static void snake_tilde_setup(void)
     class_addmethod(snake_out_tilde_class, (t_method)snake_out_tilde_dsp,
         gensym("dsp"), 0);
     class_sethelpsymbol(snake_out_tilde_class, gensym("snake-tilde"));
+
+    snake_sum_tilde_class = class_new(gensym("snake_sum~"),
+        (t_newmethod)snake_sum_tilde_new, 0, sizeof(t_snake_sum),
+            CLASS_MULTICHANNEL, 0);
+    CLASS_MAINSIGNALIN(snake_sum_tilde_class, t_snake_sum, x_f);
+    class_addmethod(snake_sum_tilde_class, (t_method)snake_sum_tilde_dsp,
+        gensym("dsp"), 0);
+    class_sethelpsymbol(snake_sum_tilde_class, gensym("snake-tilde"));
 
     class_addcreator((t_newmethod)snake_tilde_new, gensym("snake~"),
         A_GIMME, 0);

--- a/src/d_misc.c
+++ b/src/d_misc.c
@@ -271,7 +271,7 @@ static void *snake_tilde_new(t_symbol *s, int argc, t_atom *argv)
                 snake_sum_tilde_new();
         else
         {
-            pd_error(0, "list %s: unknown function", str);
+            pd_error(0, "snake~ %s: unknown function", str);
             pd_this->pd_newest = 0;
         }
     }


### PR DESCRIPTION
- extends [snake~ in] to handle and join multichannel inputs
- adds [snake~ sum] for multichannel mixdown (with additional commit for bypass option)
- adds [snake~ pick] for picking specific channels from mc signal (passing the input through if no channel numbers are given)
- adds [snake~ split] for splitting input at given index

test patch: [test-snakes-minimal.pd.zip](https://github.com/user-attachments/files/30055905/test-snakes-minimal.pd.zip)

<img width="732" height="235" alt="image" src="https://github.com/user-attachments/assets/c6d6f024-9b43-4411-9f4e-0495b35481b7" />

EDIT: removed a bunch of verbs that were part of this PR initially.