### PR TITLE
bug fixes: nonexistent  access (reports 2526, and 2585), and symbol in…

### DIFF
--- a/src/x_vexp.h
+++ b/src/x_vexp.h
@@ -210,6 +210,8 @@ struct ex_ex {
 #define EE_NOTABLE      0x08    /* NO TABLE */
 #define EE_NOVAR        0x10    /* NO VARIABLE */
 #define EE_BADSYM       0x20    /* Symbol passed for Vector */
+#define EE_BADRES       0x40    /* Bad result */
+#define EE_YO_RANGE	0x80	/* bad $y range access */
 
 typedef struct expr {
 #ifdef PD

--- a/src/x_vexp_if.c
+++ b/src/x_vexp_if.c
@@ -518,7 +518,17 @@ expr_perform(t_int *w)
                         x->exp_tmpres[j][i] = 0;
                         break;
                 default:
-                        post("expr_perform: bad result type %d", res.ex_type);
+                        if (!(x->exp_error & EE_BADRES)) {
+                                x->exp_error |= EE_BADRES;
+                                        post_error((t_object *) x,
+                                                "fexpr~: '%s': bad result, an error may have occured\n",
+                                                                        x->exp_string);
+                                post_error(x,
+                                      "fexpr~: No more such errors will be reported");
+                                post_error(x,
+                                      "fexpr~: till the next reset");
+                        }
+                        x->exp_tmpres[j][i] = 0;
                 }
         }
         /*
@@ -1360,8 +1370,17 @@ max_ex_var(struct expr *expr, t_symbol *var, struct ex_ex *optr, int idx)
                 !garray_getfloatwords(garray, &size, &vec))  {          \
                 optr->ex_type = ET_FLT;                                 \
                 optr->ex_int = 0;                                       \
-                pd_error(0, "%s: no such table '%s'",                   \
-                        e->exp_string, sym?(sym->s_name):"(null)");     \
+                if (!(e->exp_error & EE_NOTABLE)) {                     \
+                        post_error(e, "expr: '%s':  '%s': no such table ",     \
+                            e->exp_string, sym?(sym->s_name):"(null)"); \
+                        if (!IS_EXPR(e)) {                              \
+                                post_error(e,                           \
+                         "expr: No more table errors will be reported");\
+                                post_error(e,                           \
+                                   "expr: till the next reset");        \
+                                e->exp_error |= EE_NOTABLE;             \
+                        }                                               \
+                }                                                       \
                 return;                                                 \
         }
 


### PR DESCRIPTION
Fixed two bugs:

2526 - fexpr~ causes crash when trying to use a non-existent output
https://github.com/pure-data/pure-data/issues/2526

and

2585 - regression bug in expr with setting array name with a symbol input if it's on the left part of the equation
https://github.com/pure-data/pure-data/issues/2585