### PR TITLE
adds a basic theme editor

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -2389,3 +2389,20 @@ void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     for (gl = pd_this->pd_canvaslist; gl; gl = gl->gl_next)
         glist_dorevis(gl);
 }
+
+void glob_start_theme_dialog(void *dummy)
+{
+    pdgui_vmess("::dialog_theme::create_dialog", "");
+}
+
+/* send current theme colors to the GUI dialog (as #rrggbb strings) */
+void glob_request_theme_colors(void *dummy)
+{
+    char fg[16], bg[16], sel[16], gop[16];
+    /* format colors as hex strings */
+    snprintf(fg, sizeof(fg), "#%06x", THISGUI->i_foregroundcolor & 0xFFFFFF);
+    snprintf(bg, sizeof(bg), "#%06x", THISGUI->i_backgroundcolor & 0xFFFFFF);
+    snprintf(sel, sizeof(sel), "#%06x", THISGUI->i_selectcolor & 0xFFFFFF);
+    snprintf(gop, sizeof(gop), "#%06x", THISGUI->i_gopcolor & 0xFFFFFF);
+    pdgui_vmess("::dialog_theme::set_colors", "ssss", fg, bg, sel, gop);
+}

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -47,6 +47,8 @@ void glob_vis(void *dummy, t_symbol *s);
 void glob_closesubs(void *dummy);
 void glob_colors(void *dummy, t_symbol *fg, t_symbol *bg, t_symbol *sel,
     t_symbol *gop);
+void glob_request_theme_colors(void *dummy);
+void glob_start_theme_dialog(void *dummy);
 void glob_rescanaudio(void *dummy);
 
 static void glob_helpintro(t_pd *dummy)
@@ -209,6 +211,10 @@ void glob_init(void)
         gensym("close-subwindows"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_colors,
         gensym("colors"), A_SYMBOL, A_SYMBOL, A_SYMBOL, A_DEFSYMBOL, 0);
+    class_addmethod(glob_pdobject, (t_method)glob_request_theme_colors,
+        gensym("request-theme-colors"), 0);
+    class_addmethod(glob_pdobject, (t_method)glob_start_theme_dialog,
+        gensym("start-theme-dialog"), 0);
     class_addmethod(glob_pdobject, (t_method)glob_rescanaudio,
         gensym("rescan-audio"), 0);
     class_addanything(glob_pdobject, max_default);

