### PR TITLE
keep "-libs "from the cmdline separate from those loaded via preferences

### DIFF
--- a/src/s_main.c
+++ b/src/s_main.c
@@ -75,8 +75,9 @@ typedef struct _patchlist
     char *pl_args;
 } t_patchlist;
 
-static t_patchlist *sys_openlist;
-static t_namelist *sys_messagelist;
+static t_namelist *tmp_externlist = 0;
+static t_patchlist *sys_openlist = 0;
+static t_namelist *sys_messagelist = 0;
 static int sys_version;
 int sys_oldtclversion;      /* hack to warn g_rtext.c about old text sel */
 
@@ -435,6 +436,12 @@ int sys_main(int argc, const char **argv)
                 post("%s: can't load library", nl->nl_string);
         sys_oktoloadfiles(1);
     }
+    for  (nl = tmp_externlist; nl; nl = nl->nl_next)
+    {
+        if (!sys_load_lib(0, nl->nl_string))
+            post("%s: can't load library", nl->nl_string);
+    }
+
         /* open patches specifies with "-open" args */
     for (pl = sys_openlist; pl; pl = pl->pl_next)
         openit(cwd, pl->pl_file, pl->pl_args);
@@ -1233,8 +1240,8 @@ int sys_argparse(int argc, const char **argv)
             if (argc < 2)
                 goto usage;
 
-            STUFF->st_externlist =
-                namelist_append_files(STUFF->st_externlist, argv[1]);
+            tmp_externlist =
+                namelist_append_files(tmp_externlist, argv[1]);
             argc -= 2; argv += 2;
         }
         else if ((!strcmp(*argv, "-font-size") || !strcmp(*argv, "-font")))


### PR DESCRIPTION
this is an alternative implementation on how to keep loading externals after a crash was detected.

(my "best way forward" as discussed in https://github.com/pure-data/pure-data/issues/2665#issuecomment-3049124630))

libraries passed via `-lib` cmdline flags, are now stored in a separate namelist (`tmp_externlist`) which is only used during startup.

the externals in this list are *always* loaded (regardless of a detected prior crash).
they are loaded after the ones provided in the preferences (which is the original behaviour).

the only functional difference is, that we now might call `sys_load_lib` twice for a library that is mentioned both in the preferences and on the cmdline.
for libraries that were successfully loaded, this shouldn't make much of a difference (as `sys_load_lib()` will drop duplicate successful requests), but if a library cannot be loaded (e.g. because it doesn't exist) you will get the error "foobar: can't load library" twice.

i was thinking about adding the cmdline list of externals to `STUFF->st_externlist` as well (e.g. while loading),
but refrained from doing so, as I actually find it annoying that cmdline libraries can get promoted to preference libraries (when saving the prefs).

---

- Closes: https://github.com/pure-data/pure-data/issues/2665