### PR TITLE
fix ds array init when instantiated template contains arrays or texts

### DIFF
--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -153,23 +153,43 @@ void word_init(t_word *wp, t_template *template, t_gpointer *gp)
     }
 }
 
-    /* a block versions of word_init is provided because
-    creating and destroying large arrays had been absurdly slowing down patch
-    loading and closing.  The first one is created as above and the rest
-    are simply copied from the first one, in a way that now appears
-    unnecessarily convoluted. */
+    /* return 1 if all dataslots are float or symbol, 0 otherwise */
+static int template_is_flat(t_template *template)
+{
+    int i, nitems = template->t_n;
+    t_dataslot *datatypes = template->t_vec;
+    for (i = 0; i < nitems; i++)
+    {
+        int type = datatypes[i].ds_type;
+        if ((type != DT_FLOAT) && (type != DT_SYMBOL))
+            return 0;
+    }
+    return 1;
+}
+
+    /* a block versions of word_init is provided because creating and
+    destroying large arrays had been absurdly slowing down patch loading
+    and closing: if the template contains only float and symbols, the first
+    one is created as above and the rest are simply copied from the first
+    one, in a way that now appears unnecessarily convoluted. */
 void word_initvec(t_word *wp, t_template *template, t_gpointer *gp, long n)
 {
     if (n > 0)
     {
-        long ndone = 1;
-        word_init(wp, template, gp);  /* init the first one */
-        while (ndone < n)
-        {
-            long ncopy = (n-ndone > ndone ? ndone : n-ndone);
-            memcpy(wp + template->t_n*ndone, wp,
-                ncopy * template->t_n * sizeof(t_word));
-            ndone += ncopy;
+        if (template_is_flat(template)) {
+            long ndone = 1;
+            word_init(wp, template, gp);  /* init the first one */
+            while (ndone < n)
+            {
+                long ncopy = (n-ndone > ndone ? ndone : n-ndone);
+                memcpy(wp + template->t_n*ndone, wp,
+                    ncopy * template->t_n * sizeof(t_word));
+                ndone += ncopy;
+            }
+        } else {
+            for (int i = 0; i < n; i++) {
+                word_init(wp + template->t_n * i, template, gp);
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #2750

The function `g_scalar.c/word_initvec()` was designed to optimize the creation of datastructure arrays: it only creates a single instance, then copies the memory content of this instance to the other ones.
However, it does not work when the instantiated template contains `array` or `text` fields, because in this case each instance must allocate its own memory.

This PR fixes that, by testing if the template contains other fields type than "flat" floats and symbols, and if so, properly allocating each instance using `g_scalar.c/word_init()`.