### PR TITLE
reflect palette in gui, use for cords_to_foreground

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2371,10 +2371,13 @@ void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
         pd_error(0, "skipping color update");
         return;
     }
-    THISGUI->i_foregroundcolor = c_fg;
-    THISGUI->i_backgroundcolor = c_bg;
-    THISGUI->i_selectcolor = c_sel;
-    THISGUI->i_gopcolor = c_gop;
+        /* forward palette to gui */
+    pdgui_vmess("::pd_colors::set_palette", "kkkk",
+        THISGUI->i_foregroundcolor = c_fg,
+        THISGUI->i_backgroundcolor = c_bg,
+        THISGUI->i_selectcolor = c_sel,
+        THISGUI->i_gopcolor = c_gop
+    );
     for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         glist_dorevis(gl);
 }

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -241,6 +241,36 @@ namespace eval ::pdgui:: {
 }
 
 #------------------------------------------------------------------------------#
+# color palette and utilities
+
+namespace eval ::pd_colors {
+    variable palette
+    array set palette {
+        foreground "#000000"
+        background "#FFFFFF"
+        selected   "#0000FF"
+        gop        "#FF0000"
+    }
+}
+
+proc ::pd_colors::set_palette {fg bg sel gop} {
+    set ::pd_colors::palette(foreground) $fg
+    set ::pd_colors::palette(background) $bg
+    set ::pd_colors::palette(selected) $sel
+    set ::pd_colors::palette(gop) $gop
+}
+
+proc ::pd_colors::interpolate {color1 color2 amount} {
+    set amount [expr {max(0, min(1, $amount))}]
+    scan $color1 "#%2x%2x%2x" r1 g1 b1
+    scan $color2 "#%2x%2x%2x" r2 g2 b2
+    set r [expr {int($r1 + ($r2 - $r1) * $amount)}]
+    set g [expr {int($g1 + ($g2 - $g1) * $amount)}]
+    set b [expr {int($b1 + ($b2 - $b1) * $amount)}]
+    return [format "#%02x%02x%02x" $r $g $b]
+}
+
+#------------------------------------------------------------------------------#
 # coding style
 #
 # these are preliminary ideas, we'll change them as we work things out:

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -510,13 +510,14 @@ proc ::pdtk_canvas::cleanname {name} {
 
 proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
     if {$::pdtk_canvas::enable_cords_to_foreground} {
-        set col black
+        set col $::pd_colors::palette(foreground)
         if { $state == 0 } {
-            set col lightgrey
+            set col [::pd_colors::interpolate \
+                $::pd_colors::palette(background) $::pd_colors::palette(foreground) 0.17]
         }
         foreach id [$mytoplevel find withtag {cord && !selected}] {
-            # don't apply backgrouding on selected (blue) lines
-            if { [lindex [$mytoplevel itemconfigure $id -fill] 4 ] ne "blue" } {
+            # don't apply backgrounding on selected lines
+            if { [lindex [$mytoplevel itemconfigure $id -fill] 4 ] ne $::pd_colors::palette(selected) } {
                 $mytoplevel itemconfigure $id -fill $col
             }
         }


### PR DESCRIPTION
this is adding a tcl interpolation function for an attenuated foreground color and reflects the palette in the gui, updated by the `colors` message.

* closes #2686 
  * fixes the hardcoded colors for the cords_to_foreground feature, which obviously don't align well with custom palettes.

known issues:
the redundancy of setting the initial color values on the gui side is a bit ugly. it might be an option to send an initial `colors` message? but i didn't want to do this here
