### PR TITLE
clone: avoid consecutive first instance triggers via [this(, [next( after downsizing clone

### DIFF
--- a/src/g_clone.c
+++ b/src/g_clone.c
@@ -402,6 +402,8 @@ static void clone_setn(t_clone *x, t_floatarg f)
         x->x_vec = (t_copy *)t_resizebytes(x->x_vec, nwas * sizeof(t_copy),
             wantn * sizeof(t_copy));
         x->x_n = wantn;
+        if (x->x_phase >= wantn)
+            x->x_phase = wantn - 1;
     }
 }
 


### PR DESCRIPTION
downsizing now clamps the current instance id to the available ones.

* closes #2891