### PR TITLE
Quote paths in macOS application makefile

### DIFF
--- a/mac/Makefile.am
+++ b/mac/Makefile.am
@@ -25,9 +25,9 @@ pkgdata_DATA += \
 
 # build an app bundle on OSX
 app:
-	rm -rf $(abs_top_builddir)/Pd-$(VERSION).app
-	$(SH) $(top_srcdir)/mac/osx-app.sh --builddir $(abs_top_builddir) $(VERSION)
-	mv $(abs_top_builddir)/mac/Pd-$(VERSION).app $(abs_top_builddir)
+	rm -rf "$(abs_top_builddir)/Pd-$(VERSION).app"
+	$(SH) "$(top_srcdir)/mac/osx-app.sh" --builddir "$(abs_top_builddir)" $(VERSION)
+	mv "$(abs_top_builddir)/mac/Pd-$(VERSION).app" "$(abs_top_builddir)"
 
 else
 


### PR DESCRIPTION
The recent changes allow build directory paths to include spaces. Previously, using `make` would succeed, but when running `make app` on projects with absolute paths containing spaces, it would fail with an error, due to the path being split within `mac/osx-app.sh`.

This issue has now been resolved. However, I’m not entirely sure if the solutions implemented conform to best practices. I would appreciate any suggestions for alternative approaches.