### PR TITLE
Remove old zoom code

### DIFF
--- a/src/g_all_guis.c
+++ b/src/g_all_guis.c
@@ -491,7 +491,6 @@ void iemgui_receive(void *x, t_iemgui *iemgui, t_symbol *s)
 }
 
 static void iemgui_dolabelpos(t_object*obj, t_iemgui*iemgui) {
-    int zoom = glist_getzoom(iemgui->x_glist);
     int x0 = text_xpix((t_object *)obj, iemgui->x_glist);
     int y0 = text_ypix((t_object *)obj, iemgui->x_glist);
     int dx = iemgui->x_ldx, dy = iemgui->x_ldy;
@@ -504,7 +503,7 @@ static void iemgui_dolabelpos(t_object*obj, t_iemgui*iemgui) {
     }
     pdgui_vmess(0, "crs ii",
         glist_getcanvas(iemgui->x_glist), "coords", tag,
-        x0  + dx*zoom, y0 + dy*zoom);
+        x0  + dx, y0 + dy);
 }
 void iemgui_dolabel(void *x, t_iemgui *iemgui, t_symbol *s, int senditup)
 {
@@ -548,7 +547,6 @@ void iemgui_label_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av
 
 void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    int zoom = glist_getzoom(iemgui->x_glist);
     int f = (int)atom_getfloatarg(0, ac, av);
 
     if(f == 1) strcpy(iemgui->x_font, "helvetica");
@@ -569,7 +567,7 @@ void iemgui_label_font(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *a
         t_atom fontatoms[3];
         sprintf(tag, "%p_LABEL", x);
         SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-        SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+        SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
         SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
         pdgui_vmess(0, "crs rA",
             glist_getcanvas(iemgui->x_glist), "itemconfigure", tag,
@@ -602,7 +600,6 @@ void iemgui_size(void *x, t_iemgui *iemgui)
 
 void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    int zoom = glist_getzoom(iemgui->x_glist);
     iemgui->x_obj.te_xpix += (int)atom_getfloatarg(0, ac, av);
     iemgui->x_obj.te_ypix += (int)atom_getfloatarg(1, ac, av);
     iemgui_do_drawmove(x, iemgui);
@@ -610,7 +607,6 @@ void iemgui_delta(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 
 void iemgui_pos(void *x, t_iemgui *iemgui, t_symbol *s, int ac, t_atom *av)
 {
-    int zoom = glist_getzoom(iemgui->x_glist);
     iemgui->x_obj.te_xpix = (int)atom_getfloatarg(0, ac, av);
     iemgui->x_obj.te_ypix = (int)atom_getfloatarg(1, ac, av);
     iemgui_do_drawmove(x, iemgui);
@@ -686,29 +682,13 @@ void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol**bflcol)
     iemgui_all_col2save(iemgui, bflcol);
 }
 
-    /* inform GUIs that glist's zoom is about to change.  The glist will
-    take care of x,y locations but we have to adjust width and height */
+    /* do nothing, kept for compatibility */
 void iemgui_zoom(t_iemgui *iemgui, t_floatarg zoom)
-{
-    int oldzoom = iemgui->x_glist->gl_zoom;
-    if (oldzoom < 1)
-        oldzoom = 1;
-    iemgui->x_w = (int)(iemgui->x_w)/oldzoom*(int)zoom;
-    iemgui->x_h = (int)(iemgui->x_h)/oldzoom*(int)zoom;
-}
+{}
 
-    /* when creating a new GUI from menu onto a zoomed canvas, pretend to
-    change the canvas's zoom so we'll get properly sized */
+    /* do nothing, kept for compatibility */
 void iemgui_newzoom(t_iemgui *iemgui)
-{
-    if (iemgui->x_glist->gl_zoom != 1)
-    {
-        int newzoom = iemgui->x_glist->gl_zoom;
-        iemgui->x_glist->gl_zoom = 1;
-        iemgui_zoom(iemgui, (t_floatarg)newzoom);
-        iemgui->x_glist->gl_zoom = newzoom;
-    }
-}
+{}
 
 void iemgui_properties(t_iemgui *iemgui, t_symbol **srl)
 {
@@ -852,7 +832,6 @@ int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv)
 void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
 {
 #define SETCOLOR(a, col) do {char color[MAXPDSTRING]; pd_snprintf(color, MAXPDSTRING-1, "#%06x", 0xffffff & col); color[MAXPDSTRING-1] = 0; SETSYMBOL(a, gensym(color));} while(0)
-    t_float zoom = iemgui->x_glist->gl_zoom;
     t_symbol *srl[3];
     int for_undo = 1;
     int i;
@@ -873,8 +852,8 @@ void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv)
         iemgui_properties(iemgui, srl);
     }
 
-    if(argc> 0) SETFLOAT (argv+ 0, iemgui->x_w/zoom);
-    if(argc> 1) SETFLOAT (argv+ 1, iemgui->x_h/zoom);
+    if(argc> 0) SETFLOAT (argv+ 0, iemgui->x_w);
+    if(argc> 1) SETFLOAT (argv+ 1, iemgui->x_h);
     if(argc> 5) SETFLOAT (argv+ 5, iemgui->x_isa.x_loadinit);
     if(argc> 6) SETFLOAT (argv+ 6, 1); /* num */
     if(argc> 7) SETSYMBOL(argv+ 7, srl[0]);
@@ -938,10 +917,8 @@ static void iemgui_draw_update(t_iemgui*x, t_glist*glist) {;}
 static void iemgui_draw_select(t_iemgui*x, t_glist*glist) {;}
 static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
 {
-    const int zoom = x->x_glist->gl_zoom;
     int xpos = text_xpix(&x->x_obj, glist);
     int ypos = text_ypix(&x->x_obj, glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     t_canvas *canvas = glist_getcanvas(glist);
     char tag_object[128], tag_label[128], tag[128];
     char *tags[] = {tag_object, tag};
@@ -957,7 +934,7 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
     if(!x->x_fsf.x_snd_able) {
         pdgui_vmess(0, "crr iiii rk rk rS",
             canvas, "create", "rectangle",
-            xpos, ypos + x->x_h + zoom - ioh, xpos + iow, ypos + x->x_h,
+            xpos, ypos + x->x_h + 1 - IEM_GUI_IOHEIGHT, xpos + IOWIDTH, ypos + x->x_h,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
@@ -971,7 +948,7 @@ static void iemgui_draw_iolets(t_iemgui*x, t_glist*glist, int old_snd_rcv_flags)
     if(!x->x_fsf.x_rcv_able) {
         pdgui_vmess(0, "crr iiii rk rk rS",
             canvas, "create", "rectangle",
-            xpos, ypos, xpos + iow, ypos - zoom + ioh,
+            xpos, ypos, xpos + IOWIDTH, ypos - 1 + IEM_GUI_IOHEIGHT,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);

--- a/src/g_all_guis.h
+++ b/src/g_all_guis.h
@@ -110,7 +110,7 @@ typedef enum {
     vertical = 1,
 } t_iem_orientation;
 
-#define IEMGUI_ZOOM(x) ((x)->x_gui.x_glist->gl_zoom)
+#define IEMGUI_ZOOM(x) (1)
 
 typedef struct _iem_fstyle_flags
 {
@@ -300,8 +300,8 @@ EXTERN void iemgui_select(t_gobj *z, t_glist *glist, int selected);
 EXTERN void iemgui_delete(t_gobj *z, t_glist *glist);
 EXTERN void iemgui_vis(t_gobj *z, t_glist *glist, int vis);
 EXTERN void iemgui_save(t_iemgui *iemgui, t_symbol **srl, t_symbol **bflcol);
-EXTERN void iemgui_zoom(t_iemgui *iemgui, t_floatarg zoom);
-EXTERN void iemgui_newzoom(t_iemgui *iemgui);
+PD_DEPRECATED EXTERN void iemgui_zoom(t_iemgui *iemgui, t_floatarg zoom); /* useless: zoom is now handled by GUI side */
+PD_DEPRECATED EXTERN void iemgui_newzoom(t_iemgui *iemgui); /* useless: zoom is now handled by GUI side */
 EXTERN void iemgui_properties(t_iemgui *iemgui, t_symbol **srl);
 EXTERN int iemgui_dialog(t_iemgui *iemgui, t_symbol **srl, int argc, t_atom *argv);
 EXTERN void iemgui_setdialogatoms(t_iemgui *iemgui, int argc, t_atom*argv);

--- a/src/g_array.c
+++ b/src/g_array.c
@@ -1350,11 +1350,6 @@ void garray_resize(t_garray *x, t_floatarg f)
     garray_resize_long(x, f);
 }
 
-/* ignore zoom for now */
-static void garray_zoom(t_garray *x, t_floatarg f)
-{
-}
-
 static void garray_edit(t_garray *x, t_floatarg f)
 {
     x->x_edit = (int)f;
@@ -1412,8 +1407,6 @@ void g_array_setup(void)
         A_SYMBOL, A_NULL);
     class_addmethod(garray_class, (t_method)garray_doresize, gensym("resize"),
         A_FLOAT, A_NULL);
-    class_addmethod(garray_class, (t_method)garray_zoom, gensym("zoom"),
-        A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_edit, gensym("edit"),
         A_FLOAT, 0);
     class_addmethod(garray_class, (t_method)garray_print, gensym("print"),

--- a/src/g_bang.c
+++ b/src/g_bang.c
@@ -21,27 +21,23 @@ static t_class *bng_class;
 #define bng_draw_io 0
 static void bng_draw_config(t_bng* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_iemgui *iemgui = &x->x_gui;
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
-    int inset = zoom;
+    int iow = IOWIDTH, ioh = IEM_GUI_IOHEIGHT;
+    int inset = 1;
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
-    /* pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol,
-        "-outline", THISGUI->i_foregroundcolor); */
     pdgui_vmess(0, "rcs ikk", "pdtk_canvas_configure_rect", canvas, tag,
-        IEMGUI_ZOOM(x), x->x_gui.x_bcol, THISGUI->i_foregroundcolor);
+        1, x->x_gui.x_bcol, THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_BUT", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
@@ -51,12 +47,12 @@ static void bng_draw_config(t_bng* x, t_glist* glist)
             the only goddam oval in the whole of Pd so let's not add a
             whole other TK proc for it */
     pdgui_vmess(0, "rcs ik k", "pdtk_canvas_configure_rect", canvas, tag,
-        IEMGUI_ZOOM(x), (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
+        1, (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
         THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+        xpos + x->x_gui.x_ldx, ypos + x->x_gui.x_ldy);
 
     if (x->x_gui.x_fsf.x_selected)
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
@@ -106,10 +102,10 @@ static void bng_draw_select(t_bng* x, t_glist* glist)
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "rcs ikk", "pdtk_canvas_configure_rect", canvas, tag,
-        IEMGUI_ZOOM(x), x->x_gui.x_bcol, col);
+        1, x->x_gui.x_bcol, col);
     sprintf(tag, "%p_BUT", x);
     pdgui_vmess(0, "rcs ik k", "pdtk_canvas_configure_rect", canvas, tag,
-        IEMGUI_ZOOM(x), (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
+        1, (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
         col);
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
@@ -123,7 +119,7 @@ static void bng_draw_update(t_bng *x, t_glist *glist)
         sprintf(tag, "%p_BUT", x);
         pdgui_vmess(0, "rcs ik k", "pdtk_canvas_configure_rect",
             glist_getcanvas(glist), tag,
-            IEMGUI_ZOOM(x), (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
+            1, (x->x_flashed ? x->x_gui.x_fcol : x->x_gui.x_bcol),
             THISGUI->i_foregroundcolor);
     }
 }
@@ -150,7 +146,7 @@ static void bng_save(t_gobj *z, t_binbuf *b)
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiiiisssiiiisss", gensym("#X"),gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("bng"), x->x_gui.x_w/IEMGUI_ZOOM(x),
+                gensym("bng"), x->x_gui.x_w,
                 x->x_flashtime_hold, x->x_flashtime_break,
                 iem_symargstoint(&x->x_gui.x_isa),
                 srl[0], srl[1], srl[2],
@@ -182,7 +178,7 @@ static void bng_properties(t_gobj *z, t_glist *owner)
 {
     t_bng *x = (t_bng *)z;
     iemgui_new_dialog(x, &x->x_gui, "bang",
-                      x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+                      x->x_gui.x_w, IEM_GUI_MINSIZE,
                       0, 0,
                       x->x_flashtime_break, x->x_flashtime_hold,
                       2,
@@ -264,7 +260,7 @@ static void bng_dialog(t_bng *x, t_symbol *s, int argc, t_atom *argv)
                             argc, argv);
 
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
-    x->x_gui.x_w = iemgui_clip_size(a) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
     bng_check_minmax(x, ftbreak, fthold);
 
@@ -310,7 +306,7 @@ static void bng_loadbang(t_bng *x, t_floatarg action)
 
 static void bng_size(t_bng *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -416,7 +412,6 @@ static void *bng_new(t_symbol *s, int argc, t_atom *argv)
     x->x_lastflashtime = clock_getlogicaltime();
     x->x_clock_hld = clock_new(x, (t_method)bng_tick_hld);
     x->x_clock_lck = clock_new(x, (t_method)bng_tick_lck);
-    iemgui_newzoom(&x->x_gui);
     outlet_new(&x->x_gui.x_obj, &s_bang);
     return (x);
 }
@@ -466,8 +461,6 @@ void g_bang_setup(void)
         gensym("label_font"), A_GIMME, 0);
     class_addmethod(bng_class, (t_method)bng_init,
         gensym("init"), A_FLOAT, 0);
-    class_addmethod(bng_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
     bng_widgetbehavior.w_getrectfn = bng_getrect;
     bng_widgetbehavior.w_displacefn = iemgui_displace;
     bng_widgetbehavior.w_selectfn = iemgui_select;

--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -415,17 +415,15 @@ t_outconnect *linetraverser_next(t_linetraverser *t)
     {
         int inplus = (t->tr_nin == 1 ? 1 : t->tr_nin - 1);
         int outplus = (t->tr_nout == 1 ? 1 : t->tr_nout - 1);
-        int iow = IOWIDTH * t->tr_x->gl_zoom;
-        int iom = IOMIDDLE * t->tr_x->gl_zoom;
         gobj_getrect(&t->tr_ob2->ob_g, t->tr_x,
             &t->tr_x21, &t->tr_y21, &t->tr_x22, &t->tr_y22);
         t->tr_lx1 = t->tr_x11 +
-            ((t->tr_x12 - t->tr_x11 - iow) * t->tr_outno) /
-                outplus + iom;
+            ((t->tr_x12 - t->tr_x11 - IOWIDTH) * t->tr_outno) /
+                outplus + IOMIDDLE;
         t->tr_ly1 = t->tr_y12;
         t->tr_lx2 = t->tr_x21 +
-            ((t->tr_x22 - t->tr_x21 - iow) * t->tr_inno)/inplus +
-                iom;
+            ((t->tr_x22 - t->tr_x21 - IOWIDTH) * t->tr_inno)/inplus +
+                IOMIDDLE;
         t->tr_ly2 = t->tr_y21;
     }
     else
@@ -541,7 +539,7 @@ t_canvas *canvas_new(void *dummy, t_symbol *sel, int argc, t_atom *argv)
     x->gl_willvis = vis;
     x->gl_edit = !UNTITLED_STRNCMP(x->gl_name->s_name);
     x->gl_font = sys_nearestfontsize(font);
-    x->gl_zoom = (owner ? owner->gl_zoom : 1);
+    x->gl_zoom = 1;
     pd_pushsym(&x->gl_pd);
     return(x);
 }
@@ -550,9 +548,6 @@ void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
 static void canvas_coords(t_glist *x, t_symbol *s, int argc, t_atom *argv)
 {
-          /* FIXME: this is a stopgap - we should always be using
-            glist_getzoom() and never gl_zoom in rest of code. */
-    x->gl_zoom = glist_getzoom(x);
     x->gl_x1 = atom_getfloatarg(0, argc, argv);
     x->gl_y1 = atom_getfloatarg(1, argc, argv);
     x->gl_x2 = atom_getfloatarg(2, argc, argv);
@@ -618,9 +613,9 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
          */
         int xpos = (int)px1, ypos = (int)py2;
         glist_getnextxy(g, &xpos, &ypos);
-        px1 = (t_float)xpos / g->gl_zoom;
+        px1 = (t_float)xpos;
         px2 = px1 + GLIST_DEFGRAPHWIDTH;
-        py1 = (t_float)ypos / g->gl_zoom;
+        py1 = (t_float)ypos;
         py2 = py1 + GLIST_DEFGRAPHHEIGHT;
     }
 
@@ -638,7 +633,7 @@ t_glist *glist_addglist(t_glist *g, t_symbol *sym,
     x->gl_pixheight = py2 - py1;
     x->gl_font =  (canvas_getcurrent() ?
         canvas_getcurrent()->gl_font : sys_defaultfont);
-    x->gl_zoom = g->gl_zoom;
+    x->gl_zoom = 1;
     x->gl_screenx1 = GLIST_DEFCANVASXLOC;
     x->gl_screeny1 = GLIST_DEFCANVASYLOC;
     x->gl_screenx2 = GLIST_DEFCANVASWIDTH;
@@ -726,13 +721,13 @@ static void canvas_dosetbounds(t_canvas *x, int x1, int y1, int x2, int y2)
             parent. */
         t_float diff = x->gl_y1 - x->gl_y2;
         t_gobj *y;
-        x->gl_y1 = heightwas * diff/x->gl_zoom;
+        x->gl_y1 = heightwas * diff;
         x->gl_y2 = x->gl_y1 - diff;
             /* and move text objects accordingly; they should stick
             to the bottom, not the top. */
         for (y = x->gl_list; y; y = y->g_next)
             if (pd_checkobject(&y->g_pd))
-                gobj_displace(y, x, 0, heightchange/x->gl_zoom);
+                gobj_displace(y, x, 0, heightchange);
         canvas_redraw(x);
     }
 }
@@ -833,13 +828,13 @@ void canvas_drawredrect(t_canvas *x, int doit)
 {
     if (doit)
     {
-        int x1 = x->gl_zoom * x->gl_xmargin,
-            x2 = x1 + x->gl_zoom * x->gl_pixwidth,
-            y1 = x->gl_zoom * x->gl_ymargin,
-            y2 = y1 + x->gl_zoom * x->gl_pixheight;
+        int x1 = x->gl_xmargin,
+            x2 = x1 + x->gl_pixwidth,
+            y1 = x->gl_ymargin,
+            y2 = y1 + x->gl_pixheight;
         pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiiiiiii",
             glist_getcanvas(x), "GOP", "-",
-            0, x->gl_zoom, THISGUI->i_gopcolor,
+            0, 1, THISGUI->i_gopcolor,
             x1,y1, x1,y2, x2,y2, x2,y1, x1,y1);
     }
     else
@@ -967,20 +962,17 @@ int glist_getfont(t_glist *x)
 
 int glist_getzoom(t_glist *x)
 {
-    t_glist *gl2 = x;
-    while (!glist_istoplevel(gl2) && gl2->gl_owner)
-        gl2 = gl2->gl_owner;
-    return (gl2->gl_zoom);
+    return 1;
 }
 
 int glist_fontwidth(t_glist *x)
 {
-    return (sys_zoomfontwidth(glist_getfont(x), glist_getzoom(x), 0));
+    return (sys_zoomfontwidth(glist_getfont(x), 1, 0));
 }
 
 int glist_fontheight(t_glist *x)
 {
-    return (sys_zoomfontheight(glist_getfont(x), glist_getzoom(x), 0));
+    return (sys_zoomfontheight(glist_getfont(x), 1, 0));
 }
 
 void canvas_free(t_canvas *x)
@@ -1030,8 +1022,8 @@ static void canvas_drawlines(t_canvas *x)
             sprintf(tag, "l%p", oc);
             pdgui_vmess("pdtk_canvas_create_patchcord", "crrr ik iiii",
                 glist_getcanvas(x), tag, "-", "-",
-                    (outlet_getsymbol(t.tr_outlet) == &s_signal ? 2:1)
-                        * x->gl_zoom, THISGUI->i_foregroundcolor,
+                    outlet_getsymbol(t.tr_outlet) == &s_signal ? 2 : 1,
+                    THISGUI->i_foregroundcolor,
                     t.tr_lx1, t.tr_ly1, t.tr_lx2, t.tr_ly2);
         }
     }
@@ -1098,16 +1090,8 @@ void canvas_deletelinesforio(t_canvas *x, t_text *text,
     }
 }
 
-typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
-
 static void canvas_pop(t_canvas *x, t_floatarg fvis)
 {
-    if (glist_istoplevel(x) && (sys_zoom_open == 2))
-    {
-        t_zoomfn zoommethod = (t_zoomfn)zgetfn(&x->gl_pd, gensym("zoom"));
-        if (zoommethod)
-            (*zoommethod)(&x->gl_pd, (t_floatarg)2);
-    }
     if (fvis != 0)
         canvas_vis(x, 1);
     pd_popsym(&x->gl_pd);

--- a/src/g_canvas.h
+++ b/src/g_canvas.h
@@ -212,7 +212,7 @@ struct _glist
     unsigned int gl_hidetext:1;     /* hide object-name + args when GO */
     unsigned int gl_private:1;      /* private flag used in x_scalar.c */
     unsigned int gl_isclone:1;      /* exists as part of a clone object */
-    int gl_zoom;                    /* zoom factor (integer zoom-in only) */
+    int gl_zoom;                    /* old-style zoom factor, kept for compatibility; always 1*/
     void *gl_privatedata;           /* private data */
 };
 
@@ -430,7 +430,7 @@ EXTERN t_glist *glist_findgraph(t_glist *x);
 EXTERN int glist_getfont(t_glist *x);
 EXTERN int glist_fontwidth(t_glist *x);
 EXTERN int glist_fontheight(t_glist *x);
-EXTERN int glist_getzoom(t_glist *x);
+EXTERN int glist_getzoom(t_glist *x);  /* useless: zoom is now handled by GUI side */
 EXTERN void glist_sort(t_glist *canvas);
 EXTERN void glist_read(t_glist *x, t_symbol *filename, t_symbol *format);
 EXTERN void glist_mergefile(t_glist *x, t_symbol *filename, t_symbol *format);

--- a/src/g_editor.c
+++ b/src/g_editor.c
@@ -53,7 +53,6 @@ static t_binbuf *canvas_docopy(t_canvas *x);
 static void canvas_dopaste(t_canvas *x, t_binbuf *b);
 static void canvas_clearline(t_canvas *x);
 static t_glist *glist_finddirty(t_glist *x);
-static void canvas_zoom(t_canvas *x, t_floatarg zoom);
 static void canvas_displaceselection(t_canvas *x, int dx, int dy);
 void canvas_setgraph(t_glist *x, int flag, int nogoprect);
 
@@ -773,8 +772,8 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
             {
                 gobj_getrect(y, x, &x1, &y1, &x2, &y2);
                 buf->u_vec[i].e_index = indx;
-                buf->u_vec[i].e_xpix = x1 / x->gl_zoom;
-                buf->u_vec[i].e_ypix = y1 / x->gl_zoom;
+                buf->u_vec[i].e_xpix = x1;
+                buf->u_vec[i].e_ypix = y1;
                 i++;
             }
     }
@@ -784,8 +783,8 @@ void *canvas_undo_set_move(t_canvas *x, int selected)
         {
             gobj_getrect(y, x, &x1, &y1, &x2, &y2);
             buf->u_vec[indx].e_index = indx;
-            buf->u_vec[indx].e_xpix = x1 / x->gl_zoom;
-            buf->u_vec[indx].e_ypix = y1 / x->gl_zoom;
+            buf->u_vec[indx].e_xpix = x1;
+            buf->u_vec[indx].e_ypix = y1;
         }
     }
     THISED->canvas_undo_already_set_move = 1;
@@ -801,8 +800,8 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
         int i;
         for (i = 0; i < buf->u_n; i++)
         {
-            float newx = (buf->u_vec[i].e_xpix)*x->gl_zoom;
-            float newy = (buf->u_vec[i].e_ypix)*x->gl_zoom;
+            float newx = buf->u_vec[i].e_xpix;
+            float newy = buf->u_vec[i].e_ypix;
             t_gobj*y = glist_nth(x, buf->u_vec[i].e_index);
             if (y)
             {
@@ -813,10 +812,10 @@ int canvas_undo_move(t_canvas *x, void *z, int action)
                 glist_select(x, y);
                 gobj_getrect(y, x, &x1, &y1, &x2, &y2);
                 THISED->canvas_undo_already_set_move = 1;
-                canvas_displaceselection(x, (newx - x1)/(x->gl_zoom), (newy - y1)/(x->gl_zoom));
+                canvas_displaceselection(x, newx - x1, newy - y1);
                 THISED->canvas_undo_already_set_move = doing;
-                buf->u_vec[i].e_xpix = x1/x->gl_zoom;
-                buf->u_vec[i].e_ypix = y1/x->gl_zoom;
+                buf->u_vec[i].e_xpix = x1;
+                buf->u_vec[i].e_ypix = y1;
                 if (cl == vinlet_class) resortin = 1;
                 else if (cl == voutlet_class) resortout = 1;
             }
@@ -1994,10 +1993,6 @@ void canvas_vis(t_canvas *x, t_floatarg f)
             x->gl_havewindow = 0;
             if (glist_isvisible(gl2) && !gl2->gl_isdeleting)
             {
-                    /* make sure zoom level matches parent, ie. after an open
-                       subpatch's zoom level was changed before being closed */
-                if(x->gl_zoom != gl2->gl_zoom)
-                    canvas_zoom(x, gl2->gl_zoom);
                 gobj_vis(&x->gl_gobj, gl2, 1);
             }
         }
@@ -2505,13 +2500,12 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
         else
         {
             int noutlet;
-            int out_activeminh = OHEIGHT  * x->gl_zoom;
             int out_activemaxh = (y2 - y1) / 8;
-            int out_activeheight = OHEIGHT * 2 * x->gl_zoom;
+            int out_activeheight = OHEIGHT * 2;
             if (out_activeheight > out_activemaxh)
                 out_activeheight = out_activemaxh;
-            if (out_activeheight < out_activeminh)
-                out_activeheight = out_activeminh;
+            if (out_activeheight < OHEIGHT)
+                out_activeheight = OHEIGHT;
                 /* resize? only for "true" text boxes or canvases */
             if (xpix >= x2-4 && ypix < y2-4 && hitobj &&
                     (hitobj->te_pd->c_wb == &text_widgetbehavior ||
@@ -2540,16 +2534,15 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
                 ypix >= y2 - out_activeheight)
             {
                 int width = x2 - x1;
-                int iow = IOWIDTH * x->gl_zoom;
-                int nout1 = (noutlet > 1 ? noutlet - 1 : 1);
+                int nout1 = noutlet > 1 ? noutlet - 1 : 1;
                 int closest = ((xpix-x1) * (nout1) + width/2)/width;
                 if (noutlet == 1 || closest < noutlet)
                 {
                     if (doit)
                     {
                         int issignal = obj_issignaloutlet(hitobj, closest);
-                        int xout = x1 + IOMIDDLE * x->gl_zoom +
-                            (noutlet > 1 ? ((width - iow) * closest)/nout1 : 0);
+                        int xout = x1 + IOMIDDLE +
+                            (noutlet > 1 ? ((width - IOWIDTH) * closest)/nout1 : 0);
                         x->gl_editor->e_onmotion = MA_CONNECT;
                         x->gl_editor->e_xwas = xout;
                         x->gl_editor->e_ywas = y2;
@@ -2557,7 +2550,7 @@ static void canvas_doclick(t_canvas *x, int xpix, int ypix, int mod, int doit)
                             "ci", x, 0);
                         pdgui_vmess("pdtk_canvas_create_line", "crr iik iiii",
                             x, "x", "-",
-                            0, x->gl_zoom, THISGUI->i_foregroundcolor,
+                            0, 1, THISGUI->i_foregroundcolor,
                             (int)x->gl_editor->e_xwas,
                             (int)x->gl_editor->e_ywas,
                             xpix, ypix);
@@ -2767,8 +2760,6 @@ static int tryconnect(t_canvas*x, t_object *src, int nout,
         t_outconnect *oc = obj_connect(src, nout, sink, nin);
         if(oc)
         {
-            int iow = IOWIDTH * x->gl_zoom;
-            int iom = IOMIDDLE * x->gl_zoom;
             int x11=0, x12=0, x21=0, x22=0;
             int y11=0, y12=0, y21=0, y22=0;
             int noutlets1, ninlets, lx1, ly1, lx2, ly2;
@@ -2781,18 +2772,18 @@ static int tryconnect(t_canvas*x, t_object *src, int nout,
             ninlets = obj_ninlets(sink);
 
             lx1 = x11 + (noutlets1 > 1 ?
-                             ((x12-x11-iow) * nout)/(noutlets1-1) : 0)
-                + iom;
+                             ((x12 - x11 - IOWIDTH) * nout) / (noutlets1-1) : 0)
+                + IOMIDDLE;
             ly1 = y12;
             lx2 = x21 + (ninlets > 1 ?
-                             ((x22-x21-iow) * nin)/(ninlets-1) : 0)
-                + iom;
+                             ((x22 - x21 - IOWIDTH) * nin) / (ninlets-1) : 0)
+                + IOMIDDLE;
             ly2 = y21;
             pdgui_vmess("pdtk_canvas_create_patchcord", "crrr i k iiii",
                 glist_getcanvas(x), tag, "-", "-",
-                    (obj_issignaloutlet(src, nout) ? 2 : 1) * x->gl_zoom,
-                        THISGUI->i_foregroundcolor,
-                            lx1,ly1, lx2,ly2);
+                    obj_issignaloutlet(src, nout) ? 2 : 1,
+                    THISGUI->i_foregroundcolor,
+                    lx1,ly1, lx2,ly2);
             canvas_undo_add(x, UNDO_CONNECT, "connect",
                 canvas_undo_set_connect(x,
                     canvas_getindex(x, &src->ob_g), nout,
@@ -3344,14 +3335,12 @@ static void delay_move(t_gobj *client, t_glist *glist)
     if (x->gl_editor->e_waittodrag &&
         incx > -2 && incx < 2 && incy > -2 && incy < 2)
             return;
-    incx /= x->gl_zoom;
-    incy /= x->gl_zoom;
 
     x->gl_editor->e_waittodrag = 0;
     if (incx || incy)
         canvas_displaceselection(x, incx, incy);
-    x->gl_editor->e_xwas += incx * x->gl_zoom;
-    x->gl_editor->e_ywas += incy * x->gl_zoom;
+    x->gl_editor->e_xwas += incx;
+    x->gl_editor->e_ywas += incy;
 }
 
     /* defined in g_text.c: */
@@ -3594,41 +3583,6 @@ static void canvas_menufont(t_canvas *x)
         "i", x2->gl_font);
 }
 
-typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
-
-/* LATER, if canvas is flipped, re-scroll to preserve bottom left corner */
-static void canvas_zoom(t_canvas *x, t_floatarg zoom)
-{
-    if (zoom != x->gl_zoom && (zoom == 1 || zoom == 2))
-    {
-        t_gobj *g;
-        t_object *obj;
-        for (g = x->gl_list; g; g = g->g_next)
-            if ((obj = pd_checkobject(&g->g_pd)))
-        {
-                /* pass zoom message on to all objects, except canvases
-                   that aren't GOP */
-            t_gotfn zoommethod;
-            if ((zoommethod = zgetfn(&obj->te_pd, gensym("zoom"))) &&
-                (!(pd_class(&obj->te_pd) == canvas_class) ||
-                 (((t_glist *)obj)->gl_isgraph)))
-                    (*(t_zoomfn)zoommethod)(&obj->te_pd, zoom);
-        }
-        x->gl_zoom = zoom;
-        if (x->gl_havewindow)
-        {
-            if (!glist_isgraph(x) && (x->gl_y2 < x->gl_y1))
-            {
-                /* if it's flipped so that y grows upward,
-                fix so that zero is bottom edge as in canvas_dosetbounds() */
-                t_float diff = x->gl_y1 - x->gl_y2;
-                x->gl_y1 = (x->gl_screeny2 - x->gl_screeny1) * diff/x->gl_zoom;
-                x->gl_y2 = x->gl_y1 - diff;
-            }
-            canvas_redraw(x);
-        }
-    }
-}
 
     /* function to support searching */
 static int atoms_match(int inargc, t_atom *inargv, int searchargc,
@@ -4689,7 +4643,7 @@ void canvas_connect(t_canvas *x, t_floatarg fwhoout, t_floatarg foutno,
         sprintf(tag, "l%p", oc);
         pdgui_vmess("pdtk_canvas_create_patchcord", "crrr i k iiii",
             glist_getcanvas(x), tag, "-", "-",
-                (obj_issignaloutlet(objsrc, outno) ? 2 : 1) * x->gl_zoom,
+                obj_issignaloutlet(objsrc, outno) ? 2 : 1,
                     THISGUI->i_foregroundcolor,
                         0, 0, 0, 0);
         canvas_fixlinesfor(x, objsrc);
@@ -5219,8 +5173,8 @@ void canvas_addscalar(t_canvas *x, t_symbol *templatesym)
     /* initially place the scalar under mouse; cf.  canvas_howputnew() : */
 
     glist_getnextxy(x, &xpix, &ypix);
-    xpix = xpix/x->gl_zoom - 3;
-    ypix = ypix/x->gl_zoom - 3;
+    xpix -= 3;
+    ypix -= 3;
     template_setfloat(scalartemplate, gensym("x"), sc->sc_vec,
         glist_pixelstox(x, (float)xpix), 0);
     template_setfloat(scalartemplate, gensym("y"), sc->sc_vec,
@@ -5289,8 +5243,6 @@ void g_editor_setup(void)
         gensym("menufont"), A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_font,
         gensym("font"), A_FLOAT, A_FLOAT, A_FLOAT, A_NULL);
-    class_addmethod(canvas_class, (t_method)canvas_zoom,
-        gensym("zoom"), A_FLOAT, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_find,
         gensym("find"), A_SYMBOL, A_FLOAT, A_NULL);
     class_addmethod(canvas_class, (t_method)canvas_find_again,

--- a/src/g_editor_extras.c
+++ b/src/g_editor_extras.c
@@ -246,7 +246,6 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
 
     int _x; /* dummy variable */
     gobj_getrect(o2g(obj), x, &_x, &_x, &_x, &posY);
-    posY /= x->gl_zoom;
     posY += yoffset;
 
         /* if the object is a [trigger], we just insert new outlets */
@@ -285,7 +284,7 @@ static int triggerize_fanout(t_glist*x, t_object*obj)
             {
                 if((obj == t.tr_ob) && nout == t.tr_outno)
                 {
-                    posX = (t.tr_lx1 / t.tr_x->gl_zoom) - (IOMIDDLE - xoffset);
+                    posX = t.tr_lx1 - (IOMIDDLE - xoffset);
                     break;
                 }
             }
@@ -374,22 +373,16 @@ static int triggerize_line(t_glist*x, t_triggerize_return*tr)
 
                 /* get real x-position of the outlet */
             gobj_getrect(src, x, &posLeft, &_x, &posRight, &posSourceY);
-            posLeft /= x->gl_zoom;
-            posRight /= x->gl_zoom;
-            posSourceY /= x->gl_zoom;
             nio = obj_noutlets(obj1);
             posSource = posLeft + (posRight - posLeft - IOWIDTH) * src_out / ((nio==1)?1.:(nio-1.));
 
                 /* get real x-position of the inlet */
             gobj_getrect(dst, x, &posLeft, &posSinkY, &posRight, &_x);
-            posLeft /= x->gl_zoom;
-            posRight /= x->gl_zoom;
-            posSinkY /= x->gl_zoom;
             nio = obj_ninlets(obj2);
             posSink = posLeft + (posRight - posLeft - IOWIDTH) * dst_in / ((nio==1)?1.:(nio-1.));
 
-		/* get height of the box that will be inserted */
-            boxHeight = glist_fontheight(x) / x->gl_zoom + 4; /* ATOM_BMARGIN = 4 */
+                /* get height of the box that will be inserted */
+            boxHeight = glist_fontheight(x) + 4; /* ATOM_BMARGIN = 4 */
 
             posx = (posSource + posSink) * 0.5;
             posy = (posSourceY + posSinkY - boxHeight) >> 1;

--- a/src/g_graph.c
+++ b/src/g_graph.c
@@ -563,7 +563,7 @@ t_float glist_pixelstox(t_glist *x, t_float xpix)
         coordinates (x1, etc.) specifies the coordinate range
         of a one-pixel square at top left of the window. */
     if (!x->gl_isgraph)
-        return (x->gl_x1 + (x->gl_x2 - x->gl_x1) * xpix / x->gl_zoom);
+        return x->gl_x1 + (x->gl_x2 - x->gl_x1) * xpix;
 
         /* if we're a graph when shown on parent, but own our own
         window right now, our range in our coordinates (x1, etc.) is spread
@@ -588,7 +588,7 @@ t_float glist_pixelstox(t_glist *x, t_float xpix)
 t_float glist_pixelstoy(t_glist *x, t_float ypix)
 {
     if (!x->gl_isgraph)
-        return (x->gl_y1 + (x->gl_y2 - x->gl_y1) * ypix / x->gl_zoom);
+        return x->gl_y1 + (x->gl_y2 - x->gl_y1) * ypix;
     else if (x->gl_isgraph && x->gl_havewindow)
         return (x->gl_y1 + (x->gl_y2 - x->gl_y1) *
                 (ypix) / (x->gl_screeny2 - x->gl_screeny1));
@@ -607,7 +607,7 @@ t_float glist_pixelstoy(t_glist *x, t_float ypix)
 t_float glist_xtopixels(t_glist *x, t_float xval)
 {
     if (!x->gl_isgraph)
-        return (((xval - x->gl_x1) * x->gl_zoom) / (x->gl_x2 - x->gl_x1));
+        return (xval - x->gl_x1) / (x->gl_x2 - x->gl_x1);
     else if (x->gl_isgraph && x->gl_havewindow)
         return (x->gl_screenx2 - x->gl_screenx1) *
             (xval - x->gl_x1) / (x->gl_x2 - x->gl_x1);
@@ -624,7 +624,7 @@ t_float glist_xtopixels(t_glist *x, t_float xval)
 t_float glist_ytopixels(t_glist *x, t_float yval)
 {
     if (!x->gl_isgraph)
-        return (((yval - x->gl_y1) * x->gl_zoom) / (x->gl_y2 - x->gl_y1));
+        return (yval - x->gl_y1) / (x->gl_y2 - x->gl_y1);
     else if (x->gl_isgraph && x->gl_havewindow)
         return (x->gl_screeny2 - x->gl_screeny1) *
                 (yval - x->gl_y1) / (x->gl_y2 - x->gl_y1);
@@ -660,10 +660,10 @@ t_float glist_dpixtody(t_glist *x, t_float dypix)
 int text_xpix(t_text *x, t_glist *glist)
 {
     if (glist->gl_havewindow || !glist->gl_isgraph)
-        return (x->te_xpix * glist->gl_zoom);
+        return x->te_xpix;
     else if (glist->gl_goprect)
         return (glist_xtopixels(glist, glist->gl_x1) +
-            glist->gl_zoom * (x->te_xpix - glist->gl_xmargin));
+            x->te_xpix - glist->gl_xmargin);
     else return (glist_xtopixels(glist,
             glist->gl_x1 + (glist->gl_x2 - glist->gl_x1) *
                 x->te_xpix / (glist->gl_screenx2 - glist->gl_screenx1)));
@@ -672,10 +672,10 @@ int text_xpix(t_text *x, t_glist *glist)
 int text_ypix(t_text *x, t_glist *glist)
 {
     if (glist->gl_havewindow || !glist->gl_isgraph)
-        return (x->te_ypix * glist->gl_zoom);
+        return x->te_ypix;
     else if (glist->gl_goprect)
         return (glist_ytopixels(glist, glist->gl_y1) +
-            glist->gl_zoom * (x->te_ypix - glist->gl_ymargin));
+            x->te_ypix - glist->gl_ymargin);
     else return (glist_ytopixels(glist,
             glist->gl_y1 + (glist->gl_y2 - glist->gl_y1) *
                 x->te_ypix / (glist->gl_screeny2 - glist->gl_screeny1)));
@@ -735,7 +735,7 @@ static void _graph_create_line4(t_glist *x, int x1, int y1, int x2, int y2,
 {
     pdgui_vmess("pdtk_canvas_create_line", "crr iik iiii",
         glist_getcanvas(x->gl_owner), tag, "-",
-        0, glist_getzoom(x), THISGUI->i_foregroundcolor,
+        0, 1, THISGUI->i_foregroundcolor,
         x1, y1,  x2, y2);
 }
 
@@ -798,7 +798,7 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             pdgui_vmess(0, "crr iiiiiiiiii ri rr rr rS",
                 glist_getcanvas(x->gl_owner), "create", "polygon",
                 x1,y1, x1,y2, x2,y2, x2,y1, x1,y1,
-                "-width", glist_getzoom(x),
+                "-width", 1,
                 "-fill", "#c0c0c0",
                 "-joinstyle", "miter",
                 "-tags", 2, tags2);
@@ -818,13 +818,13 @@ static void graph_vis(t_gobj *gr, t_glist *parent_glist, int vis)
             (x->gl_ylabelx > 0.5*(x->gl_x1 + x->gl_x2) ? "w" : "e");
         char *xlabelanchor =
             (x->gl_xlabely > 0.5*(x->gl_y1 + x->gl_y2) ? "s" : "n");
-        int fs = sys_hostfontsize(glist_getfont(x), glist_getzoom(x));
+        int fs = sys_hostfontsize(glist_getfont(x), 1);
         const char *tags3[] = {tag, "label", "graph" };
 
             /* draw a rectangle around the graph */
         pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiiiiiii",
             glist_getcanvas(x->gl_owner), tag, "-",
-            0, glist_getzoom(x), THISGUI->i_foregroundcolor,
+            0, 1, THISGUI->i_foregroundcolor,
             x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1);
             /* if there's just one "garray" in the graph, write its name
                 along the top */
@@ -933,8 +933,8 @@ static void graph_graphrect(t_gobj *z, t_glist *glist,
     int x1 = text_xpix(&x->gl_obj, glist);
     int y1 = text_ypix(&x->gl_obj, glist);
     int x2, y2;
-    x2 = x1 + x->gl_zoom * x->gl_pixwidth;
-    y2 = y1 + x->gl_zoom * x->gl_pixheight;
+    x2 = x1 + x->gl_pixwidth;
+    y2 = y1 + x->gl_pixheight;
 
     *xp1 = x1;
     *yp1 = y1;

--- a/src/g_mycanvas.c
+++ b/src/g_mycanvas.c
@@ -29,40 +29,38 @@ static t_class *my_canvas_class;
 static void my_canvas_draw_io(t_my_canvas* x, t_glist* glist, int mode) { ; }
 static void my_canvas_draw_config(t_my_canvas* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int offset = (zoom > 1 ? zoom : 0); /* keep zoomed border inside visible area */
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(x->x_gui.x_font));
-    SETFLOAT (fontatoms+1, -(x->x_gui.x_fontsize)*zoom);
+    SETFLOAT (fontatoms+1, -x->x_gui.x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     sprintf(tag, "%p_RECT", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        xpos, ypos, xpos + x->x_vis_w * zoom, ypos + x->x_vis_h * zoom);
+        xpos, ypos, xpos + x->x_vis_w, ypos + x->x_vis_h);
     pdgui_vmess(0, "crs rk rk", canvas, "itemconfigure", tag,
         "-fill", x->x_gui.x_bcol,
         "-outline", x->x_gui.x_bcol);
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        xpos + offset, ypos + offset,
-        xpos + offset + x->x_gui.x_w, ypos + offset + x->x_gui.x_h);
+        xpos, ypos,
+        xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
 
     if(x->x_gui.x_fsf.x_selected)
         pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", THISGUI->i_selectcolor);
+            "-width", 1, "-outline", THISGUI->i_selectcolor);
     else
         pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-outline", x->x_gui.x_bcol);
+            "-width", 1, "-outline", x->x_gui.x_bcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xpos + x->x_gui.x_ldx * zoom,
-        ypos + x->x_gui.x_ldy * zoom);
+        xpos + x->x_gui.x_ldx,
+        ypos + x->x_gui.x_ldy);
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
         "-fill", x->x_gui.x_lcol);
@@ -125,7 +123,7 @@ static void my_canvas_save(t_gobj *z, t_binbuf *b)
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiiisssiiiissi", gensym("#X"),gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("cnv"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_vis_w, x->x_vis_h,
+                gensym("cnv"), x->x_gui.x_w, x->x_vis_w, x->x_vis_h,
                 srl[0], srl[1], srl[2], x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
                 bflcol[0], bflcol[2], iem_symargstoint(&x->x_gui.x_isa));
@@ -136,7 +134,7 @@ static void my_canvas_properties(t_gobj *z, t_glist *owner)
 {
     t_my_canvas *x = (t_my_canvas *)z;
     iemgui_new_dialog(x, &x->x_gui, "cnv",
-                      x->x_gui.x_w/IEMGUI_ZOOM(x), 1,
+                      x->x_gui.x_w, 1,
                       0, 0,
                       x->x_vis_w, x->x_vis_h,
                       0,
@@ -149,8 +147,8 @@ static void my_canvas_get_pos(t_my_canvas *x)
 {
     if(x->x_gui.x_fsf.x_snd_able && x->x_gui.x_snd->s_thing)
     {
-        x->x_at[0].a_w.w_float = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist)/IEMGUI_ZOOM(x);
-        x->x_at[1].a_w.w_float = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist)/IEMGUI_ZOOM(x);
+        x->x_at[0].a_w.w_float = text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist);
+        x->x_at[1].a_w.w_float = text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist);
         pd_list(x->x_gui.x_snd->s_thing, &s_list, 2, x->x_at);
     }
 }
@@ -178,7 +176,7 @@ static void my_canvas_dialog(t_my_canvas *x, t_symbol *s, int argc, t_atom *argv
     x->x_gui.x_isa.x_loadinit = 0;
     if(a < 1)
         a = 1;
-    x->x_gui.x_w = a * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = a;
     x->x_gui.x_h = x->x_gui.x_w;
     if(w < 1)
         w = 1;
@@ -195,7 +193,7 @@ static void my_canvas_size(t_my_canvas *x, t_symbol *s, int ac, t_atom *av)
 
     if(i < 1)
         i = 1;
-    x->x_gui.x_w = i*IEMGUI_ZOOM(x);
+    x->x_gui.x_w = i;
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -327,7 +325,6 @@ static void *my_canvas_new(t_symbol *s, int argc, t_atom *argv)
     x->x_at[0].a_type = A_FLOAT;
     x->x_at[1].a_type = A_FLOAT;
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    iemgui_newzoom(&x->x_gui);
     return (x);
 }
 
@@ -360,8 +357,6 @@ void g_mycanvas_setup(void)
         gensym("label_font"), A_GIMME, 0);
     class_addmethod(my_canvas_class, (t_method)my_canvas_get_pos,
         gensym("get_pos"), 0);
-    class_addmethod(my_canvas_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
     my_canvas_widgetbehavior.w_getrectfn  = my_canvas_getrect;
     my_canvas_widgetbehavior.w_displacefn = iemgui_displace;
     my_canvas_widgetbehavior.w_selectfn   = iemgui_select;

--- a/src/g_numbox.c
+++ b/src/g_numbox.c
@@ -118,7 +118,7 @@ static void my_numbox_calc_fontwidth(t_my_numbox *x)
         fontwidth = f;
 
     w = (int)(fontwidth * x->x_numwidth);
-    x->x_gui.x_w = (w + (x->x_gui.x_h/2)/IEMGUI_ZOOM(x) + 4) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = w + x->x_gui.x_h / 2 + 4;
 }
 
 /* gatom_float_sizelimit() from g_rtext.c */
@@ -143,21 +143,20 @@ static t_class *my_numbox_class;
 
 static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     t_iemgui *iemgui = &x->x_gui;
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int w = x->x_gui.x_w, half = x->x_gui.x_h/2;
-    int d = zoom + x->x_gui.x_h/(34*zoom);
+    int d = 1 + x->x_gui.x_h / 34;
     int corner = x->x_gui.x_h/4;
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
+    int iow = IOWIDTH, ioh = IEM_GUI_IOHEIGHT;
     char tag[128];
-    int borderwidth = zoom * (1+!!x->x_gui.x_fsf.x_change);
+    int borderwidth = 1 + !!x->x_gui.x_fsf.x_change;
 
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     unsigned int fcol = x->x_gui.x_fcol, lcol = x->x_gui.x_lcol;
@@ -188,18 +187,18 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
 
     sprintf(tag, "%p_BASE2", x);
     pdgui_vmess(0, "crs  ii ii ii ii", canvas, "coords", tag,
-        xpos + zoom, ypos + zoom,
+        xpos + 1, ypos + 1,
         xpos + half, ypos + half,
         xpos + half, ypos + half + x->x_gui.x_h%2,
-        xpos + zoom, ypos + x->x_gui.x_h - zoom);
+        xpos + 1, ypos + x->x_gui.x_h - 1);
     pdgui_vmess(0, "crs  ri rk", canvas, "itemconfigure", tag,
-        "-width", zoom,
+        "-width", 1,
         "-fill", x->x_gui.x_fcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
-        xpos + x->x_gui.x_ldx * zoom,
-        ypos + x->x_gui.x_ldy * zoom);
+        xpos + x->x_gui.x_ldx,
+        ypos + x->x_gui.x_ldy);
     pdgui_vmess(0, "crs  rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
         "-fill", lcol);
