### PR TITLE
preserve and dynamically handle "default" colors for iemguis

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -43,6 +43,7 @@ TCLFILES = \
     pd_docsdir.tcl \
     pd_guiprefs.tcl \
     pd_i18n.tcl \
+    pd_iemgui_colors.tcl \
     pd_menucommands.tcl \
     pd_menus.tcl \
     pdtcl_compat.tcl \

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -164,7 +164,16 @@ int iemgui_modulo_color(int col)
 
 unsigned int iemgui_getcolor_background(t_iemgui *x)
 {
-    return x->x_bcol_default ? THISGUI->i_backgroundcolor : x->x_bcol;
+    if (!x->x_bcol_default)
+        return x->x_bcol;
+    const char *class_name = class_getname(x->x_obj.te_pd);
+        /* interpolated color for cnv background */
+    if (!strcmp(class_name, "cnv"))
+        return interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12);
+        /* fixed color for vu background */
+    else if (!strcmp(class_name, "vu"))
+        return 0x404040;
+    return THISGUI->i_backgroundcolor;
 }
 
 unsigned int iemgui_getcolor_foreground(t_iemgui *x)

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -164,20 +164,17 @@ int iemgui_modulo_color(int col)
 
 unsigned int iemgui_getcolor_background(t_iemgui *x)
 {
-    return (x->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        THISGUI->i_backgroundcolor : x->x_bcol;
+    return x->x_bcol_default ? THISGUI->i_backgroundcolor : x->x_bcol;
 }
 
 unsigned int iemgui_getcolor_foreground(t_iemgui *x)
 {
-    return (x->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        THISGUI->i_foregroundcolor : x->x_fcol;
+    return x->x_fcol_default ? THISGUI->i_foregroundcolor : x->x_fcol;
 }
 
 unsigned int iemgui_getcolor_label(t_iemgui *x)
 {
-    return (x->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        THISGUI->i_foregroundcolor : x->x_lcol;
+    return x->x_lcol_default ? THISGUI->i_foregroundcolor : x->x_lcol;
 }
 
 t_symbol *iemgui_dollar2raute(t_symbol *s)
@@ -346,14 +343,24 @@ static t_symbol* color2symbol(unsigned int col) {
 
 static void iemgui_all_col2save(t_iemgui *iemgui, t_symbol**bflcol)
 {
-    bflcol[0] = (iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        gensym("default") : color2symbol(iemgui->x_bcol);
-    bflcol[1] = (iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        gensym("default") : color2symbol(iemgui->x_fcol);
-    bflcol[2] = (iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        gensym("default") : color2symbol(iemgui->x_lcol);
+    bflcol[0] = (iemgui->x_bcol_default) ? gensym("default") : color2symbol(iemgui->x_bcol);
+    bflcol[1] = (iemgui->x_fcol_default) ? gensym("default") : color2symbol(iemgui->x_fcol);
+    bflcol[2] = (iemgui->x_lcol_default) ? gensym("default") : color2symbol(iemgui->x_lcol);
 }
 
+static unsigned int _iemgui_default_color(colortype_t ct)
+{
+    switch (ct) {
+    case FOREGROUND:
+        return IEM_GUI_COLOR_FOREGROUND;
+    case BACKGROUND:
+        return IEM_GUI_COLOR_BACKGROUND;
+    case LABEL:
+        return IEM_GUI_COLOR_LABEL;
+    default:
+        return 0;
+    }
+}
 static unsigned int iemgui_getcolorarg(int index, int argc, t_atom*argv, colortype_t ct)
 {
     if(index < 0 || index >= argc)
@@ -368,22 +375,9 @@ static unsigned int iemgui_getcolorarg(int index, int argc, t_atom*argv, colorty
             int col = (int)strtol(s->s_name+1, 0, 16);
             return col & 0xFFFFFF;
         }
-        if (strcmp(s->s_name, "default") == 0)
-            return IEM_GUI_COLOR_DEFAULT_SENTINEL;
     }
-
 default_color:
-    switch(ct) {
-    case FOREGROUND:
-        return IEM_GUI_COLOR_FOREGROUND;
-    case BACKGROUND:
-        return IEM_GUI_COLOR_BACKGROUND;
-    case LABEL:
-        return IEM_GUI_COLOR_FOREGROUND;
-    default:
-        break;
-    }
-    return 0;
+    return _iemgui_default_color(ct);
 }
 
 static unsigned int colfromatomload(t_atom*colatom, colortype_t ct)
@@ -414,17 +408,20 @@ static unsigned int colfromatomload(t_atom*colatom, colortype_t ct)
     return (color);
 }
 
-static unsigned int _iemgui_load_color_with_default(t_atom *color_atom, colortype_t ct)
+static unsigned int _iemgui_load_color_with_default(t_atom *color_atom, colortype_t ct, int *default_flag)
 {
-    if (!color_atom) return IEM_GUI_COLOR_DEFAULT_SENTINEL;
-    return atom_getsymbolarg(0, 1, color_atom) == gensym("default") ?
-        IEM_GUI_COLOR_DEFAULT_SENTINEL : colfromatomload(color_atom, ct);
+    if (!color_atom || atom_getsymbolarg(0, 1, color_atom) == gensym("default")) {
+        *default_flag = 1;
+        return _iemgui_default_color(ct);
+    }
+    *default_flag = 0;
+    return colfromatomload(color_atom, ct);
 }
 void iemgui_all_loadcolors(t_iemgui *iemgui, t_atom*bcol, t_atom*fcol, t_atom*lcol)
 {
-    iemgui->x_bcol = _iemgui_load_color_with_default(bcol, BACKGROUND);
-    iemgui->x_fcol = _iemgui_load_color_with_default(fcol, FOREGROUND);
-    iemgui->x_lcol = _iemgui_load_color_with_default(lcol, LABEL);
+    iemgui->x_bcol = _iemgui_load_color_with_default(bcol, BACKGROUND, &iemgui->x_bcol_default);
+    iemgui->x_fcol = _iemgui_load_color_with_default(fcol, FOREGROUND, &iemgui->x_fcol_default);
+    iemgui->x_lcol = _iemgui_load_color_with_default(lcol, LABEL, &iemgui->x_lcol_default);
 }
 
 static unsigned int _iemgui_compatible_colorarg(int index, int argc, t_atom* argv, colortype_t ct)
@@ -643,23 +640,23 @@ void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
     if (ac >= 1) {
-        iemgui->x_bcol = (atom_getsymbolarg(0, ac, av) == gensym("default")) ?
-            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(0, ac, av, BACKGROUND);
+        iemgui->x_bcol_default = (atom_getsymbolarg(0, ac, av) == gensym("default"));
+        iemgui->x_bcol = _iemgui_compatible_colorarg(0, ac, av, BACKGROUND);
     }
     if (ac == 2 && pd_compatibilitylevel < 47)
             /* old versions of Pd updated foreground and label color
             if only two args; now we do it more coherently. */
     {
-        iemgui->x_lcol = (atom_getsymbolarg(1, ac, av) == gensym("default")) ?
-            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(1, ac, av, LABEL);
+        iemgui->x_lcol_default = (atom_getsymbolarg(1, ac, av) == gensym("default"));
+        iemgui->x_lcol = _iemgui_compatible_colorarg(1, ac, av, LABEL);
     }
     else if (ac >= 2) {
-        iemgui->x_fcol = (atom_getsymbolarg(1, ac, av) == gensym("default")) ?
-            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(1, ac, av, FOREGROUND);
+        iemgui->x_fcol_default = (atom_getsymbolarg(1, ac, av) == gensym("default"));
+        iemgui->x_fcol = _iemgui_compatible_colorarg(1, ac, av, FOREGROUND);
     }
     if (ac >= 3) {
-        iemgui->x_lcol = (atom_getsymbolarg(2, ac, av) == gensym("default")) ?
-            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(2, ac, av, LABEL);
+        iemgui->x_lcol_default = (atom_getsymbolarg(2, ac, av) == gensym("default"));
+        iemgui->x_lcol = _iemgui_compatible_colorarg(2, ac, av, LABEL);
     }
     if(glist_isvisible(iemgui->x_glist))
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_CONFIG);
@@ -792,9 +789,9 @@ void iemgui_new_dialog(void*x, t_iemgui*iemgui,
         iemgui_getcolor_background(iemgui),
         iemgui_getcolor_foreground(iemgui),
         iemgui_getcolor_label(iemgui),
-        !!(iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL),
-        !!(iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL),
-        !!(iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL));
+        iemgui->x_bcol_default,
+        iemgui->x_fcol_default,
+        iemgui->x_lcol_default);
 }
 
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
@@ -864,13 +861,12 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     iemgui->x_rcv = srl[1];
     iemgui->x_fsf.x_rcv_able = srl_is_valid(srl[1]);
     iemgui->x_lab = srl[2];
-        /* preserve sentinel values for default colors */
-    iemgui->x_bcol = ((unsigned int)bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        IEM_GUI_COLOR_DEFAULT_SENTINEL : (bcol & 0xffffff);
-    iemgui->x_fcol = ((unsigned int)fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        IEM_GUI_COLOR_DEFAULT_SENTINEL : (fcol & 0xffffff);
-    iemgui->x_lcol = ((unsigned int)lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
-        IEM_GUI_COLOR_DEFAULT_SENTINEL : (lcol & 0xffffff);
+    iemgui->x_bcol = bcol;
+    iemgui->x_fcol = fcol;
+    iemgui->x_lcol = lcol;
+    iemgui->x_bcol_default = bcol_default;
+    iemgui->x_fcol_default = fcol_default;
+    iemgui->x_lcol_default = lcol_default;
     iemgui->x_ldx = ldx;
     iemgui->x_ldy = ldy;
     if(f == 1) strcpy(iemgui->x_font, "helvetica");
@@ -900,9 +896,9 @@ void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
     t_symbol *srl[3];
     int for_undo = 1;
     int i;
-    int bcol_default = (iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
-    int fcol_default = (iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
-    int lcol_default = (iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
+    int bcol_default = iemgui->x_bcol_default;
+    int fcol_default = iemgui->x_fcol_default;
+    int lcol_default = iemgui->x_lcol_default;
     for(i=0; i<argc; i++)
         SETFLOAT(argv+i, -1); /* initialize */
 
@@ -934,9 +930,9 @@ void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
     if(argc>14) SETSYMBOL(argv+14, bcol_default ? gensym("default") : color2symbol(iemgui->x_bcol));
     if(argc>15) SETSYMBOL(argv+15, fcol_default ? gensym("default") : color2symbol(iemgui->x_fcol));
     if(argc>16) SETSYMBOL(argv+16, lcol_default ? gensym("default") : color2symbol(iemgui->x_lcol));
-    if(argc>18) SETFLOAT (argv+18, !!bcol_default);
-    if(argc>19) SETFLOAT (argv+19, !!fcol_default);
-    if(argc>20) SETFLOAT (argv+20, !!lcol_default);
+    if(argc>18) SETFLOAT (argv+18, bcol_default);
+    if(argc>19) SETFLOAT (argv+19, fcol_default);
+    if(argc>20) SETFLOAT (argv+20, lcol_default);
 }
 
 
@@ -1134,10 +1130,13 @@ t_iemgui *iemgui_new(t_class*cls)
     iem_inttosymargs(&x->x_isa, 0);
     iem_inttofstyle(&x->x_fsf, 0);
 
-        /* LATER: use IEM_GUI_COLOR_DEFAULT_SENTINEL here */
+        /* LATER: initialize with default:1 here */
     x->x_bcol = IEM_GUI_COLOR_BACKGROUND;
     x->x_fcol = IEM_GUI_COLOR_FOREGROUND;
     x->x_lcol = IEM_GUI_COLOR_LABEL;
+    x->x_bcol_default = 0;
+    x->x_fcol_default = 0;
+    x->x_lcol_default = 0;
 
     return x;
 }

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -37,10 +37,6 @@ typedef enum {
     UNKNOWN
 } colortype_t;
 
-#define IEM_GUI_COLOR_BACKGROUND 0xFCFCFC
-#define IEM_GUI_COLOR_FOREGROUND 0x000000
-#define IEM_GUI_COLOR_LABEL 0x000000
-
 
 /*  #define GGEE_HSLIDER_COMPATIBLE  */
 
@@ -164,6 +160,24 @@ int iemgui_modulo_color(int col)
     while(col < 0)
         col += IEM_GUI_MAX_COLOR;
     return(col);
+}
+
+unsigned int iemgui_getcolor_background(t_iemgui *x)
+{
+    return (x->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        THISGUI->i_backgroundcolor : x->x_bcol;
+}
+
+unsigned int iemgui_getcolor_foreground(t_iemgui *x)
+{
+    return (x->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        THISGUI->i_foregroundcolor : x->x_fcol;
+}
+
+unsigned int iemgui_getcolor_label(t_iemgui *x)
+{
+    return (x->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        THISGUI->i_foregroundcolor : x->x_lcol;
 }
 
 t_symbol *iemgui_dollar2raute(t_symbol *s)
@@ -332,9 +346,12 @@ static t_symbol* color2symbol(unsigned int col) {
 
 static void iemgui_all_col2save(t_iemgui *iemgui, t_symbol**bflcol)
 {
-    bflcol[0] = color2symbol(iemgui->x_bcol);
-    bflcol[1] = color2symbol(iemgui->x_fcol);
-    bflcol[2] = color2symbol(iemgui->x_lcol);
+    bflcol[0] = (iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        gensym("default") : color2symbol(iemgui->x_bcol);
+    bflcol[1] = (iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        gensym("default") : color2symbol(iemgui->x_fcol);
+    bflcol[2] = (iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        gensym("default") : color2symbol(iemgui->x_lcol);
 }
 
 static unsigned int iemgui_getcolorarg(int index, int argc, t_atom*argv, colortype_t ct)
@@ -351,10 +368,11 @@ static unsigned int iemgui_getcolorarg(int index, int argc, t_atom*argv, colorty
             int col = (int)strtol(s->s_name+1, 0, 16);
             return col & 0xFFFFFF;
         }
+        if (strcmp(s->s_name, "default") == 0)
+            return IEM_GUI_COLOR_DEFAULT_SENTINEL;
     }
 
 default_color:
-        /* LATER use THISGUI->i_*color */
     switch(ct) {
     case FOREGROUND:
         return IEM_GUI_COLOR_FOREGROUND;
@@ -380,7 +398,7 @@ static unsigned int colfromatomload(t_atom*colatom, colortype_t ct)
             colatom->a_w.w_symbol->s_name[0] == '-'))
                 color = atoi(colatom->a_w.w_symbol->s_name);
 
-        /* symbolic color */
+        /* symbolic color (including "default") */
     else return (iemgui_getcolorarg(0, 1, colatom, ct));
     if (color < 0)
     {
@@ -396,11 +414,17 @@ static unsigned int colfromatomload(t_atom*colatom, colortype_t ct)
     return (color);
 }
 
+static unsigned int _iemgui_load_color_with_default(t_atom *color_atom, colortype_t ct)
+{
+    if (!color_atom) return IEM_GUI_COLOR_DEFAULT_SENTINEL;
+    return atom_getsymbolarg(0, 1, color_atom) == gensym("default") ?
+        IEM_GUI_COLOR_DEFAULT_SENTINEL : colfromatomload(color_atom, ct);
+}
 void iemgui_all_loadcolors(t_iemgui *iemgui, t_atom*bcol, t_atom*fcol, t_atom*lcol)
 {
-    if(bcol)iemgui->x_bcol = colfromatomload(bcol, BACKGROUND);
-    if(fcol)iemgui->x_fcol = colfromatomload(fcol, FOREGROUND);
-    if(lcol)iemgui->x_lcol = colfromatomload(lcol, LABEL);
+    iemgui->x_bcol = _iemgui_load_color_with_default(bcol, BACKGROUND);
+    iemgui->x_fcol = _iemgui_load_color_with_default(fcol, FOREGROUND);
+    iemgui->x_lcol = _iemgui_load_color_with_default(lcol, LABEL);
 }
 
 static unsigned int _iemgui_compatible_colorarg(int index, int argc, t_atom* argv, colortype_t ct)
@@ -618,16 +642,25 @@ void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 
 void iemgui_color(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    if (ac >= 1)
-        iemgui->x_bcol = _iemgui_compatible_colorarg(0, ac, av, BACKGROUND);
+    if (ac >= 1) {
+        iemgui->x_bcol = (atom_getsymbolarg(0, ac, av) == gensym("default")) ?
+            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(0, ac, av, BACKGROUND);
+    }
     if (ac == 2 && pd_compatibilitylevel < 47)
             /* old versions of Pd updated foreground and label color
             if only two args; now we do it more coherently. */
-        iemgui->x_lcol = _iemgui_compatible_colorarg(1, ac, av, LABEL);
-    else if (ac >= 2)
-        iemgui->x_fcol = _iemgui_compatible_colorarg(1, ac, av, FOREGROUND);
-    if (ac >= 3)
-        iemgui->x_lcol = _iemgui_compatible_colorarg(2, ac, av, LABEL);
+    {
+        iemgui->x_lcol = (atom_getsymbolarg(1, ac, av) == gensym("default")) ?
+            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(1, ac, av, LABEL);
+    }
+    else if (ac >= 2) {
+        iemgui->x_fcol = (atom_getsymbolarg(1, ac, av) == gensym("default")) ?
+            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(1, ac, av, FOREGROUND);
+    }
+    if (ac >= 3) {
+        iemgui->x_lcol = (atom_getsymbolarg(2, ac, av) == gensym("default")) ?
+            IEM_GUI_COLOR_DEFAULT_SENTINEL : _iemgui_compatible_colorarg(2, ac, av, LABEL);
+    }
     if(glist_isvisible(iemgui->x_glist))
         (*iemgui->x_draw)(x, iemgui->x_glist, IEM_GUI_DRAW_MODE_CONFIG);
 }
@@ -743,7 +776,7 @@ void iemgui_new_dialog(void*x, t_iemgui*iemgui,
     sprintf(objname_, "|%s|", objname);
 
     pdgui_stub_vnew(&iemgui->x_obj.ob_pd, "pdtk_iemgui_dialog", x,
-        "r s ffs ffs sfsfs i iss ii si sss ii ii kkk",
+        "r s ffs ffs sfsfs i iss ii si sss ii ii kkk iii",
         objname_,
         "",
         width, width_min, "",
@@ -756,7 +789,12 @@ void iemgui_new_dialog(void*x, t_iemgui*iemgui,
         srl[0]?srl[0]->s_name:"", srl[1]?srl[1]->s_name:"", srl[2]?srl[2]->s_name:"",
         iemgui->x_ldx, iemgui->x_ldy,
         iemgui->x_fsf.x_font_style, iemgui->x_fontsize,
-        iemgui->x_bcol, iemgui->x_fcol, iemgui->x_lcol);
+        iemgui_getcolor_background(iemgui),
+        iemgui_getcolor_foreground(iemgui),
+        iemgui_getcolor_label(iemgui),
+        !!(iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL),
+        !!(iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL),
+        !!(iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL));
 }
 
 int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
@@ -770,6 +808,9 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     int bcol = (int)iemgui_getcolorarg(14, argc, argv, BACKGROUND);
     int fcol = (int)iemgui_getcolorarg(15, argc, argv, FOREGROUND);
     int lcol = (int)iemgui_getcolorarg(16, argc, argv, LABEL);
+    int bcol_default = (int)atom_getfloatarg(18, argc, argv);
+    int fcol_default = (int)atom_getfloatarg(19, argc, argv);
+    int lcol_default = (int)atom_getfloatarg(20, argc, argv);
     int rcv_changed=0, oldsndrcvable=0;
     int i;
 
@@ -823,9 +864,13 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
     iemgui->x_rcv = srl[1];
     iemgui->x_fsf.x_rcv_able = srl_is_valid(srl[1]);
     iemgui->x_lab = srl[2];
-    iemgui->x_lcol = lcol & 0xffffff;
-    iemgui->x_fcol = fcol & 0xffffff;
-    iemgui->x_bcol = bcol & 0xffffff;
+        /* preserve sentinel values for default colors */
+    iemgui->x_bcol = ((unsigned int)bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        IEM_GUI_COLOR_DEFAULT_SENTINEL : (bcol & 0xffffff);
+    iemgui->x_fcol = ((unsigned int)fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        IEM_GUI_COLOR_DEFAULT_SENTINEL : (fcol & 0xffffff);
+    iemgui->x_lcol = ((unsigned int)lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        IEM_GUI_COLOR_DEFAULT_SENTINEL : (lcol & 0xffffff);
     iemgui->x_ldx = ldx;
     iemgui->x_ldy = ldy;
     if(f == 1) strcpy(iemgui->x_font, "helvetica");
@@ -851,11 +896,13 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
 
 void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
 {
-#define SETCOLOR(a, col) do {char color[MAXPDSTRING]; pd_snprintf(color, MAXPDSTRING-1, "#%06x", 0xffffff & col); color[MAXPDSTRING-1] = 0; SETSYMBOL(a, gensym(color));} while(0)
     t_float zoom = iemgui->x_glist->gl_zoom;
     t_symbol *srl[3];
     int for_undo = 1;
     int i;
+    int bcol_default = (iemgui->x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
+    int fcol_default = (iemgui->x_fcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
+    int lcol_default = (iemgui->x_lcol == IEM_GUI_COLOR_DEFAULT_SENTINEL);
     for(i=0; i<argc; i++)
         SETFLOAT(argv+i, -1); /* initialize */
 
@@ -884,9 +931,12 @@ void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
     if(argc>11) SETFLOAT (argv+11, iemgui->x_ldy);
     if(argc>12) SETFLOAT (argv+12, iemgui->x_fsf.x_font_style);
     if(argc>13) SETFLOAT (argv+13, iemgui->x_fontsize);
-    if(argc>14) SETCOLOR (argv+14, iemgui->x_bcol);
-    if(argc>15) SETCOLOR (argv+15, iemgui->x_fcol);
-    if(argc>16) SETCOLOR (argv+16, iemgui->x_lcol);
+    if(argc>14) SETSYMBOL(argv+14, bcol_default ? gensym("default") : color2symbol(iemgui->x_bcol));
+    if(argc>15) SETSYMBOL(argv+15, fcol_default ? gensym("default") : color2symbol(iemgui->x_fcol));
+    if(argc>16) SETSYMBOL(argv+16, lcol_default ? gensym("default") : color2symbol(iemgui->x_lcol));
+    if(argc>18) SETFLOAT (argv+18, !!bcol_default);
+    if(argc>19) SETFLOAT (argv+19, !!fcol_default);
+    if(argc>20) SETFLOAT (argv+20, !!lcol_default);
 }
 
 
@@ -1084,6 +1134,7 @@ t_iemgui *iemgui_new(t_class*cls)
     iem_inttosymargs(&x->x_isa, 0);
     iem_inttofstyle(&x->x_fsf, 0);
 
+        /* LATER: use IEM_GUI_COLOR_DEFAULT_SENTINEL here */
     x->x_bcol = IEM_GUI_COLOR_BACKGROUND;
     x->x_fcol = IEM_GUI_COLOR_FOREGROUND;
     x->x_lcol = IEM_GUI_COLOR_LABEL;

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -1134,9 +1134,9 @@ t_iemgui *iemgui_new(t_class*cls)
     x->x_bcol = IEM_GUI_COLOR_BACKGROUND;
     x->x_fcol = IEM_GUI_COLOR_FOREGROUND;
     x->x_lcol = IEM_GUI_COLOR_LABEL;
-    x->x_bcol_default = 0;
-    x->x_fcol_default = 0;
-    x->x_lcol_default = 0;
+    x->x_bcol_default = THISGUI->i_iemgui_default_colors;
+    x->x_fcol_default = THISGUI->i_iemgui_default_colors;
+    x->x_lcol_default = THISGUI->i_iemgui_default_colors;
 
     return x;
 }

--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -43,6 +43,11 @@
 #define IEM_GUI_COLOR_SELECTED       0x0000FF
 #define IEM_GUI_COLOR_NORMAL         0x000000
 #define IEM_GUI_COLOR_EDITED         0xFF0000
+#define IEM_GUI_COLOR_BACKGROUND     0xFCFCFC
+#define IEM_GUI_COLOR_FOREGROUND     0x000000
+#define IEM_GUI_COLOR_LABEL          0x000000
+
+#define IEM_GUI_COLOR_DEFAULT_SENTINEL -1
 
 #define IEM_GUI_MAX_COLOR            30
 
@@ -313,6 +318,10 @@ EXTERN int iem_symargstoint(t_iem_init_symargs *symargp);
 EXTERN void iem_inttofstyle(t_iem_fstyle_flags *fstylep, int n);
 EXTERN int iem_fstyletoint(t_iem_fstyle_flags *fstylep);
 EXTERN void iemgui_setdrawfunctions(t_iemgui *iemgui, t_iemgui_drawfunctions *w);
+
+EXTERN unsigned int iemgui_getcolor_background(t_iemgui *x);
+EXTERN unsigned int iemgui_getcolor_foreground(t_iemgui *x);
+EXTERN unsigned int iemgui_getcolor_label(t_iemgui *x);
 
 #define IEMGUI_SETDRAWFUNCTIONS(x, prefix)                     \
     {                                                            \

--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -47,8 +47,6 @@
 #define IEM_GUI_COLOR_FOREGROUND     0x000000
 #define IEM_GUI_COLOR_LABEL          0x000000
 
-#define IEM_GUI_COLOR_DEFAULT_SENTINEL -1
-
 #define IEM_GUI_MAX_COLOR            30
 
 //#define IEM_GUI_DEFAULTSIZE 15
@@ -178,6 +176,10 @@ typedef struct _iemgui
     unsigned int       x_fcol;
     unsigned int       x_bcol;
     unsigned int       x_lcol;
+    /* default color flags */
+    int                x_fcol_default;
+    int                x_bcol_default;
+    int                x_lcol_default;
     /* send/receive/label as used ($args expanded) */
     t_symbol           *x_snd;              /* send symbol */
     t_symbol           *x_rcv;              /* receive */

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -38,7 +38,7 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-width", zoom, "-fill", iemgui_getcolor_background(&x->x_gui),
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_BUT", x);
@@ -46,19 +46,18 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
         xpos + inset, ypos + inset,
         xpos + x->x_gui.x_w - inset, ypos + x->x_gui.x_h - inset);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", (x->x_flashed ? x->x_gui.x_fcol :
-            x->x_gui.x_bcol), "-outline", THISGUI->i_foregroundcolor);
+        "-width", zoom, "-fill", (x->x_flashed ?
+            iemgui_getcolor_foreground(&x->x_gui) : iemgui_getcolor_background(&x->x_gui)),
+        "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
 
-    if (x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-        "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -93,7 +92,8 @@ static void bng_draw_select(t_bng* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
 
     if(x->x_gui.x_fsf.x_selected)
@@ -114,7 +114,8 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
         char tag[128];
         sprintf(tag, "%p_BUT", x);
         pdgui_vmess(0, "crs rk", glist_getcanvas(glist), "itemconfigure", tag,
-            "-fill", (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol));
+            "-fill", (x->x_flashed ?
+                iemgui_getcolor_foreground(&x->x_gui) : iemgui_getcolor_background(&x->x_gui)));
     }
 }
 
@@ -244,13 +245,13 @@ static void bng_dialog(t_bng *x, t_symbol *s, int argc, t_atom *argv)
     int ftbreak = (int)atom_getfloatarg(3, argc, argv);
     int sr_flags;
 
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT (undo+1, 0);
     SETFLOAT (undo+2, x->x_flashtime_break);
     SETFLOAT (undo+3, x->x_flashtime_hold);
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2338,8 +2338,12 @@ static void glist_dorevis(t_glist *glist)
     t_gobj *g;
     if (glist->gl_havewindow)
     {
-        canvas_vis(glist, 0);
-        canvas_vis(glist, 1);
+        pdgui_vmess("pdtk_canvas_setcolors", "^ kk",
+            glist,
+            (int)THISGUI->i_backgroundcolor,
+            (int)THISGUI->i_foregroundcolor);
+        glist_clearrtexts(glist);
+        canvas_redraw((t_canvas *)glist);
     }
     for (g = glist->gl_list; g; g = g->g_next)
         if (g->g_pd == canvas_class)

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2379,10 +2379,13 @@ void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
         pd_error(0, "skipping color update");
         return;
     }
-    THISGUI->i_foregroundcolor = c_fg;
-    THISGUI->i_backgroundcolor = c_bg;
-    THISGUI->i_selectcolor = c_sel;
-    THISGUI->i_gopcolor = c_gop;
+        /* forward palette to gui */
+    pdgui_vmess("::pd_colors::set_palette", "kkkk",
+        THISGUI->i_foregroundcolor = c_fg,
+        THISGUI->i_backgroundcolor = c_bg,
+        THISGUI->i_selectcolor = c_sel,
+        THISGUI->i_gopcolor = c_gop
+    );
     for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         glist_dorevis(gl);
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2365,6 +2365,21 @@ static unsigned int normalize_color(t_symbol *s)
     return (-1);
 }
 
+unsigned int interpolate_colors(unsigned int color1, unsigned int color2, float amount)
+{
+    amount = amount < 0 ? 0 : amount > 1 ? 1 : amount;
+    int r1 = (color1 >> 16) & 0xFF;
+    int g1 = (color1 >>  8) & 0xFF;
+    int b1 =  color1        & 0xFF;
+    int r2 = (color2 >> 16) & 0xFF;
+    int g2 = (color2 >>  8) & 0xFF;
+    int b2 =  color2        & 0xFF;
+    unsigned int r = r1 + (r2 - r1) * amount;
+    unsigned int g = g1 + (g2 - g1) * amount;
+    unsigned int b = b1 + (b2 - b1) * amount;
+    return (r << 16) | (g << 8) | b;
+}
+
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop)
 {

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2238,6 +2238,7 @@ void g_canvas_newpdinstance(void)
     THISGUI->i_backgroundcolor = 0xFFFFFF;
     THISGUI->i_selectcolor = 0x0000FF;
     THISGUI->i_gopcolor = 0xFF0000;
+    THISGUI->i_iemgui_default_colors = 0;
     g_editor_newpdinstance();
     g_template_newpdinstance();
 }
@@ -2403,4 +2404,9 @@ void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     );
     for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         glist_dorevis(gl);
+}
+
+void glob_iemgui_default_colors(void *dummy, t_floatarg use_default)
+{
+    THISGUI->i_iemgui_default_colors = use_default != 0;
 }

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -560,6 +560,7 @@ EXTERN void canvas_connect(t_canvas *x,
     t_floatarg fwhoout, t_floatarg foutno, t_floatarg fwhoin, t_floatarg finno);
 EXTERN void canvas_disconnect(t_canvas *x,
     t_float index1, t_float outno, t_float index2, t_float inno);
+EXTERN void canvas_iemgui_set_colors(t_canvas *x, t_symbol *color_type);
 EXTERN int canvas_isconnected (t_canvas *x,
     t_text *ob1, int n1, t_text *ob2, int n2);
 EXTERN void canvas_selectinrect(t_canvas *x, int lox, int loy, int hix, int hiy);

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -286,6 +286,7 @@ struct _instancecanvas  /* per-instance stuff for canvases */
     t_float i_graph_lastxpix, i_graph_lastypix;       /* state for dragging */
     unsigned int i_foregroundcolor, i_backgroundcolor;  /* color of fg & bg */
     unsigned int i_selectcolor, i_gopcolor;             /* ...selection and GOP */
+    int i_iemgui_default_colors;             /* force IEMGUI objects to use default colors */
 };
 
 void g_editor_newpdinstance(void);

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -690,6 +690,9 @@ EXTERN t_symbol *iemgui_raute2dollar(t_symbol *s);
 EXTERN t_symbol *iemgui_dollar2raute(t_symbol *s);
 EXTERN t_symbol *iemgui_put_in_braces(t_symbol *s);
 
+/* ------------- g_canvas.c ------------- */
+EXTERN unsigned int interpolate_colors(unsigned int col1, unsigned int col2, float factor);
+
 /*-------------  g_clone.c ------------- */
 EXTERN t_class *clone_class;
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -465,20 +465,20 @@ void canvas_iemgui_set_colors(t_canvas *x, t_symbol *color_type)
         const char *classname = class_getname(obj_class);
         if (!classname) continue;
 
-        if (strcmp(classname, "bng") == 0 ||
-            strcmp(classname, "tgl") == 0 ||
-            strcmp(classname, "hradio") == 0 ||
-            strcmp(classname, "vradio") == 0 ||
-            strcmp(classname, "hsl") == 0 ||
-            strcmp(classname, "vsl") == 0 ||
-            strcmp(classname, "nbx") == 0 ||
-            strcmp(classname, "cnv") == 0 ||
-            strcmp(classname, "vu") == 0)
+        if (!strcmp(classname, "bng") ||
+            !strcmp(classname, "tgl") ||
+            !strcmp(classname, "hradio") ||
+            !strcmp(classname, "vradio") ||
+            !strcmp(classname, "hsl") ||
+            !strcmp(classname, "vsl") ||
+            !strcmp(classname, "nbx") ||
+            !strcmp(classname, "cnv") ||
+            !strcmp(classname, "vu"))
         {
             iemgui = (t_iemgui *)y;
             unsigned int background_color = IEM_GUI_COLOR_BACKGROUND;
-            if (strcmp(classname, "cnv") == 0) background_color = 0xE0E0E0;
-            else if (strcmp(classname, "vu") == 0) background_color = 0x404040;
+            if (!strcmp(classname, "cnv")) background_color = 0xE0E0E0;
+            else if (!strcmp(classname, "vu")) background_color = 0x404040;
             iemgui->x_bcol = background_color;
             iemgui->x_fcol = IEM_GUI_COLOR_FOREGROUND;
             iemgui->x_lcol = IEM_GUI_COLOR_LABEL;

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -476,18 +476,15 @@ void canvas_iemgui_set_colors(t_canvas *x, t_symbol *color_type)
             strcmp(classname, "vu") == 0)
         {
             iemgui = (t_iemgui *)y;
-            if (is_adaptive) {
-                iemgui->x_bcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
-                iemgui->x_fcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
-                iemgui->x_lcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
-            } else {
-                unsigned int background_color = IEM_GUI_COLOR_BACKGROUND;
-                if (strcmp(classname, "cnv") == 0) background_color = 0xE0E0E0;
-                else if (strcmp(classname, "vu") == 0) background_color = 0x404040;
-                iemgui->x_bcol = background_color;
-                iemgui->x_fcol = IEM_GUI_COLOR_FOREGROUND;
-                iemgui->x_lcol = IEM_GUI_COLOR_LABEL;
-            }
+            unsigned int background_color = IEM_GUI_COLOR_BACKGROUND;
+            if (strcmp(classname, "cnv") == 0) background_color = 0xE0E0E0;
+            else if (strcmp(classname, "vu") == 0) background_color = 0x404040;
+            iemgui->x_bcol = background_color;
+            iemgui->x_fcol = IEM_GUI_COLOR_FOREGROUND;
+            iemgui->x_lcol = IEM_GUI_COLOR_LABEL;
+            iemgui->x_bcol_default = is_adaptive;
+            iemgui->x_fcol_default = is_adaptive;
+            iemgui->x_lcol_default = is_adaptive;
 
             if (glist_isvisible(x))
                 (*iemgui->x_draw)(y, x, IEM_GUI_DRAW_MODE_CONFIG);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -8,6 +8,7 @@
 #include "s_stuff.h"
 #include "g_canvas.h"
 #include "g_undo.h"
+#include "g_all_guis.h"
 #include "s_utf8.h" /*-- moo --*/
 #include <string.h>
 #include "m_private_utils.h"
@@ -449,6 +450,49 @@ void *canvas_undo_set_disconnect(t_canvas *x,
     buf->u_index2 = index2;
     buf->u_inletno = inno;
     return (buf);
+}
+
+void canvas_iemgui_set_colors(t_canvas *x, t_symbol *color_type)
+{
+    t_gobj *y;
+    t_iemgui *iemgui;
+    int is_adaptive = (color_type == gensym("adaptive"));
+    for (y = x->gl_list; y; y = y->g_next)
+    {
+        if (!y) continue;
+        t_class *obj_class = pd_class(&y->g_pd);
+        if (!obj_class) continue;
+        const char *classname = class_getname(obj_class);
+        if (!classname) continue;
+
+        if (strcmp(classname, "bng") == 0 ||
+            strcmp(classname, "tgl") == 0 ||
+            strcmp(classname, "hradio") == 0 ||
+            strcmp(classname, "vradio") == 0 ||
+            strcmp(classname, "hsl") == 0 ||
+            strcmp(classname, "vsl") == 0 ||
+            strcmp(classname, "nbx") == 0 ||
+            strcmp(classname, "cnv") == 0 ||
+            strcmp(classname, "vu") == 0)
+        {
+            iemgui = (t_iemgui *)y;
+            if (is_adaptive) {
+                iemgui->x_bcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
+                iemgui->x_fcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
+                iemgui->x_lcol = IEM_GUI_COLOR_DEFAULT_SENTINEL;
+            } else {
+                unsigned int background_color = IEM_GUI_COLOR_BACKGROUND;
+                if (strcmp(classname, "cnv") == 0) background_color = 0xE0E0E0;
+                else if (strcmp(classname, "vu") == 0) background_color = 0x404040;
+                iemgui->x_bcol = background_color;
+                iemgui->x_fcol = IEM_GUI_COLOR_FOREGROUND;
+                iemgui->x_lcol = IEM_GUI_COLOR_LABEL;
+            }
+
+            if (glist_isvisible(x))
+                (*iemgui->x_draw)(y, x, IEM_GUI_DRAW_MODE_CONFIG);
+        }
+    }
 }
 
 void canvas_disconnect(t_canvas *x,
@@ -5205,6 +5249,8 @@ void g_editor_setup(void)
         gensym("triggerize"), 0);
     class_addmethod(canvas_class, (t_method)canvas_disconnect,
         gensym("disconnect"), A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
+    class_addmethod(canvas_class, (t_method)canvas_iemgui_set_colors,
+        gensym("iemgui_set_colors"), A_SYMBOL, A_NULL);
 }
 
 void canvas_editor_for_class(t_class *c)

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4003,11 +4003,29 @@ static void glist_donewloadbangs(t_glist *x)
     if (x->gl_editor)
     {
         t_selection *sel;
+        int nsel = 0, i;
+        t_gobj **gobjv;
         for (sel = x->gl_editor->e_selection; sel; sel = sel->sel_next)
-            if (pd_class(&sel->sel_what->g_pd) == canvas_class)
-                canvas_loadbang((t_canvas *)(&sel->sel_what->g_pd));
-            else if (zgetfn(&sel->sel_what->g_pd, gensym("loadbang")))
-                vmess(&sel->sel_what->g_pd, gensym("loadbang"), "i", LB_LOAD);
+            nsel++;
+        if (!nsel)
+            return;
+        gobjv = (t_gobj **)getbytes(nsel * sizeof(*gobjv));
+        if (!gobjv)
+            return;
+        for (sel = x->gl_editor->e_selection, i = 0; sel;
+            sel = sel->sel_next, i++)
+            gobjv[i] = sel->sel_what;
+        for (i = 0; i < nsel; i++)
+        {
+            t_gobj *g = gobjv[i];
+            if (!g)
+                continue;
+            if (pd_class(&g->g_pd) == canvas_class)
+                canvas_loadbang((t_canvas *)(&g->g_pd));
+            else if (zgetfn(&g->g_pd, gensym("loadbang")))
+                vmess(&g->g_pd, gensym("loadbang"), "i", LB_LOAD);
+        }
+        freebytes(gobjv, nsel * sizeof(*gobjv));
     }
 }
 

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -64,7 +64,7 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
         ypos + x->x_gui.x_ldy * zoom);
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
-        "-fill", iemgui_getcolor_label(&x->x_gui));
+        "-fill", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -98,6 +98,9 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
         "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
+    sprintf(tag, "%pLABEL", x);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
+        "-fill", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -40,32 +40,31 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
     SETFLOAT (fontatoms+1, -(x->x_gui.x_fontsize)*zoom);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-    sprintf(tag, "%pRECT", x);
+    sprintf(tag, "%p_RECT", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_vis_w * zoom, ypos + x->x_vis_h * zoom);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", x->x_gui.x_bcol,
-        "-outline", x->x_gui.x_bcol);
+        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol,
+        "-outline", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
 
-    sprintf(tag, "%pBASE", x);
+    sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos + offset, ypos + offset,
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
+    pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
+        "-width", zoom,
+        "-outline", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : THISGUI->i_foregroundcolor);
 
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", x->x_gui.x_bcol);
-
-    sprintf(tag, "%pLABEL", x);
+    sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom,
         ypos + x->x_gui.x_ldy * zoom);
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
-        "-fill", x->x_gui.x_lcol);
+        "-fill", iemgui_getcolor_label(&x->x_gui));
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -76,15 +75,15 @@ static void my_canvas_draw_new(t_my_canvas *x, t_glist *glist)
     char *tags[] = {tag_object, tag, "label", "text"};
     sprintf(tag_object, "%p", x);
 
