### PR TITLE
dialogs: use `concat` instead of `list` for pdsend payloads 

### DIFF
--- a/tcl/dialog_array.tcl
+++ b/tcl/dialog_array.tcl
@@ -224,7 +224,7 @@ proc ::dialog_array::listview_edit+paste {arrayName startIndex data} {
         lappend values $value
     }
     if { $values ne {} } {
-        pdsend [list $::dialog_array::listview_id($arrayName) $offset $values]
+        pdsend [concat $::dialog_array::listview_id($arrayName) $offset $values]
         pdtk_array_listview_fillpage $arrayName
     }
 }
@@ -346,7 +346,7 @@ proc ::dialog_array::listview_close {mytoplevel arrayName} {
 }
 
 proc ::dialog_array::apply {mytoplevel} {
-    pdsend [list $mytoplevel arraydialog \
+    pdsend [concat $mytoplevel arraydialog \
                 [::dialog_gatom::escape [$mytoplevel.array.name.entry get]] \
                 [$mytoplevel.array.size.entry get] \
                 [expr $::dialog_array::saveme_button($mytoplevel) + (2 * $::dialog_array::drawas_button($mytoplevel))] \

--- a/tcl/dialog_canvas.tcl
+++ b/tcl/dialog_canvas.tcl
@@ -25,7 +25,7 @@ proc ::dialog_canvas::set_text {text} {
 proc ::dialog_canvas::apply {mytoplevel} {
     global ::dialog_canvas_text
 
-    set cmd [list $mytoplevel donecanvasdialog \
+    set cmd [concat $mytoplevel donecanvasdialog \
                  [$mytoplevel.scale.x.entry get] \
                  [$mytoplevel.scale.y.entry get] \
                  [expr $::graphme_button($mytoplevel) + 2 * $::hidetext_button($mytoplevel)] \

--- a/tcl/dialog_gatom.tcl
+++ b/tcl/dialog_gatom.tcl
@@ -67,7 +67,7 @@ proc ::dialog_gatom::apply {mytoplevel} {
     set ::dialog_gatom::init_upper($mytoplevel) $upper
 
 
-    pdsend [list $mytoplevel param \
+    pdsend [concat $mytoplevel param \
         ${width} ${lower} ${upper} \
         [::dialog_gatom::escape [$mytoplevel.gatomlabel.name.entry get]] \
         $gatomlabel_radio($mytoplevel) \

--- a/tcl/dialog_iemgui.tcl
+++ b/tcl/dialog_iemgui.tcl
@@ -285,7 +285,7 @@ proc ::dialog_iemgui::apply {mytoplevel} {
     if {$::dialog_iemgui::var_label_dx($vid) eq ""} {set ::dialog_iemgui::var_label_dx($vid) 0}
     if {$::dialog_iemgui::var_label_dy($vid) eq ""} {set ::dialog_iemgui::var_label_dy($vid) 0}
 
-    pdsend [list $mytoplevel dialog \
+    pdsend [concat $mytoplevel dialog \
                 $::dialog_iemgui::var_width($vid) \
                 $::dialog_iemgui::var_height($vid) \
                 $::dialog_iemgui::var_range_min($vid) \


### PR DESCRIPTION
reverts some of the changes in 0d0280e

* closes #2864 (tentative fix)

@umlaeute : based on #2865, i assume that you're aiming at a more elegant solution for this. but with the new validation you added, empty values are avoided anyway AFAICS - so this might be acceptable for now?