### PR TITLE
Add 'native' pipewire audio backend

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -302,6 +302,17 @@ t_symbol *canvas_realizedollar(t_canvas *x, t_symbol *s)
     return (ret);
 }
 
+t_symbol *canvas_getsymbol_realized(t_canvas *canvas, const t_atom *a)
+{
+    t_symbol *s;
+    if ((a->a_type != A_SYMBOL) && (a->a_type != A_DOLLSYM))
+        return &s_symbol;
+    s = a->a_w.w_symbol;
+    if (a->a_type == A_DOLLSYM && canvas != NULL)
+        s = canvas_realizedollar(canvas, s);
+    return s;
+}
+
 t_symbol *canvas_getcurrentdir(void)
 {
     t_canvasenvironment *e = canvas_getenv(canvas_getcurrent());

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -572,6 +572,15 @@ EXTERN int canvas_path_iterate(const t_canvas *x, t_canvas_path_iterator fun,
 /* check string for untitled canvas filename prefix */
 #define UNTITLED_STRNCMP(s) strncmp(s, "PDUNTITLED", 10)
 
+    /* utility function required for template management.
+        if the atom is a symbol, return it.
+        if the atom is a dollar symbol:
+          if canvas is not null, return the realized symbol
+          otherwise return the unchanged symbol.
+        if the atom is something else, return &s_symbol.
+    */
+EXTERN t_symbol *canvas_getsymbol_realized(t_canvas *canvas, const t_atom *a);
+
 /* ---- functions on canvasses as objects  --------------------- */
 
 EXTERN void linetraverser_start(t_linetraverser *t, t_canvas *x);

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -198,15 +198,20 @@ int canvas_readscalar(t_glist *x, int natoms, t_atom *vec,
     t_scalar *sc;
     int nextmsg = *p_nextmsg;
     int wasvis = glist_isvisible(x);
+    t_symbol *templatename;
 
-    if (nextmsg >= natoms || vec[nextmsg].a_type != A_SYMBOL)
+    if (nextmsg >= natoms ||
+        (vec[nextmsg].a_type != A_SYMBOL && vec[nextmsg].a_type != A_DOLLSYM)
+    )
     {
         if (nextmsg < natoms)
             post("stopping early: type %d", vec[nextmsg].a_type);
         *p_nextmsg = natoms;
         return (0);
     }
-    templatesym = canvas_makebindsym(vec[nextmsg].a_w.w_symbol);
+    templatename = canvas_getsymbol_realized(canvas_getcurrent(),
+        &vec[nextmsg]);
+    templatesym = canvas_makebindsym(templatename);
     *p_nextmsg = nextmsg + 1;
 
     if (!(template = template_findbyname(templatesym)))
@@ -476,6 +481,9 @@ static void glist_writelist(t_gobj *y, t_binbuf *b);
 
 void binbuf_savetext(t_binbuf *bfrom, t_binbuf *bto);
 
+    /* defined in g_template.c */
+t_symbol *template_get_creation_name(t_template *x);
+
 void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
     int amarrayelement)
 {
@@ -485,7 +493,7 @@ void canvas_writescalar(t_symbol *templatesym, t_word *w, t_binbuf *b,
     if (!amarrayelement)
     {
         t_atom templatename;
-        SETSYMBOL(&templatename, gensym(templatesym->s_name + 3));
+        SETDOLLSYM(&templatename, template_get_creation_name(template));
         binbuf_add(b, 1, &templatename);
     }
     if (!template)
@@ -664,6 +672,58 @@ static void glist_write(t_glist *x, t_symbol *filename, t_symbol *format)
     }
 }
 
+    /* ------------ routines to write out templates themselves ------- */
+
+    /* call this recursively to collect all the template names for
+    a canvas or for the selection. */
+static void canvas_collecttemplatesfor(t_canvas *x, int *ntemplatesp,
+    t_symbol ***templatevecp, int wholething)
+{
+    t_gobj *y;
+
+    for (y = x->gl_list; y; y = y->g_next)
+    {
+        if ((pd_class(&y->g_pd) == scalar_class) &&
+            (wholething || glist_isselected(x, y)))
+                canvas_addtemplatesforscalar(((t_scalar *)y)->sc_template,
+                    ((t_scalar *)y)->sc_vec,  ntemplatesp, templatevecp);
+        else if ((pd_class(&y->g_pd) == canvas_class) &&
+            (wholething || glist_isselected(x, y)))
+                canvas_collecttemplatesfor((t_canvas *)y,
+                    ntemplatesp, templatevecp, 1);
+    }
+}
+
+    /* defined in g_template.c */
+t_binbuf *template_get_creation_binbuf(t_template *x);
+
+    /* save the templates needed by a canvas to a binbuf. */
+static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
+{
+    t_symbol **templatevec = getbytes(0);
+    int i, ntemplates = 0;
+    canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
+    for (i = 0; i < ntemplates; i++)
+    {
+        t_template *template = template_findbyname(templatevec[i]);
+        int j, m;
+        if (!template)
+        {
+            bug("canvas_savetemplatesto template_findbyname");
+            continue;
+        }
+
+        t_binbuf *bb = template_get_creation_binbuf(template);
+        if (bb)
+        {
+            binbuf_addv(b, "s", &s__N);
+            binbuf_addbinbuf(b, bb);
+            binbuf_addsemi(b);
+        } else bug("canvas_savetemplatesto template_get_creation_binbuf");
+    }
+    freebytes(templatevec, ntemplates * sizeof(*templatevec));
+}
+
 /* ------ routines to save and restore canvases (patches) recursively. ----*/
 
 typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
@@ -703,6 +763,7 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
             (int)(x->gl_screeny2 - x->gl_screeny1),
                 (int)x->gl_font);
         canvas_savedeclarationsto(x, b);
+        canvas_savetemplatesto(x, b, 1);
     }
     for (y = x->gl_list; y; y = y->g_next)
         gobj_save(y, b);
