### PR TITLE
Add methods and warning for [declare]

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1626,49 +1626,37 @@ typedef struct _declare
     int x_useme;
     t_atom *x_argv; /* store creation arguments for re-triggering */
     int x_argc;
+    t_outlet *x_outlet;
 } t_declare;
 
 int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
 
-static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x, t_symbol *s)
+static void declare_loaded_absolute_paths(t_declare *x, t_symbol *s)
 {
-    t_canvasenvironment *e = canvas_getenv(x);
+    t_canvasenvironment *e = canvas_getenv(x->x_canvas);
     t_namelist *nl = e->ce_path;
         /* prefix canvas-path */
     char strbuf[MAXPDSTRING], *path;
     for (; nl; nl = nl->nl_next)
     {
         path = nl->nl_string;
-        canvas_completepath(path, strbuf, MAXPDSTRING, x);
-        if (s && s->s_thing)
-            pd_symbol(s->s_thing, gensym(strbuf));
-        else
-            logpost(z, PD_NORMAL, "loaded <path>: %s", strbuf);
+        canvas_completepath(path, strbuf, MAXPDSTRING, x->x_canvas);
+        outlet_symbol(x->x_outlet, gensym(strbuf));
     }
 }
-static void declare_loaded_paths(t_declare *z, t_canvas *x, t_symbol *s)
+static void declare_loaded_paths(t_declare *x, t_symbol *s)
 {
-    t_canvasenvironment *e = canvas_getenv(x);
+    t_canvasenvironment *e = canvas_getenv(x->x_canvas);
     t_namelist *nl = e->ce_path;
     for (; nl; nl = nl->nl_next)
-    {
-        if (s && s->s_thing)
-            pd_symbol(s->s_thing, gensym(nl->nl_string));
-        else
-            logpost(z, PD_NORMAL, "loaded <path>: %s", nl->nl_string);
-    }
+        outlet_symbol(x->x_outlet, gensym(nl->nl_string));
 }
 
 static void declare_loaded_libs(t_declare *x, t_symbol *s)
 {
     t_loadlist *ll = sys_getloadlist();
     for (; ll; ll = ll->ll_next)
-    {
-        if (s && s->s_thing)
-            pd_symbol(s->s_thing, ll->ll_name);
-        else
-            logpost(x, PD_NORMAL, "loaded <lib>: %s", ll->ll_name->s_name);
-    }
+        outlet_symbol(x->x_outlet, ll->ll_name);
 }
 
 static void declare_bang(t_declare *x)
@@ -1677,60 +1665,14 @@ static void declare_bang(t_declare *x)
                                 x->x_argc, x->x_argv, PD_DEBUG);
 }
 
-static void canvas_sendblocksize(t_canvas *x, t_symbol *s)
-{
-    int blocksize = canvas_getsignallength(x);
-    if (s && s->s_thing)
-        pd_float(s->s_thing, (t_float)blocksize);
-    else
-        logpost(0, PD_NORMAL, "<blocksize>: %d", blocksize);
-}
-
-/* query a canvas for information on loaded libraries or paths
- * a t_declare object can be passed for traceable loglevel posts.
- * LATER extend this for more patch information queries
- */
-static void canvas_query(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
-{
-    if (!argc)
-        return;
-
-    /* handle -s <symbol> flag first */
-    int i = 0;
-    t_symbol *snd_symbol = 0;
-    if (!strcmp(atom_getsymbolarg(0, argc, argv)->s_name, "-s"))
-    {
-        if (argc > 1)
-        {
-            snd_symbol = atom_getsymbolarg(1, argc, argv);
-            i++;
-        }
-        i++;
-    }
-
-    for (; i < argc; i++)
-    {
-        const char *arg = atom_getsymbolarg(i, argc, argv)->s_name;
-        if (!strcmp(arg, "paths"))
-            declare_loaded_paths(0, x, snd_symbol);
-        else if (!strcmp(arg, "libs"))
-            declare_loaded_libs(0, snd_symbol);
-        else if (!strcmp(arg, "absolute"))
-            declare_loaded_absolute_paths(0, x, snd_symbol);
-        else if (!strcmp(arg, "blocksize"))
-            canvas_sendblocksize(x, snd_symbol);
-        else post("query <%s>: unknown arg", arg);
-    }
-}
-
 static void declare_print_paths(t_declare *x, t_floatarg fabsolute)
 {
     int absflag = !!(int)fabsolute;
     t_canvas *c = x->x_canvas;
     if (absflag)
-        declare_loaded_absolute_paths(x, c, 0);
+        declare_loaded_absolute_paths(x, 0);
     else
-        declare_loaded_paths(x, c, 0);
+        declare_loaded_paths(x, 0);
 }
 
 static void declare_print_libs(t_declare *x)
@@ -1755,6 +1697,8 @@ static void *declare_new(t_symbol *s, int argc, t_atom *argv)
          * so update canvas's properties on the fly */
     if (!x->x_canvas->gl_loading)
         declare_bang(x);
+
+    x->x_outlet = outlet_new(&x->x_obj, 0);
     return (x);
 }
 
