### PR TITLE
Add StartupWMClass to pd-gui.desktop

### DIFF
--- a/linux/org.puredata.pd-gui.desktop
+++ b/linux/org.puredata.pd-gui.desktop
@@ -15,3 +15,4 @@ GenericName=Dataflow IDE
 Type=Application
 Terminal=false
 Icon=puredata
+StartupWMClass=PdWindow


### PR DESCRIPTION
This allows desktop environments to associate the main window with the desktop file and display the appropriate icon for it.