-    sprintf(tag, "%pRECT", x);
+    sprintf(tag, "%p_RECT", x);
     pdgui_vmess(0, "crr iiii rS", canvas, "create", "rectangle",
         0, 0, 0, 0, "-tags", 2, tags);
 
-    sprintf(tag, "%pBASE", x);
+    sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crr iiii rS", canvas, "create", "rectangle",
         0, 0, 0, 0, "-tags", 2, tags);
 
-    sprintf(tag, "%pLABEL", x);
+    sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crr ii rs rS", canvas, "create", "text",
         0, 0, "-anchor", "w", "-tags", 4, tags);
 
@@ -95,13 +94,10 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    sprintf(tag, "%pBASE", x);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-            "-outline", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-            "-outline", x->x_gui.x_bcol);
+    sprintf(tag, "%p_BASE", x);
+    pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
+        "-outline", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : THISGUI->i_foregroundcolor);
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */
@@ -162,8 +158,8 @@ static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv
     int w = atom_getfloatarg(2, argc, argv);
     int h = atom_getfloatarg(3, argc, argv);
     int sr_flags;
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT (undo+1, 0);
     SETFLOAT (undo+2, x->x_vis_w);
     SETFLOAT (undo+3, x->x_vis_h);
@@ -171,7 +167,7 @@ static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv
     SETSYMBOL(undo+15, gensym("none"));
 
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
@@ -253,8 +249,6 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     IEMGUI_SETDRAWFUNCTIONS(x, my_canvas);
 
     x->x_gui.x_bcol = 0xE0E0E0;