@@ -1976,6 +1920,9 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
                       t_symbol *s, int argc, t_atom *argv,
                       t_loglevel level)
 {
+    if (!x)
+        bug("canvas_declare_do: missing canvas reference.");
+
     t_canvasenvironment *e = canvas_getenv(x);
     int i, success = 1;
 #if 0
@@ -1990,7 +1937,7 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
         if ((item) && !strcmp(flag, "-path"))
         {
             if(!canvas_path(x, e, item)) {
-                logpost(z, level, "Failed to declare <path>: %s", item);
+                logpost(z, level, "Failed to add path: %s", item);
                 success = 0;
             }
             i++;
@@ -1998,7 +1945,7 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
         else if ((item) && !strcmp(flag, "-stdpath"))
         {
             if(!canvas_stdpath(e, item)) {
-                logpost(z, level, "Failed to declare <stdpath>: %s", item);
+                logpost(z, level, "Failed to add stdpath: %s", item);
                 success = 0;
             }
             i++;
@@ -2006,7 +1953,7 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
         else if ((item) && !strcmp(flag, "-lib"))
         {
             if(!canvas_lib(x, e, item)) {
-                logpost(z, level, "Failed to declare <lib>: %s", item);
+                logpost(z, level, "Failed to load library: %s", item);
                 success = 0;
             }
             i++;
@@ -2014,7 +1961,7 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
         else if ((item) && !strcmp(flag, "-stdlib"))
         {
             if(!canvas_stdlib(e, item)) {
-                logpost(z, level, "Failed to declare <stdlib>: %s", item);
+                logpost(z, level, "Failed to load stdlib: %s", item);
                 success = 0;
             }
             i++;
@@ -2325,8 +2272,6 @@ void g_canvas_setup(void)
     class_addbang(declare_class, (t_method)declare_bang);
     class_addmethod(canvas_class, (t_method)canvas_declare_message,
         gensym("declare"), A_GIMME, 0);
-    class_addmethod(canvas_class, (t_method)canvas_query,
-        gensym("query"), A_GIMME, 0);
     class_addmethod(declare_class, (t_method)declare_print_paths,
         gensym("paths"), A_DEFFLOAT, 0);
     class_addmethod(declare_class, (t_method)declare_print_libs,

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1630,7 +1630,7 @@ typedef struct _declare
 
 int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
 
-static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x)
+static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x, t_symbol *s)
 {
     t_canvasenvironment *e = canvas_getenv(x);
     t_namelist *nl = e->ce_path;
@@ -1640,22 +1640,35 @@ static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x)
     {
         path = nl->nl_string;
         canvas_completepath(path, strbuf, MAXPDSTRING, x);
-        logpost(z, PD_NORMAL, "loaded <path>: %s", strbuf);
+        if (s && s->s_thing)
+            pd_symbol(s->s_thing, gensym(strbuf));
+        else
+            logpost(z, PD_NORMAL, "loaded <path>: %s", strbuf);
     }
 }
-static void declare_loaded_paths(t_declare *z, t_canvas *x)
+static void declare_loaded_paths(t_declare *z, t_canvas *x, t_symbol *s)
 {
     t_canvasenvironment *e = canvas_getenv(x);
     t_namelist *nl = e->ce_path;
     for (; nl; nl = nl->nl_next)
-        logpost(z, PD_NORMAL, "loaded <path>: %s", nl->nl_string);
+    {
+        if (s && s->s_thing)
+            pd_symbol(s->s_thing, gensym(nl->nl_string));
+        else
+            logpost(z, PD_NORMAL, "loaded <path>: %s", nl->nl_string);
+    }
 }
 
-static void declare_loaded_libs(t_declare *x)
+static void declare_loaded_libs(t_declare *x, t_symbol *s)
 {
     t_loadlist *ll = sys_getloadlist();
     for (; ll; ll = ll->ll_next)
-        logpost(x, PD_NORMAL, "loaded <lib>: %s", ll->ll_name->s_name);
+    {
+        if (s && s->s_thing)
+            pd_symbol(s->s_thing, ll->ll_name);
+        else
+            logpost(x, PD_NORMAL, "loaded <lib>: %s", ll->ll_name->s_name);
+    }
 }
 
 static void declare_bang(t_declare *x)
@@ -1664,27 +1677,48 @@ static void declare_bang(t_declare *x)
                                 x->x_argc, x->x_argv, PD_DEBUG);
 }
 
+static void canvas_sendblocksize(t_canvas *x, t_symbol *s)
+{
+    int blocksize = canvas_getsignallength(x);
+    if (s && s->s_thing)
+        pd_float(s->s_thing, (t_float)blocksize);
+    else
+        logpost(0, PD_NORMAL, "<blocksize>: %d", blocksize);
+}
+
 /* query a canvas for information on loaded libraries or paths
  * a t_declare object can be passed for traceable loglevel posts.
  * LATER extend this for more patch information queries
  */
 static void canvas_query(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
-    int i;
-    for (i = 0; i < argc; i++)
+    if (!argc)
+        return;
+
+    /* handle -s <symbol> flag first */
+    int i = 0;
+    t_symbol *snd_symbol = 0;
+    if (!strcmp(atom_getsymbolarg(0, argc, argv)->s_name, "-s"))
+    {
+        if (argc > 1)
+        {
+            snd_symbol = atom_getsymbolarg(1, argc, argv);
+            i++;
+        }
+        i++;
+    }
+
+    for (; i < argc; i++)
     {
         const char *arg = atom_getsymbolarg(i, argc, argv)->s_name;
         if (!strcmp(arg, "paths"))
-            declare_loaded_paths(NULL, x);
+            declare_loaded_paths(0, x, snd_symbol);
         else if (!strcmp(arg, "libs"))
-            declare_loaded_libs(NULL);
+            declare_loaded_libs(0, snd_symbol);
         else if (!strcmp(arg, "absolute"))
-            declare_loaded_absolute_paths(NULL, x);
+            declare_loaded_absolute_paths(0, x, snd_symbol);
         else if (!strcmp(arg, "blocksize"))
-        {
-            int blocksize = canvas_getsignallength(x);
-            logpost(NULL, PD_NORMAL, "<blocksize>: %d", blocksize);
-        }
+            canvas_sendblocksize(x, snd_symbol);
         else post("query <%s>: unknown arg", arg);
     }
 }
@@ -1694,10 +1728,13 @@ static void declare_print_paths(t_declare *x, t_floatarg fabsolute)
     int absflag = !!(int)fabsolute;
     t_canvas *c = x->x_canvas;
     if (absflag)
-        declare_loaded_absolute_paths(x, c);
+        declare_loaded_absolute_paths(x, c, 0);
     else
-        declare_loaded_paths(x, c);
+        declare_loaded_paths(x, c, 0);
 }