@@ -207,7 +206,7 @@ static void my_numbox_draw_config(t_my_numbox* x, t_glist* glist)
 
     sprintf(tag, "%p_NUMBER", x);
     pdgui_vmess(0, "crs  ii", canvas, "coords", tag,
-        xpos + half + 2*zoom, ypos + half + d);
+        xpos + half + 2, ypos + half + d);
     pdgui_vmess(0, "crs  rs rA rk", canvas, "itemconfigure", tag,
         "-text", x->x_buf,
         "-font", 3, fontatoms,
@@ -277,7 +276,7 @@ static void my_numbox_draw_update(t_gobj *client, t_glist *glist)
     if(glist_isvisible(glist))
     {
         t_canvas *canvas = glist_getcanvas(glist);
-        int borderwidth = IEMGUI_ZOOM(x) * (1+!!x->x_gui.x_fsf.x_change);
+        int borderwidth = 1 + !!x->x_gui.x_fsf.x_change;
         char tag[128];
         sprintf(tag, "%p_NUMBER", x);
         if(x->x_gui.x_fsf.x_change)
@@ -357,7 +356,7 @@ static void my_numbox_save(t_gobj *z, t_binbuf *b)
     }
     binbuf_addv(b, "ssiisiissiisssiiiisssfi", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("nbx"), x->x_numwidth, x->x_gui.x_h/IEMGUI_ZOOM(x),
+                gensym("nbx"), x->x_numwidth, x->x_gui.x_h,
                 _float2symbol(x->x_min), _float2symbol(x->x_max),
                 x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
                 srl[0], srl[1], srl[2],
@@ -417,7 +416,7 @@ static void my_numbox_properties(t_gobj *z, t_glist *owner)
     }
     iemgui_new_dialog(x, &x->x_gui, "nbx",
                       x->x_numwidth, MINDIGITS,
-                      x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+                      x->x_gui.x_h, IEM_GUI_MINSIZE,
                       x->x_min, x->x_max,
                       0,
                       x->x_lin0_log1, "linear", "logarithmic",
@@ -462,7 +461,7 @@ static void my_numbox_dialog(t_my_numbox *x, t_symbol *s, int argc,
     x->x_numwidth = w;
     if(h < IEM_GUI_MINSIZE)
         h = IEM_GUI_MINSIZE;
-    x->x_gui.x_h = h * IEMGUI_ZOOM(x);
+    x->x_gui.x_h = h;
     if(log_height < 10)
         log_height = 10;
     x->x_log_height = log_height;
@@ -573,7 +572,7 @@ static void my_numbox_size(t_my_numbox *x, t_symbol *s, int ac, t_atom *av)
         h = (int)atom_getfloatarg(1, ac, av);
         if(h < IEM_GUI_MINSIZE)
             h = IEM_GUI_MINSIZE;
-        x->x_gui.x_h = h * IEMGUI_ZOOM(x);
+        x->x_gui.x_h = h;
     }
     my_numbox_calc_fontwidth(x);
     iemgui_size((void *)x, &x->x_gui);
@@ -789,7 +788,6 @@ static void *my_numbox_new(t_symbol *s, int argc, t_atom *argv)
     iemgui_verify_snd_ne_rcv(&x->x_gui);
     x->x_clock_wait = clock_new(x, (t_method)my_numbox_tick_wait);
     x->x_gui.x_fsf.x_change = 0;
-    iemgui_newzoom(&x->x_gui);
     my_numbox_calc_fontwidth(x);
     outlet_new(&x->x_gui.x_obj, &s_float);
     return (x);
@@ -847,8 +845,6 @@ void g_numbox_setup(void)
         gensym("init"), A_FLOAT, 0);
     class_addmethod(my_numbox_class, (t_method)my_numbox_log_height,
         gensym("log_height"), A_FLOAT, 0);
-    class_addmethod(my_numbox_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
     my_numbox_widgetbehavior.w_getrectfn =    my_numbox_getrect;
     my_numbox_widgetbehavior.w_displacefn =   iemgui_displace;
     my_numbox_widgetbehavior.w_selectfn =     iemgui_select;

--- a/src/g_radio.c
+++ b/src/g_radio.c
@@ -38,10 +38,9 @@ PD_INLINE int clamp_radio(void*x, int num) {
  */
 static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
+    int iow = IOWIDTH, ioh = IEM_GUI_IOHEIGHT;
     t_canvas *canvas = glist_getcanvas(glist);
     char tag_object[128], tag_but[128], tag[128];
     char *tags[] = {tag_object, tag};
@@ -57,7 +56,7 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     {
         int height = x->x_gui.x_h * ((x->x_orientation == horizontal)? 1: x->x_number);
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos, ypos + height + zoom - ioh,
+            xpos, ypos + height + 1 - ioh,
             xpos + iow, ypos + height,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
@@ -73,7 +72,7 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
     {
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos, ypos,
-            xpos + iow, ypos - zoom + ioh,
+            xpos + iow, ypos - 1 + ioh,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
@@ -86,10 +85,9 @@ static void radio_draw_io(t_radio* x, t_glist* glist, int old_snd_rcv_flags)
 static void radio_draw_config(t_radio* x, t_glist* glist)
 {
     int i;
-    const int zoom = IEMGUI_ZOOM(x);
     t_iemgui *iemgui = &x->x_gui;
     t_canvas *canvas = glist_getcanvas(glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
+    int iow = IOWIDTH, ioh = IEM_GUI_IOHEIGHT;
     int xx11b = text_xpix(&x->x_gui.x_obj, glist);
     int yy11b = text_ypix(&x->x_gui.x_obj, glist);
     int d, dx = 0, dy = 0, d4;
@@ -100,7 +98,7 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     if(x->x_orientation == horizontal)
@@ -124,7 +122,7 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
         pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
             xx11, yy11, xx12, yy12);
         pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-            "-width", zoom, "-fill", x->x_gui.x_bcol,
+            "-width", 1, "-fill", x->x_gui.x_bcol,
             "-outline", THISGUI->i_foregroundcolor);
 
         sprintf(tag, "%p_BUT%d", x, i);
@@ -140,7 +138,7 @@ static void radio_draw_config(t_radio* x, t_glist* glist)
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xx11b + x->x_gui.x_ldx * zoom, yy11b + x->x_gui.x_ldy * zoom);
+        xx11b + x->x_gui.x_ldx, yy11b + x->x_gui.x_ldy);
     pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
         "-font", 3, fontatoms,
         "-fill", x->x_gui.x_lcol);
@@ -260,8 +258,8 @@ static void radio_save(t_gobj *z, t_binbuf *b)
     binbuf_addv(b, "ssiisiiiisssiiiisssf", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix,
                 (int)x->x_gui.x_obj.te_ypix,
-        gensym(objname),
-                x->x_gui.x_w/IEMGUI_ZOOM(x),
+                gensym(objname),
+                x->x_gui.x_w,
                 x->x_change, iem_symargstoint(&x->x_gui.x_isa), x->x_number,
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
@@ -287,7 +285,7 @@ static void radio_properties(t_gobj *z, t_glist *owner)
         hchange = x->x_change;
 
     iemgui_new_dialog(x, &x->x_gui, objname,
-        x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+        x->x_gui.x_w, IEM_GUI_MINSIZE,
         0, 0,
         0, 0,
         0,
@@ -318,7 +316,7 @@ static void radio_dialog(t_radio *x, t_symbol *s, int argc, t_atom *argv)
     if(chg != 0) chg = 1;
     x->x_change = chg;
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
-    x->x_gui.x_w = iemgui_clip_size(a) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
     num = clamp_radio(x, num);
     if (num != x->x_number && glist_isvisible(x->x_gui.x_glist))
@@ -555,7 +553,7 @@ static void radio_orientation(t_radio *x, t_floatarg forient)
 
 static void radio_size(t_radio *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -664,7 +662,6 @@ static void *radio_donew(t_symbol *s, int argc, t_atom *argv, int old)
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    iemgui_newzoom(&x->x_gui);
     outlet_new(&x->x_gui.x_obj, &s_list);
     return (x);
 }
@@ -723,8 +720,6 @@ void g_radio_setup(void)
         gensym("number"), A_FLOAT, 0);
     class_addmethod(radio_class, (t_method)radio_orientation,
         gensym("orientation"), A_FLOAT, 0);
-    class_addmethod(radio_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
     radio_widgetbehavior.w_getrectfn = radio_getrect;
     radio_widgetbehavior.w_displacefn = iemgui_displace;
     radio_widgetbehavior.w_selectfn = iemgui_select;

--- a/src/g_readwrite.c
+++ b/src/g_readwrite.c
@@ -730,8 +730,6 @@ static void canvas_savetemplatesto(t_canvas *x, t_binbuf *b, int wholething)
 
 /* ------ routines to save and restore canvases (patches) recursively. ----*/
 
-typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
-
     /* save to a binbuf, called recursively; cf. canvas_savetofile() which
     saves the document, and is only called on root canvases. */
 static void canvas_saveto(t_canvas *x, t_binbuf *b)

--- a/src/g_rtext.c
+++ b/src/g_rtext.c
@@ -450,9 +450,9 @@ static void rtext_formattext(t_rtext *x, int *widthp, int *heightp,
         else ncolumns = widthspec_c;
     }
     *widthp = ncolumns * fontwidth +
-        (x->x_text? (LMARGIN + RMARGIN) * glist_getzoom(x->x_glist) : 0);
+        (x->x_text? LMARGIN + RMARGIN : 0);
     *heightp = nlines * fontheight +
-        (x->x_text? (TMARGIN + BMARGIN) * glist_getzoom(x->x_glist) : 0);
+        (x->x_text? TMARGIN + BMARGIN : 0);
 }
 
 /* reduce a formatted number (in <buf>) to not exceed <maxsize> chars
@@ -551,8 +551,8 @@ static void rtext_formatatom(t_rtext *x, int *widthp, int *heightp,
         *indexp = 0;
     *selstart_b_p = x->x_selstart;
     *selend_b_p = x->x_selend;
-    *widthp += (LMARGIN + RMARGIN - 2) * glist_getzoom(x->x_glist);
-    *heightp = fontheight + (TMARGIN + BMARGIN - 1) * glist_getzoom(x->x_glist);
+    *widthp += LMARGIN + RMARGIN - 2;
+    *heightp = fontheight + TMARGIN + BMARGIN - 1;
 }
 
     /* the following routine computes line breaks and carries out
@@ -633,12 +633,6 @@ static void rtext_senditup(t_rtext *x, int action, int *widthp, int *heightp,
         const char *tags[] = {x->x_tag, "text"};
         int lmargin = (x->x_text ? LMARGIN : 0),
             tmargin = (x->x_text ? TMARGIN : 0);
-        if (glist_getzoom(x->x_glist) > 1)
-        {
-            /* zoom margins */
-            lmargin *= glist_getzoom(x->x_glist);
-            tmargin *= glist_getzoom(x->x_glist);
-        }
             /* we add an extra space to the string just in case the last
             character is an unescaped backslash ('\') which would have confused
             tcl/tk by escaping the close brace otherwise.  The GUI code

--- a/src/g_scalar.c
+++ b/src/g_scalar.c
@@ -456,16 +456,16 @@ static void scalar_displace(t_gobj *z, t_glist *glist, int dx, int dy)
         goty = 0;
     if (gotx)
         *(t_float *)(((char *)(x->sc_vec)) + xonset) +=
-            glist_dpixtodx(glist, dx * glist_getzoom(glist));
+            glist_dpixtodx(glist, dx);
     if (goty)
         *(t_float *)(((char *)(x->sc_vec)) + yonset) +=
-            glist_dpixtody(glist, dy * glist_getzoom(glist));
+            glist_dpixtody(glist, dy);
     gpointer_init(&gp);
     gpointer_setglist(&gp, glist, x);
     SETPOINTER(&at[0], &gp);
-        /* report displacement in canvas coordinates (zoom-aware) */
-    SETFLOAT(&at[1], glist_dpixtodx(glist, dx * glist_getzoom(glist)));
-    SETFLOAT(&at[2], glist_dpixtody(glist, dy * glist_getzoom(glist)));
+        /* report displacement in canvas coordinates */
+    SETFLOAT(&at[1], glist_dpixtodx(glist, dx));
+    SETFLOAT(&at[2], glist_dpixtody(glist, dy));
     template_notify(template, gensym("displace"), 3, at);
     scalar_redraw(x, glist);
 }

--- a/src/g_slider.c
+++ b/src/g_slider.c
@@ -36,11 +36,9 @@ static void slider_set(t_slider *x, t_floatarg f);
  */
 static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     int lmargin = 0, tmargin=0, bmargin = 0;
     char tag_object[128], tag_knob[128], tag[128];
     char *tags[] = {tag_object, tag};
@@ -52,10 +50,10 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
 
     if(x->x_orientation == horizontal)
     {
-        lmargin = LMARGIN * zoom;
+        lmargin = LMARGIN;
     } else {
-        tmargin = TMARGIN * zoom;
-        bmargin = BMARGIN * zoom;
+        tmargin = TMARGIN;
+        bmargin = BMARGIN;
     }
 
     sprintf(tag, "%p_OUT%d", x, 0);
@@ -63,8 +61,8 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     if(!x->x_gui.x_fsf.x_snd_able)
     {
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos - lmargin, ypos + x->x_gui.x_h + bmargin + zoom - ioh,
-            xpos - lmargin + iow, ypos + x->x_gui.x_h + bmargin,
+            xpos - lmargin, ypos + x->x_gui.x_h + bmargin + 1 - IEM_GUI_IOHEIGHT,
+            xpos - lmargin + IOWIDTH, ypos + x->x_gui.x_h + bmargin,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
@@ -79,7 +77,7 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
     {
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
             xpos - lmargin, ypos - tmargin,
-            xpos - lmargin + iow, ypos - tmargin - zoom + ioh,
+            xpos - lmargin + IOWIDTH, ypos - tmargin - 1 + IEM_GUI_IOHEIGHT,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 2, tags);
@@ -91,21 +89,20 @@ static void slider_draw_io(t_slider* x, t_glist* glist, int old_snd_rcv_flags)
 
 static void slider_knob_position(t_slider*x, t_glist *glist, int val, int *x0, int *y0, int *x1, int *y1)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     if(x->x_orientation == horizontal)
     {
         int r = xpos + val;
         *x0 = r;
-        *y0 = ypos + (zoom + 1);
+        *y0 = ypos + 2;
         *x1 = r;
-        *y1 = ypos + x->x_gui.x_h - (zoom * 2);
+        *y1 = ypos + x->x_gui.x_h - 2;
     } else {
         int r = ypos + x->x_gui.x_h - val;
-        *x0 = xpos + (zoom + 1);
+        *x0 = xpos + 2;
         *y0 = r;
-        *x1 = xpos + x->x_gui.x_w - (zoom * 2);
+        *x1 = xpos + x->x_gui.x_w - 2;
         *y1 = r;
     }
 
@@ -113,28 +110,26 @@ static void slider_knob_position(t_slider*x, t_glist *glist, int val, int *x0, i
 
 static void slider_draw_config(t_slider* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     t_iemgui *iemgui = &x->x_gui;
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
     int val = ((x->x_val + 50)/100);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     int lmargin = 0, rmargin = 0, tmargin = 0, bmargin = 0;
     int a, b, c, d;
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     if(x->x_orientation == horizontal)
     {
-        lmargin = LMARGIN * zoom;
-        rmargin = RMARGIN * zoom;
+        lmargin = LMARGIN;
+        rmargin = RMARGIN;
     } else {
-        tmargin = TMARGIN * zoom;
-        bmargin = BMARGIN * zoom;
+        tmargin = TMARGIN;
+        bmargin = BMARGIN;
     }
     slider_knob_position(x, glist, val, &a, &b, &c, &d);
 
@@ -143,7 +138,7 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
         xpos - lmargin, ypos - tmargin,
         xpos + x->x_gui.x_w + rmargin, ypos + x->x_gui.x_h + bmargin);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom,
+        "-width", 1,
         "-fill", x->x_gui.x_bcol,
         "-outline", THISGUI->i_foregroundcolor);
 
@@ -151,12 +146,12 @@ static void slider_draw_config(t_slider* x, t_glist* glist)
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         a, b, c, d);
     pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
-        "-width", 1 + 2 * zoom,
+        "-width", 3,
         "-outline", x->x_gui.x_fcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+        xpos + x->x_gui.x_ldx, ypos + x->x_gui.x_ldy);
 
     if(x->x_gui.x_fsf.x_selected)
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
@@ -212,11 +207,10 @@ static void slider_draw_update(t_gobj *client, t_glist *glist)
     int a, b, c, d;
     if (glist_isvisible(glist))
     {
-        const int zoom = IEMGUI_ZOOM(x);
         t_canvas *canvas = glist_getcanvas(glist);
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
         int ypos = text_ypix(&x->x_gui.x_obj, glist);
-        int val = ((x->x_val + 50) / 100) * zoom;
+        int val = (x->x_val + 50) / 100;
         char tag[128];
         sprintf(tag, "%p_KNOB", x);
 
@@ -233,15 +227,14 @@ static void slider_getrect(t_gobj *z, t_glist *glist,
                             int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_slider* x = (t_slider*)z;
-    int zoom = glist_getzoom(glist);
     int dx1=0, dx2=0, dy1=0, dy2=0;
     if(x->x_orientation == horizontal)
     {
-        dx1 = LMARGIN*zoom;
-        dx2 = (LMARGIN + RMARGIN)*zoom;
+        dx1 = LMARGIN;
+        dx2 = LMARGIN + RMARGIN;
     } else {
-        dy1 = TMARGIN*zoom;
-        dy2 = (TMARGIN + BMARGIN)*zoom;
+        dy1 = TMARGIN;
+        dy2 = TMARGIN + BMARGIN;
     }
 
 
@@ -262,7 +255,7 @@ static void slider_save(t_gobj *z, t_binbuf *b)
     binbuf_addv(b, "ssiisiiffiisssiiiisssii", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
                 gensym((x->x_orientation==horizontal)?"hsl":"vsl"),
-                x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_gui.x_h/IEMGUI_ZOOM(x),
+                x->x_gui.x_w, x->x_gui.x_h,
                 (t_float)x->x_min, (t_float)x->x_max,
                 x->x_lin0_log1, iem_symargstoint(&x->x_gui.x_isa),
                 srl[0], srl[1], srl[2],
@@ -275,16 +268,16 @@ static void slider_save(t_gobj *z, t_binbuf *b)
 
 static int slider_check_range(t_slider *x, int v)
 {
-    if(v < IEM_SL_MINSIZE * IEMGUI_ZOOM(x))
-        v = IEM_SL_MINSIZE * IEMGUI_ZOOM(x);
+    if(v < IEM_SL_MINSIZE)
+        v = IEM_SL_MINSIZE;
     if(x->x_val > (v * 100 - 100))
     {
         x->x_val = v * 100 - 100;
     }
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max / x->x_min) / (double)(v/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max / x->x_min) / (double)(v - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(v/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) / (double)(v - 1);
 
     return v;
 }
@@ -309,9 +302,9 @@ static void slider_check_minmax(t_slider *x, double min, double max, t_float val
     x->x_min = min;
     x->x_max = max;
     if(x->x_lin0_log1)
-        x->x_k = log(x->x_max/x->x_min) / (double)(value/IEMGUI_ZOOM(x) - 1);
+        x->x_k = log(x->x_max/x->x_min) / (double)(value - 1);
     else
-        x->x_k = (x->x_max - x->x_min) / (double)(value/IEMGUI_ZOOM(x) - 1);
+        x->x_k = (x->x_max - x->x_min) / (double)(value - 1);
 }
 
 static void slider_properties(t_gobj *z, t_glist *owner)
@@ -333,8 +326,8 @@ static void slider_properties(t_gobj *z, t_glist *owner)
 
 
     iemgui_new_dialog(x, &x->x_gui, objname,
-                      x->x_gui.x_w/IEMGUI_ZOOM(x), minWidth,
-                      x->x_gui.x_h/IEMGUI_ZOOM(x), minHeight,
+                      x->x_gui.x_w, minWidth,
+                      x->x_gui.x_h, minHeight,
                       x->x_min, x->x_max,
                       0,
                       x->x_lin0_log1, "linear", "logarithmic",
@@ -347,7 +340,7 @@ static t_float slider_getfval(t_slider *x)
     t_float fval;
     int rounded_val = (x->x_gui.x_fsf.x_finemoved) ? x->x_val : (x->x_val / 100) * 100;
 
-    /* if rcv==snd, don't round the value to prevent bad dragging when zoomed-in */
+    /* if rcv==snd, don't round the value to prevent bad dragging */
     if(x->x_gui.x_fsf.x_snd_able && (x->x_gui.x_snd == x->x_gui.x_rcv))
         rounded_val = x->x_val;
 
@@ -383,11 +376,6 @@ static void slider_dialog(t_slider *x, t_symbol *s, int argc, t_atom *argv)
     int sr_flags;
     t_atom undo[18];
 
-    if(x->x_orientation == horizontal)
-        w *= IEMGUI_ZOOM(x);
-    else
-        h *= IEMGUI_ZOOM(x);
-
     iemgui_setdialogatoms(&x->x_gui, 18, undo);
     SETFLOAT(undo+2, x->x_min);
     SETFLOAT(undo+3, x->x_max);
@@ -405,12 +393,12 @@ static void slider_dialog(t_slider *x, t_symbol *s, int argc, t_atom *argv)
 
     if(x->x_orientation == horizontal)
     {
-        x->x_gui.x_h = iemgui_clip_size(h) * IEMGUI_ZOOM(x);
+        x->x_gui.x_h = iemgui_clip_size(h);
         x->x_gui.x_w = slider_check_range(x, w);
         slider_check_minmax(x, min, max, x->x_gui.x_w);
     } else {
         x->x_gui.x_h = slider_check_range(x, h);
-        x->x_gui.x_w = iemgui_clip_size(w) * IEMGUI_ZOOM(x);
+        x->x_gui.x_w = iemgui_clip_size(w);
         slider_check_minmax(x, min, max, x->x_gui.x_h);
     }
 
@@ -430,15 +418,15 @@ static void slider_motion(t_slider *x, t_floatarg dx, t_floatarg dy,
 
     if(x->x_orientation == horizontal)
     {
-        pos = x->x_gui.x_w / IEMGUI_ZOOM(x);
+        pos = x->x_gui.x_w;
         delta = dx;
     } else {
-        pos = x->x_gui.x_h / IEMGUI_ZOOM(x);
+        pos = x->x_gui.x_h;
         delta = -dy;
     }
 
     if(!x->x_gui.x_fsf.x_finemoved)
-        delta = (100 * delta) / IEMGUI_ZOOM(x);
+        delta = 100 * delta;
 
     x->x_pos += (int)delta;
     x->x_val = x->x_pos;
@@ -446,14 +434,14 @@ static void slider_motion(t_slider *x, t_floatarg dx, t_floatarg dy,
     if(x->x_val > (100 * pos - 100))
     {
         x->x_val = 100 * pos - 100;
-        x->x_pos += 50 / IEMGUI_ZOOM(x);
-        x->x_pos -= x->x_pos % (100 / IEMGUI_ZOOM(x));
+        x->x_pos += 50;
+        x->x_pos -= x->x_pos % 100;
     }
     if(x->x_val < 0)
     {
         x->x_val = 0;
-        x->x_pos -= 50 / IEMGUI_ZOOM(x);
-        x->x_pos -= x->x_pos % (100 / IEMGUI_ZOOM(x));
+        x->x_pos -= 50;
+        x->x_pos -= x->x_pos % 100;
     }
     x->x_fval = slider_getfval(x);
     if (old != x->x_val)
@@ -471,15 +459,15 @@ static void slider_click(t_slider *x, t_floatarg xpos, t_floatarg ypos,
     if(x->x_orientation == horizontal)
     {
         val = (xpos - text_xpix(&x->x_gui.x_obj, x->x_gui.x_glist));
-        maxval = x->x_gui.x_w / IEMGUI_ZOOM(x);
+        maxval = x->x_gui.x_w;
     } else {
         val = (x->x_gui.x_h + text_ypix(&x->x_gui.x_obj, x->x_gui.x_glist) - ypos);
-        maxval = x->x_gui.x_h / IEMGUI_ZOOM(x);
+        maxval = x->x_gui.x_h;
     }
     maxval = 100 * maxval - 100;
 
     if(!x->x_steady)
-        x->x_val = (int)((100.0 * val) / IEMGUI_ZOOM(x));
+        x->x_val = (int)(100.0 * val);
     if(x->x_val > maxval)
         x->x_val = maxval;
 
@@ -558,13 +546,13 @@ static void slider_size(t_slider *x, t_symbol *s, int ac, t_atom *av)
     int h = (int)atom_getfloatarg(1, ac, av);
     if(x->x_orientation == horizontal)
     {
-        x->x_gui.x_w = slider_check_range(x, w*IEMGUI_ZOOM(x));
+        x->x_gui.x_w = slider_check_range(x, w);
         if(ac > 1)
-            x->x_gui.x_h = iemgui_clip_size(h) * IEMGUI_ZOOM(x);
+            x->x_gui.x_h = iemgui_clip_size(h);
     } else {
-        x->x_gui.x_w = iemgui_clip_size(w) * IEMGUI_ZOOM(x);
+        x->x_gui.x_w = iemgui_clip_size(w);
         if(ac > 1)
-            x->x_gui.x_h = slider_check_range(x, h*IEMGUI_ZOOM(x));
+            x->x_gui.x_h = slider_check_range(x, h);
     }
     iemgui_size((void *)x, &x->x_gui);
     slider_set(x, x->x_fval);
@@ -615,7 +603,7 @@ static void slider_lin(t_slider *x)
 {
     double v = (x->x_orientation==horizontal)?x->x_gui.x_w:x->x_gui.x_h;
     x->x_lin0_log1 = 0;
-    x->x_k = (x->x_max - x->x_min) / (v/IEMGUI_ZOOM(x) - 1);
+    x->x_k = (x->x_max - x->x_min) / (v - 1);
     slider_set(x, x->x_fval);
 }
 
@@ -651,12 +639,6 @@ static void slider_orientation(t_slider *x, t_floatarg forient)
     x->x_orientation = orient;
 
     iemgui_size(x, &x->x_gui);
-}
-
-static void slider_zoom(t_slider *x, t_floatarg f)
-{
-    iemgui_zoom(&x->x_gui, f);
-    (*x->x_gui.x_draw)(x, x->x_gui.x_glist, IEM_GUI_DRAW_MODE_UPDATE);
 }
 
 static void slider_loadbang(t_slider *x, t_floatarg action)
@@ -753,7 +735,6 @@ static void *slider_new(t_symbol *s, int argc, t_atom *argv)
     }
 
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    iemgui_newzoom(&x->x_gui);
     slider_check_minmax(x, min, max,
         (x->x_orientation==horizontal)?x->x_gui.x_w:x->x_gui.x_h);
 
@@ -812,8 +793,6 @@ void g_slider_setup(void)
         gensym("steady"), A_FLOAT, 0);
     class_addmethod(slider_class, (t_method)slider_orientation,
         gensym("orientation"), A_FLOAT, 0);
-    class_addmethod(slider_class, (t_method)slider_zoom,
-        gensym("zoom"), A_CANT, 0);
     slider_widgetbehavior.w_getrectfn =    slider_getrect;
     slider_widgetbehavior.w_displacefn =   iemgui_displace;
     slider_widgetbehavior.w_selectfn =     iemgui_select;

--- a/src/g_template.c
+++ b/src/g_template.c
@@ -1431,8 +1431,6 @@ static void curve_vis(t_gobj *z, t_glist *glist,
                     basey + fielddesc_getcoord(f+1, template, data, 1));
             }
             if (width < 1) width = 1;
-            if (glist->gl_isgraph)
-                width *= glist_getzoom(glist);
             outline = numbertocolor(
                 fielddesc_getfloat(&x->x_outlinecolor, template, data, 1));
             if (flags & CLOSED)
@@ -1477,11 +1475,10 @@ static void curve_motionfn(void *z, t_floatarg dx, t_floatarg dy, t_floatarg up)
     if (THISTMPL->curve_motion_vertex < 0)   /* drag the whole object */
     {
         t_glist *glist = THISTMPL->curve_motion_glist;
-        t_float zoom = (t_float)glist_getzoom(glist);
         int idtx, idty;
             /* accumulate fractional parts (while displace API expects ints) */
-        THISTMPL->curve_motion_xfrac += dx / zoom;
-        THISTMPL->curve_motion_yfrac += dy / zoom;
+        THISTMPL->curve_motion_xfrac += dx;
+        THISTMPL->curve_motion_yfrac += dy;
         idtx = (int)THISTMPL->curve_motion_xfrac;
         idty = (int)THISTMPL->curve_motion_yfrac;
         THISTMPL->curve_motion_xfrac -= idtx;
@@ -2040,9 +2037,6 @@ static void plot_vis(t_gobj *z, t_glist *glist,
     sprintf(tag0, "plot%p_array%p_onset%+d%+d%+d", data, elem, wonset, xonset,
         yonset);
 
-    if (glist->gl_isgraph)
-        linewidth *= glist_getzoom(glist);
-
     if (tovis)
     {
          /* we use t_word because pdgui_vmess() has a convenient FLOATWORDS
@@ -2219,17 +2213,10 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                 }
             ouch:
 
-                /* pdgui_vmess(0, "crr ri rk rk ri rS",
-                    glist_getcanvas(glist), "create", "polygon",
-                    "-width", (glist->gl_isgraph ? glist_getzoom(glist) : 1),
-                    "-fill", outline,
-                    "-outline", outline,
-                    "-smooth", (style == PLOTSTYLE_BEZ),
-                    "-tags", 3, tags); */
                 pdgui_vmess("pdtk_canvas_create_poly", "cr ii i kk iiii",
                     glist_getcanvas(glist), tag0,
                     1, (style == PLOTSTYLE_BEZ),
-                    (glist->gl_isgraph ? glist_getzoom(glist) : 1),
+                    1,
                     outline, outline,
                     0, 0, 0, 0);
 
@@ -3089,14 +3076,14 @@ static void drawtext_vis(t_gobj *z, t_glist *glist,
             /* draw label */
         /* SETSYMBOL(fontatoms+0, gensym(sys_font));
         SETFLOAT (fontatoms+1,
-            -sys_hostfontsize(glist_getfont(glist), glist_getzoom(glist)));
+            -sys_hostfontsize(glist_getfont(glist), 1));
         SETSYMBOL(fontatoms+2, gensym(sys_fontweight)); */
             /* display label */
         if (*x->x_label->s_name)
             pdgui_vmess("pdtk_text_new", "cS iis i k",
                 glist_getcanvas(glist), 2, tags,
                 xloc, yloc, x->x_label->s_name,
-                sys_hostfontsize(glist_getfont(glist), glist_getzoom(glist)),
+                sys_hostfontsize(glist_getfont(glist), 1),
                 color);
             /* pdgui_vmess(0, "crr ii rs rk rs rA rS",
                 glist_getcanvas(glist), "create", "text",

--- a/src/g_text.c
+++ b/src/g_text.c
@@ -82,8 +82,8 @@ void glist_text(t_glist *gl, t_symbol *s, int argc, t_atom *argv)
         glist_noselect(gl);
         glist_nograb(gl);
         glist_getnextxy(gl, &xpix, &ypix);
-        x->te_xpix = xpix/gl->gl_zoom - 1;
-        x->te_ypix = ypix/gl->gl_zoom - 1;
+        x->te_xpix = xpix - 1;
+        x->te_ypix = ypix - 1;
         binbuf_restore(x->te_binbuf, 1, &at);
         glist_add(gl, &x->te_g);
         glist_noselect(gl);
@@ -175,7 +175,7 @@ extern int sys_noautopatch;
 static void canvas_howputnew(t_canvas *x, int *connectp,
     int *xpixp, int *ypixp, int *indexp, int *totalp)
 {
-    float dx = 5.5 * x->gl_zoom;
+    float dx = 5.5;
     int xpix, ypix, indx = 0, nobj = 0, n2, x1, x2, y1, y2;
     int connectme = (x->gl_editor->e_selection &&
         !x->gl_editor->e_selection->sel_next && !sys_noautopatch);
@@ -211,20 +211,20 @@ static void canvas_howputnew(t_canvas *x, int *connectp,
                just below the one we connect from! */
         if(g) {
             gobj_getrect(g, x, &x1, &y1, &x2, &y2);
-            *xpixp = x1 / x->gl_zoom;
-            *ypixp = (y2+dx) / x->gl_zoom;  /* 5 pixels down, rounded */
+            *xpixp = x1 ;
+            *ypixp = y2 + dx;  /* 5 pixels down, rounded */
         } else {
                 /* just in case */
             glist_getnextxy(x, xpixp, ypixp);
-            *xpixp = *xpixp/x->gl_zoom - 3;
-            *ypixp = *ypixp/x->gl_zoom - 3;
+            *xpixp = *xpixp - 3;
+            *ypixp = *ypixp - 3;
         }
     }
     else
     {
         glist_getnextxy(x, xpixp, ypixp);
-        *xpixp = *xpixp/x->gl_zoom - 3;
-        *ypixp = *ypixp/x->gl_zoom - 3;
+        *xpixp = *xpixp - 3;
+        *ypixp = *ypixp - 3;
         glist_noselect(x);
     }
     *connectp = connectme;
@@ -498,7 +498,6 @@ static void message_click(t_message *x,
     t_rtext *y = glist_getrtext(x->m_glist, &x->m_text, 0);
     if (glist_isvisible(x->m_glist) && y)
     {
-        /* not zooming click width for now as it gets too fat */
         char buf[MAXPDSTRING];
         sprintf(buf, "%sR", rtext_gettag(y));
         pdgui_vmess(0, "crs ri",
@@ -522,7 +521,7 @@ static void message_tick(t_message *x)
             glist_getcanvas(x->m_glist),
             "itemconfigure",
             buf,
-            "-width", glist_getzoom(x->m_glist));
+            "-width", 1);
     }
 }
 
@@ -1085,29 +1084,29 @@ static int gatom_fontsize(t_gatom *x)
 static void gatom_getwherelabel(t_gatom *x, t_glist *glist, int *xp, int *yp)
 {
     int x1, y1, x2, y2;
-    int zoom = glist_getzoom(glist), fontsize = gatom_fontsize(x);
+    int fontsize = gatom_fontsize(x);
     text_getrect(&x->a_text.te_g, glist, &x1, &y1, &x2, &y2);
     if (x->a_wherelabel == ATOM_LABELLEFT)
     {
-        *xp = x1 - 3 * zoom - (
+        *xp = x1 - 3 - (
             (int)strlen(canvas_realizedollar(x->a_glist, x->a_label)->s_name) *
-                sys_zoomfontwidth(fontsize, zoom, 0));
-        *yp = y1 + 2 * zoom;
+                sys_zoomfontwidth(fontsize, 1, 0));
+        *yp = y1 + 2;
     }
     else if (x->a_wherelabel == ATOM_LABELRIGHT)
     {
-        *xp = x2 + 2 * zoom;
-        *yp = y1 + 2 * zoom;
+        *xp = x2 + 2;
+        *yp = y1 + 2;
     }
     else if (x->a_wherelabel == ATOM_LABELUP)
     {
-        *xp = x1 - 1 * zoom;
-        *yp = y1 - 1 * zoom - sys_zoomfontheight(fontsize, zoom, 0);
+        *xp = x1 - 1;
+        *yp = y1 - 1 - sys_zoomfontheight(fontsize, 1, 0);
     }
     else
     {
-        *xp = x1 - 1 * zoom;
-        *yp = y2 + 3 * zoom;
+        *xp = x1 - 1;
+        *yp = y2 + 3;
     }
 }
 
@@ -1122,7 +1121,7 @@ static void gatom_displace(t_gobj *z, t_glist *glist,
         sprintf(buf, "%p.l", x);
         pdgui_vmess("pdtk_canvas_move", "cs ii",
             glist_getcanvas(glist), buf,
-            dx * glist->gl_zoom, dy * glist->gl_zoom);
+            dx, dy);
     }
 }
 
@@ -1148,7 +1147,7 @@ static void gatom_vis(t_gobj *z, t_glist *glist, int vis)
                 3, tags,
                 (double)x1, (double)y1,
                 canvas_realizedollar(x->a_glist, x->a_label)->s_name,
-                gatom_fontsize(x) * glist_getzoom(glist),
+                gatom_fontsize(x),
                 THISGUI->i_foregroundcolor);
         }
         else pdgui_vmess("pdtk_canvas_delete", "cs",
@@ -1294,19 +1293,8 @@ static void text_getrect(t_gobj *z, t_glist *glist,
         we aren't visible yet. */
     else if (x->te_type == T_ATOM && x->te_width > 0)
     {
-        width = x->te_width * glist_fontwidth(glist);
-        height = glist_fontheight(glist);
-        if (glist_getzoom(glist) > 1)
-        {
-            /* zoom margins */
-            width += ATOM_RMARGIN * glist_getzoom(glist);
-            height += ATOM_BMARGIN * glist_getzoom(glist);
-        }
-        else
-        {
-            width += ATOM_RMARGIN;
-            height += ATOM_BMARGIN;
-        }
+        width = x->te_width * glist_fontwidth(glist) + ATOM_RMARGIN;
+        height = glist_fontheight(glist) + ATOM_BMARGIN;
     }
         /* if we're invisible we don't know our size so we just lie about
         it.  This is called on invisible boxes to establish order of inlets
@@ -1337,7 +1325,7 @@ static void text_displace(t_gobj *z, t_glist *glist,
     x->te_ypix += dy;
     if (glist_isvisible(glist) && (y = glist_getrtext(glist, x, 0)))
     {
-        rtext_displace(y, glist->gl_zoom * dx, glist->gl_zoom * dy);
+        rtext_displace(y, dx, dy);
         text_drawborder(x, glist, rtext_gettag(y), 0);
         canvas_fixlinesfor(glist, x);
     }
@@ -1531,8 +1519,8 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
 {
     int n = obj_noutlets(ob), nplus = (n == 1 ? 1 : n-1), i;
     int width = x2 - x1;
-    int iow = IOWIDTH * glist->gl_zoom;
-    int ih = IHEIGHT * glist->gl_zoom, oh = OHEIGHT * glist->gl_zoom;
+    int iow = IOWIDTH;
+    int ih = IHEIGHT, oh = OHEIGHT;
     char *tags[2];
     char tagbuf[128];
 
@@ -1540,26 +1528,20 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
     if (glist_isgraph(glist) && !glist->gl_havewindow)
         return;
 
-    /* draw over border, so assume border width = 1 pixel * glist->gl_zoom */
+    /* draw over border, so assume border width = 1 pixel */
     for (i = 0; i < n; i++)
     {
         int onset = x1 + (width - iow) * i / nplus;
         sprintf(tagbuf, "%so%d", tag, i);
         if (firsttime)
-            /* pdgui_vmess(0, "crr iiii rS rk rk",
-                glist_getcanvas(glist), "create", "rectangle",
-                onset, y2 - oh + glist->gl_zoom, onset + iow, y2,
-                "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", THISGUI->i_foregroundcolor,
-                "-outline", THISGUI->i_foregroundcolor); */
             pdgui_vmess("pdtk_canvas_create_rect", "crri kk iiii",
                 glist_getcanvas(glist), tagbuf, "-", 1,
                 THISGUI->i_foregroundcolor, THISGUI->i_foregroundcolor,
-                onset, y2 - oh + glist->gl_zoom, onset + iow, y2);
+                onset, y2 - oh + 1, onset + iow, y2);
         else
             pdgui_vmess(0, "crs iiii",
                 glist_getcanvas(glist), "coords", tagbuf,
-                onset, y2 - oh + glist->gl_zoom, onset + iow, y2);
+                onset, y2 - oh + 1, onset + iow, y2);
     }
     n = obj_ninlets(ob);
     nplus = (n == 1 ? 1 : n-1);
@@ -1568,21 +1550,14 @@ void glist_drawiofor(t_glist *glist, t_object *ob, int firsttime,
         int onset = x1 + (width - iow) * i / nplus;
         sprintf(tagbuf, "%si%d", tag, i);
         if (firsttime)
-            /* pdgui_vmess(0, "crr iiii rS rk rk",
-                glist_getcanvas(glist),
-                "create", "rectangle",
-                onset, y1, onset + iow, y1 + ih - glist->gl_zoom,
-                "-tags", (int)(sizeof(tags)/sizeof(*tags)), tags,
-                "-fill", THISGUI->i_foregroundcolor,
-                "-outline", THISGUI->i_foregroundcolor); */
             pdgui_vmess("pdtk_canvas_create_rect", "crri kk iiii",
                 glist_getcanvas(glist), tagbuf, "-", 1,
                 THISGUI->i_foregroundcolor, THISGUI->i_foregroundcolor,
-                onset, y1, onset + iow, y1 + ih - glist->gl_zoom);
+                onset, y1, onset + iow, y1 + ih - 1);
         else
             pdgui_vmess(0, "crs iiii",
                 glist_getcanvas(glist), "coords", tagbuf,
-                onset, y1, onset + iow, y1 + ih - glist->gl_zoom);
+                onset, y1, onset + iow, y1 + ih - 1);
     }
 }
 
