### PR TITLE
free rtext on deletion to prevent later hit-test crash

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -126,7 +126,7 @@ void glist_delete(t_glist *x, t_gobj *y)
     if (glist_isvisible(canvas))
         gobj_vis(y, x, 0);
     if (glist_getcanvas(x)->gl_editor && (ob = pd_checkobject(&y->g_pd)))
-        rtext = glist_getrtext(x, ob, 0);
+        rtext = glist_getrtext(x, ob, 1);
     if (x->gl_list == y) x->gl_list = y->g_next;
     else for (g = x->gl_list; g; g = g->g_next)
         if (g->g_next == y)


### PR DESCRIPTION
* closes #2761

... this seems to avoid stale rtexts during hit-testing by forcing to free them. not completely sure if there might be bad side effects though. tested with the example of the related issue.