+
+static void declare_print_libs(t_declare *x)
+{ declare_loaded_libs(x, 0); }
 
 static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 {
@@ -1988,7 +2025,7 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
 }
 
 int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
-{ return canvas_declare_do(NULL, x, s, argc, argv, PD_DEBUG); }
+{ return canvas_declare_do(0, x, s, argc, argv, PD_DEBUG); }
 
 typedef struct _canvasopen
 {
@@ -2292,7 +2329,7 @@ void g_canvas_setup(void)
         gensym("query"), A_GIMME, 0);
     class_addmethod(declare_class, (t_method)declare_print_paths,
         gensym("paths"), A_DEFFLOAT, 0);
-    class_addmethod(declare_class, (t_method)declare_loaded_libs,
+    class_addmethod(declare_class, (t_method)declare_print_libs,
         gensym("libs"), 0);
 
 /*--------------- future message to set formatting  -------------- */

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -53,7 +53,10 @@ static void canvas_takeofflist(t_canvas *x);
 static void canvas_pop(t_canvas *x, t_floatarg fvis);
 static void canvas_bind(t_canvas *x);
 static void canvas_unbind(t_canvas *x);
-void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
+typedef struct _declare t_declare;
+int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv);
+int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
+int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
 void sys_expandpath(const char *from, char *to, int bufsize);
 
 /* ---------------- generic widget behavior ------------------------- */
@@ -1635,7 +1638,7 @@ static void *declare_new(t_symbol *s, int argc, t_atom *argv)
     {
         /* the object is created by the user (not by loading a patch),
          * so update canvas's properties on the fly */
-        canvas_declare(x->x_canvas, s, argc, argv);
+        x->x_useme = canvas_declare_do(x, x->x_canvas, s, argc, argv, PD_DEBUG);
     }
     return (x);
 }
@@ -1713,21 +1716,21 @@ static int check_exists(const char*path)
 }
 #endif
 
-static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
+static int canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
     if (sys_isabsolutepath(path))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
-        return;
+        return 1;
     }
 
         /* explicit relative path, starts with ./ or ../ */
     if ((strncmp("./", path, 2) == 0) || (strncmp("../", path, 3) == 0))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
