### PR TITLE
Fix Pd colors a bit more

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -926,11 +926,11 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
     sprintf(tag, "%pOUT%d", x, 0);
     pdgui_vmess(0, "crs", canvas, "delete", tag);
     if(!x->x_fsf.x_snd_able) {
-        pdgui_vmess(0, "crr iiii rs rs rS",
+        pdgui_vmess(0, "crr iiii rk rk rS",
             canvas, "create", "rectangle",
             xpos, ypos + x->x_h + zoom - ioh, xpos + iow, ypos + x->x_h,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
         /* keep label above outlet */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);
@@ -940,11 +940,11 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
     sprintf(tag, "%pIN%d", x, 0);
     pdgui_vmess(0, "crs", canvas, "delete", tag);
     if(!x->x_fsf.x_rcv_able) {
-        pdgui_vmess(0, "crr iiii rs rs rS",
+        pdgui_vmess(0, "crr iiii rk rk rS",
             canvas, "create", "rectangle",
             xpos, ypos, xpos + iow, ypos - zoom + ioh,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
         /* keep label above inlet */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);

--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -170,9 +170,9 @@ typedef struct _iemgui
     t_iem_fstyle_flags x_fsf;
     int                x_fontsize;
     t_iem_init_symargs x_isa;
-    int                x_fcol;
-    int                x_bcol;
-    int                x_lcol;
+    unsigned int       x_fcol;
+    unsigned int       x_bcol;
+    unsigned int       x_lcol;
     /* send/receive/label as used ($args expanded) */
     t_symbol           *x_snd;              /* send symbol */
     t_symbol           *x_rcv;              /* receive */

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -37,25 +37,25 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     sprintf(tag, "%pBASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
-    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom, "-fill", x->x_gui.x_bcol,
-        "-outline", THISGUI->i_foregroundcolor->s_name);
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pBUT", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos + inset, ypos + inset,
         xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
-    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom, "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
-        "-outline", THISGUI->i_foregroundcolor->s_name);
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
 
     if (x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
@@ -88,20 +88,19 @@ static void bng_draw_new(t_bng *x, t_glist *glist)
 static void bng_draw_select(t_bng* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], lcol_buf[8] = "#000000\0";
-    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = THISGUI->i_selectcolor->s_name;
-    else
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        col = lcol = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pBUT", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void bng_draw_update(t_bng *x, t_glist *glist)

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -284,8 +284,8 @@ struct _instancecanvas  /* per-instance stuff for canvases */
     int i_dspstate;                         /* whether DSP is running */
     int i_dollarzero;                       /* counter for $0 */
     t_float i_graph_lastxpix, i_graph_lastypix;       /* state for dragging */
-    t_symbol *i_foregroundcolor, *i_backgroundcolor;  /* color of fg & bg */
-    t_symbol *i_selectcolor, *i_gopcolor;             /* ...selection and GOP */
+    unsigned int i_foregroundcolor, i_backgroundcolor;  /* color of fg & bg */
+    unsigned int i_selectcolor, i_gopcolor;             /* ...selection and GOP */
 };
 
 void g_editor_newpdinstance(void);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -61,11 +61,11 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 /* ------------------------ managing the selection ----------------- */
 void glist_deselectline(t_glist *x);
 
-static void _editor_selectlinecolor(t_glist *x, const char*color)
+static void _editor_selectlinecolor(t_glist *x, unsigned int color)
 {
     char tag[128];
     sprintf(tag, "l%p", x->gl_editor->e_selectline_tag);
-    pdgui_vmess(0, "crs rs",
+    pdgui_vmess(0, "crs rk",
         x, "itemconfigure", tag,
         "-fill", color);
 
@@ -83,7 +83,7 @@ void glist_selectline(t_glist *x, t_outconnect *oc, int index1,
         x->gl_editor->e_selectline_index2 = index2;
         x->gl_editor->e_selectline_inno = inno;
         x->gl_editor->e_selectline_tag = oc;
-        _editor_selectlinecolor(x, THISGUI->i_selectcolor->s_name);
+        _editor_selectlinecolor(x, THISGUI->i_selectcolor);
     }
 }
 
@@ -92,7 +92,7 @@ void glist_deselectline(t_glist *x)
     if (x->gl_editor)
     {
         x->gl_editor->e_selectedline = 0;
-        _editor_selectlinecolor(x, THISGUI->i_foregroundcolor->s_name);
+        _editor_selectlinecolor(x, THISGUI->i_foregroundcolor);
     }
 }
 
@@ -1916,11 +1916,11 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 pdtk_canvas_new; but if it's just white don't pass it in
                 case we're talking to an older GUI version (so that
                 pureVST can work with Pd 0.55 as its GUI) */
-            if (strcmp(THISGUI->i_backgroundcolor->s_name, "#FFFFFF"))
-                pdgui_vmess("pdtk_canvas_new", "^ ii si s", x,
+            if (THISGUI->i_backgroundcolor != 0xFFFFFF)
+                pdgui_vmess("pdtk_canvas_new", "^ ii si k", x,
                     (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1),
-                    winpos, x->gl_edit, THISGUI->i_backgroundcolor->s_name);
+                    winpos, x->gl_edit, THISGUI->i_backgroundcolor);
             else pdgui_vmess("pdtk_canvas_new", "^ ii si", x,
                     (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1), winpos, x->gl_edit);
@@ -2526,12 +2526,12 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
                         x->gl_editor->e_ywas = y2;
                         pdgui_vmess("::pdtk_canvas::cords_to_foreground",
                             "ci", x, 0);
-                        pdgui_vmess(0, "crr iiii ri rs rs",
+                        pdgui_vmess(0, "crr iiii ri rk rs",
                             x, "create", "line",
                             x->gl_editor->e_xwas,x->gl_editor->e_ywas,
                             xpix, ypix,
                             "-width", (issignal ? 2 : 1) * x->gl_zoom,
-                            "-fill", THISGUI->i_foregroundcolor->s_name,
+                            "-fill", THISGUI->i_foregroundcolor,
                             "-tags", "x");
                     }
                     else canvas_setcursor(x, CURSOR_EDITMODE_CONNECT);
@@ -2677,10 +2677,10 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
     {
         if (!shiftmod)
             glist_noselect(x);
-        pdgui_vmess(0, "crr iiii rs rs",
+        pdgui_vmess(0, "crr iiii rk rs",
             x, "create", "rectangle",
             xpix,ypix, xpix,ypix,
-            "-outline", THISGUI->i_selectcolor->s_name,
+            "-outline", THISGUI->i_selectcolor,
             "-tags", "x");
         x->gl_editor->e_xwas = xpix;
         x->gl_editor->e_ywas = ypix;
@@ -2756,11 +2756,11 @@ static int tryconnect(t_canvas*x, t_object *src, int nout,
                              ((x22-x21-iow) * nin)/(ninlets-1) : 0)
                 + iom;
             ly2 = y21;
-            pdgui_vmess(0, "crr iiii ri rs rS",
+            pdgui_vmess(0, "crr iiii ri rk rS",
                 glist_getcanvas(x), "create", "line",
                 lx1,ly1, lx2,ly2,
                 "-width", (obj_issignaloutlet(src, nout) ? 2 : 1) * x->gl_zoom,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-tags", 2, tags);
             canvas_undo_add(x, UNDO_CONNECT, "connect",
                 canvas_undo_set_connect(x,
@@ -4587,11 +4587,11 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
         char tag[128];
         char*tags[] = {tag, "cord"};
         sprintf(tag, "l%p", oc);
-        pdgui_vmess(0, "crr iiii ri rs rS",
+        pdgui_vmess(0, "crr iiii ri rk rS",
             glist_getcanvas(x), "create", "line",
             0, 0, 0, 0,
             "-width", (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
         canvas_fixlinesfor(x, objsrc);
     }

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -728,12 +728,12 @@ static void graph_create_text(
     SETSYMBOL(fontatoms+0, gensym(sys_font));
     SETFLOAT (fontatoms+1, fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
-    pdgui_vmess(0, "crr ii rs rs rr rA rS",
+    pdgui_vmess(0, "crr ii rs rk rr rA rS",
               glist_getcanvas(x),
               "create", "text",
               posX, posY,
               "-text", name,
-              "-fill", THISGUI->i_foregroundcolor->s_name,
+              "-fill", THISGUI->i_foregroundcolor,
               "-anchor", anchor,
               "-font", 3, fontatoms,
               "-tags", numtags, tags);
@@ -800,13 +800,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
         const char *tags3[] = {tag, "label", "graph" };
 
             /* draw a rectangle around the graph */
-        pdgui_vmess(0, "crr iiiiiiiiii ri rr rs rS",
+        pdgui_vmess(0, "crr iiiiiiiiii ri rr rk rS",
                   glist_getcanvas(x->gl_owner),
                   "create", "line",
                   x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
                   "-width", glist_getzoom(x),
                   "-capstyle", "projecting",
-                  "-fill", THISGUI->i_foregroundcolor->s_name,
+                  "-fill", THISGUI->i_foregroundcolor,
                   "-tags", 2, tags2);
             /* if there's just one "garray" in the graph, write its name
                 along the top */
@@ -992,9 +992,9 @@ static void graph_displace(t_gobj *z, t_glist *glist, int dx, int dy)
             canvas_fixlinesfor(glist, &x->gl_obj);
             char tag[80];
             sprintf(tag, "graph%lx", (t_int)z);
-            pdgui_vmess(0, "crs rs",
+            pdgui_vmess(0, "crs rk",
                 glist_getcanvas(glist), "itemconfigure", tag,
-                "-fill", THISGUI->i_selectcolor->s_name);
+                "-fill", THISGUI->i_selectcolor);
         }
     }
 }
@@ -1012,15 +1012,15 @@ static void graph_select(t_gobj *z, t_glist *glist, int state)
             rtext_select(y, state);
 
         sprintf(tag, "%sR",  rtext_gettag(y));
-        pdgui_vmess(0, "crs rr",
+        pdgui_vmess(0, "crs rk",
                   glist, "itemconfigure", tag,
-                  "-fill", (state? THISGUI->i_selectcolor->s_name :
-                      THISGUI->i_foregroundcolor->s_name));
+                  "-fill", (state? THISGUI->i_selectcolor :
+                      THISGUI->i_foregroundcolor));
         sprintf(tag, "graph%lx", (t_int)z);
-        pdgui_vmess(0, "crs rr",
+        pdgui_vmess(0, "crs rk",
                   glist_getcanvas(glist), "itemconfigure", tag,
-                  "-fill", (state? THISGUI->i_selectcolor->s_name :
-                      THISGUI->i_foregroundcolor->s_name));
+                  "-fill", (state? THISGUI->i_selectcolor :
+                      THISGUI->i_foregroundcolor));
     }
 }
 

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -53,8 +53,8 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
 
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs ri rs", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
+            "-width", zoom, "-outline", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
             "-width", zoom, "-outline", x->x_gui.x_bcol);
@@ -97,8 +97,8 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     char tag[128];
     sprintf(tag, "%pBASE", x);
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag,
-            "-outline", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
+            "-outline", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
             "-outline", x->x_gui.x_bcol);

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -124,20 +124,14 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-    char fcol_buf[8] = "#000000\0", lcol_buf[8] = "#000000\0";
-    const char *fcol = fcol_buf, *lcol = lcol_buf;
+    unsigned int fcol = x->x_gui.x_fcol, lcol = x->x_gui.x_lcol;
     if(x->x_gui.x_fsf.x_selected)
     {
-        lcol = THISGUI->i_selectcolor->s_name;
-        fcol = x->x_gui.x_fsf.x_change ? THISGUI->i_gopcolor->s_name : lcol;
+        fcol = lcol = THISGUI->i_selectcolor;
     }
-    else
+    if(x->x_gui.x_fsf.x_change)
     {
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
-        if(x->x_gui.x_fsf.x_change)
-            fcol = THISGUI->i_gopcolor->s_name;
-        else
-            sprintf(fcol_buf + 1, "%06x", x->x_gui.x_fcol);
+        fcol = THISGUI->i_gopcolor;
     }
 
     my_numbox_ftoa(x);
@@ -150,9 +144,9 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
         xpos + w,          ypos + x->x_gui.x_h,
         xpos,              ypos + x->x_gui.x_h,
         xpos,              ypos);
-    pdgui_vmess(0, "crs  ri rs rk", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs  ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-outline", THISGUI->i_foregroundcolor->s_name,
+        "-outline", THISGUI->i_foregroundcolor,
         "-fill", x->x_gui.x_bcol);
 
 
@@ -169,7 +163,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom,
         ypos + x->x_gui.x_ldy * zoom);
-    pdgui_vmess(0, "crs  rA rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs  rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
         "-fill", lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
@@ -177,7 +171,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     sprintf(tag, "%pNUMBER", x);
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
         xpos + half + 2*zoom, ypos + half + d);
-    pdgui_vmess(0, "crs  rs rA rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs  rs rA rk", canvas, "itemconfigure", tag,
         "-text", x->x_buf,
         "-font", 3, fontatoms,
         "-fill", fcol);
@@ -215,9 +209,9 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
 static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], fcol_buf[8] = "#000000\0", lcol_buf[8] = "#000000\0";
-    const char *bcol = THISGUI->i_foregroundcolor->s_name;
-    const char *fcol = fcol_buf, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int bcol = THISGUI->i_foregroundcolor;
+    unsigned int fcol = x->x_gui.x_fcol, lcol = x->x_gui.x_lcol;
 
     if(x->x_gui.x_fsf.x_selected)
     {
@@ -227,22 +221,17 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
             x->x_buf[0] = 0;
             sys_queuegui(x, x->x_gui.x_glist, my_numbox_draw_update);
         }
-        bcol = lcol = fcol = THISGUI->i_selectcolor->s_name;
-    }
-    else
-    {
-        sprintf(fcol_buf + 1, "%06x", x->x_gui.x_fcol);
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        bcol = lcol = fcol = THISGUI->i_selectcolor;
     }
 
     sprintf(tag, "%pBASE1", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", bcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", bcol);
     sprintf(tag, "%pBASE2", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", fcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", fcol);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
     sprintf(tag, "%pNUMBER", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", fcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", fcol);
 }
 
 static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
@@ -264,15 +253,15 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
                 x->x_buf[sl+1] = 0;
                 if(sl >= x->x_numwidth)
                     cp += sl - x->x_numwidth + 1;
-                pdgui_vmess(0, "crs rs rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_gopcolor->s_name, "-text", cp);
+                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
+                    "-fill", THISGUI->i_gopcolor, "-text", cp);
                 x->x_buf[sl] = 0;
             }
             else
             {
                 my_numbox_ftoa(x);
-                pdgui_vmess(0, "crs rs rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_gopcolor->s_name, "-text", x->x_buf);
+                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
+                    "-fill", THISGUI->i_gopcolor, "-text", x->x_buf);
                 x->x_buf[0] = 0;
             }
         }
