### PR TITLE
escape dollars on gui side for donecanvasdialog

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2106,7 +2106,7 @@ static void canvas_donecanvasdialog(t_glist *x,
         t_binbuf *b = binbuf_new();
         char *textbuf;
         int textsize;
-        binbuf_add(b, argc-13, argv+13);
+        binbuf_restore(b, argc-13, argv+13);
         binbuf_gettext(b, &textbuf, &textsize);
         binbuf_free(b);
         canvas_undo_add(x->gl_owner, UNDO_SEQUENCE_START, "typing", 0);

--- a/tcl/dialog_canvas.tcl
+++ b/tcl/dialog_canvas.tcl
@@ -25,7 +25,7 @@ proc ::dialog_canvas::set_text {text} {
 proc ::dialog_canvas::apply {mytoplevel} {
     global ::dialog_canvas_text
     if [string compare $::dialog_canvas_text $::dialog_canvas_text_before] {
-            set appendme [concat text $::dialog_canvas_text]
+        set appendme [concat text [string map {"$" "\\$"} $::dialog_canvas_text]]
     } else {
         set appendme ""
     }


### PR DESCRIPTION
properly handle (and preserve) dollargs entered in properties dialog of abstractions.
(not sure if handling more characters might be desirable - but this covers the most relevant case)

opening this PR after quick coordination with @Ant1r - see https://github.com/pure-data/pure-data/pull/2723#issuecomment-3166805844

closes #2720