### PR TITLE
fix crash when deleting scalars with text fields

### DIFF
--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -497,6 +497,7 @@ EXTERN void rtext_untype(t_rtext *x);
 EXTERN void rtext_getrect(t_rtext *x, int *x1p, int *y1p, int *x2p, int *y2p);
 EXTERN void rtext_retextforscalar(t_rtext *x, char *buf, int len,
     int xpix, int ypix);
+EXTERN void rtext_cleanupforscalar(t_scalar *sc);
 EXTERN int rtext_hit(t_rtext *x, int xpix, int ypix,
     int *x1p, int *y1p, int *x2p, int *y2p);
 t_rtext *rtext_findhit(t_glist *gl, int xpix, int ypix,

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -135,6 +135,34 @@ void rtext_free(t_rtext *x)
     freebytes(x, sizeof *x);
 }
 
+static void glist_dortextcleanupforscalar(t_glist *glist, t_scalar *sc)
+{
+    t_rtext *rtext, *next;
+    t_gobj *g;
+        /* clean up rtexts in current canvas */
+    if (glist->gl_editor)
+        for (rtext = glist->gl_editor->e_rtext; rtext; rtext = next)
+        {
+            next = rtext->x_next;
+            if (rtext->x_scalar == sc)
+                rtext_free(rtext);
+        }
+        /* recursively clean up rtexts in child canvases */
+    for (g = glist->gl_list; g; g = g->g_next)
+    {
+        if (g->g_pd == canvas_class)
+            glist_dortextcleanupforscalar((t_glist *)g, sc);
+    }
+}
+
+    /* clean up rtexts that reference a scalar being deleted */
+void rtext_cleanupforscalar(t_scalar *sc)
+{
+    t_glist *glist;
+    for (glist = pd_this->pd_canvaslist; glist; glist = glist->gl_next)
+        glist_dortextcleanupforscalar(glist, sc);
+}
+
 void rtext_setcolor(t_rtext *x, int color)
 {
     char buf[80];

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -620,6 +620,7 @@ static void scalar_free(t_scalar *x)
         pd_error(0, "scalar: couldn't find template %s", templatesym->s_name);
         return;
     }
+    rtext_cleanupforscalar(x);
     word_free(x->sc_vec, template);
     pdgui_stub_deleteforkey(x);
         /* the "size" field in the class is zero, so Pd doesn't try to free


### PR DESCRIPTION
add rtext cleanup when deleting scalars with text fields (`drawsymbol`, `drawnumber`) to prevent use-after-free crash.

not completely sure whether there might be a simpler approach without a new `rtext_cleanupforscalar()` (and without traversing all canvases and rtexts)?

- closes #2588