-    x->x_gui.x_fcol = 0x00;
-    x->x_gui.x_lcol = 0x404040;
 
     if(((argc >= 10)&&(argc <= 13))
        &&IS_A_FLOAT(argv,0)&&IS_A_FLOAT(argv,1)&&IS_A_FLOAT(argv,2))

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -44,9 +44,9 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_vis_w * zoom, ypos + x->x_vis_h * zoom);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-fill", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol,
-        "-outline", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-outline", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_BASE", x);
@@ -55,8 +55,8 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-outline", x->x_gui.x_fsf.x_selected
-            ? THISGUI->i_selectcolor : THISGUI->i_foregroundcolor);
+        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : (x->x_gui.x_bcol_default) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
@@ -96,8 +96,8 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     char tag[128];
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-        "-outline", x->x_gui.x_fsf.x_selected
-            ? THISGUI->i_selectcolor : THISGUI->i_foregroundcolor);
+        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : (x->x_gui.x_bcol_default) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
 }
 
 /* ------------------------ cnv widgetbehaviour----------------------------- */

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -44,10 +44,8 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_vis_w * zoom, ypos + x->x_vis_h * zoom);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol,
-        "-outline", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
+        "-fill", iemgui_getcolor_background(&x->x_gui),
+        "-outline", iemgui_getcolor_background(&x->x_gui));
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -55,8 +53,7 @@ static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
         xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
