### PR TITLE
use ternary statements for gui selection cases

### DIFF
--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -52,13 +52,11 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_lcol);
 
-    if (x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -51,13 +51,10 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos + offset, ypos + offset,
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
-
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", x->x_gui.x_bcol);
+    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
+        "-width", zoom,
+        "-outline", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_bcol);
 
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
@@ -96,12 +93,9 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
     sprintf(tag, "%pBASE", x);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-            "-outline", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-            "-outline", x->x_gui.x_bcol);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
+        "-outline", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_bcol);
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -268,14 +268,10 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
         else
         {
             my_numbox_ftoa(x);
-            if(x->x_gui.x_fsf.x_selected)
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_selectcolor,
-                    "-text", x->x_buf);
-            else
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", x->x_gui.x_fcol,
-                    "-text", x->x_buf);
+            pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
+                "-fill", x->x_gui.x_fsf.x_selected
+                    ? THISGUI->i_selectcolor : x->x_gui.x_fcol,
+                "-text", x->x_buf);
             x->x_buf[0] = 0;
         }
     }

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -157,13 +157,11 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_lcol);
 
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -65,13 +65,11 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_lcol);
 
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 void toggle_draw_new(t_toggle *x, t_glist *glist)

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -177,12 +177,11 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%pSCALE", x);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_lcol);
+
     sprintf(tag, "%pRLED", x);
     pdgui_vmess(0, "crs ri", canvas, "itemconfigure", tag, "-width", ledw);
 
@@ -233,12 +232,11 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos+x->x_gui.x_ldx * zoom, ypos+x->x_gui.x_ldy * zoom);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : x->x_gui.x_lcol);
+
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 
     x->x_updaterms = x->x_updatepeak = 1;


### PR DESCRIPTION
In ea0b8e3 several gui selection cases were split into separate `pdgui_vmess` statements to account for the difference in required format specifiers between pd instance colors (symbols) and iemgui colors (unsigned ints). Now that both are of the same type, we can collapse these if statements and revert back to using ternary statements.