### PR TITLE
dialog_gatom: escape blank entries

### DIFF
--- a/src/g_text.c
+++ b/src/g_text.c
@@ -990,12 +990,21 @@ static int gatom_doclick(t_gobj *z, t_glist *gl, int xpos, int ypos,
     return (1);
 }
 
+static t_float atom_floatelse(int which, int argc, const t_atom *argv,
+    t_float fallback)
+{
+    if (argc <= which) return (fallback);
+    argv += which;
+    if (argv->a_type == A_FLOAT) return (argv->a_w.w_float);
+    else return (fallback);
+}
+
     /* message back from dialog window */
 static void gatom_param(t_gatom *x, t_symbol *sel, int argc, t_atom *argv)
 {
-    t_float width = atom_getfloatarg(0, argc, argv);
-    t_float draglo = atom_getfloatarg(1, argc, argv);
-    t_float draghi = atom_getfloatarg(2, argc, argv);
+    t_float width = atom_floatelse(0, argc, argv, x->a_text.te_width);
+    t_float draglo = atom_floatelse(1, argc, argv, x->a_draglo);
+    t_float draghi = atom_floatelse(2, argc, argv, x->a_draghi);
     t_symbol *label = gatom_unescapit(atom_getsymbolarg(3, argc, argv));
     t_float wherelabel = atom_getfloatarg(4, argc, argv);
     t_symbol *symfrom = gatom_unescapit(atom_getsymbolarg(5, argc, argv));

--- a/tcl/dialog_gatom.tcl
+++ b/tcl/dialog_gatom.tcl
@@ -40,9 +40,9 @@ proc ::dialog_gatom::apply {mytoplevel} {
     global gatomlabel_radio
 
     pdsend "$mytoplevel param \
-        [$mytoplevel.width.entry get] \
-        [$mytoplevel.limits.lower.entry get] \
-        [$mytoplevel.limits.upper.entry get] \
+        [::dialog_gatom::escape [$mytoplevel.width.entry get]] \
+        [::dialog_gatom::escape [$mytoplevel.limits.lower.entry get]] \
+        [::dialog_gatom::escape [$mytoplevel.limits.upper.entry get]] \
         [::dialog_gatom::escape [$mytoplevel.gatomlabel.name.entry get]] \
         $gatomlabel_radio($mytoplevel) \
         [::dialog_gatom::escape [$mytoplevel.s_r.receive.entry get]] \


### PR DESCRIPTION
If entries for numbers are completely blank, parameters will be misinterpreted as intended for the parameter that's supposed to come before it, and values will get assigned to the wrong properties.

Example: if width entry is blank, and lower limit is set to 1, width will be set to 1 instead, while lower limit will be set to whatever non-blank parameter happens to come next.