@@ -770,67 +831,6 @@ static void canvas_saveto(t_canvas *x, t_binbuf *b)
     }
 }
 
-    /* call this recursively to collect all the template names for
-    a canvas or for the selection. */
-static void canvas_collecttemplatesfor(t_canvas *x, int *ntemplatesp,
-    t_symbol ***templatevecp, int wholething)
-{
-    t_gobj *y;
-
-    for (y = x->gl_list; y; y = y->g_next)
-    {
-        if ((pd_class(&y->g_pd) == scalar_class) &&
-            (wholething || glist_isselected(x, y)))
-                canvas_addtemplatesforscalar(((t_scalar *)y)->sc_template,
-                    ((t_scalar *)y)->sc_vec,  ntemplatesp, templatevecp);
-        else if ((pd_class(&y->g_pd) == canvas_class) &&
-            (wholething || glist_isselected(x, y)))
-                canvas_collecttemplatesfor((t_canvas *)y,
-                    ntemplatesp, templatevecp, 1);
-    }
-}
-
-    /* save the templates needed by a canvas to a binbuf. */
-static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
-{
-    t_symbol **templatevec = getbytes(0);
-    int i, ntemplates = 0;
-    canvas_collecttemplatesfor(x, &ntemplates, &templatevec, wholething);
-    for (i = 0; i < ntemplates; i++)
-    {
-        t_template *template = template_findbyname(templatevec[i]);
-        int j, m;
-        if (!template)
-        {
-            bug("canvas_savetemplatesto");
-            continue;
-        }
-        m = template->t_n;
-            /* drop "pd-" prefix from template symbol to print */
-        binbuf_addv(b, "sss", &s__N, gensym("struct"),
-            gensym(templatevec[i]->s_name + 3));
-        for (j = 0; j < m; j++)
-        {
-            t_symbol *type;
-            switch (template->t_vec[j].ds_type)
-            {
-                case DT_FLOAT: type = &s_float; break;
-                case DT_SYMBOL: type = &s_symbol; break;
-                case DT_ARRAY: type = gensym("array"); break;
-                case DT_TEXT: type = gensym("text"); break;
-                default: type = &s_float; bug("canvas_write");
-            }
-            if (template->t_vec[j].ds_type == DT_ARRAY)
-                binbuf_addv(b, "sssf", type, template->t_vec[j].ds_name,
-                    gensym(template->t_vec[j].ds_arraytemplate->s_name + 3),
-                    (double)template->t_vec[j].ds_arraydeflength);
-            else binbuf_addv(b, "ss", type, template->t_vec[j].ds_name);
-        }
-        binbuf_addsemi(b);
-    }
-    freebytes(templatevec, ntemplates * sizeof(*templatevec));
-}
-
 void canvas_reload(t_symbol *name, t_symbol *dir, t_glist *except);
 
     /* save a "root" canvas to a file; cf. canvas_saveto() which saves the
@@ -839,7 +839,6 @@ static void canvas_savetofile(t_canvas *x, t_symbol *filename, t_symbol *dir,
     float fdestroy)
 {
     t_binbuf *b = binbuf_new();
-    canvas_savetemplatesto(x, b, 1);
     canvas_saveto(x, b);
     errno = 0;
     if (binbuf_write(b, filename->s_name, dir->s_name, 0))

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -311,23 +311,25 @@ t_scalar *scalar_new(t_glist *owner, t_symbol *templatesym)
 void glist_scalar(t_glist *glist,
     t_symbol *classname, int argc, t_atom *argv)
 {
-    t_symbol *templatesym =
-        canvas_makebindsym(atom_getsymbolarg(0, argc, argv));
-    t_binbuf *b;
-    int natoms, nextmsg = 0;
-    t_atom *vec;
+    t_symbol *templatename;
+    t_symbol *templatesym;
+    t_binbuf *b = binbuf_new();
+    int nextmsg = 0;
+
+    binbuf_restore(b, argc, argv);
+    argc = binbuf_getnatom(b);
+    argv = binbuf_getvec(b);
+    templatename = canvas_getsymbol_realized(canvas_getcurrent(), &argv[0]);
+    templatesym = canvas_makebindsym(templatename);
     if (!template_findbyname(templatesym))
     {
-        pd_error(glist, "%s: no such template",
+        pd_error(glist, "glist_scalar %s: no such template",
             atom_getsymbolarg(0, argc, argv)->s_name);
+        binbuf_free(b);
         return;
     }
 
-    b = binbuf_new();
-    binbuf_restore(b, argc, argv);
-    natoms = binbuf_getnatom(b);
-    vec = binbuf_getvec(b);
-    canvas_readscalar(glist, natoms, vec, &nextmsg, 0);
+    canvas_readscalar(glist, argc, argv, &nextmsg, 0);
     binbuf_free(b);
 }
 
@@ -541,6 +543,12 @@ int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
     int hit = 0, notified = 0;
     t_canvas *templatecanvas = template_findcanvas(template);
     t_gobj *y;
+    if (!templatecanvas)
+    {
+        pd_error(sc, "scalar_doclick: no canvas found for template %s",
+            template->t_sym->s_name);
+        return 0;
+    }
     for (y = templatecanvas->gl_list; y; y = y->g_next)
     {
         const t_parentwidgetbehavior *wb = pd_getparentwidget(&y->g_pd);
@@ -577,6 +585,12 @@ int scalar_click(t_gobj *z, struct _glist *owner,
 {
     t_scalar *x = (t_scalar *)z;
     t_template *template = template_findbyname(x->sc_template);
+    if (!template)
+    {
+        pd_error(x, "scalar_click: couldn't find template %s",
+            x->sc_template->s_name);
+        return 0;
+    }
     t_float basex = template_getfloat(template, gensym("x"), x->sc_vec, 0);
     t_float basey = template_getfloat(template, gensym("y"), x->sc_vec, 0);
     return (scalar_doclick(x->sc_vec, template, x, 0,

--- a/src/s_audio_paring.c
+++ b/src/s_audio_paring.c
@@ -107,8 +107,10 @@ long sys_ringbuf_init(sys_ringbuf *rbuf, long numBytes,
 ** Return number of bytes available for reading. */
 long sys_ringbuf_getreadavailable(sys_ringbuf *rbuf)
 {
-    long ret = atomic_int_load(&rbuf->writeIndex)
-        - atomic_int_load(&rbuf->readIndex);
+    long write_idx = atomic_int_load(&rbuf->writeIndex);
+    long read_idx = atomic_int_load(&rbuf->readIndex);
+
+    long ret = write_idx - read_idx;
     if (ret < 0)
         ret += 2 * rbuf->bufferSize;
     if (ret < 0 || ret > rbuf->bufferSize)
@@ -116,6 +118,7 @@ long sys_ringbuf_getreadavailable(sys_ringbuf *rbuf)
             "consistency check failed: sys_ringbuf_getreadavailable\n");
     return (ret);
 }
