### PR TITLE
ptrobj_doget: properly check current arg's type

### DIFF
--- a/src/g_traversal.c
+++ b/src/g_traversal.c
@@ -197,7 +197,7 @@ static void ptrobj_doget(t_ptrobj *x, int argc, t_atom *argv)
     int nout, i;
     t_atom *at;
     for (i = nout = 0; i < argc; i++)
-        if (argv->a_type == A_BINBUF)
+        if (argv[i].a_type == A_BINBUF)
             nout += binbuf_getnatom(argv[i].a_w.w_binbuf);
         else nout++;
     ALLOCA(t_atom, at, nout, TRAVERSAL_NGETBYTE);


### PR DESCRIPTION
add index for the argument type check to properly count the output list length.

* closes #2743