### PR TITLE
Add "Rescan Devices" button to MIDI settings

### DIFF
--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -48,6 +48,7 @@ void glob_closesubs(void *dummy);
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop);
 void glob_rescanaudio(void *dummy);
+void glob_rescanmidi(void *dummy);
 
 static void glob_helpintro(t_pd *dummy)
 {
@@ -211,6 +212,8 @@ void glob_init(void)
         gensym("colors"), A_SYMBOL, A_SYMBOL, A_SYMBOL, A_DEFSYMBOL, 0);
     class_addmethod(glob_pdobject, (t_method)glob_rescanaudio,
         gensym("rescan-audio"), 0);
+    class_addmethod(glob_pdobject, (t_method)glob_rescanmidi,
+        gensym("rescan-midi"), 0);
     class_addanything(glob_pdobject, max_default);
     pd_bind(&glob_pdobject, gensym("pd"));
 }

--- a/src/s_libpdmidi.c
+++ b/src/s_libpdmidi.c
@@ -79,4 +79,5 @@ int sys_mididevnametonumber(int output, const char *name) { return 0; }
 void sys_mididevnumbertoname(int output, int devno, char *name, int namesize) {}
 void sys_set_midi_api(int api) {}
 void sys_gui_midipreferences(void) {}
+void glob_rescanmidi(void *dummy) {}
 int sys_midiapi;

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -719,13 +719,13 @@ void sys_gui_midipreferences(void) {
 #ifdef __APPLE__
     if (sched_get_using_audio() == SCHED_AUDIO_CALLBACK)
     {
-        pd_error(0, "Cannot load MIDI settings in 'callback' mode when audio is running.");
+        pd_error(0, "Cannot load MIDI settings in 'callback' mode when audio is running. "
+            "Please turn off DSP and rescan devices.");
         nindev = noutdev = nindevs = noutdevs = 0;
     }
     else
 #endif
     {
-        sys_reinit_midi();
         sys_get_midi_devs(indevlist, &nindevs, outdevlist, &noutdevs,
             MAXNDEV, DEVDESCSIZE);
         sys_get_midi_params(&nindev, midiindev, &noutdev, midioutdev);

--- a/src/s_midi.c
+++ b/src/s_midi.c
@@ -758,6 +758,15 @@ void glob_midi_properties(t_pd *dummy, t_floatarg flongform)
         (void *)glob_midi_properties, "");
 }
 
+    /* rescan MIDI devices */
+void glob_rescanmidi(void *dummy)
+{
+    sys_reinit_midi();
+    sys_gui_midipreferences();
+        /* refresh midi dialog (if it's open) */
+    pdgui_vmess("::dialog_midi::refresh_ui", "");
+}
+
 #define MIDI_DIALOG_DEVS 9
 
     /* new values from dialog window */

--- a/tcl/dialog_midi.tcl
+++ b/tcl/dialog_midi.tcl
@@ -7,6 +7,7 @@ namespace eval ::dialog_midi:: {
     namespace export pdtk_alsa_midi_dialog
 
     variable referenceconfig ""
+    variable standalone_window ""
 }
 
 # reference configuration string (to detect whether the config has changed)
@@ -178,6 +179,12 @@ proc ::dialog_midi::make_frame_iodevices {frame maxdevs longform} {
             -command  "::dialog_midi::make_frame_iodevices $frame $maxdevs 1"
         pack $frame.longbutton.b -expand 1 -ipadx 10 -pady 5
     }
+
+    frame $frame.refreshbutton
+    pack $frame.refreshbutton -side bottom -fill x
+    button $frame.refreshbutton.b -text [_ "Rescan Devices"] \
+        -command "pdsend \"pd rescan-midi\""
+    pack $frame.refreshbutton.b -expand 1 -ipadx 10 -pady 5
 }
 
 proc ::dialog_midi::make_frame_ports {frame inportsvar outportsvar} {
@@ -299,6 +306,19 @@ proc ::dialog_midi::set_configuration {API inputdevices indevs outputdevices  ou
     set ::midi_outdevices [lmap _ $outdevs {set _ [expr int($_) ]; if {$_ < 0} continue; set _}]
 }
 
+proc ::dialog_midi::refresh_ui {} {
+    # check if we're in the tabbed preferences
+    if {[winfo exists ${::dialog_preferences::midi_frame}]} {
+        ::preferencewindow::removechildren ${::dialog_preferences::midi_frame}
+        ::dialog_midi::fill_frame ${::dialog_preferences::midi_frame}
+    }
+    # or in the standalone midi dialog
+    if {[winfo exists $::dialog_midi::standalone_window]} {
+        destroy $::dialog_midi::standalone_window
+        ::dialog_midi::create $::dialog_midi::standalone_window
+    }
+}
+
 # start a dialog window to select midi devices.  "longform" asks us to make
 # controls for opening several devices; if not, we get an extra button to
 # turn longform on and restart the dialog.
@@ -404,6 +424,7 @@ proc ::dialog_midi::create {id} {
     wm minsize $id [winfo reqwidth $id] [winfo reqheight $id]
     position_over_window $id .pdwindow
     raise $id
+    set ::dialog_midi::standalone_window $id
 }
 
 proc ::dialog_midi::pdtk_alsa_midi_dialog {id \


### PR DESCRIPTION
this changes the midi devices rescanning to be consistent with the audio devices rescanning. it adds a similar "Rescan Devices" button to the midi settings frame.

the implicit midi reset when opening the settings is omitted.
