### PR TITLE
use proper glist for gatom_redraw

### DIFF
--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -183,8 +183,11 @@ void glist_clear(t_glist *x)
 void glist_retext(t_glist *glist, t_text *y)
 {
     t_canvas *c = glist_getcanvas(glist);
-        /* check that we have built rtexts yet.  LATER need a better test. */
-    if (glist->gl_editor && glist->gl_editor->e_rtext)
+        /* check that we have built rtexts yet.  LATER need a better test.
+        For GOP subpatches, the editor is on the parent canvas, so check c->gl_editor
+        instead of glist->gl_editor. But still use glist (subpatch) for glist_getrtext
+        to ensure rtext's x->x_glist is set correctly. */
+    if (c->gl_editor && c->gl_editor->e_rtext)
     {
         t_rtext *rt = glist_getrtext(glist, y, 0);
         if (rt)

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -634,8 +634,11 @@ static t_symbol *gatom_unescapit(t_symbol *s)
 static void gatom_redraw(t_gobj *client, t_glist *glist)
 {
     t_gatom *x = (t_gatom *)client;
-    if (glist->gl_editor)
-        glist_retext(glist, &x->a_text);
+        /* use the gatom's glist (subpatch) for retext, not the parent canvas
+        that was passed in. This ensures coordinate calculations use the
+        correct glist's coordinate system. */
+    if (x->a_glist->gl_editor || glist_getcanvas(x->a_glist)->gl_editor)
+        glist_retext(x->a_glist, &x->a_text);
 }
 
 static void gatom_senditup(t_gatom *x)


### PR DESCRIPTION
... to fix gatoms in GOP displayed at wrong coordinates on parent canvas.

* another attempt to close #2798
* also closes #2781

this PR tries to fix the glist handling instead of relying on redraws. seems to work well with the test patches in the issues above.