### PR TITLE
Fix Pd colors

### DIFF
--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -37,22 +37,28 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     sprintf(tag, "%pBASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol);
+    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-outline", THISGUI->i_foregroundcolor->s_name);
 
     sprintf(tag, "%pBUT", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos + inset, ypos + inset,
         xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
+    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+        "-width", zoom, "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
+        "-outline", THISGUI->i_foregroundcolor->s_name);
 
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
-    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms,
-        "-fill", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol));
+
+    if (x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -82,18 +88,20 @@ static void bng_draw_new(t_bng *x, t_glist *glist)
 static void bng_draw_select(t_bng* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    int col = IEM_GUI_COLOR_NORMAL, lcol = x->x_gui.x_lcol;
-    char tag[128];
+    char tag[128], lcol_buf[8] = "#000000\0";
+    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = IEM_GUI_COLOR_SELECTED;
+        col = lcol = THISGUI->i_selectcolor->s_name;
+    else
+        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pBUT", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void bng_draw_update(t_bng *x, t_glist *glist)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2208,10 +2208,10 @@ void g_canvas_newpdinstance(void)
     THISGUI->i_reloadingabstraction = 0;
     THISGUI->i_dspstate = 0;
     THISGUI->i_dollarzero = 1000;
-    THISGUI->i_foregroundcolor = gensym("black");
-    THISGUI->i_backgroundcolor = gensym("white");
-    THISGUI->i_selectcolor = gensym("blue");
-    THISGUI->i_gopcolor = gensym("red");
+    THISGUI->i_foregroundcolor = gensym("#000000");
+    THISGUI->i_backgroundcolor = gensym("#FFFFFF");
+    THISGUI->i_selectcolor = gensym("#0000FF");
+    THISGUI->i_gopcolor = gensym("#FF0000");
     g_editor_newpdinstance();
     g_template_newpdinstance();
 }
@@ -2320,14 +2320,36 @@ static void glist_dorevis(t_glist *glist)
             glist_dorevis((t_glist *)g);
 }
 
+    /* normalize a color symbol to a hex color string */
+static t_symbol *normalize_color(t_symbol *s)
+{
+    if ('#' == s->s_name[0])
+    {
+        char colname[MAXPDSTRING];
+        int col = (int)strtol(s->s_name+1, 0, 16);
+        pd_snprintf(colname, MAXPDSTRING-1, "#%06x", col & 0xFFFFFF);
+        return gensym(colname);
+    }
+    pd_error(0, "invalid color '%s' (expected hex color)", s->s_name);
+    return 0;
+}
+
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop)
 {
     t_glist *gl;
+    fg = normalize_color(fg);
+    bg = normalize_color(bg);
+    sel = normalize_color(sel);
+    gop = (gop && gop->s_name[0]) ? normalize_color(gop) : sel;
+    if (!fg || !bg || !sel || !gop) {
+        pd_error(0, "palette not updated due to invalid color(s)");
+        return;
+    }
     THISGUI->i_foregroundcolor = fg;
     THISGUI->i_backgroundcolor = bg;
     THISGUI->i_selectcolor = sel;
-    THISGUI->i_gopcolor = (*gop->s_name ? gop : sel);
+    THISGUI->i_gopcolor = gop;
     for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         glist_dorevis(gl);
 }

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1916,7 +1916,7 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 pdtk_canvas_new; but if it's just white don't pass it in
                 case we're talking to an older GUI version (so that
                 pureVST can work with Pd 0.55 as its GUI) */
