### PR TITLE
allow users to set Pd colors with color names as before

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -47,6 +47,7 @@ void glob_vis(void *dummy, t_symbol *s);
 void glob_closesubs(void *dummy);
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop);
+void glob_colors_callback(void *dummy, t_float valid, t_symbol *color,  t_float type);
 
 static void glob_helpintro(t_pd *dummy)
 {
@@ -208,6 +209,8 @@ void glob_init(void)
         gensym("close-subwindows"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_colors,
         gensym("colors"), A_SYMBOL, A_SYMBOL, A_SYMBOL, A_DEFSYMBOL, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_colors_callback,
+        gensym("colors_callback"), A_FLOAT, A_SYMBOL, A_FLOAT, 0);
     class_addanything(glob_pdobject, max_default);
     pd_bind(&glob_pdobject, gensym("pd"));
 }

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -82,6 +82,7 @@ namespace import ::pdtk_canvas::pdtk_canvas_getscroll
 namespace import ::pdtk_canvas::pdtk_canvas_setparents
 namespace import ::pdtk_canvas::pdtk_canvas_reflecttitle
 namespace import ::pdtk_canvas::pdtk_canvas_menuclose
+namespace import ::pdtk_canvas::pdtk_canvas_validate_color
 namespace import ::dialog_array::pdtk_array_dialog
 namespace import ::dialog_audio::pdtk_audio_dialog
 namespace import ::dialog_canvas::pdtk_canvas_dialog

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -203,6 +203,21 @@ proc pdtk_canvas_saveas {mytoplevel initialfile initialdir destroyflag} {
     ::pd_guiprefs::update_recentfiles $filename
 }
 
+##### validate tcl/tk color
+proc ::pdtk_canvas::pdtk_canvas_validate_color {name type} {
+    set color_escaped [string map {{ } {\\ }} $name]
+    if {[catch {winfo rgb . $color_escaped} rgb]} {
+        pdsend "pd color_callback 0 $color_escaped $type"
+        return
+    }
+    set r [format %02x [expr {[lindex $rgb 0] / 256}]]
+    set g [format %02x [expr {[lindex $rgb 1] / 256}]]
+    set b [format %02x [expr {[lindex $rgb 2] / 256}]]
+    set hex_color "#$r$g$b"
+    pdsend "pd colors_callback 1 $hex_color $type"
+}
+
+
 ##### ask user Save? Discard? Cancel?, and if so, send a message on to Pd ######
 proc ::pdtk_canvas::pdtk_canvas_menuclose {mytoplevel reply_to_pd} {
     raise $mytoplevel


### PR DESCRIPTION
This uses a tcl/tk function to validate color symbols (like "blue", "red", etc) and returns a hex symbol to be saved, like we're currently doing

closes https://github.com/pure-data/pure-data/issues/2673