### PR TITLE
stable (already merged) development branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,56 +439,6 @@ AC_ARG_ENABLE([watchdog],
 AS_IF([test "x$enable_watchdog" != "xyes"],[enable_watchdog=no])
 AM_CONDITIONAL(PD_WATCHDOG, test x$enable_watchdog = xyes)
 
-###### floatsize ########
-AC_ARG_WITH([floatsize],
-    [AS_HELP_STRING([--with-floatsize=<SIZE>],
-    [build binaries for the given floatsize;
-    SIZE can be 32 (single precision) or 64 (double precision)
-    ]
-    )],
-    [floatsize=${withval}]
-    )
-AC_MSG_CHECKING([float size])
-AS_CASE([${floatsize}],
-    [32],[],
-    [64],[],
-    [""],[],
-    [
-        AC_MSG_WARN([${floatsize}bit floats not supported...use fallback])
-        floatsize=""
-    ])
-AS_IF([test "x${floatsize}" != "x" ],
-   [
-    PD_CPPFLAGS="-DPD_FLOATSIZE=${floatsize} $PD_CPPFLAGS"
-    AC_MSG_RESULT([${floatsize}])
-   ],[AC_MSG_RESULT([default])
-   ])
-
-AS_IF([test "x${floatsize}" = "x64" && test "x${deken_cpu}" != "x" && test "x${deken_os}" != "x" && test "x${deken_ext}" != "x"],[
-      EXTERNAL_EXTENSION="${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}"
-      AC_MSG_NOTICE([default external extension...${EXTERNAL_EXTENSION}])
-      ])
-
-pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
-pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
-
-AS_CASE([${floatsize}],
-    [""],[],
-    [32],[],
-    [
-      # if we specify a non-standard floatsize, make sure that the the program is also transformed.
-      # this is especially important on Windows (where we link against a pd.dll variant)
-      AS_IF([test "${pd_transformed}" = "pd" && test "${have_program_transform_name}" = "no"],[
-        program_transform_name="s/pd\$\$/pd${floatsize}/"
-        pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
-        pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
-      ])])
-
-# on Windows, we need to link against a (floatsize-decorated) pd.dll
-AS_IF([test "x${WINDOWS}" = "xyes" ],[
-   EXTERNAL_LDFLAGS="${EXTERNAL_LDFLAGS} -l${pd_transformed}"
-])
-
 ##### libpd #####
 AC_ARG_ENABLE([libpd],
     [AS_HELP_STRING([--enable-libpd], [additionally build libpd])])
@@ -742,6 +692,60 @@ AS_IF([test "x${DEKEN_CPU}" = "xyes" -o "x${DEKEN_CPU}" = "xno"],
 AC_SUBST([DEKEN_CPU])
 AS_IF([test "x${DEKEN_CPU}" != "x"], [deken_cpu="${DEKEN_CPU}"])
 
+
+###### floatsize ########
+AC_ARG_WITH([floatsize],
+    [AS_HELP_STRING([--with-floatsize=<SIZE>],
+    [build binaries for the given floatsize;
+    SIZE can be 32 (single precision) or 64 (double precision)
+    ]
+    )],
+    [floatsize=${withval}]
+    )
+AC_MSG_CHECKING([float size])
+AS_CASE([${floatsize}],
+    [32],[],
+    [64],[],
+    [""],[],
+    [
+        AC_MSG_WARN([${floatsize}bit floats not supported...use fallback])
+        floatsize=""
+    ])
+AS_IF([test "x${floatsize}" != "x" ],
+   [
+    PD_CPPFLAGS="-DPD_FLOATSIZE=${floatsize} $PD_CPPFLAGS"
+    AC_MSG_RESULT([${floatsize}])
+   ],[AC_MSG_RESULT([default])
+   ])
+
+AS_IF([test "x${floatsize}" = "x64" && test "x${deken_cpu}" != "x" && test "x${deken_os}" != "x" && test "x${deken_ext}" != "x"],[
+      EXTERNAL_EXTENSION="${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}"
+      AC_MSG_NOTICE([default external extension...${EXTERNAL_EXTENSION}])
+      ])
+
+pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
+pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
+
+AS_CASE([${floatsize}],
+    [""],[],
+    [32],[],
+    [
+      # if we specify a non-standard floatsize, make sure that the the program is also transformed.
+      # this is especially important on Windows (where we link against a pd.dll variant)
+      AS_IF([test "${pd_transformed}" = "pd" && test "${have_program_transform_name}" = "no"],[
+        program_transform_name="s/pd\$\$/pd${floatsize}/"
+        pd_transform_name=$(echo ${program_transform_name} | sed -e 's|\$\$|$|')
+        pd_transformed=$(echo pd | sed -e "${pd_transform_name}")
+      ])])
+
+# on Windows, we need to link against a (floatsize-decorated) pd.dll
+AS_IF([test "x${WINDOWS}" = "xyes" ],[
+   EXTERNAL_LDFLAGS="${EXTERNAL_LDFLAGS} -l${pd_transformed}"
+])
+
+
+###### external extension (user override) ########
+ext=""
 AC_ARG_WITH([external-extension],
     [AS_HELP_STRING([--with-external-extension=<EXT>],
         [Extension to use for externals in extra/ (e.g. pd_linux, dll, d_fat,...)])],

--- a/configure.ac
+++ b/configure.ac
@@ -718,8 +718,10 @@ AS_IF([test "x${floatsize}" != "x" ],
    ],[AC_MSG_RESULT([default])
    ])
 
-AS_IF([test "x${floatsize}" = "x64" && test "x${deken_cpu}" != "x" && test "x${deken_os}" != "x" && test "x${deken_ext}" != "x"],[
-      EXTERNAL_EXTENSION="${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}"
+
+AS_IF([test -n "${floatsize}" && test "${floatsize}" != "32" && test -n "${deken_cpu}" && test -n "${deken_os}" && test -n "${deken_ext}"],[
+      EXTERNAL_EXTENSION=[${deken_os}-${deken_cpu}-${floatsize}.${deken_ext}]
+      EXTERNAL_EXTENSION="$(echo ${EXTERNAL_EXTENSION} | tr [[A-Z]] [[a-z]] 2>/dev/null || echo ${EXTERNAL_EXTENSION})"
       AC_MSG_NOTICE([default external extension...${EXTERNAL_EXTENSION}])
       ])
 

--- a/extra/bob~/GNUmakefile.am
+++ b/extra/bob~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/bonk~/GNUmakefile.am
+++ b/extra/bonk~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/choice/GNUmakefile.am
+++ b/extra/choice/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/fiddle~/GNUmakefile.am
+++ b/extra/fiddle~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/loop~/GNUmakefile.am
+++ b/extra/loop~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/lrshift~/GNUmakefile.am
+++ b/extra/lrshift~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/pd~/GNUmakefile.am
+++ b/extra/pd~/GNUmakefile.am
@@ -38,7 +38,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/pique/GNUmakefile.am
+++ b/extra/pique/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/sigmund~/GNUmakefile.am
+++ b/extra/sigmund~/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/extra/stdout/GNUmakefile.am
+++ b/extra/stdout/GNUmakefile.am
@@ -32,7 +32,7 @@ libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status --recheck
 
 # create convenience link for running locally
-all-local:
+all-local: $(LTLIBRARIES)
 	rm -f *.@EXTERNAL_EXTENSION@
 	-$(LN_S) $(wildcard .libs/*.@EXTERNAL_EXTENSION@) ./
 

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -890,7 +890,7 @@ void canvas_redraw(t_canvas *x)
 void glist_clearrtexts(t_glist *x)
 {
     t_glist *gl2 = glist_getcanvas(x);
-    if (glist_textedfor(gl2) == x)
+    if ((t_glist*)glist_textedfor(gl2) == x)
         glist_settexted(gl2, 0);
     if (gl2->gl_editor)
         while (gl2->gl_editor->e_rtext)

--- a/src/x_vexp_fun.c
+++ b/src/x_vexp_fun.c
@@ -106,7 +106,7 @@
 #endif
 
 #if NO_ISNAN
-PD_INLINE t_float my_isnan(t_float f) { return ((f) != (f)); }
+PD_INLINE int my_isnan(t_float f) { return ((f) != (f)); }
 # undef isnan
 # define isnan my_isnan
 #endif


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts.).

it supersedes https://github.com/pure-data/pure-data/pull/2792

---

### core
- fix return type of `isnan()` replacement (it's really a boolean (aka: `int`), and shouldn't be a `t_float`)
- cast pointer (returned by `glist_textedfor()`) to `t_glist*` to avoid a compiler warning


### autoconf build system
- fix the automatic calculation of EXTERNAL_EXTENSION
  - it should always be lowercase
  - it should take any values passed with `--with-deken-os` and `--with-deken-cpu` into account
- only attempt to create convenience symlinks for externals after the externals have actually been built (needed for parallel builds)