### PR TITLE
don't draw iolets for objects inside GOP

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -1035,8 +1035,7 @@ static void iemgui_draw(t_iemgui *x, t_glist *glist, int mode)
         break;
     default:
         /* skip drawing iolets if we're inside a GOP subpatch */
-        if (glist_isgraph(glist) && !glist->gl_havewindow
-            && glist->gl_owner && !glist->gl_isclone)
+        if (glist_isgraph(glist) && !glist->gl_havewindow)
             return;
         if(x->x_private->p_widget.draw_iolets)
             x->x_private->p_widget.draw_iolets(x, glist, mode - IEM_GUI_DRAW_MODE_IO);

--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -1034,6 +1034,10 @@ static void iemgui_draw(t_iemgui *x, t_glist *glist, int mode)
         DRAW_FUN(config, x, glist);
         break;
     default:
+        /* skip drawing iolets if we're inside a GOP subpatch */
+        if (glist_isgraph(glist) && !glist->gl_havewindow
+            && glist->gl_owner && !glist->gl_isclone)
+            return;
         if(x->x_private->p_widget.draw_iolets)
             x->x_private->p_widget.draw_iolets(x, glist, mode - IEM_GUI_DRAW_MODE_IO);
         else

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1520,6 +1520,11 @@ static const t_widgetbehavior gatom_widgetbehavior =
 void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     const char *tag, int x1, int y1, int x2, int y2)
 {
+    /* skip drawing iolets if we're inside a GOP subpatch */
+    if (glist_isgraph(glist) && !glist->gl_havewindow
+        && glist->gl_owner && !glist->gl_isclone)
+        return;
+
     int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1520,17 +1520,16 @@ static const t_widgetbehavior gatom_widgetbehavior =
 void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     const char *tag, int x1, int y1, int x2, int y2)
 {
-    /* skip drawing iolets if we're inside a GOP subpatch */
-    if (glist_isgraph(glist) && !glist->gl_havewindow
-        && glist->gl_owner && !glist->gl_isclone)
-        return;
-
     int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
     int width = x2 - x1;
     int iow = IOWIDTH * glist->gl_zoom;
     int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
     char *tags[2];
     char tagbuf[128];
+
+    /* skip drawing iolets if we're inside a GOP subpatch */
+    if (glist_isgraph(glist) && !glist->gl_havewindow)
+        return;
 
     /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
     for (i = 0; i < n; i++)


### PR DESCRIPTION
imho, this is a valid approach to address the issue of ghost iolets remaining from objects inside a deleted GOP. after all, displaying these iolets doesn't really make sense since cords aren't drawn either.

it can obviously change the appearance of patches - but they should look cleaner. :)

* closes #2768