### PR TITLE
Feature: open files in cwd

### DIFF
--- a/src/d_soundfile.c
+++ b/src/d_soundfile.c
@@ -417,6 +417,8 @@ int open_soundfile_via_namelist(const char *dirname, const char *filename,
     fd = do_open_via_path(dirname, filename, "", buf, &dummy, MAXPDSTRING,
         1, nl, 0);
     if (fd < 0)
+        fd = sys_trytoopenit("", filename, "", buf, &dummy, MAXPDSTRING, 1, 0);
+    if (fd < 0)
         return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
     return sf_fd;
@@ -430,6 +432,9 @@ int open_soundfile_via_canvas(t_canvas *canvas, const char *filename,
     char buf[MAXPDSTRING], *dummy;
     int fd, sf_fd;
     fd = canvas_open(canvas, filename, "", buf, &dummy, MAXPDSTRING, 1);
+    if (fd < 0) {
+        fd = sys_trytoopenit("", filename, "", buf, &dummy, MAXPDSTRING, 1, 1);
+    }
     if (fd < 0)
         return -1;
     sf_fd = open_soundfile_via_fd(fd, sf, skipframes);
@@ -2319,6 +2324,8 @@ static void readsf_open(t_readsf *x, t_symbol *s, int argc, t_atom *argv)
         int fd;
         fd = do_open_via_path(canvas_getdir(x->x_canvas)->s_name,
             filesym->s_name, "", buf, &dummy, MAXPDSTRING, 1, x->x_namelist, 1);
+        if (fd < 0)
+            fd = sys_trytoopenit("", filesym->s_name, "", buf, &dummy, MAXPDSTRING, 1, 1);
         if (fd >= 0)
             close(fd);
     }

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1951,6 +1951,10 @@ int canvas_open(const t_canvas *x, const char *name, const char *ext,
 
     canvas_path_iterate(x, (t_canvas_path_iterator)canvas_open_iter, &co);
 
+    if (co.fd < 0) {
+        co.fd = sys_trytoopenit("", name, ext, dirresult, nameresult, size, bin, 1);
+    }
+
     return (co.fd);
 }
 


### PR DESCRIPTION
with `[file cwd]` it is possible to change the working directory.

however, many objects (including `[soundfiler]`) won't take the CWD into account.

this patch "fixes" this:
- extend `canvas_open()` to just try to open the file without a dir as a last resort
- also extend `[soundfiler]` (read) and `[readsf~]` to fallback to opening the file without a dir as a last resort

:warning: I'm not entirely sure whether we actually want this behaviour, though.

in any case:
- Closes: https://github.com/pure-data/pure-data/issues/2888.