+        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : iemgui_getcolor_background(&x->x_gui));
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
@@ -96,8 +93,7 @@ static void my_canvas_draw_select(t_my_canvas* x, t_glist* glist)
     char tag[128];
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
-        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.12) : x->x_gui.x_bcol);
+        "-outline", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : iemgui_getcolor_background(&x->x_gui));
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag,
         "-fill", x->x_gui.x_fsf.x_selected ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -124,7 +124,8 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
-    unsigned int fcol = x->x_gui.x_fcol, lcol = x->x_gui.x_lcol;
+    unsigned int fcol = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
     if(x->x_gui.x_fsf.x_selected)
     {
         fcol = lcol = THISGUI->i_selectcolor;
@@ -136,7 +137,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
 
     my_numbox_ftoa(x);
 
-    sprintf(tag, "%pBASE1", x);
+    sprintf(tag, "%p_BASE1", x);
     pdgui_vmess(0, "crs  ii ii ii ii ii ii", canvas, "coords", tag,
         xpos,              ypos,
         xpos + w - corner, ypos,
@@ -147,19 +148,19 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
     pdgui_vmess(0, "crs  ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom,
         "-outline", THISGUI->i_foregroundcolor,
-        "-fill", x->x_gui.x_bcol);
+        "-fill", iemgui_getcolor_background(&x->x_gui));
 
 
-    sprintf(tag, "%pBASE2", x);
+    sprintf(tag, "%p_BASE2", x);
     pdgui_vmess(0, "crs  ii ii ii", canvas, "coords", tag,
         xpos + zoom, ypos + zoom,
         xpos + half, ypos + half,
         xpos + zoom, ypos + x->x_gui.x_h - zoom);
     pdgui_vmess(0, "crs  ri rk", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-fill", x->x_gui.x_fcol);
+        "-fill", THISGUI->i_foregroundcolor);
 
-    sprintf(tag, "%pLABEL", x);
+    sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom,
         ypos + x->x_gui.x_ldy * zoom);
