### PR TITLE
stable (already merged) development branch

### DIFF
--- a/gtk/canvas.c
+++ b/gtk/canvas.c
@@ -856,6 +856,14 @@ static void editmenu_edit(GtkApplicationWindow *win, void *unused,
     snprintf(cmd, 80, "%s editmode %d;\n", x->c_tag, x->c_editmode);
     socket_send(cmd);
 }
+static void editmenu_selectall(GtkApplicationWindow *win, void *unused,
+    gpointer *data)
+{
+    t_canvas *x = (t_canvas *)data;
+    char cmd[80];
+    snprintf(cmd, 80, "%s selectall;\n", x->c_tag);
+    socket_send(cmd);
+}
 
 static void putmenu_obj(GtkApplicationWindow *win, void *zz, gpointer *data)
     { winmenu_simpleitem(win, data, "obj"); }
@@ -977,6 +985,7 @@ t_canvas *gfx_canvas_new(const char *tag,
     gfx_canvas_addaction(x, win, "zcopy", G_CALLBACK(editmenu_copy));
     gfx_canvas_addaction(x, win, "zpaste", G_CALLBACK(editmenu_paste));
     gfx_canvas_addaction(x, win, "zduplicate", G_CALLBACK(editmenu_dup));
+    gfx_canvas_addaction(x, win, "zselectall", G_CALLBACK(editmenu_selectall));
     gfx_canvas_addaction(x, win, "zedit", G_CALLBACK(editmenu_edit));
 
         /* -------------- put menu ---------------- */
@@ -1001,4 +1010,3 @@ t_canvas *gfx_canvas_new(const char *tag,
 
     return (x);
 }
-

--- a/gtk/canvas.c
+++ b/gtk/canvas.c
@@ -870,7 +870,7 @@ static void putmenu_text(GtkApplicationWindow *win, void *zz, gpointer *data)
 static void putmenu_bng(GtkApplicationWindow *win, void *zz, gpointer *data)
     { winmenu_simpleitem(win, data, "bng"); }
 static void putmenu_tgl(GtkApplicationWindow *win, void *zz, gpointer *data)
-    { winmenu_simpleitem(win, data, "tgl"); }
+    { winmenu_simpleitem(win, data, "toggle"); }
 static void putmenu_n2(GtkApplicationWindow *win, void *zz, gpointer *data)
     { winmenu_simpleitem(win, data, "numbox"); }
 static void putmenu_vsl(GtkApplicationWindow *win, void *zz, gpointer *data)

--- a/gtk/canvas.c
+++ b/gtk/canvas.c
@@ -853,7 +853,7 @@ static void editmenu_edit(GtkApplicationWindow *win, void *unused,
     t_canvas *x = (t_canvas *)data;
     x->c_editmode = !x->c_editmode;
     char cmd[80];
-    snprintf(cmd, 80, "%s editmode %d\n", x->c_tag, x->c_editmode);
+    snprintf(cmd, 80, "%s editmode %d;\n", x->c_tag, x->c_editmode);
     socket_send(cmd);
 }
 

--- a/gtk/pdgtk.c
+++ b/gtk/pdgtk.c
@@ -233,7 +233,7 @@ static void pdgtk_startup(GtkApplication *app, gpointer user_data)
 
     section = g_menu_new();
     pdgtk_menuitem(app, section, _("Bang"), "win.zputbang", ACCELKEY "B");
-    pdgtk_menuitem(app, section, _("Toggle"), "win.zputtgl", ACCELKEY "B");
+    pdgtk_menuitem(app, section, _("Toggle"), "win.zputtgl", ACCELKEY "T");
     pdgtk_menuitem(app, section, _("Number2"), "win.zputn2", ACCELKEY "N");
     pdgtk_menuitem(app, section, _("Vslider"), "win.zputvsl", ACCELKEY "V");
     pdgtk_menuitem(app, section, _("Hslider"), "win.zputhsl", ACCELKEY "J");

--- a/gtk/pdgtk.c
+++ b/gtk/pdgtk.c
@@ -210,6 +210,7 @@ static void pdgtk_startup(GtkApplication *app, gpointer user_data)
     pdgtk_menuitem(app, section, _("Paste"), "win.zpaste", ACCELKEY "v");
     pdgtk_menuitem(app, section, _("Duplicate"), "win.zduplicate",
         ACCELKEY "d");
+    pdgtk_menuitem(app, section, _("Select All"), "win.zselectall", ACCELKEY "a");
     pdgtk_menuitem(app, section, _("Edit"), "win.zedit", ACCELKEY "e");
     g_menu_append_section(editmenu, 0, G_MENU_MODEL(section));
     g_object_unref(section);

--- a/gtk/tclparser.c
+++ b/gtk/tclparser.c
@@ -338,13 +338,13 @@ static int cmd_pdtk_canvas_do_create_rect(ClientData cdata, Tcl_Interp *interp,
 static int cmd_pdtk_canvas_create_rect(ClientData cdata, Tcl_Interp *interp,
     int objc, Tcl_Obj *const objv[])
 {
-    cmd_pdtk_canvas_do_create_rect(cdata, interp, objc, objv, 0);
+    return cmd_pdtk_canvas_do_create_rect(cdata, interp, objc, objv, 0);
 }
 
 static int cmd_pdtk_canvas_create_oval(ClientData cdata, Tcl_Interp *interp,
     int objc, Tcl_Obj *const objv[])
 {
-    cmd_pdtk_canvas_do_create_rect(cdata, interp, objc, objv, 1);
+    return cmd_pdtk_canvas_do_create_rect(cdata, interp, objc, objv, 1);
 }
 
  /* cmd_pdtk_canvas_move <canvas> <tag> <dx> <dy> */

--- a/gtk/tclparser.c
+++ b/gtk/tclparser.c
@@ -622,6 +622,42 @@ static int cmd_clipboard(ClientData cdata, Tcl_Interp *interp,
     return (TCL_OK);
 }
 
+static void do_logpost(const char*tag, int level, const char*msg) {
+    (void)tag;
+    (void)level;
+    fprintf(stderr, "%s", msg);
+}
+
+static int cmd_logpost(ClientData cdata, Tcl_Interp *interp,
+    int objc, Tcl_Obj *const objv[])
+{
+    if(objc == 4)
+    {
+        const char*obj = Tcl_GetString(objv[1]);
+        double level;
+        const char*msg = Tcl_GetString(objv[3]);
+        Tcl_GetDouble(interp, Tcl_GetString(objv[2]), &level);
+        do_logpost(obj, (int)level, msg);
+    } else {
+        return (TCL_ERROR);
+    }
+    return (TCL_OK);
+}
+
+static int cmd_post(ClientData cdata, Tcl_Interp *interp,
+    int objc, Tcl_Obj *const objv[])
+{
+   if(objc == 2)
+    {
+        const char*obj = "";
+        int level = 2;
+        const char*msg = Tcl_GetString(objv[1]);
+        do_logpost(obj, (int)level, msg);
+    } else {
+        return (TCL_ERROR);
+    }
+    return (TCL_OK);
+}
 
 typedef int (*t_tcl_creatorfn)(ClientData cdata, Tcl_Interp *interp,
     int objc, Tcl_Obj *const objv[]);
@@ -653,6 +689,8 @@ static t_tcl_entry tcl_knowncommands[] = {
     {"pdtk_text_editing", cmd_pdtk_text_editing},
     {"pdtk_text_select", cmd_pdtk_text_select},
     {"pdtk_clipboard_set", cmd_clipboard},
+    {"::pdwindow::logpost", cmd_logpost},
+    {"::pdwindow::post", cmd_post},
     {"set", 0},
 };
 

--- a/gtk/tclparser.c
+++ b/gtk/tclparser.c
@@ -616,11 +616,8 @@ static int cmd_clipboard(ClientData cdata, Tcl_Interp *interp,
     char *tag;
     Tcl_HashEntry *hash;
     double start = 0, end = 0;
-    if (objc == 2 && !strcmp(Tcl_GetString(objv[1]), "clear"))
-        ;  /* nothing to do - since 'append' always follows 'clear', we
-            just set the clipboard in 'append'. */
-    else if (objc == 3 && !strcmp(Tcl_GetString(objv[1]), "append"))
-        pdgtk_setclipboard(Tcl_GetString(objv[2]));
+    if (objc == 2)
+        pdgtk_setclipboard(Tcl_GetString(objv[1]));
     else return (TCL_ERROR);
     return (TCL_OK);
 }
@@ -655,7 +652,7 @@ static t_tcl_entry tcl_knowncommands[] = {
     {"pdtk_watchdog", cmd_pdtk_watchdog},
     {"pdtk_text_editing", cmd_pdtk_text_editing},
     {"pdtk_text_select", cmd_pdtk_text_select},
-    {"clipboard", cmd_clipboard},
+    {"pdtk_clipboard_set", cmd_clipboard},
     {"set", 0},
 };
 

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -528,8 +528,7 @@ static void *binbuf_toclipboard(t_binbuf *b)
     char *copytext;
     int copytextsize;
     binbuf_gettext(b, &copytext, &copytextsize);
-    pdgui_vmess("clipboard", "r", "clear");
-    pdgui_vmess("clipboard", "rp",  "append", copytextsize, copytext);
+    pdgui_vmess("pdtk_clipboard_set", "p", copytextsize, copytext);
     freebytes(copytext, copytextsize);
 }
 

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -357,7 +357,7 @@ proc ::pd_bindings::window_focusin {mytoplevel} {
     if {[winfo exists .font]} {wm transient .font $mytoplevel}
     # if we regain focus from another app, make sure to editmode cursor is right
     if {$::editmode($mytoplevel)} {
-        $mytoplevel configure -cursor hand2
+        $mytoplevel configure -cursor ${::cursor_editmode_nothing}
     }
 }
 

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -349,10 +349,13 @@ proc ::pd_bindings::window_focusin {mytoplevel} {
     set ::focused_window $mytoplevel
     ::pd_menucommands::set_filenewdir $mytoplevel
     ::dialog_font::update_font_dialog $mytoplevel
-    if {$mytoplevel eq ".pdwindow"} {
-        ::pd_menus::configure_for_pdwindow
-    } else {
-        ::pd_menus::configure_for_canvas $mytoplevel
+    switch -exact -- [winfo class ${mytoplevel}] {
+        "PdWindow" {
+            ::pd_menus::configure_for_pdwindow
+        }
+        "PatchWindow" {
+            ::pd_menus::configure_for_canvas $mytoplevel
+        }
     }
     if {[winfo exists .font]} {wm transient .font $mytoplevel}
     # if we regain focus from another app, make sure to editmode cursor is right

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -355,6 +355,10 @@ proc ::pd_bindings::window_focusin {mytoplevel} {
         }
         "PatchWindow" {
             ::pd_menus::configure_for_canvas $mytoplevel
+            set c [tkcanvas_name ${mytoplevel}]
+            if {[winfo exists ${c}]} {
+                focus ${c}
+            }
         }
     }
     if {[winfo exists .font]} {wm transient .font $mytoplevel}

--- a/tcl/pdtk_text.tcl
+++ b/tcl/pdtk_text.tcl
@@ -37,12 +37,35 @@ proc pdtk_text_set {tkcanvas tag text} {
     $tkcanvas itemconfig $tag -text [::pdtk_text::unescape $text]
 }
 
+
+# send "pastetext" messages to send a properly escaped (UTF-8 encoded)
+# text to the patch.
+# follow the text with a terminating "-2" at which point the patch carries
+# out the paste.
+proc ::pdtk_text::pasteutf8chars {w buf} {
+    set command "$w pastechars"
+    pdsend "${command} -1"
+    set maxlen [expr 75 - [string length $command] - 1]
+    set chars {}
+    for {set i 0} {$i < [expr [string length $buf] - 1]} {incr i 1} {
+        scan [string index $buf $i] %c keynum
+        lappend chars ${keynum}
+        if { [string length ${chars}] > 75 } {
+            pdsend "$command ${chars}"
+            set chars {}
+        }
+    }
+    if [llength $chars] {
+        pdsend "${command} ${chars}"
+    }
+    pdsend "$w pastechars -2"
+}
+
 # paste into an existing text box by literally "typing" the contents of the
 # clipboard, i.e. send the contents one character at a time via 'pd key'
 proc pdtk_pastetext {tkcanvas} {
-    if { [catch {set buf [clipboard get]}] } {
-        # no selection... do nothing
-    } else {
+    set buf [::pdtk_clipboard_get]
+    if { ${buf} ne {} }  {
         # turn unicode-encoded stuff (\u...) into unicode characters
         # 'unescape' needs a trailing space...
         set buf [::pdtk_text::unescape "${buf} " ]
@@ -54,29 +77,41 @@ proc pdtk_pastetext {tkcanvas} {
     }
 }
 
-# send "pastetext" messages to send the clipboard contents to the patch.
-# follow the text with a terminating "-2" at which point the patch carries
-# out the paste.
+# fetch the clipboard and send it to the patch
 proc pdtk_pasteany {tkcanvas} {
-    if { [catch {set buf [clipboard get]}] } {
-        # no selection... do nothing
-    } else {
-        # turn unicode-encoded stuff (\u...) into unicode characters
-        # 'unescape' needs a trailing space...
-        set buf [::pdtk_text::unescape "${buf} " ]
-        pdsend "[winfo toplevel $tkcanvas] pastechars -1"
-        set command "[winfo toplevel $tkcanvas] pastechars"
-        for {set i 0} {$i < [expr [string length $buf] - 1]} {incr i 1} {
-            scan [string index $buf $i] %c keynum
-            set command [concat $command " " $keynum]
-            if { [string length $command] > 75 } {
-                pdsend $command
-                set command "[winfo toplevel $tkcanvas] pastechars"
-            }
-        }
-        pdsend $command
+    set buf [::pdtk_clipboard_get]
+    if { ${buf} ne {} }  {
+        # the clipboard is unicode-encoded; we need the raw utf-8 bytes
+        set utf8buf [encoding convertto utf-8 ${buf}]
+        ::pdtk_text::pasteutf8chars [winfo toplevel $tkcanvas] ${utf8buf}
     }
-    pdsend "[winfo toplevel $tkcanvas] pastechars -2"
+}
+
+## receive a text from Pd and put it into the clipboard
+proc pdtk_clipboard_set {text} {
+    set escaped [::pdtk_text::unescape ${text}]
+    clipboard clear
+    clipboard append $escaped
+}
+## get the current text in the clipboard
+proc pdtk_clipboard_get {} {
+    # 1st try to get the text as an UTF-8 string
+    set buf {}
+
+    if { ${buf} eq {} } {
+        catch {
+            set buf [clipboard get -type UTF8_STRING]
+        }
+    }
+    # if that failed (e.g. on Windows),
+    # try to get the text as an ordinary string
+    if { ${buf} eq {} } {
+        catch {
+            set buf [clipboard get]
+        }
+    }
+
+    return ${buf}
 }
 
 # select all of the text in an existing text box


### PR DESCRIPTION
(just merged, and here it is again)

this is the permanent branch `develop` that only gets curated, small, no-brainer changes that can be easily merged into master at any time.
(as a general rule-of-thumb we shouldn't include changes to `.pd`-files (including help patches!) in this PR, as it is just too easy to end up with unresolvable file conflicts.).

it supersedes https://github.com/pure-data/pure-data/pull/2949

---

## GUI
- Closes: https://github.com/pure-data/pure-data/issues/2959 
- Closes: https://github.com/pure-data/pure-data/issues/2967

## GTK
- adjust clipboard setting to changes introduced by #2959
  in GTK land, the data sent to/from the clipboard still needs to be normalized to match the binbuf text representation:
  - unescape backslashes received from the Pd-core
  - properly escape when sending to Pd-core
- fix `Toggle` keyboard shortcut
- fix "Edit mode" keyboard shortcut
- add `Select all` keyboard shortcut
- implement `::pdwindow::post` and `::pdwindow::logpost` (currently it only prints to stdout)
- fix error when calling `pdtk_canvas_create_rect`  (by properly returning the Tcl error code)