### PR TITLE
implement "default zoom" with window resize

### DIFF
--- a/src/g_canvas.c
+++ b/src/g_canvas.c
@@ -1098,16 +1098,8 @@ void canvas_deletelinesforio(t_canvas *x, t_text *text,
     }
 }
 
-typedef void (*t_zoomfn)(void *x, t_floatarg arg1);
-
 static void canvas_pop(t_canvas *x, t_floatarg fvis)
 {
-    if (glist_istoplevel(x) && (sys_zoom_open == 2))
-    {
-        t_zoomfn zoommethod = (t_zoomfn)zgetfn(&x->gl_pd, gensym("zoom"));
-        if (zoommethod)
-            (*zoommethod)(&x->gl_pd, (t_floatarg)2);
-    }
     if (fvis != 0)
         canvas_vis(x, 1);
     pd_popsym(&x->gl_pd);

--- a/src/m_glob.c
+++ b/src/m_glob.c
@@ -123,12 +123,6 @@ void glob_plugindispatch(t_pd *dummy, t_symbol *s, int argc, t_atom *argv)
     pdgui_vmess("pdtk_plugin_dispatch", "a", argc, argv);
 }
 
-int sys_zoom_open = 1;
-void glob_zoom_open(t_pd *dummy, t_floatarg f)
-{
-    sys_zoom_open = (f != 0 ? 2 : 1);
-}
-
 void glob_init(void)
 {
     maxclass = class_new(gensym("max"), 0, 0, sizeof(t_pd),
@@ -191,8 +185,6 @@ void glob_init(void)
         gensym("save-preferences"), A_DEFSYM, 0);
     class_addmethod(glob_pdobject, (t_method)glob_forgetpreferences,
         gensym("forget-preferences"), A_DEFSYM, 0);
-    class_addmethod(glob_pdobject, (t_method)glob_zoom_open,
-        gensym("zoom-open"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_version,
         gensym("version"), A_FLOAT, 0);
     class_addmethod(glob_pdobject, (t_method)glob_perf,

--- a/src/s_file.c
+++ b/src/s_file.c
@@ -861,8 +861,6 @@ void sys_savepreferences(const char *filename)
     sys_putpreference("flags",
         (sys_flags ? sys_flags->s_name : ""));
         /* misc */
-    sprintf(buf1, "%d", sys_zoom_open);
-    sys_putpreference("zoom", buf1);
     sys_putpreference("loading", "no");
 
     sys_donesavepreferences();

--- a/src/s_inter.c
+++ b/src/s_inter.c
@@ -1134,7 +1134,6 @@ void sys_gui_preferences(void)
     pdgui_vmess("set_escaped", "ri", "::sys_verbose", sys_verbose);
     pdgui_vmess("set_escaped", "ri", "::sys_use_stdpath", sys_usestdpath);
     pdgui_vmess("set_escaped", "ri", "::sys_defeatrt", sys_defeatrt);
-    pdgui_vmess("set_escaped", "ri", "::sys_zoom_open", (sys_zoom_open == 2));
 
     pdgui_vmess("::dialog_startup::set_flags", "s",
                 (sys_flags? sys_flags->s_name : ""));

--- a/src/s_stuff.h
+++ b/src/s_stuff.h
@@ -417,7 +417,6 @@ EXTERN void inmidi_polyaftertouch(int portno,
                                   int pitch,
                                   int value);
 /* } jsarlo */
-EXTERN int sys_zoom_open;
 
 struct _instancestuff
 {

--- a/tcl/dialog_preferences.tcl
+++ b/tcl/dialog_preferences.tcl
@@ -24,7 +24,6 @@ proc ::dialog_preferences::do_apply {mytoplevel} {
     ::pd_guiprefs::write "gui_language" $::pd_i18n::language
     ::pd_guiprefs::write "use_ttknotebook" $::dialog_preferences::use_ttknotebook
     ::pd_guiprefs::write "cords_to_foreground" $::pdtk_canvas::enable_cords_to_foreground
-    pdsend "pd zoom-open $::sys_zoom_open"
 }
 proc ::dialog_preferences::apply {mytoplevel} {
     ::preferencewindow::apply $mytoplevel

--- a/tcl/dialog_preferences.tcl
+++ b/tcl/dialog_preferences.tcl
@@ -7,7 +7,6 @@ package require preferencewindow
 namespace eval ::dialog_preferences:: {
 }
 
-set ::dialog_preferences::zoom_open 0
 set ::dialog_preferences::use_ttknotebook {}
 after idle ::dialog_preferences::read
 # allow updating the audio resp MIDI frame if the backend changes
@@ -54,13 +53,9 @@ proc ::dialog_preferences::tab_changed {mytoplevel} {
 proc ::dialog_preferences::fill_frame {prefs} {
     # patch-window settings
     labelframe $prefs.extraframe -text [_ "Patch Windows" ] -padx 5 -pady 5 -borderwidth 1
-    # LATER: allow other default_zoom values than 0(100%) or 100(200%)
-    checkbutton $prefs.extraframe.zoom -text [_ "Zoom New Windows"] \
-        -variable ::dialog_preferences::zoom_open -anchor w \
-        -command {::pd_menucommands::scheduleAction \
-        ::pd_canvaszoom::set_default_zoom [expr $::dialog_preferences::zoom_open * 100]}
-    pack $prefs.extraframe.zoom -side left -expand 1
-    pack $prefs.extraframe -side top -anchor n -fill x
+    ::pd_canvaszoom::default_zoom_pref_widget $prefs.extraframe.zoom
+    pack $prefs.extraframe.zoom -anchor w -expand 1
+    pack $prefs.extraframe -side top -anchor w -fill x
 
     labelframe $prefs.guiframe -text [_ "GUI Settings" ] -padx 5 -pady 5 -borderwidth 1
     pack $prefs.guiframe -side top -anchor n -fill x

--- a/tcl/pd_bindings.tcl
+++ b/tcl/pd_bindings.tcl
@@ -568,7 +568,11 @@ proc ::pd_bindings::patch_configure {mytoplevel width height x y} {
     # however, we need position including the border decoration
     # as this is how we restore the position
     scan [wm geometry $mytoplevel] {%dx%d%[+]%d%[+]%d} width height - x - y
-    pdtk_canvas_getscroll [tkcanvas_name $mytoplevel]
+    set tkcanvas [tkcanvas_name $mytoplevel]
+    pdtk_canvas_getscroll $tkcanvas
+    set zoom [::pd_canvaszoom::getzdepth $tkcanvas]
+    set width [expr int($width / $zoom)]
+    set height [expr int($height / $zoom)]
     # send the size/location of the window and canvas to 'pd' in the form of:
     #    left top right bottom
     pdsend "$mytoplevel setbounds $x $y [expr $x + $width] [expr $y + $height]"

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -144,6 +144,8 @@ proc ::pd_canvaszoom::cleanup {canvas} {
     foreach c [list ::${canvas} ::pd_canvaszoom::canvas::${canvas}] {
         catch {
             rename ${c} {}
+            unset ::pd_canvaszoom::zsteps($c)
+            unset ::pd_canvaszoom::zdepth($c)
         }
     }
 }
@@ -163,13 +165,9 @@ proc ::pd_canvaszoom::zoominit {mytoplevel} {
         return [::pd_canvaszoom::canvas_command $c $method {*}$args]
     }
 
-    # init zoom state for this canvas, if it didn't exist
-    if { ! [info exists ::pd_canvaszoom::zsteps($c)]} {
-        # NOTE: these arrays don't get cleaned up when the canvas is destroyed
-        #       so the zoom-level is persistent when a window is closed & re-opened
-        set ::pd_canvaszoom::zsteps($c) $::pd_canvaszoom::default_zoom
-        set ::pd_canvaszoom::zdepth($c) [pd_canvaszoom::steps2depth $::pd_canvaszoom::zsteps($c)]
-    }
+    # init zoom state to the default zoom level
+    set ::pd_canvaszoom::zsteps($c) $::pd_canvaszoom::default_zoom
+    set ::pd_canvaszoom::zdepth($c) [pd_canvaszoom::steps2depth $::pd_canvaszoom::zsteps($c)]
 
     # canvas bindings for mousewheel and mousewheel-button are OS dependent
     # LATER: probably move this to pd_bindings.tcl

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -33,14 +33,24 @@ proc ::pd_canvaszoom::init_default_zoom {} {
 
     set default_zoom [::pd_guiprefs::read default_zoom]
     if { $default_zoom == {}} { set default_zoom 0 }
-
-    # update "File/Preferences/Zoom New Windows" menu entry
-    # for now, "Zoom New Windows" is a checkbox;
-    # LATER: allow other default_zoom values than 0(100%) or 100(200%)
-    set ::dialog_preferences::zoom_open [expr $default_zoom >= 100]
 }
 
 after idle ::pd_canvaszoom::init_default_zoom
+
+proc ::pd_canvaszoom::defaut_zoom_callback {widget value} {
+    ::pd_canvaszoom::set_default_zoom $value
+    set zdepth [expr int([::pd_canvaszoom::steps2depth $value] * 100)]
+    $widget configure -label [_ "Default zoom level: ${zdepth}%"]
+}
+
+proc ::pd_canvaszoom::default_zoom_pref_widget {widget} {
+    set zdepth [expr int([::pd_canvaszoom::steps2depth $::pd_canvaszoom::default_zoom] * 100)]
+    scale $widget -label [_ "Default zoom level: ${zdepth}%"] \
+        -from -100 -to 100 -resolution 20 -orient horizontal \
+        -length 200 -showvalue false \
+        -command "::pd_menucommands::scheduleAction ::pd_canvaszoom::defaut_zoom_callback $widget"
+    $widget set $::pd_canvaszoom::default_zoom
+}
 
 # multiplies by "zdepth" all consecutive numbers from the "from"th element.
 # process maximum "max_elements" elements, and round the result if "int" is not null.
@@ -92,8 +102,14 @@ proc ::pd_canvaszoom::canvas_command {c method args} {
             if {[set fontindex [lsearch -start 2 $args "-font"]] != -1} {
                 incr fontindex
                 set font [lindex $args $fontindex]
+                set fontsize [lindex $font 1]
                 set font [scalefont $font [lindex $font 1] $zdepth]
                 lset args $fontindex $font
+                # add fontsize tag
+                set tagsindex [lsearch -start 2 $args "-tags"]
+                incr tagsindex
+                set tags [concat {*}[lindex $args $tagsindex] _f$fontsize]
+                lset args $tagsindex $tags
             }
         }
         "move" {

--- a/tcl/pdtk_canvas.tcl
+++ b/tcl/pdtk_canvas.tcl
@@ -109,6 +109,11 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable \
         set ::pdtk_canvas::geometry_needs_init($mytoplevel) 1
     }
 
+    # scale window size to default zoom level
+    set zoom [::pd_canvaszoom::steps2depth $::pd_canvaszoom::default_zoom]
+    set width [expr int($width * $zoom)]
+    set height [expr int($height * $zoom)]
+
     foreach {width height geometry} [pdtk_canvas_place_window $width $height $geometry] {break;}
     set ::undo_actions($mytoplevel) no
     set ::redo_actions($mytoplevel) no
@@ -118,6 +123,7 @@ proc pdtk_canvas_new {mytoplevel width height geometry editable \
     ::pdwindow::busyrelease
     # set the loaded array for this new window so things can track state
     set ::loaded($mytoplevel) 0
+
     toplevel $mytoplevel -width $width -height $height -class PatchWindow
     wm group $mytoplevel .
     $mytoplevel configure -menu $::patch_menubar
@@ -410,8 +416,8 @@ proc ::pdtk_canvas::do_getscroll {tkcanvas} {
     }
     set mytoplevel [winfo toplevel $tkcanvas]
     set zdepth [::pd_canvaszoom::getzdepth $tkcanvas]
-    set height [expr [winfo height $tkcanvas] * $zdepth]
-    set width [expr [winfo width $tkcanvas] * $zdepth]
+    set height [expr [winfo height $tkcanvas] / $zdepth]
+    set width [expr [winfo width $tkcanvas] / $zdepth]
 
     set bbox [$tkcanvas bbox all]
     if {$bbox eq "" || [llength $bbox] != 4} {return}


### PR DESCRIPTION
fixes #2972

Rename `Zoom New Window` preference to `Default zoom level`, which can now take arbitrary values (well, for now, any zoom value that can be reached with mousewheel or key bindings).

Every patch window will be zoomed to this level when opened, and its size will be scaled accordingly.

<img width="444" height="263" alt="Screenshot_2026-08-29_16-07-05" src="https://github.com/user-attachments/assets/4e1a8feb-1221-4a29-a8da-0898299c476b" />