@@ -168,7 +169,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
         "-fill", lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 
-    sprintf(tag, "%pNUMBER", x);
+    sprintf(tag, "%p_NUMBER", x);
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
         xpos + half + 2*zoom, ypos + half + d);
     pdgui_vmess(0, "crs  rs rA rk", canvas, "itemconfigure", tag,
@@ -186,19 +187,19 @@ static void my_numbox_draw_new(t_my_numbox *x, t_glist *glist)
     char*tags[] = {tag_object, tag, "label", "text"};
     sprintf(tag_object, "%p", x);
 
-    sprintf(tag, "%pBASE1", x);
+    sprintf(tag, "%p_BASE1", x);
     pdgui_vmess(0, "crr ii rS", canvas, "create", "polygon",
         0, 0, "-tags", 2, tags);
 
-    sprintf(tag, "%pBASE2", x);
+    sprintf(tag, "%p_BASE2", x);
     pdgui_vmess(0, "crr iiii rS", canvas, "create", "line",
         0, 0, 0, 0, "-tags", 2, tags);
 
-    sprintf(tag, "%pLABEL", x);
+    sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crr ii rs rS", canvas, "create", "text",
         0, 0, "-anchor", "w", "-tags", 4, tags);
 
-    sprintf(tag, "%pNUMBER", x);
+    sprintf(tag, "%p_NUMBER", x);
     pdgui_vmess(0, "crr ii rs rS", canvas, "create", "text",
         0, 0, "-anchor", "w", "-tags", 2, tags);
 
@@ -211,7 +212,8 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
     unsigned int bcol = THISGUI->i_foregroundcolor;
-    unsigned int fcol = x->x_gui.x_fcol, lcol = x->x_gui.x_lcol;
+    unsigned int fcol = iemgui_getcolor_foreground(&x->x_gui);
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
     if(x->x_gui.x_fsf.x_selected)
     {
@@ -224,13 +226,13 @@ static void my_numbox_draw_select(t_my_numbox *x, t_glist *glist)
         bcol = lcol = fcol = THISGUI->i_selectcolor;
     }
 
-    sprintf(tag, "%pBASE1", x);
+    sprintf(tag, "%p_BASE1", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-outline", bcol);
     sprintf(tag, "%pBASE2", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", fcol);
     sprintf(tag, "%pLABEL", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
-    sprintf(tag, "%pNUMBER", x);
+    sprintf(tag, "%p_NUMBER", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", fcol);
 }
 
@@ -241,7 +243,7 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
     {
         t_canvas *canvas = glist_getcanvas(glist);
         char tag[128];
-        sprintf(tag, "%pNUMBER", x);
+        sprintf(tag, "%p_NUMBER", x);
         if(x->x_gui.x_fsf.x_change)
         {
             if(x->x_buf[0])
@@ -268,14 +270,10 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
         else
         {
             my_numbox_ftoa(x);
-            if(x->x_gui.x_fsf.x_selected)
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", THISGUI->i_selectcolor,
-                    "-text", x->x_buf);
-            else
-                pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
-                    "-fill", x->x_gui.x_fcol,
-                    "-text", x->x_buf);
+            pdgui_vmess(0, "crs rk rs", canvas, "itemconfigure", tag,
+                "-fill", x->x_gui.x_fsf.x_selected
+                    ? THISGUI->i_selectcolor : iemgui_getcolor_foreground(&x->x_gui),
+                "-text", x->x_buf);
             x->x_buf[0] = 0;
         }
     }
@@ -400,8 +398,8 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     int lilo = (int)atom_getfloatarg(4, argc, argv);
     int log_height = (int)atom_getfloatarg(6, argc, argv);
     int sr_flags;
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT(undo+0, x->x_numwidth);
     SETFLOAT(undo+2, x->x_min);
     SETFLOAT(undo+3, x->x_max);
@@ -409,7 +407,7 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     SETFLOAT(undo+6, x->x_log_height);
 
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     if(lilo != 0) lilo = 1;

--- a/src/g_radio.c
+++ b/src/g_radio.c
@@ -107,12 +107,13 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
 
     for(i = 0; i < x->x_number; i++)
     {
-        unsigned int col = (x->x_on == i) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+        unsigned int col = (x->x_on == i) ?
+            iemgui_getcolor_foreground(&x->x_gui) : iemgui_getcolor_background(&x->x_gui);
         sprintf(tag, "%p_BASE%d", x, i);
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
             xx11, yy11, xx12, yy12);
         pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-fill", x->x_gui.x_bcol,
+            "-width", zoom, "-fill", iemgui_getcolor_background(&x->x_gui),
             "-outline", THISGUI->i_foregroundcolor);
 
         sprintf(tag, "%p_BUT%d", x, i);
@@ -131,7 +132,7 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
         xx11b + x->x_gui.x_ldx * zoom, yy11b + x->x_gui.x_ldy * zoom);
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
-        "-fill", x->x_gui.x_lcol);
+        "-fill", iemgui_getcolor_label(&x->x_gui));
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -173,7 +174,8 @@ static void radio_draw_select(t_radio* x, t_glist* glist)
     int n = x->x_number, i;
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
     if(x->x_gui.x_fsf.x_selected)
         lcol = col = THISGUI->i_selectcolor;
@@ -194,13 +196,13 @@ static void radio_draw_update(t_gobj *client, t_glist *glist)
 
         sprintf(tag, "%p_BUT%d", x, x->x_drawn);
         pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-            "-fill", x->x_gui.x_bcol,
-            "-outline", x->x_gui.x_bcol);
+            "-fill", iemgui_getcolor_background(&x->x_gui),
+            "-outline", iemgui_getcolor_background(&x->x_gui));
 
         sprintf(tag, "%p_BUT%d", x, x->x_on);
         pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-            "-fill", x->x_gui.x_fcol,
-            "-outline", x->x_gui.x_fcol);
+            "-fill", iemgui_getcolor_foreground(&x->x_gui),
+            "-outline", iemgui_getcolor_foreground(&x->x_gui));
 
         x->x_drawn = x->x_on;
     }
@@ -291,8 +293,8 @@ static void radio_dialog(t_radio *x, t_symbol *s, int argc, t_atom *argv)
     int num = (int)atom_getfloatarg(6, argc, argv);
     int sr_flags;
     int redraw = 0;
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT(undo+1, 0);
     SETFLOAT(undo+2, 0);
     SETFLOAT(undo+3, 0);
@@ -300,7 +302,7 @@ static void radio_dialog(t_radio *x, t_symbol *s, int argc, t_atom *argv)
     SETFLOAT(undo+6, x->x_number);
 
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     if(chg != 0) chg = 1;

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -144,7 +144,7 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
         xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h + bmargin);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
         "-width", zoom,
-        "-fill", x->x_gui.x_bcol,
+        "-fill", iemgui_getcolor_background(&x->x_gui),
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_KNOB", x);
@@ -152,18 +152,16 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
         a, b, c, d);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", 1 + 2 * zoom,
-        "-outline", x->x_gui.x_fcol);
+        "-outline", iemgui_getcolor_foreground(&x->x_gui));
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
 
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 
@@ -195,7 +193,8 @@ static void slider_draw_select(t_slider* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
     if(x->x_gui.x_fsf.x_selected)
         col = lcol = THISGUI->i_selectcolor;
@@ -381,21 +380,21 @@ static void slider_dialog(t_slider *x, t_symbol *s, int argc, t_atom *argv)
     int lilo = (int)atom_getfloatarg(4, argc, argv);
     int steady = (int)atom_getfloatarg(17, argc, argv);
     int sr_flags;
-    t_atom undo[18];
+    t_atom undo[21];
 
     if(x->x_orientation == horizontal)
         w *= IEMGUI_ZOOM(x);
     else
         h *= IEMGUI_ZOOM(x);
 
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT(undo+2, x->x_min);
     SETFLOAT(undo+3, x->x_max);
     SETFLOAT(undo+4, x->x_lin0_log1);
     SETFLOAT(undo+17, x->x_steady);
 
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     x->x_lin0_log1 = !!lilo;

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -28,7 +28,8 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     int crossw = 1, w = x->x_gui.x_w / zoom;
-    unsigned int col = x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+    unsigned int col = x->x_on ?
+        iemgui_getcolor_foreground(&x->x_gui) : iemgui_getcolor_background(&x->x_gui);
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
@@ -45,7 +46,7 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-width", zoom, "-fill", iemgui_getcolor_background(&x->x_gui),
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_X1", x);
@@ -68,13 +69,11 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
 
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 }
 void toggle_draw_new(t_toggle *x, t_glist *glist)
@@ -119,7 +118,8 @@ void toggle_draw_select(t_toggle* x, t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
     if(x->x_gui.x_fsf.x_selected)
         col = lcol = THISGUI->i_selectcolor;
@@ -135,7 +135,8 @@ void toggle_draw_update(t_toggle *x, t_glist *glist)
     if(glist_isvisible(glist))
     {
         t_canvas *canvas = glist_getcanvas(glist);
-        unsigned int col = (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
+        unsigned int col = (x->x_on != 0.0) ?
+            iemgui_getcolor_foreground(&x->x_gui) : iemgui_getcolor_background(&x->x_gui);
         char tag[128];
         int width = x->x_gui.x_w / IEMGUI_ZOOM(x),
             xwidth = (width >= 60 ? 3: (width >= 30 ? 2 : 1));
@@ -209,14 +210,14 @@ static void toggle_dialog(t_toggle *x, t_symbol *s, int argc, t_atom *argv)
     int a = (int)atom_getfloatarg(0, argc, argv);
     t_float nonzero = (t_float)atom_getfloatarg(2, argc, argv);
     int sr_flags;
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT (undo+1, 0);
     SETFLOAT (undo+2, x->x_nonzero);
     SETFLOAT (undo+3, 0);
 
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     if(nonzero == 0.0)

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -70,7 +70,8 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
             int pkh = PEAKHEIGHT * zoom;
 
             pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill",
-                x->x_gui.x_bcol);
+                (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+                    interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
             pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
                 mid, ypos + pkh, mid, ypos + pkh);
         }
@@ -173,16 +174,16 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         xpos - hmargin, ypos - vmargin,
         xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-width", zoom, "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_SCALE", x);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
+
     sprintf(tag, "%p_RLED", x);
     pdgui_vmess(0, "crs ri", canvas, "itemconfigure", tag, "-width", ledw);
 
@@ -220,7 +221,10 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         quad1 - zoom, ypos - zoom,
         quad3 + zoom, ypos - zoom + k1*IEM_VU_STEPS);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", x->x_gui.x_bcol, "-outline", x->x_gui.x_bcol);