-            if (strcmp(THISGUI->i_backgroundcolor->s_name, "white"))
+            if (strcmp(THISGUI->i_backgroundcolor->s_name, "#FFFFFF"))
                 pdgui_vmess("pdtk_canvas_new", "^ ii si s", x,
                     (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1),

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2526,11 +2526,12 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
                         x->gl_editor->e_ywas = y2;
                         pdgui_vmess("::pdtk_canvas::cords_to_foreground",
                             "ci", x, 0);
-                        pdgui_vmess(0, "crr iiii ri rs",
+                        pdgui_vmess(0, "crr iiii ri rs rs",
                             x, "create", "line",
                             x->gl_editor->e_xwas,x->gl_editor->e_ywas,
                             xpix, ypix,
                             "-width", (issignal ? 2 : 1) * x->gl_zoom,
+                            "-fill", THISGUI->i_foregroundcolor->s_name,
                             "-tags", "x");
                     }
                     else canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
@@ -2676,9 +2677,10 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
     {
         if (!shiftmod)
             glist_noselect(x);
-        pdgui_vmess(0, "crr iiii rs",
+        pdgui_vmess(0, "crr iiii rs rs",
             x, "create", "rectangle",
             xpix,ypix, xpix,ypix,
+            "-outline", THISGUI->i_selectcolor->s_name,
             "-tags", "x");
         x->gl_editor->e_xwas = xpix;
         x->gl_editor->e_ywas = ypix;
@@ -2754,10 +2756,11 @@ static int tryconnect(t_canvas*x, t_object *src, int nout,
                              ((x22-x21-iow) * nin)/(ninlets-1) : 0)
                 + iom;
             ly2 = y21;
-            pdgui_vmess(0, "crr iiii ri rS",
+            pdgui_vmess(0, "crr iiii ri rs rS",
                 glist_getcanvas(x), "create", "line",
                 lx1,ly1, lx2,ly2,
                 "-width", (obj_issignaloutlet(src, nout) ? 2 : 1) * x->gl_zoom,
+                "-fill", THISGUI->i_foregroundcolor->s_name,
                 "-tags", 2, tags);
             canvas_undo_add(x, UNDO_CONNECT, "connect",
                 canvas_undo_set_connect(x,
@@ -4584,10 +4587,11 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
         char tag[128];
         char*tags[] = {tag, "cord"};
         sprintf(tag, "l%p", oc);
-        pdgui_vmess(0, "crr iiii ri rS",
+        pdgui_vmess(0, "crr iiii ri rs rS",
             glist_getcanvas(x), "create", "line",
             0, 0, 0, 0,
             "-width", (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom,
+            "-fill", THISGUI->i_foregroundcolor->s_name,
             "-tags", 2, tags);
         canvas_fixlinesfor(x, objsrc);
     }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -727,11 +727,12 @@ static void graph_create_text(
     SETSYMBOL(fontatoms+0, gensym(sys_font));
     SETFLOAT (fontatoms+1, fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
-    pdgui_vmess(0, "crr ii rs rr rA rS",
+    pdgui_vmess(0, "crr ii rs rs rr rA rS",
               glist_getcanvas(x),
               "create", "text",
               posX, posY,
               "-text", name,
+              "-fill", THISGUI->i_foregroundcolor->s_name,
               "-anchor", anchor,
               "-font", 3, fontatoms,
               "-tags", numtags, tags);
@@ -797,12 +798,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         const char *tags3[] = {tag, "label", "graph" };
 
             /* draw a rectangle around the graph */
-        pdgui_vmess(0, "crr iiiiiiiiii ri rr rS",
+        pdgui_vmess(0, "crr iiiiiiiiii ri rr rs rS",
                   glist_getcanvas(x->gl_owner),
                   "create", "line",
                   x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
                   "-width", glist_getzoom(x),
                   "-capstyle", "projecting",
+                  "-fill", THISGUI->i_foregroundcolor->s_name,
                   "-tags", 2, tags2);
             /* if there's just one "garray" in the graph, write its name
                 along the top */
@@ -986,6 +988,11 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
         if (glist_isvisible(glist)) {
             glist_redraw(x);
             canvas_fixlinesfor(glist, &x->gl_obj);
+            char tag[80];
+            sprintf(tag, "graph%lx", (t_int)z);
+            pdgui_vmess(0, "crs rs",
+                glist_getcanvas(glist), "itemconfigure", tag,
+                "-fill", THISGUI->i_selectcolor->s_name);
         }
     }
 }

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -51,9 +51,13 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos + offset, ypos + offset,
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom,
-        "-outline", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
+
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs ri rs", canvas, "itemconfigure", tag,
+            "-width", zoom, "-outline", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
+            "-width", zoom, "-outline", x->x_gui.x_bcol);
 
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
@@ -92,8 +96,12 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-        "-outline", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_bcol));
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag,
+            "-outline", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
+            "-outline", x->x_gui.x_bcol);
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */

--- a/src/g_radio.c
+++ b/src/g_radio.c
@@ -111,8 +111,9 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
         sprintf(tag, "%pBASE%d", x, i);
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
             xx11, yy11, xx12, yy12);
-        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-fill", x->x_gui.x_bcol);
+        pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+            "-width", zoom, "-fill", x->x_gui.x_bcol,
+            "-outline", THISGUI->i_foregroundcolor->s_name);
 
         sprintf(tag, "%pBUT%d", x, i);
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -171,17 +172,18 @@ static void radio_draw_select(t_radio* x, t_glist* glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
-    int lcol = x->x_gui.x_lcol;
-    int col = IEM_GUI_COLOR_NORMAL;
-    char tag[128];
+    char tag[128], lcol_buf[8] = "#000000\0";
+    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
 
     if(x->x_gui.x_fsf.x_selected)
-        lcol = col =  IEM_GUI_COLOR_SELECTED;
+        lcol = col = THISGUI->i_selectcolor->s_name;
+    else
+        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void radio_draw_update(t_gobj *client, t_glist *glist)

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -383,7 +383,7 @@ static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
                   glist_getcanvas(glist), "create", "line",
                   x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
                   "-width", 0,
-                  "-fill", "blue",
+                  "-fill", THISGUI->i_selectcolor->s_name,
                   "-tags", tag);
     } else {
         pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -142,9 +142,10 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos - lmargin, ypos - tmargin,
         xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h + bmargin);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-fill", x->x_gui.x_bcol);
+        "-fill", x->x_gui.x_bcol,
+        "-outline", THISGUI->i_foregroundcolor->s_name);
 
     sprintf(tag, "%pKNOB", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -157,9 +158,12 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
 
-    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms,
-        "-fill", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol));
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -190,16 +194,18 @@ static void slider_draw_new(t_slider *x, t_glist *glist)
 static void slider_draw_select(t_slider* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    int col = IEM_GUI_COLOR_NORMAL, lcol = x->x_gui.x_lcol;
-    char tag[128];
+    char tag[128], lcol_buf[8] = "#000000\0";
+    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = IEM_GUI_COLOR_SELECTED;
+        col = lcol = THISGUI->i_selectcolor->s_name;
+    else
+        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void slider_draw_update(t_gobj *client, t_glist *glist)

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -44,8 +44,9 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     sprintf(tag, "%pBASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol);
+    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-outline", THISGUI->i_foregroundcolor->s_name);
 
     sprintf(tag, "%pX1", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -64,9 +65,13 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
-    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms,
-        "-fill", (x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol));
+
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 void toggle_draw_new(t_toggle *x, t_glist *glist)
@@ -100,16 +105,18 @@ void toggle_draw_new(t_toggle *x, t_glist *glist)
 void toggle_draw_select(t_toggle* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    int col = IEM_GUI_COLOR_NORMAL, lcol = x->x_gui.x_lcol;
-    char tag[128];
+    char tag[128], lcol_buf[8] = "#000000\0";
+    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = IEM_GUI_COLOR_SELECTED;
+        col = lcol = THISGUI->i_selectcolor->s_name;
+    else
+        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 void toggle_draw_update(t_toggle *x, t_glist *glist)

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -172,14 +172,17 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos - hmargin, ypos - vmargin,
         xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
-    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom,
-        "-fill", x->x_gui.x_bcol);
+    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-outline", THISGUI->i_foregroundcolor->s_name);
 
     sprintf(tag, "%pSCALE", x);
-    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms,
-        "-fill", x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol);
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     sprintf(tag, "%pRLED", x);
     pdgui_vmess(0, "crs ri", canvas, "itemconfigure", tag, "-width", ledw);
 
@@ -230,9 +233,12 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos+x->x_gui.x_ldx * zoom, ypos+x->x_gui.x_ldy * zoom);
-    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms,
-        "-fill", x->x_gui.x_fsf.x_selected ? IEM_GUI_COLOR_SELECTED : x->x_gui.x_lcol);
+    if(x->x_gui.x_fsf.x_selected)
+        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+    else
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 
     x->x_updaterms = x->x_updatepeak = 1;
