### PR TITLE
Add canvas_defer() method

### DIFF
--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -528,6 +528,7 @@ typedef int (*t_canvasapply)(t_canvas *x, t_int x1, t_int x2, t_int x3);
 
 EXTERN void canvas_resortinlets(t_canvas *x);
 EXTERN void canvas_resortoutlets(t_canvas *x);
+EXTERN void canvas_defer(t_canvas *x, t_messfn fn, void *data);
 EXTERN void canvas_free(t_canvas *x);
 EXTERN void canvas_updatewindowlist(void);
 EXTERN void canvas_editmode(t_canvas *x, t_floatarg state);


### PR DESCRIPTION
`canvas_defer()` safely defers a canvas method call to the end of the current clock tick. If the canvas is destroyed, all pending method calls are automatically cancelled. In this case, the function is called with the first argument set to NULL, so it can still free the data object (if used).

This PR also applies `canvas_defer()` to the "menuclose" and "clear" canvas messages to prevent potential crashes during message passing (e.g. by accidentally deleting/clearing the containing canvas or a parent canvas).

Note that "clear" still deletes all scalars synchronously, otherwise we would break existing data structure patches. This is always safe because scalars don't participate in message passing and are protected by gpointers.

Here's a test patch:
[canvas-defer-test.zip](https://github.com/user-attachments/files/22712096/canvas-defer-test.zip)

Fixes https://github.com/pure-data/pure-data/issues/2773. See also the issue discussion for more context.