+        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
+        "-outline", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_PLED", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -228,17 +232,17 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         mid, ypos + PEAKHEIGHT * zoom);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", ledw+zoom, /* peak LED is slightly fatter */
-        "-fill", x->x_gui.x_bcol);
+        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
         xpos+x->x_gui.x_ldx * zoom, ypos+x->x_gui.x_ldy * zoom);
-    if(x->x_gui.x_fsf.x_selected)
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
-    else
-        pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
-            "-font", 3, fontatoms, "-fill", x->x_gui.x_lcol);
+    pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
+        "-font", 3, fontatoms,
+        "-fill", x->x_gui.x_fsf.x_selected
+            ? THISGUI->i_selectcolor : iemgui_getcolor_label(&x->x_gui));
+
     iemgui_dolabel(x, &x->x_gui, x->x_gui.x_lab, 1);
 
     x->x_updaterms = x->x_updatepeak = 1;
@@ -297,7 +301,8 @@ static void vu_draw_select(t_vu* x,t_glist* glist)
 {
     t_canvas *canvas = glist_getcanvas(glist);
     char tag[128];
-    unsigned int col = THISGUI->i_foregroundcolor, lcol = x->x_gui.x_lcol;
+    unsigned int col = THISGUI->i_foregroundcolor;
+    unsigned int lcol = iemgui_getcolor_label(&x->x_gui);
 
     if(x->x_gui.x_fsf.x_selected)
         col = lcol = THISGUI->i_selectcolor;
@@ -395,15 +400,15 @@ static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
     int h = (int)atom_getfloatarg(1, argc, argv);
     int scale = (int)atom_getfloatarg(4, argc, argv);
     int sr_flags;
-    t_atom undo[18];
-    iemgui_setdialogatoms(&x->x_gui, 18, undo);
+    t_atom undo[21];
+    iemgui_setdialogatoms(&x->x_gui, 21, undo);
     SETFLOAT(undo+2, 0.01);
     SETFLOAT(undo+3, 1);
     SETFLOAT(undo+4, x->x_scale);
     SETFLOAT(undo+5, -1);
     SETSYMBOL(undo+15, gensym("none"));
     pd_undo_set_objectstate(x->x_gui.x_glist, (t_pd*)x, gensym("dialog"),
-                            18, undo,
+                            21, undo,
                             argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -70,8 +70,7 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
             int pkh = PEAKHEIGHT * zoom;
 
             pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill",
-                (x->x_gui.x_bcol_default) ?
-                    interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
+                iemgui_getcolor_background(&x->x_gui));
             pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
                 mid, ypos + pkh, mid, ypos + pkh);
         }
@@ -174,8 +173,7 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         xpos - hmargin, ypos - vmargin,
         xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
+        "-width", zoom, "-fill", iemgui_getcolor_background(&x->x_gui),
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_SCALE", x);
@@ -221,10 +219,8 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         quad1 - zoom, ypos - zoom,
         quad3 + zoom, ypos - zoom + k1*IEM_VU_STEPS);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
-        "-outline", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
+        "-fill", iemgui_getcolor_background(&x->x_gui),
+        "-outline", iemgui_getcolor_background(&x->x_gui));
 
     sprintf(tag, "%p_PLED", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -232,8 +228,7 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         mid, ypos + PEAKHEIGHT * zoom);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", ledw+zoom, /* peak LED is slightly fatter */
-        "-fill", (x->x_gui.x_bcol_default) ?
-            interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
+        "-fill", iemgui_getcolor_background(&x->x_gui));
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -70,7 +70,7 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
             int pkh = PEAKHEIGHT * zoom;
 
             pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill",
-                (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+                (x->x_gui.x_bcol_default) ?
                     interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
             pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
                 mid, ypos + pkh, mid, ypos + pkh);
@@ -174,7 +174,7 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         xpos - hmargin, ypos - vmargin,
         xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-width", zoom, "-fill", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
         "-outline", THISGUI->i_foregroundcolor);
 
@@ -221,9 +221,9 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         quad1 - zoom, ypos - zoom,
         quad3 + zoom, ypos - zoom + k1*IEM_VU_STEPS);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
-        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-fill", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol,
-        "-outline", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-outline", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_PLED", x);
@@ -232,7 +232,7 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
         mid, ypos + PEAKHEIGHT * zoom);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
         "-width", ledw+zoom, /* peak LED is slightly fatter */
-        "-fill", (x->x_gui.x_bcol == IEM_GUI_COLOR_DEFAULT_SENTINEL) ?
+        "-fill", (x->x_gui.x_bcol_default) ?
             interpolate_colors(THISGUI->i_backgroundcolor, THISGUI->i_foregroundcolor, 0.78) : x->x_gui.x_bcol);
 
     sprintf(tag, "%p_LABEL", x);

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -47,6 +47,7 @@ void glob_vis(void *dummy, t_symbol *s);
 void glob_closesubs(void *dummy);
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop);
+void glob_iemgui_default_colors(void *dummy, t_floatarg use_default);
 void glob_rescanaudio(void *dummy);
 
 static void glob_helpintro(t_pd *dummy)
@@ -209,6 +210,8 @@ void glob_init(void)
         gensym("close-subwindows"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_colors,
         gensym("colors"), A_SYMBOL, A_SYMBOL, A_SYMBOL, A_DEFSYMBOL, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_iemgui_default_colors,
+        gensym("iemgui-default-colors"), A_DEFFLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_rescanaudio,
         gensym("rescan-audio"), 0);
     class_addanything(glob_pdobject, max_default);

--- a/tcl/Makefile.am
+++ b/tcl/Makefile.am
@@ -42,6 +42,7 @@ dist_libpdtcl_DATA = \
     pd_docsdir.tcl \
     pd_guiprefs.tcl \
     pd_i18n.tcl \
+    pd_iemgui_colors.tcl \
     pd_menucommands.tcl \
     pd_menus.tcl \
     pdtcl_compat.tcl \

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -205,20 +205,27 @@ proc ::dialog_iemgui::choose_col_bkfrlb {mytoplevel} {
     }
 }
 
