### PR TITLE
per-instance user data for classes

### DIFF
--- a/libpd/test_libpd/test_libpd.pd
+++ b/libpd/test_libpd/test_libpd.pd
@@ -1,4 +1,4 @@
-#N canvas 404 288 429 236 10;
+#N canvas 404 288 536 236 10;
 #X obj 88 107 print;
 #X obj 185 175 dac~;
 #X obj 88 83 f 0;
@@ -13,6 +13,9 @@
 #X obj 42 139 makenote 64 1;
 #X obj 42 107 + 60;
 #X msg 206 114 -0.25;
+#X obj 405 58 test;
+#X obj 405 88 test;
+#X obj 405 118 test;
 #X connect 2 0 0 0;
 #X connect 2 0 3 0;
 #X connect 2 0 12 0;

--- a/src/m_imp.h
+++ b/src/m_imp.h
@@ -34,6 +34,12 @@ typedef void* (*t_symbolmethodr)(t_pd *x, t_symbol *s);
 typedef void* (*t_listmethodr)(t_pd *x, t_symbol *s, int argc, t_atom *argv);
 typedef void* (*t_anymethodr)(t_pd *x, t_symbol *s, int argc, t_atom *argv);
 
+typedef struct _class_data
+{
+    void *data;             /* user data */
+    t_classdatafn freefn;   /* called when the instance is destroyed */
+} t_class_data;
+
 struct _class
 {
     t_symbol *c_name;                   /* name (mostly for error reporting) */
@@ -66,7 +72,12 @@ struct _class
     unsigned int c_multichannel:1;      /* can deal with multichannel sigs */
     unsigned int c_nopromotesig:1;      /* don't promote scalars to signals */
     unsigned int c_nopromoteleft:1;     /* not even the main (left) inlet */
-    t_classfreefn c_classfreefn;    /* function to call before freeing class */
+    t_classfreefn c_classfreefn;        /* function to call before freeing class */
+#ifdef PDINSTANCE
+    t_class_data *c_data;               /* per-instance data */
+#else
+    t_class_data c_data;
+#endif
 };
 
 /* m_pd.c */

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -613,8 +613,18 @@ typedef void (*t_propertiesfn)(t_gobj *x, struct _glist *glist);
 EXTERN void class_setpropertiesfn(t_class *c, t_propertiesfn f);
 EXTERN t_propertiesfn class_getpropertiesfn(const t_class *c);
 
+/* set a function to be called when the class object is freed. Use this to free
+global resources (e.g. lookup tables) allocated in the class setup function. */
 typedef void (*t_classfreefn)(t_class *);
 EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
+
+/* set per-instance user data for a given class. 'freefn', if not NULL, will be
+called when a Pd instance is about to be destroyed, so you can release the data.
+HINT: you can create and set the per-instance data lazily in the object constructor. */
+typedef void (*t_classdatafn)(void *);
+EXTERN void class_setinstancedata(t_class *c, void *data, t_classdatafn freefn);
+/* get the per-instance user data of a given class */
+EXTERN void *class_getinstancedata(t_class *c);
 
 #ifndef PD_CLASS_DEF
 #define class_addbang(x, y) class_addbang((x), (t_method)(y))

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -620,7 +620,9 @@ EXTERN void class_setfreefn(t_class *c, t_classfreefn fn);
 
 /* set per-instance user data for a given class. 'freefn', if not NULL, will be
 called when a Pd instance is about to be destroyed, so you can release the data.
-HINT: you can create and set the per-instance data lazily in the object constructor. */
+If you unset/replace existing instance data, it is your responsibility to free it.
+HINT: you can create and set the per-instance data lazily in the object constructor.
+See libpd/test_libpd/test_libpd.c for an example. */
 typedef void (*t_classdatafn)(void *);
 EXTERN void class_setinstancedata(t_class *c, void *data, t_classdatafn freefn);
 /* get the per-instance user data of a given class */


### PR DESCRIPTION
### Background

Sometimes we want to share data between all objects of a certain class.

This is trivial for constant, read-only data, such as look-up tables: we can create the data in the class setup function, store it in a global variable and release it in the class free function (`class_setfreefn`). The same goes for mutable shared data, as long as we only have a single Pd instance.

However, this becomes tricky with multiple Pd instances:
- Pd instances may run on different threads, so the shared data must be thread safe
- the shared data may contain members that are only valid for a particular Pd instance (e.g. `t_symbol *` or `t_pd *`)

There is a workaround, but it's neither trivial nor obvious:
1. create a fake Pd class, e.g. `foo_shared_class`
2. choose a reasonably unique string, e.g. "foo shared state";
3. bind an instance of `foo_shared_class` to the symbol "foo shared state"
4. call `pd_findbyclass(gensym("foo shared state"), foo_shared_class)` to retrieve the shared data

### New feature

`class_setinstancedata(t_class *c, void *data, t_classdatafn freefn);`

Set user data `data` on class `c`. The data is only visible to the current Pd instance.
`freefn`, if not NULL, is called when the Pd instance is about to be freed, allowing the user to free `data`
You can also unset/replace existing class user data, but then you are responsible for freeing the old data.

---

`void *class_getinstancedata(t_class *c);`

Retrieve the per-instance user data for class `c`

---

For a concrete example, see `libpd/test_libpd/test_libpd.c`.

### Use cases

Here are some real use cases from my own externals:

- internal preset management + object registry. When presets changes, all objects are notified, possibly emitting messages.

- shared dictionary of network sockets. Multiple objects can share the same socket and they register themselves to receive messages.

Other people have similar use cases. I remember explaining the fake class trick a few times.

It would also elegantly solve issues such as these: https://github.com/pure-data/pure-data/pull/2708