@@ -1602,21 +1577,10 @@ void text_drawborder(t_text *x, t_glist *glist,
         char *tags[] = {tagR, "obj"};
         if (firsttime)
         {
-#if 0
-            pdgui_vmess(0, "crr iiiiiiiiii rr ri rk rr rS",
-                glist_getcanvas(glist), "create", "line",
-                x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1,
-                "-dash", pattern,
-                "-width", glist->gl_zoom,
-                "-fill", THISGUI->i_foregroundcolor,
-                "-capstyle", "projecting",
-                "-tags", 2, tags);
-#else
             pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiiiiiii",
                 glist_getcanvas(glist), tagR, "-",
-                dashed, glist->gl_zoom, THISGUI->i_foregroundcolor,
+                dashed, 1, THISGUI->i_foregroundcolor,
                 x1, y1,  x2, y1,  x2, y2,  x1, y2,  x1, y1);
-#endif
         }
         else
         {
@@ -1629,12 +1593,12 @@ void text_drawborder(t_text *x, t_glist *glist,
     {
         char *tags[] = {tagR, "msg"};
         corner = ((y2-y1)/4);
-        if (corner > 10*glist->gl_zoom)
-            corner = 10*glist->gl_zoom; /* looks bad if too big */
+        if (corner > 10)
+            corner = 10; /* looks bad if too big */
         if (firsttime)
             pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiiiii iiiiii",
                 glist_getcanvas(glist), tagR, "-",
-                0, glist->gl_zoom, THISGUI->i_foregroundcolor,
+                0, 1, THISGUI->i_foregroundcolor,
                 x1, y1,  x2+corner, y1,  x2, y1+corner,  x2, y2-corner,
                 x2+corner, y2,  x1, y2,  x1, y1);
         else
@@ -1647,14 +1611,14 @@ void text_drawborder(t_text *x, t_glist *glist,
            ((t_gatom *)x)->a_flavor == A_SYMBOL))
     {
             /* number or symbol */
-        int grabbed = glist->gl_zoom * ((t_gatom *)x)->a_grabbed;
+        int grabbed = ((t_gatom *)x)->a_grabbed;
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
         if (firsttime)
             pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiiiii iiii",
                 glist_getcanvas(glist), tagR, "-",
-                0, glist->gl_zoom, THISGUI->i_foregroundcolor,
+                0, 1, THISGUI->i_foregroundcolor,
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner, x2, y2,
                 x1p, y2,  x1p, y1p);
         else
@@ -1665,19 +1629,19 @@ void text_drawborder(t_text *x, t_glist *glist,
                 x1p, y2,  x1p, y1p);
             pdgui_vmess(0, "crs ri",
                 glist_getcanvas(glist), "itemconfigure", tagR,
-                "-width", glist->gl_zoom+grabbed);
+                "-width", 1 + grabbed);
         }
     }
     else if (x->te_type == T_ATOM ) /* list (ATOM but not float or symbol) */
     {
-        int grabbed = glist->gl_zoom * ((t_gatom *)x)->a_grabbed;
+        int grabbed = ((t_gatom *)x)->a_grabbed;
         int x1p = x1 + grabbed, y1p = y1 + grabbed;
         char *tags[] = {tagR, "atom"};
         corner = ((y2-y1)/4);
         if (firsttime)
             pdgui_vmess("pdtk_canvas_create_line", "crr iik iiiiii iiiiiiii",
                 glist_getcanvas(glist), tagR, "-",
-                0, glist->gl_zoom, THISGUI->i_foregroundcolor,
+                0, 1, THISGUI->i_foregroundcolor,
                 x1p, y1p,  x2-corner, y1p,  x2, y1p+corner,
                 x2, y2-corner,  x2-corner, y2,  x1p, y2,  x1p, y1p);
         else
@@ -1688,7 +1652,7 @@ void text_drawborder(t_text *x, t_glist *glist,
                 x2-corner,y2, x1p,y2, x1p,y1p);
             pdgui_vmess(0, "crs ri",
                 glist_getcanvas(glist), "itemconfigure", tagR,
-                "-width", glist->gl_zoom+grabbed);
+                "-width", 1 + grabbed);
         }
     }
         /* for comments, just draw a bar on RHS if unlocked; when a visible
@@ -1699,7 +1663,7 @@ void text_drawborder(t_text *x, t_glist *glist,
         if (firsttime)
             pdgui_vmess("pdtk_canvas_create_line", "crr iik iiii",
                 glist_getcanvas(glist), tagR, "-",
-                0, glist->gl_zoom, THISGUI->i_foregroundcolor,
+                0, 1, THISGUI->i_foregroundcolor,
                 x2, y1,  x2, y2);
         else
             pdgui_vmess(0, "crs iiii",
@@ -1822,7 +1786,7 @@ static void text_anything(t_text *x, t_symbol *s, int argc, t_atom *argv)
 void text_getfont(t_text *x, t_glist *thisglist,
     int *fwidthp, int *fheightp, int *guifsize)
 {
-    int font, zoom;
+    int font;
     t_glist *gl;
     if (pd_class(&x->te_pd) == canvas_class &&
         ((t_glist *)(x))->gl_isgraph &&
@@ -1830,21 +1794,13 @@ void text_getfont(t_text *x, t_glist *thisglist,
             gl = (t_glist *)(x);
     else gl = thisglist;
     font =  glist_getfont(gl);
-    zoom = glist_getzoom(gl);
         /* override if atom box has its own specified font size */
     if (x->te_type == T_ATOM && ((t_gatom *)x)->a_fontsize > 0)
         font = ((t_gatom *)x)->a_fontsize;
