### PR TITLE
Fix selection rectangle for data objects with invisible text or labels

### DIFF
--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2903,6 +2903,7 @@ static void drawtext_getrect(t_gobj *z, t_glist *glist,
     t_drawtext *x = (t_drawtext *)z;
     t_rtext *rtext;
     if (!gobj_shouldvis(z, glist)
+        || !drawtext_isvisible(z, data)
         || !(rtext = glist_getforscalar(glist, sc, data, z)))
     {
         *xp1 = *yp1 = 0x7fffffff;

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2909,7 +2909,12 @@ static void drawtext_getrect(t_gobj *z, t_glist *glist,
         *xp1 = *yp1 = 0x7fffffff;
         *xp2 = *yp2 = -0x7fffffff;
     }
-    else rtext_getrect(rtext, xp1, yp1, xp2, yp2);
+    else
+    {
+        rtext_getrect(rtext, xp1, yp1, xp2, yp2);
+        if (*x->x_label->s_name)
+            *xp1 -= glist_fontwidth(glist) * strlen(x->x_label->s_name);
+    }
 }
 
 static void drawtext_displace(t_gobj *z, t_glist *glist,


### PR DESCRIPTION
this is an attempt to fix the remaining issue for #2589 mentioned in https://github.com/pure-data/pure-data/issues/2589#issuecomment-3129369190

it consists of 2 commits to:
* consider `drawtext_isvisible` for `drawtext_getrect`
* extend rect to left by label size (feels a bit hacky)

@millerpuckette not sure if this is the right approach - maybe it's also not too bad to omit the labels for selection?