### PR TITLE
stable (already merged) development branch

### DIFF
--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -94,6 +94,12 @@ proc ::dialog_audio::state2widgets {state args} {
         set s "disabled"
     }
     foreach w $args {
+        if {[winfo exist $w.menu]} {
+            if {[$w.menu index last] < 1} {
+                $w configure -state disabled
+                continue
+            }
+        }
         $w configure -state $s
     }
 

--- a/tcl/dialog_audio.tcl
+++ b/tcl/dialog_audio.tcl
@@ -380,11 +380,13 @@ proc ::dialog_audio::set_configuration { \
 }
 
 proc ::dialog_audio::refresh_ui {} {
-    # check if we're in the tabbed preferences or standalone audio dialog
+    # check if we're in the tabbed preferences
     if {[winfo exists ${::dialog_preferences::audio_frame}]} {
         ::preferencewindow::removechildren ${::dialog_preferences::audio_frame}
         ::dialog_audio::fill_frame ${::dialog_preferences::audio_frame}
-    } elseif {[winfo exists $::dialog_audio::standalone_window]} {
+    }
+    # or in the standalone audio dialog
+    if {[winfo exists $::dialog_audio::standalone_window]} {
         destroy $::dialog_audio::standalone_window
         ::dialog_audio::create $::dialog_audio::standalone_window
     }


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts.).

it supersedes https://github.com/pure-data/pure-data/pull/2666

---

### GUI
- update both standalone audio dialog and preferences on device-rescan
   (rather than only updating one of both; it's possible to have both open...)
- disable device popup menu, if there's nothing to select from