-    *fwidthp = sys_zoomfontwidth(font, zoom, 0);
-    *fheightp = sys_zoomfontheight(font, zoom, 0);
-    *guifsize = sys_hostfontsize(font, zoom);
+    *fwidthp = sys_zoomfontwidth(font, 1, 0);
+    *fheightp = sys_zoomfontheight(font, 1, 0);
+    *guifsize = sys_hostfontsize(font, 1);
 }
-
-
-/*
-        *fontwidthp =  glist_fontwidth((t_glist *)(x->x_text));
-        fontheightp =  glist_fontheight((t_glist *)(x->x_text));
-  *guifontsizep = sys_hostfontsize(font, glist_getzoom(x->x_glist));
-*/
 
 void g_text_setup(void)
 {

--- a/src/g_toggle.c
+++ b/src/g_toggle.c
@@ -21,45 +21,42 @@ static t_class *toggle_class;
 #define toggle_draw_io 0
 void toggle_draw_config(t_toggle* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_iemgui *iemgui = &x->x_gui;
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
-    int crossw = 1, w = x->x_gui.x_w / zoom;
+    int crossw = 1, w = x->x_gui.x_w;
     unsigned int col = x->x_on ? x->x_gui.x_fcol : x->x_gui.x_bcol;
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     if(w >= 30)
         crossw = 2;
     if(w >= 60)
         crossw = 3;
-    crossw *= zoom;
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
         xpos, ypos, xpos + x->x_gui.x_w, ypos + x->x_gui.x_h);
     pdgui_vmess(0, "crs ri rk rk", canvas, "itemconfigure", tag,
-        "-width", zoom, "-fill", x->x_gui.x_bcol,
+        "-width", 1, "-fill", x->x_gui.x_bcol,
         "-outline", THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_X1", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        xpos + crossw + zoom, ypos + crossw + zoom,
-        xpos + x->x_gui.x_w - crossw - zoom,
-            ypos + x->x_gui.x_h - crossw - zoom);
+        xpos + crossw + 1, ypos + crossw + 1,
+        xpos + x->x_gui.x_w - crossw - 1,
+            ypos + x->x_gui.x_h - crossw - 1);
     pdgui_vmess("pdtk_canvas_configure_line", "cs ik", canvas, tag,
         crossw, col);
 
     sprintf(tag, "%p_X2", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        xpos + crossw + zoom, ypos + x->x_gui.x_h - crossw - zoom,
-        xpos + x->x_gui.x_w - crossw - zoom, ypos + crossw + zoom);
+        xpos + crossw + 1, ypos + x->x_gui.x_h - crossw - 1,
+        xpos + x->x_gui.x_w - crossw - 1, ypos + crossw + 1);
     pdgui_vmess("pdtk_canvas_configure_line", "cs ik", canvas, tag,
         crossw, col);
     /* pdgui_vmess(0, "crs ri rk", canvas, "itemconfigure", tag,
@@ -67,7 +64,7 @@ void toggle_draw_config(t_toggle* x, t_glist* glist)
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xpos + x->x_gui.x_ldx * zoom, ypos + x->x_gui.x_ldy * zoom);
+        xpos + x->x_gui.x_ldx, ypos + x->x_gui.x_ldy);
 
     if(x->x_gui.x_fsf.x_selected)
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
@@ -137,7 +134,7 @@ void toggle_draw_update(t_toggle *x, t_glist *glist)
         t_canvas *canvas = glist_getcanvas(glist);
         unsigned int col = (x->x_on != 0.0) ? x->x_gui.x_fcol : x->x_gui.x_bcol;
         char tag[128];
-        int width = x->x_gui.x_w / IEMGUI_ZOOM(x),
+        int width = x->x_gui.x_w,
             xwidth = (width >= 60 ? 3: (width >= 30 ? 2 : 1));
         sprintf(tag, "%p_X1", x);
         pdgui_vmess("pdtk_canvas_configure_line", "cs ik", canvas, tag,
@@ -171,7 +168,7 @@ static void toggle_save(t_gobj *z, t_binbuf *b)
     binbuf_addv(b, "ssiisiisssiiiisssff", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix,
                 (int)x->x_gui.x_obj.te_ypix,
-                gensym("tgl"), x->x_gui.x_w/IEMGUI_ZOOM(x),
+                gensym("tgl"), x->x_gui.x_w,
                 iem_symargstoint(&x->x_gui.x_isa),
                 srl[0], srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
@@ -186,7 +183,7 @@ static void toggle_properties(t_gobj *z, t_glist *owner)
 {
     t_toggle *x = (t_toggle *)z;
     iemgui_new_dialog(x, &x->x_gui, "tgl",
-                      x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+                      x->x_gui.x_w, IEM_GUI_MINSIZE,
                       0, 0,
                       x->x_nonzero, 0,
                       1,
@@ -225,7 +222,7 @@ static void toggle_dialog(t_toggle *x, t_symbol *s, int argc, t_atom *argv)
     if(x->x_on != 0.0)
         x->x_on = x->x_nonzero;
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
-    x->x_gui.x_w = iemgui_clip_size(a) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size(x, &x->x_gui);
 }
@@ -277,7 +274,7 @@ static void toggle_loadbang(t_toggle *x, t_floatarg action)
 
 static void toggle_size(t_toggle *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av));
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_size((void *)x, &x->x_gui);
 }
@@ -369,7 +366,6 @@ static void *toggle_new(t_symbol *s, int argc, t_atom *argv)
     x->x_gui.x_w = iemgui_clip_size(a);
     x->x_gui.x_h = x->x_gui.x_w;
     iemgui_verify_snd_ne_rcv(&x->x_gui);
-    iemgui_newzoom(&x->x_gui);
     outlet_new(&x->x_gui.x_obj, &s_float);
     return (x);
 }
@@ -399,8 +395,6 @@ void g_toggle_setup(void)
     class_addmethod(toggle_class, (t_method)toggle_label_font, gensym("label_font"), A_GIMME, 0);
     class_addmethod(toggle_class, (t_method)toggle_init, gensym("init"), A_FLOAT, 0);
     class_addmethod(toggle_class, (t_method)toggle_nonzero, gensym("nonzero"), A_FLOAT, 0);
-    class_addmethod(toggle_class, (t_method)iemgui_zoom, gensym("zoom"),
-        A_CANT, 0);
     toggle_widgetbehavior.w_getrectfn = toggle_getrect;
     toggle_widgetbehavior.w_displacefn = iemgui_displace;
     toggle_widgetbehavior.w_selectfn = iemgui_select;

--- a/src/g_vumeter.c
+++ b/src/g_vumeter.c
@@ -27,16 +27,15 @@ static void vu_update_rms(t_vu *x, t_glist *glist)
 {
     if(glist_isvisible(glist))
     {
-        const int zoom = IEMGUI_ZOOM(x);
-        int w4 = x->x_gui.x_w / 4, off = text_ypix(&x->x_gui.x_obj, glist) - zoom;
+        int w4 = x->x_gui.x_w / 4, off = text_ypix(&x->x_gui.x_obj, glist) - 1;
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
-        int quad1 = xpos + w4 - zoom, quad3 = xpos + x->x_gui.x_w - w4 + zoom;
+        int quad1 = xpos + w4 - 1, quad3 = xpos + x->x_gui.x_w - w4 + 1;
         char tag[128];
 
         sprintf(tag, "%p_RCOVER", x);
         pdgui_vmess(0, "crs iiii", glist_getcanvas(glist), "coords", tag,
              quad1, off, quad3,
-             off + (x->x_led_size+1)*zoom*(IEM_VU_STEPS-x->x_rms));
+             off + (x->x_led_size+1) * (IEM_VU_STEPS-x->x_rms));
     }
 }
 
@@ -46,7 +45,6 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
 
     if(glist_isvisible(glist))
     {
-        const int zoom = IEMGUI_ZOOM(x);
         int xpos = text_xpix(&x->x_gui.x_obj, glist);
         int ypos = text_ypix(&x->x_gui.x_obj, glist);
         char tag[128];
@@ -56,20 +54,20 @@ static void vu_update_peak(t_vu *x, t_glist *glist)
         {
             int i = iemgui_vu_col[x->x_peak];
             int j = ypos +
-                   (x->x_led_size+1)*zoom*(IEM_VU_STEPS+1-x->x_peak) -
-                   (x->x_led_size+1)*zoom/2;
+                   (x->x_led_size+1) * (IEM_VU_STEPS+1-x->x_peak) -
+                   (x->x_led_size+1) / 2;
 
             pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-                xpos, j, xpos + x->x_gui.x_w + zoom, j);
+                xpos, j, xpos + x->x_gui.x_w + 1, j);
             pdgui_vmess("pdtk_canvas_configure_line", "cs i k",
                 canvas, tag,
-                x->x_led_size * zoom + zoom,  /* peak LED is slightly fatter */
+                x->x_led_size + 1,  /* peak LED is slightly fatter */
                 iemgui_color_hex[i]);
         }
         else
         {
             int mid = xpos + x->x_gui.x_w/2;
-            int pkh = PEAKHEIGHT * zoom;
+            int pkh = PEAKHEIGHT;
 
             pdgui_vmess("pdtk_canvas_configure_line", "cs i k",
                 canvas, tag,
@@ -85,12 +83,9 @@ static void vu_draw_update(t_gobj *client, t_glist *glist);
 
 static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int hmargin = HMARGIN * zoom, vmargin = VMARGIN * zoom;
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
     int snd_able = x->x_gui.x_fsf.x_snd_able || x->x_gui.x_fsf.x_rcv_able;
     char tag_object[128], tag_label[128], tag[128], tag_n[128];
     char *tags[] = {tag_object, tag_n, tag};
@@ -107,16 +102,16 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     {
         sprintf(tag_n, "%p_OUT%d", x, 0);
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos - hmargin, ypos + x->x_gui.x_h + vmargin + zoom - ioh,
-            xpos - hmargin + iow, ypos + x->x_gui.x_h + vmargin,
+            xpos - HMARGIN, ypos + x->x_gui.x_h + VMARGIN + 1 - IEM_GUI_IOHEIGHT,
+            xpos - HMARGIN + IOWIDTH, ypos + x->x_gui.x_h + VMARGIN,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
 
         sprintf(tag_n, "%p_OUT%d", x, 1);
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos + x->x_gui.x_w + hmargin - iow, ypos + x->x_gui.x_h + vmargin + zoom - ioh,
-            xpos + x->x_gui.x_w + hmargin, ypos + x->x_gui.x_h + vmargin,
+            xpos + x->x_gui.x_w + HMARGIN - IOWIDTH, ypos + x->x_gui.x_h + VMARGIN + 1 - IEM_GUI_IOHEIGHT,
+            xpos + x->x_gui.x_w + HMARGIN, ypos + x->x_gui.x_h + VMARGIN,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
@@ -130,16 +125,16 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
     {
         sprintf(tag_n, "%p_IN%d", x, 0);
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos - hmargin, ypos - vmargin,
-            xpos - hmargin + iow, ypos - vmargin - zoom + ioh,
+            xpos - HMARGIN, ypos - VMARGIN,
+            xpos - HMARGIN + IOWIDTH, ypos - VMARGIN - 1 + IEM_GUI_IOHEIGHT,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
 
         sprintf(tag_n, "%p_IN%d", x, 1);
         pdgui_vmess(0, "crr iiii rk rk rS", canvas, "create", "rectangle",
-            xpos + x->x_gui.x_w + hmargin - iow, ypos - vmargin,
-            xpos + x->x_gui.x_w + hmargin, ypos - vmargin - zoom + ioh,
+            xpos + x->x_gui.x_w + HMARGIN - IOWIDTH, ypos - VMARGIN,
+            xpos + x->x_gui.x_w + HMARGIN, ypos - VMARGIN - 1 + IEM_GUI_IOHEIGHT,
             "-fill", THISGUI->i_foregroundcolor,
             "-outline", THISGUI->i_foregroundcolor,
             "-tags", 3, tags);
@@ -150,34 +145,31 @@ static void vu_draw_io(t_vu* x, t_glist* glist, int old_snd_rcv_flags)
 
 static void vu_draw_config(t_vu* x, t_glist* glist)
 {
-    const int zoom = IEMGUI_ZOOM(x);
     t_iemgui *iemgui = &x->x_gui;
     t_canvas *canvas = glist_getcanvas(glist);
     int xpos = text_xpix(&x->x_gui.x_obj, glist);
     int ypos = text_ypix(&x->x_gui.x_obj, glist);
-    int hmargin = HMARGIN * zoom, vmargin = VMARGIN * zoom;
-    int iow = IOWIDTH * zoom, ioh = IEM_GUI_IOHEIGHT * zoom;
-    int ledw = x->x_led_size * zoom;
-    int fs = x->x_gui.x_fontsize * zoom;
+    int ledw = x->x_led_size;
+    int fs = x->x_gui.x_fontsize;
     int w4 = x->x_gui.x_w/4, mid = xpos + x->x_gui.x_w/2,
-        quad1 = xpos + w4 + zoom;
+        quad1 = xpos + w4 + 1;
     int quad3 = xpos + x->x_gui.x_w - w4,
-        end = xpos + x->x_gui.x_w + 4*zoom;
-    int k1 = (x->x_led_size+1)*zoom, k2 = IEM_VU_STEPS+1, k3 = k1/2;
+        end = xpos + x->x_gui.x_w + 4;
+    int k1 = x->x_led_size + 1, k2 = IEM_VU_STEPS + 1, k3 = k1 / 2;
     int led_col, yyy, k4 = ypos - k3;
     int i;
     char tag[128];
     t_atom fontatoms[3];
     SETSYMBOL(fontatoms+0, gensym(iemgui->x_font));
-    SETFLOAT (fontatoms+1, -iemgui->x_fontsize*zoom);
+    SETFLOAT (fontatoms+1, -iemgui->x_fontsize);
     SETSYMBOL(fontatoms+2, gensym(sys_fontweight));
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        xpos - hmargin, ypos - vmargin,
-        xpos+x->x_gui.x_w + hmargin, ypos+x->x_gui.x_h + vmargin);
+        xpos - HMARGIN, ypos - VMARGIN,
+        xpos+x->x_gui.x_w + HMARGIN, ypos+x->x_gui.x_h + VMARGIN);
     pdgui_vmess(0, "rcs ikk", "pdtk_canvas_configure_rect", canvas, tag,
-        zoom, x->x_gui.x_bcol, THISGUI->i_foregroundcolor);
+        1, x->x_gui.x_bcol, THISGUI->i_foregroundcolor);
 
     sprintf(tag, "%p_SCALE", x);
     if(x->x_gui.x_fsf.x_selected)
@@ -220,23 +212,23 @@ static void vu_draw_config(t_vu* x, t_glist* glist)
 
     sprintf(tag, "%p_RCOVER", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        quad1 - zoom, ypos - zoom,
-        quad3 + zoom, ypos - zoom + k1*IEM_VU_STEPS);
+        quad1 - 1, ypos - 1,
+        quad3 + 1, ypos - 1 + k1*IEM_VU_STEPS);
     pdgui_vmess(0, "rcs ikk", "pdtk_canvas_configure_rect", canvas, tag,
         1, x->x_gui.x_bcol, x->x_gui.x_bcol);
 
     sprintf(tag, "%p_PLED", x);
     pdgui_vmess(0, "crs iiii", canvas, "coords", tag,
-        mid, ypos + PEAKHEIGHT * zoom,
-        mid, ypos + PEAKHEIGHT * zoom);
+        mid, ypos + PEAKHEIGHT,
+        mid, ypos + PEAKHEIGHT);
     pdgui_vmess("pdtk_canvas_configure_line", "cs i k",
         canvas, tag,
-        ledw+zoom,  /* peak LED is slightly fatter */
+        ledw + 1,  /* peak LED is slightly fatter */
         x->x_gui.x_bcol);
 
     sprintf(tag, "%p_LABEL", x);
     pdgui_vmess(0, "crs ii", canvas, "coords", tag,
-        xpos+x->x_gui.x_ldx * zoom, ypos+x->x_gui.x_ldy * zoom);
+        xpos+x->x_gui.x_ldx, ypos+x->x_gui.x_ldy);
     if(x->x_gui.x_fsf.x_selected)
         pdgui_vmess(0, "crs rA rk", canvas, "itemconfigure", tag,
             "-font", 3, fontatoms, "-fill", THISGUI->i_selectcolor);
