### PR TITLE
check mouse above rtext only for mouse click

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -2381,8 +2381,8 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
     }
 
         /* is the mouse over a text, in either an object box or a scalar? */
-    rtext = rtext_findhit(x, xpix, ypix, &hitobj, &hitscalar,
-        &hitwords, &hitdrawtext);
+    rtext = doit ? rtext_findhit(x, xpix, ypix, &hitobj, &hitscalar,
+        &hitwords, &hitdrawtext) : 0;
 
        /* did we click when there's an active text? */
     if (doit && x->gl_editor->e_textedfor)


### PR DESCRIPTION
sorry for the PR spam from my side! - but maybe some of it actually helps. this here is also something i checked a few weeks ago. for me, it improves CPU usage for the test patch in #2766 quite a bit more (by another ~50%) compared to the current master at b876394.

i wonder if anything relevant is missing when restricting this to the `doit` case though.