### PR TITLE
disallow zero-channel signals

### DIFF
--- a/src/d_ugen.c
+++ b/src/d_ugen.c
@@ -530,7 +530,9 @@ t_signal *signal_new(int length, int nchans, t_float sr, t_sample *scalarptr)
     int allocsize = 0;
     t_signal *ret, **whichlist;
     if (sr < 1)
-        bug("signal_new");
+        bug("signal_new: 'sr' cannot be less than 1");
+    if (nchans < 1)
+        bug("signal_new: 'nchans' cannot be less than 1");
     if (length && !scalarptr)
     {
             /* figure out which free list to use, depending on size of vector */
@@ -613,7 +615,15 @@ void signal_setborrowed(t_signal *sig, t_signal *sig2)
 void signal_setmultiout(t_signal **sig, int nchans)
 {
     int overlap = (*sig)->s_overlap;
-    *sig = signal_new((*sig)->s_length, nchans, (*sig)->s_sr, 0);
+    if (nchans > 0)
+        *sig = signal_new((*sig)->s_length, nchans, (*sig)->s_sr, 0);
+    else
+    {
+            /* replace with empty single-channel signal */
+        bug("signal_setmultiout: 'nchans' cannot be less than 1");
+        *sig = signal_new((*sig)->s_length, 1, (*sig)->s_sr, 0);
+        dsp_add_zero((*sig)->s_vec, (*sig)->s_length);
+    }
     (*sig)->s_overlap = overlap;
 }
 

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -533,9 +533,9 @@ EXTERN const t_parentwidgetbehavior *pd_getparentwidget(t_pd *x);
     deal with multichannel inputs.  In this case the channel counts of
     the inputs might not match; it's up to the dsp method to figure out what
     to do.  Also, the output signal vectors aren't allocated.  The output
-    channel counts have to be specified by the object at DSP time.  If
-    the object can't put itself on the DSP chain it then has to create
-    outputs anyway and arrange to zero them.
+    channel counts have to be specified by the object at DSP time with the
+    signal_setmultiout() function.  If the object can't put itself on the DSP
+    chain it then has to create outputs anyway and arrange to zero them.
 
     By default, if a tilde object's inputs are unconnected, Pd fills them
     in by adding scalar-to-vector conversions to the DSP chain as needed before
@@ -729,6 +729,10 @@ typedef t_int *(*t_perfroutine)(t_int *args);
 
 EXTERN t_signal *signal_new(int length, int nchans, t_float sr,
     t_sample *scalarptr);
+    /* a multichannel class (see CLASS_MULTICHANNEL) must call this function
+    on every output to replace the dummy signal with a real signal with the
+    appropriate channel count. NOTE: 'nchans' cannot be less than one, i.e.
+    empty signals are not allowed! */
 EXTERN void signal_setmultiout(t_signal **sig, int nchans);
 
 EXTERN t_int *plus_perform(t_int *args);


### PR DESCRIPTION
Some externals might accidentally (or willingly) create output signals with zero channels. However, many objects, both built-in and external, assume that signals always have at least one channel.

This PR explicitly disallows zero-channel signals and prevents external authors from creating them: if `nchans` is less than 1, `signal_setmultiout()` prints an error message and creates an empty single-channel signal instead.

I've also documented this requirement in `m_pd.h`.

See also the discussion in https://github.com/pure-data/pure-data/issues/2954