@@ -317,7 +309,7 @@ static void vu_draw_select(t_vu* x,t_glist* glist)
 
     sprintf(tag, "%p_BASE", x);
     pdgui_vmess(0, "rcs ikk", "pdtk_canvas_configure_rect", canvas, tag,
-        IEMGUI_ZOOM(x), x->x_gui.x_bcol, col);
+        1, x->x_gui.x_bcol, col);
     sprintf(tag, "%p_SCALE", x);
     pdgui_vmess(0, "crs rk", canvas, "itemconfigure", tag, "-fill", lcol);
     sprintf(tag, "%p_LABEL", x);
@@ -345,12 +337,11 @@ static void vu_getrect(t_gobj *z, t_glist *glist,
                        int *xp1, int *yp1, int *xp2, int *yp2)
 {
     t_vu* x = (t_vu*)z;
-    int hmargin = HMARGIN * IEMGUI_ZOOM(x), vmargin = VMARGIN * IEMGUI_ZOOM(x);
 
-    *xp1 = text_xpix(&x->x_gui.x_obj, glist) - hmargin;
-    *yp1 = text_ypix(&x->x_gui.x_obj, glist) - vmargin;
-    *xp2 = *xp1 + x->x_gui.x_w + hmargin*2;
-    *yp2 = *yp1 + x->x_gui.x_h + vmargin*2;
+    *xp1 = text_xpix(&x->x_gui.x_obj, glist) - HMARGIN;
+    *yp1 = text_ypix(&x->x_gui.x_obj, glist) - VMARGIN;
+    *xp2 = *xp1 + x->x_gui.x_w + HMARGIN * 2;
+    *yp2 = *yp1 + x->x_gui.x_h + VMARGIN * 2;
 }
 
 static void vu_save(t_gobj *z, t_binbuf *b)
