### PR TITLE
stable development branch

### DIFF
--- a/doc/1.manual/resources/chapter5.htm
+++ b/doc/1.manual/resources/chapter5.htm
@@ -25,7 +25,7 @@
 <H3> <A href="#s5.1" id="s5.1"> 5.1. Release notes </A> </H3><section><div>
 
 
-</div></section><section class="releasenote"><h4 id="0.55-2">0.56-0</h4><div>
+</div></section><section class="releasenote"><h4 id="0.56-0">0.56-0</h4><div>
 
 <p>The dafault sample rate is now 48000.  (All the same sample rates as before
 are still supported).</p>

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -75,6 +75,12 @@ proc ::pd_menus::create_menubar {} {
             -underline $underlined -menu $m
     }
 
+    # create separate help menu for pdwindow on macOS (system integration)
+    if {$::windowingsystem eq "aqua" && $::tcl_version >= 8.5} {
+        build_help_menu [menu $::pdwindow_menubar.help]
+        $::pdwindow_menubar entryconfigure "Help" -menu $::pdwindow_menubar.help
+    }
+
     if {$::windowingsystem eq "win32"} {create_system_menu $::patch_menubar}
     . configure -menu $::patch_menubar
 }


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts.).

it supersedes https://github.com/pure-data/pure-data/pull/2625
---

### GUI
- Closes: https://github.com/pure-data/pure-data/issues/2628

### Documentation
- fixes `id` in the release-notes (so we can link directly to the `0.56-0`)