### PR TITLE
defer freeing canvas in canvas_menuclose()

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -44,6 +44,7 @@ struct _instanceeditor
 
 void glist_readfrombinbuf(t_glist *x, const t_binbuf *b, const char *filename,
     int selectem);
+void canvas_free_deferred(t_canvas *x);
 
 /* ------------------ forward declarations --------------- */
 static void canvas_doclear(t_canvas *x);
@@ -3542,10 +3543,10 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                 gensym(buf), 2, backmsg,
                 "yes");
         }
-        else pd_free(&x->gl_pd);
+        else canvas_free_deferred(x);
     }
     else if (force == 1)
-        pd_free(&x->gl_pd);
+        canvas_free_deferred(x);
     else if (force == 2)
     {
         canvas_dirty(x, 0);
@@ -3562,7 +3563,7 @@ void canvas_menuclose(t_canvas *x, t_floatarg fforce)
                         canvas_getrootfor(g), gensym(buf), 2, backmsg);
             return;
         }
-        else pd_free(&x->gl_pd);
+        else canvas_free_deferred(x);
     }
     else if (force == 3)
     {


### PR DESCRIPTION
This avoids memory issues when programmatically closing multiple canvasses bound to the same name or closing a canvas from within itself.

Fixes https://github.com/pure-data/pure-data/issues/2773.

~~For a more general solution, see https://github.com/pure-data/pure-data/pull/2776.~~