@@ -362,7 +353,7 @@ static void vu_save(t_gobj *z, t_binbuf *b)
     iemgui_save(&x->x_gui, srl, bflcol);
     binbuf_addv(b, "ssiisiissiiiissii", gensym("#X"), gensym("obj"),
                 (int)x->x_gui.x_obj.te_xpix, (int)x->x_gui.x_obj.te_ypix,
-                gensym("vu"), x->x_gui.x_w/IEMGUI_ZOOM(x), x->x_gui.x_h/IEMGUI_ZOOM(x),
+                gensym("vu"), x->x_gui.x_w, x->x_gui.x_h,
                 srl[1], srl[2],
                 x->x_gui.x_ldx, x->x_gui.x_ldy,
                 iem_fstyletoint(&x->x_gui.x_fsf), x->x_gui.x_fontsize,
@@ -379,7 +370,7 @@ void vu_check_height(t_vu *x, int h)
     if(n < IEM_VU_MINSIZE)
         n = IEM_VU_MINSIZE;
     x->x_led_size = n - 1;
-    x->x_gui.x_h = (IEM_VU_STEPS * n) * IEMGUI_ZOOM(x);
+    x->x_gui.x_h = IEM_VU_STEPS * n;
 }
 
 static void vu_scale(t_vu *x, t_floatarg fscale)
