### PR TITLE
Fix possible crash in sched_send_dacs()

### DIFF
--- a/src/s_audio_jack.c
+++ b/src/s_audio_jack.c
@@ -668,9 +668,8 @@ int jack_send_dacs(void)
 #ifdef THREADSIGNAL
         if (sched_idletask())
         {
-                /* we might have received a message to close audio
-                or switch to the callback scheduler! */
-            if (sched_get_using_audio() != SCHED_AUDIO_POLL)
+                /* we might have received a "dsp" message or audio dialog message! */
+            if (!jack_client || sched_get_using_audio() != SCHED_AUDIO_POLL)
                 return SENDDACS_NO;
                 /* otherwise check the ringbuffer again */
             continue;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -542,9 +542,8 @@ int pa_send_dacs(void)
 #ifdef THREADSIGNAL
         if (sched_idletask())
         {
-                /* we might have received a message to turn off DSP
-                or switch to the callback scheduler! */
-            if (sched_get_using_audio() != SCHED_AUDIO_POLL)
+                /* we might have received a "dsp" message or audio dialog message! */
+            if (!pa_stream || sched_get_using_audio() != SCHED_AUDIO_POLL)
                 return SENDDACS_NO;
                 /* otherwise check the ringbuffer again */
             continue;

--- a/src/s_audio_pa.c
+++ b/src/s_audio_pa.c
@@ -187,8 +187,8 @@ static int pa_fifo_callback(const void *inputBuffer,
                 sys_ringbuf_getreadavailable(&pa_outring),
                 sys_ringbuf_getwriteavailable(&pa_inring));
 #endif
-    if (infiforoom < nframes * STUFF->st_inchannels * sizeof(t_sample) ||
-        outfiforoom < nframes * STUFF->st_outchannels * sizeof(t_sample))
+    if (infiforoom < nframes * STUFF->st_inchannels * sizeof(float) ||
+        outfiforoom < nframes * STUFF->st_outchannels * sizeof(float))
     {
         /* data late: output zeros, drop inputs, and leave FIFos untouched */
         if (pa_started)
@@ -533,9 +533,9 @@ int pa_send_dacs(void)
 
     while (
         (sys_ringbuf_getreadavailable(&pa_inring) <
-            (long)(STUFF->st_inchannels * DEFDACBLKSIZE*sizeof(t_sample))) ||
+            (long)(STUFF->st_inchannels * DEFDACBLKSIZE*sizeof(float))) ||
         (sys_ringbuf_getwriteavailable(&pa_outring) <
-            (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(t_sample))))
+            (long)(STUFF->st_outchannels * DEFDACBLKSIZE*sizeof(float))))
     {
 #ifdef THREADSIGNAL
         if (sched_idletask())


### PR DESCRIPTION
`sched_idletask()` may turn off DSP or change audio settings. In this case, we must return early with `SENDDACS_NO`!

Fixes https://github.com/pure-data/pure-data/issues/2760, which is a serious regression in Pd 0.56 caused by 73acd66c8a04a151404ef4a6c2f0edae0214f10d.