### PR TITLE
allow typing "{" and "}" in Pd patches.

### DIFF
--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -3165,11 +3165,6 @@ void canvas_key(t_canvas *x, t_symbol *s, int ac, t_atom *av)
     else gotkeysym = gensym("?");
     fflag = (av[0].a_type == A_FLOAT ? av[0].a_w.w_float : 0);
     keynum = (av[1].a_type == A_FLOAT ? av[1].a_w.w_float : 0);
-    if (keynum == '{' || keynum == '}')
-    {
-        post("keycode %d: dropped", (int)keynum);
-        return;
-    }
 #if 0
     post("keynum %d, down %d", (int)keynum, down);
 #endif


### PR DESCRIPTION
Typing these are already possible in PlugData and even in Vanilla's [text]. Support is already given but not fully practical because we can't type it, even though we can generate these symbols with [makefilename %c] and insert it in messages.

- closes https://github.com/pure-data/pure-data/issues/505

The issue above has detoured a bit in my opinion on a parallel discussion about expanding Pd's syntax. In the end, curlies are already partially supported and it's not trivial to use them for a new syntax. Also, it's not like we can't expand Pd's syntax in other ways and this has been discussed in the referenced issue. I guess the discussion ended up being an unnecessary obstacle in the way.

Also, somewhat related, there was another PR about expanding the syntax - see https://github.com/pure-data/pure-data/pull/875