### PR TITLE
pd_free: don't free anything past freemethod if `c_size` is zero

### DIFF
--- a/src/m_pd.c
+++ b/src/m_pd.c
@@ -34,6 +34,7 @@ void pd_free(t_pd *x)
 {
     t_class *c = *x;
     if (c->c_freemethod) (*(t_freemethod)(c->c_freemethod))(x);
+    if (!c->c_size) return;
     if (c->c_patchable)
     {
         while (((t_object *)x)->ob_outlet)
@@ -43,7 +44,7 @@ void pd_free(t_pd *x)
         if (((t_object *)x)->ob_binbuf)
             binbuf_free(((t_object *)x)->ob_binbuf);
     }
-    if (c->c_size) t_freebytes(x, c->c_size);
+    t_freebytes(x, c->c_size);
 }
 
 void gobj_save(t_gobj *x, t_binbuf *b)


### PR DESCRIPTION
If a developer wants total control over the memory management of their external, such that they also free the pd object, they could set the class size to zero.

Currently, this might already work, but if an allocator deliberately poisons the freed memory, pd will crash when it tries to free patchable items.