### PR TITLE
a few bugfixes about zooming

### DIFF
--- a/src/g_template.c
+++ b/src/g_template.c
@@ -2042,7 +2042,6 @@ static void plot_vis(t_gobj *z, t_glist *glist,
 
     if (glist->gl_isgraph)
         linewidth *= glist_getzoom(glist);
-
     if (tovis)
     {
          /* we use t_word because pdgui_vmess() has a convenient FLOATWORDS
@@ -2090,25 +2089,14 @@ static void plot_vis(t_gobj *z, t_glist *glist,
                     maxyval = yval;
                 if (i == nelem-1 || inextx != ixpix)
                 {
-                    pdgui_vmess("pdtk_canvas_create_rect", "crri kk iiii",
-                        glist_getcanvas(glist), tag0, "-", 0,
-                        color, THISGUI->i_backgroundcolor,
+                    pdgui_vmess("pdtk_canvas_create_line", "crr iik iiii",
+                        glist_getcanvas(glist), tag0, "-",
+                        0, (int)linewidth, color,
                         ixpix , (int) glist_ytopixels(glist, basey +
                             fielddesc_cvttocoord(yfielddesc, minyval)),
-                        inextx, (int)(glist_ytopixels(glist, basey +
+                        inextx, (int)glist_ytopixels(glist, basey +
                             fielddesc_cvttocoord(yfielddesc, maxyval))
-                                + linewidth));
-
-                    /* pdgui_vmess(0, "crr iiii rk rf rS",
-                        glist_getcanvas(glist), "create", "rectangle",
-                        ixpix , (int) glist_ytopixels(glist, basey +
-                            fielddesc_cvttocoord(yfielddesc, minyval)),
-                        inextx, (int)(glist_ytopixels(glist, basey +
-                            fielddesc_cvttocoord(yfielddesc, maxyval))
-                                + linewidth),
-                        "-fill", color,
-                        "-width", 0.,
-                        "-tags", 3, tags); */
+                    );
                     ndrawn++;
                     minyval = 1e20;
                     maxyval = -1e20;

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -230,6 +230,7 @@ proc ::pd_canvaszoom::toastzoom {c} {
     variable zdepth
     if { ! [info exists zdepth($c)] } {return}
     set zoom [expr int($zdepth($c) * 100)]
+    set c ::pd_canvaszoom::canvas::$c
     set scrollregion [$c cget -scrollregion]
     set x0 [lindex $scrollregion 0]
     set y0 [lindex $scrollregion 1]
@@ -239,8 +240,8 @@ proc ::pd_canvaszoom::toastzoom {c} {
     set yT [expr $y0 + $H * [lindex [$c yview] 0] + 3]
     after cancel ::pd_canvaszoom::delete_toastzoom $c
     delete_toastzoom $c
-    ::pd_canvaszoom::canvas::$c create rectangle $xT $yT [expr $xT + 50] [expr $yT + 16] -tags _zoomtoast_ -fill "#E7E7E7"
-    ::pd_canvaszoom::canvas::$c create text [expr $xT + 5] $yT -tags _zoomtoast_ \
+    $c create rectangle $xT $yT [expr $xT + 50] [expr $yT + 16] -tags _zoomtoast_ -fill "#E7E7E7"
+    $c create text [expr $xT + 5] $yT -tags _zoomtoast_ \
         -text "$zoom% " \
         -fill black -anchor nw -font [get_font_for_size 14]
     after 1200 ::pd_canvaszoom::delete_toastzoom $c

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -63,8 +63,46 @@ proc ::pd_canvaszoom::scale_consecutive_numbers {from zdepth int max_elements ar
 proc ::pd_canvaszoom::canvas_command {c method args} {
     set zdepth [getzdepth $c]
     # puts "canvas_command: $c $method $args"
+
+    # itemconfig[ure] always needs to be filtered (even when zdepth==1.0),
+    # otherwise outdated _f or _t tags could be left untouched
+    if {[string first "itemconfig" $method] == 0} {
+        # scale width
+        set widthindex [lsearch -start 1 $args "-width"]
+        if {$widthindex != -1} {
+            incr widthindex
+            set args [scale_consecutive_numbers $widthindex $zdepth 0 1 {*}$args]
+        }
+        # scale font
+        set fontindex [lsearch -start 1 $args "-font"]
+        if {$fontindex != -1} {
+            incr fontindex
+            set item [lindex $args 0]
+            set font [lindex $args $fontindex]
+            set newfont [scalefont $font [lindex $font 1] $zdepth]
+            lset args $fontindex $newfont
+            # remove font tag
+            foreach {tag} [::pd_canvaszoom::canvas::$c gettags $item] {
+                if {"_f" in [string range $tag 0 1]} {
+                    ::pd_canvaszoom::canvas::$c dtag $item $tag
+                }
+            }
+            # add the new font tag
+            ::pd_canvaszoom::canvas::$c addtag _f[lindex $font 1] withtag $item"
+        }
+        # if changing the text content, remove text tag
+        if {[lsearch -start 1 $args "-text"] != -1} {
+            set item [lindex $args 0]
+            foreach {tag} [::pd_canvaszoom::canvas::$c gettags $item] {
+                if {"_t" in [string range $tag 0 1]} {
+                    ::pd_canvaszoom::canvas::$c dtag $item $tag
+                }
+            }
+        }
+    }
+
     if { $zdepth == 1.0 } { return [::pd_canvaszoom::canvas::$c $method {*}$args] }
-    switch -glob $method {
+    switch $method {
         "create" {
             # scale coordinates
             set args [scale_consecutive_numbers 1 $zdepth 0 1e6 {*}$args]
@@ -77,7 +115,6 @@ proc ::pd_canvaszoom::canvas_command {c method args} {
                 set tags [lindex $args $tagsindex]
                 # don't scale rect selection outline width (tagged "x")
                 if {{x} ni $tags} {
-                    lset args $tagsindex $tags
                     set args [linsert $args $tagsindex+1 -width 1.0]
                     set widthindex [lsearch -start 2 $args "-width"]
                 }
@@ -101,40 +138,6 @@ proc ::pd_canvaszoom::canvas_command {c method args} {
         }
         "coords" {
             set args [scale_consecutive_numbers 1 $zdepth 0 1e6 {*}$args]
-        }
-        "itemconfig*" {
-            # scale width
-            set widthindex [lsearch -start 1 $args "-width"]
-            if {$widthindex != -1} {
-                incr widthindex
-                set args [scale_consecutive_numbers $widthindex $zdepth 0 1 {*}$args]
-            }
-            # scale font
-            set fontindex [lsearch -start 1 $args "-font"]
-            if {$fontindex != -1} {
-                incr fontindex
-                set item [lindex $args 0]
-                set font [lindex $args $fontindex]
-                set newfont [scalefont $font [lindex $font 1] $zdepth]
-                lset args $fontindex $newfont
-                # remove font tag
-                foreach {tag} [::pd_canvaszoom::canvas::$c gettags $item] {
-                    if {"_f" in [string range $tag 0 1]} {
-                        ::pd_canvaszoom::canvas::$c dtag $item $tag
-                    }
-                }
-                # add the new font tag
-                ::pd_canvaszoom::canvas::$c addtag _f[lindex $font 1] withtag $item"
-            }
-            # if changing the text content, remove text tag
-            if {[lsearch -start 1 $args "-text"] != -1} {
-                set item [lindex $args 0]
-                foreach {tag} [::pd_canvaszoom::canvas::$c gettags $item] {
-                    if {"_t" in [string range $tag 0 1]} {
-                        ::pd_canvaszoom::canvas::$c dtag $item $tag
-                    }
-                }
-            }
         }
     }
     return [::pd_canvaszoom::canvas::$c $method {*}$args]

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -129,8 +129,14 @@ proc ::pd_canvaszoom::canvas_command {c method args} {
             if {[set fontindex [lsearch -start 2 $args "-font"]] != -1} {
                 incr fontindex
                 set font [lindex $args $fontindex]
-                set font [scalefont $font [lindex $font 1] $zdepth]
+                set realfontsize [lindex $font 1]
+                set font [scalefont $font $realfontsize $zdepth]
                 lset args $fontindex $font
+                # add font tag
+                set tagsindex [lsearch -start 2 $args "-tags"]
+                incr tagsindex
+                set tags [lindex $args $tagsindex]
+                lset args $tagsindex [list {*}$tags _f$realfontsize]
             }
         }
         "move" {


### PR DESCRIPTION
fixes #2976:
- array with 'points' style is badly drawn at zoom level other than 100%. The solution here is to draw it as lines instead of rectangles (which had to use a white outline color, hence the glitches). 
- when a text content is modified at 100% zoom, an optimization was preventing the text tag (that is added by zoom processing) to be updated. 

This PR also fixes:
- when a text is created at different zoom levels (excepting integer levels like 200% or 400%), the actual font size (stored in a font tag) is different because of rounding error. The solution is to always add the font tag during text creation (excepting if current zoom is 100%, because no rounding problem in this case). 


