### PR TITLE
Restore array size after coming back from non-GOP [graph]

### DIFF
--- a/src/g_array.c
+++ b/src/g_array.c
@@ -737,6 +737,8 @@ static void garray_delete(t_gobj *z, t_glist *glist)
 static void garray_vis(t_gobj *z, t_glist *glist, int vis)
 {
     t_garray *x = (t_garray *)z;
+    if(x->x_glist && x->x_glist->gl_goprect && x->x_glist->gl_x2 == 1)
+        x->x_glist->gl_x2 = x->x_scalar->sc_vec->w_array->a_n;
     gobj_vis(&x->x_scalar->sc_gobj, glist, vis);
 }
 


### PR DESCRIPTION
This is a simple fix that just puts the size of the array into the size of the graph, no extra storage needed.

It is in fact rather dumb, so dumb that we restore the size of the first array only. If there are more than one arrays, then this may result in one array being larger than the gop area, and thus some unwanted/weird resizing. But, I think that problem is even more of an edge case, as it may be less likely to have 2 arrays on the same graph and do the non-gop -> gop dance.

This could be done smarter: some iteration on all array sizes might be worth the effort to get the max size and restore to that size, but for now the problem in the related issue should be solved.

Closes:
- https://github.com/pure-data/pure-data/issues/566.