### PR TITLE
Make sure loadbang sends LB_LOAD as integer to avoid warnings

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1143,7 +1143,7 @@ static void canvas_loadbangabstractions(t_canvas *x)
         else if ((pd_class(&y->g_pd) == clone_class) &&
             zgetfn(&y->g_pd, s))
         {
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_LOAD);
+            pd_vmess(&y->g_pd, s, "i", LB_LOAD);
         }
 }
 
@@ -1162,7 +1162,7 @@ void canvas_loadbangsubpatches(t_canvas *x)
             (pd_class(&y->g_pd) != clone_class) &&
             zgetfn(&y->g_pd, s))
         {
-            pd_vmess(&y->g_pd, s, "f", (t_floatarg)LB_LOAD);
+            pd_vmess(&y->g_pd, s, "i", LB_LOAD);
         }
 }
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -4007,7 +4007,7 @@ static void glist_donewloadbangs(t_glist *x)
             if (pd_class(&sel->sel_what->g_pd) == canvas_class)
                 canvas_loadbang((t_canvas *)(&sel->sel_what->g_pd));
             else if (zgetfn(&sel->sel_what->g_pd, gensym("loadbang")))
-                vmess(&sel->sel_what->g_pd, gensym("loadbang"), "f", LB_LOAD);
+                vmess(&sel->sel_what->g_pd, gensym("loadbang"), "i", LB_LOAD);
     }
 }
 

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -1772,7 +1772,7 @@ void text_setto(t_text *x, t_glist *glist, const char *buf, int bufsize)
                 if (pd_class(pd_this->pd_newest) == canvas_class)
                     canvas_loadbang((t_canvas *)pd_this->pd_newest);
                 else if (zgetfn(pd_this->pd_newest, gensym("loadbang")))
-                    vmess(pd_this->pd_newest, gensym("loadbang"), "f", LB_LOAD);
+                    vmess(pd_this->pd_newest, gensym("loadbang"), "i", LB_LOAD);
             }
         }
             /* if we made a new "pd" or changed a window name,

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -310,7 +310,7 @@ void pd_popsym(t_pd *x)
 void pd_doloadbang(void)
 {
     if (lastpopped)
-        pd_vmess(lastpopped, gensym("loadbang"), "f", LB_LOAD);
+        pd_vmess(lastpopped, gensym("loadbang"), "i", LB_LOAD);
     lastpopped = 0;
 }
 


### PR DESCRIPTION
There's more information on the related issue. The fix boldly changes the format string to "i", and valgrind stops complaining. 

Closes #2842 