### PR TITLE
Unbind "#A" when a canvas is freed

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -758,6 +758,8 @@ static void canvas_unbind(t_canvas *x)
 {
     if (strcmp(x->gl_name->s_name, "Pd"))
         pd_unbind(&x->gl_pd, canvas_makebindsym(x->gl_name));
+    if (pd_isbound(&x->gl_pd, gensym("#A")))
+        pd_unbind(&x->gl_pd, gensym("#A"));
 }
 
 void canvas_reflecttitle(t_canvas *x)

--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -157,6 +157,21 @@ void pd_bind(t_pd *x, t_symbol *s)
     else s->s_thing = x;
 }
 
+int pd_isbound(t_pd *x, t_symbol *s)
+{
+    if (s->s_thing == x)
+        return (1);
+    else if (s->s_thing && *s->s_thing == bindlist_class)
+    {
+        t_bindlist *b = (t_bindlist *)s->s_thing;
+        t_bindelem *e;
+        for (e = b->b_list; e; e = e->e_next)
+            if (e->e_who == x)
+                return (1);
+    }
+    return (0);
+}
+
 void pd_unbind(t_pd *x, t_symbol *s)
 {
 #ifdef VST_CLEANSER

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -443,6 +443,7 @@ EXTERN t_pd *pd_new(t_class *cls);
 EXTERN void pd_free(t_pd *x);
 EXTERN void pd_bind(t_pd *x, t_symbol *s);
 EXTERN void pd_unbind(t_pd *x, t_symbol *s);
+EXTERN int pd_isbound(t_pd *x, t_symbol *s);
 EXTERN t_pd *pd_findbyclass(t_symbol *s, const t_class *c);
 EXTERN t_pd *pd_findbyclassname(t_symbol *s, const t_symbol *classname);
 EXTERN void pd_pushsym(t_pd *x);


### PR DESCRIPTION
This PR fixes a bug where freeing a canvas leaves the symbol `#A` pointing at freed memory.

`canvas_popabstraction()` binds every new abstraction to `#A` and nothing ever unbinds it, so once the canvas is freed the binding dangles. The next `garray_free()` or `textbuf_free()` walks it, since both run `while ((x2 = pd_findbyclass(gensym("#A"), ...))) pd_unbind(x2, gensym("#A"));`, and `pd_findbyclass()` dereferences `*e->e_who`.

Steps to reproduce:

`myabs.pd` is an abstraction containing only an inlet wired to an outlet. `repro.pd` has an empty subpatch `holder`, a subpatch `arrays` containing an array, and a `loadbang` firing one message box:

```
; pd-holder obj 20 20 myabs ; pd-holder clear ; pd-arrays clear ; pd quit
```

[pd-A-binding-repro.zip](https://github.com/user-attachments/files/31077819/pd-A-binding-repro.zip)

Run it headless against a build made with `-fsanitize=address`:

```
$ pd -nogui -noaudio -nomidi -path . repro.pd
==28588==ERROR: AddressSanitizer: heap-use-after-free
    #0 pd_findbyclass  m_pd.c:206
    #1 garray_free     g_array.c:618
```

In an ordinary build the read is silent, so it tends to surface later as an unrelated crash.

The fix is to drop the `#A` binding in `canvas_unbind()`, alongside the canvas's own bind symbol:

- `canvas_unbind()` unbinds `#A` when the canvas is bound to it
- adds `pd_isbound()`, since bindlists are private to `m_pd.c` and callers cannot otherwise unbind conditionally

closes #2777
closes #2079