-        return;
+        return 1;
     }
 
         /* check if path is a subdir of the canvas-path */
@@ -1735,7 +1738,7 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
     if (check_exists(strbuf))
     {
         e->ce_path = namelist_append(e->ce_path, path, 0);
-        return;
+        return 1;
     }
 
         /* check whether the given subdir is in one of the user search-paths */
@@ -1746,7 +1749,7 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
         if (check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
-            return;
+            return 1;
         }
     }
 
@@ -1758,31 +1761,26 @@ static void canvas_path(t_canvas *x, t_canvasenvironment *e, const char *path)
         if (check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
-            return;
+            return 1;
         }
     }
+    return 0;
 }
-static void canvas_lib(t_canvas *x, t_canvasenvironment *e, const char *lib)
+static int canvas_lib(t_canvas *x, t_canvasenvironment *e, const char *lib)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
     if (sys_isabsolutepath(lib))
-    {
-        sys_load_lib(x, lib);
-        return;
-    }
+        return sys_load_lib(x, lib);
 
         /* explicit relative path, starts with ./ or ../ */
     if ((strncmp("./", lib, 2) == 0) || (strncmp("../", lib, 3) == 0))
-    {
-        sys_load_lib(x, lib);
-        return;
-    }
+        return sys_load_lib(x, lib);
 
         /* prefix canvas-path */
     canvas_completepath(lib, strbuf, MAXPDSTRING, x);
     if (sys_load_lib(x, lib))
-        return;
+        return 1;
 
     /* check whether the given lib is located in one of the user search-paths */
     for (nl=STUFF->st_searchpath; nl; nl=nl->nl_next)
@@ -1790,18 +1788,19 @@ static void canvas_lib(t_canvas *x, t_canvasenvironment *e, const char *lib)
         pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, lib);
         strbuf[MAXPDSTRING-1]=0;
         if (sys_load_lib(x, strbuf))
-            return;
+            return 1;
     }
+    return 0;
 }
 
-static void canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
+static int canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
     if (sys_isabsolutepath(stdpath))
     {
         e->ce_path = namelist_append(e->ce_path, stdpath, 0);
-        return;
+        return 1;
     }
 
         /* strip "extra/"-prefix */
@@ -1813,7 +1812,7 @@ static void canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
     if (check_exists(strbuf))
     {
         e->ce_path = namelist_append(e->ce_path, strbuf, 0);
-        return;
+        return 1;
     }
 
     /* check whether the given subdir is in one of the standard-paths */
@@ -1824,19 +1823,17 @@ static void canvas_stdpath(t_canvasenvironment *e, const char *stdpath)
         if (check_exists(strbuf))
         {
             e->ce_path = namelist_append(e->ce_path, strbuf, 0);
-            return;
+            return 1;
         }
     }
+    return 0;
 }
-static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
+static int canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
 {
     t_namelist *nl;
     char strbuf[MAXPDSTRING];
     if (sys_isabsolutepath(stdlib))
-    {
-        sys_load_lib(0, stdlib);
-        return;
-    }
+        return sys_load_lib(0, stdlib);
 
         /* strip    "extra/"-prefix */
     if (!strncmp("extra/", stdlib, 6))
@@ -1845,7 +1842,7 @@ static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
         /* prefix full pd-path (including extra) */
     canvas_completepath(stdlib, strbuf, MAXPDSTRING, 0);
     if (sys_load_lib(0, strbuf))
-        return;
+        return 1;
 
     /* check whether the given lib is located in one of the standard-paths */
     for (nl=STUFF->st_staticpath; nl; nl=nl->nl_next)
@@ -1853,15 +1850,17 @@ static void canvas_stdlib(t_canvasenvironment *e, const char *stdlib)
         pd_snprintf(strbuf, MAXPDSTRING-1, "%s/%s", nl->nl_string, stdlib);
         strbuf[MAXPDSTRING-1]=0;
         if (sys_load_lib(0, strbuf))
-            return;
+            return 1;
     }
+    return 0;
 }
 