@@ -280,8 +269,8 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
         {
             my_numbox_ftoa(x);
             if(x->x_gui.x_fsf.x_selected)
-                pdgui_vmess(0, "crs rs rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_selectcolor->s_name,
+                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
+                    "-fill", THISGUI->i_selectcolor,
                     "-text", x->x_buf);
             else
                 pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,

--- a/src/g_radio.c
+++ b/src/g_radio.c
@@ -44,11 +44,11 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     if(!x->x_gui.x_fsf.x_snd_able)
     {
         int height = x->x_gui.x_h * ((x->x_orientation == horizontal)? 1: x->x_number);
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos, ypos + height + zoom - ioh,
             xpos + iow, ypos + height,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
 
             /* keep buttons above outlet */
@@ -59,11 +59,11 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     pdgui_vmess(0, "crs", canvas, "delete", tag);
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos, ypos,
             xpos + iow, ypos - zoom + ioh,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
 
             /* keep buttons above inlet */
@@ -107,13 +107,13 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
 
     for(i = 0; i < x->x_number; i++)
     {
-        int col = (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+        unsigned int col = (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
         sprintf(tag, "%pBASE%d", x, i);
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
             xx11, yy11, xx12, yy12);
-        pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+        pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
             "-width", zoom, "-fill", x->x_gui.x_bcol,
-            "-outline", THISGUI->i_foregroundcolor->s_name);
+            "-outline", THISGUI->i_foregroundcolor);
 
         sprintf(tag, "%pBUT%d", x, i);
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -172,18 +172,16 @@ static void radio_draw_select(t_radio* x, t_glist* glist)
 {
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], lcol_buf[8] = "#000000\0";
-    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
 
     if(x->x_gui.x_fsf.x_selected)
-        lcol = col = THISGUI->i_selectcolor->s_name;
-    else
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        lcol = col = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void radio_draw_update(t_gobj *client, t_glist *glist)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -36,7 +36,7 @@ struct _rtext
     t_word *x_words;        /* ... and if so, associated data */
     t_gobj *x_drawtext;     /* ... and the drawing instruction */
     t_glist *x_glist;       /* glist owner belongs to */
-    t_symbol *x_color;      /* X11-style name of color to draw */
+    unsigned int x_color;      /* (A)RGB value */
     char x_tag[50];         /* tag for gui */
     struct _rtext *x_next;  /* next in editor list */
     int x_xpix;           /* (x,y) origin in pixels */
@@ -166,12 +166,9 @@ void rtext_free(t_rtext *x)
     freebytes(x, sizeof(*x));
 }
 
-void rtext_setcolor(t_rtext *x, int color)
+void rtext_setcolor(t_rtext *x, unsigned int color)
 {
-    char buf[80];
-    pd_snprintf(buf, 80, "#%06x", color);
-    buf[79] = 0;
-    x->x_color = gensym(buf);
+    x->x_color = color;
 }
 
 
@@ -620,15 +617,14 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
             character is an unescaped backslash ('\') which would have confused
             tcl/tk by escaping the close brace otherwise.  The GUI code
             drops the last character in the string. */
-        pdgui_vmess("pdtk_text_new", "c S ii s i r",
+        pdgui_vmess("pdtk_text_new", "c S ii s i k",
             canvas,
             2, tags,
             x->x_xpix + lmargin, x->x_ypix + tmargin,
             tempbuf,
             guifontsize,
             (x->x_text && glist_isselected(x->x_glist, &x->x_text->te_g)?
-                THISGUI->i_selectcolor->s_name :
-                    x->x_color->s_name));
+                THISGUI->i_selectcolor : x->x_color));
     }
     else if (action == SEND_UPDATE)
     {
@@ -730,10 +726,10 @@ void rtext_displace(t_rtext *x, int dx, int dy)
 
 void rtext_select(t_rtext *x, int state)
 {
-    pdgui_vmess(0, "crs rr",
+    pdgui_vmess(0, "crs rk",
         glist_getcanvas(x->x_glist), "itemconfigure", x->x_tag,
-        "-fill", (state? THISGUI->i_selectcolor->s_name:
-            THISGUI->i_foregroundcolor->s_name));
+        "-fill", (state? THISGUI->i_selectcolor:
+            THISGUI->i_foregroundcolor));
 }
 
 void rtext_activate(t_rtext *x, int state)

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -379,11 +379,11 @@ static void scalar_drawselectrect(t_scalar *x, t_glist *glist, int state)
         int x1, y1, x2, y2;
         scalar_getrect(&x->sc_gobj, glist, &x1, &y1, &x2, &y2);
         x1--; x2++; y1--; y2++;
-        pdgui_vmess(0, "crr iiiiiiiiii ri rr rs",
+        pdgui_vmess(0, "crr iiiiiiiiii ri rk rs",
                   glist_getcanvas(glist), "create", "line",
                   x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
                   "-width", 0,
-                  "-fill", THISGUI->i_selectcolor->s_name,
+                  "-fill", THISGUI->i_selectcolor,
                   "-tags", tag);
     } else {
         pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", tag);

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -62,11 +62,11 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     pdgui_vmess(0, "crs", canvas, "delete", tag);
     if(!x->x_gui.x_fsf.x_snd_able)
     {
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos - lmargin, ypos + x->x_gui.x_h + bmargin + zoom - ioh,
             xpos - lmargin + iow, ypos + x->x_gui.x_h + bmargin,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
 
             /* keep knob above outlet */
@@ -77,11 +77,11 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     pdgui_vmess(0, "crs", canvas, "delete", tag);
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos - lmargin, ypos - tmargin,
             xpos - lmargin + iow, ypos - tmargin - zoom + ioh,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
 
             /* keep knob above inlet */
@@ -142,10 +142,10 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos - lmargin, ypos - tmargin,
         xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h + bmargin);
-    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom,
         "-fill", x->x_gui.x_bcol,
-        "-outline", THISGUI->i_foregroundcolor->s_name);
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pKNOB", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -159,8 +159,8 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
 
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
             "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
@@ -194,18 +194,16 @@ static void slider_draw_new(t_slider *x, t_glist *glist)
 static void slider_draw_select(t_slider* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], lcol_buf[8] = "#000000\0";
-    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = THISGUI->i_selectcolor->s_name;
-    else
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        col = lcol = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void slider_draw_update(t_gobj *client, t_glist *glist)

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2910,7 +2910,7 @@ static void drawtext_activate(t_gobj *z, t_glist *glist,
     post("drawtext_activate %d", state);
 }
 
-void rtext_setcolor(t_rtext *x, int color);
+void rtext_setcolor(t_rtext *x, unsigned int color);
 
 static void drawtext_vis(t_gobj *z, t_glist *glist,
     t_word *data, t_template *template, t_scalar *sc,

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1133,13 +1133,13 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
                 "text"
             };
             gatom_getwherelabel(x, glist, &x1, &y1);
-            pdgui_vmess("pdtk_text_new", "cS ff s ir",
+            pdgui_vmess("pdtk_text_new", "cS ff s ik",
                 glist_getcanvas(glist),
                 3, tags,
                 (double)x1, (double)y1,
                 canvas_realizedollar(x->a_glist, x->a_label)->s_name,
                 gatom_fontsize(x) * glist_getzoom(glist),
-                THISGUI->i_foregroundcolor->s_name);
+                THISGUI->i_foregroundcolor);
         }
         else
             pdgui_vmess(0, "crs", glist_getcanvas(glist), "delete", buf);
