### PR TITLE
make bang's circle color the same as the bang's foreground color

### DIFF
--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -47,7 +47,7 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
         xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom, "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
-        "-outline", THISGUI->i_foregroundcolor);
+        "-outline", x->x_gui.x_fcol);
 
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
@@ -89,16 +89,17 @@ static void bng_draw_select(t_bng* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
-
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = x->x_gui.x_lcol;
+    unsigned int fcol = x->x_gui.x_fcol;
 
     if(x->x_gui.x_fsf.x_selected)
-        col = lcol = THISGUI->i_selectcolor;
+        col = lcol = fcol = THISGUI->i_selectcolor;
 
     sprintf(tag, "%pBASE", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
     sprintf(tag, "%pBUT", x);
-    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", col);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", fcol);
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
 }


### PR DESCRIPTION
The circle is not visible when the background color is the same as the foreground color - as in black background with the default black foreground. 

this is an improved version of https://github.com/pure-data/pure-data/pull/2735

Some screenshots.

<img width="127" height="130" alt="Screenshot 2025-08-13 at 01 18 36" src="https://github.com/user-attachments/assets/a3ee5df4-5093-41a6-90a9-7d329d2daebd" />
<img width="100" height="114" alt="Screenshot 2025-08-13 at 01 18 51" src="https://github.com/user-attachments/assets/96a5cb53-e78f-4905-8634-5c63ba0c04fe" />
<img width="201" height="236" alt="Screenshot 2025-08-13 at 01 23 20" src="https://github.com/user-attachments/assets/a9bddb94-8f69-4a54-9150-e6464fbbcb75" />