-
-void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+int canvas_declare_do(t_declare *z, t_canvas *x,
+                      t_symbol *s, int argc, t_atom *argv,
+                      t_loglevel level)
 {
-    int i;
     t_canvasenvironment *e = canvas_getenv(x);
+    int i, success = 1;
 #if 0
     startpost("declare:: %s", s->s_name);
     postatom(argc, argv);
@@ -1873,26 +1872,48 @@ void canvas_declare(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
         const char *item = (argc > i+1)?atom_getsymbolarg(i+1, argc, argv)->s_name:0;
         if ((item) && !strcmp(flag, "-path"))
         {
-            canvas_path(x, e, item);
+            if(!canvas_path(x, e, item)) {
+                logpost(z, level, "Failed to declare <path>: %s", item);
+                success = 0;
+            }
             i++;
         }
         else if ((item) && !strcmp(flag, "-stdpath"))
         {
-            canvas_stdpath(e, item);
+            if(!canvas_stdpath(e, item)) {
+                logpost(z, level, "Failed to declare <stdpath>: %s", item);
+                success = 0;
+            }
             i++;
         }
         else if ((item) && !strcmp(flag, "-lib"))
         {
-            canvas_lib(x, e, item);
+            if(!canvas_lib(x, e, item)) {
+                logpost(z, level, "Failed to declare <lib>: %s", item);
+                success = 0;
+            }
             i++;
         }
         else if ((item) && !strcmp(flag, "-stdlib"))
         {
-            canvas_stdlib(e, item);
+            if(!canvas_stdlib(e, item)) {
+                logpost(z, level, "Failed to declare <stdlib>: %s", item);
+                success = 0;
+            }
             i++;
         }
         else post("declare: %s: unknown declaration", flag);
     }
+    return success;
+}
+
+int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+{ return canvas_declare_do(NULL, x, s, argc, argv, PD_DEBUG); }
+
+int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv)
+{
+    t_canvas *x = z->x_canvas;
+    return canvas_declare_do(z, x, s, argc, argv, PD_DEBUG);
 }
 
 typedef struct _canvasopen
@@ -2190,7 +2211,7 @@ void g_canvas_setup(void)
 /*---------------------------- declare ------------------- */
     declare_class = class_new(gensym("declare"), (t_newmethod)declare_new,
         (t_method)declare_free, sizeof(t_declare), CLASS_NOINLET, A_GIMME, 0);
-    class_addmethod(canvas_class, (t_method)canvas_declare,
+    class_addmethod(canvas_class, (t_method)canvas_declare_message,
         gensym("declare"), A_GIMME, 0);
 
 /*--------------- future message to set formatting  -------------- */

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -54,10 +54,7 @@ static void canvas_pop(t_canvas *x, t_floatarg fvis);
 static void canvas_bind(t_canvas *x);
 static void canvas_unbind(t_canvas *x);
 static void canvas_completepath(const char *from, char *to, int bufsize, t_canvas *x);
-typedef struct _declare t_declare;
-int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv);
 int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
-int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
 void sys_expandpath(const char *from, char *to, int bufsize);
 
 /* ---------------- generic widget behavior ------------------------- */
@@ -1631,6 +1628,8 @@ typedef struct _declare
     int x_argc;
 } t_declare;
 