@@ -1344,12 +1344,12 @@ static void text_select(t_gobj *z, t_glist *glist, int state)
         {
             char buf[MAXPDSTRING];
             sprintf(buf, "%sR", rtext_gettag(y));
-            pdgui_vmess(0, "crs rr",
+            pdgui_vmess(0, "crs rk",
                 glist,
                 "itemconfigure",
                 buf,
-                "-fill", (state? THISGUI->i_selectcolor->s_name :
-                    THISGUI->i_foregroundcolor->s_name));
+                "-fill", (state? THISGUI->i_selectcolor :
+                    THISGUI->i_foregroundcolor));
         }
     }
 }
@@ -1534,12 +1534,12 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
         tags[0] = tagbuf;
         tags[1] = "outlet";
         if (firsttime)
-            pdgui_vmess(0, "crr iiii rS rr rr",
+            pdgui_vmess(0, "crr iiii rS rk rk",
                 glist_getcanvas(glist), "create", "rectangle",
                 onset, y2 - oh + glist->gl_zoom, onset + iow, y2,
                 "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
-                "-outline", THISGUI->i_foregroundcolor->s_name);
+                "-fill", THISGUI->i_foregroundcolor,
+                "-outline", THISGUI->i_foregroundcolor);
         else
             pdgui_vmess(0, "crs iiii",
                 glist_getcanvas(glist), "coords", tagbuf,
@@ -1554,13 +1554,13 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
         tags[0] = tagbuf;
         tags[1] = "inlet";
         if (firsttime)
-            pdgui_vmess(0, "crr iiii rS rr rr",
+            pdgui_vmess(0, "crr iiii rS rk rk",
                 glist_getcanvas(glist),
                 "create", "rectangle",
                 onset, y1, onset + iow, y1 + ih - glist->gl_zoom,
                 "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
-                "-outline", THISGUI->i_foregroundcolor->s_name);
+                "-fill", THISGUI->i_foregroundcolor,
+                "-outline", THISGUI->i_foregroundcolor);
         else
             pdgui_vmess(0, "crs iiii",
                 glist_getcanvas(glist), "coords", tagbuf,
@@ -1583,12 +1583,12 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *pattern = ((pd_class(&x->te_pd) == text_class) ? "-" : "\"\"");
         char *tags[] = {tagR, "obj"};
         if (firsttime)
-            pdgui_vmess(0, "crr iiiiiiiiii rr ri rr rr rS",
+            pdgui_vmess(0, "crr iiiiiiiiii rr ri rk rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1,
                 "-dash", pattern,
                 "-width", glist->gl_zoom,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
         else
@@ -1608,12 +1608,12 @@ void text_drawborder(t_text *x, t_glist *glist,
         if (corner > 10*glist->gl_zoom)
             corner = 10*glist->gl_zoom; /* looks bad if too big */
         if (firsttime)
-            pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rr rr rS",
+            pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rk rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1, y1,  x2+corner, y1,  x2, y1+corner,  x2, y2-corner,
                 x2+corner, y2,  x1, y2,  x1, y1,
                 "-width", glist->gl_zoom,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
         else
@@ -1631,12 +1631,12 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
         if (firsttime)
-            pdgui_vmess(0, "crr iiiiiiiiiiii ri rr rr rS",
+            pdgui_vmess(0, "crr iiiiiiiiiiii ri rk rr rS",
                 glist_getcanvas(glist), "create", "line",
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner, x2, y2,
                 x1p, y2,  x1p, y1p,
                 "-width", glist->gl_zoom+grabbed,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
         else
@@ -1657,13 +1657,13 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
         if (firsttime)
-            pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rr rr rS",
+            pdgui_vmess(0, "crr iiiiiiiiiiiiii ri rk rr rS",
                 glist_getcanvas(glist),
                 "create", "line",
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner,
                 x2, y2-corner,  x2-corner, y2,  x1p, y2,  x1p, y1p,
                 "-width", glist->gl_zoom+grabbed,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-capstyle", "projecting",
                 "-tags", 2, tags);
         else
@@ -1684,10 +1684,10 @@ void text_drawborder(t_text *x, t_glist *glist,
     {
         char *tags[] = {tagR, "commentbar"};
         if (firsttime)
-            pdgui_vmess(0, "crr iiii rr rS",
+            pdgui_vmess(0, "crr iiii rk rS",
                 glist_getcanvas(glist), "create", "line",
                 x2, y1,  x2, y2,
-                "-fill", THISGUI->i_foregroundcolor->s_name,
+                "-fill", THISGUI->i_foregroundcolor,
                 "-tags", 2, tags);
         else
             pdgui_vmess(0, "crs iiii",

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -28,7 +28,7 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     int crossw = 1, w = x->x_gui.x_w / zoom;
-    int col = x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+    unsigned int col = x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol;
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
@@ -44,9 +44,9 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     sprintf(tag, "%pBASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
-    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom, "-fill", x->x_gui.x_bcol,
-        "-outline", THISGUI->i_foregroundcolor->s_name);
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pX1", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -67,8 +67,8 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
 
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
             "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
@@ -105,18 +105,16 @@ void toggle_draw_new(t_toggle *x, t_glist *glist)
 void toggle_draw_select(t_toggle* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], lcol_buf[8] = "#000000\0";
-    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = THISGUI->i_selectcolor->s_name;
-    else
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        col = lcol = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 void toggle_draw_update(t_toggle *x, t_glist *glist)
@@ -124,7 +122,7 @@ void toggle_draw_update(t_toggle *x, t_glist *glist)
     if(glist_isvisible(glist))
     {
         t_canvas *canvas = glist_getcanvas(glist);
-        int col = (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+        unsigned int col = (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
         char tag[128];
 
         sprintf(tag, "%pX1", x);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -102,19 +102,19 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     if(!snd_able)
     {
         sprintf(tag_n, "%pOUT%d", x, 0);
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos - hmargin, ypos + x->x_gui.x_h + vmargin + zoom - ioh,
             xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
 
         sprintf(tag_n, "%pOUT%d", x, 1);
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + zoom - ioh,
             xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
             /* keep label above outlets */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);
@@ -125,19 +125,19 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     if(!x->x_gui.x_fsf.x_rcv_able)
     {
         sprintf(tag_n, "%pIN%d", x, 0);
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos - hmargin, ypos - vmargin,
             xpos - hmargin + iow, ypos - vmargin - zoom + ioh,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
 
         sprintf(tag_n, "%pIN%d", x, 1);
-        pdgui_vmess(0, "crr iiii rs rs rS", canvas, "create", "rectangle",
+        pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
             xpos + x->x_gui.x_w + hmargin, ypos - vmargin - zoom + ioh,
-            "-fill", THISGUI->i_foregroundcolor->s_name,
-            "-outline", THISGUI->i_foregroundcolor->s_name,
+            "-fill", THISGUI->i_foregroundcolor,
+            "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
             /* keep label above inlets */
         pdgui_vmess(0, "crss", canvas, "lower", tag, tag_label);
@@ -172,14 +172,14 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos - hmargin, ypos - vmargin,
         xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
-    pdgui_vmess(0, "crs ri rk rs", canvas, "itemconfigure", tag,
+    pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom, "-fill", x->x_gui.x_bcol,
-        "-outline", THISGUI->i_foregroundcolor->s_name);
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pSCALE", x);
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
             "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
@@ -234,8 +234,8 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos+x->x_gui.x_ldx * zoom, ypos+x->x_gui.x_ldy * zoom);
     if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rs", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor->s_name);
+        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
             "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
@@ -296,20 +296,18 @@ static void vu_draw_new(t_vu *x, t_glist *glist)
 static void vu_draw_select(t_vu* x,t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
-    char tag[128], lcol_buf[8] = "#000000\0";
-    const char *col = THISGUI->i_foregroundcolor->s_name, *lcol = lcol_buf;
+    char tag[128];
+    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = THISGUI->i_selectcolor->s_name;
-    else
-        sprintf(lcol_buf + 1, "%06x", x->x_gui.x_lcol);
+        col = lcol = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pSCALE", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
     sprintf(tag, "%pLABEL", x);
-    pdgui_vmess(0, "crs rs", canvas, "itemconfigure", tag, "-fill", lcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }
 
 static void vu_draw_update(t_gobj *client, t_glist *glist)


### PR DESCRIPTION
this builds on (and includes) https://github.com/pure-data/pure-data/pull/2668/
but adds the following:

- use `unsigned int` for the internal representation of colors (rather than a symbol) (ffafeaa10526466e912b6dd6ce5d5876cb5ae633)
  - as a consequence, we can get back to using `k` (the *color* specifier) in `pdgui_vmess()` for sending colors to Pd-GUI again (rather than a weird mixture of `k`, `s` (escaped strings) and `r` (raw strings).
- the 2nd commit (929212f9b831e58c9d37edd7dafb56ee9ed38521) allows iemgui's to understand a color `default` which just uses whitish for the background, and black for label/foreground.
  - this is mean **only** as a smallish change to allow future versions of Pd to use the `default` color in a more meaningful way (as in: use the colors from Pd's color scheme)
  - it will get the "default" colors for `[vu]` and `[cnv]` wrong (as they don't typically have a `#FFFFFF` background), but i think the overall experience is better than making everything `#000000` (which is what is currently happening)
  - this is *not* for the users to be used yet (and probably shouldn't be documented yet)