@@ -394,8 +385,8 @@ static void vu_properties(t_gobj *z, t_glist *owner)
     t_vu *x = (t_vu *)z;
 
     iemgui_new_dialog(x, &x->x_gui, "vu",
-                      x->x_gui.x_w/IEMGUI_ZOOM(x), IEM_SL_MINSIZE,
-                      x->x_gui.x_h/IEMGUI_ZOOM(x), IEM_GUI_MINSIZE,
+                      x->x_gui.x_w, IEM_SL_MINSIZE,
+                      x->x_gui.x_h, IEM_GUI_MINSIZE,
                       0, 0,
                       0,
                       x->x_scale, "no scale", "scale",
@@ -423,7 +414,7 @@ static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
     sr_flags = iemgui_dialog(&x->x_gui, srl, argc, argv);
     x->x_gui.x_fsf.x_snd_able = 0;
     x->x_gui.x_isa.x_loadinit = 0;
-    x->x_gui.x_w = iemgui_clip_size(w) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size(w);
     vu_check_height(x, h);
     if(scale != 0)
         scale = 1;
@@ -433,7 +424,7 @@ static void vu_dialog(t_vu *x, t_symbol *s, int argc, t_atom *argv)
 
 static void vu_size(t_vu *x, t_symbol *s, int ac, t_atom *av)
 {
-    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av)) * IEMGUI_ZOOM(x);
+    x->x_gui.x_w = iemgui_clip_size((int)atom_getfloatarg(0, ac, av));
     if(ac > 1)
         vu_check_height(x, (int)atom_getfloatarg(1, ac, av));
     iemgui_size((void *)x, &x->x_gui);