+int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
+
 static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x)
 {
     t_canvasenvironment *e = canvas_getenv(x);
@@ -1669,28 +1668,36 @@ static void declare_bang(t_declare *x)
  * a t_declare object can be passed for traceable loglevel posts.
  * LATER extend this for more patch information queries
  */
-static void canvas_query_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+static void canvas_query(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 {
     int i;
     for (i = 0; i < argc; i++)
     {
         const char *arg = atom_getsymbolarg(i, argc, argv)->s_name;
         if (!strcmp(arg, "paths"))
-            declare_loaded_paths(z, x);
+            declare_loaded_paths(NULL, x);
         else if (!strcmp(arg, "libs"))
-            declare_loaded_libs(z);
+            declare_loaded_libs(NULL);
         else if (!strcmp(arg, "absolute"))
-            declare_loaded_absolute_paths(z, x);
+            declare_loaded_absolute_paths(NULL, x);
+        else if (!strcmp(arg, "blocksize"))
+        {
+            int blocksize = canvas_getsignallength(x);
+            logpost(NULL, PD_NORMAL, "<blocksize>: %d", blocksize);
+        }
         else post("query <%s>: unknown arg", arg);
     }
 }
 
-static void canvas_query(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
-{ canvas_query_do(NULL, x, s, argc, argv); }
-
-static void declare_query(t_declare *x, t_symbol *s, int argc, t_atom *argv)
-{ canvas_query_do(x, x->x_canvas, s, argc, argv); }
-
+static void declare_print_paths(t_declare *x, t_floatarg fabsolute)
+{
+    int absflag = !!(int)fabsolute;
+    t_canvas *c = x->x_canvas;
+    if (absflag)
+        declare_loaded_absolute_paths(x, c);
+    else
+        declare_loaded_paths(x, c);
+}
 
 static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 {
@@ -1982,9 +1989,6 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
 
 int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 { return canvas_declare_do(NULL, x, s, argc, argv, PD_DEBUG); }
-
-int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv)
-{ return canvas_declare_do(z, z->x_canvas, s, argc, argv, PD_DEBUG); }
 
 typedef struct _canvasopen
 {
@@ -2286,8 +2290,10 @@ void g_canvas_setup(void)
         gensym("declare"), A_GIMME, 0);
     class_addmethod(canvas_class, (t_method)canvas_query,
         gensym("query"), A_GIMME, 0);
-    class_addmethod(declare_class, (t_method)declare_query,
-        gensym("query"), A_GIMME, 0);
+    class_addmethod(declare_class, (t_method)declare_print_paths,
+        gensym("paths"), A_DEFFLOAT, 0);
+    class_addmethod(declare_class, (t_method)declare_loaded_libs,
+        gensym("libs"), 0);
 
 /*--------------- future message to set formatting  -------------- */
     class_addmethod(canvas_class, (t_method)canvas_f,

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -54,7 +54,7 @@ static void canvas_pop(t_canvas *x, t_floatarg fvis);
 static void canvas_bind(t_canvas *x);
 static void canvas_unbind(t_canvas *x);
 static void canvas_completepath(const char *from, char *to, int bufsize, t_canvas *x);
-int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
+static void canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
 void sys_expandpath(const char *from, char *to, int bufsize);
 
 /* ---------------- generic widget behavior ------------------------- */
@@ -1957,8 +1957,8 @@ int canvas_declare_do(t_declare *z, t_canvas *x,
     return success;
 }
 
-int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
-{ return canvas_declare_do(0, x, s, argc, argv, PD_DEBUG); }
+static void canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+{ canvas_declare_do(0, x, s, argc, argv, PD_DEBUG); }
 
 typedef struct _canvasopen
 {

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1626,7 +1626,55 @@ typedef struct _declare
     t_object x_obj;
     t_canvas *x_canvas;
     int x_useme;
+    t_atom *x_argv; /* store creation arguments for re-triggering */
+    int x_argc;
 } t_declare;
+
+static void declare_loaded_paths(t_declare *z, t_canvas *x)
+{
+    t_canvasenvironment *e = canvas_getenv(x);
+    t_namelist *nl = e->ce_path;
+    for (; nl; nl = nl->nl_next)
+        logpost(z, PD_NORMAL, "loaded <path>: %s", nl->nl_string);
+}
+
+static void declare_loaded_libs(t_declare *x)
+{
+    t_loadlist *ll = sys_getloadlist();
+    for (; ll; ll = ll->ll_next)
+        logpost(x, PD_NORMAL, "loaded <lib>: %s", ll->ll_name->s_name);
+}
+
+static void declare_bang(t_declare *x)
+{
+    x->x_useme = canvas_declare_do(x, x->x_canvas, &s_list,
+                                x->x_argc, x->x_argv, PD_DEBUG);
+}
+
+/* query a canvas for information on loaded libraries or paths
+ * a t_declare object can be passed for traceable loglevel posts.
+ * LATER extend this for more patch information queries
+ */
+static void canvas_query_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+{
+    int i;
+    for (i = 0; i < argc; i++)
+    {
+        const char *arg = atom_getsymbolarg(i, argc, argv)->s_name;
+        if (!strcmp(arg, "paths"))
+            declare_loaded_paths(z, x);
+        else if (!strcmp(arg, "libs"))
+            declare_loaded_libs(z);
+        else post("query <%s>: unknown arg", arg);
+    }
+}
+
+static void canvas_query(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
+{ canvas_query_do(NULL, x, s, argc, argv); }
+
+static void declare_query(t_declare *x, t_symbol *s, int argc, t_atom *argv)
+{ canvas_query_do(x, x->x_canvas, s, argc, argv); }
+
 
 static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 {
@@ -1634,12 +1682,19 @@ static void *declare_new(t_symbol *s, int argc, t_atom *argv)
     x->x_useme = 1;
     x->x_canvas = canvas_getcurrent();
         /* LATER update environment and/or load libraries */
-    if (!x->x_canvas->gl_loading)
+    x->x_argc = argc;
+    if (argc > 0)
     {
+        x->x_argv = (t_atom *)getbytes(argc * sizeof(t_atom));
+        memcpy(x->x_argv, argv, argc * sizeof(t_atom));
+    }
+    else
+        x->x_argv = NULL;
+
         /* the object is created by the user (not by loading a patch),
          * so update canvas's properties on the fly */
-        x->x_useme = canvas_declare_do(x, x->x_canvas, s, argc, argv, PD_DEBUG);
-    }
+    if (!x->x_canvas->gl_loading)
+        declare_bang(x);
     return (x);
 }
 
@@ -1647,6 +1702,8 @@ static void declare_free(t_declare *x)
 {
     x->x_useme = 0;
         /* LATER update environment */
+    if (x->x_argv)
+        freebytes(x->x_argv, x->x_argc * sizeof(t_atom));
 }
 
 void canvas_savedeclarationsto(t_canvas *x, t_binbuf *b)
@@ -1911,10 +1968,7 @@ int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv)
 { return canvas_declare_do(NULL, x, s, argc, argv, PD_DEBUG); }
 
 int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv)
-{
-    t_canvas *x = z->x_canvas;
-    return canvas_declare_do(z, x, s, argc, argv, PD_DEBUG);
-}
+{ return canvas_declare_do(z, z->x_canvas, s, argc, argv, PD_DEBUG); }
 
 typedef struct _canvasopen
 {
@@ -2210,9 +2264,14 @@ void g_canvas_setup(void)
 
 /*---------------------------- declare ------------------- */
     declare_class = class_new(gensym("declare"), (t_newmethod)declare_new,
-        (t_method)declare_free, sizeof(t_declare), CLASS_NOINLET, A_GIMME, 0);
+        (t_method)declare_free, sizeof(t_declare), CLASS_DEFAULT, A_GIMME, 0);
+    class_addbang(declare_class, (t_method)declare_bang);
     class_addmethod(canvas_class, (t_method)canvas_declare_message,
         gensym("declare"), A_GIMME, 0);
+    class_addmethod(canvas_class, (t_method)canvas_query,
+        gensym("query"), A_GIMME, 0);
+    class_addmethod(declare_class, (t_method)declare_query,
+        gensym("query"), A_GIMME, 0);
 
 /*--------------- future message to set formatting  -------------- */
     class_addmethod(canvas_class, (t_method)canvas_f,

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -53,6 +53,7 @@ static void canvas_takeofflist(t_canvas *x);
 static void canvas_pop(t_canvas *x, t_floatarg fvis);
 static void canvas_bind(t_canvas *x);
 static void canvas_unbind(t_canvas *x);
+static void canvas_completepath(const char *from, char *to, int bufsize, t_canvas *x);
 typedef struct _declare t_declare;
 int canvas_declare(t_declare *z, t_symbol *s, int argc, t_atom *argv);
 int canvas_declare_message(t_canvas *x, t_symbol *s, int argc, t_atom *argv);
@@ -1630,6 +1631,19 @@ typedef struct _declare
     int x_argc;
 } t_declare;
 
+static void declare_loaded_absolute_paths(t_declare *z, t_canvas *x)
+{
+    t_canvasenvironment *e = canvas_getenv(x);
+    t_namelist *nl = e->ce_path;
+        /* prefix canvas-path */
+    char strbuf[MAXPDSTRING], *path;
+    for (; nl; nl = nl->nl_next)
+    {
+        path = nl->nl_string;
+        canvas_completepath(path, strbuf, MAXPDSTRING, x);
+        logpost(z, PD_NORMAL, "loaded <path>: %s", strbuf);
+    }
+}
 static void declare_loaded_paths(t_declare *z, t_canvas *x)
 {
     t_canvasenvironment *e = canvas_getenv(x);
@@ -1665,6 +1679,8 @@ static void canvas_query_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_
             declare_loaded_paths(z, x);
         else if (!strcmp(arg, "libs"))
             declare_loaded_libs(z);
+        else if (!strcmp(arg, "absolute"))
+            declare_loaded_absolute_paths(z, x);
         else post("query <%s>: unknown arg", arg);
     }
 }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1631,8 +1631,15 @@ typedef struct _declare
 
 int canvas_declare_do(t_declare *z, t_canvas *x, t_symbol *s, int argc, t_atom *argv, t_loglevel level);
 
-static void declare_loaded_absolute_paths(t_declare *x, t_symbol *s)
+static void declare_bang(t_declare *x)
 {
+    x->x_useme = canvas_declare_do(x, x->x_canvas, &s_list,
+                                x->x_argc, x->x_argv, PD_DEBUG);
+}
+
+static void declare_output_paths(t_declare *x, t_floatarg fabsolute)
+{
+    int absflag = !!(int)fabsolute;
     t_canvasenvironment *e = canvas_getenv(x->x_canvas);
     t_namelist *nl = e->ce_path;
         /* prefix canvas-path */
@@ -1640,43 +1647,22 @@ static void declare_loaded_absolute_paths(t_declare *x, t_symbol *s)
     for (; nl; nl = nl->nl_next)
     {
         path = nl->nl_string;
-        canvas_completepath(path, strbuf, MAXPDSTRING, x->x_canvas);
-        outlet_symbol(x->x_outlet, gensym(strbuf));
+        if (absflag)
+        {
+            canvas_completepath(path, strbuf, MAXPDSTRING, x->x_canvas);
+            outlet_symbol(x->x_outlet, gensym(strbuf));
+        }
+        else
+            outlet_symbol(x->x_outlet, gensym(path));
     }
 }
-static void declare_loaded_paths(t_declare *x, t_symbol *s)
-{
-    t_canvasenvironment *e = canvas_getenv(x->x_canvas);
-    t_namelist *nl = e->ce_path;
-    for (; nl; nl = nl->nl_next)
-        outlet_symbol(x->x_outlet, gensym(nl->nl_string));
-}
 
-static void declare_loaded_libs(t_declare *x, t_symbol *s)
+static void declare_output_libs(t_declare *x)
 {
     t_loadlist *ll = sys_getloadlist();
     for (; ll; ll = ll->ll_next)
         outlet_symbol(x->x_outlet, ll->ll_name);
 }
-
-static void declare_bang(t_declare *x)
-{
-    x->x_useme = canvas_declare_do(x, x->x_canvas, &s_list,
-                                x->x_argc, x->x_argv, PD_DEBUG);
-}
-
-static void declare_print_paths(t_declare *x, t_floatarg fabsolute)
-{
-    int absflag = !!(int)fabsolute;
-    t_canvas *c = x->x_canvas;
-    if (absflag)
-        declare_loaded_absolute_paths(x, 0);
-    else
-        declare_loaded_paths(x, 0);
-}
-
-static void declare_print_libs(t_declare *x)
-{ declare_loaded_libs(x, 0); }
 
 static void *declare_new(t_symbol *s, int argc, t_atom *argv)
 {
@@ -2272,9 +2258,9 @@ void g_canvas_setup(void)
     class_addbang(declare_class, (t_method)declare_bang);
     class_addmethod(canvas_class, (t_method)canvas_declare_message,
         gensym("declare"), A_GIMME, 0);
-    class_addmethod(declare_class, (t_method)declare_print_paths,
+    class_addmethod(declare_class, (t_method)declare_output_paths,
         gensym("paths"), A_DEFFLOAT, 0);
-    class_addmethod(declare_class, (t_method)declare_print_libs,
+    class_addmethod(declare_class, (t_method)declare_output_libs,
         gensym("libs"), 0);
 
 /*--------------- future message to set formatting  -------------- */

--- a/src/s_loader.c
+++ b/src/s_loader.c
@@ -215,13 +215,7 @@ const char**sys_get_dllextensions(void)
     return sys_dllextent;
 }
 
-    /* maintain list of loaded modules to avoid repeating loads */
-typedef struct _loadedlist
-{
-    struct _loadedlist *ll_next;
-    t_symbol *ll_name;
-} t_loadlist;
-
+    /* moved t_loadlist to stuff.h to be used by canvas.c */
 static t_loadlist *sys_loaded;
 int sys_onloadlist(const char *classname) /* return true if already loaded */
 {
@@ -241,6 +235,12 @@ void sys_putonloadlist(const char *classname)
     ll->ll_next = sys_loaded;
     sys_loaded = ll;
     /* post("put on list %s", classname); */
+}
+
+    /* get a pointer to the list of loaded modules */
+t_loadlist *sys_getloadlist(void)
+{
+    return sys_loaded;
 }
 
 void class_set_extern_dir(t_symbol *s);

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -465,3 +465,13 @@ EXTERN size_t pd_strnlen(const char*s, size_t maxlen);
 
 EXTERN const char *pd_extraflags;     /* a place to stick an extra startup arg */
  /* this is used by 'stdout' but could be useful elsewhere perhaps. */
+
+    /* maintain list of loaded modules to avoid repeating loads */
+typedef struct _loadedlist
+{
+    struct _loadedlist *ll_next;
+    t_symbol *ll_name;
+} t_loadlist;
+
+/* defined in loader.c but used by declare in canvas.c to get the loaded libs */
+t_loadlist *sys_getloadlist(void);


### PR DESCRIPTION
### declare iolets and methods
This PR adds an inlet to [declare], and some methods: a "bang", "paths [0,1]", and "libs":
- The "bang" allows the user to re-run the object without re-creating it (or closing and opening the patch). 
- The "path [0,1]" method outputs the loaded paths (0 or no argument) or the absolute paths (1) on a canvas.
- The "libs" method outputs the loaded libraries (i.e., loaded classes and abstractions) on the instance (whatever libs were loaded (via s_loader.c))


### declare warnings
The warnings are all on the debug level (3), and they are only clickable when triggered by the object. If the canvas triggered the declares (e.g., on patch load, via message), they won't be traceable. 

Please let me know what you think, it's not set in stone. The PR closes https://github.com/pure-data/pure-data/issues/281, in the hopes that the solution is sane and in line with the op.

- Closes: #281
- Closes: #660
- Closes: #886