### PR TITLE
vline~: don't drop pending segments while DSP is running

### DIFF
--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -334,17 +334,15 @@ static void vline_tilde_float(t_vline *x, t_float f)
         where lots of them get added while DSP isn't running. We add 0.1 msec
         to the stop time limit just in case of truncation error in case it and
         the current time are logically, but not numerically, equal. */
-    while (x->x_list && timenow > x->x_list->s_stoptime + 0.1)
+    while (!pd_getdspstate() && x->x_list &&
+        timenow > x->x_list->s_stoptime + 0.1)
     {
         t_vseg *was = x->x_list;
         x->x_list = x->x_list->s_next;
         freebytes(was, sizeof(*was));
-        if (!x->x_list)
-        {
-            vline_tilde_stop(x);
-            return;
-        }
     }
+    if (!x->x_list)
+        x->x_tail = 0;
         /* negative delay input means stop and jump immediately to new value */
     if (inlet2 < 0)
     {

--- a/src/d_ctl.c
+++ b/src/d_ctl.c
@@ -334,16 +334,16 @@ static void vline_tilde_float(t_vline *x, t_float f)
         where lots of them get added while DSP isn't running. We add 0.1 msec
         to the stop time limit just in case of truncation error in case it and
         the current time are logically, but not numerically, equal. */
-    while (x->x_list && timenow > x->x_list->s_stoptime + 0.1)
+    if (!pd_getdspstate())
     {
-        t_vseg *was = x->x_list;
-        x->x_list = x->x_list->s_next;
-        freebytes(was, sizeof(*was));
-        if (!x->x_list)
+        while (x->x_list && timenow > x->x_list->s_stoptime + 0.1)
         {
-            vline_tilde_stop(x);
-            return;
+            t_vseg *was = x->x_list;
+            x->x_list = x->x_list->s_next;
+            freebytes(was, sizeof(*was));
         }
+        if (!x->x_list)
+            x->x_tail = 0;
     }
         /* negative delay input means stop and jump immediately to new value */
     if (inlet2 < 0)


### PR DESCRIPTION
don't drop pending segments while DSP is running. if the list empties, clear the tail but still insert new segment.

* closes #2956 

i do wonder if the additional DSP check might cause other issues - but afaict, segments accumulating during dsp:off were the reason for the original fix, so it should probably be fine.