-proc ::dialog_iemgui::reset_col_to_default {mytoplevel} {
+proc ::dialog_iemgui::update_adaptive_state {mytoplevel} {
     set vid [string trimleft $mytoplevel .]
     set colortype $::dialog_iemgui::var_colortype($vid)
-    if {$colortype == 0} {
+    set default_var {}
+    switch -- $colortype {
+        0 { set default_var ::dialog_iemgui::var_color_background_default($vid) }
+        1 { set default_var ::dialog_iemgui::var_color_foreground_default($vid) }
+        2 { set default_var ::dialog_iemgui::var_color_label_default($vid) }
+    }
+    $mytoplevel.colors.adapt.tgl configure -variable $default_var
+}
+
+proc ::dialog_iemgui::toggle_color_default {mytoplevel} {
+    set vid [string trimleft $mytoplevel .]
+    set colortype $::dialog_iemgui::var_colortype($vid)
+    if {$colortype == 0 && $::dialog_iemgui::var_color_background_default($vid)} {
         set ::dialog_iemgui::var_color_background($vid) $::pd_colors::palette(background)
-        set ::dialog_iemgui::var_color_background_default($vid) 1
-    }
-    if {$colortype == 1} {
+    } elseif {$colortype == 1 && $::dialog_iemgui::var_color_foreground_default($vid)} {
         set ::dialog_iemgui::var_color_foreground($vid) $::pd_colors::palette(foreground)
-        set ::dialog_iemgui::var_color_foreground_default($vid) 1
-    }
-    if {$colortype == 2} {
+    } elseif {$colortype == 2 && $::dialog_iemgui::var_color_label_default($vid)} {
         set ::dialog_iemgui::var_color_label($vid) $::pd_colors::palette(foreground)
-        set ::dialog_iemgui::var_color_label_default($vid) 1
     }
     ::dialog_iemgui::set_col_example $mytoplevel
 }
@@ -662,13 +669,16 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
     pack $mytoplevel.colors.select -side top
     radiobutton $mytoplevel.colors.select.radio0 \
         -value 0 -variable ::dialog_iemgui::var_colortype($vid) \
-        -text [_ "Background"] -justify left
+        -text [_ "Background"] -justify left \
+        -command "::dialog_iemgui::update_adaptive_state $mytoplevel"
     radiobutton $mytoplevel.colors.select.radio1 \
         -value 1 -variable ::dialog_iemgui::var_colortype($vid) \
-        -text [_ "Front"] -justify left
+        -text [_ "Front"] -justify left \
+        -command "::dialog_iemgui::update_adaptive_state $mytoplevel"
     radiobutton $mytoplevel.colors.select.radio2 \
         -value 2 -variable ::dialog_iemgui::var_colortype($vid) \
-        -text [_ "Label"] -justify left
+        -text [_ "Label"] -justify left \
+        -command "::dialog_iemgui::update_adaptive_state $mytoplevel"
     if { $::dialog_iemgui::var_color_foreground($vid) ne "none" } {
         pack $mytoplevel.colors.select.radio0 $mytoplevel.colors.select.radio1 \
             $mytoplevel.colors.select.radio2 -side left
@@ -677,15 +687,13 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
     }
 
     frame $mytoplevel.colors.sections
-    pack $mytoplevel.colors.sections -side top
+    pack $mytoplevel.colors.sections -side top -pady 5
     button $mytoplevel.colors.sections.but -text [_ "Compose color"] \
         -command "::dialog_iemgui::choose_col_bkfrlb $mytoplevel"
-    button $mytoplevel.colors.sections.reset -text [_ "Adapt to theme"] \
-        -command "::dialog_iemgui::reset_col_to_default $mytoplevel"
-    pack $mytoplevel.colors.sections.but $mytoplevel.colors.sections.reset -side left -anchor w -pady 5 \
+    pack $mytoplevel.colors.sections.but -side left -anchor w \
         -expand yes -fill x
     frame $mytoplevel.colors.sections.exp
-    pack $mytoplevel.colors.sections.exp -side right -padx 5
+    pack $mytoplevel.colors.sections.exp -side right -padx 2
     if { $::dialog_iemgui::var_color_foreground($vid) ne "none" } {
         label $mytoplevel.colors.sections.exp.fr_bk -text "o=||=o" -width 6 \
             -background $::dialog_iemgui::var_color_background($vid) \
@@ -708,7 +716,14 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
         -activeforeground $::dialog_iemgui::var_color_label($vid) \
         -font [list $current_font 14 $::font_weight] -padx 2 -pady 2 -relief ridge
     pack $mytoplevel.colors.sections.exp.lb_bk $mytoplevel.colors.sections.exp.fr_bk \
-        -side right -anchor e -expand yes -fill both -pady 7
+        -side right -anchor e -expand yes -fill both
+
+    frame $mytoplevel.colors.adapt
+    pack $mytoplevel.colors.adapt -side top
+    checkbutton $mytoplevel.colors.adapt.tgl -text [_ "Adapt to theme"] \
+        -command "::dialog_iemgui::toggle_color_default $mytoplevel"
+    $mytoplevel.colors.adapt.tgl configure -variable ::dialog_iemgui::var_color_background_default($vid)
+    pack $mytoplevel.colors.adapt.tgl
 
     # color scheme by Mary Ann Benedetto http://piR2.org
     foreach r {r1 r2 r3} hexcols {

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -41,6 +41,10 @@ array set ::dialog_iemgui::var_color_foreground {} ;# var_iemgui_fcol
 array set ::dialog_iemgui::var_color_label {} ;# var_iemgui_lcol
 array set ::dialog_iemgui::var_colortype {} ;# var_iemgui_l2_f1_b0
 
+array set ::dialog_iemgui::var_color_background_default {}
+array set ::dialog_iemgui::var_color_foreground_default {}
+array set ::dialog_iemgui::var_color_label_default {}
+
 #### original values (to fall back from invalid ones))
 array set ::dialog_iemgui::old_width {}
 array set ::dialog_iemgui::old_height {}
@@ -131,19 +135,23 @@ proc ::dialog_iemgui::clip_fontsize {mytoplevel} {
 proc ::dialog_iemgui::set_col_example {mytoplevel} {
     set vid [string trimleft $mytoplevel .]
 
-    set fgcol $::dialog_iemgui::var_color_label($vid)
+    set display_bg $::dialog_iemgui::var_color_background($vid)
+    set display_fg $::dialog_iemgui::var_color_foreground($vid)
+    set display_lb $::dialog_iemgui::var_color_label($vid)
+
+    set fgcol $display_lb
     $mytoplevel.colors.sections.exp.lb_bk configure \
-        -background $::dialog_iemgui::var_color_background($vid) \
-        -activebackground $::dialog_iemgui::var_color_background($vid) \
+        -background $display_bg \
+        -activebackground $display_bg \
         -foreground $fgcol -activeforeground $fgcol
 
-    set fgcol $::dialog_iemgui::var_color_foreground($vid)
+    set fgcol $display_fg
     if { $fgcol eq "none" } {
-        set fgcol $::dialog_iemgui::var_color_background($vid)
+        set fgcol $display_bg
     }
     $mytoplevel.colors.sections.exp.fr_bk configure \
-        -background $::dialog_iemgui::var_color_background($vid) \
-        -activebackground $::dialog_iemgui::var_color_background($vid) \
+        -background $display_bg \
+        -activebackground $display_bg \
         -foreground $fgcol -activeforeground $fgcol
 
     # for OSX live updates
@@ -156,9 +164,18 @@ proc ::dialog_iemgui::preset_col {mytoplevel presetcol} {
     set vid [string trimleft $mytoplevel .]
 
     switch -- $::dialog_iemgui::var_colortype($vid) {
-        0 { set ::dialog_iemgui::var_color_background($vid) $presetcol }
-        1 { set ::dialog_iemgui::var_color_foreground($vid) $presetcol }
-        2 { set ::dialog_iemgui::var_color_label($vid) $presetcol }
+        0 {
+            set ::dialog_iemgui::var_color_background($vid) $presetcol
+            set ::dialog_iemgui::var_color_background_default($vid) 0
+        }
+        1 {
+            set ::dialog_iemgui::var_color_foreground($vid) $presetcol
+            set ::dialog_iemgui::var_color_foreground_default($vid) 0
+        }
+        2 {
+            set ::dialog_iemgui::var_color_label($vid) $presetcol
+            set ::dialog_iemgui::var_color_label_default($vid) 0
+        }
     }
 
     ::dialog_iemgui::set_col_example $mytoplevel
@@ -186,6 +203,24 @@ proc ::dialog_iemgui::choose_col_bkfrlb {mytoplevel} {
     if { $color ne "" } {
         ::dialog_iemgui::preset_col $mytoplevel $color
     }
+}
+
+proc ::dialog_iemgui::reset_col_to_default {mytoplevel} {
+    set vid [string trimleft $mytoplevel .]
+    set colortype $::dialog_iemgui::var_colortype($vid)
+    if {$colortype == 0} {
+        set ::dialog_iemgui::var_color_background($vid) $::pd_colors::palette(background)
+        set ::dialog_iemgui::var_color_background_default($vid) 1
+    }
+    if {$colortype == 1} {
+        set ::dialog_iemgui::var_color_foreground($vid) $::pd_colors::palette(foreground)
+        set ::dialog_iemgui::var_color_foreground_default($vid) 1
+    }
+    if {$colortype == 2} {
+        set ::dialog_iemgui::var_color_label($vid) $::pd_colors::palette(foreground)
+        set ::dialog_iemgui::var_color_label_default($vid) 1
+    }
+    ::dialog_iemgui::set_col_example $mytoplevel
 }
 
 proc ::dialog_iemgui::popupmenu {path varname labels {command {}}} {
@@ -285,7 +320,14 @@ proc ::dialog_iemgui::apply {mytoplevel} {
     if {$::dialog_iemgui::var_label_dx($vid) eq ""} {set ::dialog_iemgui::var_label_dx($vid) 0}
     if {$::dialog_iemgui::var_label_dy($vid) eq ""} {set ::dialog_iemgui::var_label_dy($vid) 0}
 
-    pdsend [list $mytoplevel dialog \
+    set bcol [expr {$::dialog_iemgui::var_color_background_default($vid) ? \
+        "default" : [string tolower $::dialog_iemgui::var_color_background($vid)]}]
+    set fcol [expr {$::dialog_iemgui::var_color_foreground_default($vid) ? \
+        "default" : [string tolower $::dialog_iemgui::var_color_foreground($vid)]}]
+    set lcol [expr {$::dialog_iemgui::var_color_label_default($vid) ? \
+        "default" : [string tolower $::dialog_iemgui::var_color_label($vid)]}]
+
+    pdsend [concat $mytoplevel dialog \
                 $::dialog_iemgui::var_width($vid) \
                 $::dialog_iemgui::var_height($vid) \
                 $::dialog_iemgui::var_range_min($vid) \
@@ -300,10 +342,13 @@ proc ::dialog_iemgui::apply {mytoplevel} {
                 $::dialog_iemgui::var_label_dy($vid) \
                 $::dialog_iemgui::var_label_font($vid) \
                 $::dialog_iemgui::var_label_fontsize($vid) \
-                [string tolower $::dialog_iemgui::var_color_background($vid)] \
-                [string tolower $::dialog_iemgui::var_color_foreground($vid)] \
-                [string tolower $::dialog_iemgui::var_color_label($vid)] \
+                $bcol \
+                $fcol \
+                $lcol \
                 $::dialog_iemgui::var_steady($vid) \
+                $::dialog_iemgui::var_color_background_default($vid) \
+                $::dialog_iemgui::var_color_foreground_default($vid) \
+                $::dialog_iemgui::var_color_label_default($vid) \
                ]
 
     foreach v ${fallbacks} {
@@ -340,7 +385,8 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
                                        snd rcv \
                                        gui_name \
                                        gn_dx gn_dy gn_f gn_fs \
-                                       bcol fcol lcol} {
+                                       bcol fcol lcol \
+                                       bcol_default fcol_default lcol_default} {
 
     set vid [string trimleft $mytoplevel .]
     set snd [::pdtk_text::unescape $snd]
@@ -371,9 +417,18 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
     set ::dialog_iemgui::var_label_font($vid) $gn_f
     set ::dialog_iemgui::var_label_fontsize($vid) $gn_fs
 
-    set ::dialog_iemgui::var_color_background($vid) $bcol
-    set ::dialog_iemgui::var_color_foreground($vid) $fcol
-    set ::dialog_iemgui::var_color_label($vid) $lcol
+    set ::dialog_iemgui::var_color_background($vid) \
+        [expr {$bcol_default ? $::pd_colors::palette(background) : $bcol}]
+    set ::dialog_iemgui::var_color_background_default($vid) $bcol_default
+
+    set ::dialog_iemgui::var_color_foreground($vid) \
+        [expr {$fcol_default ? $::pd_colors::palette(foreground) : $fcol}]
+    set ::dialog_iemgui::var_color_foreground_default($vid) $fcol_default
+
+    set ::dialog_iemgui::var_color_label($vid) \
+        [expr {$lcol_default ? $::pd_colors::palette(foreground) : $lcol}]
+    set ::dialog_iemgui::var_color_label_default($vid) $lcol_default
+
     set ::dialog_iemgui::var_colortype($vid) 0
 
     # fallback values (in case the user enters garbage)
@@ -625,7 +680,9 @@ proc ::dialog_iemgui::pdtk_iemgui_dialog {mytoplevel mainheader dim_header_UNUSE
     pack $mytoplevel.colors.sections -side top
     button $mytoplevel.colors.sections.but -text [_ "Compose color"] \
         -command "::dialog_iemgui::choose_col_bkfrlb $mytoplevel"
-    pack $mytoplevel.colors.sections.but -side left -anchor w -pady 5 \
+    button $mytoplevel.colors.sections.reset -text [_ "Adapt to theme"] \
+        -command "::dialog_iemgui::reset_col_to_default $mytoplevel"
+    pack $mytoplevel.colors.sections.but $mytoplevel.colors.sections.reset -side left -anchor w -pady 5 \
         -expand yes -fill x
     frame $mytoplevel.colors.sections.exp
     pack $mytoplevel.colors.sections.exp -side right -padx 5

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -800,6 +800,7 @@ proc load_plugin_script {filename} {
 proc load_startup_plugins {} {
     # load built-in plugins
     load_plugin_script [file join $::sys_guidir pd_deken.tcl]
+    load_plugin_script [file join $::sys_guidir pd_iemgui_colors.tcl]
 
     if { $::port > 0 && $::host ne "" } { } else {
         # only run the docsdir plugin if Pd is started via the GUI

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -242,6 +242,36 @@ namespace eval ::pdgui:: {
 }
 
 #------------------------------------------------------------------------------#
+# color palette and utilities
+
+namespace eval ::pd_colors {
+    variable palette
+    array set palette {
+        foreground "#000000"
+        background "#FFFFFF"
+        selected   "#0000FF"
+        gop        "#FF0000"
+    }
+}
+
+proc ::pd_colors::set_palette {fg bg sel gop} {
+    set ::pd_colors::palette(foreground) $fg
+    set ::pd_colors::palette(background) $bg
+    set ::pd_colors::palette(selected) $sel
+    set ::pd_colors::palette(gop) $gop
+}
+
+proc ::pd_colors::interpolate {color1 color2 amount} {
+    set amount [expr {max(0, min(1, $amount))}]
+    scan $color1 "#%2x%2x%2x" r1 g1 b1
+    scan $color2 "#%2x%2x%2x" r2 g2 b2
+    set r [expr {int($r1 + ($r2 - $r1) * $amount)}]
+    set g [expr {int($g1 + ($g2 - $g1) * $amount)}]
+    set b [expr {int($b1 + ($b2 - $b1) * $amount)}]
+    return [format "#%02x%02x%02x" $r $g $b]
+}
+
+#------------------------------------------------------------------------------#
 # coding style
 #
 # these are preliminary ideas, we'll change them as we work things out:

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -81,6 +81,7 @@ namespace import ::pdtk_canvas::pdtk_canvas_editmode
 namespace import ::pdtk_canvas::pdtk_canvas_getscroll
 namespace import ::pdtk_canvas::pdtk_canvas_setparents
 namespace import ::pdtk_canvas::pdtk_canvas_reflecttitle
+namespace import ::pdtk_canvas::pdtk_canvas_setcolors
 namespace import ::pdtk_canvas::pdtk_canvas_menuclose
 namespace import ::dialog_array::pdtk_array_dialog
 namespace import ::dialog_audio::pdtk_audio_dialog

--- a/tcl/pd_iemgui_colors.tcl
+++ b/tcl/pd_iemgui_colors.tcl
@@ -1,48 +1,34 @@
 # IEMGUI Colors Management Plugin for Pure Data
-# Adds a submenu to the "Tools" menu for bulk setting IEMGUI object colors of a patch window
+# Adds a submenu to the patch window's "Edit" menu for bulk setting IEMGUI object colors
+
+package provide pd_iemgui_colors 0.1
 
 namespace eval ::iemgui_colors:: {}
 
-proc ::iemgui_colors::add_colors_menu {toolsmenu} {
-    if {![winfo exists $toolsmenu]} {
+proc ::iemgui_colors::initialize {} {
+    set editmenu $::patch_menubar.edit
+    if {![winfo exists $editmenu]} {
         return
     }
-    $toolsmenu add separator
-    set colorsmenu [menu $toolsmenu.colors -tearoff 0]
-    $toolsmenu add cascade -label [_ "Set GUI object colors"] -menu $colorsmenu
-    $colorsmenu add command -label [_ "adaptive"] \
+    $editmenu add separator
+    set colorsmenu [menu $editmenu.colors -tearoff 0]
+    $editmenu add cascade -label [_ "Set GUI Object Colors"] -menu $colorsmenu
+    $colorsmenu add command -label [_ "Adaptive Colors"] \
         -command {::iemgui_colors::set_colors adaptive}
-    $colorsmenu add command -label [_ "standard"] \
+    $colorsmenu add command -label [_ "Standard Colors"] \
         -command {::iemgui_colors::set_colors standard}
 }
 
 proc ::iemgui_colors::set_colors {color_type} {
-    if {[info exists ::focused_window] && [winfo class $::focused_window] eq "PatchWindow"} {
-        raise $::focused_window
-        set color_type_label [expr {$color_type eq "adaptive" ? [_ "adaptive"] : [_ "standard"]}]
-        set result [tk_messageBox -type okcancel -icon question -default "ok" \
-            -message [_ "Set %s colors for all GUI objects in this patch?" $color_type_label] \
-            -parent $::focused_window]
-        if {$result eq "ok"} {
-            ::pdsend "$::focused_window iemgui_set_colors $color_type"
-        }
-    } else {
-        tk_messageBox -type ok -icon info \
-            -message [_ "Select a patch window first to change colors."]
-    }
-}
-
-proc ::iemgui_colors::initialize {} {
-    set toolsmenu {}
-    set pdmenu [.pdwindow cget -menu]
-    for {set m 0} {$m <= [$pdmenu index end]} {incr m} {
-        set _m [$pdmenu entrycget $m -menu]
-        switch -glob $_m {
-            *.tools { set toolsmenu $_m }
-        }
-    }
-    if { [winfo exists ${toolsmenu}] } {
-        ::iemgui_colors::add_colors_menu ${toolsmenu}
+    raise $::focused_window
+    set message [expr {$color_type eq "adaptive" ? \
+        [_ "Set adaptive colors for all GUI objects in this patch?"] : \
+        [_ "Set standard colors for all GUI objects in this patch?"]}]
+    set result [tk_messageBox -type okcancel -icon question -default "ok" \
+        -message $message \
+        -parent $::focused_window]
+    if {$result eq "ok"} {
+        ::pdsend "$::focused_window iemgui_set_colors $color_type"
     }
 }
 

--- a/tcl/pd_iemgui_colors.tcl
+++ b/tcl/pd_iemgui_colors.tcl
@@ -1,0 +1,49 @@
+# IEMGUI Colors Management Plugin for Pure Data
+# Adds a submenu to the "Tools" menu for bulk setting IEMGUI object colors of a patch window
+
+namespace eval ::iemgui_colors:: {}
+
+proc ::iemgui_colors::add_colors_menu {toolsmenu} {
+    if {![winfo exists $toolsmenu]} {
+        return
+    }
+    $toolsmenu add separator
+    set colorsmenu [menu $toolsmenu.colors -tearoff 0]
+    $toolsmenu add cascade -label [_ "Set GUI object colors"] -menu $colorsmenu
+    $colorsmenu add command -label [_ "adaptive"] \
+        -command {::iemgui_colors::set_colors adaptive}
+    $colorsmenu add command -label [_ "standard"] \
+        -command {::iemgui_colors::set_colors standard}
+}
+
+proc ::iemgui_colors::set_colors {color_type} {
+    if {[info exists ::focused_window] && [winfo class $::focused_window] eq "PatchWindow"} {
+        raise $::focused_window
+        set color_type_label [expr {$color_type eq "adaptive" ? [_ "adaptive"] : [_ "standard"]}]
+        set result [tk_messageBox -type okcancel -icon question -default "ok" \
+            -message [_ "Set %s colors for all GUI objects in this patch?" $color_type_label] \
+            -parent $::focused_window]
+        if {$result eq "ok"} {
+            ::pdsend "$::focused_window iemgui_set_colors $color_type"
+        }
+    } else {
+        tk_messageBox -type ok -icon info \
+            -message [_ "Select a patch window first to change colors."]
+    }
+}
+
+proc ::iemgui_colors::initialize {} {
+    set toolsmenu {}
+    set pdmenu [.pdwindow cget -menu]
+    for {set m 0} {$m <= [$pdmenu index end]} {incr m} {
+        set _m [$pdmenu entrycget $m -menu]
+        switch -glob $_m {
+            *.tools { set toolsmenu $_m }
+        }
+    }
+    if { [winfo exists ${toolsmenu}] } {
+        ::iemgui_colors::add_colors_menu ${toolsmenu}
+    }
+}
+
+::iemgui_colors::initialize

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -519,13 +519,14 @@ proc ::pdtk_canvas::cleanname {name} {
 
 proc ::pdtk_canvas::cords_to_foreground {mytoplevel {state 1}} {
     if {$::pdtk_canvas::enable_cords_to_foreground} {
-        set col black
+        set col $::pd_colors::palette(foreground)
         if { $state == 0 } {
-            set col lightgrey
+            set col [::pd_colors::interpolate \
+                $::pd_colors::palette(background) $::pd_colors::palette(foreground) 0.17]
         }
         foreach id [$mytoplevel find withtag {cord && !selected}] {
-            # don't apply backgrouding on selected (blue) lines
-            if { [lindex [$mytoplevel itemconfigure $id -fill] 4 ] ne "blue" } {
+            # don't apply backgrounding on selected lines
+            if { [lindex [$mytoplevel itemconfigure $id -fill] 4 ] ne $::pd_colors::palette(selected) } {
                 $mytoplevel itemconfigure $id -fill $col
             }
         }

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -17,6 +17,7 @@ namespace eval ::pdtk_canvas:: {
     namespace export pdtk_canvas_getscroll
     namespace export pdtk_canvas_setparents
     namespace export pdtk_canvas_reflecttitle
+    namespace export pdtk_canvas_setcolors
     namespace export pdtk_canvas_menuclose
 }
 
@@ -171,6 +172,14 @@ proc pdtk_canvas_raise {mytoplevel} {
     raise $mytoplevel
     set mycanvas $mytoplevel.c
     focus $mycanvas
+}
+
+proc ::pdtk_canvas::pdtk_canvas_setcolors {mytoplevel bgcolor fgcolor} {
+    set cv [tkcanvas_name $mytoplevel]
+    if {![winfo exists $cv]} {
+        return
+    }
+    $cv configure -background $bgcolor -insertbackground $fgcolor
 }
 
 proc pdtk_canvas_saveas {mytoplevel initialfile initialdir destroyflag} {


### PR DESCRIPTION
this is an attempt for dynamically handling the `"default"` color that was introduced with b38ef00. this draft should provide a basis for testing and further discussion.

* includes #2692
* includes #2702
* supersedes #2679
* closes #2639

to discuss (list probably not exhaustive):
1. ~is it reasonable to handle the `"default"` color via the `-1`/ `0xffffffff` sentinel value internally?~ EDIT: used additional flags now
2. ~similarly: is it a good approach to send additional "default" flags to the properties dialog (and back)?~ EDIT: assuming that the flags are a good idea, this question is obsolete
3. there is now an "Adapt to theme" ~button~ toggle in the iemgui properties, which represents and is applied for the selected color type (bg, fg, label). probably makes sense - but needs quite a few clicks to set all 3 colors that way.
4. for [cnv] and [vu], the background color adapts to the current palette with an interpolated value between bg and fg colors. this doesn't always work too well (see video). maybe, [vu] should generally have a dark background. not so sure about [cnv]'s background color ... a [different interpolation](https://observablehq.com/@zanarmstrong/comparing-interpolating-in-different-color-spaces) might give better results - but also seems overkill.
5. since `"default"` colors will appear all black (parsed to `0`) in Pd versions < 0.56 and obviously, patches with old discrete colors don't adapt to a custom palette, there is now a new submenu in the ~"Tools"~ patch window's "Edit" menu to set all iemguis of a patch to the old standard colors or the new adaptive colors (aka `"default"`). ~the functionality probably makes sense - but not so sure about the placement of the actions.~
6. these menu actions trigger a confirmation dialog - might not be needed, but since this is currently not undoable and potentially impactful, i thought it might be good to protect this action.
7. ~might also (or alternatively) be good to have a mode to generally set iemguis to adaptive colors on creation (or when loading a patch - at least if they have the standard colors).~ EDIT: added a global `iemgui-default-colors` message for this now.
8. also not sure about all these terms and where to use what (towards users) - adaptive, standard, default, theme, palette, GUI object, iemgui, ...

in some distant future, iemguis could/should be generally initialised with the `"default"` colors on creation.

---

here's a demo:

[test-patch-colors.pd.zip](https://github.com/user-attachments/files/21989645/test-patch-colors.pd.zip)

https://github.com/user-attachments/assets/1b5f9c35-1af4-421f-b0dd-58458ee03494

"Colors" section in properties dialog with additional "Adapt to theme" toggle:

<img width="299" height="214" alt="image" src="https://github.com/user-attachments/assets/2a6bfed3-3628-4f7e-ba49-b835651e4419" />


