### PR TITLE
restore 'Pd Help' menu entry for Pd window on macOS

### DIFF
--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -75,6 +75,12 @@ proc ::pd_menus::create_menubar {} {
             -underline $underlined -menu $m
     }
 
+    # create separate help menu for pdwindow on macOS (system integration)
+    if {$::windowingsystem eq "aqua" && $::tcl_version >= 8.5} {
+        build_help_menu [menu $::pdwindow_menubar.help]
+        $::pdwindow_menubar entryconfigure "Help" -menu $::pdwindow_menubar.help
+    }
+
     if {$::windowingsystem eq "win32"} {create_system_menu $::patch_menubar}
     . configure -menu $::patch_menubar
 }


### PR DESCRIPTION
macOS system integration requires separate 'Help' menu objects per menubar. this adds dedicated 'Help' menu for pdwindow on macOS Tk 8.5+ to enable automatic 'Pd Help' entry.

closes #2628