--- a/tcl/dialog_theme.tcl
+++ b/tcl/dialog_theme.tcl
@@ -1,0 +1,124 @@
+package provide dialog_theme 0.1
+package require pd_guiprefs
+
+namespace eval ::dialog_theme:: {
+}
+
+package provide dialog_theme 0.1
+package require pd_guiprefs
+package require pd_i18n
+
+namespace eval ::dialog_theme:: {
+}
+
+proc ::dialog_theme::set_colors {fg bg sel gop} {
+    # called from C to report current colors as hex strings
+    if {[string length $fg]} { set ::dialog_theme::foreground $fg }
+    if {[string length $bg]} { set ::dialog_theme::background $bg }
+    if {[string length $sel]} { set ::dialog_theme::selection $sel }
+    if {[string length $gop]} { set ::dialog_theme::gop $gop }
+}
+
+proc ::dialog_theme::color_to_hex {color} {
+    if {[string match "#*" $color]} {
+        return $color
+    } else {
+        return [format "#%06x" [winfo rgb . $color]]
+    }
+}
+
+proc ::dialog_theme::choose_color {var} {
+    set color [tk_chooseColor -initialcolor [set $var] -title "Choose color"]
+    if {$color ne ""} {
+        set $var $color
+    }
+}
+
+proc ::dialog_theme::apply {mytoplevel} {
+    set fg [::dialog_theme::color_to_hex $::dialog_theme::foreground]
+    set bg [::dialog_theme::color_to_hex $::dialog_theme::background]
+    set sel [::dialog_theme::color_to_hex $::dialog_theme::selection]
+    set gop [::dialog_theme::color_to_hex $::dialog_theme::gop]
+    pdsend "pd colors $fg $bg $sel $gop"
+    # persist gui preferences so colors survive restart
+    ::pd_guiprefs::write "foregroundcolor" $fg
+    ::pd_guiprefs::write "backgroundcolor" $bg
+    ::pd_guiprefs::write "selectioncolor" $sel
+    ::pd_guiprefs::write "gopcolor" $gop
+}
+
+proc ::dialog_theme::ok {mytoplevel} {
+    ::dialog_theme::apply $mytoplevel
+    pdsend "pd save-preferences"
+    destroy $mytoplevel
+}
+
+proc ::dialog_theme::cancel {mytoplevel} {
+    destroy $mytoplevel
+}
+
+proc ::dialog_theme::create_dialog {{mytoplevel .theme}} {
+    destroy $mytoplevel
+
+    toplevel $mytoplevel -class DialogWindow
+    ::pd_menus::menubar_for_dialog $mytoplevel
+    wm title $mytoplevel [_ "Theme Editor"]
+    wm group $mytoplevel .
+    wm transient $mytoplevel $::focused_window
+    ::pd_bindings::dialog_bindings $mytoplevel "theme"
+
+    # try to read persisted colors from preferences, fall back to core defaults
+    set fg [::pd_guiprefs::read foregroundcolor]
+    set bg [::pd_guiprefs::read backgroundcolor]
+    set sel [::pd_guiprefs::read selectioncolor]
+    set gop [::pd_guiprefs::read gopcolor]
+
+    if {$fg eq ""} { set fg "#000000" }
+    if {$bg eq ""} { set bg "#ffffff" }
+    if {$sel eq ""} { set sel "#0000ff" }
+    if {$gop eq ""} { set gop "#ff0000" }
+
+    set ::dialog_theme::foreground $fg
+    set ::dialog_theme::background $bg
+    set ::dialog_theme::selection $sel
+    set ::dialog_theme::gop $gop
+
+    # request actual current values from Pd core (C) -- may override above
+    pdsend "pd request-theme-colors"
+
+    frame $mytoplevel.colors
+    pack $mytoplevel.colors -side top -fill both -expand 1 -padx 10 -pady 10
+
+    labelframe $mytoplevel.colors.fg -text [_ "Foreground"] -padx 5 -pady 5
+    pack $mytoplevel.colors.fg -side top -fill x
+    entry $mytoplevel.colors.fg.entry -textvariable ::dialog_theme::foreground -width 10
+    button $mytoplevel.colors.fg.button -text [_ "Choose..."] -command "::dialog_theme::choose_color ::dialog_theme::foreground"
+    pack $mytoplevel.colors.fg.entry $mytoplevel.colors.fg.button -side left
+
+    labelframe $mytoplevel.colors.bg -text [_ "Background"] -padx 5 -pady 5
+    pack $mytoplevel.colors.bg -side top -fill x
+    entry $mytoplevel.colors.bg.entry -textvariable ::dialog_theme::background -width 10
+    button $mytoplevel.colors.bg.button -text [_ "Choose..."] -command "::dialog_theme::choose_color ::dialog_theme::background"
+    pack $mytoplevel.colors.bg.entry $mytoplevel.colors.bg.button -side left
+
+    labelframe $mytoplevel.colors.sel -text [_ "Selection"] -padx 5 -pady 5
+    pack $mytoplevel.colors.sel -side top -fill x
+    entry $mytoplevel.colors.sel.entry -textvariable ::dialog_theme::selection -width 10
+    button $mytoplevel.colors.sel.button -text [_ "Choose..."] -command "::dialog_theme::choose_color ::dialog_theme::selection"
+    pack $mytoplevel.colors.sel.entry $mytoplevel.colors.sel.button -side left
+
+    labelframe $mytoplevel.colors.gop -text [_ "Graph on Parent"] -padx 5 -pady 5
+    pack $mytoplevel.colors.gop -side top -fill x
+    entry $mytoplevel.colors.gop.entry -textvariable ::dialog_theme::gop -width 10
+    button $mytoplevel.colors.gop.button -text [_ "Choose..."] -command "::dialog_theme::choose_color ::dialog_theme::gop"
+    pack $mytoplevel.colors.gop.entry $mytoplevel.colors.gop.button -side left
+
+    frame $mytoplevel.buttons
+    pack $mytoplevel.buttons -side bottom -fill x -padx 10 -pady 10
+    button $mytoplevel.buttons.apply -text [_ "Apply"] -command "::dialog_theme::apply $mytoplevel"
+    button $mytoplevel.buttons.ok -text [_ "OK"] -command "::dialog_theme::ok $mytoplevel"
+    button $mytoplevel.buttons.cancel -text [_ "Cancel"] -command "::dialog_theme::cancel $mytoplevel"
+    pack $mytoplevel.buttons.apply $mytoplevel.buttons.ok $mytoplevel.buttons.cancel -side left -expand 1
+
+    position_over_window $mytoplevel $::focused_window
+}

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -47,6 +47,7 @@ package require dialog_midi
 package require dialog_path
 package require dialog_startup
 package require dialog_preferences