@@ -290,18 +296,20 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
 static void vu_draw_select(t_vu* x,t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    int col = IEM_GUI_COLOR_NORMAL;
-    int lcol = x->x_gui.x_lcol;
-    char tag[128];
+    char tag[128], lcol_buf[8] = "#000000\0";
+    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = IEM_GUI_COLOR_SELECTED;
+        col = lcol = THISGUI->i_selectcolor->s_name;
+    else
+        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pSCALE", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void vu_draw_update(t_gobj *client, t_glist *glist)


### PR DESCRIPTION
Fixes some issues with Pd's colors. This is a reboot of https://github.com/pure-data/pure-data/pull/2646

It's made simpler and packed into 3 commits:

- [x] Some basic items didn't conform with Pd's colors: Cords weren't created with the foreground color. GOPs and array names didn't retain foreground colors when reopening the patch. The selection rectangle was hardcoded to black and now is the same as the selection color. Displacing GOPs changed the selection color to foreground (also applied to array name and this was an old bug prior to adding colors).
- [x] Iemguis now change their outline color to Pd's foreground, as well as selection color to Pd's selection color. Scalars also use the selection color.
- [x] Pd should restrict color names to hex numbers preceded by "#". This makes it easier to catch illegal symbols that trigger tcl/tk errors. It also makes life easier for other forks (which won't need to bother to support fancy tcl/tk color names like "mistyrose"). In the end, it's also desirable if we want to set iemguis's background and foreground colors to Pd's
- [ ] Unrestrict color names to also allow "blue", "red" and whatnot... but store these as hex symbols. This process also allows validating and preventing tcl/tk errors. It also makes things work with iemguis. Pd forks can also find a way to support tcl/tk colors, after all, they provide all the table values for all supported symbols.

------

- closes https://github.com/pure-data/pure-data/issues/2663
- partially closes items in https://github.com/pure-data/pure-data/issues/2642