### PR TITLE
fix crash when closing text window's subpatch

### DIFF
--- a/tcl/pdtk_textwindow.tcl
+++ b/tcl/pdtk_textwindow.tcl
@@ -18,6 +18,7 @@ proc pdtk_textwindow_open {name geometry title font} {
     } else {
         toplevel $name
         wm title $name $title
+        ::pd_menus::menubar_for_dialog $name
         wm geometry $name $geometry
         wm protocol $name WM_DELETE_WINDOW \
             [concat pdtk_textwindow_close $name 1]


### PR DESCRIPTION
use menubar for macos via `::pd_menus::menubar_for_dialog` helper similar to other windows.

this avoids a crash that occurs when the editor gets focus after closing its subpatch via cmd+w (no idea why this doesn't also happen when closing the subpatch with mouse click).

* closes #2729
