### PR TITLE
audio settings: add refresh button for device list

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -26,6 +26,7 @@ void glob_start_preference_dialog(t_pd *dummy, t_symbol*s);
 void glob_audio_properties(t_pd *dummy, t_floatarg flongform);
 void glob_audio_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_audio_setapi(t_pd *dummy, t_floatarg f);
+void glob_audio_refresh_devicelist(t_pd *dummy);
 void glob_midi_properties(t_pd *dummy, t_floatarg flongform);
 void glob_midi_dialog(t_pd *dummy, t_symbol *s, int argc, t_atom *argv);
 void glob_midi_setapi(t_pd *dummy, t_floatarg f);
@@ -161,6 +162,8 @@ void glob_init(void)
         gensym("audio-dialog"), A_GIMME, 0);
     class_addmethod(glob_pdobject, (t_method)glob_audio_setapi,
         gensym("audio-setapi"), A_FLOAT, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_audio_refresh_devicelist,
+        gensym("audio-refresh-devicelist"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_midi_setapi,
         gensym("midi-setapi"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_midi_properties,

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -66,7 +66,6 @@ t_semaphore *pa_sem;
 #define POLL_TIMEOUT 2.0
 #endif
 static double pa_lastdactime;
-
 static int pa_initialized;
 
 static void pa_init(void)        /* Initialize PortAudio  */

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -183,6 +183,7 @@ void pa_close_audio(void);
 int pa_send_dacs(void);
 int pa_reopen_audio(void);
 void pa_listdevs(void);
+void pa_reinitialize(void);
 void pa_getdevs(char *indevlist, int *nindevs,
     char *outdevlist, int *noutdevs, int *canmulti,
         int maxndev, int devdescsize);

--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -57,6 +57,10 @@ proc ::dialog_audio::config2string { } {
         "]
 }
 
+proc ::dialog_audio::refresh_devicelist {mytoplevel} {
+    pdsend "pd audio-refresh-devicelist"
+}
+
 proc ::dialog_audio::apply {mytoplevel {force ""}} {
     set config [config2string]
     if { $force ne "" || $config ne $::dialog_audio::referenceconfig} {
@@ -207,6 +211,13 @@ proc ::dialog_audio::fill_frame_iodevices {frame maxdevs longform} {
         }
         pack $frame.longbutton.b -expand 1 -ipadx 10 -pady 5
     }
+
+    set mytoplevel [winfo toplevel $frame]
+    frame $frame.refreshbutton
+    pack $frame.refreshbutton -side bottom -fill x -pady 5
+    button $frame.refreshbutton.b -text [_ "Refresh Device List"] \
+        -command "::dialog_audio::refresh_devicelist $mytoplevel"
+    pack $frame.refreshbutton.b -expand 1 -ipadx 10 -pady 5
 }
 
 
@@ -370,6 +381,21 @@ proc ::dialog_audio::set_configuration { \
     set ::audio_advance ${advance}
     set ::audio_use_callback ${use_callback}
     set ::audio_can_multidevice ${can_multidevice}
+}
+
+proc ::dialog_audio::refresh_ui {} {
+    # check if we're in the preferences window
+    if {[winfo exists ${::dialog_preferences::audio_frame}]} {
+        ::preferencewindow::removechildren ${::dialog_preferences::audio_frame}
+        ::dialog_audio::fill_frame ${::dialog_preferences::audio_frame}
+    }
+    # check if we have the standalone dialog open
+    foreach w [winfo children .] {
+        if {[winfo class $w] eq "DialogWindow" && [wm title $w] eq [_ "Audio Settings"]} {
+            destroy $w
+            ::dialog_audio::create $w
+        }
+    }
 }
 
 proc ::dialog_audio::create {mytoplevel} {

--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -5,6 +5,7 @@ package require pdtcl_compat
 namespace eval ::dialog_audio:: {
     namespace export pdtk_audio_dialog
     variable referenceconfig ""
+    variable standalone_window ""
 }
 set ::audio_samplerate 48000
 set ::audio_advance 25
@@ -212,11 +213,10 @@ proc ::dialog_audio::fill_frame_iodevices {frame maxdevs longform} {
         pack $frame.longbutton.b -expand 1 -ipadx 10 -pady 5
     }
 
-    set mytoplevel [winfo toplevel $frame]
     frame $frame.refreshbutton
-    pack $frame.refreshbutton -side bottom -fill x -pady 5
+    pack $frame.refreshbutton -side bottom -fill x
     button $frame.refreshbutton.b -text [_ "Refresh Device List"] \
-        -command "::dialog_audio::refresh_devicelist $mytoplevel"
+        -command "::dialog_audio::refresh_devicelist [winfo toplevel $frame]"
     pack $frame.refreshbutton.b -expand 1 -ipadx 10 -pady 5
 }
 
@@ -384,17 +384,13 @@ proc ::dialog_audio::set_configuration { \
 }
 
 proc ::dialog_audio::refresh_ui {} {
-    # check if we're in the preferences window
+    # check if we're in the tabbed preferences or standalone audio dialog
     if {[winfo exists ${::dialog_preferences::audio_frame}]} {
         ::preferencewindow::removechildren ${::dialog_preferences::audio_frame}
         ::dialog_audio::fill_frame ${::dialog_preferences::audio_frame}
-    }
-    # check if we have the standalone dialog open
-    foreach w [winfo children .] {
-        if {[winfo class $w] eq "DialogWindow" && [wm title $w] eq [_ "Audio Settings"]} {
-            destroy $w
-            ::dialog_audio::create $w
-        }
+    } elseif {[winfo exists $::dialog_audio::standalone_window]} {
+        destroy $::dialog_audio::standalone_window
+        ::dialog_audio::create $::dialog_audio::standalone_window
     }
 }
 
@@ -474,6 +470,7 @@ proc ::dialog_audio::create {mytoplevel} {
     wm minsize $mytoplevel [winfo reqwidth $mytoplevel] [winfo reqheight $mytoplevel]
     position_over_window $mytoplevel .pdwindow
     raise $mytoplevel
+    set ::dialog_audio::standalone_window $mytoplevel
 }
 
 # legacy proc forthe audio-dialog


### PR DESCRIPTION
this is an attempt to allow hotplugging of audio devices for portaudio.

currently, the button generically closes and reopens audio (if it was open) - this might be restricted to portaudio only? and also not sure if it's actually necessary to handle the `was_open` state - or just do close/reopen?

for the preferences window, it repopulates the previous content. the standalone dialog is completely recreated.