+package require dialog_theme
 package require helpbrowser
 package require pd_menucommands
 package require opt_parser

--- a/tcl/pd_menucommands.tcl
+++ b/tcl/pd_menucommands.tcl
@@ -171,6 +171,15 @@ proc ::pd_menucommands::menu_preference_dialog {} {
     pdsend "pd start-preference-dialog"
 }
 
+proc ::pd_menucommands::menu_theme_dialog {} {
+    if {[winfo exists .theme]} {
+        raise .theme
+        focus .theme
+    } else {
+        pdsend "pd start-theme-dialog"
+    }
+}
+
 proc ::pd_menucommands::menu_manual {} {
     ::pd_menucommands::menu_doc_open doc/1.manual index.htm
 }

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -337,6 +337,8 @@ proc ::pd_menus::build_window_menu {mymenu} {
     $mymenu add command -label [_ "Close subwindows"] \
         -command {pdsend "pd close-subwindows"}
     $mymenu add  separator
+    $mymenu add command -label [_ "Theme Editor..."] \
+        -command {::pd_menucommands::scheduleAction menu_theme_dialog}
     $mymenu add command -label [_ "Pd window"] -command {::pd_menucommands::scheduleAction menu_raise_pdwindow} \
         -accelerator "$accelerator+R"
     $mymenu add command -label [_ "Parent Window"] \

--- a/tcl/pkgIndex.tcl
+++ b/tcl/pkgIndex.tcl
@@ -22,6 +22,7 @@ package ifneeded dialog_message 0.1 [list source [file join $dir dialog_message.
 package ifneeded dialog_midi 0.1 [list source [file join $dir dialog_midi.tcl]]
 package ifneeded dialog_path 0.1 [list source [file join $dir dialog_path.tcl]]
 package ifneeded dialog_startup 0.1 [list source [file join $dir dialog_startup.tcl]]
+package ifneeded dialog_theme 0.1 [list source [file join $dir dialog_theme.tcl]]
 package ifneeded helpbrowser 0.3 [list source [file join $dir helpbrowser.tcl]]
 package ifneeded opt_parser 0.1 [list source [file join $dir opt_parser.tcl]]
 package ifneeded pd_bindings 0.1 [list source [file join $dir pd_bindings.tcl]]


### PR DESCRIPTION
Adds a basic color editor for "foregreound", "background", "selection" and "graph on parent" colors.

The colors can be applied without closing the editor window and are saved on "OK".

<img width="781" height="543" alt="screenshot" src="https://github.com/user-attachments/assets/4069d9a0-0ed9-4b30-af42-bd6695ed2b07" />