### PR TITLE
Fix message box height after binbuf conversion

### DIFF
--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -648,6 +648,8 @@ void rtext_retext(t_rtext *x)
     x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize+1);
     x->x_buf[x->x_bufsize] = 0;
     rtext_findscreenlocation(x);
+        /* force dimension recalculation after text conversion */
+    x->x_pixwidth = x->x_pixheight = -1;
     rtext_senditup(x, SEND_UPDATE, &w, &h, &indx);
 }
 


### PR DESCRIPTION
invalidate pixel dimensions in `rtext_retext()` to force height recalculation

also in this case: not completely sure if this is a good solution - so needs proper review.

closes #2612