### PR TITLE
displace message: output zoom-aware canvas coordinates

### DIFF
--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -446,17 +446,16 @@ static void scalar_displace(t_gobj *z, t_glist *glist, int dx, int dy)
         goty = 0;
     if (gotx)
         *(t_float *)(((char *)(x->sc_vec)) + xonset) +=
-            glist->gl_zoom * dx * (glist_pixelstox(glist, 1) -
-                glist_pixelstox(glist, 0));
+            glist_dpixtodx(glist, dx * glist_getzoom(glist));
     if (goty)
         *(t_float *)(((char *)(x->sc_vec)) + yonset) +=
-            glist->gl_zoom * dy * (glist_pixelstoy(glist, 1) -
-                glist_pixelstoy(glist, 0));
+            glist_dpixtody(glist, dy * glist_getzoom(glist));
     gpointer_init(&gp);
     gpointer_setglist(&gp, glist, x);
     SETPOINTER(&at[0], &gp);
-    SETFLOAT(&at[1], (t_float)dx);
-    SETFLOAT(&at[2], (t_float)dy);
+        /* report displacement in canvas coordinates (zoom-aware) */
+    SETFLOAT(&at[1], glist_dpixtodx(glist, dx * glist_getzoom(glist)));
+    SETFLOAT(&at[2], glist_dpixtody(glist, dy * glist_getzoom(glist)));
     template_notify(template, gensym("displace"), 3, at);
     scalar_redraw(x, glist);
 }
@@ -561,8 +560,8 @@ int scalar_doclick(t_word *data, t_template *template, t_scalar *sc,
             {
                 t_atom at[6];
                 SETFLOAT(at, 0); /* unused - later bashed to the gpointer */
-                SETFLOAT(at+1, xpix - glist_xtopixels(owner, xloc));
-                SETFLOAT(at+2, ypix - glist_ytopixels(owner, yloc));
+                SETFLOAT(at+1, glist_dpixtodx(owner, xpix - glist_xtopixels(owner, xloc)));
+                SETFLOAT(at+2, glist_dpixtody(owner, ypix - glist_ytopixels(owner, yloc)));
                 SETFLOAT(at+3, shift);
                 SETFLOAT(at+4, alt);
                 SETFLOAT(at+5, dbl);

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -51,9 +51,11 @@ struct _instancetemplate
 {
     int curve_motion_vertex;
     t_float curve_motion_xcumulative;
+    t_float curve_motion_xfrac;  /* fractional remainder for whole-object drag */
     t_float curve_motion_xbase;
     t_float curve_motion_xper;
     t_float curve_motion_ycumulative;
+    t_float curve_motion_yfrac;
     t_float curve_motion_ybase;
     t_float curve_motion_yper;
     t_glist *curve_motion_glist;
@@ -1455,8 +1457,19 @@ static void curve_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
     }
     if (THISTMPL->curve_motion_vertex < 0)   /* drag the whole object */
     {
-        gobj_displace(&THISTMPL->curve_motion_scalar->sc_gobj,
-            THISTMPL->curve_motion_glist, dx, dy);
+        t_glist *glist = THISTMPL->curve_motion_glist;
+        t_float zoom = (t_float)glist_getzoom(glist);
+        int idtx, idty;
+            /* accumulate fractional parts (while displace API expects ints) */
+        THISTMPL->curve_motion_xfrac += dx / zoom;
+        THISTMPL->curve_motion_yfrac += dy / zoom;
+        idtx = (int)THISTMPL->curve_motion_xfrac;
+        idty = (int)THISTMPL->curve_motion_yfrac;
+        THISTMPL->curve_motion_xfrac -= idtx;
+        THISTMPL->curve_motion_yfrac -= idty;
+        if (idtx || idty)
+            gobj_displace(&THISTMPL->curve_motion_scalar->sc_gobj,
+                glist, idtx, idty);
         return;
     }
     f = x->x_vec + THISTMPL->curve_motion_vertex;
@@ -1565,6 +1578,8 @@ static int curve_click(t_gobj *z, t_glist *glist,
             - glist_pixelstoy(glist, 0);
         THISTMPL->curve_motion_xcumulative = 0;
         THISTMPL->curve_motion_ycumulative = 0;
+        THISTMPL->curve_motion_xfrac = 0;
+        THISTMPL->curve_motion_yfrac = 0;
         THISTMPL->curve_motion_glist = glist;
         THISTMPL->curve_motion_scalar = sc;
         THISTMPL->curve_motion_array = ap;


### PR DESCRIPTION
this is an attempt to output canvas coordinates, making them independent of the current zoom level.

* related to #2846
* closes #2856

the fractional handling feels a bit awkward, but switching the displace API to floats felt out of scope here.

test patch: [test-displace.pd.zip](https://github.com/user-attachments/files/25931773/test-displace.pd.zip)