@@ -580,8 +571,6 @@ static void *vu_new(t_symbol *s, int argc, t_atom *argv)
     inlet_new(&x->x_gui.x_obj, &x->x_gui.x_obj.ob_pd, &s_float, gensym("ft1"));
     x->x_out_rms = outlet_new(&x->x_gui.x_obj, &s_float);
     x->x_out_peak = outlet_new(&x->x_gui.x_obj, &s_float);
-    x->x_gui.x_h /= IEMGUI_ZOOM(x); /* unzoom, to prevent double-application in iemgui_newzoom */
-    iemgui_newzoom(&x->x_gui);
     return (x);
 }
 
@@ -613,8 +602,6 @@ void g_vumeter_setup(void)
         gensym("label_pos"), A_GIMME, 0);
     class_addmethod(vu_class, (t_method)vu_label_font,
         gensym("label_font"), A_GIMME, 0);
-    class_addmethod(vu_class, (t_method)iemgui_zoom,
-        gensym("zoom"), A_CANT, 0);
     vu_widgetbehavior.w_getrectfn =    vu_getrect;
     vu_widgetbehavior.w_displacefn =   iemgui_displace;
     vu_widgetbehavior.w_selectfn =     iemgui_select;

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -123,12 +123,6 @@ void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     pdgui_vmess("pdtk_plugin_dispatch", "a", argc, argv);
 }
 
-int sys_zoom_open = 1;
-void glob_zoom_open(t_pd *dummy, t_floatarg f)
-{
-    sys_zoom_open = (f != 0 ? 2 : 1);
-}
-
 void glob_init(void)
 {
     maxclass = class_new(gensym("max"), 0, 0, sizeof(t_pd),
@@ -191,8 +185,6 @@ void glob_init(void)
         gensym("save-preferences"), A_DEFSYM, 0);
     class_addmethod(glob_pdobject, (t_method)glob_forgetpreferences,
         gensym("forget-preferences"), A_DEFSYM, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_zoom_open,
-        gensym("zoom-open"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_version,
         gensym("version"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_perf,

--- a/src/m_pd.h
+++ b/src/m_pd.h
@@ -495,6 +495,7 @@ EXTERN void canvas_makefilename(const t_glist *c, const char *file,
 EXTERN t_symbol *canvas_getdir(const t_glist *x);
 EXTERN char sys_font[]; /* default typeface set in s_main.c */
 EXTERN char sys_fontweight[]; /* default font weight set in s_main.c */
+/* in the following functions, 'zoom' argument is not used */
 EXTERN int sys_hostfontsize(int fontsize, int zoom);
 EXTERN int sys_zoomfontwidth(int fontsize, int zoom, int worstcase);
 EXTERN int sys_zoomfontheight(int fontsize, int zoom, int worstcase);

--- a/src/notes.txt
+++ b/src/notes.txt
@@ -97,7 +97,6 @@ option-drag an outlet to make a new, connected object
 make a way to make multiple connections
 "fix width" menu item
 close-subwindows menu item
-canvas zooming (use tcl/tk canvas scale command?)
 
 data:
 add -x [-n?] flag to drawnumbers

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -861,8 +861,6 @@ void sys_savepreferences(const char *filename)
     sys_putpreference("flags",
         (sys_flags ? sys_flags->s_name : ""));
         /* misc */
-    sprintf(buf1, "%d", sys_zoom_open);
-    sys_putpreference("zoom", buf1);
     sys_putpreference("loading", "no");
 
     sys_donesavepreferences();

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1867,10 +1867,7 @@ void sys_doneglobinit( void)
 
     /* start the GUI up.  Before we actually draw our "visible" windows
     we have to wait for the GUI to give us our font metrics, see
-    glob_initfromgui().  LATER it would be cool to figure out what metrics
-    we really need and tell the GUI - that way we can support arbitrary
-    zoom with appropriate font sizes.   And/or: if we ever move definitively
-    to a vector-based GUI lib we might be able to skip this step altogether. */
+    glob_initfromgui(). */
 int sys_startgui(const char *libdir)
 {
     t_canvas *x;

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1134,7 +1134,6 @@ void sys_gui_preferences(void)
     pdgui_vmess("set_escaped", "ri", "::sys_verbose", sys_verbose);
     pdgui_vmess("set_escaped", "ri", "::sys_use_stdpath", sys_usestdpath);
     pdgui_vmess("set_escaped", "ri", "::sys_defeatrt", sys_defeatrt);
-    pdgui_vmess("set_escaped", "ri", "::sys_zoom_open", (sys_zoom_open == 2));
 
     pdgui_vmess("::dialog_startup::set_flags", "s",
                 (sys_flags? sys_flags->s_name : ""));

--- a/src/s_main.c
+++ b/src/s_main.c
@@ -129,16 +129,12 @@ static t_fontinfo sys_fontspec[] = {
     {8, 5, 11}, {10, 6, 13}, {12, 7, 16},
     {16, 10, 19}, {24, 14, 29}, {36, 22, 44}};
 #define NFONT (sizeof(sys_fontspec)/sizeof(*sys_fontspec))
-#define NZOOM 2
 
     /* here are actual measured font sizes; they are overwritten from the
     GUI if/when the GUI starts up. */
-static t_fontinfo sys_gotfonts[NZOOM][NFONT]  = {
-  {{8,  5, 11},  {10,  6, 13},  {12,  7, 16},  {16, 10, 19},  {24, 14, 29},
-    {36, 22, 44}},
-  {{16, 10, 22},  {20, 12, 26},  {24, 14, 32},  {32, 20, 38},  {48, 28, 58},
-    {72, 44, 88}}
-};
+static t_fontinfo sys_gotfonts[NFONT]  = {
+  {8,  5, 11},  {10,  6, 13},  {12,  7, 16},  {16, 10, 19},  {24, 14, 29},
+    {36, 22, 44}};
 
 /* here are some measured font size structs for example:
 MSW:
@@ -172,27 +168,29 @@ int sys_nearestfontsize(int fontsize)
     return (sys_fontspec[sys_findfont(fontsize)].fi_pointsize);
 }
 
+/* in the following functions, 'zoom' or 'zoomarg' arguments aren't used anymore,
+but are kept for compatibility */
+
 int sys_hostfontsize(int fontsize, int zoom)
 {
-    zoom = (zoom < 1 ? 1 : (zoom > NZOOM ? NZOOM : zoom));
-    return (sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_pointsize);
+    return (sys_gotfonts[sys_findfont(fontsize)].fi_pointsize);
 }
 
 int sys_zoomfontwidth(int fontsize, int zoomarg, int worstcase)
 {
-    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
+    int ret;
     if (worstcase)
-        ret = zoom * sys_fontspec[sys_findfont(fontsize)].fi_width;
-    else ret = sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_width;
+        ret = sys_fontspec[sys_findfont(fontsize)].fi_width;
+    else ret = sys_gotfonts[sys_findfont(fontsize)].fi_width;
     return (ret < 1 ? 1 : ret);
 }
 
 int sys_zoomfontheight(int fontsize, int zoomarg, int worstcase)
 {
-    int zoom = (zoomarg < 1 ? 1 : (zoomarg > NZOOM ? NZOOM : zoomarg)), ret;
+    int ret;
     if (worstcase)
-        ret = (zoom * sys_fontspec[sys_findfont(fontsize)].fi_height);
-    else ret = sys_gotfonts[zoom-1][sys_findfont(fontsize)].fi_height;
+        ret = sys_fontspec[sys_findfont(fontsize)].fi_height;
+    else ret = sys_gotfonts[sys_findfont(fontsize)].fi_height;
     return (ret < 1 ? 1 : ret);
 }
 
@@ -290,19 +288,18 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
     int did_fontwarning = 0;
     int j;
     sys_oldtclversion = atom_getfloatarg(1, argc, argv);
-    if (argc != 2 + 3 * NZOOM * NFONT)
+    if (argc != 2 + 3 * NFONT)
         bug("glob_initfromgui");
-    for (j = 0; j < NZOOM; j++)
-        for (i = 0; i < NFONT; i++)
+    for (i = 0; i < NFONT; i++)
     {
-        int size   = atom_getfloatarg(3 * (i + j * NFONT) + 2, argc, argv);
-        int width  = atom_getfloatarg(3 * (i + j * NFONT) + 3, argc, argv);
-        int height = atom_getfloatarg(3 * (i + j * NFONT) + 4, argc, argv);
+        int size   = atom_getfloatarg(3 * i + 2, argc, argv);
+        int width  = atom_getfloatarg(3 * i + 3, argc, argv);
+        int height = atom_getfloatarg(3 * i + 4, argc, argv);
         if (!(size && width && height))
         {
-            size   = (j+1)*sys_fontspec[i].fi_pointsize;
-            width  = (j+1)*sys_fontspec[i].fi_width;
-            height = (j+1)*sys_fontspec[i].fi_height;
+            size   = sys_fontspec[i].fi_pointsize;
+            width  = sys_fontspec[i].fi_width;
+            height = sys_fontspec[i].fi_height;
             if (!did_fontwarning)
             {
                 logpost(NULL,
@@ -310,13 +307,13 @@ void glob_initfromgui(void *dummy, t_symbol *s, int argc, t_atom *argv)
                 did_fontwarning = 1;
             }
         }
-        sys_gotfonts[j][i].fi_pointsize = size;
-        sys_gotfonts[j][i].fi_width = width;
-        sys_gotfonts[j][i].fi_height = height;
+        sys_gotfonts[i].fi_pointsize = size;
+        sys_gotfonts[i].fi_width = width;
+        sys_gotfonts[i].fi_height = height;
 #if 0
             fprintf(stderr, "font (%d %d %d)\n",
-                sys_gotfonts[j][i].fi_pointsize, sys_gotfonts[j][i].fi_width,
-                    sys_gotfonts[j][i].fi_height);
+                sys_gotfonts[i].fi_pointsize, sys_gotfonts[i].fi_width,
+                    sys_gotfonts[i].fi_height);
 #endif
     }
     sys_doneglobinit();  /* tell s_inter.c to vis our canvases now that

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -417,7 +417,6 @@ EXTERN void inmidi_polyaftertouch(int portno,
                                   int pitch,
                                   int value);
 /* } jsarlo */
-EXTERN int sys_zoom_open;
 
 struct _instancestuff
 {

--- a/src/x_text.c
+++ b/src/x_text.c
@@ -110,8 +110,7 @@ static void textbuf_open(t_textbuf *x)
         char buf[40];
         sprintf(buf, "%dx%d", 600, 340);
         pdgui_vmess("pdtk_textwindow_open", "^r si", x, buf,
-            x->b_sym->s_name, sys_hostfontsize(glist_getfont(x->b_canvas),
-                glist_getzoom(x->b_canvas)));
+            x->b_sym->s_name, sys_hostfontsize(glist_getfont(x->b_canvas), 1));
         sprintf(buf, ".x%lx", (unsigned long)x);
         x->b_guiconnect = guiconnect_new(&x->b_ob.ob_pd, gensym(buf));
         textbuf_senditup(x);

--- a/tcl/dialog_preferences.tcl
+++ b/tcl/dialog_preferences.tcl
@@ -24,7 +24,6 @@ proc ::dialog_preferences::do_apply {mytoplevel} {
     ::pd_guiprefs::write "gui_language" $::pd_i18n::language
     ::pd_guiprefs::write "use_ttknotebook" $::dialog_preferences::use_ttknotebook
     ::pd_guiprefs::write "cords_to_foreground" $::pdtk_canvas::enable_cords_to_foreground
-    pdsend "pd zoom-open $::sys_zoom_open"
 }
 proc ::dialog_preferences::apply {mytoplevel} {
     ::preferencewindow::apply $mytoplevel

--- a/tcl/pd-gui.tcl
+++ b/tcl/pd-gui.tcl
@@ -534,7 +534,6 @@ proc pdtk_pd_startup {major minor bugfix test
     if {$::tcl_version >= 8.5} {find_default_font}
     set_base_font $sys_font $sys_fontweight
     set ::font_measured [fit_font_into_metrics $::font_family $::font_weight $::font_metrics]
-    set ::font_zoom2_measured [fit_font_into_metrics $::font_family $::font_weight $::font_zoom2_metrics]
     ::pd_bindings::setup
     ::pd_menus::create_menubar
     ::pdwindow::create_window
@@ -543,7 +542,7 @@ proc pdtk_pd_startup {major minor bugfix test
     ::pdwindow::create_window_finalize
     load_startup_plugins
     pdsend "pd init [enquote_path [pwd]] $oldtclversion \
-        $::font_measured $::font_zoom2_measured"
+        $::font_measured"
     open_filestoopen
     set ::done_init 1
 }


### PR DESCRIPTION
Since the adoption of https://github.com/pure-data/pure-data/pull/1659 (yay!), the legacy zoom code isn't needed anymore.
Here is a global cleanup.