### PR TITLE
Import deken v0.10.18

### DIFF
--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -28,10 +28,10 @@ package require Tcl 8.4 9
 
 package require http 2
 # try enabling https if possible
-if { [catch {package require tls 1.7} ] } {} else {
+if { [catch {package require tls 1.7-} ] } {} else {
     ::tls::init \
         -autoservername 1 \
-        -ssl2 false -ssl3 false -tls1 true
+        -tls1 false -tls1.1 false
     ::http::register https 443 ::tls::socket
 }
 # try enabling PROXY support if possible
@@ -108,7 +108,7 @@ proc ::deken::versioncheck {version} {
 }
 
 ## put the current version of this package here:
-if { [::deken::versioncheck 0.10.10] } {
+if { [::deken::versioncheck 0.10.14] } {
 
 namespace eval ::deken:: {
     namespace export open_searchui
@@ -956,6 +956,8 @@ proc ::deken::utilities::parse_filename {filename} {
             }
         }
     }
+    # normalize version
+    set version [string map {_ ~} ${version}]
     return [list ${pkgname} ${version} ${archs}]
 }
 
@@ -1338,7 +1340,10 @@ proc ::deken::preferences::create {winid} {
                 -command {set ::deken::preferences::add_to_path \
                               [set ::deken::preferences::add_to_path_temp \
                                    [::deken::utilities::tristate ${::deken::preferences::add_to_path_temp} 1 0]]}
-        set msg "- Always add to search path\n- Never add to search path\n- Prompt before adding"
+        set msg0 [_ "- Always add to search path" ]
+        set msg1 [_ "- Never add to search path" ]
+        set msg2 [_ "- Prompt before adding" ]
+        set msg [string cat $msg0 "\n" $msg1 "\n" $msg2]
         bind ${winid}.install.add_to_path <Enter> "::deken::balloon::show ${winid}.install_balloon %X \[winfo rooty %W\] \{${msg}\} 0 30"
         bind ${winid}.install.add_to_path <Leave> [list ::deken::balloon::hide ${winid}.install_balloon]
 

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -17,10 +17,6 @@
 ## - redirect ::deken::post to ::pdwindow::post (that is: use the results pane only for results)
 ## + make the "add to path" thingy configurable
 
-# The minimum version of TCL that allows the plugin to run
-package require Tcl 8.4 9
-# If Tk or Ttk is needed
-#package require Ttk
 # Any elements of the Pd GUI that are required
 # + require everything and all your script needs.
 #   If a requirement is missing,
@@ -37,8 +33,11 @@ if { [catch {package require tls 1.7-} ] } {} else {
 # try enabling PROXY support if possible
 if { [catch {package require autoproxy} ] } {} else {
     ::autoproxy::init
-    if { ! [catch {package present tls} stdout] } {
+    # autoproxy is currently broken with Tcl-9.x
+    if { [package vcompare $::tcl_version 9] < 0 } {
+      if { ! [catch {package present tls} stdout] } {
         ::http::register https 443 ::autoproxy::tls_socket
+      }
     }
 }
 
@@ -108,7 +107,7 @@ proc ::deken::versioncheck {version} {
 }
 
 ## put the current version of this package here:
-if { [::deken::versioncheck 0.10.16] } {
+if { [::deken::versioncheck 0.10.18] } {
 
 namespace eval ::deken:: {
     namespace export open_searchui

--- a/tcl/pd_deken.tcl
+++ b/tcl/pd_deken.tcl
@@ -108,7 +108,7 @@ proc ::deken::versioncheck {version} {
 }
 
 ## put the current version of this package here:
-if { [::deken::versioncheck 0.10.14] } {
+if { [::deken::versioncheck 0.10.16] } {
 
 namespace eval ::deken:: {
     namespace export open_searchui
@@ -831,6 +831,41 @@ proc ::deken::utilities::httpuseragent {} {
     return ${httpagent}
 }
 
+# poor man's ::uri::resolve : resolves the specified url relative to base.
+#
+# A non-relative url is returned unchanged, whereas for a relative url the
+# missing parts are taken from base and prepended to it.
+# The result of this operation is returned. For an empty url the result is base.
+proc ::deken::utilities::resolveurl {base url} {
+    set urlex {^([A-Za-z][A-Za-z0-9+.-]*://[^/?#]+)(/.*|[?#].*)?$}
+
+    if { ${url} eq {} } {
+        return ${base}
+    }
+
+    if { ! [regexp ${urlex} ${base} -> schemeAuth0 path0]} {
+        set schemeAuth0 ""
+        set path0 ${base}
+    }
+    if { ! [regexp ${urlex} ${url} -> schemeAuth1 path1]} {
+        set schemeAuth1 ""
+        set path1 ${url}
+    }
+
+    if { ${schemeAuth1} eq {} } {
+        # relative URL
+        if {[string index $path1 0] eq "/"} {
+            set location "${schemeAuth0}${path1}"
+        } else {
+            set location "${schemeAuth0}/${path1}"
+        }
+    } else {
+        set location ${url}
+    }
+
+    return ${location}
+}
+
 # wrapper around ::http::geturl that follows redirects
 proc ::deken::utilities::geturl {url args} {
     set token [::http::geturl ${url} {*}$args]
@@ -840,6 +875,8 @@ proc ::deken::utilities::geturl {url args} {
         array set meta $state(meta)
         foreach {k location} [array get meta Location] {
             ::http::cleanup ${token}
+
+            set location [::deken::utilities::resolveurl ${url} ${location}]
             return [::deken::utilities::geturl ${location} {*}$args]
         }
     }
@@ -3357,8 +3394,10 @@ proc ::deken::search::dekenserver::search {term} {
     foreach {k v} [array get ::deken::search::dekenserver::urls_ephemeral_existing] {
         lappend tmpurls ${v}
     }
+    # deken-specific socket config
+
+    # check if https is usable for the primary URL
     if {$::deken::search::dekenserver::use_url_primary} {
-        #::http::unregister https
         if { [info exists ::deken::search::dekenserver::url_primary ]} {
             if { $::deken::search::dekenserver::url_primary eq {}} {
                 unset ::deken::search::dekenserver::url_primary
@@ -3368,6 +3407,8 @@ proc ::deken::search::dekenserver::search {term} {
         if { ![info exists ::deken::search::dekenserver::url_primary ]} {
             # check default URL for usability (first https://, then http://)
             set url ${::deken::search::dekenserver::url_primary_default}
+            # set deken useragent
+            set httpagent [::deken::utilities::httpuseragent]
             if {[catch {
                 set httpresult [::deken::utilities::geturl ${url}]
                 ::http::cleanup ${httpresult}
@@ -3376,7 +3417,10 @@ proc ::deken::search::dekenserver::search {term} {
                     # does NOT start with http://
                     set protoend [string first "://" $url]
                     if { $protoend > 0 } {
-                        set url "http[string range $url $protoend end]"
+                        set url2 "http[string range $url $protoend end]"
+                        set msg [_ "Downgrading %s to %s" ${url} ${url2}]
+                        ::deken::post ${msg} warn
+                        set url ${url2}
                     } else {
                         set url ""
                     }
@@ -3384,6 +3428,9 @@ proc ::deken::search::dekenserver::search {term} {
                     set url ""
                 }
             }
+            # restore http settings
+            ::http::config -useragent ${httpagent}
+
             set ::deken::search::dekenserver::url_primary ${url}
             # set the ..._default for the deken prefs textvariable
             if { $url ne {}} {
@@ -3392,6 +3439,7 @@ proc ::deken::search::dekenserver::search {term} {
             unset url
         }
     }
+
     # all the search URLs
     set urls {}
     if { ${::deken::search::dekenserver::use_url_primary} } {
@@ -3570,7 +3618,14 @@ proc ::deken::search::dekenserver::search_server {term dekenurl} {
     set contents [::http::data ${token}]
     ::http::cleanup ${token}
 
-    return [split ${contents} "\n"]
+    set results {}
+    foreach line [split ${contents} "\n"] {
+        if {[llength [split ${line} "\t"]] > 1} {
+            lappend results $line
+        }
+    }
+
+    return $results
 }
 
 proc ::deken::search::dekenserver::contextmenu {widget theX theY pkgname URL} {


### PR DESCRIPTION
https://github.com/pure-data/deken/commit/0f5db96db8150cf584119efd03e0b5b42049b017

- fix compatibility with TclTLS-1.8 and TclTLS-2.0 (we do want people to use `https://` when possible)
  Closes: https://github.com/pure-data/deken/issues/317
- emit a warning when downgrading `https://` to `http://`
- properly set "User Agent" when performing the check whether `https://` is usable
- handle relative redirects
- basic validity check on search-results
- make `add-to-searchpath` popup translatable
- normalize package versions (`_` in version strings becomes `~`, so the sorting matches the web interface)
- improve Tcl-9.x compatibility