### PR TITLE
report xruns to user

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -45,7 +45,6 @@ static jack_port_t *input_port[MAX_JACK_PORTS];
 static jack_port_t *output_port[MAX_JACK_PORTS];
 static jack_client_t *jack_client = NULL;
 const char *jack_client_names[MAX_CLIENTS];
-static volatile int jack_dio_error;
 static volatile int jack_didshutdown;
 static t_audiocallback jack_callback;
 static int jack_should_autoconnect = 1;
@@ -82,7 +81,7 @@ static int jack_polling_callback(jack_nframes_t nframes, void *unused)
     {
         /* data late: output zeros, drop inputs, and leave FIFOs untouched */
         if (jack_started)
-            jack_dio_error = 1;
+            sys_report_xrun(nframes);
         for (j = 0; j < STUFF->st_outchannels; j++)
         {
             if ((jp = jack_port_get_buffer(output_port[j], nframes)))
@@ -208,7 +207,7 @@ static void jack_shutdown(void *arg)
 
 static int jack_xrun(void* arg)
 {
-    jack_dio_error = 1;
+    sys_reportxrun(jack_blocksize);
     return 0;
 }
 
@@ -439,7 +438,6 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     jack_sem = sys_semaphore_create();
 #endif
     jack_didshutdown = 0;
-    jack_dio_error = 0;
 
     if ((inchans == 0) && (outchans == 0)) return 1;
 
@@ -482,7 +480,7 @@ int jack_open_audio(int inchans, int outchans, t_audiocallback callback)
     jack_set_process_callback(jack_client,
         (callback? callbackprocess : jack_polling_callback), 0);
 
-    jack_set_error_function (pd_jack_error_callback);
+    jack_set_error_function(pd_jack_error_callback);
 
 #ifdef JACK_XRUN
     jack_set_xrun_callback (jack_client, jack_xrun, NULL);
@@ -675,11 +673,7 @@ int jack_send_dacs(void)
         return (SENDDACS_NO);
 #endif
     }
-    if (jack_dio_error)
-    {
-        sys_log_error(ERR_RESYNC);
-        jack_dio_error = 0;
-    }
+
     jack_started = 1;
 
     ALLOCA(t_sample, muxbuffer, muxbufsize, MAX_ALLOCA_SAMPLES);

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -158,6 +158,7 @@ extern int sys_schedadvance;
 
 int sys_send_dacs(void);
 void sys_reportidle(void);
+void sys_reportxrun(int nsamples);
 void sys_listdevs(void);
 EXTERN void sys_set_audio_settings(t_audiosettings *as);
 EXTERN void sys_get_audio_settings(t_audiosettings *as);


### PR DESCRIPTION
Currently, xruns only flash the "Audio I/O Error" message. Now we also send the number of dropped samples to "pd-xrun", so the user can handle it.

Xruns are reported from the audio callback with the `sys_reportxrun` function, which just increments an atomic counter. In `sched_idletask` we atomically check and reset the counter and take the appropriate action.