### PR TITLE
fix crash when accidentally using a non-reblockable vectorsize in subpatch

### DIFF
--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -1222,6 +1222,26 @@ void ugen_done_graph(t_dspcontext *dc)
         pd_error(blk, "%s: invalid reblocking from %d to %d detected (canvas was not scheduled)",
                  switched?"switch~":"block~",
                  parent_vecsize, calcsize);
+        for (u = dc->dc_ugenlist; u; u = u->u_next)
+        {
+            t_pd *zz = &u->u_obj->ob_pd;
+            if (pd_class(zz) == voutlet_class)
+            {
+                struct _voutlet *zz_out = (struct _voutlet *)zz;
+                t_signal **outsigs = dc->dc_iosigs;
+                if (outsigs) {
+                    outsigs += dc->dc_ninlets;
+                    voutlet_dspprolog(zz_out,
+                                      outsigs, calcsize,
+                                      THIS->u_phase + offset, period, frequency,
+                                      1, 1, 0, 1);
+                    voutlet_dspepilog(zz_out,
+                                      outsigs, calcsize,
+                                      THIS->u_phase + offset, period, frequency,
+                                      1, 1, 0, 1);
+                }
+            }
+        }
         goto cleanup;
     }
 


### PR DESCRIPTION
as described in #2801, having an `[outlet~]` in a subpatch that uses a non-reblockable vectorsize (e.g. `2024`) will crash Pd.

this PR fixes this by checking, whether it is actually possible to reblock (that is: whether the parent vectorsize is an integer multiple of the child vectorsize, or vice versa).
if reblocking is not possible, the entire canvas is not scheduled (and an error is printed, pointing to the offending `[block~]`).

the logic only kicks in, if we actually need reblocking (that is: there is at least one `[outlet~]` resp. `[inlet~]`).

so:
- [x]   a subpatch with `[block~ 192]` will keep working (regardless of iolet~s)
- [x] a subpatch witch `[block~ 193]` but no iolet~s will keep working (at least as good as before)
- [x] a subpatch with `[block~ 193]` and an `[outlet~]` will behave as if switched OFF


status:
- Closes: https://github.com/pure-data/pure-data/issues/2801