### PR TITLE
Flip menu order and move 'Load Meter' entry to 'Tools'

### DIFF
--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -59,7 +59,7 @@ proc ::pd_menus::create_menubar {} {
     $::patch_menubar add cascade -label [_ Put] \
             -underline 0 -menu $::patch_menubar.put
 
-    foreach mymenu "find media window tools help" {
+    foreach mymenu "find window media tools help" {
         if {$mymenu eq "find"} {
             set underlined 3
         } {

--- a/tcl/pd_menus.tcl
+++ b/tcl/pd_menus.tcl
@@ -283,8 +283,6 @@ proc ::pd_menus::build_media_menu {mymenu} {
     $mymenu add  separator
     $mymenu add command -label [_ "Test Audio and MIDI..."] \
         -command {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools testtone.pd}
-    $mymenu add command -label [_ "Load Meter"] \
-        -command {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools load-meter.pd}
 
     set audio_apilist_length [llength $::audio_apilist]
     if {$audio_apilist_length > 0} {$mymenu add separator}
@@ -347,6 +345,9 @@ proc ::pd_menus::build_window_menu {mymenu} {
 proc ::pd_menus::build_tools_menu {mymenu} {
     variable accelerator
 
+    $mymenu add command -label [_ "Load Meter"] \
+        -command {::pd_menucommands::scheduleAction menu_doc_open doc/7.stuff/tools load-meter.pd}
+    $mymenu add  separator
     $mymenu add command -label [_ "Message..."] \
         -accelerator "$accelerator+Shift+M" \
         -command {::pd_menucommands::scheduleAction menu_message_dialog}


### PR DESCRIPTION
mainly wanted to see what the suggestions in #2853 felt like - but why not make this a PR right away ...

tested on macos.

<img width="219" height="184" alt="image" src="https://github.com/user-attachments/assets/aef9ed38-3e63-42a1-88a0-69c10ac15118" />

<img width="230" height="125" alt="image" src="https://github.com/user-attachments/assets/3e4ea1c3-a3ba-4c69-80cf-137dc83f2e13" />

* closes #2853

(EDIT: not moving the "test audio and midi" entry anymore with this PR)