### PR TITLE
fix rtext lifecycle (never draw to gui from glist_getrtext())

### DIFF
--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -77,6 +77,9 @@ void drawtext_newtext(t_gobj *drawtext, t_glist *gl, t_scalar *sc,
     t_word *words, char *buf);
 int drawtext_isvisible(t_gobj *z, t_word *words);
 
+    /* defined later: */
+static void rtext_refreshbuffer(t_rtext *x);
+
 /* find the rtext that goes with a text item.  Return zero if the
 text item is invisible, either because the glist itself is, or because
 the item is in a GOP subpatch and its (x,y) origin is outside the GOP
@@ -107,7 +110,7 @@ t_rtext *glist_getrtext(t_glist *gl, t_text *who, int really)
         return (0);
     x = rtext_add(gl, last);
     x->x_text = who;
-    rtext_retext(x);
+    rtext_refreshbuffer(x);
     return (x);
 }
 
@@ -675,8 +678,7 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
         t_freebytes(tempbuf, 2 * x->x_bufsize + 1);
 }
 
-    /* make or remake text buffer from binbuf (text boxes only) */
-void rtext_retext(t_rtext *x)
+static void rtext_refreshbuffer(t_rtext *x)
 {
     int w = 0, h = 0, indx;
     if (x->x_buf)
@@ -687,6 +689,13 @@ void rtext_retext(t_rtext *x)
         /* allocate extra space for hidden null terminator */
     x->x_buf = resizebytes(x->x_buf, x->x_bufsize, x->x_bufsize+1);
     x->x_buf[x->x_bufsize] = 0;
+}
+
+    /* make or remake text buffer from binbuf (text boxes only) */
+void rtext_retext(t_rtext *x)
+{
+    int w = 0, h = 0, indx;
+    rtext_refreshbuffer(x);
     rtext_findscreenlocation(x);
         /* force dimension recalculation after text conversion */
     x->x_pixwidth = x->x_pixheight = -1;


### PR DESCRIPTION
fixes the bug signaled in https://github.com/pure-data/pure-data/issues/2759#issuecomment-3258622392 : 

> when a text is created, the associated pdtk_text is ***set*** before being ***created***

by making sure `glist_getrtext()` never sends commands to GUI.

This problem didn't seem to cause much harm, only useless trafic to GUI (and hard-to-understand logs).