+
 /***************************************************************************
 ** Return number of bytes available for writing. */
 long sys_ringbuf_getwriteavailable(sys_ringbuf *rbuf)

--- a/src/s_audio_pipewire.c
+++ b/src/s_audio_pipewire.c
@@ -1,0 +1,605 @@
+/* Copyright (c) 1997-2003 Guenter Geiger, Miller Puckette, Larry Troxler,
+* Winfried Ritsch, Karl MacMillan, and others.
+* For information on usage and redistribution, and for a DISCLAIMER OF ALL
+* WARRANTIES, see the file, "LICENSE.txt," in this distribution.  */
+
+/* this file inputs and outputs audio using the pipewire API available on linux. */
+
+/* support for pipewire 0.3 by Charles K. Neimog <charlesneimog@outlook.com> */
+
+#ifdef USEAPI_PIPEWIRE
+
+#include "m_pd.h"
+#include "s_stuff.h"
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <pipewire/pipewire.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/param/latency-utils.h>
+#include <spa/param/param.h>
+
+#include "m_private_utils.h"
+#include "s_audio_paring.h"
+
+/* enable thread signaling instead of polling (like JACK backend) */
+#if 1
+#define THREADSIGNAL
+#endif
+
+#define MAX_BUFFERS 4
+#define MAX_ALLOCA_SAMPLES  (16*1024)
+
+/* ------------------------------- Backend state ------------------------------- */
+typedef struct _pw_state {
+    int samplerate;
+    int blocksize;
+    int in_n_devices;
+    int out_n_devices;
+
+    unsigned in_channels;
+    unsigned out_channels;
+
+    unsigned desired_block;
+
+    struct pw_thread_loop *tloop;
+    struct pw_stream *stream_in;
+    struct pw_stream *stream_out;
+
+    struct spa_hook stream_in_listener;
+    struct spa_hook stream_out_listener;
+
+    /* sys_ringbuf-based FIFOs (interleaved t_sample audio) */
+    sys_ringbuf inring;         /* PW -> Pd */
+    sys_ringbuf outring;        /* Pd -> PW */
+    char *inbuf;                /* backing storage for inring */
+    char *outbuf;               /* backing storage for outring */
+
+#ifdef THREADSIGNAL
+    t_semaphore *sem;           /* wake Pd scheduler when audio thread has work */
+#endif
+
+    int running;
+    volatile int dio_error;     /* set on over/underruns */
+} t_pw_state;
+
+static t_pw_state pw_state;
+static int pw_inited = 0;
+
+/* ------------------ PipeWire callbacks ------------------ */
+static void pw_in_param_changed(void *data, uint32_t id, const struct spa_pod *param)
+{
+    (void)data; (void)id; (void)param;
+    logpost(0, PD_DEBUG, "[pipewire] input param changed");
+}
+
+static void pw_in_process(void *data)
+{
+    t_pw_state *st = (t_pw_state *)data;
+    if (!st || !st->stream_in) return;
+
+    struct pw_buffer *b = pw_stream_dequeue_buffer(st->stream_in);
+    if (!b) return;
+
+    struct spa_buffer *buf = b->buffer;
+    if (!buf || buf->n_datas <= 0 || buf->datas[0].data == NULL) {
+        pw_stream_queue_buffer(st->stream_in, b);
+        return;
+    }
+
+    void *base = buf->datas[0].data;
+    size_t maxsize = (size_t)buf->datas[0].maxsize;
+    size_t chunk_offset = 0;
+    size_t chunk_size = 0;
+    if (buf->datas[0].chunk) {
+        chunk_offset = (size_t)buf->datas[0].chunk->offset;
+        chunk_size   = (size_t)buf->datas[0].chunk->size;
+    }
+    if (chunk_offset > maxsize) {
+        pw_stream_queue_buffer(st->stream_in, b);
+        return;
+    }
+    size_t nbytes = chunk_size ? chunk_size : (maxsize - chunk_offset);
+    if (nbytes == 0) {
+        pw_stream_queue_buffer(st->stream_in, b);
+        return;
+    }
+
+    const void *src = (const char *)base + chunk_offset;
+
+    /* Write interleaved float/t_sample bytes into input ring */
+    long written = sys_ringbuf_write(&st->inring, src, (long)nbytes, st->inbuf);
+    if (written < (long)nbytes) {
+        /* overflow: drop tail */
+        st->dio_error = 1;
+    }
+
+#ifdef THREADSIGNAL
+    if (st->sem) sys_semaphore_post(st->sem);
+#endif
+    pw_stream_queue_buffer(st->stream_in, b);
+}
+
+static const struct pw_stream_events stream_in_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .param_changed = pw_in_param_changed,
+    .process       = pw_in_process,
+};
+
+static void pw_out_param_changed(void *data, uint32_t id, const struct spa_pod *param)
+{
+    (void)data; (void)id; (void)param;
+    logpost(0, PD_DEBUG, "[pipewire] output param changed");
+}
+
+static void pw_out_process(void *data)
+{
+    t_pw_state *st = (t_pw_state *)data;
+    if (!st || !st->stream_out) return;
+
+    struct pw_buffer *b = pw_stream_dequeue_buffer(st->stream_out);
+    if (!b) return;
+
+    struct spa_buffer *buf = b->buffer;
+    if (!buf || buf->n_datas <= 0 || buf->datas[0].data == NULL) {
+        pw_stream_queue_buffer(st->stream_out, b);
+        return;
+    }
+
+    char *dst = (char *)buf->datas[0].data;
+    uint32_t max_bytes = buf->datas[0].maxsize;
+
+    /* read interleaved bytes from output ring */
+    long got = sys_ringbuf_read(&st->outring, dst, (long)max_bytes, st->outbuf);
+    if (got < (long)max_bytes) {
+        /* underrun: zero remainder */
+        memset(dst + got, 0, (size_t)max_bytes - (size_t)got);
+        st->dio_error = 1;
+    }
+
+    if (buf->datas[0].chunk) {
+        buf->datas[0].chunk->offset = 0;
+        buf->datas[0].chunk->stride = (int)st->out_channels * (int)sizeof(t_sample);
+        buf->datas[0].chunk->size   = max_bytes;
+    }
+
+#ifdef THREADSIGNAL
+    if (st->sem) sys_semaphore_post(st->sem);
+#endif
+    pw_stream_queue_buffer(st->stream_out, b);
+}
+
+static const struct pw_stream_events stream_out_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .param_changed = pw_out_param_changed,
+    .process       = pw_out_process,
+};
+
+/* -------------------------- Helpers: make/conn streams -------------------------- */
+static int pw_make_capture_stream(t_pw_state *st)
+{
+    unsigned sr = (unsigned)(st->samplerate > 0 ? st->samplerate : 48000);
+
+    char rate_prop[32];
+    snprintf(rate_prop, sizeof(rate_prop), "%u/1", sr);
+    char latency_prop[32];
+    snprintf(latency_prop, sizeof(latency_prop), "%u/%u", (unsigned)st->desired_block, sr);
+
+    struct pw_properties *props =
+        pw_properties_new(PW_KEY_MEDIA_TYPE, "Audio",
+                          PW_KEY_MEDIA_CATEGORY, "Capture",
+                          PW_KEY_MEDIA_ROLE, "Production",
+                          NULL);
+    pw_properties_set(props, PW_KEY_NODE_RATE,    rate_prop);
+    pw_properties_set(props, PW_KEY_NODE_LATENCY, latency_prop);
+
+    st->stream_in = pw_stream_new_simple(pw_thread_loop_get_loop(st->tloop),
+                                         "info.puredata.Pd", props,
+                                         &stream_in_events, st);
+    if (!st->stream_in) return -1;
+
+    struct spa_audio_info_raw info;
+    spa_zero(info);
+    info.format   = SPA_AUDIO_FORMAT_F32;
+    info.channels = st->in_channels > 0 ? (uint32_t)st->in_channels : 0;
+    info.rate     = sr;
+
+    uint8_t buf[512];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+    const struct spa_pod *params[3];
+    uint32_t n_params = 0;
+
+    /* 1) format */
+    params[n_params++] = spa_pod_builder_add_object(
+        &b, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
+        SPA_FORMAT_mediaType,      SPA_POD_Id(SPA_MEDIA_TYPE_audio),
+        SPA_FORMAT_mediaSubtype,   SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+        SPA_FORMAT_AUDIO_format,   SPA_POD_Id(info.format),
+        SPA_FORMAT_AUDIO_channels, SPA_POD_Int((int)info.channels),
+        SPA_FORMAT_AUDIO_rate,     SPA_POD_Int((int)info.rate));
+
+    /* 2) latency param: request exact blocksize on INPUT */
+    struct spa_latency_info lat;
+    spa_zero(lat);
+    lat.direction   = SPA_DIRECTION_INPUT;
+    lat.min_quantum = (float)st->desired_block;
+    lat.max_quantum = (float)st->desired_block;
+
+    uint8_t lbuf[256];
+    struct spa_pod_builder lb = SPA_POD_BUILDER_INIT(lbuf, sizeof(lbuf));
+    params[n_params++] = spa_latency_build(&lb, SPA_PARAM_Latency, &lat);
+
+    /* 3) buffers sized for one block */
+    int frames     = st->blocksize;
+    int stride     = (int)st->in_channels * (int)sizeof(t_sample);
+    int size_bytes = frames * stride;
+
+    params[n_params++] = spa_pod_builder_add_object(
+        &b, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+        SPA_PARAM_BUFFERS_buffers, SPA_POD_Int(MAX_BUFFERS),
+        SPA_PARAM_BUFFERS_blocks,  SPA_POD_Int(1),
+        SPA_PARAM_BUFFERS_size,    SPA_POD_Int(size_bytes),
+        SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(stride));
+
+    uint32_t flags = PW_STREAM_FLAG_AUTOCONNECT |
+                     PW_STREAM_FLAG_MAP_BUFFERS |
+                     PW_STREAM_FLAG_RT_PROCESS;
+
+    if (pw_stream_connect(st->stream_in, PW_DIRECTION_INPUT, PW_ID_ANY, flags, params, n_params) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int pw_make_playback_stream(t_pw_state *st)
+{
+    unsigned sr = (unsigned)(st->samplerate > 0 ? st->samplerate : 48000);
+
+    char rate_prop[32];
+    snprintf(rate_prop, sizeof(rate_prop), "%u/1", sr);
+    char latency_prop[32];
+    snprintf(latency_prop, sizeof(latency_prop), "%u/%u", (unsigned)st->desired_block, sr);
+
+    struct pw_properties *props =
+        pw_properties_new(PW_KEY_MEDIA_TYPE, "Audio",
+                          PW_KEY_MEDIA_CATEGORY, "Playback",
+                          PW_KEY_MEDIA_ROLE, "Production",
+                          NULL);
+    pw_properties_set(props, PW_KEY_NODE_RATE,    rate_prop);
+    pw_properties_set(props, PW_KEY_NODE_LATENCY, latency_prop);
+
+    st->stream_out = pw_stream_new_simple(pw_thread_loop_get_loop(st->tloop),
+                                          "info.puredata.Pd", props,
+                                          &stream_out_events, st);
+    if (!st->stream_out) return -1;
+
+    struct spa_audio_info_raw info;
+    spa_zero(info);
+    info.format   = SPA_AUDIO_FORMAT_F32;
+    info.channels = st->out_channels > 0 ? (uint32_t)st->out_channels : 0;
+    info.rate     = sr;
+
+    uint8_t buf[512];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+    const struct spa_pod *params[3];
+    uint32_t n_params = 0;
+
+    /* 1) format */
+    params[n_params++] = spa_pod_builder_add_object(
+        &b, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
+        SPA_FORMAT_mediaType,      SPA_POD_Id(SPA_MEDIA_TYPE_audio),
+        SPA_FORMAT_mediaSubtype,   SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+        SPA_FORMAT_AUDIO_format,   SPA_POD_Id(info.format),
+        SPA_FORMAT_AUDIO_channels, SPA_POD_Int((int)info.channels),
+        SPA_FORMAT_AUDIO_rate,     SPA_POD_Int((int)info.rate));
+
+    /* 2) latency param: request exact blocksize on OUTPUT */
+    struct spa_latency_info lat;
+    spa_zero(lat);
+    lat.direction   = SPA_DIRECTION_OUTPUT;
+    lat.min_quantum = (float)st->desired_block;
+    lat.max_quantum = (float)st->desired_block;
+
+    uint8_t lbuf[256];
+    struct spa_pod_builder lb = SPA_POD_BUILDER_INIT(lbuf, sizeof(lbuf));
+    params[n_params++] = spa_latency_build(&lb, SPA_PARAM_Latency, &lat);
+
+    /* 3) buffers sized for one block */
+    int frames     = st->blocksize;
+    int stride     = (int)st->out_channels * (int)sizeof(t_sample);
+    int size_bytes = frames * stride;
+
+    params[n_params++] = spa_pod_builder_add_object(
+        &b, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+        SPA_PARAM_BUFFERS_buffers, SPA_POD_Int(MAX_BUFFERS),
+        SPA_PARAM_BUFFERS_blocks,  SPA_POD_Int(1),
+        SPA_PARAM_BUFFERS_size,    SPA_POD_Int(size_bytes),
+        SPA_PARAM_BUFFERS_stride,  SPA_POD_Int(stride));
+
+    uint32_t flags = PW_STREAM_FLAG_AUTOCONNECT |
+                     PW_STREAM_FLAG_MAP_BUFFERS |
+                     PW_STREAM_FLAG_RT_PROCESS;
+
+    if (pw_stream_connect(st->stream_out, PW_DIRECTION_OUTPUT, PW_ID_ANY, flags, params, n_params) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int pipewire_open_audio(int naudioindev, int *audioindev, int nchindev,
+    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
+    int *choutdev, int rate, int blocksize)
+{
+    if (!pw_inited) {
+        pw_init(NULL, NULL);
+        pw_inited = 1;
+    }
+
+    // count chs
+    unsigned in_ch = 0, out_ch = 0;
+    if (chindev && naudioindev > 0)
+        for (int i = 0; i < naudioindev; i++)
+            in_ch += (unsigned)((chindev[i] > 0) ? chindev[i] : 0);
+    if (choutdev && naudiooutdev > 0)
+        for (int i = 0; i < naudiooutdev; i++)
+            out_ch += (unsigned)((choutdev[i] > 0) ? choutdev[i] : 0);
+
+
+    // configure
+    memset(&pw_state, 0, sizeof(pw_state));
+    pw_state.samplerate    = rate;
+    pw_state.blocksize     = blocksize;
+    pw_state.desired_block = (unsigned)blocksize;
+    pw_state.in_n_devices  = naudioindev;
+    pw_state.out_n_devices = naudiooutdev;
+    pw_state.in_channels   = in_ch;
+    pw_state.out_channels  = out_ch;
+
+#ifdef THREADSIGNAL
+    pw_state.sem = sys_semaphore_create();
+#endif
+
+    pw_state.tloop = pw_thread_loop_new("Pure Data", NULL);
+    if (!pw_state.tloop) {
+        logpost(0, PD_CRITICAL, "pipewire failed to create thread loop");
+        goto fail;
+    }
+    if (pw_thread_loop_start(pw_state.tloop) != 0) {
+        logpost(0, PD_CRITICAL, "[pipewire] failed to start thread loop");
+        goto fail;
+    }
+
+    pw_thread_loop_lock(pw_state.tloop);
+
+    // compute advance_samples and align to blocksize
+    int advance_samples = (int)(sys_schedadvance * (double)rate / 1.e6);
+    if (DEFDACBLKSIZE > 0)
+        advance_samples -= (advance_samples % DEFDACBLKSIZE);
+    if (advance_samples < blocksize)
+        advance_samples = blocksize;
+
+    /* Create sys_ringbufs with backing buffers.
+       IMPORTANT: use pw_state.{in,out}_channels here and sizes in BYTES. */
+    if (pw_state.in_channels > 0) {
+        pw_state.inbuf = malloc(sizeof(t_sample) * STUFF->st_inchannels * advance_samples);
+        if (!pw_state.inbuf) {
+            pw_thread_loop_unlock(pw_state.tloop);
+            goto fail;
+        }
+        /* start empty; if you want to prefill, memset to 0 and pass insize_bytes as 4th arg */
+        sys_ringbuf_init(&pw_state.inring,
+            sizeof(t_sample) * STUFF->st_inchannels * advance_samples,
+                         pw_state.inbuf,
+                         sizeof(t_sample) * STUFF->st_inchannels * advance_samples);
+    }
+
+    if (pw_state.out_channels > 0) {
+        pw_state.outbuf = malloc(sizeof(t_sample) * STUFF->st_outchannels * advance_samples);
+        if (!pw_state.outbuf) {
+            pw_thread_loop_unlock(pw_state.tloop);
+            goto fail;
+        }
+        sys_ringbuf_init(&pw_state.outring,
+            sizeof(t_sample) * STUFF->st_outchannels * advance_samples,
+                         pw_state.outbuf, 0);
+    }
+
+    if (pw_state.in_channels > 0) {
+        if (pw_make_capture_stream(&pw_state) < 0) {
+            logpost(0, PD_CRITICAL, "[pipewire] failed to create capture stream");
+            pw_thread_loop_unlock(pw_state.tloop);
+            goto fail;
+        }
+    }
+    if (pw_state.out_channels > 0) {
+        if (pw_make_playback_stream(&pw_state) < 0) {
+            logpost(0, PD_CRITICAL, "[pipewire] failed to create playback stream");
+            pw_thread_loop_unlock(pw_state.tloop);
+            goto fail;
+        }
+    }
+    pw_thread_loop_unlock(pw_state.tloop);
+
+    pw_state.running = 1;
+    pw_state.dio_error = 0;
+    return 0;
+
+fail:
+    if (pw_state.tloop) {
+        pw_thread_loop_unlock(pw_state.tloop);
+        pw_thread_loop_stop(pw_state.tloop);
+        pw_thread_loop_destroy(pw_state.tloop);
+        pw_state.tloop = NULL;
+    }
+    if (pw_state.stream_in) {
+        pw_stream_destroy(pw_state.stream_in);
+        pw_state.stream_in = NULL;
+    }
+    if (pw_state.stream_out){
+        pw_stream_destroy(pw_state.stream_out);
+        pw_state.stream_out = NULL;
+    }
+
+#ifdef THREADSIGNAL
+    if (pw_state.sem) { sys_semaphore_destroy(pw_state.sem); pw_state.sem = NULL; }
+#endif
+
+    if (pw_state.inbuf)  {
+        free(pw_state.inbuf);
+        pw_state.inbuf = NULL;
+    }
+    if (pw_state.outbuf) {
+        free(pw_state.outbuf);
+        pw_state.outbuf = NULL;
+    }
+    pw_state.running = 0;
+    return 1;
+}
+
+void pipewire_close_audio(void)
+{
+    if (!pw_state.tloop && !pw_state.stream_in && !pw_state.stream_out && !pw_state.inbuf && !pw_state.outbuf)
+        return;
+
+    if (pw_state.tloop) {
+        pw_thread_loop_lock(pw_state.tloop);
+        if (pw_state.stream_in) {
+            pw_stream_disconnect(pw_state.stream_in);
+            pw_stream_destroy(pw_state.stream_in);
+            pw_state.stream_in = NULL;
+        }
+        if (pw_state.stream_out) {
+            pw_stream_disconnect(pw_state.stream_out);
+            pw_stream_destroy(pw_state.stream_out);
+            pw_state.stream_out = NULL;
+        }
+        pw_thread_loop_unlock(pw_state.tloop);
+
+        pw_thread_loop_stop(pw_state.tloop);
+        pw_thread_loop_destroy(pw_state.tloop);
+        pw_state.tloop = NULL;
+    }
+
+#ifdef THREADSIGNAL
+    if (pw_state.sem) {
+        sys_semaphore_destroy(pw_state.sem);
+        pw_state.sem = NULL;
+    }
+#endif
+
+    if (pw_state.inbuf) {
+        free(pw_state.inbuf);
+        pw_state.inbuf = NULL;
+    }
+    if (pw_state.outbuf){
+        free(pw_state.outbuf);
+        pw_state.outbuf = NULL;
+    }
+
+    pw_state.running = 0;
+    pw_state.dio_error = 0;
+
+    pw_deinit();
+    pw_inited = 0;
+}
+
+int sched_idletask(void);
+
+/* Move one Pd block between Pd and PipeWire using sys_ringbuf like JACK's polling mode. */
+int pipewire_send_dacs(void)
+{
+    t_sample *muxbuffer;
+    t_sample *fp, *fp2, *jp;
+    int j, ch;
+    const size_t muxbufsize =
+        DEFDACBLKSIZE * (pw_state.in_channels > pw_state.out_channels ?
+                         pw_state.in_channels : pw_state.out_channels);
+    int retval = SENDDACS_YES;
+
+    if (!pw_state.running || (!pw_state.in_channels && !pw_state.out_channels))
+        return SENDDACS_NO;
+
+    /* compute required/available in bytes */
+    long need_in_bytes  = (long)pw_state.in_channels  * (long)DEFDACBLKSIZE * (long)sizeof(t_sample);
+    long need_out_bytes = (long)pw_state.out_channels * (long)DEFDACBLKSIZE * (long)sizeof(t_sample);
+
+    while (
+        (pw_state.in_channels  && sys_ringbuf_getreadavailable(&pw_state.inring)  < need_in_bytes) ||
+        (pw_state.out_channels && sys_ringbuf_getwriteavailable(&pw_state.outring) < need_out_bytes))
+    {
+#ifdef THREADSIGNAL
+        if (sched_idletask())
+            continue;
+        if (pw_state.sem)
+            sys_semaphore_wait(pw_state.sem);
+        retval = SENDDACS_SLEPT;
+#else
+        return SENDDACS_NO;
+#endif
+    }
+
+    if (pw_state.dio_error) {
+        /* log a resync like JACK backend does */
+        sys_log_error(ERR_RESYNC);
+        pw_state.dio_error = 0;
+    }
+
+    ALLOCA(t_sample, muxbuffer, muxbufsize, MAX_ALLOCA_SAMPLES);
+
+    /* Input: de-interleave from ring to STUFF->st_soundin */
+    if (pw_state.in_channels)
+    {
+        sys_ringbuf_read(&pw_state.inring, muxbuffer, need_in_bytes, pw_state.inbuf);
+        for (fp = muxbuffer, ch = 0; ch < (int)pw_state.in_channels; ch++, fp++)
+        {
+            jp = STUFF->st_soundin + ch * DEFDACBLKSIZE;
+            for (j = 0, fp2 = fp; j < DEFDACBLKSIZE;
+                 j++, fp2 += pw_state.in_channels)
+            {
+                jp[j] = *fp2;
+            }
+        }
+    }
+
+    /* Output: interleave from STUFF->st_soundout to ring */
+    if (pw_state.out_channels)
+    {
+        for (fp = muxbuffer, ch = 0; ch < (int)pw_state.out_channels; ch++, fp++)
+        {
+            jp = STUFF->st_soundout + ch * DEFDACBLKSIZE;
+            for (j = 0, fp2 = fp; j < DEFDACBLKSIZE;
+                 j++, fp2 += pw_state.out_channels)
+            {
+                *fp2 = jp[j];
+            }
+        }
+        sys_ringbuf_write(&pw_state.outring, muxbuffer, need_out_bytes, pw_state.outbuf);
+    }
+
+    /* clear Pd's output buffer for next block (as in JACK backend) */
+    if (pw_state.out_channels && STUFF->st_soundout)
+        memset(STUFF->st_soundout, 0,
+               (size_t)DEFDACBLKSIZE * (size_t)pw_state.out_channels * sizeof(t_sample));
+
+    FREEA(t_sample, muxbuffer, muxbufsize, MAX_ALLOCA_SAMPLES);
+    return retval;
+}
+
+void pipewire_getdevs(char *indevlist, int *nindevs,
+    char *outdevlist, int *noutdevs, int *canmulti,
+        int maxndev, int devdescsize)
+{
+    int i, ndev;
+    *canmulti = 0;  /* supports multiple devices */
+    ndev = 1;
+    for (i = 0; i < ndev; i++)
+    {
+        sprintf(indevlist + i * devdescsize, "PipeWire");
+        sprintf(outdevlist + i * devdescsize, "PipeWire");
+    }
+    *nindevs = *noutdevs = ndev;
+}
+#endif
+

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -100,10 +100,11 @@ typedef struct _audiosettings
 #define API_MMIO 3
 #define API_PORTAUDIO 4
 #define API_JACK 5
-#define API_SGI 6           /* gone */
-#define API_AUDIOUNIT 7
-#define API_ESD 8           /* no idea what this was, probably gone now */
-#define API_DUMMY 9
+#define API_PIPEWIRE 6
+#define API_SGI 7           /* gone */
+#define API_AUDIOUNIT 9
+#define API_ESD 9           /* no idea what this was, probably gone now */
+#define API_DUMMY 10
 
     /* figure out which API should be the default.  The one we judge most
     likely to offer a working device takes precedence so that if you
@@ -129,6 +130,9 @@ typedef struct _audiosettings
 #elif defined(USEAPI_JACK)
 # define API_DEFAULT API_JACK
 # define API_DEFSTRING "Jack audio connection kit"
+#elif defined(USEAPI_PIPEWIRE)
+# define API_DEFAULT API_PIPEWIRE
+# define API_DEFSTRING "PipeWire"
 #elif defined(USEAPI_MMIO)
 # define API_DEFAULT API_MMIO
 # define API_DEFSTRING "MMIO"
@@ -219,6 +223,20 @@ void jack_getdevs(char *indevlist, int *nindevs,
 void jack_listdevs(void);
 void jack_client_name(const char *name);
 void jack_autoconnect(int);
+
+int pipewire_open_audio(int naudioindev, int *audioindev, int nchindev,
+    int *chindev, int naudiooutdev, int *audiooutdev, int nchoutdev,
+    int *choutdev, int rate, int blocksize);
+void pipewire_close_audio(void);
+int pipewire_send_dacs(void);
+int pipewire_reopen_audio(void);
+void pipewire_reportidle(void);
+void pipewire_getdevs(char *indevlist, int *nindevs,
+    char *outdevlist, int *noutdevs, int *canmulti,
+        int maxndev, int devdescsize);
+void pipewire_listdevs(void);
+void pipewire_client_name(const char *name);
+
 
 int mmio_open_audio(int naudioindev, int *audioindev,
     int nchindev, int *chindev, int naudiooutdev, int *audiooutdev,


### PR DESCRIPTION
Hello,

@umlaeute, could you take a look?

I’m proposing this because using JACK with PipeWire introduces some limitations, while ALSA and PortAudio give me even more issues.

With JACK, the main problems are:

- *Changing block size is not straightforward*: This is crucial for me: sometimes I need a reactive system, but other times—especially with [pd-upic](https://github.com/charlesneimog/pd-upic)), I need a huge block size to listen properly without rendering offline.

- *Output device switching is neither persistent nor fast*: (Possibly a configuration issue, but still.) I work mainly on laptops and frequently switch between Bluetooth headphones and audio interfaces. Globally, this is straightforward with tools like [pwvucontrol](https://flathub.org/apps/com.saivert.pwvucontrol), but for some reason, Pure Data isn’t recognized as a client when using ALSA or JACK. Either on `pwvucontrol` or `pavucontrol`, and `Helmut` is again not persistent.
 
This PR solves this issues for me!

But I yet have some problems to understand the `ringbuffers`, so this is my best provide a good solution for my problem hehe.