### PR TITLE
bugfix/default zoom scale

### DIFF
--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -38,18 +38,27 @@ proc ::pd_canvaszoom::init_default_zoom {} {
 after idle ::pd_canvaszoom::init_default_zoom
 
 proc ::pd_canvaszoom::default_zoom_callback {widget value} {
+    set value [expr 20 * int($value / 20.)]
     ::pd_canvaszoom::set_default_zoom $value
     set zdepth [expr int([::pd_canvaszoom::steps2depth $value] * 100)]
-    $widget configure -label [_ "Default zoom level: %d%%" ${zdepth}]
+    ${widget}.l configure -text [_ "Default zoom level: %d%%" ${zdepth}]
 }
 
 proc ::pd_canvaszoom::default_zoom_pref_widget {widget} {
-    set zdepth [expr int([::pd_canvaszoom::steps2depth $::pd_canvaszoom::default_zoom] * 100)]
-    scale $widget -label [_ "Default zoom level: %d%%" ${zdepth}] \
-        -from -100 -to 100 -resolution 20 -orient horizontal \
-        -length 200 -showvalue false \
+    frame $widget
+    label ${widget}.l
+
+    if [catch {::ttk::scale ${widget}.z} ] {
+        scale ${widget}.z -showvalue false
+    }
+    ${widget}.z configure \
+        -from -100 -to 100 -orient horizontal \
+        -length 200 \
+        -variable ::pd_canvaszoom::default_zoom \
         -command [list ::pd_menucommands::scheduleAction ::pd_canvaszoom::default_zoom_callback ${widget}]
-    $widget set $::pd_canvaszoom::default_zoom
+
+    pack ${widget}.l ${widget}.z -anchor w
+    ::pd_canvaszoom::default_zoom_callback ${widget} ${::pd_canvaszoom::default_zoom}
 }
 
 # multiplies by "zdepth" all consecutive numbers from the "from"th element.

--- a/tcl/pd_canvaszoom.tcl
+++ b/tcl/pd_canvaszoom.tcl
@@ -37,18 +37,18 @@ proc ::pd_canvaszoom::init_default_zoom {} {
 
 after idle ::pd_canvaszoom::init_default_zoom
 
-proc ::pd_canvaszoom::defaut_zoom_callback {widget value} {
+proc ::pd_canvaszoom::default_zoom_callback {widget value} {
     ::pd_canvaszoom::set_default_zoom $value
     set zdepth [expr int([::pd_canvaszoom::steps2depth $value] * 100)]
-    $widget configure -label [_ "Default zoom level: ${zdepth}%"]
+    $widget configure -label [_ "Default zoom level: %d%%" ${zdepth}]
 }
 
 proc ::pd_canvaszoom::default_zoom_pref_widget {widget} {
     set zdepth [expr int([::pd_canvaszoom::steps2depth $::pd_canvaszoom::default_zoom] * 100)]
-    scale $widget -label [_ "Default zoom level: ${zdepth}%"] \
+    scale $widget -label [_ "Default zoom level: %d%%" ${zdepth}] \
         -from -100 -to 100 -resolution 20 -orient horizontal \
         -length 200 -showvalue false \
-        -command "::pd_menucommands::scheduleAction ::pd_canvaszoom::defaut_zoom_callback $widget"
+        -command [list ::pd_menucommands::scheduleAction ::pd_canvaszoom::default_zoom_callback ${widget}]
     $widget set $::pd_canvaszoom::default_zoom
 }
 


### PR DESCRIPTION
- fix typo in procname `defaut_zoom_callback` (should read: `default_zoom_callback`)
- make the string "Default zoom level" in the preferences translatable
- separatee widgets for the slider and the associated label "Default zoom level"
   - Closes: https://github.com/pure-data/pure-data/issues/2978
- prefer `::ttk::scale` over `scale` (if available)

### `::ttk::scale`

<img width="331" height="148" alt="image" src="https://github.com/user-attachments/assets/e30ed885-e154-4e1b-a75e-e31fce1bed57" />


### normal `scale`
<img width="343" height="145" alt="image" src="https://github.com/user-attachments/assets/cbe15ce1-d271-4e84-9ced-1afe86b4dcd7" />

i don't really care much about `::ttk:scale` vs `::scale` but the former usually has a more *native* look and feel.


maybe @Ant1r wants to have a look before this gets accepted...