### PR TITLE
fix text caret with foreground color

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -1917,10 +1917,11 @@ void canvas_vis(t_canvas *x, t_floatarg f)
                 case we're talking to an older GUI version (so that
                 pureVST can work with Pd 0.55 as its GUI) */
             if (THISGUI->i_backgroundcolor != 0xFFFFFF)
-                pdgui_vmess("pdtk_canvas_new", "^ ii si k", x,
+                pdgui_vmess("pdtk_canvas_new", "^ ii si kk", x,
                     (int)(x->gl_screenx2 - x->gl_screenx1),
-                (int)(x->gl_screeny2 - x->gl_screeny1),
-                    winpos, x->gl_edit, THISGUI->i_backgroundcolor);
+                    (int)(x->gl_screeny2 - x->gl_screeny1),
+                    winpos, x->gl_edit,
+                    THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor);
             else pdgui_vmess("pdtk_canvas_new", "^ ii si", x,
                     (int)(x->gl_screenx2 - x->gl_screenx1),
                 (int)(x->gl_screeny2 - x->gl_screeny1), winpos, x->gl_edit);

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -99,7 +99,7 @@ proc pdtk_canvas_place_window {width height geometry} {
 # canvas new/saveas
 
 proc pdtk_canvas_new {mytoplevel width height geometry editable \
-        {bgcolor "white"} } {
+        {bgcolor "white"} {fgcolor "black"} } {
     if { "" eq $geometry } {
         # no position set: this is a new window (rather than one loaded from file)
         # we set a flag here, so we can query (and report) the actual geometry,
@@ -135,7 +135,7 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable \
         -highlightthickness 0 -scrollregion [list 0 0 $width $height] \
         -xscrollcommand "$mytoplevel.xscroll set" \
         -yscrollcommand "$mytoplevel.yscroll set" \
-        -background $bgcolor
+        -background $bgcolor -insertbackground $fgcolor
     scrollbar $mytoplevel.xscroll -orient horizontal -command "$tkcanvas xview"
     scrollbar $mytoplevel.yscroll -orient vertical -command "$tkcanvas yview"
     pack $tkcanvas -side left -expand 1 -fill both


### PR DESCRIPTION
This applies Pd's foreground color to the text caret.

Right now it defaults to black, so it becomes invisible with a black background

This issue is mentioned amongst others in https://github.com/pure-data/pure-data/issues/2674

-------

It was a small change that required also sending THISGUI->i_foregroundcolor (besides THISGUI->i_backgroundcolor) to "pdtk_canvas_new" and use "-insertbackground" to configure it